### PR TITLE
add `messages` to `RunContext`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_system_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/_system_prompt.py
@@ -21,7 +21,7 @@ class SystemPromptRunner(Generic[AgentDeps]):
 
     async def run(self, deps: AgentDeps) -> str:
         if self._takes_ctx:
-            args = (RunContext(deps, 0),)
+            args = (RunContext(deps, 0, [], None),)
         else:
             args = ()
 

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -220,9 +220,13 @@ class ModelResponse:
     message_kind: Literal['model-response'] = 'model-response'
     """Message source identifier, this type is available on all messages as a discriminator."""
 
-    @staticmethod
-    def from_text(content: str, timestamp: datetime | None = None) -> ModelResponse:
-        return ModelResponse([TextPart(content)], timestamp=timestamp or _now_utc())
+    @classmethod
+    def from_text(cls, content: str, timestamp: datetime | None = None) -> ModelResponse:
+        return cls([TextPart(content)], timestamp=timestamp or _now_utc())
+
+    @classmethod
+    def from_tool_call(cls, tool_call: ToolCallPart) -> ModelResponse:
+        return cls([tool_call])
 
 
 Message = Union[SystemPrompt, UserPrompt, ToolReturn, RetryPrompt, ModelResponse]


### PR DESCRIPTION
Particularly important for dynamic tools, when deciding whether a tool should be registered for a particular step.