### PR TITLE
feat: add optional base_url kwarg to OpenAIModel

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -128,6 +128,23 @@ agent = Agent(model)
 ...
 ```
 
+#### `base_url` argument
+
+To use another OpenAI compatible API, such as [OpenRouter](https://openrouter.ai), you can configure that via the [`base_url` argument][pydantic_ai.models.openai.OpenAIModel.__init__]:
+
+```python {title="openai_model_base_url.py"}
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIModel
+
+model = OpenAIModel(
+    'anthropic/claude-3.5-sonnet',
+    base_url='https://openrouter.ai/api/v1',
+    api_key='your-api-key',
+)
+agent = Agent(model)
+...
+```
+
 #### Custom OpenAI Client
 
 `OpenAIModel` also accepts a custom `AsyncOpenAI` client via the [`openai_client` parameter][pydantic_ai.models.openai.OpenAIModel.__init__],

--- a/docs/install.md
+++ b/docs/install.md
@@ -130,7 +130,7 @@ agent = Agent(model)
 
 #### `base_url` argument
 
-To use another OpenAI compatible API, such as [OpenRouter](https://openrouter.ai), you can configure that via the [`base_url` argument][pydantic_ai.models.openai.OpenAIModel.__init__]:
+To use another OpenAI-compatible API, such as [OpenRouter](https://openrouter.ai), you can make use of the [`base_url` argument][pydantic_ai.models.openai.OpenAIModel.__init__]:
 
 ```python {title="openai_model_base_url.py"}
 from pydantic_ai import Agent

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -82,7 +82,7 @@ class OpenAIModel(Model):
                 will be used if available.
             openai_client: An existing
                 [`AsyncOpenAI`](https://github.com/openai/openai-python?tab=readme-ov-file#async-usage)
-                client to use, if provided, `base_url`, `api_key`, and `http_client` must be `None`.
+                client to use. If provided, `base_url`, `api_key`, and `http_client` must be `None`.
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
         """
         self.model_name: OpenAIModelName = model_name

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -65,6 +65,7 @@ class OpenAIModel(Model):
         self,
         model_name: OpenAIModelName,
         *,
+        base_url: str | None = None,
         api_key: str | None = None,
         openai_client: AsyncOpenAI | None = None,
         http_client: AsyncHTTPClient | None = None,
@@ -75,22 +76,25 @@ class OpenAIModel(Model):
             model_name: The name of the OpenAI model to use. List of model names available
                 [here](https://github.com/openai/openai-python/blob/v1.54.3/src/openai/types/chat_model.py#L7)
                 (Unfortunately, despite being ask to do so, OpenAI do not provide `.inv` files for their API).
+            base_url: The base url for the OpenAI requests, if not provided, the `OPENAI_BASE_URL` environment variable
+                will be used if available. Otherwise, defaults to OpenAI's base url.
             api_key: The API key to use for authentication, if not provided, the `OPENAI_API_KEY` environment variable
                 will be used if available.
             openai_client: An existing
                 [`AsyncOpenAI`](https://github.com/openai/openai-python?tab=readme-ov-file#async-usage)
-                client to use, if provided, `api_key` and `http_client` must be `None`.
+                client to use, if provided, `base_url`, `api_key`, and `http_client` must be `None`.
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
         """
         self.model_name: OpenAIModelName = model_name
         if openai_client is not None:
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'
+            assert base_url is None, 'Cannot provide both `openai_client` and `base_url`'
             assert api_key is None, 'Cannot provide both `openai_client` and `api_key`'
             self.client = openai_client
         elif http_client is not None:
-            self.client = AsyncOpenAI(api_key=api_key, http_client=http_client)
+            self.client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
         else:
-            self.client = AsyncOpenAI(api_key=api_key, http_client=cached_async_http_client())
+            self.client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=cached_async_http_client())
 
     async def agent_model(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -76,7 +76,7 @@ class OpenAIModel(Model):
             model_name: The name of the OpenAI model to use. List of model names available
                 [here](https://github.com/openai/openai-python/blob/v1.54.3/src/openai/types/chat_model.py#L7)
                 (Unfortunately, despite being ask to do so, OpenAI do not provide `.inv` files for their API).
-            base_url: The base url for the OpenAI requests, if not provided, the `OPENAI_BASE_URL` environment variable
+            base_url: The base url for the OpenAI requests. If not provided, the `OPENAI_BASE_URL` environment variable
                 will be used if available. Otherwise, defaults to OpenAI's base url.
             api_key: The API key to use for authentication, if not provided, the `OPENAI_API_KEY` environment variable
                 will be used if available.

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -50,8 +50,17 @@ pytestmark = [
 
 def test_init():
     m = OpenAIModel('gpt-4', api_key='foobar')
+    assert str(m.client.base_url) == 'https://api.openai.com/v1/'
     assert m.client.api_key == 'foobar'
     assert m.name() == 'openai:gpt-4'
+
+
+def test_init_with_base_url():
+    m = OpenAIModel('gpt-4', base_url='https://example.com/v1', api_key='foobar')
+    assert str(m.client.base_url) == 'https://example.com/v1/'
+    assert m.client.api_key == 'foobar'
+    assert m.name() == 'openai:gpt-4'
+    m.name()
 
 
 @dataclass


### PR DESCRIPTION
hihi :v: regarding the short exchange over on this issue:
https://github.com/pydantic/pydantic-ai/pull/215#issuecomment-2538677887

noticed that the proposed syntax wasnt actually available on OpenAIModel yet, so i figured that's the PR you meant you'd be open to?

if you'd rather not introduce the API addition rn,  i also have a purely docs change in this branch:

https://github.com/pydantic/pydantic-ai/compare/main...sambarnes:pydantic-ai:sam/openrouter-example

totally open to driving this PR home tho if this is along the lines of what ya were thinkin :)
