### PR TITLE
Fix: group multiple tool responses into a single user message

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -271,7 +271,7 @@ class GeminiAgentModel(AgentModel):
     ) -> tuple[list[_GeminiTextPart], list[_GeminiContent]]:
         sys_prompt_parts: list[_GeminiTextPart] = []
         contents: list[_GeminiContent] = []
-        grouped_tool_responses = []
+        grouped_tool_responses: list[ToolReturnPart] = []
         for m in messages:
             if isinstance(m, ModelRequest):
                 for part in m.parts:

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -434,7 +434,6 @@ def _content_tool_return(messages: list[ToolReturnPart]) -> _GeminiContent:
     return _GeminiContent(role='user', parts=parts)
 
 
-
 def _content_retry_prompt(m: RetryPromptPart) -> _GeminiContent:
     if m.tool_name is None:
         part = _GeminiTextPart(text=m.model_response())

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -732,3 +732,60 @@ async def test_empty_text_ignored():
             'parts': [{'function_call': {'name': 'final_result', 'args': {'response': [1, 2, 123]}}}],
         }
     )
+
+async def test_group_multiple_tool_responses(allow_model_requests: None):
+    from pydantic_ai.messages import ToolReturnPart, ModelRequest
+    from pydantic_ai.models.gemini import GeminiAgentModel, ApiKeyAuth
+    from httpx import AsyncClient
+
+    # Mock dependencies
+    mock_http_client = AsyncClient()
+    mock_auth = ApiKeyAuth(api_key="mock-api-key")
+
+    # Create mock ToolReturnPart objects
+    tool_responses = [
+        ToolReturnPart(
+            tool_name="solve_math",
+            content={"result": "x^3/3 + C"}  # Pass content as a dictionary
+        ),
+        ToolReturnPart(
+            tool_name="summarize_text",
+            content={"summary": "A fluffy cat met a dog."}
+        ),
+    ]
+
+    # Wrap ToolReturnPart objects in ModelRequest
+    model_requests = [
+        ModelRequest(parts=[tr]) for tr in tool_responses
+    ]
+
+    # Create a mock GeminiAgentModel
+    agent_model = GeminiAgentModel(
+        http_client=mock_http_client,
+        model_name="gemini-1.5-flash",
+        auth=mock_auth,
+        url="mock-url",
+        function_tools=[],
+        allow_text_result=True,
+        result_tools=[]
+    )
+
+    # Generate contents using _message_to_gemini_content
+    sys_prompt_parts, contents = agent_model._message_to_gemini_content(model_requests)
+
+    # Assertions
+    assert len(contents) == 1  # Only one content object should be created
+    user_content = contents[0]
+    assert user_content["role"] == "user"  # The role should be user
+    assert len(user_content["parts"]) == 2  # Both tool responses should be grouped
+
+    # Validate the first tool response
+    assert user_content["parts"][0]["function_response"]["name"] == "solve_math"
+    assert user_content["parts"][0]["function_response"]["response"]["result"] == "x^3/3 + C"
+
+    # Validate the second tool response
+    assert user_content["parts"][1]["function_response"]["name"] == "summarize_text"
+    assert user_content["parts"][1]["function_response"]["response"]["summary"] == "A fluffy cat met a dog."
+
+
+


### PR DESCRIPTION
## **Fix: Properly group tool responses in Gemini API integration**

### **Problem Statement**
When handling multiple tool responses in the Gemini integration, the library incorrectly generated separate `user` messages for each tool response. This behavior caused payload mismatches when interacting with the Gemini API, as the API expects all tool responses from a single interaction turn to be grouped into a single `user` message.

This bug led to the following issues:
1. Mismatch between the number of function calls and responses, triggering Gemini API errors.
2. Violations of the expected schema for `contents` in the payload, where multiple `user` entries were incorrectly sent instead of one.

#### **Error Message from the Gemini API**
The bug caused the following 400 error from the Gemini API:
`{ "error": { "code": 400, "message": "Please ensure that the number of function response parts should be equal to number of function call parts of the function call turn.", "status": "INVALID_ARGUMENT" } }`


### **Solution**
This fix ensures that:
1. Multiple `ToolReturnPart` objects are grouped into a single `user` message.
2. The `_message_to_gemini_content` method is updated to correctly process tool responses and generate the expected payload structure.

### **Testing**
- A new test, `test_group_multiple_tool_responses`, was added to the `test_gemini.py` file.
- The test validates that:
  1. Multiple `ToolReturnPart` objects are grouped into one `user` message.
  2. The resulting payload matches the expected structure, including role assignments and response content.

### **Relevant Documentation**
- Gemini API Function Calling Documentation: [Link](https://ai.google.dev/gemini-api/docs/function-calling)

### **Testing the Fix**
The fix was tested with the following scenarios:
1. Multiple tool responses in a single interaction.
2. Validation of the grouped payload structure.
3. Full test suite to ensure no regressions.

All tests passed successfully, and the issue was resolved.
****
