### PR TITLE
Added docs contribution docs, a troubleshooting item for docs changes

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -46,8 +46,6 @@ make
 
 ## Documentation Changes
 
-Documentation is generated using [Material](https://squidfunk.github.io/mkdocs-material/) (which is built on top of [Mkdocs](https://www.mkdocs.org)). Most changes will involve editing or creating markdown files in the [/docs](https://github.com/pydantic/pydantic-ai/tree/main/docs) directory and adjusting the docs page structure in [mkdocs.yml](https://github.com/pydantic/pydantic-ai/blob/main/mkdocs.yml).
-
 To run the documentation page locally, run:
 
 ```bash

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -44,6 +44,16 @@ To run code formatting, linting, static type checks, and tests with coverage rep
 make
 ```
 
+## Documentation Changes
+
+Documentation is generated using [Material](https://squidfunk.github.io/mkdocs-material/) (which is built on top of [Mkdocs](https://www.mkdocs.org)). Most changes will involve editing or creating markdown files in the [/docs](https://github.com/pydantic/pydantic-ai/tree/main/docs) directory and adjusting the docs page structure in [mkdocs.yml](https://github.com/pydantic/pydantic-ai/blob/main/mkdocs.yml).
+
+To run the documentation page locally, run:
+
+```bash
+uv run mkdocs serve
+```
+
 ## Rules for adding new models to PydanticAI {#new-model-rules}
 
 To avoid an excessive workload for the maintainers of PydanticAI, we can't accept all model contributions, so we're setting the following rules for when we'll accept new models and when we won't. This should hopefully reduce the chances of disappointment and wasted work.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,15 +19,3 @@ Note: This fix also applies to Google Colab.
 ### `UserError: API key must be provided or set in the [MODEL]_API_KEY environment variable`
 
 If you're running into issues with setting the API key for your model, visit the [Models](models.md) page to learn more about how to set an environment variable and/or pass in an `api_key` argument.
-
-
-## Documentation Editing - Cairo Library Not Found
-
-```text
-ERROR - "cairosvg" Python module is installed, but it crashed with:
-        no library called "cairo-2" was found
-        no library called "cairo" was found
-        no library called "libcairo-2" was found
-```
-
-This is a known issue that's addressed in the [Material documentation](https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/#troubleshooting) and seems to come up for Mac users. See a workaround in the aforementioned link.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,3 +19,15 @@ Note: This fix also applies to Google Colab.
 ### `UserError: API key must be provided or set in the [MODEL]_API_KEY environment variable`
 
 If you're running into issues with setting the API key for your model, visit the [Models](models.md) page to learn more about how to set an environment variable and/or pass in an `api_key` argument.
+
+
+## Documentation Editing - Cairo Library Not Found
+
+```text
+ERROR - "cairosvg" Python module is installed, but it crashed with:
+        no library called "cairo-2" was found
+        no library called "cairo" was found
+        no library called "libcairo-2" was found
+```
+
+This is a known issue that's addressed in the [Material documentation](https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/#troubleshooting) and seems to come up for Mac users. See a workaround in the aforementioned link.


### PR DESCRIPTION
Documentation change:
- Added an item in the "Contributing" section that tells contributors how to run the documentation page locally

Should partially address the items in #595 