### PR TITLE
Remove `_utils.Either`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, is_dataclass
 from datetime import datetime, timezone
 from functools import partial
 from types import GenericAlias
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, Union
 
 from pydantic import BaseModel
 from pydantic.json_schema import JsonSchemaValue
@@ -77,61 +77,6 @@ UNSET = Unset()
 
 def is_set(t_or_unset: T | Unset) -> TypeGuard[T]:
     return t_or_unset is not UNSET
-
-
-Left = TypeVar('Left')
-Right = TypeVar('Right')
-
-
-class Either(Generic[Left, Right]):
-    """Two member Union that records which member was set, this is analogous to Rust enums with two variants.
-
-    Usage:
-
-    ```python
-    if left_thing := either.left:
-        use_left(left_thing.value)
-    else:
-        use_right(either.right)
-    ```
-    """
-
-    __slots__ = '_left', '_right'
-
-    @overload
-    def __init__(self, *, left: Left) -> None: ...
-
-    @overload
-    def __init__(self, *, right: Right) -> None: ...
-
-    def __init__(self, left: Left | Unset = UNSET, right: Right | Unset = UNSET) -> None:
-        if left is not UNSET:
-            assert right is UNSET, '`Either` must receive exactly one argument - `left` or `right`'
-            self._left: Option[Left] = Some(cast(Left, left))
-        else:
-            assert right is not UNSET, '`Either` must receive exactly one argument - `left` or `right`'
-            self._left = None
-            self._right = cast(Right, right)
-
-    @property
-    def left(self) -> Option[Left]:
-        return self._left
-
-    @property
-    def right(self) -> Right:
-        return self._right
-
-    def is_left(self) -> bool:
-        return self._left is not None
-
-    def whichever(self) -> Left | Right:
-        return self._left.value if self._left is not None else self.right
-
-    def __repr__(self):
-        if left := self._left:
-            return f'Either(left={left.value!r})'
-        else:
-            return f'Either(right={self.right!r})'
 
 
 @asynccontextmanager

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ import pytest
 from inline_snapshot import snapshot
 
 from pydantic_ai import UserError
-from pydantic_ai._utils import UNSET, Either, PeekableAsyncStream, check_object_json_schema, group_by_temporal
+from pydantic_ai._utils import UNSET, PeekableAsyncStream, check_object_json_schema, group_by_temporal
 
 from .models.mock_async_stream import MockAsyncStream
 
@@ -47,13 +47,6 @@ def test_check_object_json_schema():
     array_schema = {'type': 'array', 'items': {'type': 'string'}}
     with pytest.raises(UserError, match='^Schema must be an object$'):
         check_object_json_schema(array_schema)
-
-
-def test_either():
-    assert repr(Either[int, int](left=123)) == 'Either(left=123)'
-    assert Either(left=123).whichever() == 123
-    assert repr(Either[int, int](right=456)) == 'Either(right=456)'
-    assert Either(right=456).whichever() == 456
 
 
 @pytest.mark.parametrize('peek_first', [True, False])


### PR DESCRIPTION
I found usage of this class difficult to understand in-line due to the fact that you can't readily see the semantic meaning of the left vs. right, and in python we can just use context-specific "marker" classes to hold a tag to differentiate the left vs. right.

Especially since the only use of this was in `TestModel`, it seemed reasonable to remove.

I'll note that the logic in `TestModel` is fairly difficult to follow; I think I have equivalent logic now (and all tests are passing), but I do wonder if we can simplify the implementation of TestModel in some way. But changes to the actual behavior are outside the scope of what I want to achieve with this PR.