### PR TITLE
docs: fix typos in `testing-evals` and RAG example

### DIFF
--- a/docs/testing-evals.md
+++ b/docs/testing-evals.md
@@ -62,7 +62,7 @@ def weather_forecast(
         return ctx.deps.get_forecast(location, forecast_date)
 
 
-async def run_weather_forecast(  # (3)!
+async def run_weather_forecast(  # (4)!
     user_prompts: list[tuple[str, int]], conn: DatabaseConn
 ):
     """Run weather forecast for a list of user prompts and save."""

--- a/examples/pydantic_ai_examples/rag.py
+++ b/examples/pydantic_ai_examples/rag.py
@@ -142,6 +142,7 @@ async def insert_doc_section(
         exists = await pool.fetchval('SELECT 1 FROM doc_sections WHERE url = $1', url)
         if exists:
             logfire.info('Skipping {url=}', url=url)
+            return
 
         with logfire.span('create embedding for {url=}', url=url):
             embedding = await openai.embeddings.create(


### PR DESCRIPTION
The annotations in the code block in the [Testing and evals](https://ai.pydantic.dev/testing-evals/#unit-testing-with-testmodel) section use the same number.

In the [RAG example](https://github.com/pydantic/pydantic-ai/blob/main/examples/pydantic_ai_examples/rag.py#L144), when the URL is already in the database, it logs the information but does not return. Is this the intended behavior?
