### PR TITLE
Validate chatcompletion to avoid unexpected bugs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -203,6 +203,8 @@ class OpenAIAgentModel(AgentModel):
     @staticmethod
     def _process_response(response: chat.ChatCompletion) -> ModelResponse:
         """Process a non-streamed response, and prepare a message to return."""
+        if not response.created:
+            raise UnexpectedModelBehavior('Response has no timestamp', body=response.to_json())
         timestamp = datetime.fromtimestamp(response.created, tz=timezone.utc)
         choice = response.choices[0]
         items: list[ModelResponsePart] = []

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -473,6 +473,17 @@ async def test_no_content(allow_model_requests: None):
             pass
 
 
+async def test_no_sync_content(allow_model_requests: None):
+    mock_client = MockOpenAI.create_mock(
+        chat.ChatCompletion(id='', choices=[], created=0, model='', object='chat.completion')
+    )
+    m = OpenAIModel('gpt-4', openai_client=mock_client)
+    agent = Agent(m, result_type=MyTypedDict)
+
+    with pytest.raises(UnexpectedModelBehavior, match='Response has no timestamp'):
+        await agent.run('')
+
+
 async def test_no_delta(allow_model_requests: None):
     stream = (
         chunk([]),


### PR DESCRIPTION
Fixes #527 


This PR addresses the incorrect handling of error responses from the API when a rate limit is exceeded. The changes include:

- Adding a check for the presence of a timestamp in the API response and raising an appropriate error if it is missing.
- Updating the _process_response method in pydantic_ai/models/openai.py to handle the absence of a timestamp.
- Adding new tests in tests/models/test_openai.py to ensure proper error handling when the timestamp is missing from the response.

These changes ensure that the appropriate error message is surfaced when a rate limit is exceeded, instead of throwing a date-time parsing exception.