### PR TITLE
Rename `Cost` to `Usage`

### DIFF
--- a/docs/api/models/ollama.md
+++ b/docs/api/models/ollama.md
@@ -31,8 +31,8 @@ agent = Agent('ollama:llama3.2', result_type=CityLocation)
 result = agent.run_sync('Where were the olympics held in 2012?')
 print(result.data)
 #> city='London' country='United Kingdom'
-print(result.cost())
-#> Cost(request_tokens=57, response_tokens=8, total_tokens=65, details=None)
+print(result.usage())
+#> Usage(request_tokens=57, response_tokens=8, total_tokens=65, details=None)
 ```
 
 ## Example using a remote server
@@ -59,8 +59,8 @@ agent = Agent(model=ollama_model, result_type=CityLocation)
 result = agent.run_sync('Where were the olympics held in 2012?')
 print(result.data)
 #> city='London' country='United Kingdom'
-print(result.cost())
-#> Cost(request_tokens=57, response_tokens=8, total_tokens=65, details=None)
+print(result.usage())
+#> Usage(request_tokens=57, response_tokens=8, total_tokens=65, details=None)
 ```
 
 1. The name of the model running on the remote server

--- a/docs/api/result.md
+++ b/docs/api/result.md
@@ -7,4 +7,4 @@
         - ResultData
         - RunResult
         - StreamedRunResult
-        - Cost
+        - Usage

--- a/docs/results.md
+++ b/docs/results.md
@@ -1,5 +1,5 @@
 Results are the final values returned from [running an agent](agents.md#running-agents).
-The result values are wrapped in [`RunResult`][pydantic_ai.result.RunResult] and [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] so you can access other data like [cost][pydantic_ai.result.Cost] of the run and [message history](message-history.md#accessing-messages-from-results)
+The result values are wrapped in [`RunResult`][pydantic_ai.result.RunResult] and [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] so you can access other data like [usage][pydantic_ai.result.Usage] of the run and [message history](message-history.md#accessing-messages-from-results)
 
 Both `RunResult` and `StreamedRunResult` are generic in the data they wrap, so typing information about the data returned by the agent is preserved.
 
@@ -18,8 +18,8 @@ agent = Agent('gemini-1.5-flash', result_type=CityLocation)
 result = agent.run_sync('Where were the olympics held in 2012?')
 print(result.data)
 #> city='London' country='United Kingdom'
-print(result.cost())
-#> Cost(request_tokens=57, response_tokens=8, total_tokens=65, details=None)
+print(result.usage())
+#> Usage(request_tokens=57, response_tokens=8, total_tokens=65, details=None)
 ```
 
 _(This example is complete, it can be run "as is")_

--- a/docs/testing-evals.md
+++ b/docs/testing-evals.md
@@ -18,7 +18,7 @@ Unless you're really sure you know better, you'll probably want to follow roughl
 * Use [`pytest`](https://docs.pytest.org/en/stable/) as your test harness
 * If you find yourself typing out long assertions, use [inline-snapshot](https://15r10nk.github.io/inline-snapshot/latest/)
 * Similarly, [dirty-equals](https://dirty-equals.helpmanual.io/latest/) can be useful for comparing large data structures
-* Use [`TestModel`][pydantic_ai.models.test.TestModel] or [`FunctionModel`][pydantic_ai.models.function.FunctionModel] in place of your actual model to avoid the cost, latency and variability of real LLM calls
+* Use [`TestModel`][pydantic_ai.models.test.TestModel] or [`FunctionModel`][pydantic_ai.models.function.FunctionModel] in place of your actual model to avoid the usage, latency and variability of real LLM calls
 * Use [`Agent.override`][pydantic_ai.agent.Agent.override] to replace your model inside your application logic
 * Set [`ALLOW_MODEL_REQUESTS=False`][pydantic_ai.models.ALLOW_MODEL_REQUESTS] globally to block any requests from being made to non-test models accidentally
 

--- a/pydantic_ai_examples/pydantic_model.py
+++ b/pydantic_ai_examples/pydantic_model.py
@@ -30,4 +30,4 @@ agent = Agent(model, result_type=MyModel)
 if __name__ == '__main__':
     result = agent.run_sync('The windy city in the US of A.')
     print(result.data)
-    print(result.cost())
+    print(result.usage())

--- a/pydantic_ai_examples/stream_markdown.py
+++ b/pydantic_ai_examples/stream_markdown.py
@@ -43,7 +43,7 @@ async def main():
                 async with agent.run_stream(prompt, model=model) as result:
                     async for message in result.stream():
                         live.update(Markdown(message))
-            console.log(result.cost())
+            console.log(result.usage())
         else:
             console.log(f'{model} requires {env_var} to be set.')
 

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -237,7 +237,7 @@ class Agent(Generic[AgentDeps, ResultData]):
             for tool in self._function_tools.values():
                 tool.current_retry = 0
 
-            cost = result.Cost()
+            usage = result.Usage()
 
             model_settings = merge_model_settings(self.model_settings, model_settings)
 
@@ -248,12 +248,12 @@ class Agent(Generic[AgentDeps, ResultData]):
                     agent_model = await self._prepare_model(model_used, deps, messages)
 
                 with _logfire.span('model request', run_step=run_step) as model_req_span:
-                    model_response, request_cost = await agent_model.request(messages, model_settings)
+                    model_response, request_usage = await agent_model.request(messages, model_settings)
                     model_req_span.set_attribute('response', model_response)
-                    model_req_span.set_attribute('cost', request_cost)
+                    model_req_span.set_attribute('usage', request_usage)
 
                 messages.append(model_response)
-                cost += request_cost
+                usage += request_usage
 
                 with _logfire.span('handle model response', run_step=run_step) as handle_span:
                     final_result, tool_responses = await self._handle_model_response(model_response, deps, messages)
@@ -266,10 +266,10 @@ class Agent(Generic[AgentDeps, ResultData]):
                     if final_result is not None:
                         result_data = final_result.data
                         run_span.set_attribute('all_messages', messages)
-                        run_span.set_attribute('cost', cost)
+                        run_span.set_attribute('usage', usage)
                         handle_span.set_attribute('result', result_data)
                         handle_span.message = 'handle model response -> final result'
-                        return result.RunResult(messages, new_message_index, result_data, cost)
+                        return result.RunResult(messages, new_message_index, result_data, usage)
                     else:
                         # continue the conversation
                         handle_span.set_attribute('tool_responses', tool_responses)
@@ -385,7 +385,7 @@ class Agent(Generic[AgentDeps, ResultData]):
             for tool in self._function_tools.values():
                 tool.current_retry = 0
 
-            cost = result.Cost()
+            usage = result.Usage()
             model_settings = merge_model_settings(self.model_settings, model_settings)
 
             run_step = 0
@@ -434,7 +434,7 @@ class Agent(Generic[AgentDeps, ResultData]):
                                 yield result.StreamedRunResult(
                                     messages,
                                     new_message_index,
-                                    cost,
+                                    usage,
                                     result_stream,
                                     self._result_schema,
                                     deps,
@@ -455,8 +455,8 @@ class Agent(Generic[AgentDeps, ResultData]):
                                 handle_span.set_attribute('tool_responses', tool_responses)
                                 tool_responses_str = ' '.join(r.part_kind for r in tool_responses)
                                 handle_span.message = f'handle model response -> {tool_responses_str}'
-                                # the model_response should have been fully streamed by now, we can add it's cost
-                                cost += model_response.cost()
+                                # the model_response should have been fully streamed by now, we can add its usage
+                                usage += model_response.usage()
 
     @contextmanager
     def override(
@@ -988,7 +988,7 @@ class Agent(Generic[AgentDeps, ResultData]):
                 response = _messages.RetryPromptPart(
                     content='Plain text responses are not permitted, please call one of the functions instead.',
                 )
-                # stream the response, so cost is correct
+                # stream the response, so usage is correct
                 async for _ in model_response:
                     pass
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -20,7 +20,7 @@ from ..messages import ModelMessage, ModelResponse
 from ..settings import ModelSettings
 
 if TYPE_CHECKING:
-    from ..result import Cost
+    from ..result import Usage
     from ..tools import ToolDefinition
 
 
@@ -122,7 +122,7 @@ class AgentModel(ABC):
     @abstractmethod
     async def request(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
-    ) -> tuple[ModelResponse, Cost]:
+    ) -> tuple[ModelResponse, Usage]:
         """Make a request to the model."""
         raise NotImplementedError()
 
@@ -164,10 +164,10 @@ class StreamTextResponse(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def cost(self) -> Cost:
-        """Return the cost of the request.
+    def usage(self) -> Usage:
+        """Return the usage of the request.
 
-        NOTE: this won't return the ful cost until the stream is finished.
+        NOTE: this won't return the full usage until the stream is finished.
         """
         raise NotImplementedError()
 
@@ -205,10 +205,10 @@ class StreamStructuredResponse(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def cost(self) -> Cost:
-        """Get the cost of the request.
+    def usage(self) -> Usage:
+        """Get the usage of the request.
 
-        NOTE: this won't return the full cost until the stream is finished.
+        NOTE: this won't return the full usage until the stream is finished.
         """
         raise NotImplementedError()
 
@@ -235,7 +235,7 @@ The testing models [`TestModel`][pydantic_ai.models.test.TestModel] and
 def check_allow_model_requests() -> None:
     """Check if model requests are allowed.
 
-    If you're defining your own models that have cost or latency associated with their use, you should call this in
+    If you're defining your own models that have costs or latency associated with their use, you should call this in
     [`Model.agent_model`][pydantic_ai.models.Model.agent_model].
 
     Raises:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -158,9 +158,9 @@ class AnthropicAgentModel(AgentModel):
 
     async def request(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
-    ) -> tuple[ModelResponse, result.Cost]:
+    ) -> tuple[ModelResponse, result.Usage]:
         response = await self._messages_create(messages, False, model_settings)
-        return self._process_response(response), _map_cost(response)
+        return self._process_response(response), _map_usage(response)
 
     @asynccontextmanager
     async def request_stream(
@@ -315,7 +315,7 @@ def _map_tool_call(t: ToolCallPart) -> ToolUseBlockParam:
     )
 
 
-def _map_cost(message: AnthropicMessage | RawMessageStreamEvent) -> result.Cost:
+def _map_usage(message: AnthropicMessage | RawMessageStreamEvent) -> result.Usage:
     if isinstance(message, AnthropicMessage):
         usage = message.usage
     else:
@@ -332,11 +332,11 @@ def _map_cost(message: AnthropicMessage | RawMessageStreamEvent) -> result.Cost:
             usage = None
 
     if usage is None:
-        return result.Cost()
+        return result.Usage()
 
     request_tokens = getattr(usage, 'input_tokens', None)
 
-    return result.Cost(
+    return result.Usage(
         # Usage coming from the RawMessageDeltaEvent doesn't have input token data, hence this getattr
         request_tokens=request_tokens,
         response_tokens=usage.output_tokens,

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -25,7 +25,7 @@ from ..messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from ..result import Cost
+from ..result import Usage
 from ..settings import ModelSettings
 from ..tools import ToolDefinition
 from . import (
@@ -158,9 +158,9 @@ class GroqAgentModel(AgentModel):
 
     async def request(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
-    ) -> tuple[ModelResponse, result.Cost]:
+    ) -> tuple[ModelResponse, result.Usage]:
         response = await self._completions_create(messages, False, model_settings)
-        return self._process_response(response), _map_cost(response)
+        return self._process_response(response), _map_usage(response)
 
     @asynccontextmanager
     async def request_stream(
@@ -228,7 +228,7 @@ class GroqAgentModel(AgentModel):
     async def _process_streamed_response(response: AsyncStream[ChatCompletionChunk]) -> EitherStreamedResponse:
         """Process a streamed response, and prepare a streaming response to return."""
         timestamp: datetime | None = None
-        start_cost = Cost()
+        start_usage = Usage()
         # the first chunk may contain enough information so we iterate until we get either `tool_calls` or `content`
         while True:
             try:
@@ -236,19 +236,19 @@ class GroqAgentModel(AgentModel):
             except StopAsyncIteration as e:
                 raise UnexpectedModelBehavior('Streamed response ended without content or tool calls') from e
             timestamp = timestamp or datetime.fromtimestamp(chunk.created, tz=timezone.utc)
-            start_cost += _map_cost(chunk)
+            start_usage += _map_usage(chunk)
 
             if chunk.choices:
                 delta = chunk.choices[0].delta
 
                 if delta.content is not None:
-                    return GroqStreamTextResponse(delta.content, response, timestamp, start_cost)
+                    return GroqStreamTextResponse(delta.content, response, timestamp, start_usage)
                 elif delta.tool_calls is not None:
                     return GroqStreamStructuredResponse(
                         response,
                         {c.index: c for c in delta.tool_calls},
                         timestamp,
-                        start_cost,
+                        start_usage,
                     )
 
     @classmethod
@@ -308,7 +308,7 @@ class GroqStreamTextResponse(StreamTextResponse):
     _first: str | None
     _response: AsyncStream[ChatCompletionChunk]
     _timestamp: datetime
-    _cost: result.Cost
+    _usage: result.Usage
     _buffer: list[str] = field(default_factory=list, init=False)
 
     async def __anext__(self) -> None:
@@ -318,7 +318,7 @@ class GroqStreamTextResponse(StreamTextResponse):
             return None
 
         chunk = await self._response.__anext__()
-        self._cost = _map_cost(chunk)
+        self._usage = _map_usage(chunk)
 
         try:
             choice = chunk.choices[0]
@@ -335,8 +335,8 @@ class GroqStreamTextResponse(StreamTextResponse):
         yield from self._buffer
         self._buffer.clear()
 
-    def cost(self) -> Cost:
-        return self._cost
+    def usage(self) -> Usage:
+        return self._usage
 
     def timestamp(self) -> datetime:
         return self._timestamp
@@ -349,11 +349,11 @@ class GroqStreamStructuredResponse(StreamStructuredResponse):
     _response: AsyncStream[ChatCompletionChunk]
     _delta_tool_calls: dict[int, ChoiceDeltaToolCall]
     _timestamp: datetime
-    _cost: result.Cost
+    _usage: result.Usage
 
     async def __anext__(self) -> None:
         chunk = await self._response.__anext__()
-        self._cost = _map_cost(chunk)
+        self._usage = _map_usage(chunk)
 
         try:
             choice = chunk.choices[0]
@@ -384,8 +384,8 @@ class GroqStreamStructuredResponse(StreamStructuredResponse):
 
         return ModelResponse(items, timestamp=self._timestamp)
 
-    def cost(self) -> Cost:
-        return self._cost
+    def usage(self) -> Usage:
+        return self._usage
 
     def timestamp(self) -> datetime:
         return self._timestamp
@@ -400,7 +400,7 @@ def _map_tool_call(t: ToolCallPart) -> chat.ChatCompletionMessageToolCallParam:
     )
 
 
-def _map_cost(completion: ChatCompletionChunk | ChatCompletion) -> result.Cost:
+def _map_usage(completion: ChatCompletionChunk | ChatCompletion) -> result.Usage:
     usage = None
     if isinstance(completion, ChatCompletion):
         usage = completion.usage
@@ -408,9 +408,9 @@ def _map_cost(completion: ChatCompletionChunk | ChatCompletion) -> result.Cost:
         usage = completion.x_groq.usage
 
     if usage is None:
-        return result.Cost()
+        return result.Usage()
 
-    return result.Cost(
+    return result.Usage(
         request_tokens=usage.prompt_tokens,
         response_tokens=usage.completion_tokens,
         total_tokens=usage.total_tokens,

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -40,7 +40,7 @@ from pydantic_ai.models.gemini import (
     _GeminiTools,
     _GeminiUsageMetaData,
 )
-from pydantic_ai.result import Cost
+from pydantic_ai.result import Usage
 from pydantic_ai.tools import ToolDefinition
 
 from ..conftest import ClientWithHandler, IsNow, TestEnv
@@ -396,7 +396,7 @@ async def test_text_success(get_gemini_client: GetGeminiClient):
             ModelResponse.from_text(content='Hello world', timestamp=IsNow(tz=timezone.utc)),
         ]
     )
-    assert result.cost() == snapshot(Cost(request_tokens=1, response_tokens=2, total_tokens=3))
+    assert result.usage() == snapshot(Usage(request_tokens=1, response_tokens=2, total_tokens=3))
 
     result = await agent.run('Hello', message_history=result.new_messages())
     assert result.data == 'Hello world'
@@ -517,7 +517,7 @@ async def test_request_tool_call(get_gemini_client: GetGeminiClient):
             ModelResponse.from_text(content='final response', timestamp=IsNow(tz=timezone.utc)),
         ]
     )
-    assert result.cost() == snapshot(Cost(request_tokens=3, response_tokens=6, total_tokens=9))
+    assert result.usage() == snapshot(Usage(request_tokens=3, response_tokens=6, total_tokens=9))
 
 
 async def test_unexpected_response(client_with_handler: ClientWithHandler, env: TestEnv, allow_model_requests: None):
@@ -572,12 +572,12 @@ async def test_stream_text(get_gemini_client: GetGeminiClient):
     async with agent.run_stream('Hello') as result:
         chunks = [chunk async for chunk in result.stream(debounce_by=None)]
         assert chunks == snapshot(['Hello ', 'Hello world'])
-    assert result.cost() == snapshot(Cost(request_tokens=2, response_tokens=4, total_tokens=6))
+    assert result.usage() == snapshot(Usage(request_tokens=2, response_tokens=4, total_tokens=6))
 
     async with agent.run_stream('Hello') as result:
         chunks = [chunk async for chunk in result.stream_text(delta=True, debounce_by=None)]
         assert chunks == snapshot(['', 'Hello ', 'world'])
-    assert result.cost() == snapshot(Cost(request_tokens=2, response_tokens=4, total_tokens=6))
+    assert result.usage() == snapshot(Usage(request_tokens=2, response_tokens=4, total_tokens=6))
 
 
 async def test_stream_text_no_data(get_gemini_client: GetGeminiClient):
@@ -609,7 +609,7 @@ async def test_stream_structured(get_gemini_client: GetGeminiClient):
     async with agent.run_stream('Hello') as result:
         chunks = [chunk async for chunk in result.stream(debounce_by=None)]
         assert chunks == snapshot([(1, 2), (1, 2), (1, 2)])
-    assert result.cost() == snapshot(Cost(request_tokens=1, response_tokens=2, total_tokens=3))
+    assert result.usage() == snapshot(Usage(request_tokens=1, response_tokens=2, total_tokens=3))
 
 
 async def test_stream_structured_tool_calls(get_gemini_client: GetGeminiClient):
@@ -652,7 +652,7 @@ async def test_stream_structured_tool_calls(get_gemini_client: GetGeminiClient):
     async with agent.run_stream('Hello') as result:
         response = await result.get_data()
         assert response == snapshot((1, 2))
-    assert result.cost() == snapshot(Cost(request_tokens=3, response_tokens=6, total_tokens=9))
+    assert result.usage() == snapshot(Usage(request_tokens=3, response_tokens=6, total_tokens=9))
     assert result.all_messages() == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))]),

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -22,7 +22,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from pydantic_ai.result import Cost
+from pydantic_ai.result import Usage
 
 from ..conftest import IsNow, try_import
 
@@ -128,14 +128,14 @@ async def test_request_simple_success(allow_model_requests: None):
 
     result = await agent.run('hello')
     assert result.data == 'world'
-    assert result.cost() == snapshot(Cost())
+    assert result.usage() == snapshot(Usage())
 
     # reset the index so we get the same response again
     mock_client.index = 0  # type: ignore
 
     result = await agent.run('hello', message_history=result.new_messages())
     assert result.data == 'world'
-    assert result.cost() == snapshot(Cost())
+    assert result.usage() == snapshot(Usage())
     assert result.all_messages() == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
@@ -411,7 +411,7 @@ async def test_stream_structured(allow_model_requests: None):
         )
         assert result.is_complete
 
-    assert result.cost() == snapshot(Cost())
+    assert result.usage() == snapshot(Usage())
     assert result.all_messages() == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='', timestamp=IsNow(tz=timezone.utc))]),

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -228,15 +228,15 @@ async def test_multiple_completions(allow_model_requests: None):
 
     # Then
     assert result.data == 'world'
-    assert result.cost().request_tokens == 1
-    assert result.cost().response_tokens == 1
-    assert result.cost().total_tokens == 1
+    assert result.usage().request_tokens == 1
+    assert result.usage().response_tokens == 1
+    assert result.usage().total_tokens == 1
 
     result = await agent.run('hello again', message_history=result.new_messages())
     assert result.data == 'hello again'
-    assert result.cost().request_tokens == 1
-    assert result.cost().response_tokens == 1
-    assert result.cost().total_tokens == 1
+    assert result.usage().request_tokens == 1
+    assert result.usage().response_tokens == 1
+    assert result.usage().total_tokens == 1
     assert result.all_messages() == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
@@ -266,21 +266,21 @@ async def test_three_completions(allow_model_requests: None):
 
     # Them
     assert result.data == 'world'
-    assert result.cost().request_tokens == 1
-    assert result.cost().response_tokens == 1
-    assert result.cost().total_tokens == 1
+    assert result.usage().request_tokens == 1
+    assert result.usage().response_tokens == 1
+    assert result.usage().total_tokens == 1
 
     result = await agent.run('hello again', message_history=result.all_messages())
     assert result.data == 'hello again'
-    assert result.cost().request_tokens == 1
-    assert result.cost().response_tokens == 1
-    assert result.cost().total_tokens == 1
+    assert result.usage().request_tokens == 1
+    assert result.usage().response_tokens == 1
+    assert result.usage().total_tokens == 1
 
     result = await agent.run('final message', message_history=result.all_messages())
     assert result.data == 'final message'
-    assert result.cost().request_tokens == 1
-    assert result.cost().response_tokens == 1
-    assert result.cost().total_tokens == 1
+    assert result.usage().request_tokens == 1
+    assert result.usage().response_tokens == 1
+    assert result.usage().total_tokens == 1
     assert result.all_messages() == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
@@ -314,9 +314,9 @@ async def test_stream_text(allow_model_requests: None):
             ['hello ', 'hello world ', 'hello world welcome ', 'hello world welcome mistral']
         )
         assert result.is_complete
-        assert result.cost().request_tokens == 5
-        assert result.cost().response_tokens == 5
-        assert result.cost().total_tokens == 5
+        assert result.usage().request_tokens == 5
+        assert result.usage().response_tokens == 5
+        assert result.usage().total_tokens == 5
 
 
 async def test_stream_text_finish_reason(allow_model_requests: None):
@@ -349,9 +349,9 @@ async def test_no_delta(allow_model_requests: None):
         assert not result.is_complete
         assert [c async for c in result.stream(debounce_by=None)] == snapshot(['hello ', 'hello world'])
         assert result.is_complete
-        assert result.cost().request_tokens == 3
-        assert result.cost().response_tokens == 3
-        assert result.cost().total_tokens == 3
+        assert result.usage().request_tokens == 3
+        assert result.usage().response_tokens == 3
+        assert result.usage().total_tokens == 3
 
 
 #####################
@@ -388,9 +388,9 @@ async def test_request_model_structured_with_arguments_dict_response(allow_model
 
     # Then
     assert result.data == CityLocation(city='paris', country='france')
-    assert result.cost().request_tokens == 1
-    assert result.cost().response_tokens == 2
-    assert result.cost().total_tokens == 3
+    assert result.usage().request_tokens == 1
+    assert result.usage().response_tokens == 2
+    assert result.usage().total_tokens == 3
     assert result.all_messages() == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='User prompt value', timestamp=IsNow(tz=timezone.utc))]),
@@ -448,10 +448,10 @@ async def test_request_model_structured_with_arguments_str_response(allow_model_
 
     # Then
     assert result.data == CityLocation(city='paris', country='france')
-    assert result.cost().request_tokens == 1
-    assert result.cost().response_tokens == 1
-    assert result.cost().total_tokens == 1
-    assert result.cost().details is None
+    assert result.usage().request_tokens == 1
+    assert result.usage().response_tokens == 1
+    assert result.usage().total_tokens == 1
+    assert result.usage().details is None
     assert result.all_messages() == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='User prompt value', timestamp=IsNow(tz=timezone.utc))]),
@@ -503,10 +503,10 @@ async def test_request_result_type_with_arguments_str_response(allow_model_reque
 
     # Then
     assert result.data == 42
-    assert result.cost().request_tokens == 1
-    assert result.cost().response_tokens == 1
-    assert result.cost().total_tokens == 1
-    assert result.cost().details is None
+    assert result.usage().request_tokens == 1
+    assert result.usage().response_tokens == 1
+    assert result.usage().total_tokens == 1
+    assert result.usage().details is None
     assert result.all_messages() == snapshot(
         [
             ModelRequest(
@@ -642,12 +642,12 @@ async def test_stream_structured_with_all_typd(allow_model_requests: None):
             ]
         )
         assert result.is_complete
-        assert result.cost().request_tokens == 10
-        assert result.cost().response_tokens == 10
-        assert result.cost().total_tokens == 10
+        assert result.usage().request_tokens == 10
+        assert result.usage().response_tokens == 10
+        assert result.usage().total_tokens == 10
 
-        # double check cost matches stream count
-        assert result.cost().response_tokens == len(stream)
+        # double check usage matches stream count
+        assert result.usage().response_tokens == len(stream)
 
 
 async def test_stream_result_type_primitif_dict(allow_model_requests: None):
@@ -733,12 +733,12 @@ async def test_stream_result_type_primitif_dict(allow_model_requests: None):
             ]
         )
         assert result.is_complete
-        assert result.cost().request_tokens == 34
-        assert result.cost().response_tokens == 34
-        assert result.cost().total_tokens == 34
+        assert result.usage().request_tokens == 34
+        assert result.usage().response_tokens == 34
+        assert result.usage().total_tokens == 34
 
-        # double check cost matches stream count
-        assert result.cost().response_tokens == len(stream)
+        # double check usage matches stream count
+        assert result.usage().response_tokens == len(stream)
 
 
 async def test_stream_result_type_primitif_int(allow_model_requests: None):
@@ -766,12 +766,12 @@ async def test_stream_result_type_primitif_int(allow_model_requests: None):
         v = [c async for c in result.stream(debounce_by=None)]
         assert v == snapshot([1, 1, 1])
         assert result.is_complete
-        assert result.cost().request_tokens == 6
-        assert result.cost().response_tokens == 6
-        assert result.cost().total_tokens == 6
+        assert result.usage().request_tokens == 6
+        assert result.usage().response_tokens == 6
+        assert result.usage().total_tokens == 6
 
-        # double check cost matches stream count
-        assert result.cost().response_tokens == len(stream)
+        # double check usage matches stream count
+        assert result.usage().response_tokens == len(stream)
 
 
 async def test_stream_result_type_primitif_array(allow_model_requests: None):
@@ -861,12 +861,12 @@ async def test_stream_result_type_primitif_array(allow_model_requests: None):
             ]
         )
         assert result.is_complete
-        assert result.cost().request_tokens == 35
-        assert result.cost().response_tokens == 35
-        assert result.cost().total_tokens == 35
+        assert result.usage().request_tokens == 35
+        assert result.usage().response_tokens == 35
+        assert result.usage().total_tokens == 35
 
-        # double check cost matches stream count
-        assert result.cost().response_tokens == len(stream)
+        # double check usage matches stream count
+        assert result.usage().response_tokens == len(stream)
 
 
 async def test_stream_result_type_basemodel(allow_model_requests: None):
@@ -950,12 +950,12 @@ async def test_stream_result_type_basemodel(allow_model_requests: None):
             ]
         )
         assert result.is_complete
-        assert result.cost().request_tokens == 34
-        assert result.cost().response_tokens == 34
-        assert result.cost().total_tokens == 34
+        assert result.usage().request_tokens == 34
+        assert result.usage().response_tokens == 34
+        assert result.usage().total_tokens == 34
 
-        # double check cost matches stream count
-        assert result.cost().response_tokens == len(stream)
+        # double check usage matches stream count
+        assert result.usage().response_tokens == len(stream)
 
 
 #####################
@@ -1020,9 +1020,9 @@ async def test_request_tool_call(allow_model_requests: None):
 
     # Then
     assert result.data == 'final response'
-    assert result.cost().request_tokens == 6
-    assert result.cost().response_tokens == 4
-    assert result.cost().total_tokens == 10
+    assert result.usage().request_tokens == 6
+    assert result.usage().response_tokens == 4
+    assert result.usage().total_tokens == 10
     assert result.all_messages() == snapshot(
         [
             ModelRequest(
@@ -1156,9 +1156,9 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
 
     # Then
     assert result.data == {'lat': 51, 'lng': 0}
-    assert result.cost().request_tokens == 7
-    assert result.cost().response_tokens == 4
-    assert result.cost().total_tokens == 12
+    assert result.usage().request_tokens == 7
+    assert result.usage().response_tokens == 4
+    assert result.usage().total_tokens == 12
     assert result.all_messages() == snapshot(
         [
             ModelRequest(
@@ -1292,12 +1292,12 @@ async def test_stream_tool_call_with_return_type(allow_model_requests: None):
         assert v == snapshot([{'won': True}, {'won': True}])
         assert result.is_complete
         assert result.timestamp() == datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
-        assert result.cost().request_tokens == 4
-        assert result.cost().response_tokens == 4
-        assert result.cost().total_tokens == 4
+        assert result.usage().request_tokens == 4
+        assert result.usage().response_tokens == 4
+        assert result.usage().total_tokens == 4
 
-        # double check cost matches stream count
-        assert result.cost().response_tokens == 4
+        # double check usage matches stream count
+        assert result.usage().response_tokens == 4
 
     assert result.all_messages() == snapshot(
         [
@@ -1395,12 +1395,12 @@ async def test_stream_tool_call(allow_model_requests: None):
         assert v == snapshot(['final ', 'final response'])
         assert result.is_complete
         assert result.timestamp() == datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
-        assert result.cost().request_tokens == 6
-        assert result.cost().response_tokens == 6
-        assert result.cost().total_tokens == 6
+        assert result.usage().request_tokens == 6
+        assert result.usage().response_tokens == 6
+        assert result.usage().total_tokens == 6
 
-        # double check cost matches stream count
-        assert result.cost().response_tokens == 6
+        # double check usage matches stream count
+        assert result.usage().response_tokens == 6
 
     assert result.all_messages() == snapshot(
         [
@@ -1496,12 +1496,12 @@ async def test_stream_tool_call_with_retry(allow_model_requests: None):
         assert v == snapshot(['final ', 'final response'])
         assert result.is_complete
         assert result.timestamp() == datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
-        assert result.cost().request_tokens == 7
-        assert result.cost().response_tokens == 7
-        assert result.cost().total_tokens == 7
+        assert result.usage().request_tokens == 7
+        assert result.usage().response_tokens == 7
+        assert result.usage().total_tokens == 7
 
-        # double check cost matches stream count
-        assert result.cost().response_tokens == 7
+        # double check usage matches stream count
+        assert result.usage().response_tokens == 7
 
     assert result.all_messages() == snapshot(
         [

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -23,7 +23,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.result import Cost
+from pydantic_ai.result import Usage
 
 from ..conftest import IsNow
 
@@ -399,7 +399,7 @@ async def test_stream_text():
                 ModelResponse.from_text(content='hello world', timestamp=IsNow(tz=timezone.utc)),
             ]
         )
-        assert result.cost() == snapshot(Cost())
+        assert result.usage() == snapshot(Usage())
 
 
 class Foo(BaseModel):
@@ -420,7 +420,7 @@ async def test_stream_structure():
     agent = Agent(FunctionModel(stream_function=stream_structured_function), result_type=Foo)
     async with agent.run_stream('') as result:
         assert await result.get_data() == snapshot(Foo(x=1))
-        assert result.cost() == snapshot(Cost())
+        assert result.usage() == snapshot(Usage())
 
 
 async def test_pass_neither():

--- a/tests/models/test_ollama.py
+++ b/tests/models/test_ollama.py
@@ -11,7 +11,7 @@ from pydantic_ai.messages import (
     ModelResponse,
     UserPromptPart,
 )
-from pydantic_ai.result import Cost
+from pydantic_ai.result import Usage
 
 from ..conftest import IsNow, try_import
 
@@ -44,14 +44,14 @@ async def test_request_simple_success(allow_model_requests: None):
 
     result = await agent.run('hello')
     assert result.data == 'world'
-    assert result.cost() == snapshot(Cost())
+    assert result.usage() == snapshot(Usage())
 
     # reset the index so we get the same response again
     mock_client.index = 0  # type: ignore
 
     result = await agent.run('hello', message_history=result.new_messages())
     assert result.data == 'world'
-    assert result.cost() == snapshot(Cost())
+    assert result.usage() == snapshot(Usage())
     assert result.all_messages() == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -22,7 +22,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from pydantic_ai.result import Cost
+from pydantic_ai.result import Usage
 
 from ..conftest import IsNow, try_import
 
@@ -137,14 +137,14 @@ async def test_request_simple_success(allow_model_requests: None):
 
     result = await agent.run('hello')
     assert result.data == 'world'
-    assert result.cost() == snapshot(Cost())
+    assert result.usage() == snapshot(Usage())
 
     # reset the index so we get the same response again
     mock_client.index = 0  # type: ignore
 
     result = await agent.run('hello', message_history=result.new_messages())
     assert result.data == 'world'
-    assert result.cost() == snapshot(Cost())
+    assert result.usage() == snapshot(Usage())
     assert result.all_messages() == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
@@ -166,7 +166,7 @@ async def test_request_simple_usage(allow_model_requests: None):
 
     result = await agent.run('Hello')
     assert result.data == 'world'
-    assert result.cost() == snapshot(Cost(request_tokens=2, response_tokens=1, total_tokens=3))
+    assert result.usage() == snapshot(Usage(request_tokens=2, response_tokens=1, total_tokens=3))
 
 
 async def test_request_structured_response(allow_model_requests: None):
@@ -322,8 +322,8 @@ async def test_request_tool_call(allow_model_requests: None):
             ModelResponse.from_text(content='final response', timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc)),
         ]
     )
-    assert result.cost() == snapshot(
-        Cost(request_tokens=5, response_tokens=3, total_tokens=9, details={'cached_tokens': 3})
+    assert result.usage() == snapshot(
+        Usage(request_tokens=5, response_tokens=3, total_tokens=9, details={'cached_tokens': 3})
     )
 
 
@@ -358,7 +358,7 @@ async def test_stream_text(allow_model_requests: None):
         assert not result.is_complete
         assert [c async for c in result.stream(debounce_by=None)] == snapshot(['hello ', 'hello world'])
         assert result.is_complete
-        assert result.cost() == snapshot(Cost(request_tokens=6, response_tokens=3, total_tokens=9))
+        assert result.usage() == snapshot(Usage(request_tokens=6, response_tokens=3, total_tokens=9))
 
 
 async def test_stream_text_finish_reason(allow_model_requests: None):
@@ -425,9 +425,9 @@ async def test_stream_structured(allow_model_requests: None):
             ]
         )
         assert result.is_complete
-        assert result.cost() == snapshot(Cost(request_tokens=20, response_tokens=10, total_tokens=30))
-        # double check cost matches stream count
-        assert result.cost().response_tokens == len(stream)
+        assert result.usage() == snapshot(Usage(request_tokens=20, response_tokens=10, total_tokens=30))
+        # double check usage matches stream count
+        assert result.usage().response_tokens == len(stream)
 
 
 async def test_stream_structured_finish_reason(allow_model_requests: None):
@@ -482,4 +482,4 @@ async def test_no_delta(allow_model_requests: None):
         assert not result.is_complete
         assert [c async for c in result.stream(debounce_by=None)] == snapshot(['hello ', 'hello world'])
         assert result.is_complete
-        assert result.cost() == snapshot(Cost(request_tokens=6, response_tokens=3, total_tokens=9))
+        assert result.usage() == snapshot(Usage(request_tokens=6, response_tokens=3, total_tokens=9))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -26,7 +26,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import cached_async_http_client
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.result import Cost, RunResult
+from pydantic_ai.result import RunResult, Usage
 from pydantic_ai.tools import ToolDefinition
 
 from .conftest import IsNow, TestEnv
@@ -505,7 +505,7 @@ def test_run_with_history_new(set_event_loop: None):
             ],
             _new_message_index=4,
             data='{"ret_a":"a-apple"}',
-            _cost=Cost(),
+            _usage=Usage(),
         )
     )
     new_msg_part_kinds = [(m.kind, [p.part_kind for p in m.parts]) for m in result2.all_messages()]
@@ -547,7 +547,7 @@ def test_run_with_history_new(set_event_loop: None):
             ],
             _new_message_index=4,
             data='{"ret_a":"a-apple"}',
-            _cost=Cost(),
+            _usage=Usage(),
         )
     )
 
@@ -646,7 +646,7 @@ def test_run_with_history_new_structured(set_event_loop: None):
                 ),
             ],
             _new_message_index=5,
-            _cost=Cost(),
+            _usage=Usage(),
         )
     )
     new_msg_part_kinds = [(m.kind, [p.part_kind for p in m.parts]) for m in result2.all_messages()]

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -90,9 +90,9 @@ async def test_text(http_client: httpx.AsyncClient, tmp_path: Path, get_model: G
     result = await agent.run('What is the capital of France?')
     print('Text response:', result.data)
     assert 'paris' in result.data.lower()
-    print('Text cost:', result.cost())
-    cost = result.cost()
-    assert cost.total_tokens is not None and cost.total_tokens > 0
+    print('Text usage:', result.usage())
+    usage = result.usage()
+    assert usage.total_tokens is not None and usage.total_tokens > 0
 
 
 stream_params = [p for p in params if p.id != 'anthropic']
@@ -105,10 +105,10 @@ async def test_stream(http_client: httpx.AsyncClient, tmp_path: Path, get_model:
         data = await result.get_data()
     print('Stream response:', data)
     assert 'paris' in data.lower()
-    print('Stream cost:', result.cost())
-    cost = result.cost()
+    print('Stream usage:', result.usage())
+    usage = result.usage()
     if get_model.__name__ != 'ollama':
-        assert cost.total_tokens is not None and cost.total_tokens > 0
+        assert usage.total_tokens is not None and usage.total_tokens > 0
 
 
 class MyModel(BaseModel):
@@ -124,6 +124,6 @@ async def test_structured(http_client: httpx.AsyncClient, tmp_path: Path, get_mo
     result = await agent.run('What is the capital of the UK?')
     print('Structured response:', result.data)
     assert result.data.city.lower() == 'london'
-    print('Structured cost:', result.cost())
-    cost = result.cost()
-    assert cost.total_tokens is not None and cost.total_tokens > 0
+    print('Structured usage:', result.usage())
+    usage = result.usage()
+    assert usage.total_tokens is not None and usage.total_tokens > 0

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -161,7 +161,7 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary], set_event_lo
                     },
                 ]
             ),
-            'cost': IsJson({'request_tokens': None, 'response_tokens': None, 'total_tokens': None, 'details': None}),
+            'usage': IsJson({'request_tokens': None, 'response_tokens': None, 'total_tokens': None, 'details': None}),
             'logfire.json_schema': IsJson(
                 {
                     'type': 'object',
@@ -254,7 +254,7 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary], set_event_lo
                                 },
                             ],
                         },
-                        'cost': {'type': 'object', 'title': 'Cost', 'x-python-datatype': 'dataclass'},
+                        'usage': {'type': 'object', 'title': 'Usage', 'x-python-datatype': 'dataclass'},
                     },
                 }
             ),

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -22,7 +22,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.result import Cost
+from pydantic_ai.result import Usage
 
 from .conftest import IsNow
 
@@ -58,7 +58,7 @@ async def test_streamed_text_response():
         response = await result.get_data()
         assert response == snapshot('{"ret_a":"a-apple"}')
         assert result.is_complete
-        assert result.cost() == snapshot(Cost())
+        assert result.usage() == snapshot(Usage())
         assert result.timestamp() == IsNow(tz=timezone.utc)
         assert result.all_messages() == snapshot(
             [


### PR DESCRIPTION
While looking through @sydney-runkle's work on execution limits, I became pretty strongly convinced that this type should be called/thought of as `Usage` rather than `Cost`, and I wanted to rename it.

Some more specific reasons:
* I think it makes more sense to describe the method that returns this struct as "Return the usage of the request" than "Return the cost of the request" when we are just getting token counts and not a monetary value. The word "cost" just feels like it should be referring to money.
* Right now, the docstring of the Cost class says:
    > You'll need to look up the documentation of the model you're using to convent "token count" costs to monetary costs.

	I think the fact that we need to use quotes in `"token count" costs` is representative that it's not obvious/expected that cost isn't money, and if we call this class `Usage`, we can avoid that phrase `"token count" costs` entirely. We can just say "you'll need to look up the documentation of the model you're using to convert usage into monetary costs".
* `Usage` provides a clear place to track request count (which we want to add limits to), and it doesn't feel at all out of place weird to add that field to a type called `Usage` in the way it kind of does feel weird to add it to a type called `Cost`. (Though even if we keep the name as `Cost`, I want to add request count to that structure rather than store usage state on something else..)
* Anthropic uses the term "usage" for everything related to token counts — see here https://github.com/anthropics/anthropic-sdk-python#token-counting. (Sydney pointed this out to me after I suggested it; I wanted to use that term independently/before I realized Anthropic did too.) I see this as confirmation that this name is a reasonable choice, and using it also has the benefit of matching existing LLM SDK conventions (i.e., anthropic's).

I'm going to open some subsequent PRs implementing the ExecutionLimit stuff based on @sydney-runkle's work on top of this, I just wanted to make this its own PR to keep it easier to review diffs.