### PR TITLE
Use OpenAI's Structured Outputs feature to prevent validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ env*/
 /pydantic_ai_examples/.chat_app_messages.sqlite
 .cache/
 .vscode/
+*.ipynb

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -133,7 +133,11 @@ class OpenAIModel(Model):
     def _map_response_format(f: ToolDefinition) -> ResponseFormatJSONSchema:
         return {
             'type': 'json_schema',
-            'json_schema': {'name': f.name, 'description': f.description, 'schema': f.parameters_json_schema}
+            'json_schema': {
+                'name': f.name, 
+                'description': f.description, 
+                'schema': f.parameters_json_schema
+            },
         }
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -133,11 +133,7 @@ class OpenAIModel(Model):
     def _map_response_format(f: ToolDefinition) -> ResponseFormatJSONSchema:
         return {
             'type': 'json_schema',
-            'json_schema': {
-                'name': f.name, 
-                'description': f.description, 
-                'schema': f.parameters_json_schema
-            },
+            'json_schema': {'name': f.name, 'description': f.description, 'schema': f.parameters_json_schema},
         }
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -133,11 +133,7 @@ class OpenAIModel(Model):
     def _map_response_format(f: ToolDefinition) -> ResponseFormatJSONSchema:
         return {
             'type': 'json_schema',
-            'json_schema': {
-                'name': f.name,
-                'description': f.description,
-                'schema': f.parameters_json_schema
-            }
+            'json_schema': {'name': f.name, 'description': f.description, 'schema': f.parameters_json_schema}
         }
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -5,11 +5,11 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from itertools import chain
+from openai.types import ResponseFormatJSONSchema
 from typing import Literal, Union, overload
 
 from httpx import AsyncClient as AsyncHTTPClient
 from typing_extensions import assert_never
-from openai.types import ResponseFormatJSONSchema
 
 from .. import UnexpectedModelBehavior, _utils, result
 from .._utils import guard_tool_call_id as _guard_tool_call_id

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -114,12 +114,7 @@ class OpenAIModel(Model):
         check_allow_model_requests()
         tools = [self._map_tool_definition(r) for r in function_tools]
         response_format = self._map_response_format(result_tools[0]) if result_tools else None
-        return OpenAIAgentModel(
-            self.client,
-            self.model_name,
-            tools,
-            response_format
-        )
+        return OpenAIAgentModel(self.client, self.model_name, tools, response_format)
 
     def name(self) -> str:
         return f'openai:{self.model_name}'

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -9,7 +9,6 @@ from typing import Literal, Union, overload
 
 from httpx import AsyncClient as AsyncHTTPClient
 from typing_extensions import assert_never
-
 from openai.types import ResponseFormatJSONSchema
 
 from .. import UnexpectedModelBehavior, _utils, result


### PR DESCRIPTION
Used the result_tools parameter to generate a json_schema which is passed to the OpenAI client as response_format. This guides the model to format it's responses according to the given schema, preventing validation errors.