### PR TITLE
use `RunContext` more widely

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_result.py
+++ b/pydantic_ai_slim/pydantic_ai/_result.py
@@ -30,20 +30,20 @@ class ResultValidator(Generic[AgentDeps, ResultData]):
         self,
         result: ResultData,
         tool_call: _messages.ToolCallPart | None,
-        run_ctx: RunContext[AgentDeps],
+        run_context: RunContext[AgentDeps],
     ) -> ResultData:
         """Validate a result but calling the function.
 
         Args:
             result: The result data after Pydantic validation the message content.
             tool_call: The original tool call message, `None` if there was no tool call.
-            run_ctx: The current run context.
+            run_context: The current run context.
 
         Returns:
             Result of either the validated result data (ok) or a retry message (Err).
         """
         if self._takes_ctx:
-            ctx = run_ctx.replace_with(tool_name=tool_call.tool_name if tool_call else None)
+            ctx = run_context.replace_with(tool_name=tool_call.tool_name if tool_call else None)
             args = ctx, result
         else:
             args = (result,)

--- a/pydantic_ai_slim/pydantic_ai/_result.py
+++ b/pydantic_ai_slim/pydantic_ai/_result.py
@@ -29,25 +29,22 @@ class ResultValidator(Generic[AgentDeps, ResultData]):
     async def validate(
         self,
         result: ResultData,
-        deps: AgentDeps,
-        retry: int,
         tool_call: _messages.ToolCallPart | None,
-        messages: list[_messages.ModelMessage],
+        run_ctx: RunContext[AgentDeps],
     ) -> ResultData:
         """Validate a result but calling the function.
 
         Args:
             result: The result data after Pydantic validation the message content.
-            deps: The agent dependencies.
-            retry: The current retry number.
             tool_call: The original tool call message, `None` if there was no tool call.
-            messages: The messages exchanged so far in the conversation.
+            run_ctx: The current run context.
 
         Returns:
             Result of either the validated result data (ok) or a retry message (Err).
         """
         if self._takes_ctx:
-            args = RunContext(deps, retry, messages, tool_call.tool_name if tool_call else None), result
+            ctx = run_ctx.replace_with(tool_name=tool_call.tool_name if tool_call else None)
+            args = ctx, result
         else:
             args = (result,)
 

--- a/pydantic_ai_slim/pydantic_ai/_system_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/_system_prompt.py
@@ -19,9 +19,9 @@ class SystemPromptRunner(Generic[AgentDeps]):
         self._takes_ctx = len(inspect.signature(self.function).parameters) > 0
         self._is_async = inspect.iscoroutinefunction(self.function)
 
-    async def run(self, deps: AgentDeps) -> str:
+    async def run(self, run_ctx: RunContext[AgentDeps]) -> str:
         if self._takes_ctx:
-            args = (RunContext(deps, 0, [], None),)
+            args = (run_ctx,)
         else:
             args = ()
 

--- a/pydantic_ai_slim/pydantic_ai/_system_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/_system_prompt.py
@@ -19,9 +19,9 @@ class SystemPromptRunner(Generic[AgentDeps]):
         self._takes_ctx = len(inspect.signature(self.function).parameters) > 0
         self._is_async = inspect.iscoroutinefunction(self.function)
 
-    async def run(self, run_ctx: RunContext[AgentDeps]) -> str:
+    async def run(self, run_context: RunContext[AgentDeps]) -> str:
         if self._takes_ctx:
-            args = (run_ctx,)
+            args = (run_context,)
         else:
             args = ()
 

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -247,7 +247,9 @@ class Tool(Generic[AgentDeps]):
         else:
             return tool_def
 
-    async def run(self, message: _messages.ToolCallPart, run_ctx: RunContext[AgentDeps]) -> _messages.ModelRequestPart:
+    async def run(
+        self, message: _messages.ToolCallPart, run_context: RunContext[AgentDeps]
+    ) -> _messages.ModelRequestPart:
         """Run the tool function asynchronously."""
         try:
             if isinstance(message.args, _messages.ArgsJson):
@@ -257,7 +259,7 @@ class Tool(Generic[AgentDeps]):
         except ValidationError as e:
             return self._on_error(e, message)
 
-        args, kwargs = self._call_args(args_dict, message, run_ctx)
+        args, kwargs = self._call_args(args_dict, message, run_context)
         try:
             if self._is_async:
                 function = cast(Callable[[Any], Awaitable[str]], self.function)
@@ -279,12 +281,12 @@ class Tool(Generic[AgentDeps]):
         self,
         args_dict: dict[str, Any],
         message: _messages.ToolCallPart,
-        run_ctx: RunContext[AgentDeps],
+        run_context: RunContext[AgentDeps],
     ) -> tuple[list[Any], dict[str, Any]]:
         if self._single_arg_name:
             args_dict = {self._single_arg_name: args_dict}
 
-        ctx = dataclasses.replace(run_ctx, retry=self.current_retry, tool_name=message.tool_name)
+        ctx = dataclasses.replace(run_context, retry=self.current_retry, tool_name=message.tool_name)
         args = [ctx] if self.takes_ctx else []
         for positional_field in self._positional_fields:
             args.append(args_dict.pop(positional_field))

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -1,22 +1,17 @@
 from __future__ import annotations as _annotations
 
+import dataclasses
 import inspect
 from collections.abc import Awaitable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, Union, cast
+from typing import Any, Callable, Generic, TypeVar, Union, cast
 
 from pydantic import ValidationError
 from pydantic_core import SchemaValidator
 from typing_extensions import Concatenate, ParamSpec, TypeAlias
 
-from . import _pydantic, _utils, messages as _messages
+from . import _pydantic, _utils, messages as _messages, models
 from .exceptions import ModelRetry, UnexpectedModelBehavior
-
-if TYPE_CHECKING:
-    from .result import ResultData
-else:
-    ResultData = Any
-
 
 __all__ = (
     'AgentDeps',
@@ -37,7 +32,7 @@ AgentDeps = TypeVar('AgentDeps')
 """Type variable for agent dependencies."""
 
 
-@dataclass
+@dataclasses.dataclass
 class RunContext(Generic[AgentDeps]):
     """Information about the current call."""
 
@@ -49,6 +44,19 @@ class RunContext(Generic[AgentDeps]):
     """Messages exchanged in the conversation so far."""
     tool_name: str | None
     """Name of the tool being called."""
+    model: models.Model
+    """The model used in this run."""
+
+    def replace_with(
+        self, retry: int | None = None, tool_name: str | None | _utils.Unset = _utils.UNSET
+    ) -> RunContext[AgentDeps]:
+        # Create a new `RunContext` a new `retry` value and `tool_name`.
+        kwargs = {}
+        if retry is not None:
+            kwargs['retry'] = retry
+        if tool_name is not _utils.UNSET:
+            kwargs['tool_name'] = tool_name
+        return dataclasses.replace(self, **kwargs)
 
 
 ToolParams = ParamSpec('ToolParams')
@@ -64,6 +72,8 @@ SystemPromptFunc = Union[
 
 Usage `SystemPromptFunc[AgentDeps]`.
 """
+
+ResultData = TypeVar('ResultData')
 
 ResultValidatorFunc = Union[
     Callable[[RunContext[AgentDeps], ResultData], ResultData],
@@ -237,9 +247,7 @@ class Tool(Generic[AgentDeps]):
         else:
             return tool_def
 
-    async def run(
-        self, deps: AgentDeps, message: _messages.ToolCallPart, conv_messages: list[_messages.ModelMessage]
-    ) -> _messages.ModelRequestPart:
+    async def run(self, message: _messages.ToolCallPart, run_ctx: RunContext[AgentDeps]) -> _messages.ModelRequestPart:
         """Run the tool function asynchronously."""
         try:
             if isinstance(message.args, _messages.ArgsJson):
@@ -249,7 +257,7 @@ class Tool(Generic[AgentDeps]):
         except ValidationError as e:
             return self._on_error(e, message)
 
-        args, kwargs = self._call_args(deps, args_dict, message, conv_messages)
+        args, kwargs = self._call_args(args_dict, message, run_ctx)
         try:
             if self._is_async:
                 function = cast(Callable[[Any], Awaitable[str]], self.function)
@@ -269,15 +277,15 @@ class Tool(Generic[AgentDeps]):
 
     def _call_args(
         self,
-        deps: AgentDeps,
         args_dict: dict[str, Any],
         message: _messages.ToolCallPart,
-        conv_messages: list[_messages.ModelMessage],
+        run_ctx: RunContext[AgentDeps],
     ) -> tuple[list[Any], dict[str, Any]]:
         if self._single_arg_name:
             args_dict = {self._single_arg_name: args_dict}
 
-        args = [RunContext(deps, self.current_retry, conv_messages, message.tool_name)] if self.takes_ctx else []
+        ctx = dataclasses.replace(run_ctx, retry=self.current_retry, tool_name=message.tool_name)
+        args = [ctx] if self.takes_ctx else []
         for positional_field in self._positional_fields:
             args.append(args_dict.pop(positional_field))
         if self._var_positional_field:


### PR DESCRIPTION
Also add `model` to `RunContext`.

This was part of my new agent handoff work, but I decided to spit it out.