### PR TITLE
Standardize "py" -> "python" in code blocks with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,12 @@ repos:
       - id: replace-py-code-blocks
         name: Replace ```py with ```python
         # first pattern matches ```py <info> and second matches lone ```py<eol>
-        entry: sed -i '' 's/```py \(.*\)/```python \1/; s/```py$/```python/'
+        entry: |
+          if [[ "$(uname)" == "Darwin" ]]; then
+            sed -i '' 's/```py \(.*\)/```python \1/; s/```py$/```python/' "$@"
+          else
+            sed -i 's/```py \(.*\)/```python \1/; s/```py$/```python/' "$@"
+          fi
         language: system
         files: \.py$|\.md$
-        pass_filenames: false
+        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,4 +38,4 @@ repos:
         entry: sed -i '' 's/```py \(.*\)/```python \1/; s/```py$/```python/'
         language: system
         files: \.py$|\.md$
-        pass_filenames: false
+        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         pass_filenames: false
       - id: replace-py-code-blocks
         name: Replace ```py with ```python
-        entry: sed -i '' 's/```py/```python/g'
+        entry: sed -i '' 's/```py\([[:space:]]*\)/```python\1/g'
         language: system
         files: \.py$|\.md$
         pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         pass_filenames: false
       - id: replace-py-code-blocks
         name: Replace ```py with ```python
-        entry: sed -i '' 's/```py\([[:space:]]*\)/```python\1/g'
+        entry: sed -i '' 's/```py/```python/g'
         language: system
         files: \.py$|\.md$
         pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,9 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      - id: replace-py-code-blocks
+        name: Replace ```py with ```python
+        entry: sed -i '' 's/```py/```python/g'
+        language: system
+        files: \.py$|\.md$
+        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
         pass_filenames: false
       - id: replace-py-code-blocks
         name: Replace ```py with ```python
+        # first pattern matches ```py <info> and second matches lone ```py<eol>
         entry: sed -i '' 's/```py \(.*\)/```python \1/; s/```py$/```python/'
         language: system
         files: \.py$|\.md$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,10 +32,3 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
-      - id: replace-py-code-blocks
-        name: Replace ```py with ```python
-        # first pattern matches ```py <info> and second matches lone ```py<eol>
-        entry: sed -i '' 's/```py \(.*\)/```python \1/; s/```py$/```python/'
-        language: system
-        files: \.py$|\.md$
-        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,12 +35,7 @@ repos:
       - id: replace-py-code-blocks
         name: Replace ```py with ```python
         # first pattern matches ```py <info> and second matches lone ```py<eol>
-        entry: |
-          if [[ "$(uname)" == "Darwin" ]]; then
-            sed -i '' 's/```py \(.*\)/```python \1/; s/```py$/```python/' "$@"
-          else
-            sed -i 's/```py \(.*\)/```python \1/; s/```py$/```python/' "$@"
-          fi
+        entry: sed -i '' 's/```py \(.*\)/```python \1/; s/```py$/```python/'
         language: system
         files: \.py$|\.md$
-        pass_filenames: true
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         pass_filenames: false
       - id: replace-py-code-blocks
         name: Replace ```py with ```python
-        entry: sed -i '' 's/```py/```python/g'
+        entry: sed -i '' 's/```py \(.*\)/```python \1/; s/```py$/```python/'
         language: system
         files: \.py$|\.md$
         pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,4 +38,4 @@ repos:
         entry: sed -i '' 's/```py \(.*\)/```python \1/; s/```py$/```python/'
         language: system
         files: \.py$|\.md$
-        pass_filenames: true
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ PydanticAI is in early beta, the API is still subject to change and there's a lo
 
 Here's a minimal example of PydanticAI:
 
-```py
+```python
 from pydantic_ai import Agent
 
 # Define a very simple agent including the model to use, you can also set the model when running the agent.
@@ -80,7 +80,7 @@ Here is a concise example using PydanticAI to build a support agent for a bank:
 
 **(Better documented example [in the docs](https://ai.pydantic.dev/#tools-dependency-injection-example))**
 
-```py
+```python
 from dataclasses import dataclass
 
 from pydantic import BaseModel, Field

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -95,7 +95,7 @@ You can also pass messages from previous runs to continue a conversation or prov
     to manage conflicts between event loops that occur between jupyter's event loops and `pydantic-ai`'s.
 
     Before you execute any agent runs, do the following:
-    ```python {test="skip", lint="skip"}
+    ```python {test="skip" lint="skip"}
     import nest_asyncio
     nest_asyncio.apply()
     ```
@@ -106,7 +106,7 @@ An agent **run** might represent an entire conversation — there's no limit to 
 
 Here's an example of a conversation comprised of multiple runs:
 
-```python {title="conversation_example.py", hl_lines="13"}
+```python {title="conversation_example.py" hl_lines="13"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o')
@@ -144,7 +144,7 @@ In particular, agents are generic in both the type of their dependencies and the
 
 Consider the following script with type mistakes:
 
-```python {title="type_mistakes.py", hl_lines="18 28"}
+```python {title="type_mistakes.py" hl_lines="18 28"}
 from dataclasses import dataclass
 
 from pydantic_ai import Agent, RunContext

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -106,7 +106,7 @@ An agent **run** might represent an entire conversation — there's no limit to 
 
 Here's an example of a conversation comprised of multiple runs:
 
-```python {title="conversation_example.py",hl_lines="13"}
+```python {title="conversation_example.py", hl_lines="13"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o')
@@ -144,7 +144,7 @@ In particular, agents are generic in both the type of their dependencies and the
 
 Consider the following script with type mistakes:
 
-```python {title="type_mistakes.py",hl_lines="18 28"}
+```python {title="type_mistakes.py", hl_lines="18 28"}
 from dataclasses import dataclass
 
 from pydantic_ai import Agent, RunContext
@@ -301,7 +301,7 @@ _(This example is complete, it can be run "as is")_
 
 Let's print the messages from that game to see what happened:
 
-```python {title="dice_game_messages.py"
+```python {title="dice_game_messages.py"}
 from dice_game import dice_result
 
 print(dice_result.all_messages())
@@ -399,7 +399,7 @@ sequenceDiagram
 
 As well as using the decorators, we can register tools via the `tools` argument to the [`Agent` constructor][pydantic_ai.Agent.__init__]. This is useful when you want to re-use tools, and can also give more fine-grained control over the tools.
 
-```python {title="dice_game_tool_kwarg.py"
+```python {title="dice_game_tool_kwarg.py"}
 import random
 
 from pydantic_ai import Agent, RunContext, Tool
@@ -452,7 +452,7 @@ Even better, PydanticAI extracts the docstring from functions and (thanks to [gr
 
 To demonstrate a tool's schema, here we use [`FunctionModel`][pydantic_ai.models.function.FunctionModel] to print the schema a model would receive:
 
-```python {title="tool_schema.py"
+```python {title="tool_schema.py"}
 from pydantic_ai import Agent
 from pydantic_ai.messages import Message, ModelAnyResponse, ModelTextResponse
 from pydantic_ai.models.function import AgentInfo, FunctionModel
@@ -509,7 +509,7 @@ If a tool has a single parameter that can be represented as an object in JSON sc
 
 Here's an example, we use [`TestModel.agent_model_function_tools`][pydantic_ai.models.test.TestModel.agent_model_function_tools] to inspect the tool schema that would be passed to the model.
 
-```python {title="single_parameter_tool.py"
+```python {title="single_parameter_tool.py"}
 from pydantic import BaseModel
 
 from pydantic_ai import Agent
@@ -577,7 +577,7 @@ Here's a simple `prepare` method that only includes the tool if the value of the
 
 As with the previous example, we use [`TestModel`][pydantic_ai.models.test.TestModel] to demonstrate the behavior without calling a real model.
 
-```python {title="tool_only_if_42.py"
+```python {title="tool_only_if_42.py"}
 from typing import Union
 
 from pydantic_ai import Agent, RunContext
@@ -612,7 +612,7 @@ Here's a more complex example where we change the description of the `name` para
 
 For the sake of variation, we create this tool using the [`Tool`][pydantic_ai.tools.Tool] dataclass.
 
-```python {title="customize_name.py"
+```python {title="customize_name.py"}
 from __future__ import annotations
 
 from typing import Literal
@@ -678,7 +678,7 @@ You can also raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] from within
 
 Here's an example:
 
-```python {title="tool_retry.py"
+```python {title="tool_retry.py"}
 from fake_database import DatabaseConn
 from pydantic import BaseModel
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -17,7 +17,7 @@ In typing terms, agents are generic in their dependency and result types, e.g., 
 
 Here's a toy example of an agent that simulates a roulette wheel:
 
-```python title="roulette_wheel.py"
+```python {title="roulette_wheel.py"}
 from pydantic_ai import Agent, RunContext
 
 roulette_agent = Agent(  # (1)!
@@ -67,7 +67,7 @@ There are three ways to run an agent:
 
 Here's a simple example demonstrating all three:
 
-```python title="run_agent.py"
+```python {title="run_agent.py"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o')
@@ -106,7 +106,7 @@ An agent **run** might represent an entire conversation — there's no limit to 
 
 Here's an example of a conversation comprised of multiple runs:
 
-```python title="conversation_example.py" hl_lines="13"
+```python {title="conversation_example.py",hl_lines="13"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o')
@@ -144,7 +144,7 @@ In particular, agents are generic in both the type of their dependencies and the
 
 Consider the following script with type mistakes:
 
-```python title="type_mistakes.py" hl_lines="18 28"
+```python {title="type_mistakes.py",hl_lines="18 28"}
 from dataclasses import dataclass
 
 from pydantic_ai import Agent, RunContext
@@ -203,7 +203,7 @@ You can add both to a single agent; they're appended in the order they're define
 
 Here's an example using both types of system prompts:
 
-```python title="system_prompts.py"
+```python {title="system_prompts.py"}
 from datetime import date
 
 from pydantic_ai import Agent, RunContext
@@ -258,7 +258,7 @@ There are a number of ways to register tools with an agent:
 
 Here's an example using both:
 
-```python title="dice_game.py"
+```python {title="dice_game.py"}
 import random
 
 from pydantic_ai import Agent, RunContext
@@ -301,7 +301,7 @@ _(This example is complete, it can be run "as is")_
 
 Let's print the messages from that game to see what happened:
 
-```python title="dice_game_messages.py"
+```python {title="dice_game_messages.py"
 from dice_game import dice_result
 
 print(dice_result.all_messages())
@@ -399,7 +399,7 @@ sequenceDiagram
 
 As well as using the decorators, we can register tools via the `tools` argument to the [`Agent` constructor][pydantic_ai.Agent.__init__]. This is useful when you want to re-use tools, and can also give more fine-grained control over the tools.
 
-```python title="dice_game_tool_kwarg.py"
+```python {title="dice_game_tool_kwarg.py"
 import random
 
 from pydantic_ai import Agent, RunContext, Tool
@@ -452,7 +452,7 @@ Even better, PydanticAI extracts the docstring from functions and (thanks to [gr
 
 To demonstrate a tool's schema, here we use [`FunctionModel`][pydantic_ai.models.function.FunctionModel] to print the schema a model would receive:
 
-```python title="tool_schema.py"
+```python {title="tool_schema.py"
 from pydantic_ai import Agent
 from pydantic_ai.messages import Message, ModelAnyResponse, ModelTextResponse
 from pydantic_ai.models.function import AgentInfo, FunctionModel
@@ -509,7 +509,7 @@ If a tool has a single parameter that can be represented as an object in JSON sc
 
 Here's an example, we use [`TestModel.agent_model_function_tools`][pydantic_ai.models.test.TestModel.agent_model_function_tools] to inspect the tool schema that would be passed to the model.
 
-```python title="single_parameter_tool.py"
+```python {title="single_parameter_tool.py"
 from pydantic import BaseModel
 
 from pydantic_ai import Agent
@@ -577,7 +577,7 @@ Here's a simple `prepare` method that only includes the tool if the value of the
 
 As with the previous example, we use [`TestModel`][pydantic_ai.models.test.TestModel] to demonstrate the behavior without calling a real model.
 
-```python title="tool_only_if_42.py"
+```python {title="tool_only_if_42.py"
 from typing import Union
 
 from pydantic_ai import Agent, RunContext
@@ -612,7 +612,7 @@ Here's a more complex example where we change the description of the `name` para
 
 For the sake of variation, we create this tool using the [`Tool`][pydantic_ai.tools.Tool] dataclass.
 
-```python title="customize_name.py"
+```python {title="customize_name.py"
 from __future__ import annotations
 
 from typing import Literal
@@ -678,7 +678,7 @@ You can also raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] from within
 
 Here's an example:
 
-```python title="tool_retry.py"
+```python {title="tool_retry.py"
 from fake_database import DatabaseConn
 from pydantic import BaseModel
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -17,7 +17,7 @@ In typing terms, agents are generic in their dependency and result types, e.g., 
 
 Here's a toy example of an agent that simulates a roulette wheel:
 
-```py title="roulette_wheel.py"
+```python title="roulette_wheel.py"
 from pydantic_ai import Agent, RunContext
 
 roulette_agent = Agent(  # (1)!
@@ -67,7 +67,7 @@ There are three ways to run an agent:
 
 Here's a simple example demonstrating all three:
 
-```py title="run_agent.py"
+```python title="run_agent.py"
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o')
@@ -95,7 +95,7 @@ You can also pass messages from previous runs to continue a conversation or prov
     to manage conflicts between event loops that occur between jupyter's event loops and `pydantic-ai`'s.
 
     Before you execute any agent runs, do the following:
-    ```py {test="skip", lint="skip"}
+    ```python {test="skip", lint="skip"}
     import nest_asyncio
     nest_asyncio.apply()
     ```
@@ -106,7 +106,7 @@ An agent **run** might represent an entire conversation — there's no limit to 
 
 Here's an example of a conversation comprised of multiple runs:
 
-```py title="conversation_example.py" hl_lines="13"
+```python title="conversation_example.py" hl_lines="13"
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o')
@@ -144,7 +144,7 @@ In particular, agents are generic in both the type of their dependencies and the
 
 Consider the following script with type mistakes:
 
-```py title="type_mistakes.py" hl_lines="18 28"
+```python title="type_mistakes.py" hl_lines="18 28"
 from dataclasses import dataclass
 
 from pydantic_ai import Agent, RunContext
@@ -203,7 +203,7 @@ You can add both to a single agent; they're appended in the order they're define
 
 Here's an example using both types of system prompts:
 
-```py title="system_prompts.py"
+```python title="system_prompts.py"
 from datetime import date
 
 from pydantic_ai import Agent, RunContext
@@ -258,7 +258,7 @@ There are a number of ways to register tools with an agent:
 
 Here's an example using both:
 
-```py title="dice_game.py"
+```python title="dice_game.py"
 import random
 
 from pydantic_ai import Agent, RunContext
@@ -301,7 +301,7 @@ _(This example is complete, it can be run "as is")_
 
 Let's print the messages from that game to see what happened:
 
-```py title="dice_game_messages.py"
+```python title="dice_game_messages.py"
 from dice_game import dice_result
 
 print(dice_result.all_messages())
@@ -399,7 +399,7 @@ sequenceDiagram
 
 As well as using the decorators, we can register tools via the `tools` argument to the [`Agent` constructor][pydantic_ai.Agent.__init__]. This is useful when you want to re-use tools, and can also give more fine-grained control over the tools.
 
-```py title="dice_game_tool_kwarg.py"
+```python title="dice_game_tool_kwarg.py"
 import random
 
 from pydantic_ai import Agent, RunContext, Tool
@@ -452,7 +452,7 @@ Even better, PydanticAI extracts the docstring from functions and (thanks to [gr
 
 To demonstrate a tool's schema, here we use [`FunctionModel`][pydantic_ai.models.function.FunctionModel] to print the schema a model would receive:
 
-```py title="tool_schema.py"
+```python title="tool_schema.py"
 from pydantic_ai import Agent
 from pydantic_ai.messages import Message, ModelAnyResponse, ModelTextResponse
 from pydantic_ai.models.function import AgentInfo, FunctionModel
@@ -509,7 +509,7 @@ If a tool has a single parameter that can be represented as an object in JSON sc
 
 Here's an example, we use [`TestModel.agent_model_function_tools`][pydantic_ai.models.test.TestModel.agent_model_function_tools] to inspect the tool schema that would be passed to the model.
 
-```py title="single_parameter_tool.py"
+```python title="single_parameter_tool.py"
 from pydantic import BaseModel
 
 from pydantic_ai import Agent
@@ -577,7 +577,7 @@ Here's a simple `prepare` method that only includes the tool if the value of the
 
 As with the previous example, we use [`TestModel`][pydantic_ai.models.test.TestModel] to demonstrate the behavior without calling a real model.
 
-```py title="tool_only_if_42.py"
+```python title="tool_only_if_42.py"
 from typing import Union
 
 from pydantic_ai import Agent, RunContext
@@ -612,7 +612,7 @@ Here's a more complex example where we change the description of the `name` para
 
 For the sake of variation, we create this tool using the [`Tool`][pydantic_ai.tools.Tool] dataclass.
 
-```py title="customize_name.py"
+```python title="customize_name.py"
 from __future__ import annotations
 
 from typing import Literal
@@ -678,7 +678,7 @@ You can also raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] from within
 
 Here's an example:
 
-```py title="tool_retry.py"
+```python title="tool_retry.py"
 from fake_database import DatabaseConn
 from pydantic import BaseModel
 
@@ -726,7 +726,7 @@ If models behave unexpectedly (e.g., the retry limit is exceeded, or their API r
 
 In these cases, [`agent.last_run_messages`][pydantic_ai.Agent.last_run_messages] can be used to access the messages exchanged during the run to help diagnose the issue.
 
-```py
+```python
 from pydantic_ai import Agent, ModelRetry, UnexpectedModelBehavior
 
 agent = Agent('openai:gpt-4o')

--- a/docs/api/models/ollama.md
+++ b/docs/api/models/ollama.md
@@ -8,14 +8,14 @@ For details on how to set up authentication with this model, see [model configur
 
 With `ollama` installed, you can run the server with the model you want to use:
 
-```bash title="terminal-run-ollama"
+```bash {title="terminal-run-ollama"}
 ollama run llama3.2
 ```
 (this will pull the `llama3.2` model if you don't already have it downloaded)
 
 Then run your code, here's a minimal example:
 
-```python title="ollama_example.py"
+```python {title="ollama_example.py"}
 from pydantic import BaseModel
 
 from pydantic_ai import Agent
@@ -37,7 +37,7 @@ print(result.cost())
 
 ## Example using a remote server
 
-```python title="ollama_example_with_remote_server.py"
+```python {title="ollama_example_with_remote_server.py"}
 from pydantic import BaseModel
 
 from pydantic_ai import Agent

--- a/docs/api/models/ollama.md
+++ b/docs/api/models/ollama.md
@@ -15,7 +15,7 @@ ollama run llama3.2
 
 Then run your code, here's a minimal example:
 
-```py title="ollama_example.py"
+```python title="ollama_example.py"
 from pydantic import BaseModel
 
 from pydantic_ai import Agent
@@ -37,7 +37,7 @@ print(result.cost())
 
 ## Example using a remote server
 
-```py title="ollama_example_with_remote_server.py"
+```python title="ollama_example_with_remote_server.py"
 from pydantic import BaseModel
 
 from pydantic_ai import Agent

--- a/docs/api/models/vertexai.md
+++ b/docs/api/models/vertexai.md
@@ -19,7 +19,7 @@ see [model configuration for Gemini via VertexAI](../../install.md#gemini-via-ve
 
 With the default google project already configured in your environment using "application default credentials":
 
-```py title="vertex_example_env.py"
+```python title="vertex_example_env.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.vertexai import VertexAIModel
 
@@ -32,7 +32,7 @@ print(result.data)
 
 Or using a service account JSON file:
 
-```py title="vertex_example_service_account.py"
+```python title="vertex_example_service_account.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.vertexai import VertexAIModel
 

--- a/docs/api/models/vertexai.md
+++ b/docs/api/models/vertexai.md
@@ -19,7 +19,7 @@ see [model configuration for Gemini via VertexAI](../../install.md#gemini-via-ve
 
 With the default google project already configured in your environment using "application default credentials":
 
-```python title="vertex_example_env.py"
+```python {title="vertex_example_env.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.vertexai import VertexAIModel
 
@@ -32,7 +32,7 @@ print(result.data)
 
 Or using a service account JSON file:
 
-```python title="vertex_example_service_account.py"
+```python {title="vertex_example_service_account.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.vertexai import VertexAIModel
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,7 +12,7 @@ Here's an example of defining an agent that requires dependencies.
 
 (**Note:** dependencies aren't actually used in this example, see [Accessing Dependencies](#accessing-dependencies) below)
 
-```py title="unused_dependencies.py"
+```python title="unused_dependencies.py"
 from dataclasses import dataclass
 
 import httpx
@@ -54,7 +54,7 @@ _(This example is complete, it can be run "as is")_
 Dependencies are accessed through the [`RunContext`][pydantic_ai.tools.RunContext] type, this should be the first parameter of system prompt functions etc.
 
 
-```py title="system_prompt_dependencies.py" hl_lines="20-27"
+```python title="system_prompt_dependencies.py" hl_lines="20-27"
 from dataclasses import dataclass
 
 import httpx
@@ -112,7 +112,7 @@ to use `async` methods where dependencies perform IO, although synchronous depen
 
 Here's the same example as above, but with a synchronous dependency:
 
-```py title="sync_dependencies.py"
+```python title="sync_dependencies.py"
 from dataclasses import dataclass
 
 import httpx
@@ -160,7 +160,7 @@ _(This example is complete, it can be run "as is")_
 
 As well as system prompts, dependencies can be used in [tools](agents.md#function-tools) and [result validators](results.md#result-validators-functions).
 
-```py title="full_example.py" hl_lines="27-35 38-48"
+```python title="full_example.py" hl_lines="27-35 38-48"
 from dataclasses import dataclass
 
 import httpx
@@ -233,7 +233,7 @@ while calling application code which in turn calls the agent.
 
 This is done via the [`override`][pydantic_ai.Agent.override] method on the agent.
 
-```py title="joke_app.py"
+```python title="joke_app.py"
 from dataclasses import dataclass
 
 import httpx
@@ -275,7 +275,7 @@ async def application_code(prompt: str) -> str:  # (3)!
 3. Application code that calls the agent, in a real application this might be an API endpoint.
 4. Call the agent from within the application code, in a real application this call might be deep within a call stack. Note `app_deps` here will NOT be used when deps are overridden.
 
-```py title="test_joke_app.py" hl_lines="10-12"
+```python title="test_joke_app.py" hl_lines="10-12"
 from joke_app import MyDeps, application_code, joke_agent
 
 
@@ -300,7 +300,7 @@ async def test_application_code():
 
 Since dependencies can be any python type, and agents are just python objects, agents can be dependencies of other agents.
 
-```py title="agents_as_dependencies.py"
+```python title="agents_as_dependencies.py"
 from dataclasses import dataclass
 
 from pydantic_ai import Agent, RunContext

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -54,7 +54,7 @@ _(This example is complete, it can be run "as is")_
 Dependencies are accessed through the [`RunContext`][pydantic_ai.tools.RunContext] type, this should be the first parameter of system prompt functions etc.
 
 
-```python {title="system_prompt_dependencies.py", hl_lines="20-27"}
+```python {title="system_prompt_dependencies.py" hl_lines="20-27"}
 from dataclasses import dataclass
 
 import httpx
@@ -160,7 +160,7 @@ _(This example is complete, it can be run "as is")_
 
 As well as system prompts, dependencies can be used in [tools](agents.md#function-tools) and [result validators](results.md#result-validators-functions).
 
-```python {title="full_example.py", hl_lines="27-35 38-48"}
+```python {title="full_example.py" hl_lines="27-35 38-48"}
 from dataclasses import dataclass
 
 import httpx
@@ -275,7 +275,7 @@ async def application_code(prompt: str) -> str:  # (3)!
 3. Application code that calls the agent, in a real application this might be an API endpoint.
 4. Call the agent from within the application code, in a real application this call might be deep within a call stack. Note `app_deps` here will NOT be used when deps are overridden.
 
-```python {title="test_joke_app.py", hl_lines="10-12"}
+```python {title="test_joke_app.py" hl_lines="10-12"}
 from joke_app import MyDeps, application_code, joke_agent
 
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,7 +12,7 @@ Here's an example of defining an agent that requires dependencies.
 
 (**Note:** dependencies aren't actually used in this example, see [Accessing Dependencies](#accessing-dependencies) below)
 
-```python title="unused_dependencies.py"
+```python {title="unused_dependencies.py"
 from dataclasses import dataclass
 
 import httpx
@@ -54,7 +54,7 @@ _(This example is complete, it can be run "as is")_
 Dependencies are accessed through the [`RunContext`][pydantic_ai.tools.RunContext] type, this should be the first parameter of system prompt functions etc.
 
 
-```python title="system_prompt_dependencies.py" hl_lines="20-27"
+```python {title="system_prompt_dependencies.py" hl_lines="20-27"
 from dataclasses import dataclass
 
 import httpx
@@ -112,7 +112,7 @@ to use `async` methods where dependencies perform IO, although synchronous depen
 
 Here's the same example as above, but with a synchronous dependency:
 
-```python title="sync_dependencies.py"
+```python {title="sync_dependencies.py"
 from dataclasses import dataclass
 
 import httpx
@@ -160,7 +160,7 @@ _(This example is complete, it can be run "as is")_
 
 As well as system prompts, dependencies can be used in [tools](agents.md#function-tools) and [result validators](results.md#result-validators-functions).
 
-```python title="full_example.py" hl_lines="27-35 38-48"
+```python {title="full_example.py" hl_lines="27-35 38-48"
 from dataclasses import dataclass
 
 import httpx
@@ -233,7 +233,7 @@ while calling application code which in turn calls the agent.
 
 This is done via the [`override`][pydantic_ai.Agent.override] method on the agent.
 
-```python title="joke_app.py"
+```python {title="joke_app.py"
 from dataclasses import dataclass
 
 import httpx
@@ -275,7 +275,7 @@ async def application_code(prompt: str) -> str:  # (3)!
 3. Application code that calls the agent, in a real application this might be an API endpoint.
 4. Call the agent from within the application code, in a real application this call might be deep within a call stack. Note `app_deps` here will NOT be used when deps are overridden.
 
-```python title="test_joke_app.py" hl_lines="10-12"
+```python {title="test_joke_app.py" hl_lines="10-12"
 from joke_app import MyDeps, application_code, joke_agent
 
 
@@ -300,7 +300,7 @@ async def test_application_code():
 
 Since dependencies can be any python type, and agents are just python objects, agents can be dependencies of other agents.
 
-```python title="agents_as_dependencies.py"
+```python {title="agents_as_dependencies.py"
 from dataclasses import dataclass
 
 from pydantic_ai import Agent, RunContext

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,7 +12,7 @@ Here's an example of defining an agent that requires dependencies.
 
 (**Note:** dependencies aren't actually used in this example, see [Accessing Dependencies](#accessing-dependencies) below)
 
-```python {title="unused_dependencies.py"
+```python {title="unused_dependencies.py"}
 from dataclasses import dataclass
 
 import httpx
@@ -54,7 +54,7 @@ _(This example is complete, it can be run "as is")_
 Dependencies are accessed through the [`RunContext`][pydantic_ai.tools.RunContext] type, this should be the first parameter of system prompt functions etc.
 
 
-```python {title="system_prompt_dependencies.py" hl_lines="20-27"
+```python {title="system_prompt_dependencies.py", hl_lines="20-27"}
 from dataclasses import dataclass
 
 import httpx
@@ -112,7 +112,7 @@ to use `async` methods where dependencies perform IO, although synchronous depen
 
 Here's the same example as above, but with a synchronous dependency:
 
-```python {title="sync_dependencies.py"
+```python {title="sync_dependencies.py"}
 from dataclasses import dataclass
 
 import httpx
@@ -160,7 +160,7 @@ _(This example is complete, it can be run "as is")_
 
 As well as system prompts, dependencies can be used in [tools](agents.md#function-tools) and [result validators](results.md#result-validators-functions).
 
-```python {title="full_example.py" hl_lines="27-35 38-48"
+```python {title="full_example.py", hl_lines="27-35 38-48"}
 from dataclasses import dataclass
 
 import httpx
@@ -233,7 +233,7 @@ while calling application code which in turn calls the agent.
 
 This is done via the [`override`][pydantic_ai.Agent.override] method on the agent.
 
-```python {title="joke_app.py"
+```python {title="joke_app.py"}
 from dataclasses import dataclass
 
 import httpx
@@ -275,7 +275,7 @@ async def application_code(prompt: str) -> str:  # (3)!
 3. Application code that calls the agent, in a real application this might be an API endpoint.
 4. Call the agent from within the application code, in a real application this call might be deep within a call stack. Note `app_deps` here will NOT be used when deps are overridden.
 
-```python {title="test_joke_app.py" hl_lines="10-12"
+```python {title="test_joke_app.py", hl_lines="10-12"}
 from joke_app import MyDeps, application_code, joke_agent
 
 
@@ -300,7 +300,7 @@ async def test_application_code():
 
 Since dependencies can be any python type, and agents are just python objects, agents can be dependencies of other agents.
 
-```python {title="agents_as_dependencies.py"
+```python {title="agents_as_dependencies.py"}
 from dataclasses import dataclass
 
 from pydantic_ai import Agent, RunContext

--- a/docs/examples/bank-support.md
+++ b/docs/examples/bank-support.md
@@ -18,6 +18,6 @@ python/uv-run -m pydantic_ai_examples.bank_support
 
 ## Example Code
 
-```python title="bank_support.py"
+```python {title="bank_support.py"}
 #! pydantic_ai_examples/bank_support.py
 ```

--- a/docs/examples/bank-support.md
+++ b/docs/examples/bank-support.md
@@ -18,6 +18,6 @@ python/uv-run -m pydantic_ai_examples.bank_support
 
 ## Example Code
 
-```py title="bank_support.py"
+```python title="bank_support.py"
 #! pydantic_ai_examples/bank_support.py
 ```

--- a/docs/examples/chat-app.md
+++ b/docs/examples/chat-app.md
@@ -29,7 +29,7 @@ TODO screenshot.
 
 Python code that runs the chat app:
 
-```py title="chat_app.py"
+```python title="chat_app.py"
 #! pydantic_ai_examples/chat_app.py
 ```
 

--- a/docs/examples/chat-app.md
+++ b/docs/examples/chat-app.md
@@ -29,18 +29,18 @@ TODO screenshot.
 
 Python code that runs the chat app:
 
-```python title="chat_app.py"
+```python {title="chat_app.py"}
 #! pydantic_ai_examples/chat_app.py
 ```
 
 Simple HTML page to render the app:
 
-```html title="chat_app.html"
+```html {title="chat_app.html"}
 #! pydantic_ai_examples/chat_app.html
 ```
 
 TypeScript to handle rendering the messages, to keep this simple (and at the risk of offending frontend developers) the typescript code is passed to the browser as plain text and transpiled in the browser.
 
-```ts title="chat_app.ts"
+```ts {title="chat_app.ts"}
 #! pydantic_ai_examples/chat_app.ts
 ```

--- a/docs/examples/pydantic-model.md
+++ b/docs/examples/pydantic-model.md
@@ -25,6 +25,6 @@ PYDANTIC_AI_MODEL=gemini-1.5-pro python/uv-run -m pydantic_ai_examples.pydantic_
 
 ## Example Code
 
-```python title="pydantic_model.py"
+```python {title="pydantic_model.py"
 #! pydantic_ai_examples/pydantic_model.py
 ```

--- a/docs/examples/pydantic-model.md
+++ b/docs/examples/pydantic-model.md
@@ -25,6 +25,6 @@ PYDANTIC_AI_MODEL=gemini-1.5-pro python/uv-run -m pydantic_ai_examples.pydantic_
 
 ## Example Code
 
-```python {title="pydantic_model.py"
+```python {title="pydantic_model.py"}
 #! pydantic_ai_examples/pydantic_model.py
 ```

--- a/docs/examples/pydantic-model.md
+++ b/docs/examples/pydantic-model.md
@@ -25,6 +25,6 @@ PYDANTIC_AI_MODEL=gemini-1.5-pro python/uv-run -m pydantic_ai_examples.pydantic_
 
 ## Example Code
 
-```py title="pydantic_model.py"
+```python title="pydantic_model.py"
 #! pydantic_ai_examples/pydantic_model.py
 ```

--- a/docs/examples/rag.md
+++ b/docs/examples/rag.md
@@ -44,6 +44,6 @@ python/uv-run -m pydantic_ai_examples.rag search "How do I configure logfire to 
 
 ## Example Code
 
-```py title="rag.py"
+```python title="rag.py"
 #! pydantic_ai_examples/rag.py
 ```

--- a/docs/examples/rag.md
+++ b/docs/examples/rag.md
@@ -44,6 +44,6 @@ python/uv-run -m pydantic_ai_examples.rag search "How do I configure logfire to 
 
 ## Example Code
 
-```python title="rag.py"
+```python {title="rag.py"
 #! pydantic_ai_examples/rag.py
 ```

--- a/docs/examples/rag.md
+++ b/docs/examples/rag.md
@@ -44,6 +44,6 @@ python/uv-run -m pydantic_ai_examples.rag search "How do I configure logfire to 
 
 ## Example Code
 
-```python {title="rag.py"
+```python {title="rag.py"}
 #! pydantic_ai_examples/rag.py
 ```

--- a/docs/examples/sql-gen.md
+++ b/docs/examples/sql-gen.md
@@ -34,6 +34,6 @@ This model uses `gemini-1.5-flash` by default since Gemini is good at single sho
 
 ## Example Code
 
-```py title="sql_gen.py"
+```python title="sql_gen.py"
 #! pydantic_ai_examples/sql_gen.py
 ```

--- a/docs/examples/sql-gen.md
+++ b/docs/examples/sql-gen.md
@@ -34,6 +34,6 @@ This model uses `gemini-1.5-flash` by default since Gemini is good at single sho
 
 ## Example Code
 
-```python title="sql_gen.py"
+```python {title="sql_gen.py"
 #! pydantic_ai_examples/sql_gen.py
 ```

--- a/docs/examples/sql-gen.md
+++ b/docs/examples/sql-gen.md
@@ -34,6 +34,6 @@ This model uses `gemini-1.5-flash` by default since Gemini is good at single sho
 
 ## Example Code
 
-```python {title="sql_gen.py"
+```python {title="sql_gen.py"}
 #! pydantic_ai_examples/sql_gen.py
 ```

--- a/docs/examples/stream-markdown.md
+++ b/docs/examples/stream-markdown.md
@@ -16,6 +16,6 @@ python/uv-run -m pydantic_ai_examples.stream_markdown
 
 ## Example Code
 
-```py
+```python
 #! pydantic_ai_examples/stream_markdown.py
 ```

--- a/docs/examples/stream-whales.md
+++ b/docs/examples/stream-whales.md
@@ -21,6 +21,6 @@ Should give an output like this:
 
 ## Example Code
 
-```python {title="stream_whales.py"
+```python {title="stream_whales.py"}
 #! pydantic_ai_examples/stream_whales.py
 ```

--- a/docs/examples/stream-whales.md
+++ b/docs/examples/stream-whales.md
@@ -21,6 +21,6 @@ Should give an output like this:
 
 ## Example Code
 
-```py title="stream_whales.py"
+```python title="stream_whales.py"
 #! pydantic_ai_examples/stream_whales.py
 ```

--- a/docs/examples/stream-whales.md
+++ b/docs/examples/stream-whales.md
@@ -21,6 +21,6 @@ Should give an output like this:
 
 ## Example Code
 
-```python title="stream_whales.py"
+```python {title="stream_whales.py"
 #! pydantic_ai_examples/stream_whales.py
 ```

--- a/docs/examples/weather-agent.md
+++ b/docs/examples/weather-agent.md
@@ -25,6 +25,6 @@ python/uv-run -m pydantic_ai_examples.weather_agent
 
 ## Example Code
 
-```python title="pydantic_ai_examples/weather_agent.py"
+```python {title="pydantic_ai_examples/weather_agent.py"}
 #! pydantic_ai_examples/weather_agent.py
 ```

--- a/docs/examples/weather-agent.md
+++ b/docs/examples/weather-agent.md
@@ -25,6 +25,6 @@ python/uv-run -m pydantic_ai_examples.weather_agent
 
 ## Example Code
 
-```py title="pydantic_ai_examples/weather_agent.py"
+```python title="pydantic_ai_examples/weather_agent.py"
 #! pydantic_ai_examples/weather_agent.py
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ PydanticAI is a Python Agent Framework designed to make it less painful to build
 
 Here's a minimal example of PydanticAI:
 
-```py title="hello_world.py"
+```python title="hello_world.py"
 from pydantic_ai import Agent
 
 agent = Agent(  # (1)!
@@ -54,7 +54,7 @@ Not very interesting yet, but we can easily add "tools", dynamic system prompts,
 
 Here is a concise example using PydanticAI to build a support agent for a bank:
 
-```py title="bank_support.py"
+```python title="bank_support.py"
 from dataclasses import dataclass
 
 from pydantic import BaseModel, Field
@@ -144,7 +144,7 @@ To understand the flow of the above runs, we can watch the agent in action using
 
 To do this, we need to set up logfire, and add the following to our code:
 
-```py title="bank_support_with_logfire.py"  hl_lines="4-6" test="skip" lint="skip"
+```python title="bank_support_with_logfire.py"  hl_lines="4-6" test="skip" lint="skip"
 ...
 from bank_database import DatabaseConn
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -144,7 +144,7 @@ To understand the flow of the above runs, we can watch the agent in action using
 
 To do this, we need to set up logfire, and add the following to our code:
 
-```python {title="bank_support_with_logfire.py", hl_lines="4-6", test="skip", lint="skip"}
+```python {title="bank_support_with_logfire.py" hl_lines="4-6" test="skip" lint="skip"}
 ...
 from bank_database import DatabaseConn
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -144,7 +144,7 @@ To understand the flow of the above runs, we can watch the agent in action using
 
 To do this, we need to set up logfire, and add the following to our code:
 
-```python {title="bank_support_with_logfire.py",hl_lines="4-6",test="skip",lint="skip"}
+```python {title="bank_support_with_logfire.py", hl_lines="4-6", test="skip", lint="skip"}
 ...
 from bank_database import DatabaseConn
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ PydanticAI is a Python Agent Framework designed to make it less painful to build
 
 Here's a minimal example of PydanticAI:
 
-```python title="hello_world.py"
+```python {title="hello_world.py"}
 from pydantic_ai import Agent
 
 agent = Agent(  # (1)!
@@ -54,7 +54,7 @@ Not very interesting yet, but we can easily add "tools", dynamic system prompts,
 
 Here is a concise example using PydanticAI to build a support agent for a bank:
 
-```python title="bank_support.py"
+```python {title="bank_support.py"}
 from dataclasses import dataclass
 
 from pydantic import BaseModel, Field
@@ -144,7 +144,7 @@ To understand the flow of the above runs, we can watch the agent in action using
 
 To do this, we need to set up logfire, and add the following to our code:
 
-```python title="bank_support_with_logfire.py"  hl_lines="4-6" test="skip" lint="skip"
+```python {title="bank_support_with_logfire.py",hl_lines="4-6",test="skip",lint="skip"}
 ...
 from bank_database import DatabaseConn
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -90,7 +90,7 @@ export OPENAI_API_KEY='your-api-key'
 
 You can then use [`OpenAIModel`][pydantic_ai.models.openai.OpenAIModel] by name:
 
-```python title="openai_model_by_name.py"
+```python {title="openai_model_by_name.py"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o')
@@ -99,7 +99,7 @@ agent = Agent('openai:gpt-4o')
 
 Or initialise the model directly with just the model name:
 
-```python title="openai_model_init.py"
+```python {title="openai_model_init.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIModel
 
@@ -112,7 +112,7 @@ agent = Agent(model)
 
 If you don't want to or can't set the environment variable, you can pass it at runtime via the [`api_key` argument][pydantic_ai.models.openai.OpenAIModel.__init__]:
 
-```python title="openai_model_api_key.py"
+```python {title="openai_model_api_key.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIModel
 
@@ -128,7 +128,7 @@ so you can customise the `organization`, `project`, `base_url` etc. as defined i
 
 You could also use the [`AsyncAzureOpenAI`](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/switching-endpoints) client to use the Azure OpenAI API.
 
-```python title="openai_azure.py"
+```python {title="openai_azure.py"}
 from openai import AsyncAzureOpenAI
 
 from pydantic_ai import Agent
@@ -169,7 +169,7 @@ export GEMINI_API_KEY=your-api-key
 
 You can then use [`GeminiModel`][pydantic_ai.models.gemini.GeminiModel] by name:
 
-```python title="gemini_model_by_name.py"
+```python {title="gemini_model_by_name.py"}
 from pydantic_ai import Agent
 
 agent = Agent('gemini-1.5-flash')
@@ -178,7 +178,7 @@ agent = Agent('gemini-1.5-flash')
 
 Or initialise the model directly with just the model name:
 
-```python title="gemini_model_init.py"
+```python {title="gemini_model_init.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.gemini import GeminiModel
 
@@ -191,7 +191,7 @@ agent = Agent(model)
 
 If you don't want to or can't set the environment variable, you can pass it at runtime via the [`api_key` argument][pydantic_ai.models.gemini.GeminiModel.__init__]:
 
-```python title="gemini_model_api_key.py"
+```python {title="gemini_model_api_key.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.gemini import GeminiModel
 
@@ -226,7 +226,7 @@ Luckily if you're running PydanticAI inside GCP, or you have the [`gcloud` CLI](
 
 To use `VertexAIModel`, with [application default credentials](https://cloud.google.com/docs/authentication/application-default-credentials) configured (e.g. with `gcloud`), you can simply use:
 
-```python title="vertexai_application_default_credentials.py"
+```python {title="vertexai_application_default_credentials.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.vertexai import VertexAIModel
 
@@ -248,7 +248,7 @@ If instead of application default credentials, you want to authenticate with a s
 
 Once you have the JSON file, you can use it thus:
 
-```python title="vertexai_service_account.py"
+```python {title="vertexai_service_account.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.vertexai import VertexAIModel
 
@@ -266,7 +266,7 @@ Whichever way you authenticate, you can specify which region requests will be se
 
 Using a region close to your application can improve latency and might be important from a regulatory perspective.
 
-```python title="vertexai_region.py"
+```python {title="vertexai_region.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.vertexai import VertexAIModel
 
@@ -293,7 +293,7 @@ export GROQ_API_KEY='your-api-key'
 
 You can then use [`GroqModel`][pydantic_ai.models.groq.GroqModel] by name:
 
-```python title="groq_model_by_name.py"
+```python {title="groq_model_by_name.py"}
 from pydantic_ai import Agent
 
 agent = Agent('groq:llama-3.1-70b-versatile')
@@ -302,7 +302,7 @@ agent = Agent('groq:llama-3.1-70b-versatile')
 
 Or initialise the model directly with just the model name:
 
-```python title="groq_model_init.py"
+```python {title="groq_model_init.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.groq import GroqModel
 
@@ -315,7 +315,7 @@ agent = Agent(model)
 
 If you don't want to or can't set the environment variable, you can pass it at runtime via the [`api_key` argument][pydantic_ai.models.groq.GroqModel.__init__]:
 
-```python title="groq_model_api_key.py"
+```python {title="groq_model_api_key.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.groq import GroqModel
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -90,7 +90,7 @@ export OPENAI_API_KEY='your-api-key'
 
 You can then use [`OpenAIModel`][pydantic_ai.models.openai.OpenAIModel] by name:
 
-```py title="openai_model_by_name.py"
+```python title="openai_model_by_name.py"
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o')
@@ -99,7 +99,7 @@ agent = Agent('openai:gpt-4o')
 
 Or initialise the model directly with just the model name:
 
-```py title="openai_model_init.py"
+```python title="openai_model_init.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIModel
 
@@ -112,7 +112,7 @@ agent = Agent(model)
 
 If you don't want to or can't set the environment variable, you can pass it at runtime via the [`api_key` argument][pydantic_ai.models.openai.OpenAIModel.__init__]:
 
-```py title="openai_model_api_key.py"
+```python title="openai_model_api_key.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIModel
 
@@ -128,7 +128,7 @@ so you can customise the `organization`, `project`, `base_url` etc. as defined i
 
 You could also use the [`AsyncAzureOpenAI`](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/switching-endpoints) client to use the Azure OpenAI API.
 
-```py title="openai_azure.py"
+```python title="openai_azure.py"
 from openai import AsyncAzureOpenAI
 
 from pydantic_ai import Agent
@@ -169,7 +169,7 @@ export GEMINI_API_KEY=your-api-key
 
 You can then use [`GeminiModel`][pydantic_ai.models.gemini.GeminiModel] by name:
 
-```py title="gemini_model_by_name.py"
+```python title="gemini_model_by_name.py"
 from pydantic_ai import Agent
 
 agent = Agent('gemini-1.5-flash')
@@ -178,7 +178,7 @@ agent = Agent('gemini-1.5-flash')
 
 Or initialise the model directly with just the model name:
 
-```py title="gemini_model_init.py"
+```python title="gemini_model_init.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.gemini import GeminiModel
 
@@ -191,7 +191,7 @@ agent = Agent(model)
 
 If you don't want to or can't set the environment variable, you can pass it at runtime via the [`api_key` argument][pydantic_ai.models.gemini.GeminiModel.__init__]:
 
-```py title="gemini_model_api_key.py"
+```python title="gemini_model_api_key.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.gemini import GeminiModel
 
@@ -226,7 +226,7 @@ Luckily if you're running PydanticAI inside GCP, or you have the [`gcloud` CLI](
 
 To use `VertexAIModel`, with [application default credentials](https://cloud.google.com/docs/authentication/application-default-credentials) configured (e.g. with `gcloud`), you can simply use:
 
-```py title="vertexai_application_default_credentials.py"
+```python title="vertexai_application_default_credentials.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.vertexai import VertexAIModel
 
@@ -248,7 +248,7 @@ If instead of application default credentials, you want to authenticate with a s
 
 Once you have the JSON file, you can use it thus:
 
-```py title="vertexai_service_account.py"
+```python title="vertexai_service_account.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.vertexai import VertexAIModel
 
@@ -266,7 +266,7 @@ Whichever way you authenticate, you can specify which region requests will be se
 
 Using a region close to your application can improve latency and might be important from a regulatory perspective.
 
-```py title="vertexai_region.py"
+```python title="vertexai_region.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.vertexai import VertexAIModel
 
@@ -293,7 +293,7 @@ export GROQ_API_KEY='your-api-key'
 
 You can then use [`GroqModel`][pydantic_ai.models.groq.GroqModel] by name:
 
-```py title="groq_model_by_name.py"
+```python title="groq_model_by_name.py"
 from pydantic_ai import Agent
 
 agent = Agent('groq:llama-3.1-70b-versatile')
@@ -302,7 +302,7 @@ agent = Agent('groq:llama-3.1-70b-versatile')
 
 Or initialise the model directly with just the model name:
 
-```py title="groq_model_init.py"
+```python title="groq_model_init.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.groq import GroqModel
 
@@ -315,7 +315,7 @@ agent = Agent(model)
 
 If you don't want to or can't set the environment variable, you can pass it at runtime via the [`api_key` argument][pydantic_ai.models.groq.GroqModel.__init__]:
 
-```py title="groq_model_api_key.py"
+```python title="groq_model_api_key.py"
 from pydantic_ai import Agent
 from pydantic_ai.models.groq import GroqModel
 

--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -53,7 +53,7 @@ py-cli logfire projects new
 
 The last step is to add logfire to your code:
 
-```python title="adding_logfire.py"
+```python {title="adding_logfire.py"}
 import logfire
 
 logfire.configure()

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -27,7 +27,7 @@ and [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] (returned by [`A
 
 Example of accessing methods on a [`RunResult`][pydantic_ai.result.RunResult] :
 
-```python title="run_result_messages.py" hl_lines="10 28"
+```python {title="run_result_messages.py",hl_lines="10 28"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')
@@ -75,7 +75,7 @@ _(This example is complete, it can be run "as is")_
 
 Example of accessing methods on a [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] :
 
-```python title="streamed_run_result_messages.py" hl_lines="9 31"
+```python {title="streamed_run_result_messages.py",hl_lines="9 31"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')
@@ -142,7 +142,7 @@ To use existing messages in a run, pass them to the `message_history` parameter 
     [`all_messages()`][pydantic_ai.result.RunResult.all_messages] or [`new_messages()`][pydantic_ai.result.RunResult.new_messages].
 
 
-```python title="Reusing messages in a conversation" hl_lines="9 13"
+```python {title="Reusing messages in a conversation",hl_lines="9 13"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -27,7 +27,7 @@ and [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] (returned by [`A
 
 Example of accessing methods on a [`RunResult`][pydantic_ai.result.RunResult] :
 
-```py title="run_result_messages.py" hl_lines="10 28"
+```python title="run_result_messages.py" hl_lines="10 28"
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')
@@ -75,7 +75,7 @@ _(This example is complete, it can be run "as is")_
 
 Example of accessing methods on a [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] :
 
-```py title="streamed_run_result_messages.py" hl_lines="9 31"
+```python title="streamed_run_result_messages.py" hl_lines="9 31"
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')
@@ -142,7 +142,7 @@ To use existing messages in a run, pass them to the `message_history` parameter 
     [`all_messages()`][pydantic_ai.result.RunResult.all_messages] or [`new_messages()`][pydantic_ai.result.RunResult.new_messages].
 
 
-```py title="Reusing messages in a conversation" hl_lines="9 13"
+```python title="Reusing messages in a conversation" hl_lines="9 13"
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')
@@ -190,7 +190,7 @@ Since messages are defined by simple dataclasses, you can manually create and ma
 
 The message format is independent of the model used, so you can use messages in different agents, or the same agent with different models.
 
-```py
+```python
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -27,7 +27,7 @@ and [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] (returned by [`A
 
 Example of accessing methods on a [`RunResult`][pydantic_ai.result.RunResult] :
 
-```python {title="run_result_messages.py", hl_lines="10 28"}
+```python {title="run_result_messages.py" hl_lines="10 28"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')
@@ -75,7 +75,7 @@ _(This example is complete, it can be run "as is")_
 
 Example of accessing methods on a [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] :
 
-```python {title="streamed_run_result_messages.py", hl_lines="9 31"}
+```python {title="streamed_run_result_messages.py" hl_lines="9 31"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')
@@ -142,7 +142,7 @@ To use existing messages in a run, pass them to the `message_history` parameter 
     [`all_messages()`][pydantic_ai.result.RunResult.all_messages] or [`new_messages()`][pydantic_ai.result.RunResult.new_messages].
 
 
-```python {title="Reusing messages in a conversation", hl_lines="9 13"}
+```python {title="Reusing messages in a conversation" hl_lines="9 13"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -27,7 +27,7 @@ and [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] (returned by [`A
 
 Example of accessing methods on a [`RunResult`][pydantic_ai.result.RunResult] :
 
-```python {title="run_result_messages.py",hl_lines="10 28"}
+```python {title="run_result_messages.py", hl_lines="10 28"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')
@@ -75,7 +75,7 @@ _(This example is complete, it can be run "as is")_
 
 Example of accessing methods on a [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] :
 
-```python {title="streamed_run_result_messages.py",hl_lines="9 31"}
+```python {title="streamed_run_result_messages.py", hl_lines="9 31"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')
@@ -142,7 +142,7 @@ To use existing messages in a run, pass them to the `message_history` parameter 
     [`all_messages()`][pydantic_ai.result.RunResult.all_messages] or [`new_messages()`][pydantic_ai.result.RunResult.new_messages].
 
 
-```python {title="Reusing messages in a conversation",hl_lines="9 13"}
+```python {title="Reusing messages in a conversation", hl_lines="9 13"}
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o', system_prompt='Be a helpful assistant.')

--- a/docs/results.md
+++ b/docs/results.md
@@ -3,7 +3,7 @@ The result values are wrapped in [`RunResult`][pydantic_ai.result.RunResult] and
 
 Both `RunResult` and `StreamedRunResult` are generic in the data they wrap, so typing information about the data returned by the agent is preserved.
 
-```py title="olympics.py"
+```python title="olympics.py"
 from pydantic import BaseModel
 
 from pydantic_ai import Agent
@@ -43,7 +43,7 @@ Structured results (like tools) use Pydantic to build the JSON schema used for t
 
 Here's an example of returning either text or a structured value
 
-```py title="box_or_error.py"
+```python title="box_or_error.py"
 from typing import Union
 
 from pydantic import BaseModel
@@ -80,7 +80,7 @@ _(This example is complete, it can be run "as is")_
 
 Here's an example of using a union return type which registered multiple tools, and wraps non-object schemas in an object:
 
-```py title="colors_or_sizes.py"
+```python title="colors_or_sizes.py"
 from typing import Union
 
 from pydantic_ai import Agent
@@ -108,7 +108,7 @@ Some validation is inconvenient or impossible to do in Pydantic validators, in p
 
 Here's a simplified variant of the [SQL Generation example](examples/sql-gen.md):
 
-```py title="sql_gen.py"
+```python title="sql_gen.py"
 from typing import Union
 
 from fake_database import DatabaseConn, QueryError
@@ -166,7 +166,7 @@ There two main challenges with streamed results:
 
 Example of streamed text result:
 
-```py title="streamed_hello_world.py"
+```python title="streamed_hello_world.py"
 from pydantic_ai import Agent
 
 agent = Agent('gemini-1.5-flash')  # (1)!
@@ -192,7 +192,7 @@ _(This example is complete, it can be run "as is")_
 
 We can also stream text as deltas rather than the entire text in each item:
 
-```py title="streamed_delta_hello_world.py"
+```python title="streamed_delta_hello_world.py"
 from pydantic_ai import Agent
 
 agent = Agent('gemini-1.5-flash')
@@ -224,7 +224,7 @@ Not all types are supported with partial validation in Pydantic, see [pydantic/p
 
 Here's an example of streaming a use profile as it's built:
 
-```py title="streamed_user_profile.py"
+```python title="streamed_user_profile.py"
 from datetime import date
 
 from typing_extensions import TypedDict
@@ -263,7 +263,7 @@ _(This example is complete, it can be run "as is")_
 
 If you want fine-grained control of validation, particularly catching validation errors, you can use the following pattern:
 
-```py title="streamed_user_profile.py"
+```python title="streamed_user_profile.py"
 from datetime import date
 
 from pydantic import ValidationError

--- a/docs/results.md
+++ b/docs/results.md
@@ -3,7 +3,7 @@ The result values are wrapped in [`RunResult`][pydantic_ai.result.RunResult] and
 
 Both `RunResult` and `StreamedRunResult` are generic in the data they wrap, so typing information about the data returned by the agent is preserved.
 
-```python title="olympics.py"
+```python {title="olympics.py"}
 from pydantic import BaseModel
 
 from pydantic_ai import Agent
@@ -43,7 +43,7 @@ Structured results (like tools) use Pydantic to build the JSON schema used for t
 
 Here's an example of returning either text or a structured value
 
-```python title="box_or_error.py"
+```python {title="box_or_error.py"}
 from typing import Union
 
 from pydantic import BaseModel
@@ -80,7 +80,7 @@ _(This example is complete, it can be run "as is")_
 
 Here's an example of using a union return type which registered multiple tools, and wraps non-object schemas in an object:
 
-```python title="colors_or_sizes.py"
+```python {title="colors_or_sizes.py"}
 from typing import Union
 
 from pydantic_ai import Agent
@@ -108,7 +108,7 @@ Some validation is inconvenient or impossible to do in Pydantic validators, in p
 
 Here's a simplified variant of the [SQL Generation example](examples/sql-gen.md):
 
-```python title="sql_gen.py"
+```python {title="sql_gen.py"}
 from typing import Union
 
 from fake_database import DatabaseConn, QueryError
@@ -166,7 +166,7 @@ There two main challenges with streamed results:
 
 Example of streamed text result:
 
-```python title="streamed_hello_world.py"
+```python {title="streamed_hello_world.py"}
 from pydantic_ai import Agent
 
 agent = Agent('gemini-1.5-flash')  # (1)!
@@ -192,7 +192,7 @@ _(This example is complete, it can be run "as is")_
 
 We can also stream text as deltas rather than the entire text in each item:
 
-```python title="streamed_delta_hello_world.py"
+```python {title="streamed_delta_hello_world.py"}
 from pydantic_ai import Agent
 
 agent = Agent('gemini-1.5-flash')
@@ -224,7 +224,7 @@ Not all types are supported with partial validation in Pydantic, see [pydantic/p
 
 Here's an example of streaming a use profile as it's built:
 
-```python title="streamed_user_profile.py"
+```python {title="streamed_user_profile.py"}
 from datetime import date
 
 from typing_extensions import TypedDict
@@ -263,7 +263,7 @@ _(This example is complete, it can be run "as is")_
 
 If you want fine-grained control of validation, particularly catching validation errors, you can use the following pattern:
 
-```python title="streamed_user_profile.py"
+```python {title="streamed_user_profile.py"}
 from datetime import date
 
 from pydantic import ValidationError

--- a/docs/testing-evals.md
+++ b/docs/testing-evals.md
@@ -36,7 +36,7 @@ The simplest and fastest way to exercise most of your application code is using 
 
 Let's write unit tests for the following application code:
 
-```py title="weather_app.py"
+```python title="weather_app.py"
 import asyncio
 from datetime import date
 
@@ -89,7 +89,7 @@ Here we have a function that takes a list of `#!python (user_prompt, user_id)` t
 
 Here's how we would write tests using [`TestModel`][pydantic_ai.models.test.TestModel]:
 
-```py title="test_weather_app.py"
+```python title="test_weather_app.py"
 from datetime import timezone
 import pytest
 
@@ -182,7 +182,7 @@ To fully exercise `weather_forecast`, we need to use [`FunctionModel`][pydantic_
 
 Here's an example of using `FunctionModel` to test the `weather_forecast` tool with custom inputs
 
-```py title="test_weather_app2.py"
+```python title="test_weather_app2.py"
 import re
 
 import pytest
@@ -244,7 +244,7 @@ If you're writing lots of tests that all require model to be overridden, you can
 
 Here's an example of a fixture that overrides the model with `TestModel`:
 
-```py title="tests.py"
+```python title="tests.py"
 import pytest
 from weather_app import weather_agent
 
@@ -294,7 +294,7 @@ The system prompt is the developer's primary tool in controlling an agent's beha
 
 Let's assume we have the following app for running SQL generated from a user prompt (this examples omits a lot of details for brevity, see the [SQL gen](examples/sql-gen.md) example for a more complete code):
 
-```py title="sql_app.py"
+```python title="sql_app.py"
 import json
 from pathlib import Path
 from typing import Union
@@ -401,7 +401,7 @@ To get a quantitative measure of performance, we assign points to each run as fo
 
 We use 5-fold cross-validation to judge the performance of the agent using our existing set of examples.
 
-```py title="sql_app_evals.py"
+```python title="sql_app_evals.py"
 import json
 import statistics
 from pathlib import Path

--- a/docs/testing-evals.md
+++ b/docs/testing-evals.md
@@ -36,7 +36,7 @@ The simplest and fastest way to exercise most of your application code is using 
 
 Let's write unit tests for the following application code:
 
-```python title="weather_app.py"
+```python {title="weather_app.py"}
 import asyncio
 from datetime import date
 
@@ -89,7 +89,7 @@ Here we have a function that takes a list of `#!python (user_prompt, user_id)` t
 
 Here's how we would write tests using [`TestModel`][pydantic_ai.models.test.TestModel]:
 
-```python title="test_weather_app.py"
+```python {title="test_weather_app.py"}
 from datetime import timezone
 import pytest
 
@@ -182,7 +182,7 @@ To fully exercise `weather_forecast`, we need to use [`FunctionModel`][pydantic_
 
 Here's an example of using `FunctionModel` to test the `weather_forecast` tool with custom inputs
 
-```python title="test_weather_app2.py"
+```python {title="test_weather_app2.py"}
 import re
 
 import pytest
@@ -244,7 +244,7 @@ If you're writing lots of tests that all require model to be overridden, you can
 
 Here's an example of a fixture that overrides the model with `TestModel`:
 
-```python title="tests.py"
+```python {title="tests.py"}
 import pytest
 from weather_app import weather_agent
 
@@ -294,7 +294,7 @@ The system prompt is the developer's primary tool in controlling an agent's beha
 
 Let's assume we have the following app for running SQL generated from a user prompt (this examples omits a lot of details for brevity, see the [SQL gen](examples/sql-gen.md) example for a more complete code):
 
-```python title="sql_app.py"
+```python {title="sql_app.py"}
 import json
 from pathlib import Path
 from typing import Union
@@ -370,7 +370,7 @@ async def user_search(user_prompt: str) -> list[dict[str, str]]:
     request: show me error records with the tag "foobar"
     response: SELECT * FROM records WHERE level = 'error' and 'foobar' = ANY(tags)
 
-```json title="examples.json"
+```json {title="examples.json"}
 {
   "examples": [
     {
@@ -401,7 +401,7 @@ To get a quantitative measure of performance, we assign points to each run as fo
 
 We use 5-fold cross-validation to judge the performance of the agent using our existing set of examples.
 
-```python title="sql_app_evals.py"
+```python {title="sql_app_evals.py"}
 import json
 import statistics
 from pathlib import Path

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -87,7 +87,7 @@ class Either(Generic[Left, Right]):
 
     Usage:
 
-    ```py
+    ```python
     if left_thing := either.left:
         use_left(left_thing.value)
     else:
@@ -146,7 +146,7 @@ async def group_by_temporal(
 
     Usage:
 
-    ```py
+    ```python
     async with group_by_temporal(yield_groups(), 0.1) as groups_iter:
         async for groups in groups_iter:
             print(groups)

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -53,7 +53,7 @@ class Agent(Generic[AgentDeps, ResultData]):
 
     Minimal usage example:
 
-    ```py
+    ```python
     from pydantic_ai import Agent
 
     agent = Agent('openai:gpt-4o')
@@ -171,7 +171,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         """Run the agent with a user prompt in async mode.
 
         Example:
-        ```py
+        ```python
         from pydantic_ai import Agent
 
         agent = Agent('openai:gpt-4o')
@@ -262,7 +262,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         This is a convenience method that wraps `self.run` with `loop.run_until_complete()`.
 
         Example:
-        ```py
+        ```python
         from pydantic_ai import Agent
 
         agent = Agent('openai:gpt-4o')
@@ -303,7 +303,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         """Run the agent with a user prompt in async mode, returning a streamed response.
 
         Example:
-        ```py
+        ```python
         from pydantic_ai import Agent
 
         agent = Agent('openai:gpt-4o')
@@ -461,7 +461,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         the type of the function, see `tests/typed_agent.py` for tests.
 
         Example:
-        ```py
+        ```python
         from pydantic_ai import Agent, RunContext
 
         agent = Agent('test', deps_type=str)
@@ -512,7 +512,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         the type of the function, see `tests/typed_agent.py` for tests.
 
         Example:
-        ```py
+        ```python
         from pydantic_ai import Agent, ModelRetry, RunContext
 
         agent = Agent('test', deps_type=str)
@@ -568,7 +568,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         so the signature of functions decorated with `@agent.tool` is obscured.
 
         Example:
-        ```py
+        ```python
         from pydantic_ai import Agent, RunContext
 
         agent = Agent('test', deps_type=int)
@@ -640,7 +640,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         so the signature of functions decorated with `@agent.tool` is obscured.
 
         Example:
-        ```py
+        ```python
         from pydantic_ai import Agent, RunContext
 
         agent = Agent('test')

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -101,7 +101,7 @@ See [tool docs](../agents.md#tool-prepare) for more information.
 
 Example — here `only_if_42` is valid as a `ToolPrepareFunc`:
 
-```py
+```python
 from typing import Union
 
 from pydantic_ai import RunContext, Tool
@@ -157,7 +157,7 @@ class Tool(Generic[AgentDeps]):
 
         Example usage:
 
-        ```py
+        ```python
         from pydantic_ai import Agent, RunContext, Tool
 
         async def my_tool(ctx: RunContext[int], x: int, y: int) -> str:
@@ -168,7 +168,7 @@ class Tool(Generic[AgentDeps]):
 
         or with a custom prepare method:
 
-        ```py
+        ```python
         from typing import Union
 
         from pydantic_ai import Agent, RunContext, Tool


### PR DESCRIPTION
* Standardize use of "\```python" instead of "```py
* Standardize use of [superfences](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/#injecting-classes-ids-and-attributes) for attribute injection to prevent rendering issues down the line (as seen in https://github.com/pydantic/pydantic/pull/10898)