### PR TITLE
fix: update module name and include devtools as dev dependency for example scripts

### DIFF
--- a/examples/pydantic_ai_examples/stream_whales.py
+++ b/examples/pydantic_ai_examples/stream_whales.py
@@ -5,7 +5,7 @@ and displays it as a dynamic table using Rich as the data is received.
 
 Run with:
 
-    uv run -m pydantic_ai_examples.whales
+    uv run -m pydantic_ai_examples.stream_whales
 """
 
 from typing import Annotated

--- a/examples/pydantic_ai_examples/weather_agent.py
+++ b/examples/pydantic_ai_examples/weather_agent.py
@@ -6,7 +6,7 @@ the `get_weather` tool to get the weather.
 
 Run with:
 
-    uv run -m pydantic_ai_examples.weather
+    uv run -m pydantic_ai_examples.weather_agent
 """
 
 from __future__ import annotations as _annotations

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "python-multipart>=0.0.17",
     "rich>=13.9.2",
     "uvicorn>=0.32.0",
+    "devtools>=0.12.2",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -52,8 +53,3 @@ pydantic-ai-slim = { workspace = true }
 [tool.ruff]
 extend = "../pyproject.toml"
 line-length = 88
-
-[dependency-groups]
-dev = [
-    "devtools>=0.12.2",
-]

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -52,3 +52,8 @@ pydantic-ai-slim = { workspace = true }
 [tool.ruff]
 extend = "../pyproject.toml"
 line-length = 88
+
+[dependency-groups]
+dev = [
+    "devtools>=0.12.2",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1634,6 +1634,11 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "devtools" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
@@ -1644,6 +1649,9 @@ requires-dist = [
     { name = "rich", specifier = ">=13.9.2" },
     { name = "uvicorn", specifier = ">=0.32.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "devtools", specifier = ">=0.12.2" }]
 
 [[package]]
 name = "pydantic-ai-slim"

--- a/uv.lock
+++ b/uv.lock
@@ -1626,6 +1626,7 @@ version = "0.0.16"
 source = { editable = "examples" }
 dependencies = [
     { name = "asyncpg" },
+    { name = "devtools" },
     { name = "fastapi" },
     { name = "logfire", extra = ["asyncpg", "fastapi", "sqlite3"] },
     { name = "pydantic-ai-slim", extra = ["anthropic", "groq", "openai", "vertexai"] },
@@ -1634,14 +1635,10 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "devtools" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "devtools", specifier = ">=0.12.2" },
     { name = "fastapi", specifier = ">=0.115.4" },
     { name = "logfire", extras = ["asyncpg", "fastapi", "sqlite3"], specifier = ">=2.6" },
     { name = "pydantic-ai-slim", extras = ["openai", "vertexai", "groq", "anthropic"], editable = "pydantic_ai_slim" },
@@ -1649,9 +1646,6 @@ requires-dist = [
     { name = "rich", specifier = ">=13.9.2" },
     { name = "uvicorn", specifier = ">=0.32.0" },
 ]
-
-[package.metadata.requires-dev]
-dev = [{ name = "devtools", specifier = ">=0.12.2" }]
 
 [[package]]
 name = "pydantic-ai-slim"


### PR DESCRIPTION
This pull request includes updates to the `examples` directory to correct module names in the run commands and add development dependencies to the `pyproject.toml` file.

Updates to module run commands:

* [`examples/pydantic_ai_examples/stream_whales.py`](diffhunk://#diff-10be8e02a90b38f1df4169fa34f60e722bc7d88054f6fc2f3b5cca9d6bf88f77L8-R8): Updated the module name in the run command from `pydantic_ai_examples.whales` to `pydantic_ai_examples.stream_whales`.
* [`examples/pydantic_ai_examples/weather_agent.py`](diffhunk://#diff-620921c93ffce6d5233e0aecfe84e33b5202de4883264d10dd27c753eac69a47L9-R9): Updated the module name in the run command from `pydantic_ai_examples.weather` to `pydantic_ai_examples.weather_agent`.

Addition of development dependencies:

* [`examples/pyproject.toml`](diffhunk://#diff-ec621ce961014259169f920ac6f3efa7535952a8b324b14893b0261a1c631369R55-R59): Added `devtools` as dependency.