### PR TITLE
Add ability to end agent runs as a result of a tool call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ testcov: test
 	@echo "building coverage html"
 	@uv run coverage html
 
+.PHONY: update-examples  # update documentation examples
+	uv run -m pytest --update-examples
+
 # `--no-strict` so you can build the docs without insiders packages
 .PHONY: docs  # Build the documentation
 docs:

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -801,16 +801,21 @@ agent = Agent('test')
 
 
 @agent.tool
-def my_tool_call(ctx: RunContext[int], answer: str) -> str:
+def tool_one(ctx: RunContext[int], value: str) -> str:
     if ctx.deps == 42:
-        ctx.stop_run('Special dependency detected')
-    return f'Tool call: answer={answer}'
+        ctx.stop_run('Run stopped early due to special dependency value')
+    return f'tool_one call: value={value}'
+
+
+@agent.tool
+def tool_two(ctx: RunContext[int], value: str) -> str:
+    return f'tool_two call: value={value}'
 
 
 result = agent.run_sync('testing...', deps=41)
 print(result.data)
-#> {"my_tool_call":"Tool call: answer=a"}
+#> {"tool_one":"tool_one call: value=a","tool_two":"tool_two call: value=a"}
 result = agent.run_sync('testing...', deps=42)
 print(result.data)
-#> Special dependency detected
+#> Run stopped early due to special dependency value
 ```

--- a/pydantic_ai_slim/pydantic_ai/_exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/_exceptions.py
@@ -1,0 +1,22 @@
+from __future__ import annotations as _annotations
+
+from typing import Any
+
+
+class StopAgentRun(Exception):
+    """Exception raised to stop the agent run and use the provided result as the output."""
+
+    result: Any
+    """The value to use as the result of the agent run."""
+    tool_name: str | None
+    """The name of the tool call, if available."""
+
+    def __init__(self, result: Any, tool_name: str | None) -> None:
+        self.result = result
+        self.tool_name = tool_name
+
+    def __str__(self) -> str:
+        if self.tool_name:
+            return f'{self.tool_name}, result:\n{self.result}'
+        else:
+            return str(self.result)

--- a/pydantic_ai_slim/pydantic_ai/_exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/_exceptions.py
@@ -14,9 +14,3 @@ class StopAgentRun(Exception):
     def __init__(self, result: Any, tool_name: str | None) -> None:
         self.result = result
         self.tool_name = tool_name
-
-    def __str__(self) -> str:
-        if self.tool_name:
-            return f'{self.tool_name}, result:\n{self.result}'
-        else:
-            return str(self.result)

--- a/pydantic_ai_slim/pydantic_ai/_exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/_exceptions.py
@@ -10,7 +10,10 @@ class StopAgentRun(Exception):
     """The value to use as the result of the agent run."""
     tool_name: str | None
     """The name of the tool call, if available."""
+    tool_id: str | None
+    """Optional tool identifier, if available; this is used by some models including OpenAI."""
 
-    def __init__(self, result: Any, tool_name: str | None) -> None:
+    def __init__(self, result: Any, tool_name: str, tool_id: str | None = None) -> None:
         self.result = result
         self.tool_name = tool_name
+        self.tool_id = tool_id

--- a/pydantic_ai_slim/pydantic_ai/_result.py
+++ b/pydantic_ai_slim/pydantic_ai/_result.py
@@ -42,7 +42,12 @@ class ResultValidator(Generic[AgentDeps, ResultData]):
             Result of either the validated result data (ok) or a retry message (Err).
         """
         if self._takes_ctx:
-            args = RunContext(deps, retry, tool_call.tool_name if tool_call else None), result
+            args = (
+                RunContext(
+                    deps, retry, tool_call.tool_name if tool_call else None, tool_call.tool_id if tool_call else None
+                ),
+                result,
+            )
         else:
             args = (result,)
 

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -897,8 +897,8 @@ class Agent(Generic[AgentDeps, ResultData]):
             messages.extend(tool_messages)
             return _MarkFinalResult(model_response) if stop_run else None, messages
 
-    @staticmethod
     async def _run_tools(
+        self,
         tasks: list[asyncio.Task[_messages.Message]],
     ) -> tuple[list[_messages.Message], _messages.ToolReturn | None]:
         with _logfire.span('running {tools=}', tools=[t.get_name() for t in tasks]) as span:
@@ -924,7 +924,8 @@ class Agent(Generic[AgentDeps, ResultData]):
             first_tool_return: _messages.ToolReturn | None = None
             for stop_run in stop_runs:
                 tool_return = _messages.ToolReturn(
-                    tool_name=stop_run.tool_name or 'unknown tool',
+                    # TODO: need to unwind the result tool stuff; is it possible to ensure we use the right name?
+                    tool_name=self._result_schema.tool_names()[0],
                     content=stop_run.result,
                     tool_call_id=stop_run.tool_call_id,
                 )

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -856,6 +856,7 @@ class Agent(Generic[AgentDeps, ResultData]):
 
                 return None, [response]
         else:
+            assert isinstance(model_response, models.StreamStructuredResponse), f'Unexpected response: {model_response}'
             if self._result_schema is not None:
                 # if there's a result schema, iterate over the stream until we find at least one tool
                 # NOTE: this means we ignore any other tools called here
@@ -912,7 +913,7 @@ class Agent(Generic[AgentDeps, ResultData]):
                     if isinstance(r, BaseException) and not isinstance(r, _exceptions.StopAgentRun)
                 ]
                 if failures:
-                    raise failures[0]  # TODO: raise an exceptiongroup if there are more than 1?
+                    raise failures[0]  # TODO: raise an exceptiongroup if there is more than 1?
 
                 messages = [r for r in task_results if not isinstance(r, BaseException)]
                 stop_runs = [r for r in task_results if isinstance(r, _exceptions.StopAgentRun)]

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -281,7 +281,9 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
         match = self._result_schema.find_tool(message)
         if match is None:
             raise exceptions.UnexpectedModelBehavior(
-                f'Invalid message, unable to find tool: {self._result_schema.tool_names()}'
+                f'Invalid message, unable to find tool.'
+                f' Called tool names: {list({call.tool_name for call in message.calls})}.'
+                f' Expected tool names: {self._result_schema.tool_names()}'
             )
 
         call, result_tool = match

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -53,6 +53,7 @@ class RunContext(Generic[AgentDeps, ResultData]):
 
     def end_run(self, result: ResultData) -> NoReturn:
         """End the call to `agent.run` as soon as possible, using the provided value as the result."""
+        # NOTE: this means we ignore any other tools called concurrently
         raise EndAgentRun(result, tool_name=self.tool_name)
 
 

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -85,7 +85,7 @@ Usage `ResultValidator[AgentDeps, ResultData]`.
 ToolFuncContext = Callable[Concatenate[RunContext[AgentDeps], ToolParams], Any]
 """A tool function that takes `RunContext` as the first argument.
 
-Usage `ToolContextFunc[AgentDeps, ToolParams]`.
+Usage `ToolFuncContext[AgentDeps, ToolParams]`.
 """
 ToolFuncPlain = Callable[ToolParams, Any]
 """A tool function that does not take `RunContext` as the first argument.

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from pydantic_core import SchemaValidator
 from typing_extensions import Concatenate, ParamSpec, TypeAlias, TypeVar
 
-from . import _pydantic, _utils, messages
+from . import _exceptions, _pydantic, _utils, messages
 from .exceptions import ModelRetry, UnexpectedModelBehavior
 
 ResultData = TypeVar('ResultData', default=Any)
@@ -35,14 +35,6 @@ AgentDeps = TypeVar('AgentDeps')
 """Type variable for agent dependencies."""
 
 
-class EndAgentRun(Exception):
-    """Signal to end the current agent run and return the provided result."""
-
-    def __init__(self, result: Any, tool_name: str | None) -> None:
-        self.result = result
-        self.tool_name = tool_name
-
-
 @dataclass
 class RunContext(Generic[AgentDeps, ResultData]):
     """Information about the current call."""
@@ -54,10 +46,10 @@ class RunContext(Generic[AgentDeps, ResultData]):
     tool_name: str | None = None
     """Name of the tool being called."""
 
-    def end_run(self, result: ResultData) -> NoReturn:
-        """End the call to `agent.run` as soon as possible, using the provided value as the result."""
+    def stop_run(self, result: ResultData) -> NoReturn:
+        """Stop the call to `agent.run` as soon as possible, using the provided value as the result."""
         # NOTE: this means we ignore any other tools called concurrently
-        raise EndAgentRun(result, tool_name=self.tool_name)
+        raise _exceptions.StopAgentRun(result, tool_name=self.tool_name)
 
 
 ToolParams = ParamSpec('ToolParams')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -466,3 +466,12 @@ agent = Agent('test', tools=[ctx_tool], deps_type=int)
     """)
     result = mod.agent.run_sync('foobar', deps=5)
     assert result.data == snapshot('{"ctx_tool":5}')
+
+def test_ctx_stop_run():
+    """Ensure the ctx_stop_run_tool is used to complete the agent run."""
+    def ctx_stop_run_tool(ctx: RunContext[int]):
+        ctx.stop_run(ctx.deps * 'abc')
+
+    agent = Agent('test', result_type=str, tools=[Tool(ctx_stop_run_tool, takes_ctx=True)], deps_type=int)
+    result = agent.run_sync('foobar', deps=2)
+    assert result.data == snapshot('abcabc')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -467,7 +467,8 @@ agent = Agent('test', tools=[ctx_tool], deps_type=int)
     result = mod.agent.run_sync('foobar', deps=5)
     assert result.data == snapshot('{"ctx_tool":5}')
 
-def test_ctx_stop_run():
+
+def test_ctx_stop_run(set_event_loop: None):
     """Ensure the ctx_stop_run_tool is used to complete the agent run."""
     def ctx_stop_run_tool(ctx: RunContext[int]):
         ctx.stop_run(ctx.deps * 'abc')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -470,9 +470,15 @@ agent = Agent('test', tools=[ctx_tool], deps_type=int)
 
 def test_ctx_stop_run(set_event_loop: None):
     """Ensure the ctx_stop_run_tool is used to complete the agent run."""
-    def ctx_stop_run_tool(ctx: RunContext[int]):
-        ctx.stop_run(ctx.deps * 'abc')
+    def ctx_stop_run_tool(ctx: RunContext[int]) -> int:
+        if ctx.deps == 2:
+            ctx.stop_run('abc')
+        return 123
 
-    agent = Agent('test', result_type=str, tools=[Tool(ctx_stop_run_tool, takes_ctx=True)], deps_type=int)
+    agent = Agent('test', tools=[Tool(ctx_stop_run_tool, takes_ctx=True)], deps_type=int)
+
+    result = agent.run_sync('foobar', deps=1)
+    assert result.data == snapshot('{"ctx_stop_run_tool":123}')
+
     result = agent.run_sync('foobar', deps=2)
-    assert result.data == snapshot('abcabc')
+    assert result.data == snapshot('abc')


### PR DESCRIPTION
With this change, you can have tool calls end the full run early by calling `ctx.stop_run(result)` inside the tool call — this immediately ends tool execution (and type-checkers can even tell that subsequent code is unreachable).

~I've also added the ability to disable the standard result tools through a new keyword argument, so you can ensure that the only way for the agent to exit is to call a tool that exits by calling `ctx.stop_run`.~ I think we should add this in a separate PR that exposes more control over the auto-generated result tools.

I still need to add documentation and examples.

NOTE: I no longer intend for this to resolve https://github.com/pydantic/pydantic-ai/issues/127, as this is a fairly convoluted way to implement a "result tool", and I think we should just add an API for that directly. But @samuelcolvin has noted that there are other possible use cases for this feature, such as providing ways to explicitly interrupt agent execution during tool calls, etc., so I think it still makes sense to merge this.