### PR TITLE
Improve null handling for Gemini

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -693,7 +693,7 @@ class _GeminiJsonSchema:
 
     def _simplify(self, schema: dict[str, Any], refs_stack: tuple[str, ...]) -> None:
         schema.pop('title', None)
-        default = schema.pop('default', _utils.UNSET)
+        schema.pop('default', None)
         if ref := schema.pop('$ref', None):
             # noinspection PyTypeChecker
             key = re.sub(r'^#/\$defs/', '', ref)
@@ -708,11 +708,12 @@ class _GeminiJsonSchema:
         if any_of := schema.get('anyOf'):
             for item_schema in any_of:
                 self._simplify(item_schema, refs_stack)
-            if len(any_of) == 2 and {'type': 'null'} in any_of and default is None:
+            if len(any_of) == 2 and {'type': 'null'} in any_of:
                 for item_schema in any_of:
                     if item_schema != {'type': 'null'}:
                         schema.clear()
                         schema.update(item_schema)
+                        schema['nullable'] = True
                         return
 
         type_ = schema.get('type')

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -267,6 +267,7 @@ async def test_json_def_replaced_any_of(allow_model_requests: None):
                                     'lng': {'type': 'number'},
                                 },
                                 'required': ['lat', 'lng'],
+                                'nullable': True,
                                 'type': 'object',
                             }
                         },


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic-ai/issues/603

I confirmed it works and can return None by using the following script, slightly modified from the one in the issue above:

```python
import os
from pydantic import BaseModel
from pydantic_ai import Agent
from pydantic_ai.models.gemini import GeminiModel

os.environ['GEMINI_API_KEY'] = '<scrubbed>'

class AgeModel(BaseModel):
    age: int | None = None

gemini_model = GeminiModel('gemini-1.5-flash')

prompt = "The man's age was unknown. what is the age of the old man?"
agent = Agent(gemini_model, result_type=AgeModel)
age = agent.run_sync(prompt)
print(age.data)
# age=None
```

@samuelcolvin let me know if you want any testing beyond the one I updated here.