### PR TITLE
Make args handling more robust

### DIFF
--- a/docs/testing-evals.md
+++ b/docs/testing-evals.md
@@ -219,7 +219,9 @@ def call_weather_forecast(  # (1)!
         m = re.search(r'\d{4}-\d{2}-\d{2}', user_prompt.content)
         assert m is not None
         args = {'location': 'London', 'forecast_date': m.group()}  # (2)!
-        return ModelResponse(parts=[ToolCallPart.from_dict('weather_forecast', args)])
+        return ModelResponse(
+            parts=[ToolCallPart.from_raw_args('weather_forecast', args)]
+        )
     else:
         # second call, return the forecast
         msg = messages[-1].parts[0]

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -220,7 +220,7 @@ class AnthropicAgentModel(AgentModel):
             else:
                 assert isinstance(item, ToolUseBlock), 'unexpected item type'
                 items.append(
-                    ToolCallPart.from_dict(
+                    ToolCallPart.from_raw_args(
                         item.name,
                         cast(dict[str, Any], item.input),
                         item.id,
@@ -311,7 +311,7 @@ def _map_tool_call(t: ToolCallPart) -> ToolUseBlockParam:
         id=_guard_tool_call_id(t=t, model_source='Anthropic'),
         type='tool_use',
         name=t.tool_name,
-        input=t.args.args_dict,
+        input=t.args_as_dict(),
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -16,7 +16,6 @@ from typing_extensions import NotRequired, TypedDict, TypeGuard, assert_never
 
 from .. import UnexpectedModelBehavior, _utils, exceptions, result
 from ..messages import (
-    ArgsDict,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -460,8 +459,7 @@ class _GeminiFunctionCallPart(TypedDict):
 
 
 def _function_call_part_from_call(tool: ToolCallPart) -> _GeminiFunctionCallPart:
-    assert isinstance(tool.args, ArgsDict), f'Expected ArgsObject, got {tool.args}'
-    return _GeminiFunctionCallPart(function_call=_GeminiFunctionCall(name=tool.tool_name, args=tool.args.args_dict))
+    return _GeminiFunctionCallPart(function_call=_GeminiFunctionCall(name=tool.tool_name, args=tool.args_as_dict()))
 
 
 def _process_response_from_parts(parts: Sequence[_GeminiPartUnion], timestamp: datetime | None = None) -> ModelResponse:
@@ -470,7 +468,7 @@ def _process_response_from_parts(parts: Sequence[_GeminiPartUnion], timestamp: d
         if 'text' in part:
             items.append(TextPart(part['text']))
         elif 'function_call' in part:
-            items.append(ToolCallPart.from_dict(part['function_call']['name'], part['function_call']['args']))
+            items.append(ToolCallPart.from_raw_args(part['function_call']['name'], part['function_call']['args']))
         elif 'function_response' in part:
             raise exceptions.UnexpectedModelBehavior(
                 f'Unsupported response from Gemini, expected all parts to be function calls or text, got: {part!r}'

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -560,13 +560,10 @@ class MistralStreamStructuredResponse(StreamStructuredResponse):
                     # when `{"response":` then `repair_json` sets `{"response": ""}` (type not found default str)
                     # when `{"response": {` then `repair_json` sets `{"response": {}}` (type found)
                     # This ensures it's corrected to `{"response": {}}` and other required parameters and type.
-                    if not self._validate_required_json_shema(output_json, result_tool.parameters_json_schema):
+                    if not self._validate_required_json_schema(output_json, result_tool.parameters_json_schema):
                         continue
 
-                    tool = ToolCallPart.from_dict(
-                        tool_name=result_tool.name,
-                        args_dict=output_json,
-                    )
+                    tool = ToolCallPart.from_raw_args(result_tool.name, output_json)
                     calls.append(tool)
 
         return ModelResponse(calls, timestamp=self._timestamp)
@@ -578,7 +575,7 @@ class MistralStreamStructuredResponse(StreamStructuredResponse):
         return self._timestamp
 
     @staticmethod
-    def _validate_required_json_shema(json_dict: dict[str, Any], json_schema: dict[str, Any]) -> bool:
+    def _validate_required_json_schema(json_dict: dict[str, Any], json_schema: dict[str, Any]) -> bool:
         """Validate that all required parameters in the JSON schema are present in the JSON dictionary."""
         required_params = json_schema.get('required', [])
         properties = json_schema.get('properties', {})
@@ -602,7 +599,7 @@ class MistralStreamStructuredResponse(StreamStructuredResponse):
 
             if isinstance(json_dict[param], dict) and 'properties' in param_schema:
                 nested_schema = param_schema
-                if not MistralStreamStructuredResponse._validate_required_json_shema(json_dict[param], nested_schema):
+                if not MistralStreamStructuredResponse._validate_required_json_schema(json_dict[param], nested_schema):
                     return False
 
         return True
@@ -633,16 +630,7 @@ def _map_mistral_to_pydantic_tool_call(tool_call: MistralToolCall) -> ToolCallPa
     tool_call_id = tool_call.id or None
     func_call = tool_call.function
 
-    if isinstance(func_call.arguments, str):
-        return ToolCallPart.from_json(
-            tool_name=func_call.name,
-            args_json=func_call.arguments,
-            tool_call_id=tool_call_id,
-        )
-    else:
-        return ToolCallPart.from_dict(
-            tool_name=func_call.name, args_dict=func_call.arguments, tool_call_id=tool_call_id
-        )
+    return ToolCallPart.from_raw_args(func_call.name, func_call.arguments, tool_call_id)
 
 
 def _map_usage(response: MistralChatCompletionResponse | MistralCompletionChunk) -> Usage:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -13,7 +13,6 @@ from typing_extensions import assert_never
 from .. import UnexpectedModelBehavior, _utils, result
 from .._utils import guard_tool_call_id as _guard_tool_call_id
 from ..messages import (
-    ArgsJson,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -211,7 +210,7 @@ class OpenAIAgentModel(AgentModel):
             items.append(TextPart(choice.message.content))
         if choice.message.tool_calls is not None:
             for c in choice.message.tool_calls:
-                items.append(ToolCallPart.from_json(c.function.name, c.function.arguments, c.id))
+                items.append(ToolCallPart.from_raw_args(c.function.name, c.function.arguments, c.id))
         return ModelResponse(items, timestamp=timestamp)
 
     @staticmethod
@@ -372,7 +371,7 @@ class OpenAIStreamStructuredResponse(StreamStructuredResponse):
         for c in self._delta_tool_calls.values():
             if f := c.function:
                 if f.name is not None and f.arguments is not None:
-                    items.append(ToolCallPart.from_json(f.name, f.arguments, c.id))
+                    items.append(ToolCallPart.from_raw_args(f.name, f.arguments, c.id))
 
         return ModelResponse(items, timestamp=self._timestamp)
 
@@ -384,11 +383,10 @@ class OpenAIStreamStructuredResponse(StreamStructuredResponse):
 
 
 def _map_tool_call(t: ToolCallPart) -> chat.ChatCompletionMessageToolCallParam:
-    assert isinstance(t.args, ArgsJson), f'Expected ArgsJson, got {t.args}'
     return chat.ChatCompletionMessageToolCallParam(
         id=_guard_tool_call_id(t=t, model_source='OpenAI'),
         type='function',
-        function={'name': t.tool_name, 'arguments': t.args.args_json},
+        function={'name': t.tool_name, 'arguments': t.args_as_json_str()},
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -167,7 +167,7 @@ class TestAgentModel(AgentModel):
         # if there are tools, the first thing we want to do is call all of them
         if self.tool_calls and not any(isinstance(m, ModelResponse) for m in messages):
             return ModelResponse(
-                parts=[ToolCallPart.from_dict(name, self.gen_tool_args(args)) for name, args in self.tool_calls]
+                parts=[ToolCallPart.from_raw_args(name, self.gen_tool_args(args)) for name, args in self.tool_calls]
             )
 
         if messages:
@@ -179,7 +179,7 @@ class TestAgentModel(AgentModel):
             if new_retry_names:
                 return ModelResponse(
                     parts=[
-                        ToolCallPart.from_dict(name, self.gen_tool_args(args))
+                        ToolCallPart.from_raw_args(name, self.gen_tool_args(args))
                         for name, args in self.tool_calls
                         if name in new_retry_names
                     ]
@@ -205,10 +205,10 @@ class TestAgentModel(AgentModel):
             custom_result_args = self.result.right
             result_tool = self.result_tools[self.seed % len(self.result_tools)]
             if custom_result_args is not None:
-                return ModelResponse(parts=[ToolCallPart.from_dict(result_tool.name, custom_result_args)])
+                return ModelResponse(parts=[ToolCallPart.from_raw_args(result_tool.name, custom_result_args)])
             else:
                 response_args = self.gen_tool_args(result_tool)
-                return ModelResponse(parts=[ToolCallPart.from_dict(result_tool.name, response_args)])
+                return ModelResponse(parts=[ToolCallPart.from_raw_args(result_tool.name, response_args)])
 
 
 @dataclass

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -413,7 +413,7 @@ async def test_text_success(get_gemini_client: GetGeminiClient):
 async def test_request_structured_response(get_gemini_client: GetGeminiClient):
     response = gemini_response(
         _content_model_response(
-            ModelResponse(parts=[ToolCallPart.from_dict('final_result', {'response': [1, 2, 123]})])
+            ModelResponse(parts=[ToolCallPart.from_raw_args('final_result', {'response': [1, 2, 123]})])
         )
     )
     gemini_client = get_gemini_client(response)
@@ -449,12 +449,12 @@ async def test_request_tool_call(get_gemini_client: GetGeminiClient):
     responses = [
         gemini_response(
             _content_model_response(
-                ModelResponse(parts=[ToolCallPart.from_dict('get_location', {'loc_name': 'San Fransisco'})])
+                ModelResponse(parts=[ToolCallPart.from_raw_args('get_location', {'loc_name': 'San Fransisco'})])
             )
         ),
         gemini_response(
             _content_model_response(
-                ModelResponse(parts=[ToolCallPart.from_dict('get_location', {'loc_name': 'London'})])
+                ModelResponse(parts=[ToolCallPart.from_raw_args('get_location', {'loc_name': 'London'})])
             )
         ),
         gemini_response(_content_model_response(ModelResponse.from_text('final response'))),
@@ -596,7 +596,7 @@ async def test_stream_structured(get_gemini_client: GetGeminiClient):
     responses = [
         gemini_response(
             _content_model_response(
-                ModelResponse(parts=[ToolCallPart.from_dict('final_result', {'response': [1, 2]})])
+                ModelResponse(parts=[ToolCallPart.from_raw_args('final_result', {'response': [1, 2]})])
             ),
         ),
     ]
@@ -615,10 +615,10 @@ async def test_stream_structured(get_gemini_client: GetGeminiClient):
 async def test_stream_structured_tool_calls(get_gemini_client: GetGeminiClient):
     first_responses = [
         gemini_response(
-            _content_model_response(ModelResponse(parts=[ToolCallPart.from_dict('foo', {'x': 'a'})])),
+            _content_model_response(ModelResponse(parts=[ToolCallPart.from_raw_args('foo', {'x': 'a'})])),
         ),
         gemini_response(
-            _content_model_response(ModelResponse(parts=[ToolCallPart.from_dict('bar', {'y': 'b'})])),
+            _content_model_response(ModelResponse(parts=[ToolCallPart.from_raw_args('bar', {'y': 'b'})])),
         ),
     ]
     d1 = _gemini_streamed_response_ta.dump_json(first_responses, by_alias=True)
@@ -627,7 +627,7 @@ async def test_stream_structured_tool_calls(get_gemini_client: GetGeminiClient):
     second_responses = [
         gemini_response(
             _content_model_response(
-                ModelResponse(parts=[ToolCallPart.from_dict('final_result', {'response': [1, 2]})])
+                ModelResponse(parts=[ToolCallPart.from_raw_args('final_result', {'response': [1, 2]})])
             ),
         ),
     ]

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -1694,5 +1694,5 @@ def test_generate_user_output_format_multiple():
     ],
 )
 def test_validate_required_json_shema(desc: str, schema: dict[str, Any], data: dict[str, Any], expected: bool) -> None:
-    result = MistralStreamStructuredResponse._validate_required_json_shema(data, schema)  # pyright: ignore[reportPrivateUsage]
+    result = MistralStreamStructuredResponse._validate_required_json_schema(data, schema)  # pyright: ignore[reportPrivateUsage]
     assert result == expected, f'{desc} — expected {expected}, got {result}'

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -94,7 +94,7 @@ def test_tool_retry(set_event_loop: None):
         [
             ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
-                parts=[ToolCallPart.from_dict('my_ret', {'x': 0})],
+                parts=[ToolCallPart.from_raw_args('my_ret', {'x': 0})],
                 timestamp=IsNow(tz=timezone.utc),
             ),
             ModelRequest(
@@ -102,7 +102,7 @@ def test_tool_retry(set_event_loop: None):
                     RetryPromptPart(content='First call failed', tool_name='my_ret', timestamp=IsNow(tz=timezone.utc))
                 ]
             ),
-            ModelResponse(parts=[ToolCallPart.from_dict('my_ret', {'x': 0})], timestamp=IsNow(tz=timezone.utc)),
+            ModelResponse(parts=[ToolCallPart.from_raw_args('my_ret', {'x': 0})], timestamp=IsNow(tz=timezone.utc)),
             ModelRequest(parts=[ToolReturnPart(tool_name='my_ret', content='1', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse.from_text(content='{"my_ret":"1"}', timestamp=IsNow(tz=timezone.utc)),
         ]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -11,7 +11,6 @@ from types import ModuleType
 from typing import Any
 
 import httpx
-import pydantic_core
 import pytest
 from devtools import debug
 from pytest_examples import CodeExample, EvalExample, find_examples
@@ -287,10 +286,7 @@ async def stream_model_logic(
                     yield ' '.join(chunk)
                 return
             else:
-                if isinstance(response.args, ArgsDict):
-                    json_text = pydantic_core.to_json(response.args.args_dict).decode()
-                else:
-                    json_text = response.args.args_json
+                json_text = response.args_as_json_str()
 
                 yield {1: DeltaToolCall(name=response.tool_name)}
                 for chunk_index in range(0, len(json_text), 15):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -490,7 +490,7 @@ def test_dynamic_tool_use_messages(set_event_loop: None):
     async def repeat_call_foobar(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if info.function_tools:
             tool = info.function_tools[0]
-            return ModelResponse.from_tool_call(ToolCallPart.from_dict(tool.name, {'x': 42, 'y': 'a'}))
+            return ModelResponse.from_tool_call(ToolCallPart.from_raw_args(tool.name, {'x': 42, 'y': 'a'}))
         else:
             return ModelResponse.from_text('done')
 


### PR DESCRIPTION
I believe this should close #398. It would be good if @sadransh could confirm this though.

I think what was happening there was that the API response was sending data in an unexpected format (already a dict rather than just a JSON string), and our implementation of OpenAIModel assumed it would be a string, and didn't check that at runtime.

In practice, it seems like a likely mistake to be made by LLM implementers to claim to be api-compatible with a model, but have the tool data returned as a string vs. as an object, so it feels reasonable to me to be more defensive about the object we get back. In this PR, I removed the `from_json` and `from_dict` methods on `ToolCallPart` and replaced it with one `from_raw_args` that always checks the type and produces the appropriate kind of `Args` object.

I also added methods to get the args object as a json string or as a dict — while you'd expect most models to do the right thing internally, it's feasible that a user might generate some messages with one model and then run further requests to another model, but reusing the original messages. If the implementation of the other model expects the tool calls to be in a different format, we'll unnecessarily generate errors when we could just convert the data from dict to json or vice versa at runtime.

The overhead of checking the type of the tool call data when parsing or generating vendor-compatible messages seems low enough to be negligible in the grand scheme, so I think the improved handling of mis-typed responses is more beneficial than harmful.