### PR TITLE
Adding subclasses of `ModelSettings` to support specialized model requests

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -208,7 +208,7 @@ print(result_sync.data)
 
 <!-- TODO: replace this with the gemini safety settings example once added via https://github.com/pydantic/pydantic-ai/issues/373 -->
 
-If you wish to further customize model behavior, you can use a subclass of [`ModelSettings`][pydantic_ai.settings.ModelSettings], like [`AnthropicModelSettings`][models.anthropic.AnthropicModelSettings], associated with your model of choice.
+If you wish to further customize model behavior, you can use a subclass of [`ModelSettings`][pydantic_ai.settings.ModelSettings], like [`AnthropicModelSettings`][pydantic_ai.models.anthropic.AnthropicModelSettings], associated with your model of choice.
 
 For example:
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -204,6 +204,28 @@ print(result_sync.data)
 #> Rome
 ```
 
+### Model specific settings
+
+<!-- TODO: replace this with the gemini safety settings example once added via https://github.com/pydantic/pydantic-ai/issues/373 -->
+
+If you wish to further customize model behavior, you can use a subclass of [`ModelSettings`][pydantic_ai.settings.ModelSettings], like [`AnthropicModelSettings`][models.anthropic.AnthropicModelSettings], associated with your model of choice.
+
+For example:
+
+```py
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModelSettings
+
+agent = Agent('anthropic:claude-3-5-sonnet-latest')
+
+result_sync = agent.run_sync(
+    'What is the capital of Italy?',
+    model_settings=AnthropicModelSettings(anthropic_metadata={'user_id': 'my_user_id'}),
+)
+print(result_sync.data)
+#> Rome
+```
+
 ## Runs vs. Conversations
 
 An agent **run** might represent an entire conversation — there's no limit to how many messages can be exchanged in a single run. However, a **conversation** might also be composed of multiple runs, especially if you need to maintain state between separate interactions or API calls.

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -82,6 +82,8 @@ Since [the Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/model
 class AnthropicModelSettings(ModelSettings):
     """Settings used for an Anthropic model request."""
 
+    # This class is a placeholder for any future anthropic-specific settings
+
 
 @dataclass(init=False)
 class AnthropicModel(Model):

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -26,7 +26,7 @@ from ..messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from ..settings import ModelSettings
+from ..settings import AnthropicModelSettings, ModelSettings
 from ..tools import ToolDefinition
 from . import (
     AgentModel,
@@ -194,7 +194,7 @@ class AnthropicAgentModel(AgentModel):
         self, messages: list[ModelMessage], stream: bool, model_settings: ModelSettings | None
     ) -> AnthropicMessage | AsyncStream[RawMessageStreamEvent]:
         # standalone function to make it easier to override
-        model_settings = model_settings or {}
+        model_settings = cast(AnthropicModelSettings, model_settings or {})
 
         tool_choice: ToolChoiceParam | None
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -41,6 +41,7 @@ try:
     from anthropic.types import (
         Message as AnthropicMessage,
         MessageParam,
+        MetadataParam,
         RawContentBlockDeltaEvent,
         RawContentBlockStartEvent,
         RawContentBlockStopEvent,
@@ -82,7 +83,10 @@ Since [the Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/model
 class AnthropicModelSettings(ModelSettings):
     """Settings used for an Anthropic model request."""
 
-    # This class is a placeholder for any future anthropic-specific settings
+    anthropic_metadata: MetadataParam
+    """An object describing metadata about the request.
+
+    Contains `user_id`, an external identifier for the user who is associated with the request."""
 
 
 @dataclass(init=False)
@@ -226,6 +230,7 @@ class AnthropicAgentModel(AgentModel):
             temperature=model_settings.get('temperature', NOT_GIVEN),
             top_p=model_settings.get('top_p', NOT_GIVEN),
             timeout=model_settings.get('timeout', NOT_GIVEN),
+            metadata=model_settings.get('anthropic_metadata', NOT_GIVEN),
         )
 
     def _process_response(self, response: AnthropicMessage) -> ModelResponse:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -26,7 +26,7 @@ from ..messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from ..settings import AnthropicModelSettings, ModelSettings
+from ..settings import ModelSettings
 from ..tools import ToolDefinition
 from . import (
     AgentModel,
@@ -77,6 +77,10 @@ Since Anthropic supports a variety of date-stamped models, we explicitly list th
 allow any name in the type hints.
 Since [the Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models) for a full list.
 """
+
+
+class AnthropicModelSettings(ModelSettings):
+    """Settings used for an Anthropic model request."""
 
 
 @dataclass(init=False)
@@ -167,35 +171,33 @@ class AnthropicAgentModel(AgentModel):
     async def request(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
     ) -> tuple[ModelResponse, usage.Usage]:
-        response = await self._messages_create(messages, False, model_settings)
+        response = await self._messages_create(messages, False, cast(AnthropicModelSettings, model_settings or {}))
         return self._process_response(response), _map_usage(response)
 
     @asynccontextmanager
     async def request_stream(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
     ) -> AsyncIterator[StreamedResponse]:
-        response = await self._messages_create(messages, True, model_settings)
+        response = await self._messages_create(messages, True, cast(AnthropicModelSettings, model_settings or {}))
         async with response:
             yield await self._process_streamed_response(response)
 
     @overload
     async def _messages_create(
-        self, messages: list[ModelMessage], stream: Literal[True], model_settings: ModelSettings | None
+        self, messages: list[ModelMessage], stream: Literal[True], model_settings: AnthropicModelSettings
     ) -> AsyncStream[RawMessageStreamEvent]:
         pass
 
     @overload
     async def _messages_create(
-        self, messages: list[ModelMessage], stream: Literal[False], model_settings: ModelSettings | None
+        self, messages: list[ModelMessage], stream: Literal[False], model_settings: AnthropicModelSettings
     ) -> AnthropicMessage:
         pass
 
     async def _messages_create(
-        self, messages: list[ModelMessage], stream: bool, model_settings: ModelSettings | None
+        self, messages: list[ModelMessage], stream: bool, model_settings: AnthropicModelSettings
     ) -> AnthropicMessage | AsyncStream[RawMessageStreamEvent]:
         # standalone function to make it easier to override
-        model_settings = cast(AnthropicModelSettings, model_settings or {})
-
         tool_choice: ToolChoiceParam | None
 
         if not self.tools:

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -22,7 +22,7 @@ from ..messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from ..settings import CohereModelSettings, ModelSettings
+from ..settings import ModelSettings
 from ..tools import ToolDefinition
 from . import (
     AgentModel,
@@ -69,6 +69,10 @@ CohereModelName: TypeAlias = Union[
         'command-r7b-12-2024',
     ],
 ]
+
+
+class CohereModelSettings(ModelSettings):
+    """Settings used for a Cohere model request."""
 
 
 @dataclass(init=False)
@@ -153,16 +157,15 @@ class CohereAgentModel(AgentModel):
     async def request(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
     ) -> tuple[ModelResponse, result.Usage]:
-        response = await self._chat(messages, model_settings)
+        response = await self._chat(messages, cast(CohereModelSettings, model_settings or {}))
         return self._process_response(response), _map_usage(response)
 
     async def _chat(
         self,
         messages: list[ModelMessage],
-        model_settings: ModelSettings | None,
+        model_settings: CohereModelSettings,
     ) -> ChatResponse:
         cohere_messages = list(chain(*(self._map_message(m) for m in messages)))
-        model_settings = cast(CohereModelSettings, model_settings or {})
         return await self.client.chat(
             model=self.model_name,
             messages=cohere_messages,

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -74,6 +74,8 @@ CohereModelName: TypeAlias = Union[
 class CohereModelSettings(ModelSettings):
     """Settings used for a Cohere model request."""
 
+    # This class is a placeholder for any future cohere-specific settings
+
 
 @dataclass(init=False)
 class CohereModel(Model):
@@ -174,6 +176,8 @@ class CohereAgentModel(AgentModel):
             temperature=model_settings.get('temperature', OMIT),
             p=model_settings.get('top_p', OMIT),
             seed=model_settings.get('seed', OMIT),
+            presence_penalty=model_settings.get('presence_penalty', OMIT),
+            frequency_penalty=model_settings.get('frequency_penalty', OMIT),
         )
 
     def _process_response(self, response: ChatResponse) -> ModelResponse:

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from itertools import chain
-from typing import Literal, TypeAlias, Union
+from typing import Literal, TypeAlias, Union, cast
 
 from cohere import TextAssistantMessageContentItem
 from typing_extensions import assert_never
@@ -22,7 +22,7 @@ from ..messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from ..settings import ModelSettings
+from ..settings import CohereModelSettings, ModelSettings
 from ..tools import ToolDefinition
 from . import (
     AgentModel,
@@ -162,7 +162,7 @@ class CohereAgentModel(AgentModel):
         model_settings: ModelSettings | None,
     ) -> ChatResponse:
         cohere_messages = list(chain(*(self._map_message(m) for m in messages)))
-        model_settings = model_settings or {}
+        model_settings = cast(CohereModelSettings, model_settings or {})
         return await self.client.chat(
             model=self.model_name,
             messages=cohere_messages,
@@ -170,6 +170,7 @@ class CohereAgentModel(AgentModel):
             max_tokens=model_settings.get('max_tokens', OMIT),
             temperature=model_settings.get('temperature', OMIT),
             p=model_settings.get('top_p', OMIT),
+            seed=model_settings.get('seed', OMIT),
         )
 
     def _process_response(self, response: ChatResponse) -> ModelResponse:

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Annotated, Any, Literal, Protocol, Union
+from typing import Annotated, Any, Literal, Protocol, Union, cast
 from uuid import uuid4
 
 import pydantic
@@ -28,7 +28,7 @@ from ..messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from ..settings import ModelSettings
+from ..settings import GeminiModelSettings, ModelSettings
 from ..tools import ToolDefinition
 from . import (
     AgentModel,
@@ -197,6 +197,7 @@ class GeminiAgentModel(AgentModel):
             request_data['tool_config'] = self.tool_config
 
         generation_config: _GeminiGenerationConfig = {}
+        model_settings = cast(GeminiModelSettings, model_settings or {})
         if model_settings:
             if (max_tokens := model_settings.get('max_tokens')) is not None:
                 generation_config['max_output_tokens'] = max_tokens
@@ -222,7 +223,7 @@ class GeminiAgentModel(AgentModel):
             url,
             content=request_json,
             headers=headers,
-            timeout=(model_settings or {}).get('timeout', USE_CLIENT_DEFAULT),
+            timeout=model_settings.get('timeout', USE_CLIENT_DEFAULT),
         ) as r:
             if r.status_code != 200:
                 await r.aread()

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -51,6 +51,8 @@ See [the Gemini API docs](https://ai.google.dev/gemini-api/docs/models/gemini#mo
 class GeminiModelSettings(ModelSettings):
     """Settings used for a Gemini model request."""
 
+    # This class is a placeholder for any future gemini-specific settings
+
 
 @dataclass(init=False)
 class GeminiModel(Model):
@@ -210,6 +212,10 @@ class GeminiAgentModel(AgentModel):
                 generation_config['temperature'] = temperature
             if (top_p := model_settings.get('top_p')) is not None:
                 generation_config['top_p'] = top_p
+            if (presence_penalty := model_settings.get('presence_penalty')) is not None:
+                generation_config['presence_penalty'] = presence_penalty
+            if (frequency_penalty := model_settings.get('frequency_penalty')) is not None:
+                generation_config['frequency_penalty'] = frequency_penalty
         if generation_config:
             request_data['generation_config'] = generation_config
 
@@ -404,6 +410,8 @@ class _GeminiGenerationConfig(TypedDict, total=False):
     max_output_tokens: int
     temperature: float
     top_p: float
+    presence_penalty: float
+    frequency_penalty: float
 
 
 class _GeminiContent(TypedDict):

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -71,6 +71,8 @@ See [the Groq docs](https://console.groq.com/docs/models) for a full list.
 class GroqModelSettings(ModelSettings):
     """Settings used for a Groq model request."""
 
+    # This class is a placeholder for any future groq-specific settings
+
 
 @dataclass(init=False)
 class GroqModel(Model):
@@ -208,6 +210,9 @@ class GroqAgentModel(AgentModel):
             top_p=model_settings.get('top_p', NOT_GIVEN),
             timeout=model_settings.get('timeout', NOT_GIVEN),
             seed=model_settings.get('seed', NOT_GIVEN),
+            presence_penalty=model_settings.get('presence_penalty', NOT_GIVEN),
+            frequency_penalty=model_settings.get('frequency_penalty', NOT_GIVEN),
+            logit_bias=model_settings.get('logit_bias', NOT_GIVEN),
         )
 
     def _process_response(self, response: chat.ChatCompletion) -> ModelResponse:

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from itertools import chain
-from typing import Literal, overload
+from typing import Literal, cast, overload
 
 from httpx import AsyncClient as AsyncHTTPClient
 from typing_extensions import assert_never
@@ -25,7 +25,7 @@ from ..messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from ..settings import ModelSettings
+from ..settings import GroqModelSettings, ModelSettings
 from ..tools import ToolDefinition
 from . import (
     AgentModel,
@@ -191,7 +191,7 @@ class GroqAgentModel(AgentModel):
 
         groq_messages = list(chain(*(self._map_message(m) for m in messages)))
 
-        model_settings = model_settings or {}
+        model_settings = cast(GroqModelSettings, model_settings or {})
 
         return await self.client.chat.completions.create(
             model=str(self.model_name),
@@ -205,6 +205,7 @@ class GroqAgentModel(AgentModel):
             temperature=model_settings.get('temperature', NOT_GIVEN),
             top_p=model_settings.get('top_p', NOT_GIVEN),
             timeout=model_settings.get('timeout', NOT_GIVEN),
+            seed=model_settings.get('seed', NOT_GIVEN),
         )
 
     def _process_response(self, response: chat.ChatCompletion) -> ModelResponse:

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -88,6 +88,8 @@ Since [the Mistral docs](https://docs.mistral.ai/getting-started/models/models_o
 class MistralModelSettings(ModelSettings):
     """Settings used for a Mistral model request."""
 
+    # This class is a placeholder for any future mistral-specific settings
+
 
 @dataclass(init=False)
 class MistralModel(Model):
@@ -216,6 +218,8 @@ class MistralAgentModel(AgentModel):
                 top_p=model_settings.get('top_p', 1),
                 max_tokens=model_settings.get('max_tokens', UNSET),
                 timeout_ms=self._get_timeout_ms(model_settings.get('timeout')),
+                presence_penalty=model_settings.get('presence_penalty'),
+                frequency_penalty=model_settings.get('frequency_penalty'),
             )
 
         elif self.result_tools:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from itertools import chain
-from typing import Literal, Union, overload
+from typing import Literal, Union, cast, overload
 
 from httpx import AsyncClient as AsyncHTTPClient
 from typing_extensions import assert_never
@@ -25,7 +25,7 @@ from ..messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from ..settings import ModelSettings
+from ..settings import ModelSettings, OpenAIModelSettings
 from ..tools import ToolDefinition
 from . import (
     AgentModel,
@@ -189,7 +189,7 @@ class OpenAIAgentModel(AgentModel):
 
         openai_messages = list(chain(*(self._map_message(m) for m in messages)))
 
-        model_settings = model_settings or {}
+        model_settings = cast(OpenAIModelSettings, model_settings or {})
 
         return await self.client.chat.completions.create(
             model=self.model_name,
@@ -204,6 +204,7 @@ class OpenAIAgentModel(AgentModel):
             temperature=model_settings.get('temperature', NOT_GIVEN),
             top_p=model_settings.get('top_p', NOT_GIVEN),
             timeout=model_settings.get('timeout', NOT_GIVEN),
+            seed=model_settings.get('seed', NOT_GIVEN),
         )
 
     def _process_response(self, response: chat.ChatCompletion) -> ModelResponse:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -25,7 +25,7 @@ from ..messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from ..settings import ModelSettings, OpenAIModelSettings
+from ..settings import ModelSettings
 from ..tools import ToolDefinition
 from . import (
     AgentModel,
@@ -52,6 +52,10 @@ allows this model to be used more easily with other model types (ie, Ollama)
 """
 
 OpenAISystemPromptRole = Literal['system', 'developer', 'user']
+
+
+class OpenAIModelSettings(ModelSettings):
+    """Settings used for an OpenAI model request."""
 
 
 @dataclass(init=False)
@@ -153,31 +157,31 @@ class OpenAIAgentModel(AgentModel):
     async def request(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
     ) -> tuple[ModelResponse, usage.Usage]:
-        response = await self._completions_create(messages, False, model_settings)
+        response = await self._completions_create(messages, False, cast(OpenAIModelSettings, model_settings or {}))
         return self._process_response(response), _map_usage(response)
 
     @asynccontextmanager
     async def request_stream(
         self, messages: list[ModelMessage], model_settings: ModelSettings | None
     ) -> AsyncIterator[StreamedResponse]:
-        response = await self._completions_create(messages, True, model_settings)
+        response = await self._completions_create(messages, True, cast(OpenAIModelSettings, model_settings or {}))
         async with response:
             yield await self._process_streamed_response(response)
 
     @overload
     async def _completions_create(
-        self, messages: list[ModelMessage], stream: Literal[True], model_settings: ModelSettings | None
+        self, messages: list[ModelMessage], stream: Literal[True], model_settings: OpenAIModelSettings
     ) -> AsyncStream[ChatCompletionChunk]:
         pass
 
     @overload
     async def _completions_create(
-        self, messages: list[ModelMessage], stream: Literal[False], model_settings: ModelSettings | None
+        self, messages: list[ModelMessage], stream: Literal[False], model_settings: OpenAIModelSettings
     ) -> chat.ChatCompletion:
         pass
 
     async def _completions_create(
-        self, messages: list[ModelMessage], stream: bool, model_settings: ModelSettings | None
+        self, messages: list[ModelMessage], stream: bool, model_settings: OpenAIModelSettings
     ) -> chat.ChatCompletion | AsyncStream[ChatCompletionChunk]:
         # standalone function to make it easier to override
         if not self.tools:
@@ -188,8 +192,6 @@ class OpenAIAgentModel(AgentModel):
             tool_choice = 'auto'
 
         openai_messages = list(chain(*(self._map_message(m) for m in messages)))
-
-        model_settings = cast(OpenAIModelSettings, model_settings or {})
 
         return await self.client.chat.completions.create(
             model=self.model_name,

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -57,6 +57,8 @@ OpenAISystemPromptRole = Literal['system', 'developer', 'user']
 class OpenAIModelSettings(ModelSettings):
     """Settings used for an OpenAI model request."""
 
+    # This class is a placeholder for any future openai-specific settings
+
 
 @dataclass(init=False)
 class OpenAIModel(Model):
@@ -207,6 +209,9 @@ class OpenAIAgentModel(AgentModel):
             top_p=model_settings.get('top_p', NOT_GIVEN),
             timeout=model_settings.get('timeout', NOT_GIVEN),
             seed=model_settings.get('seed', NOT_GIVEN),
+            presence_penalty=model_settings.get('presence_penalty', NOT_GIVEN),
+            frequency_penalty=model_settings.get('frequency_penalty', NOT_GIVEN),
+            logit_bias=model_settings.get('logit_bias', NOT_GIVEN),
         )
 
     def _process_response(self, response: chat.ChatCompletion) -> ModelResponse:

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -85,6 +85,40 @@ class ModelSettings(TypedDict, total=False):
     * Anthropic
     """
 
+    seed: int
+    """The random seed to use for the model, theoretically allowing for deterministic results.
+
+    Supported by:
+    * OpenAI
+    * Groq
+    * Cohere
+    * Mistral
+    """
+
+
+class OpenAIModelSettings(ModelSettings):
+    """Settings used for an OpenAI model request."""
+
+
+class GroqModelSettings(ModelSettings):
+    """Settings used for a Groq model request."""
+
+
+class CohereModelSettings(ModelSettings):
+    """Settings used for a Cohere model request."""
+
+
+class MistralModelSettings(ModelSettings):
+    """Settings used for a Mistral model request."""
+
+
+class GeminiModelSettings(ModelSettings):
+    """Settings used for a Gemini model request."""
+
+
+class AnthropicModelSettings(ModelSettings):
+    """Settings used for an Anthropic model request."""
+
 
 def merge_model_settings(base: ModelSettings | None, overrides: ModelSettings | None) -> ModelSettings | None:
     """Merge two sets of model settings, preferring the overrides.

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -96,30 +96,6 @@ class ModelSettings(TypedDict, total=False):
     """
 
 
-class OpenAIModelSettings(ModelSettings):
-    """Settings used for an OpenAI model request."""
-
-
-class GroqModelSettings(ModelSettings):
-    """Settings used for a Groq model request."""
-
-
-class CohereModelSettings(ModelSettings):
-    """Settings used for a Cohere model request."""
-
-
-class MistralModelSettings(ModelSettings):
-    """Settings used for a Mistral model request."""
-
-
-class GeminiModelSettings(ModelSettings):
-    """Settings used for a Gemini model request."""
-
-
-class AnthropicModelSettings(ModelSettings):
-    """Settings used for an Anthropic model request."""
-
-
 def merge_model_settings(base: ModelSettings | None, overrides: ModelSettings | None) -> ModelSettings | None:
     """Merge two sets of model settings, preferring the overrides.
 

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -95,6 +95,36 @@ class ModelSettings(TypedDict, total=False):
     * Mistral
     """
 
+    presence_penalty: float
+    """Penalize new tokens based on whether they have appeared in the text so far.
+
+    Supported by:
+    * OpenAI
+    * Groq
+    * Cohere
+    * Gemini
+    * Mistral
+    """
+
+    frequency_penalty: float
+    """Penalize new tokens based on their existing frequency in the text so far.
+
+    Supported by:
+    * OpenAI
+    * Groq
+    * Cohere
+    * Gemini
+    * Mistral
+    """
+
+    logit_bias: dict[str, int]
+    """Modify the likelihood of specified tokens appearing in the completion.
+
+    Supported by:
+    * OpenAI
+    * Groq
+    """
+
 
 def merge_model_settings(base: ModelSettings | None, overrides: ModelSettings | None) -> ModelSettings | None:
     """Merge two sets of model settings, preferring the overrides.

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -21,7 +21,6 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from pydantic_ai.models.anthropic import AnthropicModelSettings
 from pydantic_ai.result import Usage
 from pydantic_ai.settings import ModelSettings
 
@@ -48,7 +47,7 @@ with try_import() as imports_successful:
     )
     from anthropic.types.raw_message_delta_event import Delta
 
-    from pydantic_ai.models.anthropic import AnthropicModel
+    from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
 
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='anthropic not installed'),

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -21,6 +21,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai.models.anthropic import AnthropicModelSettings
 from pydantic_ai.result import Usage
 from pydantic_ai.settings import ModelSettings
 
@@ -330,6 +331,17 @@ async def test_parallel_tool_calls(allow_model_requests: None, parallel_tool_cal
     assert get_mock_chat_completion_kwargs(mock_client)[0]['tool_choice']['disable_parallel_tool_use'] == (
         not parallel_tool_calls
     )
+
+
+async def test_anthropic_specific_metadata(allow_model_requests: None) -> None:
+    c = completion_message([TextBlock(text='world', type='text')], AnthropicUsage(input_tokens=5, output_tokens=10))
+    mock_client = MockAnthropic.create_mock(c)
+    m = AnthropicModel('claude-3-5-haiku-latest', anthropic_client=mock_client)
+    agent = Agent(m)
+
+    result = await agent.run('hello', model_settings=AnthropicModelSettings(anthropic_metadata={'user_id': '123'}))
+    assert result.data == 'world'
+    assert get_mock_chat_completion_kwargs(mock_client)[0]['metadata']['user_id'] == '123'
 
 
 async def test_stream_structured(allow_model_requests: None):

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -848,7 +848,7 @@ async def test_model_settings(client_with_handler: ClientWithHandler, env: TestE
         )
 
     gemini_client = client_with_handler(handler)
-    m = GeminiModel('gemini-1.5-flash', http_client=gemini_client)
+    m = GeminiModel('gemini-1.5-flash', http_client=gemini_client, api_key='mock')
     agent = Agent(m)
 
     result = await agent.run(

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -826,3 +826,23 @@ async def test_empty_text_ignored():
             'parts': [{'function_call': {'name': 'final_result', 'args': {'response': [1, 2, 123]}}}],
         }
     )
+
+
+async def test_model_settings(get_gemini_client: GetGeminiClient) -> None:
+    # TODO: confirm that these model settings were passed through correctly
+    response = gemini_response(_content_model_response(ModelResponse(parts=[TextPart('Hello world')])))
+    gemini_client = get_gemini_client(response)
+    m = GeminiModel('gemini-1.5-flash', http_client=gemini_client)
+    agent = Agent(m)
+
+    result = await agent.run(
+        'Hello',
+        model_settings={
+            'max_tokens': 1,
+            'temperature': 0.1,
+            'top_p': 0.2,
+            'presence_penalty': 0.3,
+            'frequency_penalty': 0.4,
+        },
+    )
+    assert result.data == 'Hello world'


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic-ai/issues/272

Also, adding a few other shared settings to `ModelSettings`:
* `seed`
* `presence_penalty`
* `frequency_penalty`
* `logit_bias`

I anticipate adding more relevant settings to model specific settings while addressing issues like https://github.com/pydantic/pydantic-ai/issues/373.

The primary goal of this PR is to get the general structure in place for `ModelSettings` expansion on a model provider basis.