### PR TITLE
GCP VertexAI: handle case when google.auth.default() uses a service account

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -178,7 +178,7 @@ def _creds_from_file(service_account_file: str | Path) -> ServiceAccountCredenti
 # pyright: reportUnknownVariableType=false
 # pyright: reportUnknownArgumentType=false
 async def _async_google_auth() -> tuple[BaseCredentials, str | None]:
-    return await run_in_executor(google.auth.default)
+    return await run_in_executor(google.auth.default, scopes=['https://www.googleapis.com/auth/cloud-platform'])
 
 
 # default expiry is 3600 seconds

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -1,7 +1,8 @@
 from __future__ import annotations as _annotations
-import os
+
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from os import getenv
 from pathlib import Path
 from typing import Literal
 
@@ -140,10 +141,11 @@ class VertexAIModel(Model):
             creds_source = 'service account file'
         else:
             creds, creds_project_id = await _async_google_auth()
-            if hasattr(creds, 'service_account_email') and getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None:
-                service_account_file_path = getenv("GOOGLE_APPLICATION_CREDENTIALS")
-                creds = _creds_from_file(service_account_file=service_account_file_path)
-                creds_source = 'service account file'
+            if hasattr(creds, 'service_account_email') and getenv('GOOGLE_APPLICATION_CREDENTIALS') is not None:
+                service_account_file_path = getenv('GOOGLE_APPLICATION_CREDENTIALS')
+                if isinstance(service_account_file_path, str):
+                    creds = _creds_from_file(service_account_file=service_account_file_path)
+                    creds_source = 'service account file'
             else:
                 creds_source = '`google.auth.default()`'
 

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -2,7 +2,6 @@ from __future__ import annotations as _annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from os import getenv
 from pathlib import Path
 from typing import Literal
 
@@ -142,12 +141,6 @@ class VertexAIModel(Model):
         else:
             creds, creds_project_id = await _async_google_auth()
             creds_source = '`google.auth.default()`'
-            if hasattr(creds, 'service_account_email') and getenv('GOOGLE_APPLICATION_CREDENTIALS') is not None:
-                service_account_file_path = getenv('GOOGLE_APPLICATION_CREDENTIALS')
-                if isinstance(service_account_file_path, str):
-                    self.service_account_file = service_account_file_path
-                    creds = _creds_from_file(service_account_file=service_account_file_path)
-                    creds_source = 'service account file'
 
         if self.project_id is None:
             if creds_project_id is None:

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -1,5 +1,5 @@
 from __future__ import annotations as _annotations
-
+import os
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -140,7 +140,12 @@ class VertexAIModel(Model):
             creds_source = 'service account file'
         else:
             creds, creds_project_id = await _async_google_auth()
-            creds_source = '`google.auth.default()`'
+            if hasattr(creds, 'service_account_email') and getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None:
+                service_account_file_path = getenv("GOOGLE_APPLICATION_CREDENTIALS")
+                creds = _creds_from_file(service_account_file=service_account_file_path)
+                creds_source = 'service account file'
+            else:
+                creds_source = '`google.auth.default()`'
 
         if self.project_id is None:
             if creds_project_id is None:

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -141,13 +141,12 @@ class VertexAIModel(Model):
             creds_source = 'service account file'
         else:
             creds, creds_project_id = await _async_google_auth()
+            creds_source = '`google.auth.default()`'
             if hasattr(creds, 'service_account_email') and getenv('GOOGLE_APPLICATION_CREDENTIALS') is not None:
                 service_account_file_path = getenv('GOOGLE_APPLICATION_CREDENTIALS')
                 if isinstance(service_account_file_path, str):
                     creds = _creds_from_file(service_account_file=service_account_file_path)
                     creds_source = 'service account file'
-            else:
-                creds_source = '`google.auth.default()`'
 
         if self.project_id is None:
             if creds_project_id is None:

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -145,6 +145,7 @@ class VertexAIModel(Model):
             if hasattr(creds, 'service_account_email') and getenv('GOOGLE_APPLICATION_CREDENTIALS') is not None:
                 service_account_file_path = getenv('GOOGLE_APPLICATION_CREDENTIALS')
                 if isinstance(service_account_file_path, str):
+                    self.service_account_file = service_account_file_path
                     creds = _creds_from_file(service_account_file=service_account_file_path)
                     creds_source = 'service account file'
 


### PR DESCRIPTION
Relates to / resolves #575 

GCP resolves default application credentials in a specific order documented here: https://cloud.google.com/docs/authentication/application-default-credentials

> Search order
ADC searches for credentials in the following locations:
> [GOOGLE_APPLICATION_CREDENTIALS environment variable](https://cloud.google.com/docs/authentication/application-default-credentials#GAC)
> [User credentials set up by using the Google Cloud CLI](https://cloud.google.com/docs/authentication/application-default-credentials#personal)
> [The attached service account, returned by the metadata server](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa)

The existing VertexAI code seems to assume that `google.auth.default()` returns either a user's credentials or the attached service account (via Workload Identity) and _not_ a service account, which has a different code branching path for auth.

~long term seems better and more idiomatic to use google's semantics of `GOOGLE_APPLICATION_CREDENTIALS` via `google.auth.default()` itself instead of explicitly passing in the `service_account_file` parameter/property to the model constructor separately, but that seems like a significant refactor of some of the codebase. This illustrates a possible (inelegant) workaround short term that got my code using a service account for auth working, not necessarily something that should be merged or the long term solution for the library.~

Ok, did some more digging, and it seems like we may just need to pass the `scopes` parameter in to `google.auth.default()` for the service account case to allow the credentials to refresh their token. Perhaps for gcloud/workload identity cases they are loaded automatically, but for service accounts they need to be more explicit. By removing my changes and adding this, using my service account via `google.auth.default()` worked. I think that potentially with this change, the `service_account_file` parameter/property and code could be deprecated in favor of GCP's application default credentials preferred flow.