### PR TITLE
update `AgentDeps` refs to `AgentDepsT`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -46,7 +46,7 @@ A function that always takes and returns the same type of data (which is the res
 * may or may not take [`RunContext`][pydantic_ai.tools.RunContext] as a first argument
 * may or may not be async
 
-Usage `ResultValidatorFunc[AgentDeps, T]`.
+Usage `ResultValidatorFunc[AgentDepsT, T]`.
 """
 
 _logfire = logfire_api.Logfire(otel_scope='pydantic-ai')

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -79,13 +79,13 @@ SystemPromptFunc = Union[
 ]
 """A function that may or maybe not take `RunContext` as an argument, and may or may not be async.
 
-Usage `SystemPromptFunc[AgentDeps]`.
+Usage `SystemPromptFunc[AgentDepsT]`.
 """
 
 ToolFuncContext = Callable[Concatenate[RunContext[AgentDepsT], ToolParams], Any]
 """A tool function that takes `RunContext` as the first argument.
 
-Usage `ToolContextFunc[AgentDeps, ToolParams]`.
+Usage `ToolContextFunc[AgentDepsT, ToolParams]`.
 """
 ToolFuncPlain = Callable[ToolParams, Any]
 """A tool function that does not take `RunContext` as the first argument.
@@ -98,7 +98,7 @@ ToolFuncEither = Union[ToolFuncContext[AgentDepsT, ToolParams], ToolFuncPlain[To
 This is just a union of [`ToolFuncContext`][pydantic_ai.tools.ToolFuncContext] and
 [`ToolFuncPlain`][pydantic_ai.tools.ToolFuncPlain].
 
-Usage `ToolFuncEither[AgentDeps, ToolParams]`.
+Usage `ToolFuncEither[AgentDepsT, ToolParams]`.
 """
 ToolPrepareFunc: TypeAlias = 'Callable[[RunContext[AgentDepsT], ToolDefinition], Awaitable[ToolDefinition | None]]'
 """Definition of a function that can prepare a tool definition at call time.
@@ -125,7 +125,7 @@ def hitchhiker(ctx: RunContext[int], answer: str) -> str:
 hitchhiker = Tool(hitchhiker, prepare=only_if_42)
 ```
 
-Usage `ToolPrepareFunc[AgentDeps]`.
+Usage `ToolPrepareFunc[AgentDepsT]`.
 """
 
 DocstringFormat = Literal['google', 'numpy', 'sphinx', 'auto']


### PR DESCRIPTION
I ran into this
```python
from pydantic_ai.result import AgentDeps, RunContext, RunResult
ImportError: cannot import name 'AgentDeps' from 'pydantic_ai.result' (/Users/nate/Library/Caches/uv/archive-v0/BMnoowLlL9n5v38uV6TLu/lib/python3.12/site-packages/pydantic_ai/result.py). Did you mean: 'AgentDepsT'?
```
and noticed things were changed [here](https://github.com/pydantic/pydantic-ai/pull/726) and it appears there were some leftover docstrings
