### PR TITLE
Disable pyright reportUnnecessaryIsInstance

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -258,11 +258,11 @@ def _estimate_cost(messages: Iterable[Message]) -> result.Cost:
             request_tokens += _string_cost(message.model_response_str())
         elif isinstance(message, RetryPrompt):
             request_tokens += _string_cost(message.model_response())
-        elif isinstance(message, ModelResponse):  # pyright: ignore[reportUnnecessaryIsInstance]
+        elif isinstance(message, ModelResponse):
             for item in message.parts:
                 if isinstance(item, TextPart):
                     response_tokens += _string_cost(item.content)
-                elif isinstance(item, ToolCallPart):  # pyright: ignore[reportUnnecessaryIsInstance]
+                elif isinstance(item, ToolCallPart):
                     call = item
                     if isinstance(call.args, ArgsJson):
                         args_str = call.args.args_json

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -289,7 +289,7 @@ class GeminiAgentModel(AgentModel):
             return _content_tool_return(m)
         elif isinstance(m, RetryPrompt):
             return _content_retry_prompt(m)
-        elif isinstance(m, ModelResponse):  # pyright: ignore[reportUnnecessaryIsInstance]
+        elif isinstance(m, ModelResponse):
             return _content_model_response(m)
         else:
             assert_never(m)
@@ -445,7 +445,7 @@ def _content_model_response(m: ModelResponse) -> _GeminiContent:
     for item in m.parts:
         if isinstance(item, ToolCallPart):
             parts.append(_function_call_part_from_call(item))
-        elif isinstance(item, TextPart):  # pyright: ignore[reportUnnecessaryIsInstance]
+        elif isinstance(item, TextPart):
             parts.append(_GeminiTextPart(text=item.content))
         else:
             assert_never(item)

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -271,13 +271,13 @@ class GroqAgentModel(AgentModel):
                     tool_call_id=_guard_tool_call_id(t=message, model_source='Groq'),
                     content=message.model_response(),
                 )
-        elif isinstance(message, ModelResponse):  # pyright: ignore[reportUnnecessaryIsInstance]
+        elif isinstance(message, ModelResponse):
             texts: list[str] = []
             tool_calls: list[chat.ChatCompletionMessageToolCallParam] = []
             for item in message.parts:
                 if isinstance(item, TextPart):
                     texts.append(item.content)
-                elif isinstance(item, ToolCallPart):  # pyright: ignore[reportUnnecessaryIsInstance]
+                elif isinstance(item, ToolCallPart):
                     tool_calls.append(_map_tool_call(item))
                 else:
                     assert_never(item)

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -259,13 +259,13 @@ class OpenAIAgentModel(AgentModel):
                     tool_call_id=_guard_tool_call_id(t=message, model_source='OpenAI'),
                     content=message.model_response(),
                 )
-        elif isinstance(message, ModelResponse):  # pyright: ignore[reportUnnecessaryIsInstance]
+        elif isinstance(message, ModelResponse):
             texts: list[str] = []
             tool_calls: list[chat.ChatCompletionMessageToolCallParam] = []
             for item in message.parts:
                 if isinstance(item, TextPart):
                     texts.append(item.content)
-                elif isinstance(item, ToolCallPart):  # pyright: ignore[reportUnnecessaryIsInstance]
+                elif isinstance(item, ToolCallPart):
                     tool_calls.append(_map_tool_call(item))
                 else:
                     assert_never(item)

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -146,7 +146,7 @@ class TestAgentModel(AgentModel):
         for item in msg.parts:
             if isinstance(item, TextPart):
                 texts.append(item.content)
-            elif isinstance(item, ToolCallPart):  # pyright: ignore[reportUnnecessaryIsInstance]
+            elif isinstance(item, ToolCallPart):
                 tool_calls.append(item)
             else:
                 assert_never(item)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ quote-style = "single"
 typeCheckingMode = "strict"
 reportUnnecessaryTypeIgnoreComment = true
 reportMissingTypeStubs = false
+reportUnnecessaryIsInstance = false
 include = ["pydantic_ai_slim", "tests", "pydantic_ai_examples"]
 venvPath = ".venv"
 # see https://github.com/microsoft/pyright/issues/7771 - we don't want to error on decorated functions in tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,9 +121,9 @@ quote-style = "single"
 
 [tool.pyright]
 typeCheckingMode = "strict"
-reportUnnecessaryTypeIgnoreComment = true
 reportMissingTypeStubs = false
 reportUnnecessaryIsInstance = false
+reportUnnecessaryTypeIgnoreComment = true
 include = ["pydantic_ai_slim", "tests", "pydantic_ai_examples"]
 venvPath = ".venv"
 # see https://github.com/microsoft/pyright/issues/7771 - we don't want to error on decorated functions in tests


### PR DESCRIPTION
I agree pretty strongly with the point made in this issue — https://github.com/microsoft/pyright/issues/6147 — this check encourages writing code that makes it easy to miss places where you should add new logic while refactoring.

I think it's unfortunate this check is on by default in strict mode, but anyway it's easy enough to opt out.