### PR TITLE
Add uv script at top of example

### DIFF
--- a/examples/pydantic_ai_examples/pydantic_model.py
+++ b/examples/pydantic_ai_examples/pydantic_model.py
@@ -13,7 +13,7 @@ Run with:
 
 or:
 
-    uv run https://github.com/pydantic/pydantic-ai/blob/main/examples/pydantic_ai_examples/pydantic_model.py
+    uv run https://raw.githubusercontent.com/pydantic/pydantic-ai/refs/heads/main/examples/pydantic_ai_examples/pydantic_model.py
 """
 
 import os

--- a/examples/pydantic_ai_examples/pydantic_model.py
+++ b/examples/pydantic_ai_examples/pydantic_model.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.12"
+# requires-python = ">=3.9"
 # dependencies = [
 #     "logfire",
 #     "pydantic-ai",

--- a/examples/pydantic_ai_examples/pydantic_model.py
+++ b/examples/pydantic_ai_examples/pydantic_model.py
@@ -1,8 +1,19 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "logfire",
+#     "pydantic-ai",
+# ]
+# ///
 """Simple example of using PydanticAI to construct a Pydantic model from a text input.
 
 Run with:
 
     uv run -m pydantic_ai_examples.pydantic_model
+
+or:
+
+    uv run https://github.com/pydantic/pydantic-ai/blob/main/examples/pydantic_ai_examples/pydantic_model.py
 """
 
 import os


### PR DESCRIPTION
Any thoughts on adding requirements to the top of the example scripts like I have done here?

It can make the examples even easier to run as a one-liner and it doesn't affect any existing functionality.

You can try it using `uv run https://raw.githubusercontent.com/raybellwaves/pydantic-ai/refs/heads/add-uv-script-at-top-of-example/examples/pydantic_ai_examples/pydantic_model.py`

<img width="1488" alt="Screenshot 2024-12-27 at 5 14 09 PM" src="https://github.com/user-attachments/assets/d40359be-5982-4776-97f1-e8b710cb3ddd" />
