### PR TITLE
Fix agent `run`/ `run_sync` docs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -243,9 +243,10 @@ class Agent(Generic[AgentDeps, ResultData]):
 
         agent = Agent('openai:gpt-4o')
 
-        result_sync = agent.run_sync('What is the capital of Italy?')
-        print(result_sync.data)
-        #> Rome
+        async def main():
+            result = await agent.run('What is the capital of France?')
+            print(result.data)
+            #> Paris
         ```
 
         Args:
@@ -383,10 +384,9 @@ class Agent(Generic[AgentDeps, ResultData]):
 
         agent = Agent('openai:gpt-4o')
 
-        async def main():
-            result = await agent.run('What is the capital of France?')
-            print(result.data)
-            #> Paris
+        result_sync = agent.run_sync('What is the capital of Italy?')
+        print(result_sync.data)
+        #> Rome
         ```
 
         Args:


### PR DESCRIPTION
Fixes #686

Updates the Agent class's documentation to show correct examples for using run and run_sync methods.