### PR TITLE
Fix o1 usage with tool calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -197,7 +197,7 @@ class GroqAgentModel(AgentModel):
             model=str(self.model_name),
             messages=groq_messages,
             n=1,
-            parallel_tool_calls=model_settings.get('parallel_tool_calls', True if self.tools else NOT_GIVEN),
+            parallel_tool_calls=model_settings.get('parallel_tool_calls', NOT_GIVEN),
             tools=self.tools or NOT_GIVEN,
             tool_choice=tool_choice or NOT_GIVEN,
             stream=stream,

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -195,7 +195,7 @@ class OpenAIAgentModel(AgentModel):
             model=self.model_name,
             messages=openai_messages,
             n=1,
-            parallel_tool_calls=model_settings.get('parallel_tool_calls', True if self.tools else NOT_GIVEN),
+            parallel_tool_calls=model_settings.get('parallel_tool_calls', NOT_GIVEN),
             tools=self.tools or NOT_GIVEN,
             tool_choice=tool_choice or NOT_GIVEN,
             stream=stream,

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -80,7 +80,7 @@ class ModelSettings(TypedDict, total=False):
     """Whether to allow parallel tool calls.
 
     Supported by:
-    * OpenAI
+    * OpenAI (some models, not o1)
     * Groq
     * Anthropic
     """


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic-ai/issues/761

Default to `NOT_GIVEN` for `parallel_tool_calls` on openai and groq models, like we do for this setting on anthropic.