### PR TITLE
Support `docstring_format` and `require_parameter_descriptions` on tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_griffe.py
+++ b/pydantic_ai_slim/pydantic_ai/_griffe.py
@@ -4,15 +4,21 @@ import logging
 import re
 from contextlib import contextmanager
 from inspect import Signature
-from typing import Any, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 
 from griffe import Docstring, DocstringSectionKind, Object as GriffeObject
+
+if TYPE_CHECKING:
+    from .tools import DocstringFormat
 
 DocstringStyle = Literal['google', 'numpy', 'sphinx']
 
 
 def doc_descriptions(
-    func: Callable[..., Any], sig: Signature, *, style: DocstringStyle | None = None
+    func: Callable[..., Any],
+    sig: Signature,
+    *,
+    docstring_format: DocstringFormat,
 ) -> tuple[str, dict[str, str]]:
     """Extract the function description and parameter descriptions from a function's docstring.
 
@@ -26,7 +32,8 @@ def doc_descriptions(
     # see https://github.com/mkdocstrings/griffe/issues/293
     parent = cast(GriffeObject, sig)
 
-    docstring = Docstring(doc, lineno=1, parser=style or _infer_docstring_style(doc), parent=parent)
+    docstring_style = _infer_docstring_style(doc) if docstring_format == 'auto' else docstring_format
+    docstring = Docstring(doc, lineno=1, parser=docstring_style, parent=parent)
     with _disable_griffe_logging():
         sections = docstring.parse()
 
@@ -41,7 +48,7 @@ def doc_descriptions(
     return main_desc, params
 
 
-def _infer_docstring_style(doc: str) -> DocstringStyle:
+def _infer_docstring_style(doc: str) -> Literal['google', 'numpy', 'sphinx']:
     """Simplistic docstring style inference."""
     for pattern, replacements, style in _docstring_style_patterns:
         matches = (

--- a/pydantic_ai_slim/pydantic_ai/_griffe.py
+++ b/pydantic_ai_slim/pydantic_ai/_griffe.py
@@ -48,7 +48,7 @@ def doc_descriptions(
     return main_desc, params
 
 
-def _infer_docstring_style(doc: str) -> Literal['google', 'numpy', 'sphinx']:
+def _infer_docstring_style(doc: str) -> DocstringStyle:
     """Simplistic docstring style inference."""
     for pattern, replacements, style in _docstring_style_patterns:
         matches = (

--- a/pydantic_ai_slim/pydantic_ai/_pydantic.py
+++ b/pydantic_ai_slim/pydantic_ai/_pydantic.py
@@ -72,6 +72,11 @@ def function_schema(  # noqa: C901
 
     description, field_descriptions = doc_descriptions(function, sig, docstring_format=docstring_format)
 
+    if require_parameter_descriptions:
+        if len(field_descriptions) != len(sig.parameters):
+            missing_params = set(sig.parameters) - set(field_descriptions)
+            errors.append(f'Missing parameter descriptions for {', '.join(missing_params)}')
+
     for index, (name, p) in enumerate(sig.parameters.items()):
         if p.annotation is sig.empty:
             if takes_ctx and index == 0:
@@ -104,10 +109,6 @@ def function_schema(  # noqa: C901
             annotation = cast(type[Any], annotation)
             field_info = FieldInfo.from_annotation(annotation)
             if field_info.description is None:
-                # TODO: figure out if this is actually where we want to warn
-                parameter_doc = field_descriptions.get(field_name)
-                if not parameter_doc and require_parameter_descriptions:
-                    errors.append(f'Missing description for parameter {field_name}')
                 field_info.description = field_descriptions.get(field_name)
 
             fields[field_name] = td_schema = gen_schema._generate_td_field_schema(  # pyright: ignore[reportPrivateUsage]

--- a/pydantic_ai_slim/pydantic_ai/_pydantic.py
+++ b/pydantic_ai_slim/pydantic_ai/_pydantic.py
@@ -75,7 +75,7 @@ def function_schema(  # noqa: C901
     if require_parameter_descriptions:
         if len(field_descriptions) != len(sig.parameters):
             missing_params = set(sig.parameters) - set(field_descriptions)
-            errors.append(f'Missing parameter descriptions for {', '.join(missing_params)}')
+            errors.append(f'Missing parameter descriptions for {", ".join(missing_params)}')
 
     for index, (name, p) in enumerate(sig.parameters.items()):
         if p.annotation is sig.empty:

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -26,6 +26,7 @@ from .result import ResultData
 from .settings import ModelSettings, merge_model_settings
 from .tools import (
     AgentDeps,
+    DocstringFormat,
     RunContext,
     Tool,
     ToolDefinition,
@@ -774,6 +775,8 @@ class Agent(Generic[AgentDeps, ResultData]):
         *,
         retries: int | None = None,
         prepare: ToolPrepareFunc[AgentDeps] | None = None,
+        docstring_format: DocstringFormat = 'auto',
+        require_parameter_descriptions: bool = False,
     ) -> Callable[[ToolFuncContext[AgentDeps, ToolParams]], ToolFuncContext[AgentDeps, ToolParams]]: ...
 
     def tool(
@@ -783,6 +786,8 @@ class Agent(Generic[AgentDeps, ResultData]):
         *,
         retries: int | None = None,
         prepare: ToolPrepareFunc[AgentDeps] | None = None,
+        docstring_format: DocstringFormat = 'auto',
+        require_parameter_descriptions: bool = False,
     ) -> Any:
         """Decorator to register a tool function which takes [`RunContext`][pydantic_ai.tools.RunContext] as its first argument.
 
@@ -820,6 +825,9 @@ class Agent(Generic[AgentDeps, ResultData]):
             prepare: custom method to prepare the tool definition for each step, return `None` to omit this
                 tool from a given step. This is useful if you want to customise a tool at call time,
                 or omit it completely from a step. See [`ToolPrepareFunc`][pydantic_ai.tools.ToolPrepareFunc].
+            docstring_format: The format of the docstring, see [`DocstringFormat`][pydantic_ai.tools.DocstringFormat].
+                Defaults to `'auto'`, such that the format is inferred from the structure of the docstring.
+            require_parameter_descriptions: If True, raise an error if a parameter description is missing. Defaults to False.
         """
         if func is None:
 
@@ -827,13 +835,13 @@ class Agent(Generic[AgentDeps, ResultData]):
                 func_: ToolFuncContext[AgentDeps, ToolParams],
             ) -> ToolFuncContext[AgentDeps, ToolParams]:
                 # noinspection PyTypeChecker
-                self._register_function(func_, True, retries, prepare)
+                self._register_function(func_, True, retries, prepare, docstring_format, require_parameter_descriptions)
                 return func_
 
             return tool_decorator
         else:
             # noinspection PyTypeChecker
-            self._register_function(func, True, retries, prepare)
+            self._register_function(func, True, retries, prepare, docstring_format, require_parameter_descriptions)
             return func
 
     @overload
@@ -846,6 +854,8 @@ class Agent(Generic[AgentDeps, ResultData]):
         *,
         retries: int | None = None,
         prepare: ToolPrepareFunc[AgentDeps] | None = None,
+        docstring_format: DocstringFormat = 'auto',
+        require_parameter_descriptions: bool = False,
     ) -> Callable[[ToolFuncPlain[ToolParams]], ToolFuncPlain[ToolParams]]: ...
 
     def tool_plain(
@@ -855,6 +865,8 @@ class Agent(Generic[AgentDeps, ResultData]):
         *,
         retries: int | None = None,
         prepare: ToolPrepareFunc[AgentDeps] | None = None,
+        docstring_format: DocstringFormat = 'auto',
+        require_parameter_descriptions: bool = False,
     ) -> Any:
         """Decorator to register a tool function which DOES NOT take `RunContext` as an argument.
 
@@ -892,17 +904,22 @@ class Agent(Generic[AgentDeps, ResultData]):
             prepare: custom method to prepare the tool definition for each step, return `None` to omit this
                 tool from a given step. This is useful if you want to customise a tool at call time,
                 or omit it completely from a step. See [`ToolPrepareFunc`][pydantic_ai.tools.ToolPrepareFunc].
+            docstring_format: The format of the docstring, see [`DocstringFormat`][pydantic_ai.tools.DocstringFormat].
+                Defaults to `'auto'`, such that the format is inferred from the structure of the docstring.
+            require_parameter_descriptions: If True, raise an error if a parameter description is missing. Defaults to False.
         """
         if func is None:
 
             def tool_decorator(func_: ToolFuncPlain[ToolParams]) -> ToolFuncPlain[ToolParams]:
                 # noinspection PyTypeChecker
-                self._register_function(func_, False, retries, prepare)
+                self._register_function(
+                    func_, False, retries, prepare, docstring_format, require_parameter_descriptions
+                )
                 return func_
 
             return tool_decorator
         else:
-            self._register_function(func, False, retries, prepare)
+            self._register_function(func, False, retries, prepare, docstring_format, require_parameter_descriptions)
             return func
 
     def _register_function(
@@ -911,10 +928,19 @@ class Agent(Generic[AgentDeps, ResultData]):
         takes_ctx: bool,
         retries: int | None,
         prepare: ToolPrepareFunc[AgentDeps] | None,
+        docstring_format: DocstringFormat,
+        require_parameter_descriptions: bool,
     ) -> None:
         """Private utility to register a function as a tool."""
         retries_ = retries if retries is not None else self._default_retries
-        tool = Tool(func, takes_ctx=takes_ctx, max_retries=retries_, prepare=prepare)
+        tool = Tool(
+            func,
+            takes_ctx=takes_ctx,
+            max_retries=retries_,
+            prepare=prepare,
+            docstring_format=docstring_format,
+            require_parameter_descriptions=require_parameter_descriptions,
+        )
         self._register_tool(tool)
 
     def _register_tool(self, tool: Tool[AgentDeps]) -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from typing import Annotated, Any, Callable, Union
+from typing import Annotated, Any, Callable, Literal, Union
 
 import pydantic_core
 import pytest
@@ -78,9 +78,10 @@ async def get_json_schema(_messages: list[ModelMessage], info: AgentInfo) -> Mod
     return ModelResponse.from_text(pydantic_core.to_json(r).decode())
 
 
-def test_docstring_google(set_event_loop: None):
+@pytest.mark.parametrize('docstring_format', ['google', 'auto'])
+def test_docstring_google(set_event_loop: None, docstring_format: Literal['google', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
-    agent.tool_plain(google_style_docstring)
+    agent.tool_plain(google_style_docstring, docstring_format=docstring_format)  # pyright: ignore[reportCallIssue]
 
     result = agent.run_sync('Hello')
     json_schema = json.loads(result.data)
@@ -116,9 +117,10 @@ def sphinx_style_docstring(foo: int, /) -> str:  # pragma: no cover
     return str(foo)
 
 
-def test_docstring_sphinx(set_event_loop: None):
+@pytest.mark.parametrize('docstring_format', ['sphinx', 'auto'])
+def test_docstring_sphinx(set_event_loop: None, docstring_format: Literal['sphinx', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
-    agent.tool_plain(sphinx_style_docstring)
+    agent.tool_plain(sphinx_style_docstring, docstring_format=docstring_format)  # pyright: ignore[reportCallIssue]
 
     result = agent.run_sync('Hello')
     json_schema = json.loads(result.data)
@@ -150,9 +152,10 @@ def numpy_style_docstring(*, foo: int, bar: str) -> str:  # pragma: no cover
     return f'{foo} {bar}'
 
 
-def test_docstring_numpy(set_event_loop: None):
+@pytest.mark.parametrize('docstring_format', ['numpy', 'auto'])
+def test_docstring_numpy(set_event_loop: None, docstring_format: Literal['numpy', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
-    agent.tool_plain(numpy_style_docstring)
+    agent.tool_plain(numpy_style_docstring, docstring_format=docstring_format)  # pyright: ignore[reportCallIssue]
 
     result = agent.run_sync('Hello')
     json_schema = json.loads(result.data)
@@ -209,9 +212,10 @@ async def google_style_docstring_no_body(
 # fmt: on
 
 
-def test_docstring_google_no_body(set_event_loop: None):
+@pytest.mark.parametrize('docstring_format', ['google', 'auto'])
+def test_docstring_google_no_body(set_event_loop: None, docstring_format: Literal['google', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
-    agent.tool_plain(google_style_docstring_no_body)
+    agent.tool_plain(google_style_docstring_no_body, docstring_format=docstring_format)  # pyright: ignore[reportCallIssue]
 
     result = agent.run_sync('')
     json_schema = json.loads(result.data)
@@ -566,3 +570,24 @@ def test_suppress_griffe_logging(set_event_loop: None, caplog: LogCaptureFixture
     # Without suppressing griffe logging, we get:
     # assert caplog.messages == snapshot(['<module>:4: No type or annotation for returned value 1'])
     assert caplog.messages == snapshot([])
+
+
+async def missing_parameter_descriptions_docstring(foo: int, bar: str) -> str:  # pragma: no cover
+    """Describes function ops, but missing parameter descriptions."""
+    return f'{foo} {bar}'
+
+
+def test_enforce_parameter_descriptions() -> None:
+    agent = Agent(FunctionModel(get_json_schema))
+
+    with pytest.raises(UserError) as exc_info:
+        agent.tool_plain(missing_parameter_descriptions_docstring, require_parameter_descriptions=True)  # pyright: ignore[reportCallIssue]
+
+    error_reason = exc_info.value.args[0]
+    error_parts = [
+        'Error generating schema for missing_parameter_descriptions_docstring',
+        'Missing parameter descriptions for ',
+        'foo',
+        'bar',
+    ]
+    assert all(err_part in error_reason for err_part in error_parts)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -81,7 +81,7 @@ async def get_json_schema(_messages: list[ModelMessage], info: AgentInfo) -> Mod
 @pytest.mark.parametrize('docstring_format', ['google', 'auto'])
 def test_docstring_google(set_event_loop: None, docstring_format: Literal['google', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
-    agent.tool_plain(google_style_docstring, docstring_format=docstring_format)  # pyright: ignore[reportCallIssue]
+    agent.tool_plain(docstring_format=docstring_format)(google_style_docstring)
 
     result = agent.run_sync('Hello')
     json_schema = json.loads(result.data)
@@ -120,7 +120,7 @@ def sphinx_style_docstring(foo: int, /) -> str:  # pragma: no cover
 @pytest.mark.parametrize('docstring_format', ['sphinx', 'auto'])
 def test_docstring_sphinx(set_event_loop: None, docstring_format: Literal['sphinx', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
-    agent.tool_plain(sphinx_style_docstring, docstring_format=docstring_format)  # pyright: ignore[reportCallIssue]
+    agent.tool_plain(docstring_format=docstring_format)(sphinx_style_docstring)
 
     result = agent.run_sync('Hello')
     json_schema = json.loads(result.data)
@@ -155,7 +155,7 @@ def numpy_style_docstring(*, foo: int, bar: str) -> str:  # pragma: no cover
 @pytest.mark.parametrize('docstring_format', ['numpy', 'auto'])
 def test_docstring_numpy(set_event_loop: None, docstring_format: Literal['numpy', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
-    agent.tool_plain(numpy_style_docstring, docstring_format=docstring_format)  # pyright: ignore[reportCallIssue]
+    agent.tool_plain(docstring_format=docstring_format)(numpy_style_docstring)
 
     result = agent.run_sync('Hello')
     json_schema = json.loads(result.data)
@@ -215,7 +215,7 @@ async def google_style_docstring_no_body(
 @pytest.mark.parametrize('docstring_format', ['google', 'auto'])
 def test_docstring_google_no_body(set_event_loop: None, docstring_format: Literal['google', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
-    agent.tool_plain(google_style_docstring_no_body, docstring_format=docstring_format)  # pyright: ignore[reportCallIssue]
+    agent.tool_plain(docstring_format=docstring_format)(google_style_docstring_no_body)
 
     result = agent.run_sync('')
     json_schema = json.loads(result.data)
@@ -581,7 +581,7 @@ def test_enforce_parameter_descriptions() -> None:
     agent = Agent(FunctionModel(get_json_schema))
 
     with pytest.raises(UserError) as exc_info:
-        agent.tool_plain(missing_parameter_descriptions_docstring, require_parameter_descriptions=True)  # pyright: ignore[reportCallIssue]
+        agent.tool_plain(require_parameter_descriptions=True)(missing_parameter_descriptions_docstring)
 
     error_reason = exc_info.value.args[0]
     error_parts = [


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic-ai/issues/59

On tools:

you can now specify `docstring_format` as one of `'google'`, `'sphinx'`, or `'numpy'`. It defaults to `'auto'`, where the docstring format will be inferred.

you can also specify `require_parameter_descriptions` to enforce that parameter descriptions are added in tool docstrings.