### PR TITLE
add `.vscode/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ env*/
 /pydantic_ai_examples/.chat_app_messages.jsonl
 .cache/
 .docs-insiders-install
+.vscode/


### PR DESCRIPTION
just to avoid everyone (using vs code or derivatives) having to do the following before making a contribution
```
echo .vscode/ >> .git/info/exclude
```