### PR TITLE
Dynamic tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ lint:
 
 .PHONY: typecheck-pyright
 typecheck-pyright:
-	uv run pyright
+	@# PYRIGHT_PYTHON_IGNORE_WARNINGS avoids the overhead of making a request to github on every invocation
+	PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright
 
 .PHONY: typecheck-mypy
 typecheck-mypy:

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -422,7 +422,7 @@ print(dice_result.data)
 ```
 
 1. The simplest way to register tools via the `Agent` constructor is to pass a list of functions, the function signature is inspected to determine if the tool takes [`RunContext`][pydantic_ai.tools.RunContext].
-2. `agent_a` and `agent_b` are identical — but we can use [`Tool`][pydantic_ai.tools.Tool] to give more fine-grained control over how tools are defined, e.g. setting their name or description, or using a custom [`prepare`][#tool-prepare].
+2. `agent_a` and `agent_b` are identical — but we can use [`Tool`][pydantic_ai.tools.Tool] to give more fine-grained control over how tools are defined, e.g. setting their name or description, or using a custom [`prepare`](#tool-prepare).
 
 _(This example is complete, it can be run "as is")_
 
@@ -564,6 +564,8 @@ Here's a simple `prepare` method that only includes the tool if the value of the
 Again we use [`TestModel`][pydantic_ai.models.test.TestModel] to demonstrate the behavior without calling a real model.
 
 ```py title="tool_only_if_42.py"
+from __future__ import annotations
+
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.tools import ToolDefinition
 
@@ -597,6 +599,8 @@ Here's a more complex example where we change the description of the `name` para
 For the sake of variation, we create this tool using the [`Tool`][pydantic_ai.tools.Tool] dataclass.
 
 ```py title="customize_name.py"
+from __future__ import annotations
+
 from typing import Literal
 
 from pydantic_ai import Agent, RunContext

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -589,7 +589,7 @@ print(result.data)
 #> success (no tool calls)
 result = agent.run_sync('testing...', deps=42)
 print(result.data)
-#> {"hitchhiker_tool":"42 0 a"}
+#> {"hitchhiker":"42 a"}
 ```
 
 _(This example is complete, it can be run "as is")_

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -462,7 +462,7 @@ def print_schema(messages: list[Message], info: AgentInfo) -> ModelAnyResponse:
     tool = info.function_tools['foobar']
     print(tool.description)
     #> Get me foobar.
-    print(tool.json_schema)
+    print(tool.parameters_json_schema)
     """
     {
         'description': 'Get me foobar.',

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -459,7 +459,7 @@ def foobar(a: int, b: str, c: dict[str, list[float]]) -> str:
 
 
 def print_schema(messages: list[Message], info: AgentInfo) -> ModelAnyResponse:
-    tool = info.function_tools['foobar']
+    tool = info.function_tools[0]
     print(tool.description)
     #> Get me foobar.
     print(tool.parameters_json_schema)
@@ -523,8 +523,8 @@ print(result.data)
 #> {"foobar":"x=0 y='a' z=3.14"}
 print(test_model.agent_model_function_tools)
 """
-{
-    'foobar': ToolDefinition(
+[
+    ToolDefinition(
         name='foobar',
         description='',
         parameters_json_schema={
@@ -540,7 +540,7 @@ print(test_model.agent_model_function_tools)
         },
         outer_typed_dict_key=None,
     )
-}
+]
 """
 ```
 
@@ -629,8 +629,8 @@ print(result.data)
 #> {"greet":"hello a"}
 print(test_model.agent_model_function_tools)
 """
-{
-    'greet': ToolDefinition(
+[
+    ToolDefinition(
         name='greet',
         description='',
         parameters_json_schema={
@@ -647,7 +647,7 @@ print(test_model.agent_model_function_tools)
         },
         outer_typed_dict_key=None,
     )
-}
+]
 """
 ```
 

--- a/docs/testing-evals.md
+++ b/docs/testing-evals.md
@@ -209,8 +209,6 @@ def call_weather_forecast(  # (1)!
 ) -> ModelAnyResponse:
     if len(messages) == 2:
         # first call, call the weather forecast tool
-        assert set(info.function_tools.keys()) == {'weather_forecast'}
-
         user_prompt = messages[1]
         m = re.search(r'\d{4}-\d{2}-\d{2}', user_prompt.content)
         assert m is not None

--- a/pydantic_ai_slim/pydantic_ai/_pydantic.py
+++ b/pydantic_ai_slim/pydantic_ai/_pydantic.py
@@ -167,12 +167,12 @@ def takes_ctx(function: Callable[..., Any]) -> bool:
         `True` if the function takes a `RunContext` as first argument, `False` otherwise.
     """
     sig = signature(function)
-    type_hints = _typing_extra.get_function_type_hints(function)
     try:
         first_param_name = next(iter(sig.parameters.keys()))
     except StopIteration:
         return False
     else:
+        type_hints = _typing_extra.get_function_type_hints(function)
         annotation = type_hints[first_param_name]
         return annotation is not sig.empty and _is_call_ctx(annotation)
 

--- a/pydantic_ai_slim/pydantic_ai/_pydantic.py
+++ b/pydantic_ai_slim/pydantic_ai/_pydantic.py
@@ -167,12 +167,14 @@ def takes_ctx(function: Callable[..., Any]) -> bool:
         `True` if the function takes a `RunContext` as first argument, `False` otherwise.
     """
     sig = signature(function)
+    type_hints = _typing_extra.get_function_type_hints(function)
     try:
-        _, first_param = next(iter(sig.parameters.items()))
+        first_param_name = next(iter(sig.parameters.keys()))
     except StopIteration:
         return False
     else:
-        return first_param.annotation is not sig.empty and _is_call_ctx(first_param.annotation)
+        annotation = type_hints[first_param_name]
+        return annotation is not sig.empty and _is_call_ctx(annotation)
 
 
 def _build_schema(

--- a/pydantic_ai_slim/pydantic_ai/_pydantic.py
+++ b/pydantic_ai_slim/pydantic_ai/_pydantic.py
@@ -17,10 +17,10 @@ from pydantic.plugin._schema_validator import create_schema_validator
 from pydantic_core import SchemaValidator, core_schema
 
 from ._griffe import doc_descriptions
-from ._utils import ObjectJsonSchema, check_object_json_schema, is_model_like
+from ._utils import check_object_json_schema, is_model_like
 
 if TYPE_CHECKING:
-    pass
+    from .tools import ObjectJsonSchema
 
 
 __all__ = 'function_schema', 'LazyTypeAdapter'

--- a/pydantic_ai_slim/pydantic_ai/_result.py
+++ b/pydantic_ai_slim/pydantic_ai/_result.py
@@ -14,7 +14,7 @@ from . import _utils, messages
 from .exceptions import ModelRetry
 from .messages import ModelStructuredResponse, ToolCall
 from .result import ResultData
-from .tools import AgentDeps, ResultValidatorFunc, RunContext
+from .tools import AgentDeps, ObjectJsonSchema, ResultValidatorFunc, RunContext
 
 
 @dataclass
@@ -130,7 +130,7 @@ class ResultTool(Generic[ResultData]):
     name: str
     description: str
     type_adapter: TypeAdapter[Any]
-    json_schema: _utils.ObjectJsonSchema
+    parameters_json_schema: ObjectJsonSchema
     outer_typed_dict_key: str | None
 
     @classmethod
@@ -142,17 +142,17 @@ class ResultTool(Generic[ResultData]):
             type_adapter = TypeAdapter(response_type)
             outer_typed_dict_key: str | None = None
             # noinspection PyArgumentList
-            json_schema = _utils.check_object_json_schema(type_adapter.json_schema())
+            parameters_json_schema = _utils.check_object_json_schema(type_adapter.json_schema())
         else:
             response_data_typed_dict = TypedDict('response_data_typed_dict', {'response': response_type})  # noqa
             type_adapter = TypeAdapter(response_data_typed_dict)
             outer_typed_dict_key = 'response'
             # noinspection PyArgumentList
-            json_schema = _utils.check_object_json_schema(type_adapter.json_schema())
+            parameters_json_schema = _utils.check_object_json_schema(type_adapter.json_schema())
             # including `response_data_typed_dict` as a title here doesn't add anything and could confuse the LLM
-            json_schema.pop('title')
+            parameters_json_schema.pop('title')
 
-        if json_schema_description := json_schema.pop('description', None):
+        if json_schema_description := parameters_json_schema.pop('description', None):
             if description is None:
                 tool_description = json_schema_description
             else:
@@ -166,7 +166,7 @@ class ResultTool(Generic[ResultData]):
             name=name,
             description=tool_description,
             type_adapter=type_adapter,
-            json_schema=json_schema,
+            parameters_json_schema=parameters_json_schema,
             outer_typed_dict_key=outer_typed_dict_key,
         )
 

--- a/pydantic_ai_slim/pydantic_ai/_result.py
+++ b/pydantic_ai_slim/pydantic_ai/_result.py
@@ -118,9 +118,9 @@ class ResultSchema(Generic[ResultData]):
         """Return the names of the tools."""
         return list(self.tools.keys())
 
-    def tool_defs(self) -> dict[str, ToolDefinition]:
+    def tool_defs(self) -> list[ToolDefinition]:
         """Get tool definitions to register with the model."""
-        return {k: t.tool_def for k, t in self.tools.items()}
+        return [t.tool_def for t in self.tools.values()]
 
 
 DEFAULT_DESCRIPTION = 'The final response which ends this conversation'

--- a/pydantic_ai_slim/pydantic_ai/_system_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/_system_prompt.py
@@ -21,7 +21,7 @@ class SystemPromptRunner(Generic[AgentDeps]):
 
     async def run(self, deps: AgentDeps) -> str:
         if self._takes_ctx:
-            args = (RunContext(deps, 0, None),)
+            args = (RunContext(deps, 0),)
         else:
             args = ()
 

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -126,6 +126,12 @@ class Either(Generic[Left, Right]):
     def whichever(self) -> Left | Right:
         return self._left.value if self._left is not None else self.right
 
+    def __repr__(self):
+        if left := self._left:
+            return f'Either(left={left.value!r})'
+        else:
+            return f'Either(right={self.right!r})'
+
 
 @asynccontextmanager
 async def group_by_temporal(

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -8,11 +8,14 @@ from dataclasses import dataclass, is_dataclass
 from datetime import datetime, timezone
 from functools import partial
 from types import GenericAlias
-from typing import Any, Callable, Generic, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, Union, cast, overload
 
 from pydantic import BaseModel
 from pydantic.json_schema import JsonSchemaValue
 from typing_extensions import ParamSpec, TypeAlias, TypeGuard, is_typeddict
+
+if TYPE_CHECKING:
+    from .tools import ObjectJsonSchema
 
 _P = ParamSpec('_P')
 _R = TypeVar('_R')
@@ -37,10 +40,6 @@ def is_model_like(type_: Any) -> bool:
         and not isinstance(type_, GenericAlias)
         and (issubclass(type_, BaseModel) or is_dataclass(type_) or is_typeddict(type_))
     )
-
-
-# With PEP-728 this should be a TypedDict with `type: Literal['object']`, and `extra_items=Any`
-ObjectJsonSchema: TypeAlias = dict[str, Any]
 
 
 def check_object_json_schema(schema: JsonSchemaValue) -> ObjectJsonSchema:

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -223,7 +223,7 @@ async def group_by_temporal(
 
     try:
         yield async_iter_groups()
-    finally:
+    finally:  # pragma: no cover
         # after iteration if a tasks still exists, cancel it, this will only happen if an error occurred
         if task:
             task.cancel('Cancelling due to error in iterator')

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -547,7 +547,7 @@ class Agent(Generic[AgentDeps, ResultData]):
                 which defaults to 1.
             prepare: custom method to prepare the tool definition for each step, return `None` to omit this
                 tool from a given step. This is useful if you want to customise a tool at call time,
-                or omit it completely from a step.
+                or omit it completely from a step. See [`ToolPrepareFunc`][pydantic_ai.tools.ToolPrepareFunc].
         """
         if func is None:
 
@@ -619,7 +619,7 @@ class Agent(Generic[AgentDeps, ResultData]):
                 which defaults to 1.
             prepare: custom method to prepare the tool definition for each step, return `None` to omit this
                 tool from a given step. This is useful if you want to customise a tool at call time,
-                or omit it completely from a step.
+                or omit it completely from a step. See [`ToolPrepareFunc`][pydantic_ai.tools.ToolPrepareFunc].
         """
         if func is None:
 
@@ -691,7 +691,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         return model_, mode_selection
 
     async def _prepare_model(self, model: models.Model, deps: AgentDeps) -> models.AgentModel:
-        """Create an agent model by building tools."""
+        """Create building tools and create an agent model."""
         function_tools: dict[str, ToolDefinition] = {}
 
         async def add_tool(key: str, tool: Tool[AgentDeps]) -> None:

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -671,7 +671,7 @@ class Agent(Generic[AgentDeps, ResultData]):
 
         await asyncio.gather(*(add_tool(k, t) for k, t in self._function_tools.items()))
 
-        return await model.prepare(
+        return await model.agent_model(
             function_tools=function_tools,
             allow_text_result=self._allow_text_result,
             result_tools=self._result_schema.tool_defs() if self._result_schema is not None else None,

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -7,7 +7,7 @@ specific LLM being used.
 from __future__ import annotations as _annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Iterable, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from functools import cache
@@ -20,7 +20,7 @@ from ..messages import Message, ModelAnyResponse, ModelStructuredResponse
 
 if TYPE_CHECKING:
     from ..result import Cost
-    from ..tools import AbstractToolDefinition
+    from ..tools import ToolDefinition
 
 
 KnownModelName = Literal[
@@ -61,13 +61,14 @@ class Model(ABC):
     """Abstract class for a model."""
 
     @abstractmethod
-    async def agent_model(
+    async def prepare(
         self,
-        function_tools: Mapping[str, AbstractToolDefinition],
+        *,
+        function_tools: dict[str, ToolDefinition],
         allow_text_result: bool,
-        result_tools: Sequence[AbstractToolDefinition] | None,
+        result_tools: dict[str, ToolDefinition] | None,
     ) -> AgentModel:
-        """Create an agent model.
+        """Create an agent model, this is called for each step of an agent run.
 
         This is async in case slow/async config checks need to be performed that can't be done in `__init__`.
 
@@ -87,7 +88,7 @@ class Model(ABC):
 
 
 class AgentModel(ABC):
-    """Model configured for a specific agent."""
+    """Model configured for each step of an Agent run."""
 
     @abstractmethod
     async def request(self, messages: list[Message]) -> tuple[ModelAnyResponse, Cost]:

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -11,7 +11,7 @@ from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from functools import cache
-from typing import TYPE_CHECKING, Literal, Protocol, Union
+from typing import TYPE_CHECKING, Literal, Union
 
 import httpx
 
@@ -19,8 +19,8 @@ from ..exceptions import UserError
 from ..messages import Message, ModelAnyResponse, ModelStructuredResponse
 
 if TYPE_CHECKING:
-    from .._utils import ObjectJsonSchema
     from ..result import Cost
+    from ..tools import AbstractToolDefinition
 
 
 KnownModelName = Literal[
@@ -254,35 +254,6 @@ def infer_model(model: Model | KnownModelName) -> Model:
         return VertexAIModel(model[9:])  # pyright: ignore[reportArgumentType]
     else:
         raise UserError(f'Unknown model: {model}')
-
-
-class AbstractToolDefinition(Protocol):
-    """Abstract definition of a function/tool.
-
-    This is used for both function tools and result tools.
-    """
-
-    @property
-    def name(self) -> str:
-        """The name of the tool."""
-        ...
-
-    @property
-    def description(self) -> str:
-        """The description of the tool."""
-        ...
-
-    @property
-    def json_schema(self) -> ObjectJsonSchema:
-        """The JSON schema for the tool's arguments."""
-        ...
-
-    @property
-    def outer_typed_dict_key(self) -> str | None:
-        """The key in the outer [TypedDict] that wraps a result tool.
-
-        This will only be set for result tools which don't have an `object` JSON schema.
-        """
 
 
 @cache

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -64,9 +64,9 @@ class Model(ABC):
     async def agent_model(
         self,
         *,
-        function_tools: dict[str, ToolDefinition],
+        function_tools: list[ToolDefinition],
         allow_text_result: bool,
-        result_tools: dict[str, ToolDefinition] | None,
+        result_tools: list[ToolDefinition],
     ) -> AgentModel:
         """Create an agent model, this is called for each step of an agent run.
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -61,7 +61,7 @@ class Model(ABC):
     """Abstract class for a model."""
 
     @abstractmethod
-    async def prepare(
+    async def agent_model(
         self,
         *,
         function_tools: dict[str, ToolDefinition],

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -51,7 +51,7 @@ class FunctionModel(Model):
         self.function = function
         self.stream_function = stream_function
 
-    async def prepare(
+    async def agent_model(
         self,
         *,
         function_tools: dict[str, ToolDefinition],

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -2,7 +2,7 @@ from __future__ import annotations as _annotations
 
 import inspect
 import re
-from collections.abc import AsyncIterator, Awaitable, Iterable, Mapping, Sequence
+from collections.abc import AsyncIterator, Awaitable, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -14,7 +14,7 @@ from typing_extensions import TypeAlias, assert_never, overload
 
 from .. import _utils, result
 from ..messages import ArgsJson, Message, ModelAnyResponse, ModelStructuredResponse, ToolCall
-from ..tools import AbstractToolDefinition
+from ..tools import ToolDefinition
 from . import AgentModel, EitherStreamedResponse, Model, StreamStructuredResponse, StreamTextResponse
 
 
@@ -51,13 +51,13 @@ class FunctionModel(Model):
         self.function = function
         self.stream_function = stream_function
 
-    async def agent_model(
+    async def prepare(
         self,
-        function_tools: Mapping[str, AbstractToolDefinition],
+        *,
+        function_tools: dict[str, ToolDefinition],
         allow_text_result: bool,
-        result_tools: Sequence[AbstractToolDefinition] | None,
+        result_tools: dict[str, ToolDefinition] | None,
     ) -> AgentModel:
-        result_tools = list(result_tools) if result_tools is not None else None
         return FunctionAgentModel(
             self.function, self.stream_function, AgentInfo(function_tools, allow_text_result, result_tools)
         )
@@ -78,7 +78,7 @@ class AgentInfo:
     This is passed as the second to functions used within [`FunctionModel`][pydantic_ai.models.function.FunctionModel].
     """
 
-    function_tools: Mapping[str, AbstractToolDefinition]
+    function_tools: dict[str, ToolDefinition]
     """The function tools available on this agent.
 
     These are the tools registered via the [`tool`][pydantic_ai.Agent.tool] and
@@ -86,7 +86,7 @@ class AgentInfo:
     """
     allow_text_result: bool
     """Whether a plain text result is allowed."""
-    result_tools: list[AbstractToolDefinition] | None
+    result_tools: dict[str, ToolDefinition] | None
     """The tools that can called as the final result of the run."""
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -14,14 +14,8 @@ from typing_extensions import TypeAlias, assert_never, overload
 
 from .. import _utils, result
 from ..messages import ArgsJson, Message, ModelAnyResponse, ModelStructuredResponse, ToolCall
-from . import (
-    AbstractToolDefinition,
-    AgentModel,
-    EitherStreamedResponse,
-    Model,
-    StreamStructuredResponse,
-    StreamTextResponse,
-)
+from ..tools import AbstractToolDefinition
+from . import AgentModel, EitherStreamedResponse, Model, StreamStructuredResponse, StreamTextResponse
 
 
 @dataclass(init=False)

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -54,9 +54,9 @@ class FunctionModel(Model):
     async def agent_model(
         self,
         *,
-        function_tools: dict[str, ToolDefinition],
+        function_tools: list[ToolDefinition],
         allow_text_result: bool,
-        result_tools: dict[str, ToolDefinition] | None,
+        result_tools: list[ToolDefinition],
     ) -> AgentModel:
         return FunctionAgentModel(
             self.function, self.stream_function, AgentInfo(function_tools, allow_text_result, result_tools)
@@ -78,7 +78,7 @@ class AgentInfo:
     This is passed as the second to functions used within [`FunctionModel`][pydantic_ai.models.function.FunctionModel].
     """
 
-    function_tools: dict[str, ToolDefinition]
+    function_tools: list[ToolDefinition]
     """The function tools available on this agent.
 
     These are the tools registered via the [`tool`][pydantic_ai.Agent.tool] and
@@ -86,7 +86,7 @@ class AgentInfo:
     """
     allow_text_result: bool
     """Whether a plain text result is allowed."""
-    result_tools: dict[str, ToolDefinition] | None
+    result_tools: list[ToolDefinition]
     """The tools that can called as the final result of the run."""
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -91,9 +91,9 @@ class GeminiModel(Model):
     async def agent_model(
         self,
         *,
-        function_tools: dict[str, ToolDefinition],
+        function_tools: list[ToolDefinition],
         allow_text_result: bool,
-        result_tools: dict[str, ToolDefinition] | None,
+        result_tools: list[ToolDefinition],
     ) -> GeminiAgentModel:
         return GeminiAgentModel(
             http_client=self.http_client,
@@ -143,14 +143,14 @@ class GeminiAgentModel(AgentModel):
         model_name: GeminiModelName,
         auth: AuthProtocol,
         url: str,
-        function_tools: dict[str, ToolDefinition],
+        function_tools: list[ToolDefinition],
         allow_text_result: bool,
-        result_tools: dict[str, ToolDefinition] | None,
+        result_tools: list[ToolDefinition],
     ):
         check_allow_model_requests()
-        tools = [_function_from_abstract_tool(t) for t in function_tools.values()]
-        if result_tools is not None:
-            tools += [_function_from_abstract_tool(t) for t in result_tools.values()]
+        tools = [_function_from_abstract_tool(t) for t in function_tools]
+        if result_tools:
+            tools += [_function_from_abstract_tool(t) for t in result_tools]
 
         if allow_text_result:
             tool_config = None

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -88,7 +88,7 @@ class GeminiModel(Model):
         self.http_client = http_client or cached_async_http_client()
         self.url = url_template.format(model=model_name)
 
-    async def prepare(
+    async def agent_model(
         self,
         *,
         function_tools: dict[str, ToolDefinition],

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -25,8 +25,8 @@ from ..messages import (
     ToolCall,
     ToolReturn,
 )
+from ..tools import AbstractToolDefinition
 from . import (
-    AbstractToolDefinition,
     AgentModel,
     EitherStreamedResponse,
     Model,
@@ -505,7 +505,7 @@ class _GeminiFunction(TypedDict):
 
 
 def _function_from_abstract_tool(tool: AbstractToolDefinition) -> _GeminiFunction:
-    json_schema = _GeminiJsonSchema(tool.json_schema).simplify()
+    json_schema = _GeminiJsonSchema(tool.parameters_json_schema).simplify()
     f = _GeminiFunction(
         name=tool.name,
         description=tool.description,

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -1,6 +1,6 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
+from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -21,7 +21,7 @@ from ..messages import (
     ToolReturn,
 )
 from ..result import Cost
-from ..tools import AbstractToolDefinition
+from ..tools import ToolDefinition
 from . import (
     AgentModel,
     EitherStreamedResponse,
@@ -107,16 +107,17 @@ class GroqModel(Model):
         else:
             self.client = AsyncGroq(api_key=api_key, http_client=cached_async_http_client())
 
-    async def agent_model(
+    async def prepare(
         self,
-        function_tools: Mapping[str, AbstractToolDefinition],
+        *,
+        function_tools: dict[str, ToolDefinition],
         allow_text_result: bool,
-        result_tools: Sequence[AbstractToolDefinition] | None,
+        result_tools: dict[str, ToolDefinition] | None,
     ) -> AgentModel:
         check_allow_model_requests()
         tools = [self._map_tool_definition(r) for r in function_tools.values()]
         if result_tools is not None:
-            tools += [self._map_tool_definition(r) for r in result_tools]
+            tools += [self._map_tool_definition(r) for r in result_tools.values()]
         return GroqAgentModel(
             self.client,
             self.model_name,
@@ -128,7 +129,7 @@ class GroqModel(Model):
         return f'groq:{self.model_name}'
 
     @staticmethod
-    def _map_tool_definition(f: AbstractToolDefinition) -> chat.ChatCompletionToolParam:
+    def _map_tool_definition(f: ToolDefinition) -> chat.ChatCompletionToolParam:
         return {
             'type': 'function',
             'function': {

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -110,14 +110,14 @@ class GroqModel(Model):
     async def agent_model(
         self,
         *,
-        function_tools: dict[str, ToolDefinition],
+        function_tools: list[ToolDefinition],
         allow_text_result: bool,
-        result_tools: dict[str, ToolDefinition] | None,
+        result_tools: list[ToolDefinition],
     ) -> AgentModel:
         check_allow_model_requests()
-        tools = [self._map_tool_definition(r) for r in function_tools.values()]
-        if result_tools is not None:
-            tools += [self._map_tool_definition(r) for r in result_tools.values()]
+        tools = [self._map_tool_definition(r) for r in function_tools]
+        if result_tools:
+            tools += [self._map_tool_definition(r) for r in result_tools]
         return GroqAgentModel(
             self.client,
             self.model_name,

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -21,8 +21,8 @@ from ..messages import (
     ToolReturn,
 )
 from ..result import Cost
+from ..tools import AbstractToolDefinition
 from . import (
-    AbstractToolDefinition,
     AgentModel,
     EitherStreamedResponse,
     Model,
@@ -134,7 +134,7 @@ class GroqModel(Model):
             'function': {
                 'name': f.name,
                 'description': f.description,
-                'parameters': f.json_schema,
+                'parameters': f.parameters_json_schema,
             },
         }
 

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -107,7 +107,7 @@ class GroqModel(Model):
         else:
             self.client = AsyncGroq(api_key=api_key, http_client=cached_async_http_client())
 
-    async def prepare(
+    async def agent_model(
         self,
         *,
         function_tools: dict[str, ToolDefinition],

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -21,8 +21,8 @@ from ..messages import (
     ToolReturn,
 )
 from ..result import Cost
+from ..tools import AbstractToolDefinition
 from . import (
-    AbstractToolDefinition,
     AgentModel,
     EitherStreamedResponse,
     Model,
@@ -114,7 +114,7 @@ class OpenAIModel(Model):
             'function': {
                 'name': f.name,
                 'description': f.description,
-                'parameters': f.json_schema,
+                'parameters': f.parameters_json_schema,
             },
         }
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -87,7 +87,7 @@ class OpenAIModel(Model):
         else:
             self.client = AsyncOpenAI(api_key=api_key, http_client=cached_async_http_client())
 
-    async def prepare(
+    async def agent_model(
         self,
         *,
         function_tools: dict[str, ToolDefinition],

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -90,14 +90,14 @@ class OpenAIModel(Model):
     async def agent_model(
         self,
         *,
-        function_tools: dict[str, ToolDefinition],
+        function_tools: list[ToolDefinition],
         allow_text_result: bool,
-        result_tools: dict[str, ToolDefinition] | None,
+        result_tools: list[ToolDefinition],
     ) -> AgentModel:
         check_allow_model_requests()
-        tools = [self._map_tool_definition(r) for r in function_tools.values()]
-        if result_tools is not None:
-            tools += [self._map_tool_definition(r) for r in result_tools.values()]
+        tools = [self._map_tool_definition(r) for r in function_tools]
+        if result_tools:
+            tools += [self._map_tool_definition(r) for r in result_tools]
         return OpenAIAgentModel(
             self.client,
             self.model_name,

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -21,8 +21,8 @@ from ..messages import (
     ToolReturn,
 )
 from ..result import Cost
+from ..tools import AbstractToolDefinition
 from . import (
-    AbstractToolDefinition,
     AgentModel,
     EitherStreamedResponse,
     Model,
@@ -128,7 +128,7 @@ class TestAgentModel(AgentModel):
             yield TestStreamStructuredResponse(msg, cost)
 
     def gen_tool_args(self, tool_def: AbstractToolDefinition) -> Any:
-        return _JsonSchemaTestData(tool_def.json_schema, self.seed).generate()
+        return _JsonSchemaTestData(tool_def.parameters_json_schema, self.seed).generate()
 
     def _request(self, messages: list[Message]) -> ModelAnyResponse:
         if self.step == 0 and self.tool_calls:

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -55,11 +55,21 @@ class TestModel(Model):
     """If set, these args will be passed to the result tool."""
     seed: int = 0
     """Seed for generating random data."""
-    # these fields are set when the model is called by the agent, they can be use when you want check
-    # these arguments in tests
     agent_model_function_tools: dict[str, ToolDefinition] | None = field(default=None, init=False)
+    """Definition of function tools passed to the model.
+
+    This is set when the model is called, so will reflect the function tools from the last step of the last run.
+    """
     agent_model_allow_text_result: bool | None = field(default=None, init=False)
+    """Whether plain text responses from the model are allowed.
+
+    This is set when the model is called, so will reflect the value from the last step of the last run.
+    """
     agent_model_result_tools: dict[str, ToolDefinition] | None = field(default=None, init=False)
+    """Definition of result tools passed to the model.
+
+    This is set when the model is called, so will reflect the result tools from the last step of the last run.
+    """
 
     async def agent_model(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -56,9 +56,10 @@ class TestModel(Model):
     seed: int = 0
     """Seed for generating random data."""
     # these fields are set when the model is called by the agent
-    agent_model_tools: dict[str, ToolDefinition] | None = field(default=None, init=False)
+    agent_model_function_tools: dict[str, ToolDefinition] | None = field(default=None, init=False)
     agent_model_allow_text_result: bool | None = field(default=None, init=False)
     agent_model_result_tools: dict[str, ToolDefinition] | None = field(default=None, init=False)
+    _agent_model: TestAgentModel | None = field(default=None, init=False)
 
     async def prepare(
         self,
@@ -67,36 +68,42 @@ class TestModel(Model):
         allow_text_result: bool,
         result_tools: dict[str, ToolDefinition] | None,
     ) -> AgentModel:
-        self.agent_model_tools = function_tools
+        self.agent_model_function_tools = function_tools
         self.agent_model_allow_text_result = allow_text_result
         self.agent_model_result_tools = result_tools
+        if self._agent_model is None:
+            self._agent_model = self._build_agent()
+        return self._agent_model
 
+    def _build_agent(self):
         if self.call_tools == 'all':
-            tool_calls = [(r.name, r) for r in function_tools.values()]
+            tool_calls = [(r.name, r) for r in self.agent_model_function_tools.values()]
         else:
-            tools_to_call = (function_tools[name] for name in self.call_tools)
+            tools_to_call = (self.agent_model_function_tools[name] for name in self.call_tools)
             tool_calls = [(r.name, r) for r in tools_to_call]
 
         if self.custom_result_text is not None:
-            assert allow_text_result, 'Plain response not allowed, but `custom_result_text` is set.'
+            assert self.agent_model_allow_text_result, 'Plain response not allowed, but `custom_result_text` is set.'
             assert self.custom_result_args is None, 'Cannot set both `custom_result_text` and `custom_result_args`.'
             result: _utils.Either[str | None, Any | None] = _utils.Either(left=self.custom_result_text)
         elif self.custom_result_args is not None:
-            assert result_tools is not None, 'No result tools provided, but `custom_result_args` is set.'
-            result_tool = next(iter(result_tools.values()))
+            assert (
+                self.agent_model_result_tools is not None
+            ), 'No result tools provided, but `custom_result_args` is set.'
+            result_tool = next(iter(self.agent_model_result_tools.values()))
 
             if k := result_tool.outer_typed_dict_key:
                 result = _utils.Either(right={k: self.custom_result_args})
             else:
                 result = _utils.Either(right=self.custom_result_args)
-        elif allow_text_result:
+        elif self.agent_model_allow_text_result:
             result = _utils.Either(left=None)
-        elif result_tools is not None:
+        elif self.agent_model_result_tools is not None:
             result = _utils.Either(right=None)
         else:
             result = _utils.Either(left=None)
 
-        result_tools_list = list(result_tools.values()) if result_tools is not None else None
+        result_tools_list = list(self.agent_model_function_tools.values()) if self.agent_model_function_tools else None
         return TestAgentModel(tool_calls, result, result_tools_list, self.seed)
 
     def name(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -59,9 +59,9 @@ class TestModel(Model):
     agent_model_function_tools: dict[str, ToolDefinition] | None = field(default=None, init=False)
     agent_model_allow_text_result: bool | None = field(default=None, init=False)
     agent_model_result_tools: dict[str, ToolDefinition] | None = field(default=None, init=False)
-    agent_model: TestAgentModel | None = field(default=None, init=False)
+    agent_model_cache: TestAgentModel | None = field(default=None, init=False)
 
-    async def prepare(
+    async def agent_model(
         self,
         *,
         function_tools: dict[str, ToolDefinition],
@@ -71,9 +71,9 @@ class TestModel(Model):
         self.agent_model_function_tools = function_tools
         self.agent_model_allow_text_result = allow_text_result
         self.agent_model_result_tools = result_tools
-        if self.agent_model is None:
-            self.agent_model = self._build_agent(function_tools, allow_text_result, result_tools)
-        return self.agent_model
+        if self.agent_model_cache is None:
+            self.agent_model_cache = self._build_agent(function_tools, allow_text_result, result_tools)
+        return self.agent_model_cache
 
     def _build_agent(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -55,11 +55,11 @@ class TestModel(Model):
     """If set, these args will be passed to the result tool."""
     seed: int = 0
     """Seed for generating random data."""
-    # these fields are set when the model is called by the agent
+    # these fields are set when the model is called by the agent, they can be use when you want check
+    # these arguments in tests
     agent_model_function_tools: dict[str, ToolDefinition] | None = field(default=None, init=False)
     agent_model_allow_text_result: bool | None = field(default=None, init=False)
     agent_model_result_tools: dict[str, ToolDefinition] | None = field(default=None, init=False)
-    agent_model_cache: TestAgentModel | None = field(default=None, init=False)
 
     async def agent_model(
         self,
@@ -71,16 +71,7 @@ class TestModel(Model):
         self.agent_model_function_tools = function_tools
         self.agent_model_allow_text_result = allow_text_result
         self.agent_model_result_tools = result_tools
-        if self.agent_model_cache is None:
-            self.agent_model_cache = self._build_agent(function_tools, allow_text_result, result_tools)
-        return self.agent_model_cache
 
-    def _build_agent(
-        self,
-        function_tools: dict[str, ToolDefinition],
-        allow_text_result: bool,
-        result_tools: dict[str, ToolDefinition] | None,
-    ) -> TestAgentModel:
         if self.call_tools == 'all':
             tool_calls = [(r.name, r) for r in function_tools.values()]
         else:

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -10,7 +9,7 @@ from httpx import AsyncClient as AsyncHTTPClient
 
 from .._utils import run_in_executor
 from ..exceptions import UserError
-from ..tools import AbstractToolDefinition
+from ..tools import ToolDefinition
 from . import Model, cached_async_http_client
 from .gemini import GeminiAgentModel, GeminiModelName
 
@@ -108,11 +107,12 @@ class VertexAIModel(Model):
         self.auth = None
         self.url = None
 
-    async def agent_model(
+    async def prepare(
         self,
-        function_tools: Mapping[str, AbstractToolDefinition],
+        *,
+        function_tools: dict[str, ToolDefinition],
         allow_text_result: bool,
-        result_tools: Sequence[AbstractToolDefinition] | None,
+        result_tools: dict[str, ToolDefinition] | None,
     ) -> GeminiAgentModel:
         url, auth = await self._ainit()
         return GeminiAgentModel(

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -107,7 +107,7 @@ class VertexAIModel(Model):
         self.auth = None
         self.url = None
 
-    async def prepare(
+    async def agent_model(
         self,
         *,
         function_tools: dict[str, ToolDefinition],

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -10,7 +10,8 @@ from httpx import AsyncClient as AsyncHTTPClient
 
 from .._utils import run_in_executor
 from ..exceptions import UserError
-from . import AbstractToolDefinition, Model, cached_async_http_client
+from ..tools import AbstractToolDefinition
+from . import Model, cached_async_http_client
 from .gemini import GeminiAgentModel, GeminiModelName
 
 try:

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -110,9 +110,9 @@ class VertexAIModel(Model):
     async def agent_model(
         self,
         *,
-        function_tools: dict[str, ToolDefinition],
+        function_tools: list[ToolDefinition],
         allow_text_result: bool,
-        result_tools: dict[str, ToolDefinition] | None,
+        result_tools: list[ToolDefinition],
     ) -> GeminiAgentModel:
         url, auth = await self._ainit()
         return GeminiAgentModel(

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -97,10 +97,14 @@ Usage `ToolFuncEither[AgentDeps, ToolParams]`.
 ToolPrepareFunc: TypeAlias = 'Callable[[RunContext[AgentDeps], ToolDefinition], Awaitable[ToolDefinition | None]]'
 """Definition of a function that can prepare a tool definition at call time.
 
-Example:
+See [tool docs](../agents.md#tool-prepare) for more information.
+
+Example — here `only_if_42` is valid as a `ToolPrepareFunc`:
 
 ```py
-from pydantic_ai import Agent, RunContext
+from typing import Union
+
+from pydantic_ai import RunContext, Tool
 from pydantic_ai.tools import ToolDefinition
 
 async def only_if_42(
@@ -108,7 +112,6 @@ async def only_if_42(
 ) -> Union[ToolDefinition, None]:
     if ctx.deps == 42:
         return tool_def
-
 
 def hitchhiker(ctx: RunContext[int], answer: str) -> str:
     return f'{ctx.deps} {answer}'

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -147,6 +147,8 @@ class Tool(Generic[AgentDeps]):
         or with a custom prepare method:
 
         ```py
+        from typing import Union
+
         from pydantic_ai import Agent, RunContext, Tool
         from pydantic_ai.tools import ToolDefinition
 
@@ -155,7 +157,7 @@ class Tool(Generic[AgentDeps]):
 
         async def prep_my_tool(
             ctx: RunContext[int], tool_def: ToolDefinition
-        ) -> ToolDefinition | None:
+        ) -> Union[ToolDefinition, None]:
             # only register the tool if `deps == 42`
             if ctx.deps == 42:
                 return tool_def

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -197,7 +197,7 @@ class Tool(Generic[AgentDeps]):
             description: Description of the tool, inferred from the function if `None`.
             prepare: custom method to prepare the tool definition for each step, return `None` to omit this
                 tool from a given step. This is useful if you want to customise a tool at call time,
-                or omit it completely from a step.
+                or omit it completely from a step. See [`ToolPrepareFunc`][pydantic_ai.tools.ToolPrepareFunc].
         """
         if takes_ctx is None:
             takes_ctx = _pydantic.takes_ctx(function)

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -97,6 +97,25 @@ Usage `ToolFuncEither[AgentDeps, ToolParams]`.
 ToolPrepareFunc: TypeAlias = 'Callable[[RunContext[AgentDeps], ToolDefinition], Awaitable[ToolDefinition | None]]'
 """Definition of a function that can prepare a tool definition at call time.
 
+Example:
+
+```py
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.tools import ToolDefinition
+
+async def only_if_42(
+    ctx: RunContext[int], tool_def: ToolDefinition
+) -> Union[ToolDefinition, None]:
+    if ctx.deps == 42:
+        return tool_def
+
+
+def hitchhiker(ctx: RunContext[int], answer: str) -> str:
+    return f'{ctx.deps} {answer}'
+
+hitchhiker = Tool(hitchhiker, prepare=only_if_42)
+```
+
 Usage `ToolPrepareFunc[AgentDeps]`.
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,6 @@ show_missing = true
 ignore_errors = true
 precision = 2
 exclude_lines = [
-    'def __repr__',
     'pragma: no cover',
     'raise NotImplementedError',
     'if TYPE_CHECKING:',

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -77,7 +77,7 @@ def test_api_key_empty(env: TestEnv):
 
 async def test_agent_model_simple(allow_model_requests: None):
     m = GeminiModel('gemini-1.5-flash', api_key='via-arg')
-    agent_model = await m.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
+    agent_model = await m.agent_model(function_tools=[], allow_text_result=True, result_tools=[])
     assert isinstance(agent_model.http_client, httpx.AsyncClient)
     assert agent_model.model_name == 'gemini-1.5-flash'
     assert isinstance(agent_model.auth, ApiKeyAuth)
@@ -88,13 +88,13 @@ async def test_agent_model_simple(allow_model_requests: None):
 
 async def test_agent_model_tools(allow_model_requests: None):
     m = GeminiModel('gemini-1.5-flash', api_key='via-arg')
-    tools = {
-        'foo': ToolDefinition(
+    tools = [
+        ToolDefinition(
             'foo',
             'This is foo',
             {'type': 'object', 'title': 'Foo', 'properties': {'bar': {'type': 'number', 'title': 'Bar'}}},
         ),
-        'apple': ToolDefinition(
+        ToolDefinition(
             'apple',
             'This is apple',
             {
@@ -104,15 +104,13 @@ async def test_agent_model_tools(allow_model_requests: None):
                 },
             },
         ),
-    }
+    ]
     result_tool = ToolDefinition(
         'result',
         'This is the tool for the final Result',
         {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}, 'required': ['spam']},
     )
-    agent_model = await m.agent_model(
-        function_tools=tools, allow_text_result=True, result_tools={'result': result_tool}
-    )
+    agent_model = await m.agent_model(function_tools=tools, allow_text_result=True, result_tools=[result_tool])
     assert agent_model.tools == snapshot(
         _GeminiTools(
             function_declarations=[
@@ -151,7 +149,7 @@ async def test_require_response_tool(allow_model_requests: None):
         'This is the tool for the final Result',
         {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
     )
-    agent_model = await m.agent_model(function_tools={}, allow_text_result=False, result_tools={'result': result_tool})
+    agent_model = await m.agent_model(function_tools=[], allow_text_result=False, result_tools=[result_tool])
     assert agent_model.tools == snapshot(
         _GeminiTools(
             function_declarations=[
@@ -208,7 +206,7 @@ async def test_json_def_replaced(allow_model_requests: None):
         'This is the tool for the final Result',
         json_schema,
     )
-    agent_model = await m.agent_model(function_tools={}, allow_text_result=True, result_tools={'result': result_tool})
+    agent_model = await m.agent_model(function_tools=[], allow_text_result=True, result_tools=[result_tool])
     assert agent_model.tools == snapshot(
         _GeminiTools(
             function_declarations=[
@@ -254,7 +252,7 @@ async def test_json_def_replaced_any_of(allow_model_requests: None):
         'This is the tool for the final Result',
         json_schema,
     )
-    agent_model = await m.agent_model(function_tools={}, allow_text_result=True, result_tools={'result': result_tool})
+    agent_model = await m.agent_model(function_tools=[], allow_text_result=True, result_tools=[result_tool])
     assert agent_model.tools == snapshot(
         _GeminiTools(
             function_declarations=[
@@ -318,7 +316,7 @@ async def test_json_def_recursive(allow_model_requests: None):
         json_schema,
     )
     with pytest.raises(UserError, match=r'Recursive `\$ref`s in JSON Schema are not supported by Gemini'):
-        await m.agent_model(function_tools={}, allow_text_result=True, result_tools={'result': result_tool})
+        await m.agent_model(function_tools=[], allow_text_result=True, result_tools=[result_tool])
 
 
 @dataclass

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -77,7 +77,7 @@ def test_api_key_empty(env: TestEnv):
 
 async def test_agent_model_simple(allow_model_requests: None):
     m = GeminiModel('gemini-1.5-flash', api_key='via-arg')
-    agent_model = await m.prepare(function_tools={}, allow_text_result=True, result_tools=None)
+    agent_model = await m.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
     assert isinstance(agent_model.http_client, httpx.AsyncClient)
     assert agent_model.model_name == 'gemini-1.5-flash'
     assert isinstance(agent_model.auth, ApiKeyAuth)
@@ -110,7 +110,9 @@ async def test_agent_model_tools(allow_model_requests: None):
         'This is the tool for the final Result',
         {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}, 'required': ['spam']},
     )
-    agent_model = await m.prepare(function_tools=tools, allow_text_result=True, result_tools={'result': result_tool})
+    agent_model = await m.agent_model(
+        function_tools=tools, allow_text_result=True, result_tools={'result': result_tool}
+    )
     assert agent_model.tools == snapshot(
         _GeminiTools(
             function_declarations=[
@@ -149,7 +151,7 @@ async def test_require_response_tool(allow_model_requests: None):
         'This is the tool for the final Result',
         {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
     )
-    agent_model = await m.prepare(function_tools={}, allow_text_result=False, result_tools={'result': result_tool})
+    agent_model = await m.agent_model(function_tools={}, allow_text_result=False, result_tools={'result': result_tool})
     assert agent_model.tools == snapshot(
         _GeminiTools(
             function_declarations=[
@@ -206,7 +208,7 @@ async def test_json_def_replaced(allow_model_requests: None):
         'This is the tool for the final Result',
         json_schema,
     )
-    agent_model = await m.prepare(function_tools={}, allow_text_result=True, result_tools={'result': result_tool})
+    agent_model = await m.agent_model(function_tools={}, allow_text_result=True, result_tools={'result': result_tool})
     assert agent_model.tools == snapshot(
         _GeminiTools(
             function_declarations=[
@@ -252,7 +254,7 @@ async def test_json_def_replaced_any_of(allow_model_requests: None):
         'This is the tool for the final Result',
         json_schema,
     )
-    agent_model = await m.prepare(function_tools={}, allow_text_result=True, result_tools={'result': result_tool})
+    agent_model = await m.agent_model(function_tools={}, allow_text_result=True, result_tools={'result': result_tool})
     assert agent_model.tools == snapshot(
         _GeminiTools(
             function_declarations=[
@@ -316,7 +318,7 @@ async def test_json_def_recursive(allow_model_requests: None):
         json_schema,
     )
     with pytest.raises(UserError, match=r'Recursive `\$ref`s in JSON Schema are not supported by Gemini'):
-        await m.prepare(function_tools={}, allow_text_result=True, result_tools={'result': result_tool})
+        await m.agent_model(function_tools={}, allow_text_result=True, result_tools={'result': result_tool})
 
 
 @dataclass

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -12,7 +12,7 @@ from inline_snapshot import snapshot
 from pydantic import BaseModel
 from typing_extensions import Literal, TypeAlias
 
-from pydantic_ai import Agent, ModelRetry, UnexpectedModelBehavior, UserError, _utils
+from pydantic_ai import Agent, ModelRetry, UnexpectedModelBehavior, UserError
 from pydantic_ai.messages import (
     ArgsDict,
     ModelStructuredResponse,
@@ -42,6 +42,7 @@ from pydantic_ai.models.gemini import (
     _GeminiUsageMetaData,
 )
 from pydantic_ai.result import Cost
+from pydantic_ai.tools import ObjectJsonSchema
 
 from ..conftest import ClientWithHandler, IsNow, TestEnv
 
@@ -90,7 +91,7 @@ class TestToolDefinition:
     __test__ = False
     name: str
     description: str
-    json_schema: _utils.ObjectJsonSchema
+    parameters_json_schema: ObjectJsonSchema
     outer_typed_dict_key: str | None = None
 
 

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -422,7 +422,7 @@ async def test_stream_structure():
     ) -> AsyncIterator[DeltaToolCalls]:
         assert agent_info.result_tools is not None
         assert len(agent_info.result_tools) == 1
-        name = agent_info.result_tools[0].name
+        name = agent_info.result_tools['final_result'].name
         yield {0: DeltaToolCall(name=name)}
         yield {0: DeltaToolCall(json_args='{"x": ')}
         yield {0: DeltaToolCall(json_args='1}')}

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -87,7 +87,7 @@ def test_simple(set_event_loop: None):
 
 async def weather_model(messages: list[Message], info: AgentInfo) -> ModelAnyResponse:  # pragma: no cover
     assert info.allow_text_result
-    assert info.function_tools.keys() == {'get_location', 'get_weather'}
+    assert {t.name for t in info.function_tools} == {'get_location', 'get_weather'}
     last = messages[-1]
     if last.role == 'user':
         return ModelStructuredResponse(
@@ -225,7 +225,7 @@ def test_var_args(set_event_loop: None):
 async def call_tool(messages: list[Message], info: AgentInfo) -> ModelAnyResponse:
     if len(messages) == 1:
         assert len(info.function_tools) == 1
-        tool_id = next(iter(info.function_tools.keys()))
+        tool_id = info.function_tools[0].name
         return ModelStructuredResponse(calls=[ToolCall.from_json(tool_id, '{}')])
     else:
         return ModelTextResponse('final response')
@@ -350,7 +350,7 @@ def test_call_all(set_event_loop: None):
 def test_retry_str(set_event_loop: None):
     call_count = 0
 
-    async def try_again(messages: list[Message], _: AgentInfo) -> ModelAnyResponse:
+    async def try_again(msgs_: list[Message], _agent_info: AgentInfo) -> ModelAnyResponse:
         nonlocal call_count
         call_count += 1
 
@@ -422,7 +422,7 @@ async def test_stream_structure():
     ) -> AsyncIterator[DeltaToolCalls]:
         assert agent_info.result_tools is not None
         assert len(agent_info.result_tools) == 1
-        name = agent_info.result_tools['final_result'].name
+        name = agent_info.result_tools[0].name
         yield {0: DeltaToolCall(name=name)}
         yield {0: DeltaToolCall(json_args='{"x": ')}
         yield {0: DeltaToolCall(json_args='1}')}

--- a/tests/models/test_vertexai.py
+++ b/tests/models/test_vertexai.py
@@ -33,7 +33,7 @@ async def test_init_service_account(tmp_path: Path, allow_model_requests: None):
     assert model.url is None
     assert model.auth is None
 
-    await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
+    await model.agent_model(function_tools=[], allow_text_result=True, result_tools=[])
 
     assert model.url == snapshot(
         'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project-id/locations/us-central1/'
@@ -58,7 +58,7 @@ async def test_init_env(mocker: MockerFixture, allow_model_requests: None):
 
     assert patch.call_count == 0
 
-    await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
+    await model.agent_model(function_tools=[], allow_text_result=True, result_tools=[])
 
     assert patch.call_count == 1
 
@@ -69,7 +69,7 @@ async def test_init_env(mocker: MockerFixture, allow_model_requests: None):
     assert model.auth is not None
     assert model.name() == snapshot('vertexai:gemini-1.5-flash')
 
-    await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
+    await model.agent_model(function_tools=[], allow_text_result=True, result_tools=[])
     assert model.url is not None
     assert model.auth is not None
     assert patch.call_count == 1
@@ -83,7 +83,7 @@ async def test_init_right_project_id(tmp_path: Path, allow_model_requests: None)
     assert model.url is None
     assert model.auth is None
 
-    await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
+    await model.agent_model(function_tools=[], allow_text_result=True, result_tools=[])
 
     assert model.url == snapshot(
         'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project-id/locations/us-central1/'
@@ -99,7 +99,7 @@ async def test_init_service_account_wrong_project_id(tmp_path: Path):
     model = VertexAIModel('gemini-1.5-flash', service_account_file=service_account_path, project_id='different')
 
     with pytest.raises(UserError) as exc_info:
-        await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
+        await model.agent_model(function_tools=[], allow_text_result=True, result_tools=[])
     assert str(exc_info.value) == snapshot(
         "The project_id you provided does not match the one from service account file: 'different' != 'my-project-id'"
     )
@@ -110,7 +110,7 @@ async def test_init_env_wrong_project_id(mocker: MockerFixture):
     model = VertexAIModel('gemini-1.5-flash', project_id='different')
 
     with pytest.raises(UserError) as exc_info:
-        await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
+        await model.agent_model(function_tools=[], allow_text_result=True, result_tools=[])
     assert str(exc_info.value) == snapshot(
         "The project_id you provided does not match the one from `google.auth.default()`: 'different' != 'my-project-id'"
     )
@@ -124,7 +124,7 @@ async def test_init_env_no_project_id(mocker: MockerFixture):
     model = VertexAIModel('gemini-1.5-flash')
 
     with pytest.raises(UserError) as exc_info:
-        await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
+        await model.agent_model(function_tools=[], allow_text_result=True, result_tools=[])
     assert str(exc_info.value) == snapshot('No project_id provided and none found in `google.auth.default()`')
 
 

--- a/tests/models/test_vertexai.py
+++ b/tests/models/test_vertexai.py
@@ -33,7 +33,7 @@ async def test_init_service_account(tmp_path: Path, allow_model_requests: None):
     assert model.url is None
     assert model.auth is None
 
-    await model.prepare({}, False, None)
+    await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
 
     assert model.url == snapshot(
         'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project-id/locations/us-central1/'
@@ -58,7 +58,7 @@ async def test_init_env(mocker: MockerFixture, allow_model_requests: None):
 
     assert patch.call_count == 0
 
-    await model.prepare({}, False, None)
+    await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
 
     assert patch.call_count == 1
 
@@ -69,7 +69,7 @@ async def test_init_env(mocker: MockerFixture, allow_model_requests: None):
     assert model.auth is not None
     assert model.name() == snapshot('vertexai:gemini-1.5-flash')
 
-    await model.prepare({}, False, None)
+    await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
     assert model.url is not None
     assert model.auth is not None
     assert patch.call_count == 1
@@ -83,7 +83,7 @@ async def test_init_right_project_id(tmp_path: Path, allow_model_requests: None)
     assert model.url is None
     assert model.auth is None
 
-    await model.prepare({}, False, None)
+    await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
 
     assert model.url == snapshot(
         'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project-id/locations/us-central1/'
@@ -99,7 +99,7 @@ async def test_init_service_account_wrong_project_id(tmp_path: Path):
     model = VertexAIModel('gemini-1.5-flash', service_account_file=service_account_path, project_id='different')
 
     with pytest.raises(UserError) as exc_info:
-        await model.prepare({}, False, None)
+        await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
     assert str(exc_info.value) == snapshot(
         "The project_id you provided does not match the one from service account file: 'different' != 'my-project-id'"
     )
@@ -110,7 +110,7 @@ async def test_init_env_wrong_project_id(mocker: MockerFixture):
     model = VertexAIModel('gemini-1.5-flash', project_id='different')
 
     with pytest.raises(UserError) as exc_info:
-        await model.prepare({}, False, None)
+        await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
     assert str(exc_info.value) == snapshot(
         "The project_id you provided does not match the one from `google.auth.default()`: 'different' != 'my-project-id'"
     )
@@ -124,7 +124,7 @@ async def test_init_env_no_project_id(mocker: MockerFixture):
     model = VertexAIModel('gemini-1.5-flash')
 
     with pytest.raises(UserError) as exc_info:
-        await model.prepare({}, False, None)
+        await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
     assert str(exc_info.value) == snapshot('No project_id provided and none found in `google.auth.default()`')
 
 

--- a/tests/models/test_vertexai.py
+++ b/tests/models/test_vertexai.py
@@ -33,7 +33,7 @@ async def test_init_service_account(tmp_path: Path, allow_model_requests: None):
     assert model.url is None
     assert model.auth is None
 
-    await model.agent_model({}, False, None)
+    await model.prepare({}, False, None)
 
     assert model.url == snapshot(
         'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project-id/locations/us-central1/'
@@ -58,7 +58,7 @@ async def test_init_env(mocker: MockerFixture, allow_model_requests: None):
 
     assert patch.call_count == 0
 
-    await model.agent_model({}, False, None)
+    await model.prepare({}, False, None)
 
     assert patch.call_count == 1
 
@@ -69,7 +69,7 @@ async def test_init_env(mocker: MockerFixture, allow_model_requests: None):
     assert model.auth is not None
     assert model.name() == snapshot('vertexai:gemini-1.5-flash')
 
-    await model.agent_model({}, False, None)
+    await model.prepare({}, False, None)
     assert model.url is not None
     assert model.auth is not None
     assert patch.call_count == 1
@@ -83,7 +83,7 @@ async def test_init_right_project_id(tmp_path: Path, allow_model_requests: None)
     assert model.url is None
     assert model.auth is None
 
-    await model.agent_model({}, False, None)
+    await model.prepare({}, False, None)
 
     assert model.url == snapshot(
         'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project-id/locations/us-central1/'
@@ -99,7 +99,7 @@ async def test_init_service_account_wrong_project_id(tmp_path: Path):
     model = VertexAIModel('gemini-1.5-flash', service_account_file=service_account_path, project_id='different')
 
     with pytest.raises(UserError) as exc_info:
-        await model.agent_model({}, False, None)
+        await model.prepare({}, False, None)
     assert str(exc_info.value) == snapshot(
         "The project_id you provided does not match the one from service account file: 'different' != 'my-project-id'"
     )
@@ -110,7 +110,7 @@ async def test_init_env_wrong_project_id(mocker: MockerFixture):
     model = VertexAIModel('gemini-1.5-flash', project_id='different')
 
     with pytest.raises(UserError) as exc_info:
-        await model.agent_model({}, False, None)
+        await model.prepare({}, False, None)
     assert str(exc_info.value) == snapshot(
         "The project_id you provided does not match the one from `google.auth.default()`: 'different' != 'my-project-id'"
     )
@@ -124,7 +124,7 @@ async def test_init_env_no_project_id(mocker: MockerFixture):
     model = VertexAIModel('gemini-1.5-flash')
 
     with pytest.raises(UserError) as exc_info:
-        await model.agent_model({}, False, None)
+        await model.prepare({}, False, None)
     assert str(exc_info.value) == snapshot('No project_id provided and none found in `google.auth.default()`')
 
 

--- a/tests/models/test_vertexai.py
+++ b/tests/models/test_vertexai.py
@@ -33,7 +33,7 @@ async def test_init_service_account(tmp_path: Path, allow_model_requests: None):
     assert model.url is None
     assert model.auth is None
 
-    await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
+    await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
 
     assert model.url == snapshot(
         'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project-id/locations/us-central1/'
@@ -58,7 +58,7 @@ async def test_init_env(mocker: MockerFixture, allow_model_requests: None):
 
     assert patch.call_count == 0
 
-    await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
+    await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
 
     assert patch.call_count == 1
 
@@ -69,7 +69,7 @@ async def test_init_env(mocker: MockerFixture, allow_model_requests: None):
     assert model.auth is not None
     assert model.name() == snapshot('vertexai:gemini-1.5-flash')
 
-    await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
+    await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
     assert model.url is not None
     assert model.auth is not None
     assert patch.call_count == 1
@@ -83,7 +83,7 @@ async def test_init_right_project_id(tmp_path: Path, allow_model_requests: None)
     assert model.url is None
     assert model.auth is None
 
-    await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
+    await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
 
     assert model.url == snapshot(
         'https://us-central1-aiplatform.googleapis.com/v1/projects/my-project-id/locations/us-central1/'
@@ -99,7 +99,7 @@ async def test_init_service_account_wrong_project_id(tmp_path: Path):
     model = VertexAIModel('gemini-1.5-flash', service_account_file=service_account_path, project_id='different')
 
     with pytest.raises(UserError) as exc_info:
-        await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
+        await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
     assert str(exc_info.value) == snapshot(
         "The project_id you provided does not match the one from service account file: 'different' != 'my-project-id'"
     )
@@ -110,7 +110,7 @@ async def test_init_env_wrong_project_id(mocker: MockerFixture):
     model = VertexAIModel('gemini-1.5-flash', project_id='different')
 
     with pytest.raises(UserError) as exc_info:
-        await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
+        await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
     assert str(exc_info.value) == snapshot(
         "The project_id you provided does not match the one from `google.auth.default()`: 'different' != 'my-project-id'"
     )
@@ -124,7 +124,7 @@ async def test_init_env_no_project_id(mocker: MockerFixture):
     model = VertexAIModel('gemini-1.5-flash')
 
     with pytest.raises(UserError) as exc_info:
-        await model.prepare(function_tools={}, allow_text_result=True, result_tools=None)
+        await model.agent_model(function_tools={}, allow_text_result=True, result_tools=None)
     assert str(exc_info.value) == snapshot('No project_id provided and none found in `google.auth.default()`')
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -192,13 +192,13 @@ def test_response_tuple(set_event_loop: None):
     assert len(m.agent_model_result_tools) == 1
 
     # to match the protocol, we just extract the attributes we care about
-    fields = 'name', 'description', 'json_schema', 'outer_typed_dict_key'
+    fields = 'name', 'description', 'parameters_json_schema', 'outer_typed_dict_key'
     agent_model_result_tool = {f: getattr(m.agent_model_result_tools[0], f) for f in fields}
     assert agent_model_result_tool == snapshot(
         {
             'name': 'final_result',
             'description': 'The final response which ends this conversation',
-            'json_schema': {
+            'parameters_json_schema': {
                 'properties': {
                     'response': {
                         'maxItems': 2,
@@ -251,13 +251,13 @@ def test_response_union_allow_str(set_event_loop: None, input_union_callable: Ca
     assert len(m.agent_model_result_tools) == 1
 
     # to match the protocol, we just extract the attributes we care about
-    fields = 'name', 'description', 'json_schema', 'outer_typed_dict_key'
+    fields = 'name', 'description', 'parameters_json_schema', 'outer_typed_dict_key'
     agent_model_result_tool = {f: getattr(m.agent_model_result_tools[0], f) for f in fields}
     assert agent_model_result_tool == snapshot(
         {
             'name': 'final_result',
             'description': 'The final response which ends this conversation',
-            'json_schema': {
+            'parameters_json_schema': {
                 'properties': {'a': {'title': 'A', 'type': 'integer'}, 'b': {'title': 'B', 'type': 'string'}},
                 'title': 'Foo',
                 'required': ['a', 'b'],
@@ -325,14 +325,14 @@ class Bar(BaseModel):
     assert len(m.agent_model_result_tools) == 2
 
     # to match the protocol, we just extract the attributes we care about
-    fields = 'name', 'description', 'json_schema', 'outer_typed_dict_key'
+    fields = 'name', 'description', 'parameters_json_schema', 'outer_typed_dict_key'
     agent_model_result_tools = [{f: getattr(t, f) for f in fields} for t in m.agent_model_result_tools]
     assert agent_model_result_tools == snapshot(
         [
             {
                 'name': 'final_result_Foo',
                 'description': 'Foo: The final response which ends this conversation',
-                'json_schema': {
+                'parameters_json_schema': {
                     'properties': {
                         'a': {'title': 'A', 'type': 'integer'},
                         'b': {'title': 'B', 'type': 'string'},
@@ -346,7 +346,7 @@ class Bar(BaseModel):
             {
                 'name': 'final_result_Bar',
                 'description': 'This is a bar model.',
-                'json_schema': {
+                'parameters_json_schema': {
                     'properties': {'b': {'title': 'B', 'type': 'string'}},
                     'required': ['b'],
                     'title': 'Bar',

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -381,13 +381,11 @@ def test_run_with_history_new(set_event_loop: None):
             ModelTextResponse(content='{"ret_a":"a-apple"}', timestamp=IsNow(tz=timezone.utc)),
         ]
     )
-    m.agent_model_cache = None
 
     # if we pass new_messages, system prompt is inserted before the message_history messages
     result2 = agent.run_sync('Hello again', message_history=result1.new_messages())
     assert result2 == snapshot(
         RunResult(
-            data='{"ret_a":"a-apple"}',
             _all_messages=[
                 SystemPrompt(content='Foobar'),
                 UserPrompt(content='Hello', timestamp=IsNow(tz=timezone.utc)),
@@ -397,24 +395,17 @@ def test_run_with_history_new(set_event_loop: None):
                 ),
                 ToolReturn(tool_name='ret_a', content='a-apple', timestamp=IsNow(tz=timezone.utc)),
                 ModelTextResponse(content='{"ret_a":"a-apple"}', timestamp=IsNow(tz=timezone.utc)),
-                # second call, notice no repeated system prompt
                 UserPrompt(content='Hello again', timestamp=IsNow(tz=timezone.utc)),
-                ModelStructuredResponse(
-                    calls=[ToolCall(tool_name='ret_a', args=ArgsDict(args_dict={'x': 'a'}))],
-                    timestamp=IsNow(tz=timezone.utc),
-                ),
-                ToolReturn(tool_name='ret_a', content='a-apple', timestamp=IsNow(tz=timezone.utc)),
                 ModelTextResponse(content='{"ret_a":"a-apple"}', timestamp=IsNow(tz=timezone.utc)),
             ],
             _new_message_index=5,
+            data='{"ret_a":"a-apple"}',
             _cost=Cost(),
         )
     )
     new_msg_roles = [msg.role for msg in result2.new_messages()]
-    assert new_msg_roles == snapshot(['user', 'model-structured-response', 'tool-return', 'model-text-response'])
+    assert new_msg_roles == snapshot(['user', 'model-text-response'])
     assert result2.new_messages_json().startswith(b'[{"content":"Hello again",')
-
-    m.agent_model_cache = None
 
     # if we pass all_messages, system prompt is NOT inserted before the message_history messages,
     # so only one system prompt
@@ -434,11 +425,6 @@ def test_run_with_history_new(set_event_loop: None):
                 ModelTextResponse(content='{"ret_a":"a-apple"}', timestamp=IsNow(tz=timezone.utc)),
                 # second call, notice no repeated system prompt
                 UserPrompt(content='Hello again', timestamp=IsNow(tz=timezone.utc)),
-                ModelStructuredResponse(
-                    calls=[ToolCall(tool_name='ret_a', args=ArgsDict(args_dict={'x': 'a'}))],
-                    timestamp=IsNow(tz=timezone.utc),
-                ),
-                ToolReturn(tool_name='ret_a', content='a-apple', timestamp=IsNow(tz=timezone.utc)),
                 ModelTextResponse(content='{"ret_a":"a-apple"}', timestamp=IsNow(tz=timezone.utc)),
             ],
             _new_message_index=5,
@@ -541,7 +527,6 @@ def test_run_sync_multiple(set_event_loop: None):
     for _ in range(2):
         result = agent.run_sync('Hello')
         assert result.data == '{"make_request":"200"}'
-        agent.model.agent_model_cache = None
 
 
 async def test_agent_name():

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -185,7 +185,7 @@ def test_response_tuple(set_event_loop: None):
     result = agent.run_sync('Hello')
     assert result.data == snapshot(('a', 'a'))
 
-    assert m.agent_model_tools == snapshot({})
+    assert m.agent_model_function_tools == snapshot({})
     assert m.agent_model_allow_text_result is False
 
     assert m.agent_model_result_tools is not None
@@ -244,7 +244,7 @@ def test_response_union_allow_str(set_event_loop: None, input_union_callable: Ca
     assert result.data == snapshot('success (no tool calls)')
     assert got_tool_call_name == snapshot(None)
 
-    assert m.agent_model_tools == snapshot({})
+    assert m.agent_model_function_tools == snapshot({})
     assert m.agent_model_allow_text_result is True
 
     assert m.agent_model_result_tools is not None
@@ -318,7 +318,7 @@ class Bar(BaseModel):
     assert result.data == mod.Foo(a=0, b='a')
     assert got_tool_call_name == snapshot('final_result_Foo')
 
-    assert m.agent_model_tools == snapshot({})
+    assert m.agent_model_function_tools == snapshot({})
     assert m.agent_model_allow_text_result is False
 
     assert m.agent_model_result_tools is not None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -381,7 +381,7 @@ def test_run_with_history_new(set_event_loop: None):
             ModelTextResponse(content='{"ret_a":"a-apple"}', timestamp=IsNow(tz=timezone.utc)),
         ]
     )
-    m.agent_model = None
+    m.agent_model_cache = None
 
     # if we pass new_messages, system prompt is inserted before the message_history messages
     result2 = agent.run_sync('Hello again', message_history=result1.new_messages())
@@ -414,7 +414,7 @@ def test_run_with_history_new(set_event_loop: None):
     assert new_msg_roles == snapshot(['user', 'model-structured-response', 'tool-return', 'model-text-response'])
     assert result2.new_messages_json().startswith(b'[{"content":"Hello again",')
 
-    m.agent_model = None
+    m.agent_model_cache = None
 
     # if we pass all_messages, system prompt is NOT inserted before the message_history messages,
     # so only one system prompt
@@ -541,7 +541,7 @@ def test_run_sync_multiple(set_event_loop: None):
     for _ in range(2):
         result = agent.run_sync('Hello')
         assert result.data == '{"make_request":"200"}'
-        agent.model.agent_model = None
+        agent.model.agent_model_cache = None
 
 
 async def test_agent_name():

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -395,6 +395,7 @@ def test_run_with_history_new(set_event_loop: None):
                 ),
                 ToolReturn(tool_name='ret_a', content='a-apple', timestamp=IsNow(tz=timezone.utc)),
                 ModelTextResponse(content='{"ret_a":"a-apple"}', timestamp=IsNow(tz=timezone.utc)),
+                # second call, notice no repeated system prompt
                 UserPrompt(content='Hello again', timestamp=IsNow(tz=timezone.utc)),
                 ModelTextResponse(content='{"ret_a":"a-apple"}', timestamp=IsNow(tz=timezone.utc)),
             ],

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -21,23 +21,19 @@ async def example_tool(ctx: RunContext[MyDeps]) -> str:
 def test_deps_used(set_event_loop: None):
     result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
     assert result.data == '{"example_tool":"MyDeps(foo=1, bar=2)"}'
-    agent.model.agent_model_cache = None
 
 
 def test_deps_override(set_event_loop: None):
     with agent.override(deps=MyDeps(foo=3, bar=4)):
         result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
         assert result.data == '{"example_tool":"MyDeps(foo=3, bar=4)"}'
-        agent.model.agent_model_cache = None
 
         with agent.override(deps=MyDeps(foo=5, bar=6)):
             result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
             assert result.data == '{"example_tool":"MyDeps(foo=5, bar=6)"}'
-            agent.model.agent_model_cache = None
 
         result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
         assert result.data == '{"example_tool":"MyDeps(foo=3, bar=4)"}'
-        agent.model.agent_model_cache = None
 
     result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
     assert result.data == '{"example_tool":"MyDeps(foo=1, bar=2)"}'

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -21,19 +21,23 @@ async def example_tool(ctx: RunContext[MyDeps]) -> str:
 def test_deps_used(set_event_loop: None):
     result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
     assert result.data == '{"example_tool":"MyDeps(foo=1, bar=2)"}'
+    agent.model.agent_model = None
 
 
 def test_deps_override(set_event_loop: None):
     with agent.override(deps=MyDeps(foo=3, bar=4)):
         result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
         assert result.data == '{"example_tool":"MyDeps(foo=3, bar=4)"}'
+        agent.model.agent_model = None
 
         with agent.override(deps=MyDeps(foo=5, bar=6)):
             result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
             assert result.data == '{"example_tool":"MyDeps(foo=5, bar=6)"}'
+            agent.model.agent_model = None
 
         result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
         assert result.data == '{"example_tool":"MyDeps(foo=3, bar=4)"}'
+        agent.model.agent_model = None
 
     result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
     assert result.data == '{"example_tool":"MyDeps(foo=1, bar=2)"}'

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -21,23 +21,23 @@ async def example_tool(ctx: RunContext[MyDeps]) -> str:
 def test_deps_used(set_event_loop: None):
     result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
     assert result.data == '{"example_tool":"MyDeps(foo=1, bar=2)"}'
-    agent.model.agent_model = None
+    agent.model.agent_model_cache = None
 
 
 def test_deps_override(set_event_loop: None):
     with agent.override(deps=MyDeps(foo=3, bar=4)):
         result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
         assert result.data == '{"example_tool":"MyDeps(foo=3, bar=4)"}'
-        agent.model.agent_model = None
+        agent.model.agent_model_cache = None
 
         with agent.override(deps=MyDeps(foo=5, bar=6)):
             result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
             assert result.data == '{"example_tool":"MyDeps(foo=5, bar=6)"}'
-            agent.model.agent_model = None
+            agent.model.agent_model_cache = None
 
         result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
         assert result.data == '{"example_tool":"MyDeps(foo=3, bar=4)"}'
-        agent.model.agent_model = None
+        agent.model.agent_model_cache = None
 
     result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
     assert result.data == '{"example_tool":"MyDeps(foo=1, bar=2)"}'

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -98,8 +98,8 @@ def test_docs_examples(
     # waiting for https://github.com/pydantic/pytest-examples/issues/43
     if 'import DatabaseConn' in example.source:
         ruff_ignore.append('I001')
-    elif 'async def my_tool(' in example.source:
-        # not sure what's going on here, just ignore it for now
+    elif 'async def my_tool(' in example.source or 'async def only_if_42(' in example.source:
+        # until https://github.com/pydantic/pytest-examples/issues/46 is fixed
         ruff_ignore.append('I001')
 
     line_length = 88

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -105,7 +105,6 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary], set_event_lo
                         'agent_model_function_tools': None,
                         'agent_model_allow_text_result': None,
                         'agent_model_result_tools': None,
-                        'agent_model_cache': None,
                     },
                     'name': 'my_agent',
                     'last_run_messages': None,

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -95,7 +95,22 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary], set_event_lo
             'code.function': 'run',
             'code.lineno': 123,
             'prompt': 'Hello',
-            'agent': '{"model":{"call_tools":"all","custom_result_text":null,"custom_result_args":null,"seed":0,"agent_model_function_tools":null,"agent_model_allow_text_result":null,"agent_model_result_tools":null,"agent_model_cache":null},"name":"my_agent","last_run_messages":null}',
+            'agent': IsJson(
+                {
+                    'model': {
+                        'call_tools': 'all',
+                        'custom_result_text': None,
+                        'custom_result_args': None,
+                        'seed': 0,
+                        'agent_model_function_tools': None,
+                        'agent_model_allow_text_result': None,
+                        'agent_model_result_tools': None,
+                        'agent_model_cache': None,
+                    },
+                    'name': 'my_agent',
+                    'last_run_messages': None,
+                }
+            ),
             'mode_selection': 'from-agent',
             'model_name': 'test-model',
             'agent_name': 'my_agent',

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 import pytest
-from dirty_equals import IsInt
+from dirty_equals import IsInt, IsJson, IsStr
 from inline_snapshot import snapshot
 from typing_extensions import NotRequired, TypedDict
 

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -95,41 +95,8 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary], set_event_lo
             'code.function': 'run',
             'code.lineno': 123,
             'prompt': 'Hello',
-            'agent': IsJson(
-                {
-                    'model': {
-                        'call_tools': 'all',
-                        'custom_result_text': None,
-                        'custom_result_args': None,
-                        'seed': 0,
-                        'agent_model_tools': {
-                            'my_ret': {
-                                'function': IsStr(regex='<function test_logfire.<locals>.my_ret at 0x.+>'),
-                                'takes_ctx': False,
-                                'max_retries': 1,
-                                'name': 'my_ret',
-                                'description': '',
-                                '_is_async': True,
-                                '_single_arg_name': None,
-                                '_positional_fields': [],
-                                '_var_positional_field': None,
-                                '_json_schema': {
-                                    'properties': {'x': {'title': 'X', 'type': 'integer'}},
-                                    'required': ['x'],
-                                    'type': 'object',
-                                    'additionalProperties': False,
-                                },
-                                '_current_retry': 0,
-                            }
-                        },
-                        'agent_model_allow_text_result': True,
-                        'agent_model_result_tools': None,
-                    },
-                    'name': 'my_agent',
-                    'last_run_messages': None,
-                }
-            ),
-            'logfire.null_args': ('custom_model',),
+            'agent': '{"model":{"call_tools":"all","custom_result_text":null,"custom_result_args":null,"seed":0,"agent_model_function_tools":null,"agent_model_allow_text_result":null,"agent_model_result_tools":null,"agent_model_cache":null},"name":"my_agent","last_run_messages":null}',
+            'mode_selection': 'from-agent',
             'model_name': 'test-model',
             'agent_name': 'my_agent',
             'logfire.msg_template': '{agent_name} run {prompt=}',
@@ -168,29 +135,10 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary], set_event_lo
                             'title': 'Agent',
                             'x-python-datatype': 'dataclass',
                             'properties': {
-                                'model': {
-                                    'type': 'object',
-                                    'title': 'TestModel',
-                                    'x-python-datatype': 'dataclass',
-                                    'properties': {
-                                        'agent_model_tools': {
-                                            'type': 'object',
-                                            'properties': {
-                                                'my_ret': {
-                                                    'type': 'object',
-                                                    'title': 'Tool',
-                                                    'x-python-datatype': 'dataclass',
-                                                    'properties': {
-                                                        'function': {'type': 'object', 'x-python-datatype': 'unknown'}
-                                                    },
-                                                }
-                                            },
-                                        }
-                                    },
-                                }
+                                'model': {'type': 'object', 'title': 'TestModel', 'x-python-datatype': 'dataclass'}
                             },
                         },
-                        'custom_model': {},
+                        'mode_selection': {},
                         'model_name': {},
                         'agent_name': {},
                         'all_messages': {

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -88,7 +88,7 @@ async def test_structured_response_iter():
     async def text_stream(_messages: list[Message], agent_info: AgentInfo) -> AsyncIterator[DeltaToolCalls]:
         assert agent_info.result_tools is not None
         assert len(agent_info.result_tools) == 1
-        name = agent_info.result_tools[0].name
+        name = agent_info.result_tools['final_result'].name
         json_data = json.dumps({'response': [1, 2, 3, 4]})
         yield {0: DeltaToolCall(name=name)}
         yield {0: DeltaToolCall(json_args=json_data[:15])}
@@ -184,7 +184,7 @@ async def test_call_tool():
             assert isinstance(last, ToolReturn)
             assert agent_info.result_tools is not None
             assert len(agent_info.result_tools) == 1
-            name = agent_info.result_tools[0].name
+            name = agent_info.result_tools['final_result'].name
             json_data = json.dumps({'response': [last.content, 2]})
             yield {0: DeltaToolCall(name=name)}
             yield {0: DeltaToolCall(json_args=json_data[:5])}

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -88,7 +88,7 @@ async def test_structured_response_iter():
     async def text_stream(_messages: list[Message], agent_info: AgentInfo) -> AsyncIterator[DeltaToolCalls]:
         assert agent_info.result_tools is not None
         assert len(agent_info.result_tools) == 1
-        name = agent_info.result_tools['final_result'].name
+        name = agent_info.result_tools[0].name
         json_data = json.dumps({'response': [1, 2, 3, 4]})
         yield {0: DeltaToolCall(name=name)}
         yield {0: DeltaToolCall(json_args=json_data[:15])}
@@ -172,7 +172,7 @@ async def test_call_tool():
         if len(messages) == 1:
             assert agent_info.function_tools is not None
             assert len(agent_info.function_tools) == 1
-            name = next(iter(agent_info.function_tools))
+            name = agent_info.function_tools[0].name
             first = messages[0]
             assert isinstance(first, UserPrompt)
             json_string = json.dumps({'x': first.content})
@@ -184,7 +184,7 @@ async def test_call_tool():
             assert isinstance(last, ToolReturn)
             assert agent_info.result_tools is not None
             assert len(agent_info.result_tools) == 1
-            name = agent_info.result_tools['final_result'].name
+            name = agent_info.result_tools[0].name
             json_data = json.dumps({'response': [last.content, 2]})
             yield {0: DeltaToolCall(name=name)}
             yield {0: DeltaToolCall(json_args=json_data[:5])}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -71,7 +71,7 @@ async def google_style_docstring(foo: int, bar: str) -> str:  # pragma: no cover
 async def get_json_schema(_messages: list[Message], info: AgentInfo) -> ModelAnyResponse:
     assert len(info.function_tools) == 1
     r = next(iter(info.function_tools.values()))
-    return ModelTextResponse(json.dumps(r.json_schema))
+    return ModelTextResponse(json.dumps(r.parameters_json_schema))
 
 
 def test_docstring_google(set_event_loop: None):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -72,7 +72,7 @@ async def google_style_docstring(foo: int, bar: str) -> str:  # pragma: no cover
 
 async def get_json_schema(_messages: list[Message], info: AgentInfo) -> ModelAnyResponse:
     assert len(info.function_tools) == 1
-    r = next(iter(info.function_tools.values()))
+    r = info.function_tools[0]
     return ModelTextResponse(json.dumps(r.parameters_json_schema))
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from typing import Annotated, Any
+from typing import Annotated, Any, Union
 
 import pytest
 from inline_snapshot import snapshot
@@ -405,7 +405,7 @@ def test_dynamic_cls_tool(set_event_loop: None):
         def tool_function(self, x: int, y: str) -> str:
             return f'{self.spam} {x} {y}'
 
-        async def prepare_tool_def(self, ctx: RunContext[int]) -> ToolDefinition | None:
+        async def prepare_tool_def(self, ctx: RunContext[int]) -> Union[ToolDefinition, None]:
             if ctx.deps != 42:
                 return await super().prepare_tool_def(ctx)
 
@@ -420,7 +420,7 @@ def test_dynamic_cls_tool(set_event_loop: None):
 def test_dynamic_plain_tool_decorator(set_event_loop: None):
     agent = Agent('test', deps_type=int)
 
-    async def prepare_tool_def(ctx: RunContext[int], tool_def: ToolDefinition) -> ToolDefinition | None:
+    async def prepare_tool_def(ctx: RunContext[int], tool_def: ToolDefinition) -> Union[ToolDefinition, None]:
         if ctx.deps != 42:
             return tool_def
 
@@ -438,7 +438,7 @@ def test_dynamic_plain_tool_decorator(set_event_loop: None):
 def test_dynamic_tool_decorator(set_event_loop: None):
     agent = Agent('test', deps_type=int)
 
-    async def prepare_tool_def(ctx: RunContext[int], tool_def: ToolDefinition) -> ToolDefinition | None:
+    async def prepare_tool_def(ctx: RunContext[int], tool_def: ToolDefinition) -> Union[ToolDefinition, None]:
         if ctx.deps != 42:
             return tool_def
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 from inline_snapshot import snapshot
 
 from pydantic_ai import UserError
-from pydantic_ai._utils import check_object_json_schema, group_by_temporal
+from pydantic_ai._utils import Either, check_object_json_schema, group_by_temporal
 
 pytestmark = pytest.mark.anyio
 
@@ -43,3 +43,10 @@ def test_check_object_json_schema():
     array_schema = {'type': 'array', 'items': {'type': 'string'}}
     with pytest.raises(UserError, match='^Schema must be an object$'):
         check_object_json_schema(array_schema)
+
+
+def test_either():
+    assert repr(Either[int, int](left=123)) == 'Either(left=123)'
+    assert Either(left=123).whichever() == 123
+    assert repr(Either[int, int](right=456)) == 'Either(right=456)'
+    assert Either(right=456).whichever() == 456

--- a/tests/typed_agent.py
+++ b/tests/typed_agent.py
@@ -7,6 +7,7 @@ from typing import Callable, Union, assert_type
 
 from pydantic_ai import Agent, ModelRetry, RunContext, Tool
 from pydantic_ai.result import RunResult
+from pydantic_ai.tools import ToolDefinition
 
 
 @dataclass
@@ -53,6 +54,30 @@ async def ok_tool(ctx: RunContext[MyDeps], x: str) -> str:
 
 # we can't add overloads for every possible signature of tool, so the type of ok_tool is obscured
 assert_type(ok_tool, Callable[[RunContext[MyDeps], str], str])  # type: ignore[assert-type]
+
+
+async def prep_ok(ctx: RunContext[MyDeps], tool_def: ToolDefinition) -> ToolDefinition | None:
+    if ctx.deps.foo == 42:
+        return None
+    else:
+        return tool_def
+
+
+@typed_agent.tool(prepare=prep_ok)
+def ok_tool_prepare(ctx: RunContext[MyDeps], x: int, y: str) -> str:
+    return f'{ctx.deps.foo} {x} {y}'
+
+
+async def prep_wrong_type(ctx: RunContext[int], tool_def: ToolDefinition) -> ToolDefinition | None:
+    if ctx.deps == 42:
+        return None
+    else:
+        return tool_def
+
+
+@typed_agent.tool(prepare=prep_wrong_type)  # type: ignore[arg-type]
+def wrong_tool_prepare(ctx: RunContext[MyDeps], x: int, y: str) -> str:
+    return f'{ctx.deps.foo} {x} {y}'
 
 
 @typed_agent.tool_plain
@@ -180,3 +205,23 @@ Agent('test', tools=[Tool(foobar_ctx), foobar_ctx, foobar_plain], deps_type=int)
 Agent('test', tools=[foobar_ctx], deps_type=str)  # pyright: ignore[reportArgumentType]
 Agent('test', tools=[foobar_ctx])  # pyright: ignore[reportArgumentType]
 Agent('test', tools=[Tool(foobar_ctx)])  # pyright: ignore[reportArgumentType]
+
+# prepare example from docs:
+
+
+def greet(name: str) -> str:
+    return f'hello {name}'
+
+
+async def prepare_greet(ctx: RunContext[str], tool_def: ToolDefinition) -> ToolDefinition | None:
+    d = f'Name of the {ctx.deps} to greet.'
+    tool_def.parameters_json_schema['properties']['name']['description'] = d
+    return tool_def
+
+
+greet_tool = Tool(greet, prepare=prepare_greet)
+assert_type(greet_tool, Tool[str])
+greet_agent = Agent[str, str]('test', tools=[greet_tool], deps_type=str)
+
+result = greet_agent.run_sync('testing...', deps='human')
+assert result.data == '{"greet":"hello a"}'

--- a/tests/typed_agent.py
+++ b/tests/typed_agent.py
@@ -161,20 +161,22 @@ def foobar_plain(x: str, y: int) -> str:
     return f'{x} {y}'
 
 
-Tool(foobar_ctx, True)
-Tool(foobar_plain, False)
+Tool(foobar_ctx, takes_ctx=True)
+Tool(foobar_ctx)
+Tool(foobar_plain, takes_ctx=False)
+Tool(foobar_plain)
 
 # unfortunately we can't type check these cases, since from a typing perspect `foobar_ctx` is valid as a plain tool
-Tool(foobar_ctx, False)
-Tool(foobar_plain, True)
+Tool(foobar_ctx, takes_ctx=False)
+Tool(foobar_plain, takes_ctx=True)
 
 Agent('test', tools=[foobar_ctx], deps_type=int)
 Agent('test', tools=[foobar_plain], deps_type=int)
 Agent('test', tools=[foobar_plain])
-Agent('test', tools=[Tool(foobar_ctx, True)], deps_type=int)
-Agent('test', tools=[Tool(foobar_plain, False)], deps_type=int)
-Agent('test', tools=[Tool(foobar_ctx, True), foobar_ctx, foobar_plain], deps_type=int)
+Agent('test', tools=[Tool(foobar_ctx)], deps_type=int)
+Agent('test', tools=[Tool(foobar_plain)], deps_type=int)
+Agent('test', tools=[Tool(foobar_ctx), foobar_ctx, foobar_plain], deps_type=int)
 
 Agent('test', tools=[foobar_ctx], deps_type=str)  # pyright: ignore[reportArgumentType]
 Agent('test', tools=[foobar_ctx])  # pyright: ignore[reportArgumentType]
-Agent('test', tools=[Tool(foobar_ctx, True)])  # pyright: ignore[reportArgumentType]
+Agent('test', tools=[Tool(foobar_ctx)])  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
As suggested by @jxnl.

This allows tools to be switched off and customized in specific steps, it's a step towards #110.

**Breaking change**: this will cause some breaking changes to the public API as we simplified the signature of `Model.agent_model` and downstream types.