### PR TITLE
Autouse the set_event_loop fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,7 @@ def try_import() -> Iterator[Callable[[], bool]]:
         import_success = True
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def set_event_loop() -> Iterator[None]:
     new_loop = asyncio.new_event_loop()
     asyncio.set_event_loop(new_loop)

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -58,7 +58,7 @@ async def return_last(messages: list[ModelMessage], _: AgentInfo) -> ModelRespon
     return ModelResponse(parts=[TextPart(' '.join(f'{k}={v!r}' for k, v in response.items()))])
 
 
-def test_simple(set_event_loop: None):
+def test_simple():
     agent = Agent(FunctionModel(return_last))
     result = agent.run_sync('Hello')
     assert result.data == snapshot("content='Hello' part_kind='user-prompt' message_count=1")
@@ -143,7 +143,7 @@ async def get_weather(_: RunContext[None], lat: int, lng: int):
         return 'Sunny'
 
 
-def test_weather(set_event_loop: None):
+def test_weather():
     result = weather_agent.run_sync('London')
     assert result.data == 'Raining in London'
     assert result.all_messages() == snapshot(
@@ -214,7 +214,7 @@ def get_var_args(ctx: RunContext[int], *args: int):
     return json.dumps({'args': args})
 
 
-def test_var_args(set_event_loop: None):
+def test_var_args():
     result = var_args_agent.run_sync('{"function": "get_var_args", "arguments": {"args": [1, 2, 3]}}', deps=123)
     response_data = json.loads(result.data)
     # Can't parse ISO timestamps with trailing 'Z' in older versions of python:
@@ -239,7 +239,7 @@ async def call_tool(messages: list[ModelMessage], info: AgentInfo) -> ModelRespo
         return ModelResponse(parts=[TextPart('final response')])
 
 
-def test_deps_none(set_event_loop: None):
+def test_deps_none():
     agent = Agent(FunctionModel(call_tool))
 
     @agent.tool
@@ -259,7 +259,7 @@ def test_deps_none(set_event_loop: None):
     assert called
 
 
-def test_deps_init(set_event_loop: None):
+def test_deps_init():
     def get_check_foobar(ctx: RunContext[tuple[str, str]]) -> str:
         nonlocal called
 
@@ -274,7 +274,7 @@ def test_deps_init(set_event_loop: None):
     assert called
 
 
-def test_model_arg(set_event_loop: None):
+def test_model_arg():
     agent = Agent()
     result = agent.run_sync('Hello', model=FunctionModel(return_last))
     assert result.data == snapshot("content='Hello' part_kind='user-prompt' message_count=1")
@@ -316,7 +316,7 @@ def spam() -> str:
     return 'foobar'
 
 
-def test_register_all(set_event_loop: None):
+def test_register_all():
     async def f(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         return ModelResponse(
             parts=[
@@ -330,7 +330,7 @@ def test_register_all(set_event_loop: None):
     assert result.data == snapshot('messages=1 allow_text_result=True tools=5')
 
 
-def test_call_all(set_event_loop: None):
+def test_call_all():
     result = agent_all.run_sync('Hello', model=TestModel())
     assert result.data == snapshot('{"foo":"1","bar":"2","baz":"3","qux":"4","quz":"a"}')
     assert result.all_messages() == snapshot(
@@ -370,7 +370,7 @@ def test_call_all(set_event_loop: None):
     )
 
 
-def test_retry_str(set_event_loop: None):
+def test_retry_str():
     call_count = 0
 
     async def try_again(msgs_: list[ModelMessage], _agent_info: AgentInfo) -> ModelResponse:
@@ -392,7 +392,7 @@ def test_retry_str(set_event_loop: None):
     assert result.data == snapshot('2')
 
 
-def test_retry_result_type(set_event_loop: None):
+def test_retry_result_type():
     call_count = 0
 
     async def try_again(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -26,7 +26,7 @@ from pydantic_ai.models.test import TestModel, _chars, _JsonSchemaTestData  # py
 from ..conftest import IsNow
 
 
-def test_call_one(set_event_loop: None):
+def test_call_one():
     agent = Agent()
     calls: list[str] = []
 
@@ -45,7 +45,7 @@ def test_call_one(set_event_loop: None):
     assert calls == ['a']
 
 
-def test_custom_result_text(set_event_loop: None):
+def test_custom_result_text():
     agent = Agent()
     result = agent.run_sync('x', model=TestModel(custom_result_text='custom'))
     assert result.data == snapshot('custom')
@@ -54,13 +54,13 @@ def test_custom_result_text(set_event_loop: None):
         agent.run_sync('x', model=TestModel(custom_result_text='custom'))
 
 
-def test_custom_result_args(set_event_loop: None):
+def test_custom_result_args():
     agent = Agent(result_type=tuple[str, str])
     result = agent.run_sync('x', model=TestModel(custom_result_args=['a', 'b']))
     assert result.data == ('a', 'b')
 
 
-def test_custom_result_args_model(set_event_loop: None):
+def test_custom_result_args_model():
     class Foo(BaseModel):
         foo: str
         bar: int
@@ -70,13 +70,13 @@ def test_custom_result_args_model(set_event_loop: None):
     assert result.data == Foo(foo='a', bar=1)
 
 
-def test_result_type(set_event_loop: None):
+def test_result_type():
     agent = Agent(result_type=tuple[str, str])
     result = agent.run_sync('x', model=TestModel())
     assert result.data == ('a', 'a')
 
 
-def test_tool_retry(set_event_loop: None):
+def test_tool_retry():
     agent = Agent()
     call_count = 0
 
@@ -120,7 +120,7 @@ def test_tool_retry(set_event_loop: None):
     )
 
 
-def test_result_tool_retry_error_handled(set_event_loop: None):
+def test_result_tool_retry_error_handled():
     class ResultModel(BaseModel):
         x: int
         y: str

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -37,7 +37,7 @@ from .conftest import IsNow, TestEnv
 pytestmark = pytest.mark.anyio
 
 
-def test_result_tuple(set_event_loop: None):
+def test_result_tuple():
     def return_tuple(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.result_tools is not None
         args_json = '{"response": ["foo", "bar"]}'
@@ -54,7 +54,7 @@ class Foo(BaseModel):
     b: str
 
 
-def test_result_pydantic_model(set_event_loop: None):
+def test_result_pydantic_model():
     def return_model(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.result_tools is not None
         args_json = '{"a": 1, "b": "foo"}'
@@ -67,7 +67,7 @@ def test_result_pydantic_model(set_event_loop: None):
     assert result.data.model_dump() == {'a': 1, 'b': 'foo'}
 
 
-def test_result_pydantic_model_retry(set_event_loop: None):
+def test_result_pydantic_model_retry():
     def return_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.result_tools is not None
         if len(messages) == 1:
@@ -125,7 +125,7 @@ def test_result_pydantic_model_retry(set_event_loop: None):
     assert result.all_messages_json().startswith(b'[{"parts":[{"content":"Hello",')
 
 
-def test_result_pydantic_model_validation_error(set_event_loop: None):
+def test_result_pydantic_model_validation_error():
     def return_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.result_tools is not None
         if len(messages) == 1:
@@ -179,7 +179,7 @@ def test_result_pydantic_model_validation_error(set_event_loop: None):
 Fix the errors and try again.""")
 
 
-def test_result_validator(set_event_loop: None):
+def test_result_validator():
     def return_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.result_tools is not None
         if len(messages) == 1:
@@ -232,7 +232,7 @@ def test_result_validator(set_event_loop: None):
     )
 
 
-def test_plain_response_then_tuple(set_event_loop: None):
+def test_plain_response_then_tuple():
     call_index = 0
 
     def return_tuple(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -298,7 +298,7 @@ def test_plain_response_then_tuple(set_event_loop: None):
     )
 
 
-def test_result_tool_return_content_str_return(set_event_loop: None):
+def test_result_tool_return_content_str_return():
     agent = Agent('test')
 
     result = agent.run_sync('Hello')
@@ -309,7 +309,7 @@ def test_result_tool_return_content_str_return(set_event_loop: None):
         result.all_messages(result_tool_return_content='foobar')
 
 
-def test_result_tool_return_content_no_tool(set_event_loop: None):
+def test_result_tool_return_content_no_tool():
     agent = Agent('test', result_type=int)
 
     result = agent.run_sync('Hello')
@@ -319,7 +319,7 @@ def test_result_tool_return_content_no_tool(set_event_loop: None):
         result.all_messages(result_tool_return_content='foobar')
 
 
-def test_response_tuple(set_event_loop: None):
+def test_response_tuple():
     m = TestModel()
 
     agent = Agent(m, result_type=tuple[str, str])
@@ -363,7 +363,7 @@ def test_response_tuple(set_event_loop: None):
     [lambda: Union[str, Foo], lambda: Union[Foo, str], lambda: str | Foo, lambda: Foo | str],
     ids=['Union[str, Foo]', 'Union[Foo, str]', 'str | Foo', 'Foo | str'],
 )
-def test_response_union_allow_str(set_event_loop: None, input_union_callable: Callable[[], Any]):
+def test_response_union_allow_str(input_union_callable: Callable[[], Any]):
     try:
         union = input_union_callable()
     except TypeError:
@@ -426,7 +426,7 @@ def test_response_union_allow_str(set_event_loop: None, input_union_callable: Ca
         ),
     ],
 )
-def test_response_multiple_return_tools(set_event_loop: None, create_module: Callable[[str], Any], union_code: str):
+def test_response_multiple_return_tools(create_module: Callable[[str], Any], union_code: str):
     module_code = f'''
 from pydantic import BaseModel
 from typing import Union
@@ -500,7 +500,7 @@ class Bar(BaseModel):
     assert got_tool_call_name == snapshot('final_result_Bar')
 
 
-def test_run_with_history_new(set_event_loop: None):
+def test_run_with_history_new():
     m = TestModel()
 
     agent = Agent(m, system_prompt='Foobar')
@@ -615,7 +615,7 @@ def test_run_with_history_new(set_event_loop: None):
     )
 
 
-def test_run_with_history_new_structured(set_event_loop: None):
+def test_run_with_history_new_structured():
     m = TestModel()
 
     class Response(BaseModel):
@@ -740,7 +740,7 @@ def test_run_with_history_new_structured(set_event_loop: None):
     assert result2.new_messages_json().startswith(b'[{"parts":[{"content":"Hello again",')
 
 
-def test_empty_tool_calls(set_event_loop: None):
+def test_empty_tool_calls():
     def empty(_: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
         return ModelResponse(parts=[])
 
@@ -750,7 +750,7 @@ def test_empty_tool_calls(set_event_loop: None):
         agent.run_sync('Hello')
 
 
-def test_unknown_tool(set_event_loop: None):
+def test_unknown_tool():
     def empty(_: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
         return ModelResponse(parts=[ToolCallPart.from_raw_args('foobar', '{}')])
 
@@ -783,7 +783,7 @@ def test_unknown_tool(set_event_loop: None):
     )
 
 
-def test_unknown_tool_fix(set_event_loop: None):
+def test_unknown_tool_fix():
     def empty(m: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
         if len(m) > 1:
             return ModelResponse(parts=[TextPart('success')])
@@ -818,7 +818,7 @@ def test_unknown_tool_fix(set_event_loop: None):
     )
 
 
-def test_model_requests_blocked(env: TestEnv, set_event_loop: None):
+def test_model_requests_blocked(env: TestEnv):
     env.set('GEMINI_API_KEY', 'foobar')
     agent = Agent('google-gla:gemini-1.5-flash', result_type=tuple[str, str], defer_model_check=True)
 
@@ -826,7 +826,7 @@ def test_model_requests_blocked(env: TestEnv, set_event_loop: None):
         agent.run_sync('Hello')
 
 
-def test_override_model(env: TestEnv, set_event_loop: None):
+def test_override_model(env: TestEnv):
     env.set('GEMINI_API_KEY', 'foobar')
     agent = Agent('google-gla:gemini-1.5-flash', result_type=tuple[int, str], defer_model_check=True)
 
@@ -835,7 +835,7 @@ def test_override_model(env: TestEnv, set_event_loop: None):
         assert result.data == snapshot((0, 'a'))
 
 
-def test_override_model_no_model(set_event_loop: None):
+def test_override_model_no_model():
     agent = Agent()
 
     with pytest.raises(UserError, match=r'`model` must be set either.+Even when `override\(model=...\)` is customiz'):
@@ -843,7 +843,7 @@ def test_override_model_no_model(set_event_loop: None):
             agent.run_sync('Hello')
 
 
-def test_run_sync_multiple(set_event_loop: None):
+def test_run_sync_multiple():
     agent = Agent('test')
 
     @agent.tool_plain
@@ -897,7 +897,7 @@ async def test_agent_name_changes():
     assert new_agent.name == 'my_agent'
 
 
-def test_name_from_global(set_event_loop: None, create_module: Callable[[str], Any]):
+def test_name_from_global(create_module: Callable[[str], Any]):
     module_code = """
 from pydantic_ai import Agent
 
@@ -1211,7 +1211,7 @@ async def test_empty_text_part():
     assert result.data == ('foo', 'bar')
 
 
-def test_heterogeneous_responses_non_streaming(set_event_loop: None) -> None:
+def test_heterogeneous_responses_non_streaming() -> None:
     """Indicates that tool calls are prioritized over text in heterogeneous responses."""
 
     def return_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -1278,7 +1278,7 @@ def test_last_run_messages() -> None:
         agent.last_run_messages  # pyright: ignore[reportDeprecated]
 
 
-def test_nested_capture_run_messages(set_event_loop: None) -> None:
+def test_nested_capture_run_messages() -> None:
     agent = Agent('test')
 
     with capture_run_messages() as messages1:
@@ -1300,7 +1300,7 @@ def test_nested_capture_run_messages(set_event_loop: None) -> None:
     assert messages1 == messages2
 
 
-def test_double_capture_run_messages(set_event_loop: None) -> None:
+def test_double_capture_run_messages() -> None:
     agent = Agent('test')
 
     with capture_run_messages() as messages:
@@ -1319,7 +1319,7 @@ def test_double_capture_run_messages(set_event_loop: None) -> None:
     )
 
 
-def test_dynamic_false_no_reevaluate(set_event_loop: None):
+def test_dynamic_false_no_reevaluate():
     """When dynamic is false (default), the system prompt is not reevaluated
     i.e: SystemPromptPart(
             content="A",       <--- Remains the same when `message_history` is passed.
@@ -1391,7 +1391,7 @@ def test_dynamic_false_no_reevaluate(set_event_loop: None):
     )
 
 
-def test_dynamic_true_reevaluate_system_prompt(set_event_loop: None):
+def test_dynamic_true_reevaluate_system_prompt():
     """When dynamic is true, the system prompt is reevaluated
     i.e: SystemPromptPart(
             content="B",       <--- Updated value
@@ -1468,7 +1468,7 @@ def test_dynamic_true_reevaluate_system_prompt(set_event_loop: None):
     )
 
 
-def test_capture_run_messages_tool_agent(set_event_loop: None) -> None:
+def test_capture_run_messages_tool_agent() -> None:
     agent_outer = Agent('test')
     agent_inner = Agent(TestModel(custom_result_text='inner agent result'))
 
@@ -1508,7 +1508,7 @@ class Bar(BaseModel):
     d: str
 
 
-def test_custom_result_type_sync(set_event_loop: None) -> None:
+def test_custom_result_type_sync() -> None:
     agent = Agent('test', result_type=Foo)
 
     assert agent.run_sync('Hello').data == snapshot(Foo(a=0, b='a'))
@@ -1529,7 +1529,7 @@ async def test_custom_result_type_async() -> None:
     assert result.data == snapshot(0)
 
 
-def test_custom_result_type_invalid(set_event_loop: None) -> None:
+def test_custom_result_type_invalid() -> None:
     agent = Agent('test')
 
     @agent.result_validator

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -18,12 +18,12 @@ async def example_tool(ctx: RunContext[MyDeps]) -> str:
     return f'{ctx.deps}'
 
 
-def test_deps_used(set_event_loop: None):
+def test_deps_used():
     result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
     assert result.data == '{"example_tool":"MyDeps(foo=1, bar=2)"}'
 
 
-def test_deps_override(set_event_loop: None):
+def test_deps_override():
     with agent.override(deps=MyDeps(foo=3, bar=4)):
         result = agent.run_sync('foobar', deps=MyDeps(foo=1, bar=2))
         assert result.data == '{"example_tool":"MyDeps(foo=3, bar=4)"}'

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -62,7 +62,6 @@ def test_docs_examples(
     client_with_handler: ClientWithHandler,
     env: TestEnv,
     tmp_path: Path,
-    set_event_loop: None,
 ):
     mocker.patch('pydantic_ai.agent.models.infer_model', side_effect=mock_infer_model)
     mocker.patch('pydantic_ai._utils.group_by_temporal', side_effect=mock_group_by_temporal)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -58,7 +58,7 @@ def get_logfire_summary(capfire: CaptureLogfire) -> Callable[[], LogfireSummary]
 
 
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-def test_logfire(get_logfire_summary: Callable[[], LogfireSummary], set_event_loop: None) -> None:
+def test_logfire(get_logfire_summary: Callable[[], LogfireSummary]) -> None:
     my_agent = Agent(model=TestModel())
 
     @my_agent.tool_plain

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -79,7 +79,7 @@ async def get_json_schema(_messages: list[ModelMessage], info: AgentInfo) -> Mod
 
 
 @pytest.mark.parametrize('docstring_format', ['google', 'auto'])
-def test_docstring_google(set_event_loop: None, docstring_format: Literal['google', 'auto']):
+def test_docstring_google(docstring_format: Literal['google', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
     agent.tool_plain(docstring_format=docstring_format)(google_style_docstring)
 
@@ -118,7 +118,7 @@ def sphinx_style_docstring(foo: int, /) -> str:  # pragma: no cover
 
 
 @pytest.mark.parametrize('docstring_format', ['sphinx', 'auto'])
-def test_docstring_sphinx(set_event_loop: None, docstring_format: Literal['sphinx', 'auto']):
+def test_docstring_sphinx(docstring_format: Literal['sphinx', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
     agent.tool_plain(docstring_format=docstring_format)(sphinx_style_docstring)
 
@@ -153,7 +153,7 @@ def numpy_style_docstring(*, foo: int, bar: str) -> str:  # pragma: no cover
 
 
 @pytest.mark.parametrize('docstring_format', ['numpy', 'auto'])
-def test_docstring_numpy(set_event_loop: None, docstring_format: Literal['numpy', 'auto']):
+def test_docstring_numpy(docstring_format: Literal['numpy', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
     agent.tool_plain(docstring_format=docstring_format)(numpy_style_docstring)
 
@@ -182,7 +182,7 @@ def unknown_docstring(**kwargs: int) -> str:  # pragma: no cover
     return str(kwargs)
 
 
-def test_docstring_unknown(set_event_loop: None):
+def test_docstring_unknown():
     agent = Agent(FunctionModel(get_json_schema))
     agent.tool_plain(unknown_docstring)
 
@@ -213,7 +213,7 @@ async def google_style_docstring_no_body(
 
 
 @pytest.mark.parametrize('docstring_format', ['google', 'auto'])
-def test_docstring_google_no_body(set_event_loop: None, docstring_format: Literal['google', 'auto']):
+def test_docstring_google_no_body(docstring_format: Literal['google', 'auto']):
     agent = Agent(FunctionModel(get_json_schema))
     agent.tool_plain(docstring_format=docstring_format)(google_style_docstring_no_body)
 
@@ -242,7 +242,7 @@ class Foo(BaseModel):
     y: str
 
 
-def test_takes_just_model(set_event_loop: None):
+def test_takes_just_model():
     agent = Agent()
 
     @agent.tool_plain
@@ -272,7 +272,7 @@ def test_takes_just_model(set_event_loop: None):
     assert result.data == snapshot('{"takes_just_model":"0 a"}')
 
 
-def test_takes_model_and_int(set_event_loop: None):
+def test_takes_model_and_int():
     agent = Agent()
 
     @agent.tool_plain
@@ -314,7 +314,7 @@ def test_takes_model_and_int(set_event_loop: None):
 
 
 # pyright: reportPrivateUsage=false
-def test_init_tool_plain(set_event_loop: None):
+def test_init_tool_plain():
     call_args: list[int] = []
 
     def plain_tool(x: int) -> int:
@@ -341,7 +341,7 @@ def ctx_tool(ctx: RunContext[int], x: int) -> int:
 
 
 # pyright: reportPrivateUsage=false
-def test_init_tool_ctx(set_event_loop: None):
+def test_init_tool_ctx():
     agent = Agent('test', tools=[Tool(ctx_tool, takes_ctx=True, max_retries=3)], deps_type=int, retries=7)
     result = agent.run_sync('foobar', deps=5)
     assert result.data == snapshot('{"ctx_tool":5}')
@@ -383,7 +383,7 @@ def test_init_plain_tool_invalid():
         Tool(ctx_tool, takes_ctx=False)
 
 
-def test_return_pydantic_model(set_event_loop: None):
+def test_return_pydantic_model():
     agent = Agent('test')
 
     @agent.tool_plain
@@ -394,7 +394,7 @@ def test_return_pydantic_model(set_event_loop: None):
     assert result.data == snapshot('{"return_pydantic_model":{"x":0,"y":"a"}}')
 
 
-def test_return_bytes(set_event_loop: None):
+def test_return_bytes():
     agent = Agent('test')
 
     @agent.tool_plain
@@ -405,7 +405,7 @@ def test_return_bytes(set_event_loop: None):
     assert result.data == snapshot('{"return_pydantic_model":"🐈 Hello"}')
 
 
-def test_return_bytes_invalid(set_event_loop: None):
+def test_return_bytes_invalid():
     agent = Agent('test')
 
     @agent.tool_plain
@@ -416,7 +416,7 @@ def test_return_bytes_invalid(set_event_loop: None):
         agent.run_sync('')
 
 
-def test_return_unknown(set_event_loop: None):
+def test_return_unknown():
     agent = Agent('test')
 
     class Foobar:
@@ -430,7 +430,7 @@ def test_return_unknown(set_event_loop: None):
         agent.run_sync('')
 
 
-def test_dynamic_cls_tool(set_event_loop: None):
+def test_dynamic_cls_tool():
     @dataclass
     class MyTool(Tool[int]):
         spam: int
@@ -455,7 +455,7 @@ def test_dynamic_cls_tool(set_event_loop: None):
     assert r.data == snapshot('success (no tool calls)')
 
 
-def test_dynamic_plain_tool_decorator(set_event_loop: None):
+def test_dynamic_plain_tool_decorator():
     agent = Agent('test', deps_type=int)
 
     async def prepare_tool_def(ctx: RunContext[int], tool_def: ToolDefinition) -> Union[ToolDefinition, None]:
@@ -473,7 +473,7 @@ def test_dynamic_plain_tool_decorator(set_event_loop: None):
     assert r.data == snapshot('success (no tool calls)')
 
 
-def test_dynamic_tool_decorator(set_event_loop: None):
+def test_dynamic_tool_decorator():
     agent = Agent('test', deps_type=int)
 
     async def prepare_tool_def(ctx: RunContext[int], tool_def: ToolDefinition) -> Union[ToolDefinition, None]:
@@ -491,7 +491,7 @@ def test_dynamic_tool_decorator(set_event_loop: None):
     assert r.data == snapshot('success (no tool calls)')
 
 
-def test_dynamic_tool_use_messages(set_event_loop: None):
+def test_dynamic_tool_use_messages():
     async def repeat_call_foobar(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if info.function_tools:
             tool = info.function_tools[0]
@@ -524,7 +524,7 @@ def test_dynamic_tool_use_messages(set_event_loop: None):
     )
 
 
-def test_future_run_context(set_event_loop: None, create_module: Callable[[str], Any]):
+def test_future_run_context(create_module: Callable[[str], Any]):
     mod = create_module("""
 from __future__ import annotations
 
@@ -549,7 +549,7 @@ async def tool_without_return_annotation_in_docstring() -> str:  # pragma: no co
     return ''
 
 
-def test_suppress_griffe_logging(set_event_loop: None, caplog: LogCaptureFixture):
+def test_suppress_griffe_logging(caplog: LogCaptureFixture):
     # This would cause griffe to emit a warning log if we didn't suppress the griffe logging.
 
     agent = Agent(FunctionModel(get_json_schema))

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -23,7 +23,7 @@ from .conftest import IsNow
 pytestmark = pytest.mark.anyio
 
 
-def test_request_token_limit(set_event_loop: None) -> None:
+def test_request_token_limit() -> None:
     test_agent = Agent(TestModel())
 
     with pytest.raises(
@@ -34,7 +34,7 @@ def test_request_token_limit(set_event_loop: None) -> None:
         )
 
 
-def test_response_token_limit(set_event_loop: None) -> None:
+def test_response_token_limit() -> None:
     test_agent = Agent(
         TestModel(custom_result_text='Unfortunately, this response exceeds the response tokens limit by a few!')
     )
@@ -45,14 +45,14 @@ def test_response_token_limit(set_event_loop: None) -> None:
         test_agent.run_sync('Hello', usage_limits=UsageLimits(response_tokens_limit=5))
 
 
-def test_total_token_limit(set_event_loop: None) -> None:
+def test_total_token_limit() -> None:
     test_agent = Agent(TestModel(custom_result_text='This utilizes 4 tokens!'))
 
     with pytest.raises(UsageLimitExceeded, match=re.escape('Exceeded the total_tokens_limit of 50 (total_tokens=55)')):
         test_agent.run_sync('Hello', usage_limits=UsageLimits(total_tokens_limit=50))
 
 
-def test_retry_limit(set_event_loop: None) -> None:
+def test_retry_limit() -> None:
     test_agent = Agent(TestModel())
 
     @test_agent.tool_plain
@@ -107,7 +107,7 @@ async def test_streamed_text_limits() -> None:
             await result.get_data()
 
 
-def test_usage_so_far(set_event_loop: None) -> None:
+def test_usage_so_far() -> None:
     test_agent = Agent(TestModel())
 
     with pytest.raises(


### PR DESCRIPTION
Not sure why this is necessary, but it seems everything works if we just autouse it, and like this, we don't need to remember to add it to tests anywhere.