### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,11 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in pyproject.toml
+    rev: v2.3.0
+    hooks:
+    - id: codespell
+      additional_dependencies:
+      - tomli

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -450,7 +450,7 @@ class Feedback(BaseNode[State, None, Email]):
 async def main():
     user = User(
         name='John Doe',
-        email='john.joe@exmaple.com',
+        email='john.joe@example.com',
         interests=['Haskel', 'Lisp', 'Fortran'],
     )
     state = State(user)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -186,7 +186,7 @@ sequenceDiagram
 
 ## Registering Function Tools via kwarg
 
-As well as using the decorators, we can register tools via the `tools` argument to the [`Agent` constructor][pydantic_ai.Agent.__init__]. This is useful when you want to re-use tools, and can also give more fine-grained control over the tools.
+As well as using the decorators, we can register tools via the `tools` argument to the [`Agent` constructor][pydantic_ai.Agent.__init__]. This is useful when you want to reuse tools, and can also give more fine-grained control over the tools.
 
 ```python {title="dice_game_tool_kwarg.py"}
 import random

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -600,7 +600,7 @@ def _map_content(content: MistralOptionalNullable[MistralContent]) -> str | None
     elif isinstance(content, str):
         result = content
 
-    # Note: Check len to handle potential mismatch between function calls and responses from the API. (`msg: not the same number of function class and reponses`)
+    # Note: Check len to handle potential mismatch between function calls and responses from the API. (`msg: not the same number of function class and responses`)
     if result and len(result) == 0:
         result = None
 

--- a/pydantic_ai_slim/pydantic_ai/models/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/models/ollama.py
@@ -80,7 +80,7 @@ class OllamaModel(Model):
     ):
         """Initialize an Ollama model.
 
-        Ollama has built-in compatability for the OpenAI chat completions API ([source](https://ollama.com/blog/openai-compatibility)), so we reuse the
+        Ollama has built-in compatibility for the OpenAI chat completions API ([source](https://ollama.com/blog/openai-compatibility)), so we reuse the
         [`OpenAIModel`][pydantic_ai.models.openai.OpenAIModel] here.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,5 +188,6 @@ snap=["create"]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = '.git*,*.svg,*.lock,*.css'
 check-hidden = true
-# ignore-regex = ''
+# Ignore "formatting" like **L**anguage
+ignore-regex = '\*\*[A-Z]\*\*[a-z]+\b'
 # ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,3 +183,10 @@ ignore_no_config = true
 [tool.inline-snapshot.shortcuts]
 snap-fix=["create", "fix"]
 snap=["create"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.svg,*.lock,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/tests/typed_graph.py
+++ b/tests/typed_graph.py
@@ -109,6 +109,6 @@ def run_g5() -> None:
     g5.run_sync(A())  # pyright: ignore[reportArgumentType]
     g5.run_sync(A(), state=MyState(x=1))  # pyright: ignore[reportArgumentType]
     g5.run_sync(A(), deps=MyDeps(y='y'))  # pyright: ignore[reportArgumentType]
-    ans, history = g5.run_sync(A(), state=MyState(x=1), deps=MyDeps(y='y'))
-    assert_type(ans, int)
+    answer, history = g5.run_sync(A(), state=MyState(x=1), deps=MyDeps(y='y'))
+    assert_type(answer, int)
     assert_type(history, list[HistoryStep[MyState, int]])


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

TODOs
- [x] verify if pre-commit hooked into CI and remove TEMP commit and potentially workflow too