### PR TITLE
Support `parallel_tool_calls` in `ModelSettings`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -186,16 +186,22 @@ class AnthropicAgentModel(AgentModel):
         self, messages: list[ModelMessage], stream: bool, model_settings: ModelSettings | None
     ) -> AnthropicMessage | AsyncStream[RawMessageStreamEvent]:
         # standalone function to make it easier to override
+        model_settings = model_settings or {}
+
+        tool_choice: ToolChoiceParam | None
+
         if not self.tools:
-            tool_choice: ToolChoiceParam | None = None
-        elif not self.allow_text_result:
-            tool_choice = {'type': 'any'}
+            tool_choice = None
         else:
-            tool_choice = {'type': 'auto'}
+            if not self.allow_text_result:
+                tool_choice = {'type': 'any'}
+            else:
+                tool_choice = {'type': 'auto'}
+
+            if allow_parallel_tool_calls := model_settings.get('parallel_tool_calls'):
+                tool_choice['disable_parallel_tool_use'] = not allow_parallel_tool_calls
 
         system_prompt, anthropic_messages = self._map_message(messages)
-
-        model_settings = model_settings or {}
 
         return await self.client.messages.create(
             max_tokens=model_settings.get('max_tokens', 1024),

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -198,7 +198,7 @@ class AnthropicAgentModel(AgentModel):
             else:
                 tool_choice = {'type': 'auto'}
 
-            if allow_parallel_tool_calls := model_settings.get('parallel_tool_calls'):
+            if (allow_parallel_tool_calls := model_settings.get('parallel_tool_calls')) is not None:
                 tool_choice['disable_parallel_tool_use'] = not allow_parallel_tool_calls
 
         system_prompt, anthropic_messages = self._map_message(messages)

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -197,7 +197,7 @@ class GroqAgentModel(AgentModel):
             model=str(self.model_name),
             messages=groq_messages,
             n=1,
-            parallel_tool_calls=True if self.tools else NOT_GIVEN,
+            parallel_tool_calls=model_settings.get('parallel_tool_calls', True if self.tools else NOT_GIVEN),
             tools=self.tools or NOT_GIVEN,
             tool_choice=tool_choice or NOT_GIVEN,
             stream=stream,

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -195,7 +195,7 @@ class OpenAIAgentModel(AgentModel):
             model=self.model_name,
             messages=openai_messages,
             n=1,
-            parallel_tool_calls=True if self.tools else NOT_GIVEN,
+            parallel_tool_calls=model_settings.get('parallel_tool_calls', True if self.tools else NOT_GIVEN),
             tools=self.tools or NOT_GIVEN,
             tool_choice=tool_choice or NOT_GIVEN,
             stream=stream,

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -12,7 +12,8 @@ if TYPE_CHECKING:
 class ModelSettings(TypedDict, total=False):
     """Settings to configure an LLM.
 
-    Here we include only settings which apply to multiple models / model providers.
+    Here we include only settings which apply to multiple models / model providers,
+    though not all of these settings are supported by all models.
     """
 
     max_tokens: int

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -25,6 +25,7 @@ class ModelSettings(TypedDict, total=False):
     * OpenAI
     * Groq
     * Cohere
+    * Mistral
     """
 
     temperature: float
@@ -42,6 +43,7 @@ class ModelSettings(TypedDict, total=False):
     * OpenAI
     * Groq
     * Cohere
+    * Mistral
     """
 
     top_p: float
@@ -58,6 +60,7 @@ class ModelSettings(TypedDict, total=False):
     * OpenAI
     * Groq
     * Cohere
+    * Mistral
     """
 
     timeout: float | Timeout
@@ -69,6 +72,16 @@ class ModelSettings(TypedDict, total=False):
     * Anthropic
     * OpenAI
     * Groq
+    * Mistral
+    """
+
+    parallel_tool_calls: bool
+    """Whether to allow parallel tool calls.
+
+    Supported by:
+    * OpenAI
+    * Groq
+    * Anthropic
     """
 
 


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic-ai/pull/633

Thanks @remigw for your work on https://github.com/pydantic/pydantic-ai/pull/633, I'll finish up here.

In another PR I'd like to create a base mock client that provides access to chat completions args for testing, where I'll also add more robust `ModelSettings` tests.