### PR TITLE
docs: fix typo in pydantic link for /api/models/gemini/

### DIFF
--- a/docs/api/models/gemini.md
+++ b/docs/api/models/gemini.md
@@ -1,7 +1,7 @@
 # `pydantic_ai.models.gemini`
 
 Custom interface to the `generativelanguage.googleapis.com` API using
-[HTTPX](https://www.python-httpx.org/) and [Pydantic](https://docs.pydantic.dev/latest/.
+[HTTPX](https://www.python-httpx.org/) and [Pydantic](https://docs.pydantic.dev/latest/).
 
 The Google SDK for interacting with the `generativelanguage.googleapis.com` API
 [`google-generativeai`](https://ai.google.dev/gemini-api/docs/quickstart?lang=python) reads like it was written by a


### PR DESCRIPTION
Correct this link typo in docs 

[pydantic_ai.models.gemini](https://ai.pydantic.dev/api/models/gemini/)

![image](https://github.com/user-attachments/assets/4ddd7020-a33c-4012-99f3-4a4dbdddc0a0)
