### PR TITLE
Add message and cost limits to run methods

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -818,7 +818,6 @@ async def test_message_limit_run_stream():
         async with agent.run_stream('Hello', message_limit=5) as result:
             pass
 
-
 async def test_cost_limit_run_stream():
     def return_model(messages: list[Message], info: AgentInfo) -> ModelAnyResponse:
         assert info.result_tools is not None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -777,13 +777,15 @@ def test_message_limit_run(set_event_loop: None):
         if len(messages) > 5:
             return ModelTextResponse(content='success')
         else:
-            return ModelStructuredResponse(calls=[ToolCall.from_json(info.result_tools[0].name, '{}')])
+            if info.result_tools:
+                return ModelStructuredResponse(calls=[ToolCall.from_json(info.result_tools[0].name, '{}')])
+            else:
+                return ModelStructuredResponse(calls=[])
 
     agent = Agent(FunctionModel(return_model), result_type=str)
 
     with pytest.raises(UnexpectedModelBehavior, match='Exceeded message limit of 5 messages'):
         agent.run_sync('Hello', message_limit=5)
-
 
 def test_cost_limit_run(set_event_loop: None):
     def return_model(messages: list[Message], info: AgentInfo) -> ModelAnyResponse:
@@ -795,21 +797,25 @@ def test_cost_limit_run(set_event_loop: None):
     with pytest.raises(UnexpectedModelBehavior, match='Exceeded cost limit of 10 tokens'):
         agent.run_sync('Hello', cost_limit=10)
 
-
 async def test_message_limit_run_stream():
     def return_model(messages: list[Message], info: AgentInfo) -> ModelAnyResponse:
         assert info.result_tools is not None
         if len(messages) > 5:
             return ModelTextResponse(content='success')
         else:
-            return ModelStructuredResponse(calls=[ToolCall.from_json(info.result_tools[0].name, '{}')])
+            if info.result_tools:
+                return ModelStructuredResponse(calls=[ToolCall.from_json(info.result_tools[0].name, '{}')])
+            else:
+                return ModelStructuredResponse(calls=[])
 
-    agent = Agent(FunctionModel(return_model), result_type=str)
+    async def stream_function(messages: list[Message], info: AgentInfo) -> AsyncIterator[ModelAnyResponse]:
+        yield return_model(messages, info)
+
+    agent = Agent(FunctionModel(return_model, stream_function=stream_function), result_type=str)
 
     with pytest.raises(UnexpectedModelBehavior, match='Exceeded message limit of 5 messages'):
         async with agent.run_stream('Hello', message_limit=5) as result:
-            async for _ in result.stream():
-                pass
+            pass
 
 
 async def test_cost_limit_run_stream():
@@ -817,9 +823,11 @@ async def test_cost_limit_run_stream():
         assert info.result_tools is not None
         return ModelTextResponse(content='success')
 
-    agent = Agent(FunctionModel(return_model), result_type=str)
+    async def stream_function(messages: list[Message], info: AgentInfo) -> AsyncIterator[ModelAnyResponse]:
+        yield return_model(messages, info)
+
+    agent = Agent(FunctionModel(return_model, stream_function=stream_function), result_type=str)
 
     with pytest.raises(UnexpectedModelBehavior, match='Exceeded cost limit of 10 tokens'):
         async with agent.run_stream('Hello', cost_limit=10) as result:
-            async for _ in result.stream():
-                pass
+            pass

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -26,6 +26,7 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.result import Cost, RunResult
 from pydantic_ai.tools import ToolDefinition
+from collections.abc import AsyncIterator
 
 from .conftest import IsNow, TestEnv
 


### PR DESCRIPTION
Fixes #70

Add `message_limit` and `cost_limit` parameters to `run()`, `run_sync()`, and `run_stream()` methods in `pydantic_ai_slim/pydantic_ai/agent.py`.

* **pydantic_ai_slim/pydantic_ai/agent.py**
  - Add `message_limit` and `cost_limit` parameters to `run` method signature.
  - Add `message_limit` and `cost_limit` parameters to `run_sync` method signature.
  - Add `message_limit` and `cost_limit` parameters to `run_stream` method signature.
  - Implement logic to check `message_limit` and `cost_limit` in `run` method.
  - Implement logic to check `message_limit` and `cost_limit` in `run_stream` method.

* **tests/test_agent.py**
  - Add unit tests for `message_limit` and `cost_limit` parameters in `run` method.
  - Add unit tests for `message_limit` and `cost_limit` parameters in `run_sync` method.
  - Add unit tests for `message_limit` and `cost_limit` parameters in `run_stream` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pydantic/pydantic-ai/pull/188?shareId=bbbfa349-c159-468c-a557-05f55fb551af).