### PR TITLE
Increase default IsNow() delta

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,14 @@ if TYPE_CHECKING:
     def IsNow(*args: Any, **kwargs: Any) -> datetime: ...
     def IsFloat(*args: Any, **kwargs: Any) -> float: ...
 else:
-    from dirty_equals import IsFloat, IsNow
+    from dirty_equals import IsFloat, IsNow as _IsNow
+
+    def IsNow(*args: Any, **kwargs: Any):
+        # Increase the default value of `delta` to 10 to reduce test flakiness on overburdened machines
+        if 'delta' not in kwargs:
+            kwargs['delta'] = 10
+        return _IsNow(*args, **kwargs)
+
 
 try:
     from logfire.testing import CaptureLogfire


### PR DESCRIPTION
This caused some issues reported (and semi-time-consumingly debugged) in https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1737559885695419

I'll note that I think it might make sense to increase the value significantly further, maybe to 60 or more, because it can end up being very difficult to debug tests with step-debugging when a given line fails somewhat early in the test due to having been paused in the debugger between when the timestamp being compared was generated, and when the timestamp used by `IsNow()` is generated. But the change currently in the PR is small enough that I think it should reduce flakiness without risking any reduction in behavior being tested.