### PR TITLE
Added troubleshooting section to the docs page

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -93,16 +93,6 @@ _(This example is complete, it can be run "as is")_
 
 You can also pass messages from previous runs to continue a conversation or provide context, as described in [Messages and Chat History](message-history.md).
 
-!!! note "jupyter notebooks"
-    If you're running `pydantic-ai` in a jupyter notebook, you might consider using [`nest-asyncio`](https://pypi.org/project/nest-asyncio/)
-    to manage conflicts between event loops that occur between jupyter's event loops and `pydantic-ai`'s.
-
-    Before you execute any agent runs, do the following:
-    ```python {test="skip" lint="skip"}
-    import nest_asyncio
-
-    nest_asyncio.apply()
-    ```
 
 ### Additional Configuration
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,7 +5,7 @@ Common/known issues are shown below with associated solutions.
 ## Jupyter Notebooks
 
 If you're running `pydantic-ai` in a jupyter notebook, you might consider using [`nest-asyncio`](https://pypi.org/project/nest-asyncio/)
-to manage conflicts between event loops that occur between jupyter's event loops and `pydantic-ai`'s.
+to manage conflicts between event loops that occur between Jupyter's event loops and `pydantic-ai`'s.
 
 Before you execute any agent runs, do the following:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,14 @@
+# Troubleshooting
+Common/known issues are shown below with associated solutions.
+
+
+## Jupyter Notebooks
+If you're running `pydantic-ai` in a jupyter notebook, you might consider using [`nest-asyncio`](https://pypi.org/project/nest-asyncio/)
+to manage conflicts between event loops that occur between jupyter's event loops and `pydantic-ai`'s.
+
+Before you execute any agent runs, do the following:
+```python {test="skip" lint="skip"}
+import nest_asyncio
+
+nest_asyncio.apply()
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,12 +1,14 @@
 # Troubleshooting
+
 Common/known issues are shown below with associated solutions.
 
-
 ## Jupyter Notebooks
+
 If you're running `pydantic-ai` in a jupyter notebook, you might consider using [`nest-asyncio`](https://pypi.org/project/nest-asyncio/)
 to manage conflicts between event loops that occur between jupyter's event loops and `pydantic-ai`'s.
 
 Before you execute any agent runs, do the following:
+
 ```python {test="skip" lint="skip"}
 import nest_asyncio
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - install.md
   - help.md
   - contributing.md
+  - troubleshooting.md
   - Documentation:
     - agents.md
     - models.md


### PR DESCRIPTION
This addresses #567 
- Added troubleshooting.md to the docs - will display under the "PydanticAI" header (screenshot below) in the client
- Moved the note from #214 into troubleshooting.md

<img width="1284" alt="image" src="https://github.com/user-attachments/assets/a2270cd0-5e9b-415f-bce8-9be5d5769b4f" />
