### PR TITLE
Had to change the chat_app FastAPI Example to get it to work after copying

### DIFF
--- a/pydantic_ai_examples/chat_app.py
+++ b/pydantic_ai_examples/chat_app.py
@@ -136,9 +136,10 @@ async def post_chat(
     return StreamingResponse(stream_messages(), media_type='text/plain')
 
 
-MessageTypeAdapter: TypeAdapter[ModelMessage] = TypeAdapter(
-    Annotated[ModelMessage, Field(discriminator='message_kind')]
-)
+# MessageTypeAdapter: TypeAdapter[ModelMessage] = TypeAdapter(
+#     Annotated[ModelMessage, Field(discriminator='message_kind')]
+# )
+
 P = ParamSpec('P')
 R = TypeVar('R')
 
@@ -223,5 +224,5 @@ if __name__ == '__main__':
     import uvicorn
 
     uvicorn.run(
-        'pydantic_ai_examples.chat_app:app', reload=True, reload_dirs=[str(THIS_DIR)]
+        'chat_app:app', reload=True, reload_dirs=[str(THIS_DIR)]
     )


### PR DESCRIPTION
I copied to examples:
```
python -m pydantic_ai_examples --copy-to examples/
```

And then tried to run it:
```
python examples/chat_app.py 
```

But had it surfacing an error ending with (adding this so someone finds this when searching)
```
pydantic.errors.PydanticUserError: Dataclass 'ModelRequest' needs a discriminator field for key 'message_kind'
```

And upon editing the file to remove the MessageTypeAdapter, I saw that it wasn't being used because uvicorn pointed to the installed version, not the current file version. Once I made this change, I was able to run this example.