### PR TITLE
Fix ModelMessage discriminator in chat_app example

### DIFF
--- a/pydantic_ai_examples/chat_app.py
+++ b/pydantic_ai_examples/chat_app.py
@@ -137,7 +137,7 @@ async def post_chat(
 
 
 MessageTypeAdapter: TypeAdapter[ModelMessage] = TypeAdapter(
-    Annotated[ModelMessage, Field(discriminator='message_kind')]
+    Annotated[ModelMessage, Field(discriminator='kind')]
 )
 P = ParamSpec('P')
 R = TypeVar('R')


### PR DESCRIPTION
`ModelRequest` and `ModelResponse` use `kind` instead of `message_kind` attribute.