### PR TITLE
[docs] update contributing guide to indicate minimum `uv` version

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,11 +9,11 @@ git clone git@github.com:<your username>/pydantic.git
 cd pydantic-ai
 ```
 
-2. Install `uv` and `pre-commit`
+2. Install `uv` (version 0.4.30 or later) and `pre-commit`
 
 We use pipx here, for other options see:
 
-* [`uv` getting install docs](https://docs.astral.sh/uv/getting-started/installation/)
+* [`uv` install docs](https://docs.astral.sh/uv/getting-started/installation/)
 * [`pre-commit` install docs](https://pre-commit.com/#install)
 
 To get `pipx` itself, see [these docs](https://pypa.github.io/pipx/)


### PR DESCRIPTION
the `--all-packages` flag for `uv sync` is [used in the Makefile](https://github.com/pydantic/pydantic-ai/blob/main/Makefile#L11-L18) was [added](https://github.com/astral-sh/uv/pull/8739) in [0.4.30](https://github.com/astral-sh/uv/releases/tag/0.4.30),