### PR TITLE
Add timestamp field for ModelRequest

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -142,6 +142,9 @@ class ModelRequest:
     kind: Literal['request'] = 'request'
     """Message type identifier, this is available on all parts as a discriminator."""
 
+    timestamp: datetime = field(default_factory=_now_utc)
+    """The timestamp of the request."""
+
 
 @dataclass
 class TextPart:


### PR DESCRIPTION
A timestamp field for the Request would be nice, analogous to the Response field.
I´m playing around with differnt model behaviours by messing with their message history, but right now it would require a lot of extra leg work to keep pydantic-ai messages "in sync" with anything external.