### PR TITLE
Add Ollama API Key Configuration Support

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/models/ollama.py
@@ -71,6 +71,7 @@ class OllamaModel(Model):
         model_name: OllamaModelName,
         *,
         base_url: str | None = 'http://localhost:11434/v1/',
+        api_key: str = 'ollama',
         openai_client: AsyncOpenAI | None = None,
         http_client: AsyncHTTPClient | None = None,
     ):
@@ -96,7 +97,7 @@ class OllamaModel(Model):
         else:
             # API key is not required for ollama but a value is required to create the client
             http_client_ = http_client or cached_async_http_client()
-            oai_client = AsyncOpenAI(base_url=base_url, api_key='ollama', http_client=http_client_)
+            oai_client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client_)
             self.openai_model = OpenAIModel(model_name=model_name, openai_client=oai_client)
 
     async def agent_model(

--- a/pydantic_ai_slim/pydantic_ai/models/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/models/ollama.py
@@ -84,6 +84,8 @@ class OllamaModel(Model):
             model_name: The name of the Ollama model to use. List of models available [here](https://ollama.com/library)
                 You must first download the model (`ollama pull <MODEL-NAME>`) in order to use the model
             base_url: The base url for the ollama requests. The default value is the ollama default
+            api_key: The API key to use for authentication. Defaults to 'ollama' for local instances,
+                but can be customized for proxy setups that require authentication
             openai_client: An existing
                 [`AsyncOpenAI`](https://github.com/openai/openai-python?tab=readme-ov-file#async-usage)
                 client to use, if provided, `base_url` and `http_client` must be `None`.


### PR DESCRIPTION
# Add Ollama API Key Configuration Support

## Description
Currently, the API key in OllamaModel is hardcoded to 'ollama', which limits scenarios where custom API keys are needed, such as when using nginx as a proxy. This change adds support for a configurable API key parameter, allowing users to set custom API keys as needed.

## Changes
- Added an optional `api_key` parameter to `OllamaModel.__init__` with a default value of 'ollama'
- Updated the API key passing logic to use the provided api_key parameter instead of the hardcoded value

## Usage Example
Using default API key
```py
model = OllamaModel('llama2')
```

Using custom API key
```py
model = OllamaModel('llama2', api_key='custom-key')
```