### PR TITLE
Ensure custom args are used when retried

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -172,7 +172,9 @@ class TestAgentModel(AgentModel):
                 if self.result_tools:
                     retry_parts.extend(
                         [
-                            ToolCallPart.from_raw_args(tool.name, self.gen_tool_args(tool))
+                            ToolCallPart.from_raw_args(
+                                tool.name, self.result.right if self.result.right else self.gen_tool_args(tool)
+                            )
                             for tool in self.result_tools
                             if tool.name in new_retry_names
                         ]

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -173,7 +173,8 @@ class TestAgentModel(AgentModel):
                     retry_parts.extend(
                         [
                             ToolCallPart.from_raw_args(
-                                tool.name, self.result.right if self.result.right else self.gen_tool_args(tool)
+                                tool.name,
+                                self.result.right if self.result.right is not None else self.gen_tool_args(tool),
                             )
                             for tool in self.result_tools
                             if tool.name in new_retry_names

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -131,6 +131,17 @@ def test_result_tool_retry_error_handled(set_event_loop: None):
     assert call_count == 3
 
 
+def test_result_tool_retry_error_handled_with_custom_args(set_event_loop: None):
+    class ResultModel(BaseModel):
+        x: int
+        y: str
+
+    agent = Agent('test', result_type=ResultModel, retries=2)
+
+    with pytest.raises(UnexpectedModelBehavior, match='Exceeded maximum retries'):
+        agent.run_sync('Hello', model=TestModel(custom_result_args={'foo': 'a', 'bar': 1}))
+
+
 def test_json_schema_test_data():
     class NestedModel(BaseModel):
         foo: str


### PR DESCRIPTION
Minor bug -- if `custom_result_args` are provided to a `TestModel` but they do not pass validation, the model doesn't use those custom args when it retries. Instead, it generates "correct" args for the result tool, which makes it hard to test expected failures.

The unit test here doesn't pass on `main`.