### PR TITLE
Refactor streaming

### DIFF
--- a/docs/api/models/base.md
+++ b/docs/api/models/base.md
@@ -7,8 +7,7 @@
         - Model
         - AgentModel
         - AbstractToolDefinition
-        - StreamTextResponse
-        - StreamStructuredResponse
+        - StreamedResponse
         - ALLOW_MODEL_REQUESTS
         - check_allow_model_requests
         - override_allow_model_requests

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -102,7 +102,7 @@ async def main():
         ]
         """
 
-        async for text in result.stream():
+        async for text in result.stream_text():
             print(text)
             #> Did you hear
             #> Did you hear about the toothpaste

--- a/docs/models.md
+++ b/docs/models.md
@@ -517,8 +517,7 @@ To implement support for models not already supported, you will need to subclass
 This in turn will require you to implement the following other abstract base classes:
 
 * [`AgentModel`][pydantic_ai.models.AgentModel]
-* [`StreamTextResponse`][pydantic_ai.models.StreamTextResponse]
-* [`StreamStructuredResponse`][pydantic_ai.models.StreamStructuredResponse]
+* [`StreamedResponse`][pydantic_ai.models.StreamedResponse]
 
 The best place to start is to review the source code for existing implementations, e.g. [`OpenAIModel`](https://github.com/pydantic/pydantic-ai/blob/main/pydantic_ai_slim/pydantic_ai/models/openai.py).
 

--- a/docs/multi-agent-applications.md
+++ b/docs/multi-agent-applications.md
@@ -148,9 +148,9 @@ async def main():
         """
         Usage(
             requests=4,
-            request_tokens=310,
+            request_tokens=309,
             response_tokens=32,
-            total_tokens=342,
+            total_tokens=341,
             details=None,
         )
         """

--- a/docs/results.md
+++ b/docs/results.md
@@ -1,5 +1,5 @@
 Results are the final values returned from [running an agent](agents.md#running-agents).
-The result values are wrapped in [`RunResult`][pydantic_ai.result.RunResult] and [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] so you can access other data like [usage][pydantic_ai.result.Usage] of the run and [message history](message-history.md#accessing-messages-from-results)
+The result values are wrapped in [`RunResult`][pydantic_ai.result.RunResult] and [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] so you can access other data like [usage][pydantic_ai.usage.Usage] of the run and [message history](message-history.md#accessing-messages-from-results)
 
 Both `RunResult` and `StreamedRunResult` are generic in the data they wrap, so typing information about the data returned by the agent is preserved.
 
@@ -176,7 +176,7 @@ agent = Agent('gemini-1.5-flash')  # (1)!
 
 async def main():
     async with agent.run_stream('Where does "hello world" come from?') as result:  # (2)!
-        async for message in result.stream():  # (3)!
+        async for message in result.stream_text():  # (3)!
             print(message)
             #> The first known
             #> The first known use of "hello,
@@ -188,7 +188,7 @@ async def main():
 
 1. Streaming works with the standard [`Agent`][pydantic_ai.Agent] class, and doesn't require any special setup, just a model that supports streaming (currently all models support streaming).
 2. The [`Agent.run_stream()`][pydantic_ai.Agent.run_stream] method is used to start a streamed run, this method returns a context manager so the connection can be closed when the stream completes.
-3. Each item yield by [`StreamedRunResult.stream()`][pydantic_ai.result.StreamedRunResult.stream] is the complete text response, extended as new data is received.
+3. Each item yield by [`StreamedRunResult.stream_text()`][pydantic_ai.result.StreamedRunResult.stream_text] is the complete text response, extended as new data is received.
 
 _(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
 

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -47,16 +47,12 @@ class ModelResponsePartsManager:
     """Manages a sequence of parts that make up a model's streamed response.
 
     Parts are generally added and/or updated by providing deltas, which are tracked by vendor-specific IDs.
-
-    Attributes:
-        _vendor_id_to_part_index: Maps a vendor's "part" ID (if provided) to the index
-            in the `_parts` list where that part (or its delta) resides.
-        _parts: A list of parts (text or tool calls) that make up the
-            current state of the model's response.
     """
 
-    _vendor_id_to_part_index: dict[VendorId, int] = field(default_factory=dict, init=False)
     _parts: list[ManagedPart] = field(default_factory=list, init=False)
+    """A list of parts (text or tool calls) that make up the current state of the model's response."""
+    _vendor_id_to_part_index: dict[VendorId, int] = field(default_factory=dict, init=False)
+    """Maps a vendor's "part" ID (if provided) to the index in `_parts` where that part resides."""
 
     def get_parts(self) -> list[ModelResponsePart]:
         """Return only model response parts that are complete (i.e., not ToolCallPartDelta's).
@@ -96,8 +92,8 @@ class ModelResponsePartsManager:
         if vendor_part_id is None:
             # If the vendor_part_id is None, check if the latest part is a TextPart to update
             if self._parts:
-                latest_part = self._parts[-1]
                 part_index = len(self._parts) - 1
+                latest_part = self._parts[part_index]
                 if isinstance(latest_part, TextPart):
                     existing_text_part_and_index = latest_part, part_index
         else:
@@ -164,8 +160,8 @@ class ModelResponsePartsManager:
             # When the vendor_part_id is None, if the tool_name is _not_ None, assume this should be a new part rather
             # than a delta on an existing one. We can change this behavior in the future if necessary for some model.
             if tool_name is None and self._parts:
-                latest_part = self._parts[-1]
                 part_index = len(self._parts) - 1
+                latest_part = self._parts[part_index]
                 if isinstance(latest_part, (ToolCallPart, ToolCallPartDelta)):
                     existing_matching_part_and_index = latest_part, part_index
         else:

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -1,0 +1,243 @@
+"""This module provides functionality to manage and update parts of a model's streamed response.
+
+The manager tracks which parts (in particular, text and tool calls) correspond to which
+vendor-specific identifiers (e.g., `index`, `tool_call_id`, etc., as appropriate for a given model),
+and produces PydanticAI-format events as appropriate for consumers of the streaming APIs.
+
+The "vendor-specific identifiers" to use depend on the semantics of the responses of the responses from the vendor,
+and are tightly coupled to the specific model being used, and the PydanticAI Model subclass implementation.
+
+This `ModelResponsePartsManager` is used in each of the subclasses of `StreamedResponse` as a way to consolidate
+event-emitting logic.
+"""
+
+from __future__ import annotations as _annotations
+
+from collections.abc import Hashable
+from dataclasses import dataclass, field
+from typing import Any, Union
+
+from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai.messages import (
+    ModelResponsePart,
+    ModelResponseStreamEvent,
+    PartDeltaEvent,
+    PartStartEvent,
+    TextPart,
+    TextPartDelta,
+    ToolCallPart,
+    ToolCallPartDelta,
+)
+
+VendorId = Hashable
+"""
+Type alias for a vendor identifier, which can be any hashable type (e.g., a string, UUID, etc.)
+"""
+
+ManagedPart = Union[ModelResponsePart, ToolCallPartDelta]
+"""
+A union of types that are managed by the ModelResponsePartsManager.
+Because many vendors have streaming APIs that may produce not-fully-formed tool calls,
+this includes ToolCallPartDelta's in addition to the more fully-formed ModelResponsePart's.
+"""
+
+
+@dataclass
+class ModelResponsePartsManager:
+    """Manages a sequence of parts that make up a model's streamed response.
+
+    Parts are generally added and/or updated by providing deltas, which are tracked by vendor-specific IDs.
+
+    Attributes:
+        _vendor_id_to_part_index: Maps a vendor's "part" ID (if provided) to the index
+            in the `_parts` list where that part (or its delta) resides.
+        _parts: A list of parts (text or tool calls) that make up the
+            current state of the model's response.
+    """
+
+    _vendor_id_to_part_index: dict[VendorId, int] = field(default_factory=dict, init=False)
+    _parts: list[ManagedPart] = field(default_factory=list, init=False)
+
+    def get_parts(self) -> list[ModelResponsePart]:
+        """Return only model response parts that are complete (i.e., not ToolCallPartDelta's).
+
+        Returns:
+            A list of ModelResponsePart objects. ToolCallPartDelta objects are excluded.
+        """
+        return [p for p in self._parts if not isinstance(p, ToolCallPartDelta)]
+
+    def handle_text_delta(
+        self,
+        *,
+        vendor_part_id: Hashable | None,
+        content: str,
+    ) -> ModelResponseStreamEvent:
+        """Handle incoming text content, creating or updating a TextPart in the manager as appropriate.
+
+        When `vendor_part_id` is None, the latest part is updated if it exists and is a TextPart;
+        otherwise, a new TextPart is created. When a non-None ID is specified, the TextPart corresponding
+        to that vendor ID is either created or updated.
+
+        Args:
+            vendor_part_id: The ID the vendor uses to identify this piece
+                of text. If None, a new part will be created unless the latest part is already
+                a TextPart.
+            content: The text content to append to the appropriate TextPart.
+
+        Returns:
+            A `PartStartEvent` if a new part was created, or a `PartDeltaEvent` if an existing part was updated.
+
+        Raises:
+            UnexpectedModelBehavior: If attempting to apply text content to a part that is
+                not a TextPart.
+        """
+        existing_text_part_and_index: tuple[TextPart, int] | None = None
+
+        if vendor_part_id is None:
+            # If the vendor_part_id is None, check if the latest part is a TextPart to update
+            if self._parts:
+                latest_part = self._parts[-1]
+                part_index = len(self._parts) - 1
+                if isinstance(latest_part, TextPart):
+                    existing_text_part_and_index = latest_part, part_index
+        else:
+            # Otherwise, attempt to look up an existing TextPart by vendor_part_id
+            part_index = self._vendor_id_to_part_index.get(vendor_part_id)
+            if part_index is not None:
+                existing_part = self._parts[part_index]
+                if not isinstance(existing_part, TextPart):
+                    raise UnexpectedModelBehavior(f'Cannot apply a text delta to {existing_part=}')
+                existing_text_part_and_index = existing_part, part_index
+
+        if existing_text_part_and_index is None:
+            # There is no existing text part that should be updated, so create a new one
+            new_part_index = len(self._parts)
+            part = TextPart(content=content)
+            if vendor_part_id is not None:
+                self._vendor_id_to_part_index[vendor_part_id] = new_part_index
+            self._parts.append(part)
+            return PartStartEvent(index=new_part_index, part=part)
+        else:
+            # Update the existing TextPart with the new content delta
+            existing_text_part, part_index = existing_text_part_and_index
+            part_delta = TextPartDelta(content_delta=content)
+            self._parts[part_index] = part_delta.apply(existing_text_part)
+            return PartDeltaEvent(index=part_index, delta=part_delta)
+
+    def handle_tool_call_delta(
+        self,
+        *,
+        vendor_part_id: Hashable | None,
+        tool_name: str | None,
+        args: str | dict[str, Any] | None,
+        tool_call_id: str | None,
+    ) -> ModelResponseStreamEvent | None:
+        """Handle or update a tool call, creating or updating a `ToolCallPart` or `ToolCallPartDelta`.
+
+        Managed items remain as `ToolCallPartDelta`s until they have both a tool_name and arguments, at which
+        point they are upgraded to `ToolCallPart`s.
+
+        If `vendor_part_id` is None, updates the latest matching ToolCallPart (or ToolCallPartDelta)
+        if any. Otherwise, a new part (or delta) may be created.
+
+        Args:
+            vendor_part_id: The ID the vendor uses for this tool call.
+                If None, the latest matching tool call may be updated.
+            tool_name: The name of the tool. If None, the manager does not enforce
+                a name match when `vendor_part_id` is None.
+            args: Arguments for the tool call, either as a string or a dictionary of key-value pairs.
+            tool_call_id: An optional string representing an identifier for this tool call.
+
+        Returns:
+            - A `PartStartEvent` if a new (fully realized) ToolCallPart is created.
+            - A `PartDeltaEvent` if an existing part is updated.
+            - `None` if no new event is emitted (e.g., the part is still incomplete).
+
+        Raises:
+            UnexpectedModelBehavior: If attempting to apply a tool call delta to a part that is not
+                a ToolCallPart or ToolCallPartDelta.
+        """
+        existing_matching_part_and_index: tuple[ToolCallPartDelta | ToolCallPart, int] | None = None
+
+        if vendor_part_id is None:
+            # vendor_part_id is None, so check if the latest part is a matching tool call or delta to update
+            # When the vendor_part_id is None, if the tool_name is _not_ None, assume this should be a new part rather
+            # than a delta on an existing one. We can change this behavior in the future if necessary for some model.
+            if tool_name is None and self._parts:
+                latest_part = self._parts[-1]
+                part_index = len(self._parts) - 1
+                if isinstance(latest_part, (ToolCallPart, ToolCallPartDelta)):
+                    existing_matching_part_and_index = latest_part, part_index
+        else:
+            # vendor_part_id is provided, so look up the corresponding part or delta
+            part_index = self._vendor_id_to_part_index.get(vendor_part_id)
+            if part_index is not None:
+                existing_part = self._parts[part_index]
+                if not isinstance(existing_part, (ToolCallPartDelta, ToolCallPart)):
+                    raise UnexpectedModelBehavior(f'Cannot apply a tool call delta to {existing_part=}')
+                existing_matching_part_and_index = existing_part, part_index
+
+        if existing_matching_part_and_index is None:
+            # No matching part/delta was found, so create a new ToolCallPartDelta (or ToolCallPart if fully formed)
+            delta = ToolCallPartDelta(tool_name_delta=tool_name, args_delta=args, tool_call_id=tool_call_id)
+            part = delta.as_part() or delta
+            if vendor_part_id is not None:
+                self._vendor_id_to_part_index[vendor_part_id] = len(self._parts)
+            new_part_index = len(self._parts)
+            self._parts.append(part)
+            # Only emit a PartStartEvent if we have enough information to produce a full ToolCallPart
+            if isinstance(part, ToolCallPart):
+                return PartStartEvent(index=new_part_index, part=part)
+        else:
+            # Update the existing part or delta with the new information
+            existing_part, part_index = existing_matching_part_and_index
+            delta = ToolCallPartDelta(tool_name_delta=tool_name, args_delta=args, tool_call_id=tool_call_id)
+            updated_part = delta.apply(existing_part)
+            self._parts[part_index] = updated_part
+            if isinstance(updated_part, ToolCallPart):
+                if isinstance(existing_part, ToolCallPartDelta):
+                    # We just upgraded a delta to a full part, so emit a PartStartEvent
+                    return PartStartEvent(index=part_index, part=updated_part)
+                else:
+                    # We updated an existing part, so emit a PartDeltaEvent
+                    return PartDeltaEvent(index=part_index, delta=delta)
+
+    def handle_tool_call_part(
+        self,
+        *,
+        vendor_part_id: Hashable | None,
+        tool_name: str,
+        args: str | dict[str, Any],
+        tool_call_id: str | None = None,
+    ) -> ModelResponseStreamEvent:
+        """Immediately create or fully-overwrite a ToolCallPart with the given information.
+
+        This does not apply a delta; it directly sets the tool call part contents.
+
+        Args:
+            vendor_part_id: The vendor's ID for this tool call part. If not
+                None and an existing part is found, that part is overwritten.
+            tool_name: The name of the tool being invoked.
+            args: The arguments for the tool call, either as a string or a dictionary.
+            tool_call_id: An optional string identifier for this tool call.
+
+        Returns:
+            ModelResponseStreamEvent: A `PartStartEvent` indicating that a new tool call part
+            has been added to the manager, or replaced an existing part.
+        """
+        new_part = ToolCallPart.from_raw_args(tool_name=tool_name, args=args, tool_call_id=tool_call_id)
+        if vendor_part_id is None:
+            # vendor_part_id is None, so we unconditionally append a new ToolCallPart to the end of the list
+            new_part_index = len(self._parts)
+            self._parts.append(new_part)
+        else:
+            # vendor_part_id is provided, so find and overwrite or create a new ToolCallPart.
+            maybe_part_index = self._vendor_id_to_part_index.get(vendor_part_id)
+            if maybe_part_index is not None:
+                new_part_index = maybe_part_index
+                self._parts[new_part_index] = new_part
+            else:
+                new_part_index = len(self._parts)
+                self._parts.append(new_part)
+            self._vendor_id_to_part_index[vendor_part_id] = new_part_index
+        return PartStartEvent(index=new_part_index, part=new_part)

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -15,7 +15,7 @@ from pydantic.json_schema import JsonSchemaValue
 from typing_extensions import ParamSpec, TypeAlias, TypeGuard, is_typeddict
 
 if TYPE_CHECKING:
-    from .messages import RetryPromptPart, ToolCallPart, ToolReturnPart
+    from . import messages as _messages
     from .tools import ObjectJsonSchema
 
 _P = ParamSpec('_P')
@@ -248,7 +248,9 @@ def now_utc() -> datetime:
     return datetime.now(tz=timezone.utc)
 
 
-def guard_tool_call_id(t: ToolCallPart | ToolReturnPart | RetryPromptPart, model_source: str) -> str:
+def guard_tool_call_id(
+    t: _messages.ToolCallPart | _messages.ToolReturnPart | _messages.RetryPromptPart, model_source: str
+) -> str:
     """Type guard that checks a `tool_call_id` is not None both for static typing and runtime."""
     assert t.tool_call_id is not None, f'{model_source} requires `tool_call_id` to be set: {t}'
     return t.tool_call_id

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -136,7 +136,7 @@ class Either(Generic[Left, Right]):
 
 @asynccontextmanager
 async def group_by_temporal(
-    aiter: AsyncIterator[T], soft_max_interval: float | None
+    aiterable: AsyncIterable[T], soft_max_interval: float | None
 ) -> AsyncIterator[AsyncIterable[list[T]]]:
     """Group items from an async iterable into lists based on time interval between them.
 
@@ -154,18 +154,18 @@ async def group_by_temporal(
     ```
 
     Args:
-        aiter: The async iterable to group.
+        aiterable: The async iterable to group.
         soft_max_interval: Maximum interval over which to group items, this should avoid a trickle of items causing
             a group to never be yielded. It's a soft max in the sense that once we're over this time, we yield items
             as soon as `aiter.__anext__()` returns. If `None`, no grouping/debouncing is performed
 
     Returns:
-        A context manager usable as an iterator async iterable of lists of items from the input async iterable.
+        A context manager usable as an async iterable of lists of items produced by the input async iterable.
     """
     if soft_max_interval is None:
 
         async def async_iter_groups_noop() -> AsyncIterator[list[T]]:
-            async for item in aiter:
+            async for item in aiterable:
                 yield [item]
 
         yield async_iter_groups_noop()
@@ -181,6 +181,7 @@ async def group_by_temporal(
         buffer: list[T] = []
         group_start_time = time.monotonic()
 
+        aiterator = aiterable.__aiter__()
         while True:
             if group_start_time is None:
                 # group hasn't started, we just wait for the maximum interval
@@ -193,7 +194,7 @@ async def group_by_temporal(
             if task is None:
                 # aiter.__anext__() returns an Awaitable[T], not a Coroutine which asyncio.create_task expects
                 # so far, this doesn't seem to be a problem
-                task = asyncio.create_task(aiter.__anext__())  # pyright: ignore[reportArgumentType]
+                task = asyncio.create_task(aiterator.__anext__())  # pyright: ignore[reportArgumentType]
 
             # we use asyncio.wait to avoid cancelling the coroutine if it's not done
             done, _ = await asyncio.wait((task,), timeout=wait_time)
@@ -232,16 +233,6 @@ async def group_by_temporal(
                 await task
 
 
-def add_optional(a: str | None, b: str | None) -> str | None:
-    """Add two optional strings."""
-    if a is None:
-        return b
-    elif b is None:
-        return a
-    else:
-        return a + b
-
-
 def sync_anext(iterator: Iterator[T]) -> T:
     """Get the next item from a sync iterator, raising `StopAsyncIteration` if it's exhausted.
 
@@ -261,3 +252,73 @@ def guard_tool_call_id(t: ToolCallPart | ToolReturnPart | RetryPromptPart, model
     """Type guard that checks a `tool_call_id` is not None both for static typing and runtime."""
     assert t.tool_call_id is not None, f'{model_source} requires `tool_call_id` to be set: {t}'
     return t.tool_call_id
+
+
+class PeekableAsyncStream(Generic[T]):
+    """Wraps an async iterable of type T and allows peeking at the *next* item without consuming it.
+
+    We only buffer one item at a time (the next item). Once that item is yielded, it is discarded.
+    This is a single-pass stream.
+    """
+
+    def __init__(self, source: AsyncIterable[T]):
+        self._source = source
+        self._source_iter: AsyncIterator[T] | None = None
+        self._buffer: T | Unset = UNSET
+        self._exhausted = False
+
+    async def peek(self) -> T | Unset:
+        """Returns the next item that would be yielded without consuming it.
+
+        Returns None if the stream is exhausted.
+        """
+        if self._exhausted:
+            return UNSET
+
+        # If we already have a buffered item, just return it.
+        if not isinstance(self._buffer, Unset):
+            return self._buffer
+
+        # Otherwise, we need to fetch the next item from the underlying iterator.
+        if self._source_iter is None:
+            self._source_iter = self._source.__aiter__()
+
+        try:
+            self._buffer = await self._source_iter.__anext__()
+        except StopAsyncIteration:
+            self._exhausted = True
+            return UNSET
+
+        return self._buffer
+
+    async def is_exhausted(self) -> bool:
+        """Returns True if the stream is exhausted, False otherwise."""
+        return isinstance(await self.peek(), Unset)
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        # For a single-pass iteration, we can return self as the iterator.
+        return self
+
+    async def __anext__(self) -> T:
+        """Yields the buffered item if present, otherwise fetches the next item from the underlying source.
+
+        Raises StopAsyncIteration if the stream is exhausted.
+        """
+        if self._exhausted:
+            raise StopAsyncIteration
+
+        # If we have a buffered item, yield it.
+        if not isinstance(self._buffer, Unset):
+            item = self._buffer
+            self._buffer = UNSET
+            return item
+
+        # Otherwise, fetch the next item from the source.
+        if self._source_iter is None:
+            self._source_iter = self._source.__aiter__()
+
+        try:
+            return await self._source_iter.__anext__()
+        except StopAsyncIteration:
+            self._exhausted = True
+            raise

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -22,7 +22,6 @@ from . import (
     result,
     usage as _usage,
 )
-from .messages import PartStartEvent, TextPart, ToolCallPart
 from .result import ResultData
 from .settings import ModelSettings, merge_model_settings
 from .tools import (
@@ -1221,13 +1220,13 @@ class Agent(Generic[AgentDeps, ResultData]):
         received_text = False
 
         async for maybe_part_event in streamed_response:
-            if isinstance(maybe_part_event, PartStartEvent):
+            if isinstance(maybe_part_event, _messages.PartStartEvent):
                 new_part = maybe_part_event.part
-                if isinstance(new_part, TextPart):
+                if isinstance(new_part, _messages.TextPart):
                     received_text = True
                     if self._allow_text_result(result_schema):
                         return _MarkFinalResult(streamed_response, None)
-                elif isinstance(new_part, ToolCallPart):
+                elif isinstance(new_part, _messages.ToolCallPart):
                     if result_schema is not None and (match := result_schema.find_tool([new_part])):
                         call, _ = match
                         return _MarkFinalResult(streamed_response, call.tool_name)
@@ -1240,7 +1239,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         if not model_response.parts:
             raise exceptions.UnexpectedModelBehavior('Received empty model response')
         for p in model_response.parts:
-            if isinstance(p, ToolCallPart):
+            if isinstance(p, _messages.ToolCallPart):
                 if tool := self._function_tools.get(p.tool_name):
                     tasks.append(asyncio.create_task(tool.run(p, run_context), name=p.tool_name))
                 else:

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -22,6 +22,7 @@ from . import (
     result,
     usage as _usage,
 )
+from .messages import PartStartEvent, TextPart, ToolCallPart
 from .result import ResultData
 from .settings import ModelSettings, merge_model_settings
 from .tools import (
@@ -536,7 +537,7 @@ class Agent(Generic[AgentDeps, ResultData]):
                         model_req_span.__exit__(None, None, None)
 
                         with _logfire.span('handle model response') as handle_span:
-                            maybe_final_result = await self._handle_streamed_model_response(
+                            maybe_final_result = await self._handle_streamed_response(
                                 model_response, run_context, result_schema
                             )
 
@@ -1126,7 +1127,7 @@ class Agent(Generic[AgentDeps, ResultData]):
         final_result: _MarkFinalResult[RunResultData] | None = None
 
         parts: list[_messages.ModelRequestPart] = []
-        if result_schema := result_schema:
+        if result_schema is not None:
             if match := result_schema.find_tool(tool_calls):
                 call, result_tool = match
                 try:
@@ -1205,76 +1206,58 @@ class Agent(Generic[AgentDeps, ResultData]):
                 parts.extend(task_results)
         return parts
 
-    async def _handle_streamed_model_response(
+    async def _handle_streamed_response(
         self,
-        model_response: models.EitherStreamedResponse,
+        streamed_response: models.StreamedResponse,
         run_context: RunContext[AgentDeps],
         result_schema: _result.ResultSchema[RunResultData] | None,
-    ) -> (
-        _MarkFinalResult[models.EitherStreamedResponse]
-        | tuple[_messages.ModelResponse, list[_messages.ModelRequestPart]]
-    ):
+    ) -> _MarkFinalResult[models.StreamedResponse] | tuple[_messages.ModelResponse, list[_messages.ModelRequestPart]]:
         """Process a streamed response from the model.
 
         Returns:
             Either a final result or a tuple of the model response and the tool responses for the next request.
             If a final result is returned, the conversation should end.
         """
-        if isinstance(model_response, models.StreamTextResponse):
-            # plain string response
-            if self._allow_text_result(result_schema):
-                return _MarkFinalResult(model_response, None)
-            else:
-                self._incr_result_retry(run_context)
-                response = _messages.RetryPromptPart(
-                    content='Plain text responses are not permitted, please call one of the functions instead.',
-                )
-                # stream the response, so usage is correct
-                async for _ in model_response:
-                    pass
+        received_text = False
 
-                text = ''.join(model_response.get(final=True))
-                return _messages.ModelResponse([_messages.TextPart(text)]), [response]
-        elif isinstance(model_response, models.StreamStructuredResponse):
-            if result_schema is not None:
-                # if there's a result schema, iterate over the stream until we find at least one tool
-                # NOTE: this means we ignore any other tools called here
-                structured_msg = model_response.get()
-                while not structured_msg.parts:
-                    try:
-                        await model_response.__anext__()
-                    except StopAsyncIteration:
-                        break
-                    structured_msg = model_response.get()
+        async for maybe_part_event in streamed_response:
+            if isinstance(maybe_part_event, PartStartEvent):
+                new_part = maybe_part_event.part
+                if isinstance(new_part, TextPart):
+                    received_text = True
+                    if self._allow_text_result(result_schema):
+                        return _MarkFinalResult(streamed_response, None)
+                elif isinstance(new_part, ToolCallPart):
+                    if result_schema is not None and (match := result_schema.find_tool([new_part])):
+                        call, _ = match
+                        return _MarkFinalResult(streamed_response, call.tool_name)
+                else:
+                    assert_never(new_part)
 
-                if match := result_schema.find_tool(structured_msg.parts):
-                    call, _ = match
-                    return _MarkFinalResult(model_response, call.tool_name)
+        tasks: list[asyncio.Task[_messages.ModelRequestPart]] = []
+        parts: list[_messages.ModelRequestPart] = []
+        model_response = streamed_response.get()
+        if not model_response.parts:
+            raise exceptions.UnexpectedModelBehavior('Received empty model response')
+        for p in model_response.parts:
+            if isinstance(p, ToolCallPart):
+                if tool := self._function_tools.get(p.tool_name):
+                    tasks.append(asyncio.create_task(tool.run(p, run_context), name=p.tool_name))
+                else:
+                    parts.append(self._unknown_tool(p.tool_name, run_context, result_schema))
 
-            # the model is calling a tool function, consume the response to get the next message
-            async for _ in model_response:
-                pass
-            model_response_msg = model_response.get()
-            if not model_response_msg.parts:
-                raise exceptions.UnexpectedModelBehavior('Received empty tool call message')
+        if received_text and not tasks and not parts:
+            # Can only get here if self._allow_text_result returns `False` for the provided result_schema
+            self._incr_result_retry(run_context)
+            model_response = _messages.RetryPromptPart(
+                content='Plain text responses are not permitted, please call one of the functions instead.',
+            )
+            return streamed_response.get(), [model_response]
 
-            # we now run all tool functions in parallel
-            tasks: list[asyncio.Task[_messages.ModelRequestPart]] = []
-            parts: list[_messages.ModelRequestPart] = []
-            for item in model_response_msg.parts:
-                if isinstance(item, _messages.ToolCallPart):
-                    call = item
-                    if tool := self._function_tools.get(call.tool_name):
-                        tasks.append(asyncio.create_task(tool.run(call, run_context), name=call.tool_name))
-                    else:
-                        parts.append(self._unknown_tool(call.tool_name, run_context, result_schema))
-
-            with _logfire.span('running {tools=}', tools=[t.get_name() for t in tasks]):
-                task_results: Sequence[_messages.ModelRequestPart] = await asyncio.gather(*tasks)
-                parts.extend(task_results)
-            return model_response_msg, parts
-        else:
-            assert_never(model_response)
+        with _logfire.span('running {tools=}', tools=[t.get_name() for t in tasks]):
+            task_results: Sequence[_messages.ModelRequestPart] = await asyncio.gather(*tasks)
+            parts.extend(task_results)
+        return model_response, parts
 
     async def _validate_result(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -149,21 +149,28 @@ class StreamedResponse(ABC):
     _event_iterator: AsyncIterator[ModelResponseStreamEvent] | None = field(default=None, init=False)
 
     def __aiter__(self) -> AsyncIterator[ModelResponseStreamEvent]:
-        """Stream the response as an async iterable of (optional) `ModelResponseStreamEvent`s."""
+        """Stream the response as an async iterable of [`ModelResponseStreamEvent`][pydantic_ai.messages.ModelResponseStreamEvent]s."""
         if self._event_iterator is None:
             self._event_iterator = self._get_event_iterator()
         return self._event_iterator
 
     @abstractmethod
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+        """Return an async iterator of [`ModelResponseStreamEvent`][pydantic_ai.messages.ModelResponseStreamEvent]s.
+
+        This method should be implemented by subclasses to translate the vendor-specific stream of events into
+        pydantic_ai-format events.
+        """
         raise NotImplementedError()
         # noinspection PyUnreachableCode
         yield
 
     def get(self) -> ModelResponse:
+        """Build a [`ModelResponse`][pydantic_ai.messages.ModelResponse] from the data received from the stream so far."""
         return ModelResponse(parts=self._parts_manager.get_parts(), timestamp=self.timestamp())
 
     def usage(self) -> Usage:
+        """Get the usage of the response so far. This will not be the final usage until the stream is exhausted."""
         return self._usage
 
     @abstractmethod

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -7,20 +7,22 @@ specific LLM being used.
 from __future__ import annotations as _annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Iterable, Iterator
+from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager, contextmanager
+from dataclasses import dataclass, field
 from datetime import datetime
 from functools import cache
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal
 
 import httpx
 
+from .._parts_manager import ModelResponsePartsManager
 from ..exceptions import UserError
-from ..messages import ModelMessage, ModelResponse
+from ..messages import ModelMessage, ModelResponse, ModelResponseStreamEvent
 from ..settings import ModelSettings
+from ..usage import Usage
 
 if TYPE_CHECKING:
-    from ..result import Usage
     from ..tools import ToolDefinition
 
 
@@ -129,96 +131,45 @@ class AgentModel(ABC):
     @asynccontextmanager
     async def request_stream(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
-    ) -> AsyncIterator[EitherStreamedResponse]:
+    ) -> AsyncIterator[StreamedResponse]:
         """Make a request to the model and return a streaming response."""
+        # This method is not required, but you need to implement it if you want to support streamed responses
         raise NotImplementedError(f'Streamed requests not supported by this {self.__class__.__name__}')
         # yield is required to make this a generator for type checking
         # noinspection PyUnreachableCode
         yield  # pragma: no cover
 
 
-class StreamTextResponse(ABC):
-    """Streamed response from an LLM when returning text."""
-
-    def __aiter__(self) -> AsyncIterator[None]:
-        """Stream the response as an async iterable, building up the text as it goes.
-
-        This is an async iterator that yields `None` to avoid doing the work of validating the input and
-        extracting the text field when it will often be thrown away.
-        """
-        return self
-
-    @abstractmethod
-    async def __anext__(self) -> None:
-        """Process the next chunk of the response, see above for why this returns `None`."""
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get(self, *, final: bool = False) -> Iterable[str]:
-        """Returns an iterable of text since the last call to `get()` — e.g. the text delta.
-
-        Args:
-            final: If True, this is the final call, after iteration is complete, the response should be fully validated
-                and all text extracted.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def usage(self) -> Usage:
-        """Return the usage of the request.
-
-        NOTE: this won't return the full usage until the stream is finished.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def timestamp(self) -> datetime:
-        """Get the timestamp of the response."""
-        raise NotImplementedError()
-
-
-class StreamStructuredResponse(ABC):
+@dataclass
+class StreamedResponse(ABC):
     """Streamed response from an LLM when calling a tool."""
 
-    def __aiter__(self) -> AsyncIterator[None]:
-        """Stream the response as an async iterable, building up the tool call as it goes.
+    _usage: Usage = field(default_factory=Usage, init=False)
+    _parts_manager: ModelResponsePartsManager = field(default_factory=ModelResponsePartsManager, init=False)
+    _event_iterator: AsyncIterator[ModelResponseStreamEvent] | None = field(default=None, init=False)
 
-        This is an async iterator that yields `None` to avoid doing the work of building the final tool call when
-        it will often be thrown away.
-        """
-        return self
+    def __aiter__(self) -> AsyncIterator[ModelResponseStreamEvent]:
+        """Stream the response as an async iterable of (optional) `ModelResponseStreamEvent`s."""
+        if self._event_iterator is None:
+            self._event_iterator = self._get_event_iterator()
+        return self._event_iterator
 
     @abstractmethod
-    async def __anext__(self) -> None:
-        """Process the next chunk of the response, see above for why this returns `None`."""
+    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         raise NotImplementedError()
+        # noinspection PyUnreachableCode
+        yield
 
-    @abstractmethod
-    def get(self, *, final: bool = False) -> ModelResponse:
-        """Get the `ModelResponse` at this point.
+    def get(self) -> ModelResponse:
+        return ModelResponse(parts=self._parts_manager.get_parts(), timestamp=self.timestamp())
 
-        The `ModelResponse` may or may not be complete, depending on whether the stream is finished.
-
-        Args:
-            final: If True, this is the final call, after iteration is complete, the response should be fully validated.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
     def usage(self) -> Usage:
-        """Get the usage of the request.
-
-        NOTE: this won't return the full usage until the stream is finished.
-        """
-        raise NotImplementedError()
+        return self._usage
 
     @abstractmethod
     def timestamp(self) -> datetime:
         """Get the timestamp of the response."""
         raise NotImplementedError()
-
-
-EitherStreamedResponse = Union[StreamTextResponse, StreamStructuredResponse]
 
 
 ALLOW_MODEL_REQUESTS = True

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -1,6 +1,6 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterable, AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -10,13 +10,14 @@ from typing import Literal, overload
 from httpx import AsyncClient as AsyncHTTPClient
 from typing_extensions import assert_never
 
-from .. import UnexpectedModelBehavior, _utils, result
+from .. import UnexpectedModelBehavior, _utils, usage
 from .._utils import guard_tool_call_id as _guard_tool_call_id
 from ..messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
     ModelResponsePart,
+    ModelResponseStreamEvent,
     RetryPromptPart,
     SystemPromptPart,
     TextPart,
@@ -24,15 +25,12 @@ from ..messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from ..result import Usage
 from ..settings import ModelSettings
 from ..tools import ToolDefinition
 from . import (
     AgentModel,
-    EitherStreamedResponse,
     Model,
-    StreamStructuredResponse,
-    StreamTextResponse,
+    StreamedResponse,
     cached_async_http_client,
     check_allow_model_requests,
 )
@@ -41,7 +39,6 @@ try:
     from groq import NOT_GIVEN, AsyncGroq, AsyncStream
     from groq.types import chat
     from groq.types.chat import ChatCompletion, ChatCompletionChunk
-    from groq.types.chat.chat_completion_chunk import ChoiceDeltaToolCall
 except ImportError as _import_error:
     raise ImportError(
         'Please install `groq` to use the Groq model, '
@@ -157,14 +154,14 @@ class GroqAgentModel(AgentModel):
 
     async def request(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
-    ) -> tuple[ModelResponse, result.Usage]:
+    ) -> tuple[ModelResponse, usage.Usage]:
         response = await self._completions_create(messages, False, model_settings)
         return self._process_response(response), _map_usage(response)
 
     @asynccontextmanager
     async def request_stream(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
-    ) -> AsyncIterator[EitherStreamedResponse]:
+    ) -> AsyncIterator[StreamedResponse]:
         response = await self._completions_create(messages, True, model_settings)
         async with response:
             yield await self._process_streamed_response(response)
@@ -217,38 +214,23 @@ class GroqAgentModel(AgentModel):
         choice = response.choices[0]
         items: list[ModelResponsePart] = []
         if choice.message.content is not None:
-            items.append(TextPart(choice.message.content))
+            items.append(TextPart(content=choice.message.content))
         if choice.message.tool_calls is not None:
             for c in choice.message.tool_calls:
-                items.append(ToolCallPart.from_raw_args(c.function.name, c.function.arguments, c.id))
+                items.append(
+                    ToolCallPart.from_raw_args(tool_name=c.function.name, args=c.function.arguments, tool_call_id=c.id)
+                )
         return ModelResponse(items, timestamp=timestamp)
 
     @staticmethod
-    async def _process_streamed_response(response: AsyncStream[ChatCompletionChunk]) -> EitherStreamedResponse:
+    async def _process_streamed_response(response: AsyncStream[ChatCompletionChunk]) -> GroqStreamedResponse:
         """Process a streamed response, and prepare a streaming response to return."""
-        timestamp: datetime | None = None
-        start_usage = Usage()
-        # the first chunk may contain enough information so we iterate until we get either `tool_calls` or `content`
-        while True:
-            try:
-                chunk = await response.__anext__()
-            except StopAsyncIteration as e:
-                raise UnexpectedModelBehavior('Streamed response ended without content or tool calls') from e
-            timestamp = timestamp or datetime.fromtimestamp(chunk.created, tz=timezone.utc)
-            start_usage += _map_usage(chunk)
+        peekable_response = _utils.PeekableAsyncStream(response)
+        first_chunk = await peekable_response.peek()
+        if isinstance(first_chunk, _utils.Unset):
+            raise UnexpectedModelBehavior('Streamed response ended without content or tool calls')
 
-            if chunk.choices:
-                delta = chunk.choices[0].delta
-
-                if delta.content is not None:
-                    return GroqStreamTextResponse(delta.content, response, timestamp, start_usage)
-                elif delta.tool_calls is not None:
-                    return GroqStreamStructuredResponse(
-                        response,
-                        {c.index: c for c in delta.tool_calls},
-                        timestamp,
-                        start_usage,
-                    )
+        return GroqStreamedResponse(peekable_response, datetime.fromtimestamp(first_chunk.created, tz=timezone.utc))
 
     @classmethod
     def _map_message(cls, message: ModelMessage) -> Iterable[chat.ChatCompletionMessageParam]:
@@ -301,90 +283,36 @@ class GroqAgentModel(AgentModel):
 
 
 @dataclass
-class GroqStreamTextResponse(StreamTextResponse):
-    """Implementation of `StreamTextResponse` for Groq models."""
+class GroqStreamedResponse(StreamedResponse):
+    """Implementation of `StreamedResponse` for Groq models."""
 
-    _first: str | None
-    _response: AsyncStream[ChatCompletionChunk]
+    _response: AsyncIterable[ChatCompletionChunk]
     _timestamp: datetime
-    _usage: result.Usage
-    _buffer: list[str] = field(default_factory=list, init=False)
 
-    async def __anext__(self) -> None:
-        if self._first is not None:
-            self._buffer.append(self._first)
-            self._first = None
-            return None
+    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+        async for chunk in self._response:
+            self._usage += _map_usage(chunk)
 
-        chunk = await self._response.__anext__()
-        self._usage = _map_usage(chunk)
+            try:
+                choice = chunk.choices[0]
+            except IndexError:
+                continue
 
-        try:
-            choice = chunk.choices[0]
-        except IndexError:
-            raise StopAsyncIteration()
+            # Handle the text part of the response
+            content = choice.delta.content
+            if content is not None:
+                yield self._parts_manager.handle_text_delta(vendor_part_id='content', content=content)
 
-        # we don't raise StopAsyncIteration on the last chunk because usage comes after this
-        if choice.finish_reason is None:
-            assert choice.delta.content is not None, f'Expected delta with content, invalid chunk: {chunk!r}'
-        if choice.delta.content is not None:
-            self._buffer.append(choice.delta.content)
-
-    def get(self, *, final: bool = False) -> Iterable[str]:
-        yield from self._buffer
-        self._buffer.clear()
-
-    def usage(self) -> Usage:
-        return self._usage
-
-    def timestamp(self) -> datetime:
-        return self._timestamp
-
-
-@dataclass
-class GroqStreamStructuredResponse(StreamStructuredResponse):
-    """Implementation of `StreamStructuredResponse` for Groq models."""
-
-    _response: AsyncStream[ChatCompletionChunk]
-    _delta_tool_calls: dict[int, ChoiceDeltaToolCall]
-    _timestamp: datetime
-    _usage: result.Usage
-
-    async def __anext__(self) -> None:
-        chunk = await self._response.__anext__()
-        self._usage = _map_usage(chunk)
-
-        try:
-            choice = chunk.choices[0]
-        except IndexError:
-            raise StopAsyncIteration()
-
-        if choice.finish_reason is not None:
-            raise StopAsyncIteration()
-
-        assert choice.delta.content is None, f'Expected tool calls, got content instead, invalid chunk: {chunk!r}'
-
-        for new in choice.delta.tool_calls or []:
-            if current := self._delta_tool_calls.get(new.index):
-                if current.function is None:
-                    current.function = new.function
-                elif new.function is not None:
-                    current.function.name = _utils.add_optional(current.function.name, new.function.name)
-                    current.function.arguments = _utils.add_optional(current.function.arguments, new.function.arguments)
-            else:
-                self._delta_tool_calls[new.index] = new
-
-    def get(self, *, final: bool = False) -> ModelResponse:
-        items: list[ModelResponsePart] = []
-        for c in self._delta_tool_calls.values():
-            if f := c.function:
-                if f.name is not None and f.arguments is not None:
-                    items.append(ToolCallPart.from_raw_args(f.name, f.arguments, c.id))
-
-        return ModelResponse(items, timestamp=self._timestamp)
-
-    def usage(self) -> Usage:
-        return self._usage
+            # Handle the tool calls
+            for dtc in choice.delta.tool_calls or []:
+                maybe_event = self._parts_manager.handle_tool_call_delta(
+                    vendor_part_id=dtc.index,
+                    tool_name=dtc.function and dtc.function.name,
+                    args=dtc.function and dtc.function.arguments,
+                    tool_call_id=dtc.id,
+                )
+                if maybe_event is not None:
+                    yield maybe_event
 
     def timestamp(self) -> datetime:
         return self._timestamp
@@ -398,18 +326,18 @@ def _map_tool_call(t: ToolCallPart) -> chat.ChatCompletionMessageToolCallParam:
     )
 
 
-def _map_usage(completion: ChatCompletionChunk | ChatCompletion) -> result.Usage:
-    usage = None
+def _map_usage(completion: ChatCompletionChunk | ChatCompletion) -> usage.Usage:
+    response_usage = None
     if isinstance(completion, ChatCompletion):
-        usage = completion.usage
+        response_usage = completion.usage
     elif completion.x_groq is not None:
-        usage = completion.x_groq.usage
+        response_usage = completion.x_groq.usage
 
-    if usage is None:
-        return result.Usage()
+    if response_usage is None:
+        return usage.Usage()
 
-    return result.Usage(
-        request_tokens=usage.prompt_tokens,
-        response_tokens=usage.completion_tokens,
-        total_tokens=usage.total_tokens,
+    return usage.Usage(
+        request_tokens=response_usage.prompt_tokens,
+        response_tokens=response_usage.completion_tokens,
+        total_tokens=response_usage.total_tokens,
     )

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -11,7 +11,6 @@ import logfire_api
 from typing_extensions import TypeVar
 
 from . import _result, _utils, exceptions, messages as _messages, models
-from .messages import ModelResponseStreamEvent, TextPart
 from .tools import AgentDeps, RunContext
 from .usage import Usage, UsageLimits
 
@@ -232,7 +231,7 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
             # if the response currently has any parts with content, yield those before streaming
             msg = self._stream_response.get()
             for i, part in enumerate(msg.parts):
-                if isinstance(part, TextPart) and part.content:
+                if isinstance(part, _messages.TextPart) and part.content:
                     yield part.content, i
 
             async for event in usage_checking_stream:
@@ -349,7 +348,7 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
                 result_data = await validator.validate(result_data, call, self._run_ctx)
             return result_data
         else:
-            text = '\n\n'.join(x.content for x in message.parts if isinstance(x, TextPart))
+            text = '\n\n'.join(x.content for x in message.parts if isinstance(x, _messages.TextPart))
             for validator in self._result_validators:
                 text = await validator.validate(
                     text,  # pyright: ignore[reportArgumentType]
@@ -375,10 +374,10 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
 
 
 def _get_usage_checking_stream_response(
-    stream_response: AsyncIterable[ModelResponseStreamEvent],
+    stream_response: AsyncIterable[_messages.ModelResponseStreamEvent],
     limits: UsageLimits | None,
     get_usage: Callable[[], Usage],
-) -> AsyncIterable[ModelResponseStreamEvent]:
+) -> AsyncIterable[_messages.ModelResponseStreamEvent]:
     if limits is not None and limits.has_token_limits():
 
         async def _usage_checking_iterator():

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -11,6 +11,7 @@ import logfire_api
 from typing_extensions import TypeVar
 
 from . import _result, _utils, exceptions, messages as _messages, models
+from .messages import ModelResponseStreamEvent, TextPart
 from .tools import AgentDeps, RunContext
 from .usage import Usage, UsageLimits
 
@@ -169,7 +170,7 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
     """Result of a streamed run that returns structured data via a tool call."""
 
     _usage_limits: UsageLimits | None
-    _stream_response: models.EitherStreamedResponse
+    _stream_response: models.StreamedResponse
     _result_schema: _result.ResultSchema[ResultData] | None
     _run_ctx: RunContext[AgentDeps]
     _result_validators: list[_result.ResultValidator[AgentDeps, ResultData]]
@@ -200,19 +201,12 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
         Returns:
             An async iterable of the response data.
         """
-        if isinstance(self._stream_response, models.StreamTextResponse):
-            async for text in self.stream_text(debounce_by=debounce_by):
-                yield cast(ResultData, text)
-        else:
-            async for structured_message, is_last in self.stream_structured(debounce_by=debounce_by):
-                yield await self.validate_structured_result(structured_message, allow_partial=not is_last)
+        async for structured_message, is_last in self.stream_structured(debounce_by=debounce_by):
+            result = await self.validate_structured_result(structured_message, allow_partial=not is_last)
+            yield result
 
     async def stream_text(self, *, delta: bool = False, debounce_by: float | None = 0.1) -> AsyncIterator[str]:
         """Stream the text result as an async iterable.
-
-        !!! note
-            This method will fail if the response is structured,
-            e.g. if [`is_structured`][pydantic_ai.result.StreamedRunResult.is_structured] returns `True`.
 
         !!! note
             Result validators will NOT be called on the text result if `delta=True`.
@@ -228,49 +222,57 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
             self._stream_response, self._usage_limits, self.usage
         )
 
+        # Define a "merged" version of the iterator that will yield items that have already been retrieved
+        # and items that we receive while streaming. We define a dedicated async iterator for this so we can
+        # pass the combined stream to the group_by_temporal function within `_stream_text_deltas` below.
+        async def _stream_text_deltas_ungrouped() -> AsyncIterator[tuple[str, int]]:
+            # if the response currently has any parts with content, yield those before streaming
+            msg = self._stream_response.get()
+            for i, part in enumerate(msg.parts):
+                if isinstance(part, TextPart) and part.content:
+                    yield part.content, i
+
+            async for event in usage_checking_stream:
+                if (
+                    isinstance(event, _messages.PartStartEvent)
+                    and isinstance(event.part, _messages.TextPart)
+                    and event.part.content
+                ):
+                    yield event.part.content, event.index
+                elif (
+                    isinstance(event, _messages.PartDeltaEvent)
+                    and isinstance(event.delta, _messages.TextPartDelta)
+                    and event.delta.content_delta
+                ):
+                    yield event.delta.content_delta, event.index
+
+        async def _stream_text_deltas() -> AsyncIterator[str]:
+            async with _utils.group_by_temporal(_stream_text_deltas_ungrouped(), debounce_by) as group_iter:
+                async for items in group_iter:
+                    yield ''.join([content for content, _ in items])
+
         with _logfire.span('response stream text') as lf_span:
-            if isinstance(self._stream_response, models.StreamStructuredResponse):
-                raise exceptions.UserError('stream_text() can only be used with text responses')
             if delta:
-                async with _utils.group_by_temporal(usage_checking_stream, debounce_by) as group_iter:
-                    async for _ in group_iter:
-                        yield ''.join(self._stream_response.get())
-                final_delta = ''.join(self._stream_response.get(final=True))
-                if final_delta:
-                    yield final_delta
+                async for text in _stream_text_deltas():
+                    yield text
             else:
                 # a quick benchmark shows it's faster to build up a string with concat when we're
                 # yielding at each step
-                chunks: list[str] = []
-                combined = ''
-                async with _utils.group_by_temporal(usage_checking_stream, debounce_by) as group_iter:
-                    async for _ in group_iter:
-                        new = False
-                        for chunk in self._stream_response.get():
-                            chunks.append(chunk)
-                            new = True
-                        if new:
-                            combined = await self._validate_text_result(''.join(chunks))
-                            yield combined
+                deltas: list[str] = []
+                combined_validated_text = ''
+                async for text in _stream_text_deltas():
+                    deltas.append(text)
+                    combined_text = ''.join(deltas)
+                    combined_validated_text = await self._validate_text_result(combined_text)
+                    yield combined_validated_text
 
-                new = False
-                for chunk in self._stream_response.get(final=True):
-                    chunks.append(chunk)
-                    new = True
-                if new:
-                    combined = await self._validate_text_result(''.join(chunks))
-                    yield combined
-                lf_span.set_attribute('combined_text', combined)
-                await self._marked_completed(_messages.ModelResponse.from_text(combined))
+                lf_span.set_attribute('combined_text', combined_validated_text)
+                await self._marked_completed(_messages.ModelResponse.from_text(combined_validated_text))
 
     async def stream_structured(
         self, *, debounce_by: float | None = 0.1
     ) -> AsyncIterator[tuple[_messages.ModelResponse, bool]]:
         """Stream the response as an async iterable of Structured LLM Messages.
-
-        !!! note
-            This method will fail if the response is text,
-            e.g. if [`is_structured`][pydantic_ai.result.StreamedRunResult.is_structured] returns `False`.
 
         Args:
             debounce_by: by how much (if at all) to debounce/group the response chunks by. `None` means no debouncing.
@@ -285,24 +287,20 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
         )
 
         with _logfire.span('response stream structured') as lf_span:
-            if isinstance(self._stream_response, models.StreamTextResponse):
-                raise exceptions.UserError('stream_structured() can only be used with structured responses')
-            else:
-                # we should already have a message at this point, yield that first if it has any content
+            # if the message currently has any parts with content, yield before streaming
+            msg = self._stream_response.get()
+            for part in msg.parts:
+                if part.has_content():
+                    yield msg, False
+                    break
+
+            async with _utils.group_by_temporal(usage_checking_stream, debounce_by) as group_iter:
+                async for _events in group_iter:
+                    msg = self._stream_response.get()
+                    yield msg, False
                 msg = self._stream_response.get()
-                for item in msg.parts:
-                    if isinstance(item, _messages.ToolCallPart) and item.has_content():
-                        yield msg, False
-                        break
-                async with _utils.group_by_temporal(usage_checking_stream, debounce_by) as group_iter:
-                    async for _ in group_iter:
-                        msg = self._stream_response.get()
-                        for item in msg.parts:
-                            if isinstance(item, _messages.ToolCallPart) and item.has_content():
-                                yield msg, False
-                                break
-                msg = self._stream_response.get(final=True)
                 yield msg, True
+                # TODO: Should this now be `final_response` instead of `structured_response`?
                 lf_span.set_attribute('structured_response', msg)
                 await self._marked_completed(msg)
 
@@ -314,21 +312,9 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
 
         async for _ in usage_checking_stream:
             pass
-
-        if isinstance(self._stream_response, models.StreamTextResponse):
-            text = ''.join(self._stream_response.get(final=True))
-            text = await self._validate_text_result(text)
-            await self._marked_completed(_messages.ModelResponse.from_text(text))
-            return cast(ResultData, text)
-        else:
-            message = self._stream_response.get(final=True)
-            await self._marked_completed(message)
-            return await self.validate_structured_result(message)
-
-    @property
-    def is_structured(self) -> bool:
-        """Return whether the stream response contains structured data (as opposed to text)."""
-        return isinstance(self._stream_response, models.StreamStructuredResponse)
+        message = self._stream_response.get()
+        await self._marked_completed(message)
+        return await self.validate_structured_result(message)
 
     def usage(self) -> Usage:
         """Return the usage of the whole run.
@@ -346,20 +332,29 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
         self, message: _messages.ModelResponse, *, allow_partial: bool = False
     ) -> ResultData:
         """Validate a structured result message."""
-        assert self._result_schema is not None, 'Expected _result_schema to not be None'
-        assert self._result_tool_name is not None, 'Expected _result_tool_name to not be None'
-        match = self._result_schema.find_named_tool(message.parts, self._result_tool_name)
-        if match is None:
-            raise exceptions.UnexpectedModelBehavior(
-                f'Invalid message, unable to find tool: {self._result_schema.tool_names()}'
-            )
+        if self._result_schema is not None and self._result_tool_name is not None:
+            match = self._result_schema.find_named_tool(message.parts, self._result_tool_name)
+            if match is None:
+                raise exceptions.UnexpectedModelBehavior(
+                    f'Invalid response, unable to find tool: {self._result_schema.tool_names()}'
+                )
 
-        call, result_tool = match
-        result_data = result_tool.validate(call, allow_partial=allow_partial, wrap_validation_errors=False)
+            call, result_tool = match
+            result_data = result_tool.validate(call, allow_partial=allow_partial, wrap_validation_errors=False)
 
-        for validator in self._result_validators:
-            result_data = await validator.validate(result_data, call, self._run_ctx)
-        return result_data
+            for validator in self._result_validators:
+                result_data = await validator.validate(result_data, call, self._run_ctx)
+            return result_data
+        else:
+            text = '\n\n'.join(x.content for x in message.parts if isinstance(x, TextPart))
+            for validator in self._result_validators:
+                text = await validator.validate(
+                    text,  # pyright: ignore[reportArgumentType]
+                    None,
+                    self._run_ctx,
+                )
+            # Since there is no result tool, we can assume that str is compatible with ResultData
+            return cast(ResultData, text)
 
     async def _validate_text_result(self, text: str) -> str:
         for validator in self._result_validators:
@@ -377,8 +372,10 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
 
 
 def _get_usage_checking_stream_response(
-    stream_response: AsyncIterator[ResultData], limits: UsageLimits | None, get_usage: Callable[[], Usage]
-) -> AsyncIterator[ResultData]:
+    stream_response: AsyncIterable[ModelResponseStreamEvent],
+    limits: UsageLimits | None,
+    get_usage: Callable[[], Usage],
+) -> AsyncIterable[ModelResponseStreamEvent]:
     if limits is not None and limits.has_token_limits():
 
         async def _usage_checking_iterator():

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -218,6 +218,9 @@ class StreamedRunResult(_BaseRunResult[ResultData], Generic[AgentDeps, ResultDat
                 Debouncing is particularly important for long structured responses to reduce the overhead of
                 performing validation as each token is received.
         """
+        if self._result_schema and not self._result_schema.allow_text_result:
+            raise exceptions.UserError('stream_text() can only be used with text responses')
+
         usage_checking_stream = _get_usage_checking_stream_response(
             self._stream_response, self._usage_limits, self.usage
         )

--- a/tests/models/mock_async_stream.py
+++ b/tests/models/mock_async_stream.py
@@ -1,0 +1,61 @@
+"""
+This module provides an asynchronous context manager and iterator,
+`MockAsyncStream`, which wraps a synchronous iterator and exposes it
+as an asynchronous stream. It can be used in async/await code blocks
+and async for-loops, emulating asynchronous iteration behavior.
+"""
+
+from __future__ import annotations as _annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from pydantic_ai import _utils
+
+T = TypeVar('T')
+
+
+@dataclass
+class MockAsyncStream(Generic[T]):
+    """Wraps a synchronous iterator in an asynchronous interface.
+
+    This class allows a synchronous iterator to be treated as an
+    asynchronous iterator, enabling iteration in `async for` loops
+    and usage within `async with` blocks.
+
+    Attributes:
+        _iter: The underlying synchronous iterator.
+
+    Example usage:
+        async def example():
+            sync_iter = iter([1, 2, 3])
+            async_stream = MockAsyncStream(sync_iter)
+
+            async for item in async_stream:
+                print(item)
+
+            async with MockAsyncStream(sync_iter) as stream:
+                async for item in stream:
+                    print(item)
+    """
+
+    _iter: Iterator[T]
+
+    async def __anext__(self) -> T:
+        """Return the next item from the synchronous iterator as if it were asynchronous.
+
+        Calls `_utils.sync_anext` to retrieve the next item from the underlying
+        synchronous iterator. If the iterator is exhausted, `StopAsyncIteration`
+        is raised.
+        """
+        return _utils.sync_anext(self._iter)
+
+    def __aiter__(self) -> MockAsyncStream[T]:
+        return self
+
+    async def __aenter__(self) -> MockAsyncStream[T]:
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        pass

--- a/tests/models/mock_async_stream.py
+++ b/tests/models/mock_async_stream.py
@@ -24,9 +24,6 @@ class MockAsyncStream(Generic[T]):
     asynchronous iterator, enabling iteration in `async for` loops
     and usage within `async with` blocks.
 
-    Attributes:
-        _iter: The underlying synchronous iterator.
-
     Example usage:
         async def example():
             sync_iter = iter([1, 2, 3])
@@ -41,6 +38,7 @@ class MockAsyncStream(Generic[T]):
     """
 
     _iter: Iterator[T]
+    """The underlying synchronous iterator."""
 
     async def __anext__(self) -> T:
         """Return the next item from the synchronous iterator as if it were asynchronous.

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -399,7 +399,7 @@ async def test_stream_text():
                 ModelResponse.from_text(content='hello world', timestamp=IsNow(tz=timezone.utc)),
             ]
         )
-        assert result.usage() == snapshot(Usage(requests=1))
+        assert result.usage() == snapshot(Usage(requests=1, request_tokens=50, response_tokens=2, total_tokens=52))
 
 
 class Foo(BaseModel):

--- a/tests/models/test_ollama.py
+++ b/tests/models/test_ollama.py
@@ -38,7 +38,6 @@ def test_init():
 async def test_request_simple_success(allow_model_requests: None):
     c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
     mock_client = MockOpenAI.create_mock(c)
-    print('here')
     m = OllamaModel('llama3.2', openai_client=mock_client, base_url=None)
     agent = Agent(m)
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -260,7 +260,7 @@ def test_plain_response_then_tuple(set_event_loop: None):
                 ]
             ),
             ModelResponse(
-                parts=[ToolCallPart(tool_name='final_result', args=ArgsJson(args_json='{"response": ["foo", "bar"]}'))],
+                parts=[ToolCallPart.from_raw_args(tool_name='final_result', args='{"response": ["foo", "bar"]}')],
                 timestamp=IsNow(tz=timezone.utc),
             ),
             ModelRequest(
@@ -510,7 +510,7 @@ def test_run_with_history_new(set_event_loop: None):
                 ]
             ),
             ModelResponse(
-                parts=[ToolCallPart(tool_name='ret_a', args=ArgsDict(args_dict={'x': 'a'}))],
+                parts=[ToolCallPart.from_raw_args(tool_name='ret_a', args={'x': 'a'})],
                 timestamp=IsNow(tz=timezone.utc),
             ),
             ModelRequest(
@@ -622,7 +622,13 @@ def test_run_with_history_new_structured(set_event_loop: None):
                 parts=[ToolReturnPart(tool_name='ret_a', content='a-apple', timestamp=IsNow(tz=timezone.utc))]
             ),
             ModelResponse(
-                parts=[ToolCallPart(tool_name='final_result', args=ArgsDict(args_dict={'a': 0}), tool_call_id=None)],
+                parts=[
+                    ToolCallPart(
+                        tool_name='final_result',
+                        args=ArgsDict(args_dict={'a': 0}),
+                        tool_call_id=None,
+                    )
+                ],
                 timestamp=IsNow(tz=timezone.utc),
             ),
             ModelRequest(
@@ -1016,11 +1022,11 @@ class TestMultipleToolCalls:
                 ),
                 ModelResponse(
                     parts=[
-                        ToolCallPart(tool_name='regular_tool', args=ArgsDict(args_dict={'x': 42})),
-                        ToolCallPart(tool_name='final_result', args=ArgsDict(args_dict={'value': 'first'})),
-                        ToolCallPart(tool_name='another_tool', args=ArgsDict(args_dict={'y': 2})),
-                        ToolCallPart(tool_name='final_result', args=ArgsDict(args_dict={'value': 'second'})),
-                        ToolCallPart(tool_name='unknown_tool', args=ArgsDict(args_dict={'value': '???'})),
+                        ToolCallPart.from_raw_args(tool_name='regular_tool', args={'x': 42}),
+                        ToolCallPart.from_raw_args(tool_name='final_result', args={'value': 'first'}),
+                        ToolCallPart.from_raw_args(tool_name='another_tool', args={'y': 2}),
+                        ToolCallPart.from_raw_args(tool_name='final_result', args={'value': 'second'}),
+                        ToolCallPart.from_raw_args(tool_name='unknown_tool', args={'value': '???'}),
                     ],
                     timestamp=IsNow(tz=timezone.utc),
                 ),
@@ -1093,10 +1099,10 @@ class TestMultipleToolCalls:
                 ),
                 ModelResponse(
                     parts=[
-                        ToolCallPart(tool_name='regular_tool', args=ArgsDict(args_dict={'x': 1})),
-                        ToolCallPart(tool_name='final_result', args=ArgsDict(args_dict={'value': 'final'})),
-                        ToolCallPart(tool_name='another_tool', args=ArgsDict(args_dict={'y': 2})),
-                        ToolCallPart(tool_name='unknown_tool', args=ArgsDict(args_dict={'value': '???'})),
+                        ToolCallPart.from_raw_args(tool_name='regular_tool', args={'x': 1}),
+                        ToolCallPart.from_raw_args(tool_name='final_result', args={'value': 'final'}),
+                        ToolCallPart.from_raw_args(tool_name='another_tool', args={'y': 2}),
+                        ToolCallPart.from_raw_args(tool_name='unknown_tool', args={'value': '???'}),
                     ],
                     timestamp=IsNow(tz=timezone.utc),
                 ),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -118,7 +118,7 @@ def test_docs_examples(
     if opt_test.startswith('skip'):
         pytest.skip(opt_test[4:].lstrip(' -') or 'running code skipped')
     else:
-        if eval_example.update_examples:
+        if eval_example.update_examples:  # pragma: no cover
             module_dict = eval_example.run_print_update(example, call=call_name)
         else:
             module_dict = eval_example.run_print_check(example, call=call_name)

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -1,0 +1,414 @@
+from __future__ import annotations as _annotations
+
+import re
+from typing import Any
+
+import pytest
+from inline_snapshot import snapshot
+
+from pydantic_ai import UnexpectedModelBehavior
+from pydantic_ai._parts_manager import ModelResponsePartsManager
+from pydantic_ai.messages import (
+    ArgsDict,
+    ArgsJson,
+    PartDeltaEvent,
+    PartStartEvent,
+    TextPart,
+    TextPartDelta,
+    ToolCallPart,
+    ToolCallPartDelta,
+)
+
+
+@pytest.mark.parametrize('vendor_part_id', [None, 'content'])
+def test_handle_text_deltas(vendor_part_id: str | None):
+    manager = ModelResponsePartsManager()
+    assert manager.get_parts() == []
+
+    event = manager.handle_text_delta(vendor_part_id=vendor_part_id, content='hello ')
+    assert event == snapshot(
+        PartStartEvent(index=0, part=TextPart(content='hello ', part_kind='text'), event_kind='part_start')
+    )
+    assert manager.get_parts() == snapshot([TextPart(content='hello ', part_kind='text')])
+
+    event = manager.handle_text_delta(vendor_part_id=vendor_part_id, content='world')
+    assert event == snapshot(
+        PartDeltaEvent(
+            index=0, delta=TextPartDelta(content_delta='world', part_delta_kind='text'), event_kind='part_delta'
+        )
+    )
+    assert manager.get_parts() == snapshot([TextPart(content='hello world', part_kind='text')])
+
+
+def test_handle_dovetailed_text_deltas():
+    manager = ModelResponsePartsManager()
+
+    event = manager.handle_text_delta(vendor_part_id='first', content='hello ')
+    assert event == snapshot(
+        PartStartEvent(index=0, part=TextPart(content='hello ', part_kind='text'), event_kind='part_start')
+    )
+    assert manager.get_parts() == snapshot([TextPart(content='hello ', part_kind='text')])
+
+    event = manager.handle_text_delta(vendor_part_id='second', content='goodbye ')
+    assert event == snapshot(
+        PartStartEvent(index=1, part=TextPart(content='goodbye ', part_kind='text'), event_kind='part_start')
+    )
+    assert manager.get_parts() == snapshot(
+        [TextPart(content='hello ', part_kind='text'), TextPart(content='goodbye ', part_kind='text')]
+    )
+
+    event = manager.handle_text_delta(vendor_part_id='first', content='world')
+    assert event == snapshot(
+        PartDeltaEvent(
+            index=0, delta=TextPartDelta(content_delta='world', part_delta_kind='text'), event_kind='part_delta'
+        )
+    )
+    assert manager.get_parts() == snapshot(
+        [TextPart(content='hello world', part_kind='text'), TextPart(content='goodbye ', part_kind='text')]
+    )
+
+    event = manager.handle_text_delta(vendor_part_id='second', content='Samuel')
+    assert event == snapshot(
+        PartDeltaEvent(
+            index=1, delta=TextPartDelta(content_delta='Samuel', part_delta_kind='text'), event_kind='part_delta'
+        )
+    )
+    assert manager.get_parts() == snapshot(
+        [TextPart(content='hello world', part_kind='text'), TextPart(content='goodbye Samuel', part_kind='text')]
+    )
+
+
+def test_handle_tool_call_deltas():
+    manager = ModelResponsePartsManager()
+
+    event = manager.handle_tool_call_delta(vendor_part_id='first', tool_name='tool', args=None, tool_call_id=None)
+    # Not enough information to produce a part, so no event and no part
+    assert event == snapshot(None)
+    assert manager.get_parts() == snapshot([])
+
+    # Now that we have args, we can produce a part:
+    event = manager.handle_tool_call_delta(vendor_part_id='first', tool_name=None, args='{"arg1":', tool_call_id=None)
+    assert event == snapshot(
+        PartStartEvent(
+            index=0,
+            part=ToolCallPart(
+                tool_name='tool', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call'
+            ),
+            event_kind='part_start',
+        )
+    )
+    assert manager.get_parts() == snapshot(
+        [ToolCallPart(tool_name='tool', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call')]
+    )
+
+    event = manager.handle_tool_call_delta(vendor_part_id='first', tool_name='1', args=None, tool_call_id=None)
+    assert event == snapshot(
+        PartDeltaEvent(
+            index=0,
+            delta=ToolCallPartDelta(
+                tool_name_delta='1', args_delta=None, tool_call_id=None, part_delta_kind='tool_call'
+            ),
+            event_kind='part_delta',
+        )
+    )
+    assert manager.get_parts() == snapshot(
+        [ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call')]
+    )
+
+    event = manager.handle_tool_call_delta(vendor_part_id='first', tool_name=None, args='"value1"}', tool_call_id=None)
+    assert event == snapshot(
+        PartDeltaEvent(
+            index=0,
+            delta=ToolCallPartDelta(
+                tool_name_delta=None, args_delta='"value1"}', tool_call_id=None, part_delta_kind='tool_call'
+            ),
+            event_kind='part_delta',
+        )
+    )
+    assert manager.get_parts() == snapshot(
+        [
+            ToolCallPart(
+                tool_name='tool1',
+                args=ArgsJson(args_json='{"arg1":"value1"}'),
+                tool_call_id=None,
+                part_kind='tool-call',
+            )
+        ]
+    )
+
+
+def test_handle_tool_call_deltas_without_vendor_id():
+    # Note, tool_name should not be specified in subsequent deltas when the vendor_part_id is None
+    manager = ModelResponsePartsManager()
+    manager.handle_tool_call_delta(vendor_part_id=None, tool_name='tool1', args='{"arg1":', tool_call_id=None)
+    manager.handle_tool_call_delta(vendor_part_id=None, tool_name=None, args='"value1"}', tool_call_id=None)
+    assert manager.get_parts() == snapshot(
+        [
+            ToolCallPart(
+                tool_name='tool1',
+                args=ArgsJson(args_json='{"arg1":"value1"}'),
+                tool_call_id=None,
+                part_kind='tool-call',
+            )
+        ]
+    )
+
+    # This test is included just to document/demonstrate what happens if you do repeat the tool name
+    manager = ModelResponsePartsManager()
+    manager.handle_tool_call_delta(vendor_part_id=None, tool_name='tool2', args='{"arg1":', tool_call_id=None)
+    manager.handle_tool_call_delta(vendor_part_id=None, tool_name='tool2', args='"value1"}', tool_call_id=None)
+    assert manager.get_parts() == snapshot(
+        [
+            ToolCallPart(
+                tool_name='tool2', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call'
+            ),
+            ToolCallPart(
+                tool_name='tool2', args=ArgsJson(args_json='"value1"}'), tool_call_id=None, part_kind='tool-call'
+            ),
+        ]
+    )
+
+
+def test_handle_tool_call_part():
+    manager = ModelResponsePartsManager()
+
+    # Basic use of this API
+    event = manager.handle_tool_call_part(vendor_part_id='first', tool_name='tool1', args='{"arg1":', tool_call_id=None)
+    assert event == snapshot(
+        PartStartEvent(
+            index=0,
+            part=ToolCallPart(
+                tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call'
+            ),
+            event_kind='part_start',
+        )
+    )
+
+    # Add a delta
+    manager.handle_tool_call_delta(vendor_part_id='second', tool_name='tool1', args=None, tool_call_id=None)
+    assert manager.get_parts() == snapshot(
+        [ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call')]
+    )
+
+    # Override it with handle_tool_call_part
+    manager.handle_tool_call_part(vendor_part_id='second', tool_name='tool1', args='{}', tool_call_id=None)
+    assert manager.get_parts() == snapshot(
+        [
+            ToolCallPart(
+                tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call'
+            ),
+            ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{}'), tool_call_id=None, part_kind='tool-call'),
+        ]
+    )
+
+    event = manager.handle_tool_call_delta(vendor_part_id='first', tool_name=None, args='"value1"}', tool_call_id=None)
+    assert event == snapshot(
+        PartDeltaEvent(
+            index=0,
+            delta=ToolCallPartDelta(
+                tool_name_delta=None, args_delta='"value1"}', tool_call_id=None, part_delta_kind='tool_call'
+            ),
+            event_kind='part_delta',
+        )
+    )
+    assert manager.get_parts() == snapshot(
+        [
+            ToolCallPart(
+                tool_name='tool1',
+                args=ArgsJson(args_json='{"arg1":"value1"}'),
+                tool_call_id=None,
+                part_kind='tool-call',
+            ),
+            ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{}'), tool_call_id=None, part_kind='tool-call'),
+        ]
+    )
+
+    # Finally, demonstrate behavior when no vendor_part_id is provided:
+    event = manager.handle_tool_call_part(vendor_part_id=None, tool_name='tool1', args='{}', tool_call_id=None)
+    assert event == snapshot(
+        PartStartEvent(
+            index=2,
+            part=ToolCallPart(
+                tool_name='tool1', args=ArgsJson(args_json='{}'), tool_call_id=None, part_kind='tool-call'
+            ),
+            event_kind='part_start',
+        )
+    )
+    assert manager.get_parts() == snapshot(
+        [
+            ToolCallPart(
+                tool_name='tool1',
+                args=ArgsJson(args_json='{"arg1":"value1"}'),
+                tool_call_id=None,
+                part_kind='tool-call',
+            ),
+            ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{}'), tool_call_id=None, part_kind='tool-call'),
+            ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{}'), tool_call_id=None, part_kind='tool-call'),
+        ]
+    )
+
+
+@pytest.mark.parametrize('text_vendor_part_id', [None, 'content'])
+@pytest.mark.parametrize('tool_vendor_part_id', [None, 'tool'])
+def test_handle_mixed_deltas_without_text_part_id(text_vendor_part_id: str | None, tool_vendor_part_id: str | None):
+    manager = ModelResponsePartsManager()
+
+    event = manager.handle_text_delta(vendor_part_id=text_vendor_part_id, content='hello ')
+    assert event == snapshot(
+        PartStartEvent(index=0, part=TextPart(content='hello ', part_kind='text'), event_kind='part_start')
+    )
+    assert manager.get_parts() == snapshot([TextPart(content='hello ', part_kind='text')])
+
+    event = manager.handle_tool_call_delta(
+        vendor_part_id=tool_vendor_part_id, tool_name='tool1', args='{"arg1":', tool_call_id='abc'
+    )
+    assert event == snapshot(
+        PartStartEvent(
+            index=1,
+            part=ToolCallPart(
+                tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id='abc', part_kind='tool-call'
+            ),
+            event_kind='part_start',
+        )
+    )
+
+    event = manager.handle_text_delta(vendor_part_id=text_vendor_part_id, content='world')
+    if text_vendor_part_id is None:
+        assert event == snapshot(
+            PartStartEvent(
+                index=2,
+                part=TextPart(content='world', part_kind='text'),
+                event_kind='part_start',
+            )
+        )
+        assert manager.get_parts() == snapshot(
+            [
+                TextPart(content='hello ', part_kind='text'),
+                ToolCallPart(
+                    tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id='abc', part_kind='tool-call'
+                ),
+                TextPart(content='world', part_kind='text'),
+            ]
+        )
+    else:
+        assert event == snapshot(
+            PartDeltaEvent(
+                index=0, delta=TextPartDelta(content_delta='world', part_delta_kind='text'), event_kind='part_delta'
+            )
+        )
+        assert manager.get_parts() == snapshot(
+            [
+                TextPart(content='hello world', part_kind='text'),
+                ToolCallPart(
+                    tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id='abc', part_kind='tool-call'
+                ),
+            ]
+        )
+
+
+def test_cannot_convert_from_text_to_tool_call():
+    manager = ModelResponsePartsManager()
+    manager.handle_text_delta(vendor_part_id=1, content='hello')
+    with pytest.raises(
+        UnexpectedModelBehavior, match=re.escape('Cannot apply a tool call delta to existing_part=TextPart(')
+    ):
+        manager.handle_tool_call_delta(vendor_part_id=1, tool_name='tool1', args='{"arg1":', tool_call_id=None)
+
+
+def test_cannot_convert_from_tool_call_to_text():
+    manager = ModelResponsePartsManager()
+    manager.handle_tool_call_delta(vendor_part_id=1, tool_name='tool1', args='{"arg1":', tool_call_id=None)
+    with pytest.raises(
+        UnexpectedModelBehavior, match=re.escape('Cannot apply a text delta to existing_part=ToolCallPart(')
+    ):
+        manager.handle_text_delta(vendor_part_id=1, content='hello')
+
+
+def test_tool_call_id_delta():
+    manager = ModelResponsePartsManager()
+    manager.handle_tool_call_delta(vendor_part_id=1, tool_name='tool1', args='{"arg1":', tool_call_id=None)
+    assert manager.get_parts() == snapshot(
+        [
+            ToolCallPart(
+                tool_name='tool1',
+                args=ArgsJson(args_json='{"arg1":'),
+                tool_call_id=None,
+                part_kind='tool-call',
+            )
+        ]
+    )
+
+    manager.handle_tool_call_delta(vendor_part_id=1, tool_name=None, args='"value1"}', tool_call_id='id2')
+    assert manager.get_parts() == snapshot(
+        [
+            ToolCallPart(
+                tool_name='tool1',
+                args=ArgsJson(args_json='{"arg1":"value1"}'),
+                tool_call_id='id2',
+                part_kind='tool-call',
+            )
+        ]
+    )
+
+
+@pytest.mark.parametrize('apply_to_delta', [True, False])
+def test_tool_call_id_delta_failure(apply_to_delta: bool):
+    tool_name = 'tool1'
+    manager = ModelResponsePartsManager()
+    manager.handle_tool_call_delta(
+        vendor_part_id=1, tool_name=None if apply_to_delta else tool_name, args='{"arg1":', tool_call_id='id1'
+    )
+    assert (
+        manager.get_parts() == []
+        if apply_to_delta
+        else [
+            ToolCallPart(
+                tool_name='tool1',
+                args=ArgsJson(args_json='{"arg1":'),
+                tool_call_id='id1',
+                part_kind='tool-call',
+            )
+        ]
+    )
+
+    with pytest.raises(
+        UnexpectedModelBehavior,
+        match=re.escape('Cannot apply a new tool_call_id to a ToolCallPartDelta that already has one '),
+    ):
+        manager.handle_tool_call_delta(vendor_part_id=1, tool_name=None, args='"value1"}', tool_call_id='id2')
+
+
+@pytest.mark.parametrize(
+    'args1,args2,result',
+    [
+        ('{"arg1":', '"value1"}', ArgsJson(args_json='{"arg1":"value1"}')),
+        ('{"a":1}', {}, UnexpectedModelBehavior('Cannot apply dict deltas to non-dict tool arguments ')),
+        ({}, '{"b":2}', UnexpectedModelBehavior('Cannot apply JSON deltas to non-JSON tool arguments ')),
+        ({'a': 1}, {'b': 2}, ArgsDict(args_dict={'a': 1, 'b': 2})),
+    ],
+)
+@pytest.mark.parametrize('apply_to_delta', [False, True])
+def test_apply_tool_delta_variants(
+    args1: str | dict[str, Any],
+    args2: str | dict[str, Any],
+    result: ArgsJson | ArgsDict | UnexpectedModelBehavior,
+    apply_to_delta: bool,
+):
+    tool_name = 'tool1'
+
+    manager = ModelResponsePartsManager()
+    manager.handle_tool_call_delta(
+        vendor_part_id=1, tool_name=None if apply_to_delta else tool_name, args=args1, tool_call_id=None
+    )
+
+    if isinstance(result, UnexpectedModelBehavior):
+        with pytest.raises(UnexpectedModelBehavior, match=re.escape(str(result))):
+            manager.handle_tool_call_delta(vendor_part_id=1, tool_name=None, args=args2, tool_call_id=None)
+    else:
+        manager.handle_tool_call_delta(vendor_part_id=1, tool_name=None, args=args2, tool_call_id=None)
+        if apply_to_delta:
+            assert len(manager.get_parts()) == 0  # Ensure there are only deltas being managed
+            manager.handle_tool_call_delta(vendor_part_id=1, tool_name=tool_name, args=None, tool_call_id=None)
+        tool_call_part = manager.get_parts()[0]
+        assert isinstance(tool_call_part, ToolCallPart)
+        assert tool_call_part.args == result

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import datetime
 import json
 from collections.abc import AsyncIterator
 from datetime import timezone
@@ -8,7 +9,7 @@ import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel
 
-from pydantic_ai import Agent, UnexpectedModelBehavior, UserError, capture_run_messages
+from pydantic_ai import Agent, UnexpectedModelBehavior, capture_run_messages
 from pydantic_ai.messages import (
     ArgsDict,
     ArgsJson,
@@ -41,7 +42,6 @@ async def test_streamed_text_response():
 
     async with test_agent.run_stream('Hello') as result:
         assert test_agent.name == 'test_agent'
-        assert not result.is_structured
         assert not result.is_complete
         assert result.all_messages() == snapshot(
             [
@@ -66,14 +66,6 @@ async def test_streamed_text_response():
         response = await result.get_data()
         assert response == snapshot('{"ret_a":"a-apple"}')
         assert result.is_complete
-        assert result.usage() == snapshot(
-            Usage(
-                requests=2,
-                request_tokens=103,
-                response_tokens=11,
-                total_tokens=114,
-            )
-        )
         assert result.timestamp() == IsNow(tz=timezone.utc)
         assert result.all_messages() == snapshot(
             [
@@ -88,6 +80,14 @@ async def test_streamed_text_response():
                 ModelResponse.from_text(content='{"ret_a":"a-apple"}', timestamp=IsNow(tz=timezone.utc)),
             ]
         )
+        assert result.usage() == snapshot(
+            Usage(
+                requests=2,
+                request_tokens=103,
+                response_tokens=11,
+                total_tokens=114,
+            )
+        )
 
 
 async def test_streamed_structured_response():
@@ -97,7 +97,6 @@ async def test_streamed_structured_response():
 
     async with agent.run_stream('') as result:
         assert agent.name == 'fig_jam'
-        assert result.is_structured
         assert not result.is_complete
         response = await result.get_data()
         assert response == snapshot(('a', 'a'))
@@ -124,10 +123,11 @@ async def test_structured_response_iter():
 
     assert chunks == snapshot([[1], [1, 2, 3, 4], [1, 2, 3, 4]])
 
-    async with agent.run_stream('Hello') as result:
-        with pytest.raises(UserError, match=r'stream_text\(\) can only be used with text responses'):
-            async for _ in result.stream_text():
-                pass
+    # TODO: Can we remove the following check now?
+    # async with agent.run_stream('Hello') as result:
+    #     with pytest.raises(UserError, match=r'stream_text\(\) can only be used with text responses'):
+    #         async for _ in result.stream_text():
+    #             pass
 
 
 async def test_streamed_text_stream():
@@ -136,15 +136,21 @@ async def test_streamed_text_stream():
     agent = Agent(m)
 
     async with agent.run_stream('Hello') as result:
-        assert not result.is_structured
         # typehint to test (via static typing) that the stream type is correctly inferred
-        chunks: list[str] = [c async for c in result.stream()]
-        # one chunk due to group_by_temporal
+        chunks: list[str] = [c async for c in result.stream_text()]
+        # one chunk with `stream_text()` due to group_by_temporal
         assert chunks == snapshot(['The cat sat on the mat.'])
         assert result.is_complete
 
     async with agent.run_stream('Hello') as result:
-        assert [c async for c in result.stream(debounce_by=None)] == snapshot(
+        # typehint to test (via static typing) that the stream type is correctly inferred
+        chunks: list[str] = [c async for c in result.stream()]
+        # two chunks with `stream()` due to not-final vs. final
+        assert chunks == snapshot(['The cat sat on the mat.', 'The cat sat on the mat.'])
+        assert result.is_complete
+
+    async with agent.run_stream('Hello') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(
             [
                 'The ',
                 'The cat ',
@@ -156,14 +162,21 @@ async def test_streamed_text_stream():
         )
 
     async with agent.run_stream('Hello') as result:
+        # with stream_text, there is no need to do partial validation, so we only get the final message once:
+        assert [c async for c in result.stream_text(delta=False, debounce_by=None)] == snapshot(
+            ['The ', 'The cat ', 'The cat sat ', 'The cat sat on ', 'The cat sat on the ', 'The cat sat on the mat.']
+        )
+
+    async with agent.run_stream('Hello') as result:
         assert [c async for c in result.stream_text(delta=True, debounce_by=None)] == snapshot(
             ['The ', 'cat ', 'sat ', 'on ', 'the ', 'mat.']
         )
 
-    async with agent.run_stream('Hello') as result:
-        with pytest.raises(UserError, match=r'stream_structured\(\) can only be used with structured responses'):
-            async for _ in result.stream_structured():
-                pass
+    # TODO: Can we remove the following check now?
+    # async with agent.run_stream('Hello') as result:
+    #     with pytest.raises(UserError, match=r'stream_structured\(\) can only be used with structured responses'):
+    #         async for _ in result.stream_structured():
+    #             pass
 
 
 async def test_plain_response():
@@ -180,7 +193,7 @@ async def test_plain_response():
 
     with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum retries \(1\) for result validation'):
         async with agent.run_stream(''):
-            pass
+            pass  # pragma: no cover
 
     assert call_index == 2
 
@@ -271,9 +284,9 @@ async def test_call_tool_empty():
 
     agent = Agent(FunctionModel(stream_function=stream_structured_function), result_type=tuple[str, int])
 
-    with pytest.raises(UnexpectedModelBehavior, match='Received empty tool call message'):
+    with pytest.raises(UnexpectedModelBehavior, match='Received empty model response'):
         async with agent.run_stream('hello'):
-            pass
+            pass  # pragma: no cover
 
 
 async def test_call_tool_wrong_name():
@@ -289,7 +302,8 @@ async def test_call_tool_wrong_name():
     with capture_run_messages() as messages:
         with pytest.raises(UnexpectedModelBehavior, match=r'Exceeded maximum retries \(1\) for result validation'):
             async with agent.run_stream('hello'):
-                pass
+                pass  # pragma: no cover
+
     assert messages == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
@@ -495,7 +509,6 @@ async def test_exhaustive_strategy_executes_all_tools():
     )
 
 
-@pytest.mark.xfail(reason='final result tool not first is not yet supported')
 async def test_early_strategy_with_final_result_in_middle():
     """Test that 'early' strategy stops at first final result, regardless of position."""
     tool_called: list[str] = []
@@ -523,14 +536,93 @@ async def test_early_strategy_with_final_result_in_middle():
 
     async with agent.run_stream('test early strategy with final result in middle') as result:
         response = await result.get_data()
-        assert response.value == snapshot('first')
+        assert response.value == snapshot('final')
         messages = result.all_messages()
 
     # Verify no tools were called
     assert tool_called == []
 
     # Verify we got appropriate tool returns
-    assert messages == snapshot()
+    assert messages == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content='test early strategy with final ' 'result in middle',
+                        timestamp=IsNow(tz=datetime.timezone.utc),
+                        part_kind='user-prompt',
+                    )
+                ],
+                kind='request',
+            ),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='regular_tool',
+                        args=ArgsJson(args_json='{"x": 1}'),
+                        tool_call_id=None,
+                        part_kind='tool-call',
+                    ),
+                    ToolCallPart(
+                        tool_name='final_result',
+                        args=ArgsJson(args_json='{"value": "final"}'),
+                        tool_call_id=None,
+                        part_kind='tool-call',
+                    ),
+                    ToolCallPart(
+                        tool_name='another_tool',
+                        args=ArgsJson(args_json='{"y": 2}'),
+                        tool_call_id=None,
+                        part_kind='tool-call',
+                    ),
+                    ToolCallPart(
+                        tool_name='unknown_tool',
+                        args=ArgsJson(args_json='{"value": "???"}'),
+                        tool_call_id=None,
+                        part_kind='tool-call',
+                    ),
+                ],
+                timestamp=IsNow(tz=datetime.timezone.utc),
+                kind='response',
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='regular_tool',
+                        content='Tool not executed - a final ' 'result was already processed.',
+                        tool_call_id=None,
+                        timestamp=IsNow(tz=datetime.timezone.utc),
+                        part_kind='tool-return',
+                    ),
+                    ToolReturnPart(
+                        tool_name='final_result',
+                        content='Final result processed.',
+                        tool_call_id=None,
+                        timestamp=IsNow(tz=datetime.timezone.utc),
+                        part_kind='tool-return',
+                    ),
+                    ToolReturnPart(
+                        tool_name='another_tool',
+                        content='Tool not executed - a final ' 'result was already processed.',
+                        tool_call_id=None,
+                        timestamp=IsNow(tz=datetime.timezone.utc),
+                        part_kind='tool-return',
+                    ),
+                    RetryPromptPart(
+                        content='Unknown tool name: '
+                        "'unknown_tool'. Available tools: "
+                        'regular_tool, another_tool, '
+                        'final_result',
+                        tool_name=None,
+                        tool_call_id=None,
+                        timestamp=IsNow(tz=datetime.timezone.utc),
+                        part_kind='retry-prompt',
+                    ),
+                ],
+                kind='request',
+            ),
+        ]
+    )
 
 
 async def test_early_strategy_does_not_apply_to_tool_calls_without_final_tool():

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -79,7 +79,6 @@ async def test_streamed_text_limits() -> None:
 
     async with test_agent.run_stream('Hello', usage_limits=UsageLimits(response_tokens_limit=10)) as result:
         assert test_agent.name == 'test_agent'
-        assert not result.is_structured
         assert not result.is_complete
         assert result.all_messages() == snapshot(
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,9 @@ import pytest
 from inline_snapshot import snapshot
 
 from pydantic_ai import UserError
-from pydantic_ai._utils import Either, check_object_json_schema, group_by_temporal
+from pydantic_ai._utils import UNSET, Either, PeekableAsyncStream, check_object_json_schema, group_by_temporal
+
+from .models.mock_async_stream import MockAsyncStream
 
 pytestmark = pytest.mark.anyio
 
@@ -50,3 +52,27 @@ def test_either():
     assert Either(left=123).whichever() == 123
     assert repr(Either[int, int](right=456)) == 'Either(right=456)'
     assert Either(right=456).whichever() == 456
+
+
+@pytest.mark.parametrize('peek_first', [True, False])
+@pytest.mark.anyio
+async def test_peekable_async_stream(peek_first: bool):
+    async_stream = MockAsyncStream(iter([1, 2, 3]))
+    peekable_async_stream = PeekableAsyncStream(async_stream)
+
+    items: list[int] = []
+
+    # We need to both peek before starting the stream, and not, to achieve full coverage
+    if peek_first:
+        assert not await peekable_async_stream.is_exhausted()
+        assert await peekable_async_stream.peek() == 1
+
+    async for item in peekable_async_stream:
+        items.append(item)
+
+        # The next line is included mostly for the sake of achieving coverage
+        assert await peekable_async_stream.peek() == (item + 1 if item < 3 else UNSET)
+
+    assert await peekable_async_stream.is_exhausted()
+    assert await peekable_async_stream.peek() is UNSET
+    assert items == [1, 2, 3]


### PR DESCRIPTION
This PR refactors streaming in the following ways:
* Remove `EitherStreamingResponse` and just have APIs that return (what is currently called) a `StreamingTextResponse` or `StreamingStructuredResponse`
* Replace the use of `StreamingTextResponse` with `StreamingStructuredResponse` everywhere that you aren't streaming deltas
* Modify the `StreamingStructuredResponse` to be an async iterator that yields PydanticAI-format `ModelResponsePartDelta`s, rather than just yielding `None`. Then, expose this publicly as the API for iterating over the deltas. Optionally, offer a way to disable the building of the ModelResponse to save memory usage.

Remaining things to do:
* [ ] Improve documentation of edited code; update existing docs related to streaming if necessary..
* [ ] (In a separate PR) Add a new public `stream_events` API or similar for consuming all updates. (This was requested in e.g. #640)