### PR TITLE
for run_agent.py example scripts , won't execute automatically

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -71,6 +71,7 @@ There are three ways to run an agent:
 Here's a simple example demonstrating all three:
 
 ```python {title="run_agent.py"}
+import asyncio
 from pydantic_ai import Agent
 
 agent = Agent('openai:gpt-4o')
@@ -88,6 +89,8 @@ async def main():
     async with agent.run_stream('What is the capital of the UK?') as response:
         print(await response.get_data())
         #> London
+
+asyncio.run(main())
 ```
 _(This example is complete, it can be run "as is")_
 


### PR DESCRIPTION
For run_agent.py example scripts , the main() function is designed to be executed asynchronously and won't execute automatically. To fix this, add asyncio.run(main()).

[Source Example](https://ai.pydantic.dev/agents/#running-agents)
![image](https://github.com/user-attachments/assets/74ad21e4-d227-4356-9e4b-a05646f90727)
