### PR TITLE
Ollama support

### DIFF
--- a/docs/api/models/ollama.md
+++ b/docs/api/models/ollama.md
@@ -1,0 +1,6 @@
+# `pydantic_ai.models.openai`
+
+## Setup
+For details on how to set up authentication with this model, see [model configuration for Ollama](../../install.md#ollama).
+
+::: pydantic_ai.models.ollama

--- a/docs/install.md
+++ b/docs/install.md
@@ -323,3 +323,13 @@ model = GroqModel('llama-3.1-70b-versatile', api_key='your-api-key')
 agent = Agent(model)
 ...
 ```
+
+### Ollama
+
+To use [Ollama](https://ollama.com/), you must first download the Ollama client, and then download a model.
+
+You must also ensure the Ollama server is running when trying to make requests to it
+
+#### `base_url` argument
+
+The [`base_url` argument](pydantic_ai.models.ollama.OllamaModel.__init__) is currently set to the default Ollama server value.

--- a/pydantic_ai_examples/pydantic_model_ollama.py
+++ b/pydantic_ai_examples/pydantic_model_ollama.py
@@ -1,0 +1,35 @@
+"""Simple example of using PydanticAI to construct a Pydantic model from a text input.
+
+Run with:
+
+    uv run -m pydantic_ai_examples.pydantic_model
+"""
+
+import os
+from typing import cast
+
+import logfire
+from pydantic import BaseModel
+
+from pydantic_ai import Agent
+from pydantic_ai.models import KnownModelName
+
+# 'if-token-present' means nothing will be sent (and the example will work) if you don't have logfire configured
+logfire.configure(send_to_logfire='if-token-present')
+
+
+class MyModel(BaseModel):
+    city: str
+    country: str
+
+
+model = cast(
+    KnownModelName, os.getenv('PYDANTIC_AI_MODEL', 'ollama:qwen2.5-coder:latest')
+)
+print(f'Using model: {model}')
+agent = Agent(model, result_type=MyModel)
+
+if __name__ == '__main__':
+    result = agent.run_sync('The big apple in the US of A.')
+    print(result.data)
+    print(result.cost())

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -257,7 +257,7 @@ def infer_model(model: Model | KnownModelName) -> Model:
     elif model.startswith('ollama:'):
         from .ollama import OllamaModel
 
-        return OllamaModel(model[7:])  # pyright: ignore[reportArgumentType]
+        return OllamaModel(model[7:])  # As type is currently str, do not need to ignore reportArgumentType
     else:
         raise UserError(f'Unknown model: {model}')
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -49,6 +49,8 @@ KnownModelName = Literal[
     'gemini-1.5-pro',
     'vertexai:gemini-1.5-flash',
     'vertexai:gemini-1.5-pro',
+    'ollama:llama-3.2:latest',
+    'ollama:qwen2.5-coder:latest',
     'test',
 ]
 """Known model names that can be used with the `model` parameter of [`Agent`][pydantic_ai.Agent].
@@ -252,6 +254,10 @@ def infer_model(model: Model | KnownModelName) -> Model:
         from .vertexai import VertexAIModel
 
         return VertexAIModel(model[9:])  # pyright: ignore[reportArgumentType]
+    elif model.startswith('ollama:'):
+        from .ollama import OllamaModel
+
+        return OllamaModel(model[7:])  # pyright: ignore[reportArgumentType]
     else:
         raise UserError(f'Unknown model: {model}')
 

--- a/pydantic_ai_slim/pydantic_ai/models/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/models/ollama.py
@@ -15,14 +15,37 @@ from . import (
 
 try:
     from openai import AsyncOpenAI
-    from openai.types import ChatModel, chat
+    from openai.types import chat
 except ImportError as e:
     raise ImportError(
         'Please install `openai` to use the OpenAI model, '
         "you can use the `openai` optional group — `pip install 'pydantic-ai[openai]'`"
     ) from e
 
+# Only required in the below typing is enforced
+# try:
+#     from ollama import list, ListResponse
+# except ImportError as e:
+#     raise ImportError(
+#         'Please install `ollama` to use the Ollama model, '
+#         "you can use the `ollama` optional group — `pip install 'pydantic-ai[ollama]'`"
+#     ) from e
+
+
 from .openai import OpenAIAgentModel
+
+# NB: Currently commented out but this is
+# a possible approach to type the ollama model names
+# # This is really nasty, but ollama doesn't
+# # expose a type of all available models, and as
+# # there are 100's and being udpated all the time,
+# # it seems difficult to maintain a list of all possible
+# # versions statically.
+# # This code gets the ones that are _currently_ available
+# # to the user as they are ones that they have already downloaded
+# ollama_ls: ListResponse = list()
+# ollama_available_models: list[str] = [x.model for x in ollama_ls.models]
+# OllamaModelName = Literal[tuple(ollama_available_models)]
 
 
 # Inherits from this model
@@ -35,12 +58,12 @@ class OllamaModel(Model):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    model_name: ChatModel
+    model_name: str
     client: AsyncOpenAI = field(repr=False)
 
     def __init__(
         self,
-        model_name: ChatModel,
+        model_name: str,
         *,
         base_url: str = 'http://localhost:11434/v1/',
         openai_client: AsyncOpenAI | None = None,
@@ -51,19 +74,19 @@ class OllamaModel(Model):
         Ollama has built-in compatability with the OpenAI chat completions API ([source](https://ollama.com/blog/openai-compatibility)), and so these models are built ontop of that
 
         Args:
-            model_name: The name of the OpenAI model to use. List of model names available
-                [here](https://github.com/openai/openai-python/blob/v1.54.3/src/openai/types/chat_model.py#L7)
-                (Unfortunately, despite being ask to do so, OpenAI do not provide `.inv` files for their API).
+            model_name: The name of the Ollama model to use. List of models available [here](https://ollama.com/library)
+                NB: You must first download the model (ollama pull <MODEL-NAME>) in order to use the model
             base_url: The base url for the ollama requests. The default value is the ollama default
             openai_client: An existing
                 [`AsyncOpenAI`](https://github.com/openai/openai-python?tab=readme-ov-file#async-usage)
                 client to use, if provided, `api_key` and `http_client` must be `None`.
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
         """
-        self.model_name: ChatModel = model_name
+        self.model_name: str = model_name
         if openai_client is not None:
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'
             self.client = openai_client
+            print('Using existing client')
         elif http_client is not None:
             # API key is not required for ollama but a value is required to create the client
             self.client = AsyncOpenAI(base_url=base_url, api_key='ollama', http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/models/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/models/ollama.py
@@ -1,0 +1,103 @@
+from __future__ import annotations as _annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+
+from httpx import AsyncClient as AsyncHTTPClient
+
+from . import (
+    AbstractToolDefinition,
+    AgentModel,
+    Model,
+    cached_async_http_client,
+    check_allow_model_requests,
+)
+
+try:
+    from openai import AsyncOpenAI
+    from openai.types import ChatModel, chat
+except ImportError as e:
+    raise ImportError(
+        'Please install `openai` to use the OpenAI model, '
+        "you can use the `openai` optional group — `pip install 'pydantic-ai[openai]'`"
+    ) from e
+
+from .openai import OpenAIAgentModel
+
+
+# Inherits from this model
+@dataclass(init=False)
+class OllamaModel(Model):
+    """A model that uses the OpenAI API.
+
+    Internally, this uses the [OpenAI Python client](https://github.com/openai/openai-python) to interact with the API.
+
+    Apart from `__init__`, all methods are private or match those of the base class.
+    """
+
+    model_name: ChatModel
+    client: AsyncOpenAI = field(repr=False)
+
+    def __init__(
+        self,
+        model_name: ChatModel,
+        *,
+        base_url: str = 'http://localhost:11434/v1/',
+        openai_client: AsyncOpenAI | None = None,
+        http_client: AsyncHTTPClient | None = None,
+    ):
+        """Initialize an Ollama model.
+
+        Ollama has built-in compatability with the OpenAI chat completions API ([source](https://ollama.com/blog/openai-compatibility)), and so these models are built ontop of that
+
+        Args:
+            model_name: The name of the OpenAI model to use. List of model names available
+                [here](https://github.com/openai/openai-python/blob/v1.54.3/src/openai/types/chat_model.py#L7)
+                (Unfortunately, despite being ask to do so, OpenAI do not provide `.inv` files for their API).
+            base_url: The base url for the ollama requests. The default value is the ollama default
+            openai_client: An existing
+                [`AsyncOpenAI`](https://github.com/openai/openai-python?tab=readme-ov-file#async-usage)
+                client to use, if provided, `api_key` and `http_client` must be `None`.
+            http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
+        """
+        self.model_name: ChatModel = model_name
+        if openai_client is not None:
+            assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'
+            self.client = openai_client
+        elif http_client is not None:
+            # API key is not required for ollama but a value is required to create the client
+            self.client = AsyncOpenAI(base_url=base_url, api_key='ollama', http_client=http_client)
+        else:
+            # API key is not required for ollama but a value is required to create the client
+            self.client = AsyncOpenAI(base_url=base_url, api_key='ollama', http_client=cached_async_http_client())
+
+    async def agent_model(
+        self,
+        function_tools: Mapping[str, AbstractToolDefinition],
+        allow_text_result: bool,
+        result_tools: Sequence[AbstractToolDefinition] | None,
+    ) -> AgentModel:
+        check_allow_model_requests()
+        tools = [self._map_tool_definition(r) for r in function_tools.values()]
+        if result_tools is not None:
+            tools += [self._map_tool_definition(r) for r in result_tools]
+        return OpenAIAgentModel(
+            self.client,
+            self.model_name,
+            allow_text_result,
+            tools,
+        )
+
+    def name(self) -> str:
+        return f'ollama:{self.model_name}'
+
+    @staticmethod
+    def _map_tool_definition(f: AbstractToolDefinition) -> chat.ChatCompletionToolParam:
+        return {
+            'type': 'function',
+            'function': {
+                'name': f.name,
+                'description': f.description,
+                'parameters': f.json_schema,
+            },
+        }

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -124,7 +124,7 @@ class OpenAIAgentModel(AgentModel):
     """Implementation of `AgentModel` for OpenAI models."""
 
     client: AsyncOpenAI
-    model_name: ChatModel
+    model_name: ChatModel | str
     allow_text_result: bool
     tools: list[chat.ChatCompletionToolParam]
 

--- a/tests/models/test_ollama.py
+++ b/tests/models/test_ollama.py
@@ -1,0 +1,61 @@
+from __future__ import annotations as _annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from inline_snapshot import snapshot
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelTextResponse,
+    UserPrompt,
+)
+from pydantic_ai.result import Cost
+
+from ..conftest import IsNow, try_import
+
+with try_import() as imports_successful:
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
+
+    from pydantic_ai.models.ollama import OllamaModel
+
+from .test_openai import MockOpenAI, completion_message
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='openai not installed'),
+    pytest.mark.anyio,
+]
+
+
+def test_init():
+    m = OllamaModel('llama-3.2:latest', base_url='foobar/')
+    assert m.client.api_key == 'ollama'
+    assert m.client.base_url == 'foobar/'
+    assert m.name() == 'ollama:llama-3.2:latest'
+
+
+async def test_request_simple_success(allow_model_requests: None):
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    print('here')
+    m = OllamaModel('llama-3.2:latest', openai_client=mock_client)
+    agent = Agent(m)
+
+    result = await agent.run('hello')
+    assert result.data == 'world'
+    assert result.cost() == snapshot(Cost())
+
+    # reset the index so we get the same response again
+    mock_client.index = 0  # type: ignore
+
+    result = await agent.run('hello', message_history=result.new_messages())
+    assert result.data == 'world'
+    assert result.cost() == snapshot(Cost())
+    assert result.all_messages() == snapshot(
+        [
+            UserPrompt(content='hello', timestamp=IsNow(tz=timezone.utc)),
+            ModelTextResponse(content='world', timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)),
+            UserPrompt(content='hello', timestamp=IsNow(tz=timezone.utc)),
+            ModelTextResponse(content='world', timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)),
+        ]
+    )


### PR DESCRIPTION
A PR to implement an `OllamaModel` and allow for easy access to Ollama.

A few questions / notes:

 - The main issue with Ollama is the typing of the model names. Ollama has 100's of different models and many more are added daily/weekly, so maintaining a complete list (like for [Gemini](https://github.com/cal859/pydantic-ai/blob/6201af4dc8130aeb9ee81d073bae98d02acdb709/pydantic_ai_slim/pydantic_ai/models/gemini.py#L40)) seems like it will be quite difficult. It is possible to pull the models available to the _current user_, using `ollama.list()`, and I have put a (commented out) example of how this would work in the `models/ollama.py` file, but for now, I have just left as `str` as the type
 - The second issue with the above typing is, because there is so much overlap with this code and the openai code, I didn't want to completely replicate the code between them, so I am using the existing `OpenAIAgentModel`, rather than reimplementing that, but then to get that work with the `Ollama` model, I have had to allow a much more general `str` type as well as the much more tightly defined `ChatModel` type

Otherwise, this works well.