### PR TITLE
Change: Internal Discriminator Modification

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -352,6 +352,7 @@ except UnexpectedModelBehavior as e:
             content='Please get me the volume of a box with size 6.',
             timestamp=datetime.datetime(...),
             role='user',
+            message_kind='user-prompt',
         ),
         ModelResponse(
             parts=[
@@ -359,18 +360,20 @@ except UnexpectedModelBehavior as e:
                     tool_name='calc_volume',
                     args=ArgsDict(args_dict={'size': 6}),
                     tool_call_id=None,
-                    kind='tool-call',
+                    part_kind='tool-call',
                 )
             ],
-            role='model-response',
             timestamp=datetime.datetime(...),
+            role='model',
+            message_kind='model-response',
         ),
         RetryPrompt(
             content='Please try again.',
             tool_name='calc_volume',
             tool_call_id=None,
             timestamp=datetime.datetime(...),
-            role='retry-prompt',
+            role='user',
+            message_kind='retry-prompt',
         ),
         ModelResponse(
             parts=[
@@ -378,11 +381,12 @@ except UnexpectedModelBehavior as e:
                     tool_name='calc_volume',
                     args=ArgsDict(args_dict={'size': 6}),
                     tool_call_id=None,
-                    kind='tool-call',
+                    part_kind='tool-call',
                 )
             ],
-            role='model-response',
             timestamp=datetime.datetime(...),
+            role='model',
+            message_kind='model-response',
         ),
     ]
     """

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -40,21 +40,25 @@ print(result.data)
 print(result.all_messages())
 """
 [
-    SystemPrompt(content='Be a helpful assistant.', role='system'),
+    SystemPrompt(
+        content='Be a helpful assistant.', role='user', message_kind='system-prompt'
+    ),
     UserPrompt(
         content='Tell me a joke.',
         timestamp=datetime.datetime(...),
         role='user',
+        message_kind='user-prompt',
     ),
     ModelResponse(
         parts=[
             TextPart(
                 content='Did you hear about the toothpaste scandal? They called it Colgate.',
-                kind='text',
+                part_kind='text',
             )
         ],
-        role='model-response',
         timestamp=datetime.datetime(...),
+        role='model',
+        message_kind='model-response',
     ),
 ]
 """
@@ -67,16 +71,18 @@ print(result.new_messages())
         content='Tell me a joke.',
         timestamp=datetime.datetime(...),
         role='user',
+        message_kind='user-prompt',
     ),
     ModelResponse(
         parts=[
             TextPart(
                 content='Did you hear about the toothpaste scandal? They called it Colgate.',
-                kind='text',
+                part_kind='text',
             )
         ],
-        role='model-response',
         timestamp=datetime.datetime(...),
+        role='model',
+        message_kind='model-response',
     ),
 ]
 """
@@ -97,11 +103,16 @@ async def main():
         print(result.all_messages())
         """
         [
-            SystemPrompt(content='Be a helpful assistant.', role='system'),
+            SystemPrompt(
+                content='Be a helpful assistant.',
+                role='user',
+                message_kind='system-prompt',
+            ),
             UserPrompt(
                 content='Tell me a joke.',
                 timestamp=datetime.datetime(...),
                 role='user',
+                message_kind='user-prompt',
             ),
         ]
         """
@@ -117,21 +128,27 @@ async def main():
         print(result.all_messages())
         """
         [
-            SystemPrompt(content='Be a helpful assistant.', role='system'),
+            SystemPrompt(
+                content='Be a helpful assistant.',
+                role='user',
+                message_kind='system-prompt',
+            ),
             UserPrompt(
                 content='Tell me a joke.',
                 timestamp=datetime.datetime(...),
                 role='user',
+                message_kind='user-prompt',
             ),
             ModelResponse(
                 parts=[
                     TextPart(
                         content='Did you hear about the toothpaste scandal? They called it Colgate.',
-                        kind='text',
+                        part_kind='text',
                     )
                 ],
-                role='model-response',
                 timestamp=datetime.datetime(...),
+                role='model',
+                message_kind='model-response',
             ),
         ]
         """
@@ -173,36 +190,42 @@ print(result2.data)
 print(result2.all_messages())
 """
 [
-    SystemPrompt(content='Be a helpful assistant.', role='system'),
+    SystemPrompt(
+        content='Be a helpful assistant.', role='user', message_kind='system-prompt'
+    ),
     UserPrompt(
         content='Tell me a joke.',
         timestamp=datetime.datetime(...),
         role='user',
+        message_kind='user-prompt',
     ),
     ModelResponse(
         parts=[
             TextPart(
                 content='Did you hear about the toothpaste scandal? They called it Colgate.',
-                kind='text',
+                part_kind='text',
             )
         ],
-        role='model-response',
         timestamp=datetime.datetime(...),
+        role='model',
+        message_kind='model-response',
     ),
     UserPrompt(
         content='Explain?',
         timestamp=datetime.datetime(...),
         role='user',
+        message_kind='user-prompt',
     ),
     ModelResponse(
         parts=[
             TextPart(
                 content='This is an excellent joke invent by Samuel Colvin, it needs no explanation.',
-                kind='text',
+                part_kind='text',
             )
         ],
-        role='model-response',
         timestamp=datetime.datetime(...),
+        role='model',
+        message_kind='model-response',
     ),
 ]
 """
@@ -233,36 +256,42 @@ print(result2.data)
 print(result2.all_messages())
 """
 [
-    SystemPrompt(content='Be a helpful assistant.', role='system'),
+    SystemPrompt(
+        content='Be a helpful assistant.', role='user', message_kind='system-prompt'
+    ),
     UserPrompt(
         content='Tell me a joke.',
         timestamp=datetime.datetime(...),
         role='user',
+        message_kind='user-prompt',
     ),
     ModelResponse(
         parts=[
             TextPart(
                 content='Did you hear about the toothpaste scandal? They called it Colgate.',
-                kind='text',
+                part_kind='text',
             )
         ],
-        role='model-response',
         timestamp=datetime.datetime(...),
+        role='model',
+        message_kind='model-response',
     ),
     UserPrompt(
         content='Explain?',
         timestamp=datetime.datetime(...),
         role='user',
+        message_kind='user-prompt',
     ),
     ModelResponse(
         parts=[
             TextPart(
                 content='This is an excellent joke invent by Samuel Colvin, it needs no explanation.',
-                kind='text',
+                part_kind='text',
             )
         ],
-        role='model-response',
         timestamp=datetime.datetime(...),
+        role='model',
+        message_kind='model-response',
     ),
 ]
 """

--- a/docs/testing-evals.md
+++ b/docs/testing-evals.md
@@ -127,12 +127,14 @@ async def test_forecast():
     assert weather_agent.last_run_messages == [  # (6)!
         SystemPrompt(
             content='Providing a weather forecast at the locations the user provides.',
-            role='system',
+            role='user',
+            message_kind='system-prompt',
         ),
         UserPrompt(
             content='What will the weather be like in London on 2024-11-28?',
             timestamp=IsNow(tz=timezone.utc),  # (7)!
             role='user',
+            message_kind='user-prompt',
         ),
         ModelResponse(
             parts=[
@@ -148,14 +150,16 @@ async def test_forecast():
                 )
             ],
             timestamp=IsNow(tz=timezone.utc),
-            role='model-response',
+            role='model',
+            message_kind='model-response',
         ),
         ToolReturn(
             tool_name='weather_forecast',
             content='Sunny with a chance of rain',
             tool_call_id=None,
             timestamp=IsNow(tz=timezone.utc),
-            role='tool-return',
+            role='user',
+            message_kind='tool-return',
         ),
         ModelResponse(
             parts=[
@@ -164,7 +168,8 @@ async def test_forecast():
                 )
             ],
             timestamp=IsNow(tz=timezone.utc),
-            role='model-response',
+            role='model',
+            message_kind='model-response',
         ),
     ]
 ```
@@ -219,7 +224,7 @@ def call_weather_forecast(  # (1)!
     else:
         # second call, return the forecast
         msg = messages[-1]
-        assert msg.role == 'tool-return'
+        assert msg.message_kind == 'tool-return'
         return ModelResponse.from_text(f'The forecast is: {msg.content}')
 
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -70,12 +70,14 @@ print(dice_result.all_messages())
 [
     SystemPrompt(
         content="You're a dice game, you should roll the die and see if the number you get back matches the user's guess. If so, tell them they're a winner. Use the player's name in the response.",
-        role='system',
+        role='user',
+        message_kind='system-prompt',
     ),
     UserPrompt(
         content='My guess is 4',
         timestamp=datetime.datetime(...),
         role='user',
+        message_kind='user-prompt',
     ),
     ModelResponse(
         parts=[
@@ -83,18 +85,20 @@ print(dice_result.all_messages())
                 tool_name='roll_die',
                 args=ArgsDict(args_dict={}),
                 tool_call_id=None,
-                kind='tool-call',
+                part_kind='tool-call',
             )
         ],
-        role='model-response',
         timestamp=datetime.datetime(...),
+        role='model',
+        message_kind='model-response',
     ),
     ToolReturn(
         tool_name='roll_die',
         content='4',
         tool_call_id=None,
         timestamp=datetime.datetime(...),
-        role='tool-return',
+        role='user',
+        message_kind='tool-return',
     ),
     ModelResponse(
         parts=[
@@ -102,28 +106,31 @@ print(dice_result.all_messages())
                 tool_name='get_player_name',
                 args=ArgsDict(args_dict={}),
                 tool_call_id=None,
-                kind='tool-call',
+                part_kind='tool-call',
             )
         ],
-        role='model-response',
         timestamp=datetime.datetime(...),
+        role='model',
+        message_kind='model-response',
     ),
     ToolReturn(
         tool_name='get_player_name',
         content='Anne',
         tool_call_id=None,
         timestamp=datetime.datetime(...),
-        role='tool-return',
+        role='user',
+        message_kind='tool-return',
     ),
     ModelResponse(
         parts=[
             TextPart(
                 content="Congratulations Anne, you guessed correctly! You're a winner!",
-                kind='text',
+                part_kind='text',
             )
         ],
-        role='model-response',
         timestamp=datetime.datetime(...),
+        role='model',
+        message_kind='model-response',
     ),
 ]
 """

--- a/pydantic_ai_examples/chat_app.py
+++ b/pydantic_ai_examples/chat_app.py
@@ -98,7 +98,7 @@ async def post_chat(
 
 
 MessageTypeAdapter: TypeAdapter[Message] = TypeAdapter(
-    Annotated[Message, Field(discriminator='role')]
+    Annotated[Message, Field(discriminator='message_kind')]
 )
 P = ParamSpec('P')
 R = TypeVar('R')

--- a/pydantic_ai_examples/chat_app.ts
+++ b/pydantic_ai_examples/chat_app.ts
@@ -37,6 +37,7 @@ async function onFetchResponse(response: Response): Promise<void> {
 // in production, you might not want to keep this format all the way to the frontend
 interface Message {
   role: string
+  message_kind: string
   content: string
   timestamp: string
 }

--- a/pydantic_ai_examples/chat_app.ts
+++ b/pydantic_ai_examples/chat_app.ts
@@ -36,7 +36,6 @@ async function onFetchResponse(response: Response): Promise<void> {
 // The format of messages, this matches pydantic-ai both for brevity and understanding
 // in production, you might not want to keep this format all the way to the frontend
 interface Message {
-  role: string
   message_kind: string
   content: string
   timestamp: string
@@ -51,14 +50,14 @@ function addMessages(responseText: string) {
   const messages: Message[] = lines.filter(line => line.length > 1).map(j => JSON.parse(j))
   for (const message of messages) {
     // we use the timestamp as a crude element id
-    const {timestamp, role, content} = message
+    const {timestamp, message_kind, content} = message
     const id = `msg-${timestamp}`
     let msgDiv = document.getElementById(id)
     if (!msgDiv) {
       msgDiv = document.createElement('div')
       msgDiv.id = id
-      msgDiv.title = `${role} at ${timestamp}`
-      msgDiv.classList.add('border-top', 'pt-2', role)
+      msgDiv.title = `${message_kind} at ${timestamp}`
+      msgDiv.classList.add('border-top', 'pt-2', message_kind)
       convElement.appendChild(msgDiv)
     }
     msgDiv.innerHTML = marked.parse(content)

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -250,7 +250,7 @@ class Agent(Generic[AgentDeps, ResultData]):
                     model_response, request_cost = await agent_model.request(messages, model_settings)
                     model_req_span.set_attribute('response', model_response)
                     model_req_span.set_attribute('cost', request_cost)
-                    model_req_span.message = f'model request -> {model_response.role}'
+                    model_req_span.message = f'model request -> {model_response.message_kind}'
 
                 messages.append(model_response)
                 cost += request_cost
@@ -272,7 +272,7 @@ class Agent(Generic[AgentDeps, ResultData]):
                     else:
                         # continue the conversation
                         handle_span.set_attribute('tool_responses', response_messages)
-                        response_msgs = ' '.join(r.role for r in response_messages)
+                        response_msgs = ' '.join(r.message_kind for r in response_messages)
                         handle_span.message = f'handle model response -> {response_msgs}'
 
     def run_sync(
@@ -429,7 +429,7 @@ class Agent(Generic[AgentDeps, ResultData]):
                             else:
                                 # continue the conversation
                                 handle_span.set_attribute('tool_responses', response_messages)
-                                response_msgs = ' '.join(r.role for r in response_messages)
+                                response_msgs = ' '.join(r.message_kind for r in response_messages)
                                 handle_span.message = f'handle model response -> {response_msgs}'
                                 # the model_response should have been fully streamed by now, we can add it's cost
                                 cost += model_response.cost()
@@ -795,7 +795,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         self, deps: AgentDeps, user_prompt: str, message_history: list[_messages.Message] | None
     ) -> tuple[int, list[_messages.Message]]:
         # if message history includes system prompts, we don't want to regenerate them
-        if message_history and any(m.role == 'system' for m in message_history):
+        if message_history and any(m.message_kind == 'system-prompt' for m in message_history):
             # shallow copy messages
             messages = message_history.copy()
         else:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -196,7 +196,7 @@ class AnthropicAgentModel(AgentModel):
         anthropic_messages: list[MessageParam] = []
 
         for m in messages:
-            if m.role == 'system':
+            if m.message_kind == 'system-prompt':
                 system_prompt += m.content
             else:
                 anthropic_messages.append(self._map_message(m))

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -1241,11 +1241,12 @@ async def test_stream_tool_call_with_return_type(allow_model_requests: None):
 
     assert result.all_messages() == snapshot(
         [
-            SystemPrompt(content='this is the system prompt', role='system'),
+            SystemPrompt(content='this is the system prompt', role='user', message_kind='system-prompt'),
             UserPrompt(
                 content='User prompt value',
                 timestamp=IsNow(tz=timezone.utc),
                 role='user',
+                message_kind='user-prompt',
             ),
             ModelResponse(
                 parts=[
@@ -1262,20 +1263,24 @@ async def test_stream_tool_call_with_return_type(allow_model_requests: None):
                 content='{"lat": 51, "lng": 0}',
                 tool_call_id='1',
                 timestamp=IsNow(tz=timezone.utc),
-                role='tool-return',
+                role='user',
+                message_kind='tool-return',
             ),
             ToolReturn(
                 tool_name='final_result',
                 content='Final result processed.',
                 tool_call_id='1',
                 timestamp=IsNow(tz=timezone.utc),
-                role='tool-return',
+                role='user',
+                message_kind='tool-return',
             ),
             ModelResponse(
                 parts=[
                     ToolCallPart(tool_name='final_result', args=ArgsJson(args_json='{"won": true}'), tool_call_id='1')
                 ],
                 timestamp=IsNow(tz=timezone.utc),
+                role='model',
+                message_kind='model-response',
             ),
         ]
     )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -132,8 +132,10 @@ def test_result_pydantic_model_validation_error(set_event_loop: None):
     result = agent.run_sync('Hello')
     assert isinstance(result.data, Bar)
     assert result.data.model_dump() == snapshot({'a': 1, 'b': 'bar'})
-    message_roles = [m.role for m in result.all_messages()]
-    assert message_roles == snapshot(['user', 'model-response', 'retry-prompt', 'model-response', 'tool-return'])
+    messages_kinds = [m.message_kind for m in result.all_messages()]
+    assert messages_kinds == snapshot(
+        ['user-prompt', 'model-response', 'retry-prompt', 'model-response', 'tool-return']
+    )
 
     retry_prompt = result.all_messages()[2]
     assert isinstance(retry_prompt, RetryPrompt)
@@ -467,8 +469,8 @@ def test_run_with_history_new(set_event_loop: None):
             _cost=Cost(),
         )
     )
-    new_msg_roles = [msg.role for msg in result2.new_messages()]
-    assert new_msg_roles == snapshot(['user', 'model-response'])
+    new_msg_kinds = [msg.message_kind for msg in result2.new_messages()]
+    assert new_msg_kinds == snapshot(['user-prompt', 'model-response'])
     assert result2.new_messages_json().startswith(b'[{"content":"Hello again",')
 
     # if we pass all_messages, system prompt is NOT inserted before the message_history messages,
@@ -565,8 +567,8 @@ def test_run_with_history_new_structured(set_event_loop: None):
             _cost=Cost(),
         )
     )
-    new_msg_roles = [msg.role for msg in result2.new_messages()]
-    assert new_msg_roles == snapshot(['user', 'model-response', 'tool-return'])
+    new_msg_kinds = [msg.message_kind for msg in result2.new_messages()]
+    assert new_msg_kinds == snapshot(['user-prompt', 'model-response', 'tool-return'])
     assert result2.new_messages_json().startswith(b'[{"content":"Hello again",')
 
     # if we pass all_messages, system prompt is NOT inserted before the message_history messages,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -215,7 +215,7 @@ text_responses: dict[str, str | ToolCallPart] = {
 
 async def model_logic(messages: list[Message], info: AgentInfo) -> ModelResponse:  # pragma: no cover
     m = messages[-1]
-    if m.role == 'user':
+    if m.message_kind == 'user-prompt':
         if response := text_responses.get(m.content):
             if isinstance(response, str):
                 return ModelResponse.from_text(content=response)
@@ -225,24 +225,28 @@ async def model_logic(messages: list[Message], info: AgentInfo) -> ModelResponse
         if re.fullmatch(r'sql prompt \d+', m.content):
             return ModelResponse.from_text(content='SELECT 1')
 
-    elif m.role == 'tool-return' and m.tool_name == 'roulette_wheel':
+    elif m.message_kind == 'tool-return' and m.tool_name == 'roulette_wheel':
         win = m.content == 'winner'
         return ModelResponse(parts=[ToolCallPart(tool_name='final_result', args=ArgsDict({'response': win}))])
-    elif m.role == 'tool-return' and m.tool_name == 'roll_die':
+    elif m.message_kind == 'tool-return' and m.tool_name == 'roll_die':
         return ModelResponse(parts=[ToolCallPart(tool_name='get_player_name', args=ArgsDict({}))])
-    elif m.role == 'tool-return' and m.tool_name == 'get_player_name':
+    elif m.message_kind == 'tool-return' and m.tool_name == 'get_player_name':
         return ModelResponse.from_text(content="Congratulations Anne, you guessed correctly! You're a winner!")
-    if m.role == 'retry-prompt' and isinstance(m.content, str) and m.content.startswith("No user found with name 'Joh"):
+    if (
+        m.message_kind == 'retry-prompt'
+        and isinstance(m.content, str)
+        and m.content.startswith("No user found with name 'Joh")
+    ):
         return ModelResponse(parts=[ToolCallPart(tool_name='get_user_by_name', args=ArgsDict({'name': 'John Doe'}))])
-    elif m.role == 'tool-return' and m.tool_name == 'get_user_by_name':
+    elif m.message_kind == 'tool-return' and m.tool_name == 'get_user_by_name':
         args = {
             'message': 'Hello John, would you be free for coffee sometime next week? Let me know what works for you!',
             'user_id': 123,
         }
         return ModelResponse(parts=[ToolCallPart(tool_name='final_result', args=ArgsDict(args))])
-    elif m.role == 'retry-prompt' and m.tool_name == 'calc_volume':
+    elif m.message_kind == 'retry-prompt' and m.tool_name == 'calc_volume':
         return ModelResponse(parts=[ToolCallPart(tool_name='calc_volume', args=ArgsDict({'size': 6}))])
-    elif m.role == 'tool-return' and m.tool_name == 'customer_balance':
+    elif m.message_kind == 'tool-return' and m.tool_name == 'customer_balance':
         args = {
             'support_advice': 'Hello John, your current account balance, including pending transactions, is $123.45.',
             'block_card': False,
@@ -258,7 +262,7 @@ async def stream_model_logic(
     messages: list[Message], info: AgentInfo
 ) -> AsyncIterator[str | DeltaToolCalls]:  # pragma: no cover
     m = messages[-1]
-    if m.role == 'user':
+    if m.message_kind == 'user-prompt':
         if response := text_responses.get(m.content):
             if isinstance(response, str):
                 words = response.split(' ')

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -120,30 +120,38 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary], set_event_lo
             'logfire.span_type': 'span',
             'all_messages': IsJson(
                 [
-                    {'content': 'Hello', 'timestamp': IsStr(regex=r'\d{4}-\d{2}-.+'), 'role': 'user'},
+                    {
+                        'content': 'Hello',
+                        'timestamp': IsStr(regex=r'\d{4}-\d{2}-.+'),
+                        'role': 'user',
+                        'message_kind': 'user-prompt',
+                    },
                     {
                         'parts': [
                             {
                                 'tool_name': 'my_ret',
                                 'args': {'args_dict': {'x': 0}},
                                 'tool_call_id': None,
-                                'kind': 'tool-call',
+                                'part_kind': 'tool-call',
                             }
                         ],
-                        'role': 'model-response',
                         'timestamp': IsStr(regex=r'\d{4}-\d{2}-.+'),
+                        'role': 'model',
+                        'message_kind': 'model-response',
                     },
                     {
                         'tool_name': 'my_ret',
                         'content': '1',
                         'tool_call_id': None,
                         'timestamp': IsStr(regex=r'\d{4}-\d{2}-.+'),
-                        'role': 'tool-return',
+                        'role': 'user',
+                        'message_kind': 'tool-return',
                     },
                     {
-                        'parts': [{'content': '{"my_ret":"1"}', 'kind': 'text'}],
-                        'role': 'model-response',
+                        'parts': [{'content': '{"my_ret":"1"}', 'part_kind': 'text'}],
                         'timestamp': IsStr(regex=r'\d{4}-\d{2}-.+'),
+                        'role': 'model',
+                        'message_kind': 'model-response',
                     },
                 ]
             ),


### PR DESCRIPTION
Following up on https://github.com/pydantic/pydantic-ai/pull/232#discussion_r1884385346, where we discussed that this change should be added to a separate PR.

This PR changes the `Messages` structures such that each one has:

* `message_kind`: a discriminator used to identify the message type
* `role`: either `'model'` or `'user'`, like Gemini has, and similar to Anthropic's `'assistant'` or `'user'`

Message parts, which are used to construct a `ModelResponse` now have a `part_kind` discriminator instead of just a plain `kind`.