### PR TITLE
Fix README docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,26 +37,26 @@ We built PydanticAI with one simple aim: to bring that FastAPI feeling to GenAI 
 Built by the team behind [Pydantic](https://docs.pydantic.dev/latest/) (the validation layer of the OpenAI SDK, the Anthropic SDK, LangChain, LlamaIndex, AutoGPT, Transformers, CrewAI, Instructor and many more).
 
 * __Model-agnostic__
-Supports OpenAI, Anthropic, Gemini, Ollama, Groq, and Mistral, and there is a simple interface to implement support for [other models](models.md).
+Supports OpenAI, Anthropic, Gemini, Ollama, Groq, and Mistral, and there is a simple interface to implement support for [other models](docs/models.md).
 
 * __Pydantic Logfire Integration__
-Seamlessly [integrates](logfire.md) with [Pydantic Logfire](https://pydantic.dev/logfire) for real-time debugging, performance monitoring, and behavior tracking of your LLM-powered applications.
+Seamlessly [integrates](docs/logfire.md) with [Pydantic Logfire](https://pydantic.dev/logfire) for real-time debugging, performance monitoring, and behavior tracking of your LLM-powered applications.
 
 * __Type-safe__
-Designed to make type checking as useful as possible for you, so it [integrates](agents.md#static-type-checking) well with static type checkers, like [`mypy`](https://github.com/python/mypy) and [`pyright`](https://github.com/microsoft/pyright).
+Designed to make type checking as useful as possible for you, so it [integrates](docs/agents.md#static-type-checking) well with static type checkers, like [`mypy`](https://github.com/python/mypy) and [`pyright`](https://github.com/microsoft/pyright).
 
 * __Python-centric Design__
 Leverages Python’s familiar control flow and agent composition to build your AI-driven projects, making it easy to apply standard Python best practices you'd use in any other (non-AI) project
 
 * __Structured Responses__
-Harnesses the power of [Pydantic](https://docs.pydantic.dev/latest/) to [validate and structure](results.md#structured-result-validation) model outputs, ensuring responses are consistent across runs.
+Harnesses the power of [Pydantic](https://docs.pydantic.dev/latest/) to [validate and structure](docs/results.md#structured-result-validation) model outputs, ensuring responses are consistent across runs.
 
 * __Dependency Injection System__
-Offers an optional [dependency injection](dependencies.md) system to provide data and services to your agent's [system prompts](agents.md#system-prompts), [tools](tools.md) and [result validators](results.md#result-validators-functions).
+Offers an optional [dependency injection](docs/dependencies.md) system to provide data and services to your agent's [system prompts](docs/agents.md#system-prompts), [tools](docs/tools.md) and [result validators](docs/results.md#result-validators-functions).
 This is useful for testing and eval-driven iterative development.
 
 * __Streamed Responses__
-Provides the ability to [stream](results.md#streamed-results) LLM outputs continuously, with immediate validation, ensuring rapid and accurate results.
+Provides the ability to [stream](docs/results.md#streamed-results) LLM outputs continuously, with immediate validation, ensuring rapid and accurate results.
 
 ## In Beta!
 


### PR DESCRIPTION
Closes #616

Fixes the README links to use the correct `docs` path.