### PR TITLE
Improve string format handling for gemini

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -721,6 +721,12 @@ class _GeminiJsonSchema:
             self._object(schema, refs_stack)
         elif type_ == 'array':
             return self._array(schema, refs_stack)
+        elif type_ == 'string' and (fmt := schema.pop('format', None)):
+            description = schema.get('description')
+            if description:
+                schema['description'] = f'{description} (format: {fmt})'
+            else:
+                schema['description'] = f'Format: {fmt}'
 
     def _object(self, schema: dict[str, Any], refs_stack: tuple[str, ...]) -> None:
         ad_props = schema.pop('additionalProperties', None)

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -1,6 +1,7 @@
 # pyright: reportPrivateUsage=false
 from __future__ import annotations as _annotations
 
+import datetime
 import json
 from collections.abc import AsyncIterator, Callable, Sequence
 from dataclasses import dataclass
@@ -9,7 +10,7 @@ from datetime import timezone
 import httpx
 import pytest
 from inline_snapshot import snapshot
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import Literal, TypeAlias
 
 from pydantic_ai import Agent, ModelRetry, UnexpectedModelBehavior, UserError
@@ -315,6 +316,57 @@ async def test_json_def_recursive(allow_model_requests: None):
     )
     with pytest.raises(UserError, match=r'Recursive `\$ref`s in JSON Schema are not supported by Gemini'):
         await m.agent_model(function_tools=[], allow_text_result=True, result_tools=[result_tool])
+
+
+async def test_json_def_date(allow_model_requests: None):
+    class FormattedStringFields(BaseModel):
+        d: datetime.date
+        dt: datetime.datetime
+        t: datetime.time = Field(description='')
+        td: datetime.timedelta = Field(description='my timedelta')
+
+    json_schema = FormattedStringFields.model_json_schema()
+    assert json_schema == snapshot(
+        {
+            'properties': {
+                'd': {'format': 'date', 'title': 'D', 'type': 'string'},
+                'dt': {'format': 'date-time', 'title': 'Dt', 'type': 'string'},
+                't': {'format': 'time', 'title': 'T', 'type': 'string', 'description': ''},
+                'td': {'format': 'duration', 'title': 'Td', 'type': 'string', 'description': 'my timedelta'},
+            },
+            'required': ['d', 'dt', 't', 'td'],
+            'title': 'FormattedStringFields',
+            'type': 'object',
+        }
+    )
+
+    m = GeminiModel('gemini-1.5-flash', api_key='via-arg')
+    result_tool = ToolDefinition(
+        'result',
+        'This is the tool for the final Result',
+        json_schema,
+    )
+    agent_model = await m.agent_model(function_tools=[], allow_text_result=True, result_tools=[result_tool])
+    assert agent_model.tools == snapshot(
+        _GeminiTools(
+            function_declarations=[
+                _GeminiFunction(
+                    description='This is the tool for the final ' 'Result',
+                    name='result',
+                    parameters={
+                        'properties': {
+                            'd': {'description': 'Format: date', 'type': 'string'},
+                            'dt': {'description': 'Format: date-time', 'type': 'string'},
+                            't': {'description': 'Format: time', 'type': 'string'},
+                            'td': {'description': 'my timedelta (format: duration)', 'type': 'string'},
+                        },
+                        'required': ['d', 'dt', 't', 'td'],
+                        'type': 'object',
+                    },
+                )
+            ]
+        )
+    )
 
 
 @dataclass


### PR DESCRIPTION
Addresses an issue demonstrated in https://github.com/pydantic/pydantic-ai/issues/582.

In particular, this PR pops the `'format'` field from string schemas (the presence of which is causing API errors), and uses it to modify the field description, which seems to result in responses that don't have errors and parse successfully.

This PR doesn't go as far as was requested in that issue, but the approach I've used here seems reasonable given we do get API errors without it, it seems like a common usage scenario, and I also confirmed manually with `gemini-1.5-flash` that the changes in this PR result in responses that parse successfully, at least for the specific prompt/model I was using (basically the one from that issue).

Weirdly, the [VertexAI docs](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output) say that:

> For the format field, Vertex AI supports the following values: date, date-time, duration, and time. The description and format of each value is described in the [OpenAPI Initiative Registry](https://spec.openapis.org/registry/format/)

But in practice it didn't seem to work with any of these. If/when those format values do start to work, we could revert this change.