### PR TITLE
support `X | None = None` with Gemini

### DIFF
--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -261,14 +261,12 @@ async def test_json_def_replaced_any_of(allow_model_requests: None):
                     parameters={
                         'properties': {
                             'op_location': {
-                                'anyOf': [
-                                    {
-                                        'properties': {'lat': {'type': 'number'}, 'lng': {'type': 'number'}},
-                                        'required': ['lat', 'lng'],
-                                        'type': 'object',
-                                    },
-                                    {'type': 'null'},
-                                ]
+                                'properties': {
+                                    'lat': {'type': 'number'},
+                                    'lng': {'type': 'number'},
+                                },
+                                'required': ['lat', 'lng'],
+                                'type': 'object',
                             }
                         },
                         'type': 'object',


### PR DESCRIPTION
Fix #533.

Gemini has pretty poor support for JSON schema, so you'll need to set a default of `None` on any optional field, e.g.

```py
class AgeModel(BaseModel):
    age: int | None = None  # <-- this will work

class AgeModel(BaseModel):
    age: int | None  # <-- this will NOT work
```