### PR TITLE
docs: fix model name in ollama example

### DIFF
--- a/docs/api/models/ollama.md
+++ b/docs/api/models/ollama.md
@@ -26,7 +26,7 @@ class CityLocation(BaseModel):
     country: str
 
 
-agent = Agent('llama3.2', result_type=CityLocation)
+agent = Agent('ollama:llama3.2', result_type=CityLocation)
 
 result = agent.run_sync('Where were the olympics held in 2012?')
 print(result.data)


### PR DESCRIPTION
This PR essentially reverts https://github.com/pydantic/pydantic-ai/pull/279

When I followed https://github.com/pydantic/pydantic-ai/blob/af79e3d05fd8bc355e67402d5914a9c7c7bc8be5/docs/api/models/ollama.md?plain=1#L29

I got `pydantic_ai.exceptions.UserError: Unknown model: llama3.2`

```
Traceback (most recent call last):
  File "/dev/github.com/pydantic/pydantic-ai/test.py", line 11, in <module>
    agent = Agent('llama3.2', result_type=CityLocation)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/dev/github.com/pydantic/pydantic-ai/.venv/lib/python3.12/site-packages/pydantic_ai/agent.py", line 160, in __init__
    self.model = models.infer_model(model)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/dev/github.com/pydantic/pydantic-ai/.venv/lib/python3.12/site-packages/pydantic_ai/models/__init__.py", line 302, in infer_model
    raise UserError(f'Unknown model: {model}')
pydantic_ai.exceptions.UserError: Unknown model: llama3.2
```

turns out the `Agent` class initialization checks the prefix:

https://github.com/pydantic/pydantic-ai/blob/af79e3d05fd8bc355e67402d5914a9c7c7bc8be5/pydantic_ai_slim/pydantic_ai/models/__init__.py#L66

https://github.com/pydantic/pydantic-ai/blob/af79e3d05fd8bc355e67402d5914a9c7c7bc8be5/pydantic_ai_slim/pydantic_ai/models/__init__.py#L293