### PR TITLE
pydantic-ai-graph - simplify public generics

### DIFF
--- a/pydantic_ai_graph/pydantic_ai_graph/__init__.py
+++ b/pydantic_ai_graph/pydantic_ai_graph/__init__.py
@@ -1,5 +1,16 @@
-from .graph import Graph
+from .graph import Graph, GraphRun, GraphRunner
 from .nodes import BaseNode, End, GraphContext
-from .state import AbstractState, Snapshot
+from .state import AbstractState, EndEvent, GraphHistoryItem, Step
 
-__all__ = 'BaseNode', 'End', 'GraphContext', 'Graph', 'Snapshot', 'AbstractState'
+__all__ = (
+    'Graph',
+    'GraphRunner',
+    'GraphRun',
+    'BaseNode',
+    'End',
+    'GraphContext',
+    'AbstractState',
+    'EndEvent',
+    'GraphHistoryItem',
+    'Step',
+)

--- a/pydantic_ai_graph/pydantic_ai_graph/__init__.py
+++ b/pydantic_ai_graph/pydantic_ai_graph/__init__.py
@@ -1,6 +1,6 @@
 from .graph import Graph, GraphRun, GraphRunner
 from .nodes import BaseNode, End, GraphContext
-from .state import AbstractState, EndEvent, GraphHistoryItem, Step
+from .state import AbstractState, EndEvent, Step, StepOrEnd
 
 __all__ = (
     'Graph',
@@ -11,6 +11,6 @@ __all__ = (
     'GraphContext',
     'AbstractState',
     'EndEvent',
-    'GraphHistoryItem',
+    'StepOrEnd',
     'Step',
 )

--- a/pydantic_ai_graph/pydantic_ai_graph/_utils.py
+++ b/pydantic_ai_graph/pydantic_ai_graph/_utils.py
@@ -49,3 +49,17 @@ def type_arg_name(arg: Any) -> str:
         return 'None'
     else:
         return arg.__name__
+
+
+def get_parent_namespace(frame: types.FrameType | None) -> dict[str, Any] | None:
+    """Attempt to get the namespace where the graph was defined.
+
+    If the graph is defined with generics `Graph[a, b]` then another frame is inserted, and we have to skip that
+    to get the correct namespace.
+    """
+    if frame is not None:
+        if back := frame.f_back:
+            if back.f_code.co_filename.endswith('/typing.py'):
+                return get_parent_namespace(back)
+            else:
+                return back.f_locals

--- a/pydantic_ai_graph/pydantic_ai_graph/graph.py
+++ b/pydantic_ai_graph/pydantic_ai_graph/graph.py
@@ -2,150 +2,79 @@ from __future__ import annotations as _annotations
 
 import base64
 import inspect
-import types
-from dataclasses import dataclass
-from datetime import datetime, timezone
+from dataclasses import dataclass, field
 from pathlib import Path
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Generic
 
 import logfire_api
-from typing_extensions import TypeVar, assert_never
+from typing_extensions import Never, ParamSpec, Protocol, TypeVar, assert_never
 
 from . import _utils
-from .nodes import BaseNode, End, GraphContext, GraphOutputT, NodeDef
-from .state import Snapshot, StateT
+from ._utils import get_parent_namespace
+from .nodes import BaseNode, End, GraphContext, NodeDef
+from .state import EndEvent, GraphHistoryItem, StateT, Step
 
-__all__ = ('Graph',)
+__all__ = ('Graph', 'GraphRun', 'GraphRunner')
 
 _logfire = logfire_api.Logfire(otel_scope='pydantic-ai-graph')
-GraphInputT = TypeVar('GraphInputT', default=Any)
+
+RunSignatureT = ParamSpec('RunSignatureT')
+RunEndT = TypeVar('RunEndT', default=None)
+NodeRunEndT = TypeVar('NodeRunEndT', covariant=True, default=Never)
 
 
-# noinspection PyTypeHints
+class StartNodeProtocol(Protocol[RunSignatureT, StateT, NodeRunEndT]):
+    def get_id(self) -> str: ...
+    def __call__(self, *args: RunSignatureT.args, **kwargs: RunSignatureT.kwargs) -> BaseNode[StateT, NodeRunEndT]: ...
+
+
 @dataclass(init=False)
-class Graph(Generic[StateT, GraphInputT, GraphOutputT]):
+class Graph(Generic[StateT, RunEndT]):
     """Definition of a graph."""
 
-    first_node: NodeDef[StateT, Any, Any]
-    nodes: dict[str, NodeDef[StateT, Any, Any]]
-    name: str | None
+    name: str
+    nodes: tuple[type[BaseNode[StateT, RunEndT]], ...]
+    node_defs: dict[str, NodeDef[StateT, RunEndT]]
 
     def __init__(
         self,
-        first_node: type[BaseNode[StateT, GraphInputT, GraphOutputT]],
-        *other_nodes: type[BaseNode[StateT, Any, GraphOutputT]],
-        name: str | None = None,
+        name: str = 'graph',
+        nodes: tuple[type[BaseNode[StateT, RunEndT]], ...] = (),
         state_type: type[StateT] | None = None,
     ):
-        parent_namespace = get_parent_namespace(inspect.currentframe())
-        self.first_node = first_node.get_node_def(parent_namespace)
-        self.nodes = nodes = {self.first_node.node_id: self.first_node}
-        for node in other_nodes:
-            node_def = node.get_node_def(parent_namespace)
-            nodes[node_def.node_id] = node_def
-
-        self._check()
         self.name = name
 
-    async def run(
-        self,
-        input_data: GraphInputT,
-        state: StateT = None,
-        history: list[Snapshot] | None = None,
-    ) -> tuple[GraphOutputT, list[Snapshot]]:
-        current_node_def = self.first_node
-        current_node = current_node_def.node(input_data)
-        ctx = GraphContext(state)
-        if history:
-            run_history = history[:]
-        else:
-            run_history = []
+        _nodes_by_id: dict[str, type[BaseNode[StateT, RunEndT]]] = {}
+        for node in nodes:
+            node_id = node.get_id()
+            if (existing_node := _nodes_by_id.get(node_id)) and existing_node is not node:
+                raise ValueError(f'Node ID "{node_id}" is not unique — found in {existing_node} and {node}')
+            else:
+                _nodes_by_id[node_id] = node
+        self.nodes = tuple(_nodes_by_id.values())
 
-        with _logfire.span(
-            '{graph_name} run {input=}',
-            graph_name=self.name or 'graph',
-            input=input_data,
-            graph=self,
-        ) as run_span:
-            while True:
-                with _logfire.span('run node {node_id}', node_id=current_node_def.node_id):
-                    start_ts = datetime.now(tz=timezone.utc)
-                    start = perf_counter()
-                    # noinspection PyUnresolvedReferences
-                    next_node = await current_node.run(ctx)
-                    duration = perf_counter() - start
+        parent_namespace = get_parent_namespace(inspect.currentframe())
+        _node_defs: dict[str, NodeDef[StateT, RunEndT]] = {}
+        for node in self.nodes:
+            _node_defs[node.get_id()] = node.get_node_def(parent_namespace)
+        self.node_defs = _node_defs
 
-                if isinstance(next_node, End):
-                    if current_node_def.can_end:
-                        run_history.append(
-                            Snapshot.from_state(current_node_def.node_id, 'END', start_ts, duration, ctx.state)
-                        )
-                        run_span.set_attribute('history', run_history)
-                        return next_node.data, run_history
-                    else:
-                        raise ValueError(f'Node {current_node_def.node_id} cannot end the graph')
-                elif isinstance(next_node, BaseNode):
-                    next_node_id = next_node.get_id()
-                    run_history.append(
-                        Snapshot.from_state(current_node_def.node_id, next_node_id, start_ts, duration, ctx.state)
-                    )
-                    try:
-                        next_node_def = self.nodes[next_node_id]
-                    except KeyError as e:
-                        raise ValueError(
-                            f'Node {current_node_def.node_id} cannot go to {next_node_id} which is not in the Graph'
-                        ) from e
+        self._validate_edges()
 
-                    if not current_node_def.dest_any and next_node_id not in current_node_def.next_node_ids:
-                        raise ValueError(
-                            f'Node {current_node_def.node_id} cannot go to {next_node_id} which is not in its '
-                            f'list of allowed next nodes'
-                        )
+    def validate_next_node(self, next_node: BaseNode[StateT, RunEndT]) -> None:
+        next_node_id = next_node.get_id()
+        if next_node_id not in self.node_defs:
+            raise ValueError(f'Node "{next_node_id}" is not in the graph.')
 
-                    current_node_def = next_node_def
-                    current_node = next_node
-                else:
-                    if TYPE_CHECKING:
-                        assert_never(next_node)
-                    else:
-                        raise TypeError(f'Invalid node type: {type(next_node)} expected BaseNode or End')
-
-    def mermaid_code(self) -> str:
-        lines = ['graph TD']
-        # order of destination nodes should match their order in `self.nodes`
-        node_order = {nid: index for index, nid in enumerate(self.nodes.keys())}
-        for node_id, node in self.nodes.items():
-            if node_id == self.first_node.node_id:
-                lines.append(f'  START --> {node_id}')
-            if node.dest_any:
-                for next_node_id in self.nodes:
-                    lines.append(f'  {node_id} --> {next_node_id}')
-            for _, next_node_id in sorted((node_order[nid], nid) for nid in node.next_node_ids):
-                lines.append(f'  {node_id} --> {next_node_id}')
-            if node.can_end:
-                lines.append(f'  {node_id} --> END')
-        return '\n'.join(lines)
-
-    def mermaid_image(self, mermaid_ink_params: dict[str, str | int] | None = None) -> bytes:
-        import httpx
-
-        code_base64 = base64.b64encode(self.mermaid_code().encode()).decode()
-
-        response = httpx.get(f'https://mermaid.ink/img/{code_base64}', params=mermaid_ink_params)
-        response.raise_for_status()
-        return response.content
-
-    def mermaid_save(self, path: Path | str, mermaid_ink_params: dict[str, str | int] | None = None) -> None:
-        image_data = self.mermaid_image(mermaid_ink_params)
-        Path(path).write_bytes(image_data)
-
-    def _check(self):
+    def _validate_edges(self):
+        known_node_ids = set(self.node_defs.keys())
         bad_edges: dict[str, list[str]] = {}
-        for node in self.nodes.values():
-            node_bad_edges = node.next_node_ids - self.nodes.keys()
+
+        for node_id, node_def in self.node_defs.items():
+            node_bad_edges = node_def.next_node_ids - known_node_ids
             for bad_edge in node_bad_edges:
-                bad_edges.setdefault(bad_edge, []).append(f'"{node.node_id}"')
+                bad_edges.setdefault(bad_edge, []).append(f'"{node_id}"')
 
         if bad_edges:
             bad_edges_list = [f'"{k}" is referenced by {_utils.comma_and(v)}' for k, v in bad_edges.items()]
@@ -155,16 +84,150 @@ class Graph(Generic[StateT, GraphInputT, GraphOutputT]):
                 b = '\n'.join(f' {be}' for be in bad_edges_list)
                 raise ValueError(f'Nodes are referenced in the graph but not included in the graph:\n{b}')
 
+    async def run(
+        self, state: StateT, node: BaseNode[StateT, RunEndT]
+    ) -> tuple[RunEndT, list[GraphHistoryItem[StateT, RunEndT]]]:
+        if not isinstance(node, self.nodes):
+            raise ValueError(f'Node "{node.get_id()}" is not in the graph.')
+        run = GraphRun[StateT, RunEndT](state=state)
+        result = await run.run(self.name, node)
+        history = run.history
+        return result, history
 
-def get_parent_namespace(frame: types.FrameType | None) -> dict[str, Any] | None:
-    """Attempt to get the namespace where the graph was defined.
+    def get_runner(
+        self,
+        first_node: StartNodeProtocol[RunSignatureT, StateT, RunEndT],
+    ) -> GraphRunner[RunSignatureT, StateT, RunEndT]:
+        return GraphRunner(
+            graph=self,
+            first_node=first_node,
+        )
 
-    If the graph is defined with generics `Graph[a, b]` then another frame is inserted, and we have to skip that
-    to get the correct namespace.
+
+@dataclass
+class GraphRunner(Generic[RunSignatureT, StateT, RunEndT]):
+    """Runner for a graph.
+
+    This is a separate class from Graph so that you can get a type-safe runner from a graph definition
+    without needing to manually annotate the paramspec of the start node.
     """
-    if frame is not None:
-        if back := frame.f_back:
-            if back.f_code.co_filename.endswith('/typing.py'):
-                return get_parent_namespace(back)
-            else:
-                return back.f_locals
+
+    graph: Graph[StateT, RunEndT]
+    first_node: StartNodeProtocol[RunSignatureT, StateT, RunEndT]
+
+    def __post_init__(self):
+        if self.first_node not in self.graph.nodes:
+            raise ValueError(f'Start node "{self.first_node.get_id()}" is not in the graph.')
+
+    async def run(
+        self, state: StateT, /, *args: RunSignatureT.args, **kwargs: RunSignatureT.kwargs
+    ) -> tuple[RunEndT, list[GraphHistoryItem[StateT, RunEndT]]]:
+        run = GraphRun[StateT, RunEndT](state=state)
+        result = await run.run(self.graph.name, self.first_node(*args, **kwargs))
+        history = run.history
+        return result, history
+
+    def mermaid_code(self) -> str:
+        return mermaid_code(self.graph, self.first_node)
+
+    def mermaid_image(self, mermaid_ink_params: dict[str, str | int] | None = None) -> bytes:
+        return mermaid_image(self.graph, self.first_node, mermaid_ink_params)
+
+    def mermaid_save(self, path: Path | str, mermaid_ink_params: dict[str, str | int] | None = None) -> None:
+        mermaid_save(path, self.graph, self.first_node, mermaid_ink_params)
+
+
+@dataclass
+class GraphRun(Generic[StateT, RunEndT]):
+    """Stateful run of a graph."""
+
+    state: StateT
+    history: list[GraphHistoryItem[StateT, RunEndT]] = field(default_factory=list)
+
+    async def run(self, graph_name: str, start: BaseNode[StateT, RunEndT]) -> RunEndT:
+        current_node = start
+
+        with _logfire.span(
+            '{graph_name} run {start=}',
+            graph_name=graph_name,
+            start=start,
+        ) as run_span:
+            while True:
+                next_node = await self.step(current_node)
+                if isinstance(next_node, End):
+                    self.history.append(EndEvent(self.state, next_node))
+                    run_span.set_attribute('history', self.history)
+                    return next_node.data
+                elif isinstance(next_node, BaseNode):
+                    current_node = next_node
+                else:
+                    if TYPE_CHECKING:
+                        assert_never(next_node)
+                    else:
+                        raise TypeError(f'Invalid node type: {type(next_node)}. Expected `BaseNode` or `End`.')
+
+    async def step(self, node: BaseNode[StateT, RunEndT]) -> BaseNode[StateT, RunEndT] | End[RunEndT]:
+        history_step = Step(self.state, node)
+        self.history.append(history_step)
+
+        ctx = GraphContext(self.state)
+        with _logfire.span('run node {node_id}', node_id=node.get_id()):
+            start = perf_counter()
+            next_node = await node.run(ctx)
+            history_step.duration = perf_counter() - start
+        return next_node
+
+
+def mermaid_code(
+    graph: Graph[Any, Any], start: StartNodeProtocol[..., Any, Any] | tuple[StartNodeProtocol[..., Any, Any], ...] = ()
+) -> str:
+    if not isinstance(start, tuple):
+        start = (start,)
+
+    for node in start:
+        if node not in graph.nodes:
+            raise ValueError(f'Start node "{node.get_id()}" is not in the graph.')
+
+    node_order = {node_id: index for index, node_id in enumerate(graph.node_defs)}
+
+    lines = ['graph TD']
+    for node in graph.nodes:
+        node_id = node.get_id()
+        node_def = graph.node_defs[node_id]
+        if node in start:
+            lines.append(f'  START --> {node_id}')
+        if node_def.returns_base_node:
+            for next_node_id in graph.nodes:
+                lines.append(f'  {node_id} --> {next_node_id}')
+        else:
+            for _, next_node_id in sorted((node_order[node_id], node_id) for node_id in node_def.next_node_ids):
+                lines.append(f'  {node_id} --> {next_node_id}')
+        if node_def.returns_end:
+            lines.append(f'  {node_id} --> END')
+
+    return '\n'.join(lines)
+
+
+def mermaid_image(
+    graph: Graph[Any, Any],
+    start: StartNodeProtocol[..., Any, Any] | tuple[StartNodeProtocol[..., Any, Any], ...] = (),
+    mermaid_ink_params: dict[str, str | int] | None = None,
+) -> bytes:
+    import httpx
+
+    code_base64 = base64.b64encode(mermaid_code(graph, start).encode()).decode()
+
+    response = httpx.get(f'https://mermaid.ink/img/{code_base64}', params=mermaid_ink_params)
+    response.raise_for_status()
+    return response.content
+
+
+def mermaid_save(
+    path: Path | str,
+    graph: Graph[Any, Any],
+    start: StartNodeProtocol[..., Any, Any] | tuple[StartNodeProtocol[..., Any, Any], ...] = (),
+    mermaid_ink_params: dict[str, str | int] | None = None,
+) -> None:
+    # TODO: do something with the path file extension, e.g. error if it's incompatible, or use it to specify a param
+    image_data = mermaid_image(graph, start, mermaid_ink_params)
+    Path(path).write_bytes(image_data)

--- a/pydantic_ai_graph/pydantic_ai_graph/nodes.py
+++ b/pydantic_ai_graph/pydantic_ai_graph/nodes.py
@@ -1,29 +1,21 @@
 from __future__ import annotations as _annotations
 
-from abc import ABC, ABCMeta, abstractmethod
+from abc import abstractmethod
 from dataclasses import dataclass
 from functools import cache
-from typing import Any, ClassVar, Generic, get_args, get_origin, get_type_hints
+from typing import Any, ClassVar, Generic, get_origin, get_type_hints
 
-from typing_extensions import TypeVar
+from typing_extensions import Never, TypeVar
 
 from . import _utils
 from .state import StateT
 
-__all__ = (
-    'NodeInputT',
-    'GraphOutputT',
-    'GraphContext',
-    'End',
-    'BaseNode',
-    'NodeDef',
-)
+__all__ = ('GraphContext', 'End', 'BaseNode', 'NodeDef')
 
-NodeInputT = TypeVar('NodeInputT', default=Any)
-GraphOutputT = TypeVar('GraphOutputT', default=Any)
+RunEndT = TypeVar('RunEndT', default=None)
+NodeRunEndT = TypeVar('NodeRunEndT', covariant=True, default=Never)
 
 
-# noinspection PyTypeHints
 @dataclass
 class GraphContext(Generic[StateT]):
     """Context for a graph."""
@@ -31,61 +23,50 @@ class GraphContext(Generic[StateT]):
     state: StateT
 
 
-# noinspection PyTypeHints
-class End(ABC, Generic[NodeInputT]):
+@dataclass
+class End(Generic[RunEndT]):
     """Type to return from a node to signal the end of the graph."""
 
-    __slots__ = ('data',)
+    data: RunEndT
 
-    def __init__(self, input_data: NodeInputT) -> None:
-        self.data = input_data
-
-
-class _BaseNodeMeta(ABCMeta):
-    def __repr__(cls):
-        base: Any = cls.__orig_bases__[0]  # type: ignore
-        args = get_args(base)
-        if len(args) == 3 and args[2] is Any:
-            if args[1] is Any:
-                args = args[:1]
-            else:
-                args = args[:2]
-        args = ', '.join(_utils.type_arg_name(a) for a in args)
-        return f'{cls.__name__}({base.__name__}[{args}])'
+    @classmethod
+    def get_id(cls) -> str:
+        return 'End'
 
 
-# noinspection PyTypeHints
-class BaseNode(Generic[StateT, NodeInputT, GraphOutputT], metaclass=_BaseNodeMeta):
+class BaseNode(Generic[StateT, NodeRunEndT]):
     """Base class for a node."""
 
-    node_id: ClassVar[str | None] = None
-    __slots__ = ('input_data',)
-
-    def __init__(self, input_data: NodeInputT) -> None:
-        self.input_data = input_data
+    _node_id: ClassVar[str | None] = None
 
     @abstractmethod
-    async def run(self, ctx: GraphContext[StateT]) -> BaseNode[StateT, Any, Any] | End[GraphOutputT]: ...
+    async def run(self, ctx: GraphContext[StateT]) -> BaseNode[StateT, Any] | End[NodeRunEndT]: ...
 
     @classmethod
     @cache
     def get_id(cls) -> str:
-        return cls.node_id or cls.__name__
+        return cls._node_id or cls.__name__
 
     @classmethod
-    def get_node_def(cls, local_ns: dict[str, Any] | None) -> NodeDef[StateT, Any, Any]:
+    def get_node_def(cls, local_ns: dict[str, Any] | None) -> NodeDef[StateT, NodeRunEndT]:
         type_hints = get_type_hints(cls.run, localns=local_ns)
         next_node_ids: set[str] = set()
-        can_end: bool = False
-        dest_any: bool = False
-        for return_type in _utils.get_union_args(type_hints['return']):
+        returns_end: bool = False
+        returns_base_node: bool = False
+        try:
+            return_hint = type_hints['return']
+        except KeyError:
+            raise TypeError(f'Node {cls} is missing a return type hint on its `run` method')
+
+        for return_type in _utils.get_union_args(return_hint):
             return_type_origin = get_origin(return_type) or return_type
-            if return_type_origin is BaseNode:
-                dest_any = True
+            if return_type_origin is End:
+                returns_end = True
+            elif return_type_origin is BaseNode:
+                # TODO: Should we disallow this? More generally, what do we do about sub-subclasses?
+                returns_base_node = True
             elif issubclass(return_type_origin, BaseNode):
                 next_node_ids.add(return_type.get_id())
-            elif return_type_origin is End:
-                can_end = True
             else:
                 raise TypeError(f'Invalid return type: {return_type}')
 
@@ -93,21 +74,20 @@ class BaseNode(Generic[StateT, NodeInputT, GraphOutputT], metaclass=_BaseNodeMet
             cls,
             cls.get_id(),
             next_node_ids,
-            can_end,
-            dest_any,
+            returns_end,
+            returns_base_node,
         )
 
 
-# noinspection PyTypeHints
 @dataclass
-class NodeDef(ABC, Generic[StateT, NodeInputT, GraphOutputT]):
+class NodeDef(Generic[StateT, NodeRunEndT]):
     """Definition of a node.
 
     Used by [`Graph`][pydantic_ai_graph.graph.Graph] store information about a node.
     """
 
-    node: type[BaseNode[StateT, NodeInputT, GraphOutputT]]
+    node: type[BaseNode[StateT, NodeRunEndT]]
     node_id: str
     next_node_ids: set[str]
-    can_end: bool
-    dest_any: bool
+    returns_end: bool
+    returns_base_node: bool

--- a/pydantic_ai_graph/pydantic_ai_graph/nodes.py
+++ b/pydantic_ai_graph/pydantic_ai_graph/nodes.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 from abc import abstractmethod
 from dataclasses import dataclass
 from functools import cache
-from typing import Any, ClassVar, Generic, get_origin, get_type_hints
+from typing import Any, Generic, get_origin, get_type_hints
 
 from typing_extensions import Never, TypeVar
 
@@ -29,15 +29,9 @@ class End(Generic[RunEndT]):
 
     data: RunEndT
 
-    @classmethod
-    def get_id(cls) -> str:
-        return 'End'
-
 
 class BaseNode(Generic[StateT, NodeRunEndT]):
     """Base class for a node."""
-
-    _node_id: ClassVar[str | None] = None
 
     @abstractmethod
     async def run(self, ctx: GraphContext[StateT]) -> BaseNode[StateT, Any] | End[NodeRunEndT]: ...
@@ -45,7 +39,7 @@ class BaseNode(Generic[StateT, NodeRunEndT]):
     @classmethod
     @cache
     def get_id(cls) -> str:
-        return cls._node_id or cls.__name__
+        return cls.__name__
 
     @classmethod
     def get_node_def(cls, local_ns: dict[str, Any] | None) -> NodeDef[StateT, NodeRunEndT]:

--- a/pydantic_ai_graph/pydantic_ai_graph/state.py
+++ b/pydantic_ai_graph/pydantic_ai_graph/state.py
@@ -1,13 +1,18 @@
 from __future__ import annotations as _annotations
 
+import copy
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Union
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Generic, Literal, Union
 
-from typing_extensions import TypeVar
+from typing_extensions import Never, TypeVar
 
-__all__ = 'AbstractState', 'StateT', 'Snapshot'
+__all__ = 'AbstractState', 'StateT', 'Step', 'EndEvent', 'GraphHistoryItem'
+
+if TYPE_CHECKING:
+    from pydantic_ai_graph import BaseNode
+    from pydantic_ai_graph.nodes import End
 
 
 class AbstractState(ABC):
@@ -19,33 +24,40 @@ class AbstractState(ABC):
         raise NotImplementedError
 
 
+RunEndT = TypeVar('RunEndT', default=None)
+NodeRunEndT = TypeVar('NodeRunEndT', covariant=True, default=Never)
 StateT = TypeVar('StateT', bound=Union[None, AbstractState], default=None)
 
 
 @dataclass
-class Snapshot:
-    """Snapshot of a graph."""
+class Step(Generic[StateT, RunEndT]):
+    """History item describing the execution of a step of a graph."""
 
-    last_node_id: str
-    next_node_id: str
-    start_ts: datetime
-    duration: float
-    state: bytes | None = None
+    state: StateT
+    node: BaseNode[StateT, RunEndT]
+    start_ts: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+    duration: float | None = None
 
-    @classmethod
-    def from_state(
-        cls, last_node_id: str, next_node_id: str, start_ts: datetime, duration: float, state: StateT
-    ) -> Snapshot:
-        return cls(
-            last_node_id=last_node_id,
-            next_node_id=next_node_id,
-            start_ts=start_ts,
-            duration=duration,
-            state=state.serialize() if state is not None else None,
-        )
+    kind: Literal['start_step'] = 'start_step'
 
-    def summary(self) -> str:
-        s = f'{self.last_node_id} -> {self.next_node_id}'
-        if self.duration > 1e-5:
-            s += f' ({self.duration:.6f}s)'
-        return s
+    def __post_init__(self):
+        # Copy the state to prevent it from being modified by other code
+        self.state = copy.deepcopy(self.state)
+
+
+@dataclass
+class EndEvent(Generic[StateT, RunEndT]):
+    """History item describing the end of a graph run."""
+
+    state: StateT
+    result: End[RunEndT]
+    ts: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+    kind: Literal['end'] = 'end'
+
+    def __post_init__(self):
+        # Copy the state to prevent it from being modified by other code
+        self.state = copy.deepcopy(self.state)
+
+
+GraphHistoryItem = Union[Step[StateT, RunEndT], EndEvent[StateT, RunEndT]]

--- a/pydantic_ai_graph/pydantic_ai_graph/state.py
+++ b/pydantic_ai_graph/pydantic_ai_graph/state.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Generic, Literal, Union
 
 from typing_extensions import Never, TypeVar
 
-__all__ = 'AbstractState', 'StateT', 'Step', 'EndEvent', 'GraphHistoryItem'
+__all__ = 'AbstractState', 'StateT', 'Step', 'EndEvent', 'StepOrEnd'
 
 if TYPE_CHECKING:
     from pydantic_ai_graph import BaseNode
@@ -60,4 +60,4 @@ class EndEvent(Generic[StateT, RunEndT]):
         self.state = copy.deepcopy(self.state)
 
 
-GraphHistoryItem = Union[Step[StateT, RunEndT], EndEvent[StateT, RunEndT]]
+StepOrEnd = Union[Step[StateT, RunEndT], EndEvent[StateT, RunEndT]]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,12 +1,13 @@
 from __future__ import annotations as _annotations
 
+from dataclasses import dataclass
 from datetime import timezone
 from typing import Union
 
 import pytest
 from inline_snapshot import snapshot
 
-from pydantic_ai_graph import BaseNode, End, Graph, GraphContext, Snapshot
+from pydantic_ai_graph import BaseNode, End, EndEvent, Graph, GraphContext, Step
 
 from .conftest import IsFloat, IsNow
 
@@ -14,85 +15,101 @@ pytestmark = pytest.mark.anyio
 
 
 async def test_graph():
-    class Float2String(BaseNode[None, float]):
+    @dataclass
+    class Float2String(BaseNode[None]):
+        input_data: float
+
         async def run(self, ctx: GraphContext) -> String2Length:
             return String2Length(str(self.input_data))
 
-    class String2Length(BaseNode[None, str]):
+    @dataclass
+    class String2Length(BaseNode[None]):
+        input_data: str
+
         async def run(self, ctx: GraphContext) -> Double:
             return Double(len(self.input_data))
 
-    class Double(BaseNode[None, int, int]):
+    @dataclass
+    class Double(BaseNode[None, int]):
+        input_data: int
+
         async def run(self, ctx: GraphContext) -> Union[String2Length, End[int]]:  # noqa: UP007
             if self.input_data == 7:
                 return String2Length('x' * 21)
             else:
                 return End(self.input_data * 2)
 
-    g = Graph[None, float, int](
-        Float2String,
-        String2Length,
-        Double,
-    )
-    result, history = await g.run(3.14)
+    g = Graph[None, int](nodes=(Float2String, String2Length, Double))
+    runner = g.get_runner(Float2String)
+    result, history = await runner.run(None, 3.14)
     # len('3.14') * 2 == 8
     assert result == 8
     assert history == snapshot(
         [
-            Snapshot(
-                last_node_id='Float2String',
-                next_node_id='String2Length',
+            Step(
+                state=None,
+                node=Float2String(input_data=3.14),
                 start_ts=IsNow(tz=timezone.utc),
-                duration=IsFloat(gt=0, lt=1e-3),
+                duration=IsFloat(),
             ),
-            Snapshot(
-                last_node_id='String2Length',
-                next_node_id='Double',
+            Step(
+                state=None,
+                node=String2Length(input_data='3.14'),
                 start_ts=IsNow(tz=timezone.utc),
-                duration=IsFloat(gt=0, lt=1e-3),
+                duration=IsFloat(),
             ),
-            Snapshot(
-                last_node_id='Double',
-                next_node_id='END',
+            Step(
+                state=None,
+                node=Double(input_data=4),
                 start_ts=IsNow(tz=timezone.utc),
-                duration=IsFloat(gt=0, lt=1e-3),
+                duration=IsFloat(),
+            ),
+            EndEvent(
+                state=None,
+                result=End(data=8),
+                ts=IsNow(tz=timezone.utc),
             ),
         ]
     )
-    result, history = await g.run(3.14159)
+    result, history = await runner.run(None, 3.14159)
     # len('3.14159') == 7, 21 * 2 == 42
     assert result == 42
     assert history == snapshot(
         [
-            Snapshot(
-                last_node_id='Float2String',
-                next_node_id='String2Length',
+            Step(
+                state=None,
+                node=Float2String(input_data=3.14159),
                 start_ts=IsNow(tz=timezone.utc),
-                duration=IsFloat(gt=0, lt=1e-3),
+                duration=IsFloat(),
             ),
-            Snapshot(
-                last_node_id='String2Length',
-                next_node_id='Double',
+            Step(
+                state=None,
+                node=String2Length(input_data='3.14159'),
                 start_ts=IsNow(tz=timezone.utc),
-                duration=IsFloat(gt=0, lt=1e-3),
+                duration=IsFloat(),
             ),
-            Snapshot(
-                last_node_id='Double',
-                next_node_id='String2Length',
+            Step(
+                state=None,
+                node=Double(input_data=7),
                 start_ts=IsNow(tz=timezone.utc),
-                duration=IsFloat(gt=0, lt=1e-3),
+                duration=IsFloat(),
             ),
-            Snapshot(
-                last_node_id='String2Length',
-                next_node_id='Double',
+            Step(
+                state=None,
+                node=String2Length(input_data='xxxxxxxxxxxxxxxxxxxxx'),
                 start_ts=IsNow(tz=timezone.utc),
-                duration=IsFloat(gt=0, lt=1e-3),
+                duration=IsFloat(),
             ),
-            Snapshot(
-                last_node_id='Double',
-                next_node_id='END',
+            Step(
+                state=None,
+                node=Double(input_data=21),
                 start_ts=IsNow(tz=timezone.utc),
-                duration=IsFloat(gt=0, lt=1e-3),
+                duration=IsFloat(),
+            ),
+            EndEvent(
+                state=None,
+                result=End(data=42),
+                ts=IsNow(tz=timezone.utc),
             ),
         ]
     )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -16,14 +16,14 @@ pytestmark = pytest.mark.anyio
 
 async def test_graph():
     @dataclass
-    class Float2String(BaseNode[None]):
+    class Float2String(BaseNode):
         input_data: float
 
         async def run(self, ctx: GraphContext) -> String2Length:
             return String2Length(str(self.input_data))
 
     @dataclass
-    class String2Length(BaseNode[None]):
+    class String2Length(BaseNode):
         input_data: str
 
         async def run(self, ctx: GraphContext) -> Double:

--- a/tests/typed_agent.py
+++ b/tests/typed_agent.py
@@ -3,7 +3,9 @@
 from collections.abc import Awaitable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Callable, TypeAlias, Union, assert_type
+from typing import Callable, TypeAlias, Union
+
+from typing_extensions import assert_type
 
 from pydantic_ai import Agent, ModelRetry, RunContext, Tool
 from pydantic_ai.result import RunResult

--- a/tests/typed_graph.py
+++ b/tests/typed_graph.py
@@ -8,7 +8,7 @@ from pydantic_ai_graph import BaseNode, End, Graph, GraphContext
 
 
 @dataclass
-class Float2String(BaseNode[None]):
+class Float2String(BaseNode):
     input_data: float
 
     async def run(self, ctx: GraphContext) -> String2Length:
@@ -16,7 +16,7 @@ class Float2String(BaseNode[None]):
 
 
 @dataclass
-class String2Length(BaseNode[None]):
+class String2Length(BaseNode):
     input_data: str
 
     async def run(self, ctx: GraphContext) -> Double:

--- a/tests/typed_graph.py
+++ b/tests/typed_graph.py
@@ -1,7 +1,8 @@
 from __future__ import annotations as _annotations
 
 from dataclasses import dataclass
-from typing import assert_type
+
+from typing_extensions import assert_type
 
 from pydantic_ai_graph import BaseNode, End, Graph, GraphContext
 
@@ -69,5 +70,5 @@ g3 = Graph(
 # because String2Length came before Double, the output type is Any
 assert_type(g3, Graph[None, X])
 
-Graph[None, float, bytes](Float2String, String2Length, Double)  # type: ignore[arg-type]
-Graph[None, int, str](Double)  # type: ignore[arg-type]
+Graph[None, bytes](Float2String, String2Length, Double)  # type: ignore[arg-type]
+Graph[None, str](Double)  # type: ignore[arg-type]

--- a/tests/typed_graph.py
+++ b/tests/typed_graph.py
@@ -6,12 +6,18 @@ from typing import assert_type
 from pydantic_ai_graph import BaseNode, End, Graph, GraphContext
 
 
-class Float2String(BaseNode[None, float]):
+@dataclass
+class Float2String(BaseNode[None]):
+    input_data: float
+
     async def run(self, ctx: GraphContext) -> String2Length:
         return String2Length(str(self.input_data))
 
 
-class String2Length(BaseNode[None, str]):
+@dataclass
+class String2Length(BaseNode[None]):
+    input_data: str
+
     async def run(self, ctx: GraphContext) -> Double:
         return Double(len(self.input_data))
 
@@ -21,7 +27,10 @@ class X:
     v: int
 
 
-class Double(BaseNode[None, int, X]):
+@dataclass
+class Double(BaseNode[None, X]):
+    input_data: int
+
     async def run(self, ctx: GraphContext) -> String2Length | End[X]:
         if self.input_data == 7:
             return String2Length('x' * 21)
@@ -29,7 +38,7 @@ class Double(BaseNode[None, int, X]):
             return End(X(self.input_data * 2))
 
 
-def use_double(node: BaseNode[None, int, X]) -> None:
+def use_double(node: BaseNode[None, X]) -> None:
     """Shoe that `Double` is valid as a `BaseNode[None, int, X]`."""
     print(node)
 
@@ -37,24 +46,28 @@ def use_double(node: BaseNode[None, int, X]) -> None:
 use_double(Double(1))
 
 
-g1 = Graph[None, float, X](
-    Float2String,
-    String2Length,
-    Double,
+g1 = Graph[None, X](
+    nodes=(
+        Float2String,
+        String2Length,
+        Double,
+    )
 )
-assert_type(g1, Graph[None, float, X])
+assert_type(g1, Graph[None, X])
 
 
-g2 = Graph(Double)
-assert_type(g2, Graph[None, int, X])
+g2 = Graph(nodes=(Double,))
+assert_type(g2, Graph[None, X])
 
 g3 = Graph(
-    Float2String,
-    String2Length,
-    Double,
+    nodes=(
+        Float2String,
+        String2Length,
+        Double,
+    )
 )
 # because String2Length came before Double, the output type is Any
-assert_type(g3, Graph[None, float])
+assert_type(g3, Graph[None, X])
 
 Graph[None, float, bytes](Float2String, String2Length, Double)  # type: ignore[arg-type]
 Graph[None, int, str](Double)  # type: ignore[arg-type]


### PR DESCRIPTION
This is a refactoring of the work in #528 attempting to reduce the number of user-facing generic parameters.

There are some things that we can probably adjust/remove, such as the introduction of _both_ `GraphRunner` and `GraphRun`. But there are some benefits to this, as it provides a way to get nearly the same API we currently have without BaseNode being aware of the input type, and without forcing BaseNode subclasses to have a fixed signature.

Some of the less consequential changes in here (such as moving/duplicating typevars) were done because I was hitting cyclic import errors and/or spurious type errors (I think I maybe ran into some bugs in pyright that I no longer know how to reproduce).

I'm happy to rework the implementation based on feedback if there's interest, but I don't really want to go through adding lots of tests and documenting everything if this line of implementation is going to be rejected, so @samuelcolvin maybe we can discuss synchronously.