### PR TITLE
Add support for `user` role system prompts `o1-preview-2024-09-12`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -51,7 +51,7 @@ Using this more broad type for the model name instead of the ChatModel definitio
 allows this model to be used more easily with other model types (ie, Ollama)
 """
 
-OpenAISystemPromptRole = Literal['system', 'developer']
+OpenAISystemPromptRole = Literal['system', 'developer', 'user']
 
 
 @dataclass(init=False)
@@ -261,6 +261,8 @@ class OpenAIAgentModel(AgentModel):
             if isinstance(part, SystemPromptPart):
                 if self.system_prompt_role == 'developer':
                     yield chat.ChatCompletionDeveloperMessageParam(role='developer', content=part.content)
+                elif self.system_prompt_role == 'user':
+                    yield chat.ChatCompletionUserMessageParam(role='user', content=part.content)
                 else:
                     yield chat.ChatCompletionSystemMessageParam(role='system', content=part.content)
             elif isinstance(part, UserPromptPart):

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -514,7 +514,7 @@ async def test_no_delta(allow_model_requests: None):
         assert result.usage() == snapshot(Usage(requests=1, request_tokens=6, response_tokens=3, total_tokens=9))
 
 
-@pytest.mark.parametrize('system_prompt_role', ['system', 'developer', None])
+@pytest.mark.parametrize('system_prompt_role', ['system', 'developer', 'user', None])
 async def test_system_prompt_role(
     allow_model_requests: None, system_prompt_role: OpenAISystemPromptRole | None
 ) -> None:


### PR DESCRIPTION
While `o1-2024-12-17` requires the system prompt to be set by role `developer`, `o1-preview-2024-09-12` expects it from role `user`. This PR allows `system_prompt_role` to also be set to `user` for OpenAI models.

This is poorly documented, but can be seen in docs for Reasoning models: https://platform.openai.com/docs/guides/reasoning?reasoning-prompt-examples=coding#prompt-examples