### PR TITLE
Update __init__ to include usage module

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -3,6 +3,7 @@ from importlib.metadata import version
 from .agent import Agent, capture_run_messages
 from .exceptions import AgentRunError, ModelRetry, UnexpectedModelBehavior, UsageLimitExceeded, UserError
 from .tools import RunContext, Tool
+from .usage import Usage, UsageLimits
 
 __all__ = (
     'Agent',
@@ -13,7 +14,10 @@ __all__ = (
     'ModelRetry',
     'UnexpectedModelBehavior',
     'UsageLimitExceeded',
+    'Usage',
+    'UsageLimits',
     'UserError',
     '__version__',
 )
+
 __version__ = version('pydantic_ai_slim')


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic-ai/issues/581

If `usage` is intended to be a module, it needs to be included in `__all__`.

This allows the following usage:

> from pydantic_ai.usage import Usage, UsageLimits

This follows the pattern of usage included in the flight booking example here: https://ai.pydantic.dev/examples/flight-booking/