### PR TITLE
DOC: small note on cd examples

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -38,8 +38,7 @@ TL;DR: in most cases you'll need to set one of the following environment variabl
 
 ### Running Examples
 
-To run the examples (this will work whether you installed `pydantic_ai`, or cloned the repo. 
-If you cloned the repo don't forget to `cd examples`), run:
+To run the examples (this will work whether you installed `pydantic_ai`, or cloned the repo. If you cloned the repo don't forget to `cd examples`), run:
 
 ```bash
 python/uv-run -m pydantic_ai_examples.<example_module_name>

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -38,7 +38,8 @@ TL;DR: in most cases you'll need to set one of the following environment variabl
 
 ### Running Examples
 
-To run the examples (this will work whether you installed `pydantic_ai`, or cloned the repo), run:
+To run the examples (this will work whether you installed `pydantic_ai`, or cloned the repo. 
+If you cloned the repo don't forget to `cd examples`), run:
 
 ```bash
 python/uv-run -m pydantic_ai_examples.<example_module_name>


### PR DESCRIPTION
This adds a small note that if you clone the repo you should do `cd examples`. 

I got `/Users/raybell/Documents/PYTHON_dev/pydantic-ai/.venv/bin/python: Error while finding module specification for 'pydantic_ai_examples.pydantic_model' (ModuleNotFoundError: No module named 'pydantic_ai_examples')` first time round :facepalm: