### PR TITLE
Remove ArgsDict and ArgsJson

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -463,7 +463,7 @@ with capture_run_messages() as messages:  # (2)!
                 parts=[
                     ToolCallPart(
                         tool_name='calc_volume',
-                        args=ArgsDict(args_dict={'size': 6}),
+                        args={'size': 6},
                         tool_call_id=None,
                         part_kind='tool-call',
                     )
@@ -488,7 +488,7 @@ with capture_run_messages() as messages:  # (2)!
                 parts=[
                     ToolCallPart(
                         tool_name='calc_volume',
-                        args=ArgsDict(args_dict={'size': 6}),
+                        args={'size': 6},
                         tool_call_id=None,
                         part_kind='tool-call',
                     )

--- a/docs/testing-evals.md
+++ b/docs/testing-evals.md
@@ -98,7 +98,6 @@ from dirty_equals import IsNow
 from pydantic_ai import models, capture_run_messages
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.messages import (
-    ArgsDict,
     ModelResponse,
     SystemPromptPart,
     TextPart,
@@ -142,12 +141,10 @@ async def test_forecast():
             parts=[
                 ToolCallPart(
                     tool_name='weather_forecast',
-                    args=ArgsDict(
-                        args_dict={
-                            'location': 'a',
-                            'forecast_date': '2024-01-01',  # (8)!
-                        }
-                    ),
+                    args={
+                        'location': 'a',
+                        'forecast_date': '2024-01-01',  # (8)!
+                    },
                     tool_call_id=None,
                 )
             ],
@@ -223,9 +220,7 @@ def call_weather_forecast(  # (1)!
         m = re.search(r'\d{4}-\d{2}-\d{2}', user_prompt.content)
         assert m is not None
         args = {'location': 'London', 'forecast_date': m.group()}  # (2)!
-        return ModelResponse(
-            parts=[ToolCallPart.from_raw_args('weather_forecast', args)]
-        )
+        return ModelResponse(parts=[ToolCallPart('weather_forecast', args)])
     else:
         # second call, return the forecast
         msg = messages[-1].parts[0]

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -86,10 +86,7 @@ print(dice_result.all_messages())
     ModelResponse(
         parts=[
             ToolCallPart(
-                tool_name='roll_die',
-                args=ArgsDict(args_dict={}),
-                tool_call_id=None,
-                part_kind='tool-call',
+                tool_name='roll_die', args={}, tool_call_id=None, part_kind='tool-call'
             )
         ],
         model_name='function:model_logic',
@@ -112,7 +109,7 @@ print(dice_result.all_messages())
         parts=[
             ToolCallPart(
                 tool_name='get_player_name',
-                args=ArgsDict(args_dict={}),
+                args={},
                 tool_call_id=None,
                 part_kind='tool-call',
             )

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -221,7 +221,7 @@ class ModelResponsePartsManager:
             ModelResponseStreamEvent: A `PartStartEvent` indicating that a new tool call part
             has been added to the manager, or replaced an existing part.
         """
-        new_part = ToolCallPart.from_raw_args(tool_name=tool_name, args=args, tool_call_id=tool_call_id)
+        new_part = ToolCallPart(tool_name=tool_name, args=args, tool_call_id=tool_call_id)
         if vendor_part_id is None:
             # vendor_part_id is None, so we unconditionally append a new ToolCallPart to the end of the list
             new_part_index = len(self._parts)

--- a/pydantic_ai_slim/pydantic_ai/_result.py
+++ b/pydantic_ai_slim/pydantic_ai/_result.py
@@ -201,14 +201,10 @@ class ResultTool(Generic[ResultDataT]):
         """
         try:
             pyd_allow_partial: Literal['off', 'trailing-strings'] = 'trailing-strings' if allow_partial else 'off'
-            if isinstance(tool_call.args, _messages.ArgsJson):
-                result = self.type_adapter.validate_json(
-                    tool_call.args.args_json or '', experimental_allow_partial=pyd_allow_partial
-                )
+            if isinstance(tool_call.args, str):
+                result = self.type_adapter.validate_json(tool_call.args, experimental_allow_partial=pyd_allow_partial)
             else:
-                result = self.type_adapter.validate_python(
-                    tool_call.args.args_dict, experimental_allow_partial=pyd_allow_partial
-                )
+                result = self.type_adapter.validate_python(tool_call.args, experimental_allow_partial=pyd_allow_partial)
         except ValidationError as e:
             if wrap_validation_errors:
                 m = _messages.RetryPromptPart(

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -13,7 +13,6 @@ from typing_extensions import assert_never
 from .. import UnexpectedModelBehavior, _utils, usage
 from .._utils import guard_tool_call_id as _guard_tool_call_id
 from ..messages import (
-    ArgsDict,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -242,7 +241,7 @@ class AnthropicAgentModel(AgentModel):
             else:
                 assert isinstance(item, ToolUseBlock), 'unexpected item type'
                 items.append(
-                    ToolCallPart.from_raw_args(
+                    ToolCallPart(
                         tool_name=item.name,
                         args=cast(dict[str, Any], item.input),
                         tool_call_id=item.id,
@@ -319,7 +318,6 @@ class AnthropicAgentModel(AgentModel):
 
 
 def _map_tool_call(t: ToolCallPart) -> ToolUseBlockParam:
-    assert isinstance(t.args, ArgsDict), f'Expected ArgsDict, got {t.args}'
     return ToolUseBlockParam(
         id=_guard_tool_call_id(t=t, model_source='Anthropic'),
         type='tool_use',

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -191,7 +191,7 @@ class CohereAgentModel(AgentModel):
         for c in response.message.tool_calls or []:
             if c.function and c.function.name and c.function.arguments:
                 parts.append(
-                    ToolCallPart.from_raw_args(
+                    ToolCallPart(
                         tool_name=c.function.name,
                         args=c.function.arguments,
                         tool_call_id=c.id,

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -453,7 +453,7 @@ def _process_response_from_parts(
             items.append(TextPart(content=part['text']))
         elif 'function_call' in part:
             items.append(
-                ToolCallPart.from_raw_args(
+                ToolCallPart(
                     tool_name=part['function_call']['name'],
                     args=part['function_call']['args'],
                 )

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -224,9 +224,7 @@ class GroqAgentModel(AgentModel):
             items.append(TextPart(content=choice.message.content))
         if choice.message.tool_calls is not None:
             for c in choice.message.tool_calls:
-                items.append(
-                    ToolCallPart.from_raw_args(tool_name=c.function.name, args=c.function.arguments, tool_call_id=c.id)
-                )
+                items.append(ToolCallPart(tool_name=c.function.name, args=c.function.arguments, tool_call_id=c.id))
         return ModelResponse(items, model_name=self.model_name, timestamp=timestamp)
 
     async def _process_streamed_response(self, response: AsyncStream[ChatCompletionChunk]) -> GroqStreamedResponse:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -223,7 +223,7 @@ class OpenAIAgentModel(AgentModel):
             items.append(TextPart(choice.message.content))
         if choice.message.tool_calls is not None:
             for c in choice.message.tool_calls:
-                items.append(ToolCallPart.from_raw_args(c.function.name, c.function.arguments, c.id))
+                items.append(ToolCallPart(c.function.name, c.function.arguments, c.id))
         return ModelResponse(items, model_name=self.model_name, timestamp=timestamp)
 
     async def _process_streamed_response(self, response: AsyncStream[ChatCompletionChunk]) -> OpenAIStreamedResponse:

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -12,7 +12,6 @@ import pydantic_core
 
 from .. import _utils
 from ..messages import (
-    ArgsJson,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -152,7 +151,7 @@ class TestAgentModel(AgentModel):
         # if there are tools, the first thing we want to do is call all of them
         if self.tool_calls and not any(isinstance(m, ModelResponse) for m in messages):
             return ModelResponse(
-                parts=[ToolCallPart.from_raw_args(name, self.gen_tool_args(args)) for name, args in self.tool_calls],
+                parts=[ToolCallPart(name, self.gen_tool_args(args)) for name, args in self.tool_calls],
                 model_name=self.model_name,
             )
 
@@ -166,7 +165,7 @@ class TestAgentModel(AgentModel):
                 # Handle retries for both function tools and result tools
                 # Check function tools first
                 retry_parts: list[ModelResponsePart] = [
-                    ToolCallPart.from_raw_args(name, self.gen_tool_args(args))
+                    ToolCallPart(name, self.gen_tool_args(args))
                     for name, args in self.tool_calls
                     if name in new_retry_names
                 ]
@@ -174,7 +173,7 @@ class TestAgentModel(AgentModel):
                 if self.result_tools:
                     retry_parts.extend(
                         [
-                            ToolCallPart.from_raw_args(
+                            ToolCallPart(
                                 tool.name,
                                 self.result.right if self.result.right is not None else self.gen_tool_args(tool),
                             )
@@ -207,13 +206,11 @@ class TestAgentModel(AgentModel):
             result_tool = self.result_tools[self.seed % len(self.result_tools)]
             if custom_result_args is not None:
                 return ModelResponse(
-                    parts=[ToolCallPart.from_raw_args(result_tool.name, custom_result_args)], model_name=self.model_name
+                    parts=[ToolCallPart(result_tool.name, custom_result_args)], model_name=self.model_name
                 )
             else:
                 response_args = self.gen_tool_args(result_tool)
-                return ModelResponse(
-                    parts=[ToolCallPart.from_raw_args(result_tool.name, response_args)], model_name=self.model_name
-                )
+                return ModelResponse(parts=[ToolCallPart(result_tool.name, response_args)], model_name=self.model_name)
 
 
 @dataclass
@@ -244,9 +241,8 @@ class TestStreamedResponse(StreamedResponse):
                     self._usage += _get_string_usage(word)
                     yield self._parts_manager.handle_text_delta(vendor_part_id=i, content=word)
             else:
-                args = part.args.args_json if isinstance(part.args, ArgsJson) else part.args.args_dict
                 yield self._parts_manager.handle_tool_call_part(
-                    vendor_part_id=i, tool_name=part.tool_name, args=args, tool_call_id=part.tool_call_id
+                    vendor_part_id=i, tool_name=part.tool_name, args=part.args, tool_call_id=part.tool_call_id
                 )
 
     def timestamp(self) -> datetime:

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -264,10 +264,10 @@ class Tool(Generic[AgentDepsT]):
     ) -> _messages.ModelRequestPart:
         """Run the tool function asynchronously."""
         try:
-            if isinstance(message.args, _messages.ArgsJson):
-                args_dict = self._validator.validate_json(message.args.args_json)
+            if isinstance(message.args, str):
+                args_dict = self._validator.validate_json(message.args)
             else:
-                args_dict = self._validator.validate_python(message.args.args_dict)
+                args_dict = self._validator.validate_python(message.args)
         except ValidationError as e:
             return self._on_error(e, message)
 

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -11,7 +11,6 @@ from inline_snapshot import snapshot
 
 from pydantic_ai import Agent, ModelRetry
 from pydantic_ai.messages import (
-    ArgsDict,
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
@@ -186,7 +185,7 @@ async def test_request_structured_response(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsDict(args_dict={'response': [1, 2, 3]}),
+                        args={'response': [1, 2, 3]},
                         tool_call_id='123',
                     )
                 ],
@@ -248,7 +247,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsDict(args_dict={'loc_name': 'San Francisco'}),
+                        args={'loc_name': 'San Francisco'},
                         tool_call_id='1',
                     )
                 ],
@@ -269,7 +268,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsDict(args_dict={'loc_name': 'London'}),
+                        args={'loc_name': 'London'},
                         tool_call_id='2',
                     )
                 ],

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -169,7 +169,7 @@ async def test_request_structured_response(allow_model_requests: None):
             ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
                 parts=[
-                    ToolCallPart.from_raw_args(
+                    ToolCallPart(
                         tool_name='final_result',
                         args='{"response": [1, 2, 123]}',
                         tool_call_id='123',
@@ -255,7 +255,7 @@ async def test_request_tool_call(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[
-                    ToolCallPart.from_raw_args(
+                    ToolCallPart(
                         tool_name='get_location',
                         args='{"loc_name": "San Fransisco"}',
                         tool_call_id='1',
@@ -276,7 +276,7 @@ async def test_request_tool_call(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[
-                    ToolCallPart.from_raw_args(
+                    ToolCallPart(
                         tool_name='get_location',
                         args='{"loc_name": "London"}',
                         tool_call_id='2',

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -15,7 +15,6 @@ from typing_extensions import Literal, TypeAlias
 
 from pydantic_ai import Agent, ModelRetry, UnexpectedModelBehavior, UserError
 from pydantic_ai.messages import (
-    ArgsDict,
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
@@ -474,9 +473,7 @@ async def test_text_success(get_gemini_client: GetGeminiClient):
 
 async def test_request_structured_response(get_gemini_client: GetGeminiClient):
     response = gemini_response(
-        _content_model_response(
-            ModelResponse(parts=[ToolCallPart.from_raw_args('final_result', {'response': [1, 2, 123]})])
-        )
+        _content_model_response(ModelResponse(parts=[ToolCallPart('final_result', {'response': [1, 2, 123]})]))
     )
     gemini_client = get_gemini_client(response)
     m = GeminiModel('gemini-1.5-flash', http_client=gemini_client)
@@ -491,7 +488,7 @@ async def test_request_structured_response(get_gemini_client: GetGeminiClient):
                 parts=[
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsDict(args_dict={'response': [1, 2, 123]}),
+                        args={'response': [1, 2, 123]},
                     )
                 ],
                 model_name='gemini-1.5-flash',
@@ -511,16 +508,14 @@ async def test_request_structured_response(get_gemini_client: GetGeminiClient):
 async def test_request_tool_call(get_gemini_client: GetGeminiClient):
     responses = [
         gemini_response(
-            _content_model_response(
-                ModelResponse(parts=[ToolCallPart.from_raw_args('get_location', {'loc_name': 'San Fransisco'})])
-            )
+            _content_model_response(ModelResponse(parts=[ToolCallPart('get_location', {'loc_name': 'San Fransisco'})]))
         ),
         gemini_response(
             _content_model_response(
                 ModelResponse(
                     parts=[
-                        ToolCallPart.from_raw_args('get_location', {'loc_name': 'London'}),
-                        ToolCallPart.from_raw_args('get_location', {'loc_name': 'New York'}),
+                        ToolCallPart('get_location', {'loc_name': 'London'}),
+                        ToolCallPart('get_location', {'loc_name': 'New York'}),
                     ]
                 )
             )
@@ -554,7 +549,7 @@ async def test_request_tool_call(get_gemini_client: GetGeminiClient):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsDict(args_dict={'loc_name': 'San Fransisco'}),
+                        args={'loc_name': 'San Fransisco'},
                     )
                 ],
                 model_name='gemini-1.5-flash',
@@ -573,11 +568,11 @@ async def test_request_tool_call(get_gemini_client: GetGeminiClient):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsDict(args_dict={'loc_name': 'London'}),
+                        args={'loc_name': 'London'},
                     ),
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsDict(args_dict={'loc_name': 'New York'}),
+                        args={'loc_name': 'New York'},
                     ),
                 ],
                 model_name='gemini-1.5-flash',
@@ -664,9 +659,7 @@ async def test_stream_text_no_data(get_gemini_client: GetGeminiClient):
 async def test_stream_structured(get_gemini_client: GetGeminiClient):
     responses = [
         gemini_response(
-            _content_model_response(
-                ModelResponse(parts=[ToolCallPart.from_raw_args('final_result', {'response': [1, 2]})])
-            ),
+            _content_model_response(ModelResponse(parts=[ToolCallPart('final_result', {'response': [1, 2]})])),
         ),
     ]
     json_data = _gemini_streamed_response_ta.dump_json(responses, by_alias=True)
@@ -684,10 +677,10 @@ async def test_stream_structured(get_gemini_client: GetGeminiClient):
 async def test_stream_structured_tool_calls(get_gemini_client: GetGeminiClient):
     first_responses = [
         gemini_response(
-            _content_model_response(ModelResponse(parts=[ToolCallPart.from_raw_args('foo', {'x': 'a'})])),
+            _content_model_response(ModelResponse(parts=[ToolCallPart('foo', {'x': 'a'})])),
         ),
         gemini_response(
-            _content_model_response(ModelResponse(parts=[ToolCallPart.from_raw_args('bar', {'y': 'b'})])),
+            _content_model_response(ModelResponse(parts=[ToolCallPart('bar', {'y': 'b'})])),
         ),
     ]
     d1 = _gemini_streamed_response_ta.dump_json(first_responses, by_alias=True)
@@ -695,9 +688,7 @@ async def test_stream_structured_tool_calls(get_gemini_client: GetGeminiClient):
 
     second_responses = [
         gemini_response(
-            _content_model_response(
-                ModelResponse(parts=[ToolCallPart.from_raw_args('final_result', {'response': [1, 2]})])
-            ),
+            _content_model_response(ModelResponse(parts=[ToolCallPart('final_result', {'response': [1, 2]})])),
         ),
     ]
     d2 = _gemini_streamed_response_ta.dump_json(second_responses, by_alias=True)
@@ -727,8 +718,8 @@ async def test_stream_structured_tool_calls(get_gemini_client: GetGeminiClient):
             ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
                 parts=[
-                    ToolCallPart(tool_name='foo', args=ArgsDict(args_dict={'x': 'a'})),
-                    ToolCallPart(tool_name='bar', args=ArgsDict(args_dict={'y': 'b'})),
+                    ToolCallPart(tool_name='foo', args={'x': 'a'}),
+                    ToolCallPart(tool_name='bar', args={'y': 'b'}),
                 ],
                 model_name='gemini-1.5-flash',
                 timestamp=IsNow(tz=timezone.utc),
@@ -743,7 +734,7 @@ async def test_stream_structured_tool_calls(get_gemini_client: GetGeminiClient):
                 parts=[
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsDict(args_dict={'response': [1, 2]}),
+                        args={'response': [1, 2]},
                     )
                 ],
                 model_name='gemini-1.5-flash',
@@ -772,7 +763,7 @@ async def test_stream_text_heterogeneous(get_gemini_client: GetGeminiClient):
                     _function_call_part_from_call(
                         ToolCallPart(
                             tool_name='get_location',
-                            args=ArgsDict(args_dict={'loc_name': 'San Fransisco'}),
+                            args={'loc_name': 'San Fransisco'},
                         )
                     ),
                 ],
@@ -795,7 +786,7 @@ async def test_empty_text_ignored():
     content = _content_model_response(
         ModelResponse(
             parts=[
-                ToolCallPart.from_raw_args('final_result', {'response': [1, 2, 123]}),
+                ToolCallPart('final_result', {'response': [1, 2, 123]}),
                 TextPart(content='xxx'),
             ]
         )
@@ -814,7 +805,7 @@ async def test_empty_text_ignored():
     content = _content_model_response(
         ModelResponse(
             parts=[
-                ToolCallPart.from_raw_args('final_result', {'response': [1, 2, 123]}),
+                ToolCallPart('final_result', {'response': [1, 2, 123]}),
                 TextPart(content=''),
             ]
         )

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -13,7 +13,6 @@ from typing_extensions import TypedDict
 
 from pydantic_ai import Agent, ModelRetry, UnexpectedModelBehavior
 from pydantic_ai.messages import (
-    ArgsJson,
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
@@ -183,7 +182,7 @@ async def test_request_structured_response(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsJson(args_json='{"response": [1, 2, 123]}'),
+                        args='{"response": [1, 2, 123]}',
                         tool_call_id='123',
                     )
                 ],
@@ -269,7 +268,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsJson(args_json='{"loc_name": "San Fransisco"}'),
+                        args='{"loc_name": "San Fransisco"}',
                         tool_call_id='1',
                     )
                 ],
@@ -290,7 +289,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsJson(args_json='{"loc_name": "London"}'),
+                        args='{"loc_name": "London"}',
                         tool_call_id='2',
                     )
                 ],
@@ -422,7 +421,7 @@ async def test_stream_structured(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsJson(args_json='{"first": "One", "second": "Two"}'),
+                        args='{"first": "One", "second": "Two"}',
                     )
                 ],
                 model_name='llama-3.1-70b-versatile',

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -14,8 +14,6 @@ from typing_extensions import TypedDict
 from pydantic_ai.agent import Agent
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import (
-    ArgsDict,
-    ArgsJson,
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
@@ -395,7 +393,7 @@ async def test_request_model_structured_with_arguments_dict_response(allow_model
                 parts=[
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsDict(args_dict={'city': 'paris', 'country': 'france'}),
+                        args={'city': 'paris', 'country': 'france'},
                         tool_call_id='123',
                     )
                 ],
@@ -457,7 +455,7 @@ async def test_request_model_structured_with_arguments_str_response(allow_model_
                 parts=[
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsJson(args_json='{"city": "paris", "country": "france"}'),
+                        args='{"city": "paris", "country": "france"}',
                         tool_call_id='123',
                     )
                 ],
@@ -518,7 +516,7 @@ async def test_request_result_type_with_arguments_str_response(allow_model_reque
                 parts=[
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsJson(args_json='{"response": 42}'),
+                        args='{"response": 42}',
                         tool_call_id='123',
                     )
                 ],
@@ -1103,7 +1101,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsJson(args_json='{"loc_name": "San Fransisco"}'),
+                        args='{"loc_name": "San Fransisco"}',
                         tool_call_id='1',
                     )
                 ],
@@ -1124,7 +1122,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsJson(args_json='{"loc_name": "London"}'),
+                        args='{"loc_name": "London"}',
                         tool_call_id='2',
                     )
                 ],
@@ -1243,7 +1241,7 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsJson(args_json='{"loc_name": "San Fransisco"}'),
+                        args='{"loc_name": "San Fransisco"}',
                         tool_call_id='1',
                     )
                 ],
@@ -1264,7 +1262,7 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsJson(args_json='{"loc_name": "London"}'),
+                        args='{"loc_name": "London"}',
                         tool_call_id='2',
                     )
                 ],
@@ -1285,7 +1283,7 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsJson(args_json='{"lat": 51, "lng": 0}'),
+                        args='{"lat": 51, "lng": 0}',
                         tool_call_id='1',
                     )
                 ],
@@ -1386,7 +1384,7 @@ async def test_stream_tool_call_with_return_type(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsJson(args_json='{"loc_name": "San Fransisco"}'),
+                        args='{"loc_name": "San Fransisco"}',
                         tool_call_id='1',
                     )
                 ],
@@ -1404,9 +1402,7 @@ async def test_stream_tool_call_with_return_type(allow_model_requests: None):
                 ]
             ),
             ModelResponse(
-                parts=[
-                    ToolCallPart(tool_name='final_result', args=ArgsJson(args_json='{"won": true}'), tool_call_id='1')
-                ],
+                parts=[ToolCallPart(tool_name='final_result', args='{"won": true}', tool_call_id='1')],
                 model_name='mistral-large-latest',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
             ),
@@ -1491,7 +1487,7 @@ async def test_stream_tool_call(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsJson(args_json='{"loc_name": "San Fransisco"}'),
+                        args='{"loc_name": "San Fransisco"}',
                         tool_call_id='1',
                     )
                 ],
@@ -1597,7 +1593,7 @@ async def test_stream_tool_call_with_retry(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsJson(args_json='{"loc_name": "San Fransisco"}'),
+                        args='{"loc_name": "San Fransisco"}',
                         tool_call_id='1',
                     )
                 ],
@@ -1618,7 +1614,7 @@ async def test_stream_tool_call_with_retry(allow_model_requests: None):
                 parts=[
                     ToolCallPart(
                         tool_name='get_location',
-                        args=ArgsJson(args_json='{"loc_name": "London"}'),
+                        args='{"loc_name": "London"}',
                         tool_call_id='2',
                     )
                 ],

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -100,7 +100,7 @@ async def weather_model(messages: list[ModelMessage], info: AgentInfo) -> ModelR
     if isinstance(last, UserPromptPart):
         return ModelResponse(
             parts=[
-                ToolCallPart.from_raw_args(
+                ToolCallPart(
                     'get_location',
                     json.dumps({'location_description': last.content}),
                 )
@@ -108,7 +108,7 @@ async def weather_model(messages: list[ModelMessage], info: AgentInfo) -> ModelR
         )
     elif isinstance(last, ToolReturnPart):
         if last.tool_name == 'get_location':
-            return ModelResponse(parts=[ToolCallPart.from_raw_args('get_weather', last.model_response_str())])
+            return ModelResponse(parts=[ToolCallPart('get_weather', last.model_response_str())])
         elif last.tool_name == 'get_weather':
             location_name: str | None = None
             for m in messages:
@@ -150,7 +150,7 @@ def test_weather():
         [
             ModelRequest(parts=[UserPromptPart(content='London', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
-                parts=[ToolCallPart.from_raw_args('get_location', '{"location_description": "London"}')],
+                parts=[ToolCallPart('get_location', '{"location_description": "London"}')],
                 model_name='function:weather_model',
                 timestamp=IsNow(tz=timezone.utc),
             ),
@@ -163,7 +163,7 @@ def test_weather():
             ),
             ModelResponse(
                 parts=[
-                    ToolCallPart.from_raw_args(
+                    ToolCallPart(
                         'get_weather',
                         '{"lat": 51, "lng": 0}',
                     )
@@ -193,7 +193,7 @@ async def call_function_model(messages: list[ModelMessage], _: AgentInfo) -> Mod
             details = json.loads(last.content)
             return ModelResponse(
                 parts=[
-                    ToolCallPart.from_raw_args(
+                    ToolCallPart(
                         details['function'],
                         json.dumps(details['arguments']),
                     )
@@ -234,7 +234,7 @@ async def call_tool(messages: list[ModelMessage], info: AgentInfo) -> ModelRespo
     if len(messages) == 1:
         assert len(info.function_tools) == 1
         tool_name = info.function_tools[0].name
-        return ModelResponse(parts=[ToolCallPart.from_raw_args(tool_name, '{}')])
+        return ModelResponse(parts=[ToolCallPart(tool_name, '{}')])
     else:
         return ModelResponse(parts=[TextPart('final response')])
 
@@ -343,11 +343,11 @@ def test_call_all():
             ),
             ModelResponse(
                 parts=[
-                    ToolCallPart.from_raw_args('foo', {'x': 0}),
-                    ToolCallPart.from_raw_args('bar', {'x': 0}),
-                    ToolCallPart.from_raw_args('baz', {'x': 0}),
-                    ToolCallPart.from_raw_args('qux', {'x': 0}),
-                    ToolCallPart.from_raw_args('quz', {'x': 'a'}),
+                    ToolCallPart('foo', {'x': 0}),
+                    ToolCallPart('bar', {'x': 0}),
+                    ToolCallPart('baz', {'x': 0}),
+                    ToolCallPart('qux', {'x': 0}),
+                    ToolCallPart('quz', {'x': 'a'}),
                 ],
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
@@ -399,7 +399,7 @@ def test_retry_result_type():
         nonlocal call_count
         call_count += 1
 
-        return ModelResponse(parts=[ToolCallPart.from_raw_args('final_result', {'x': call_count})])
+        return ModelResponse(parts=[ToolCallPart('final_result', {'x': call_count})])
 
     class Foo(BaseModel):
         x: int

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -96,7 +96,7 @@ def test_tool_retry():
         [
             ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
-                parts=[ToolCallPart.from_raw_args('my_ret', {'x': 0})],
+                parts=[ToolCallPart('my_ret', {'x': 0})],
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
             ),
@@ -106,7 +106,7 @@ def test_tool_retry():
                 ]
             ),
             ModelResponse(
-                parts=[ToolCallPart.from_raw_args('my_ret', {'x': 0})],
+                parts=[ToolCallPart('my_ret', {'x': 0})],
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
             ),

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -213,7 +213,7 @@ async def test_request_structured_response(allow_model_requests: None):
             ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
                 parts=[
-                    ToolCallPart.from_raw_args(
+                    ToolCallPart(
                         tool_name='final_result',
                         args='{"response": [1, 2, 123]}',
                         tool_call_id='123',
@@ -301,7 +301,7 @@ async def test_request_tool_call(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[
-                    ToolCallPart.from_raw_args(
+                    ToolCallPart(
                         tool_name='get_location',
                         args='{"loc_name": "San Fransisco"}',
                         tool_call_id='1',
@@ -322,7 +322,7 @@ async def test_request_tool_call(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[
-                    ToolCallPart.from_raw_args(
+                    ToolCallPart(
                         tool_name='get_location',
                         args='{"loc_name": "London"}',
                         tool_call_id='2',

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -18,7 +18,6 @@ from pytest_mock import MockerFixture
 
 from pydantic_ai._utils import group_by_temporal
 from pydantic_ai.messages import (
-    ArgsDict,
     ModelMessage,
     ModelResponse,
     RetryPromptPart,
@@ -187,87 +186,83 @@ text_responses: dict[str, str | ToolCallPart] = {
     'Who was Albert Einstein?': 'Albert Einstein was a German-born theoretical physicist.',
     'What was his most famous equation?': "Albert Einstein's most famous equation is (E = mc^2).",
     'What is the date?': 'Hello Frank, the date today is 2032-01-02.',
-    'Put my money on square eighteen': ToolCallPart(tool_name='roulette_wheel', args=ArgsDict({'square': 18})),
-    'I bet five is the winner': ToolCallPart(tool_name='roulette_wheel', args=ArgsDict({'square': 5})),
-    'My guess is 4': ToolCallPart(tool_name='roll_die', args=ArgsDict({})),
+    'Put my money on square eighteen': ToolCallPart(tool_name='roulette_wheel', args={'square': 18}),
+    'I bet five is the winner': ToolCallPart(tool_name='roulette_wheel', args={'square': 5}),
+    'My guess is 4': ToolCallPart(tool_name='roll_die', args={}),
     'Send a message to John Doe asking for coffee next week': ToolCallPart(
-        tool_name='get_user_by_name', args=ArgsDict({'name': 'John'})
+        tool_name='get_user_by_name', args={'name': 'John'}
     ),
-    'Please get me the volume of a box with size 6.': ToolCallPart(tool_name='calc_volume', args=ArgsDict({'size': 6})),
+    'Please get me the volume of a box with size 6.': ToolCallPart(tool_name='calc_volume', args={'size': 6}),
     'Where does "hello world" come from?': (
         'The first known use of "hello, world" was in a 1974 textbook about the C programming language.'
     ),
-    'What is my balance?': ToolCallPart(tool_name='customer_balance', args=ArgsDict({'include_pending': True})),
+    'What is my balance?': ToolCallPart(tool_name='customer_balance', args={'include_pending': True}),
     'I just lost my card!': ToolCallPart(
         tool_name='final_result',
-        args=ArgsDict(
-            {
-                'support_advice': (
-                    "I'm sorry to hear that, John. "
-                    'We are temporarily blocking your card to prevent unauthorized transactions.'
-                ),
-                'block_card': True,
-                'risk': 8,
-            }
-        ),
+        args={
+            'support_advice': (
+                "I'm sorry to hear that, John. "
+                'We are temporarily blocking your card to prevent unauthorized transactions.'
+            ),
+            'block_card': True,
+            'risk': 8,
+        },
     ),
     'Where were the olympics held in 2012?': ToolCallPart(
         tool_name='final_result',
-        args=ArgsDict({'city': 'London', 'country': 'United Kingdom'}),
+        args={'city': 'London', 'country': 'United Kingdom'},
     ),
     'The box is 10x20x30': 'Please provide the units for the dimensions (e.g., cm, in, m).',
     'The box is 10x20x30 cm': ToolCallPart(
         tool_name='final_result',
-        args=ArgsDict({'width': 10, 'height': 20, 'depth': 30, 'units': 'cm'}),
+        args={'width': 10, 'height': 20, 'depth': 30, 'units': 'cm'},
     ),
     'red square, blue circle, green triangle': ToolCallPart(
         tool_name='final_result_list',
-        args=ArgsDict({'response': ['red', 'blue', 'green']}),
+        args={'response': ['red', 'blue', 'green']},
     ),
     'square size 10, circle size 20, triangle size 30': ToolCallPart(
         tool_name='final_result_list_2',
-        args=ArgsDict({'response': [10, 20, 30]}),
+        args={'response': [10, 20, 30]},
     ),
     'get me uses who were last active yesterday.': ToolCallPart(
         tool_name='final_result_Success',
-        args=ArgsDict({'sql_query': 'SELECT * FROM users WHERE last_active::date = today() - interval 1 day'}),
+        args={'sql_query': 'SELECT * FROM users WHERE last_active::date = today() - interval 1 day'},
     ),
     'My name is Ben, I was born on January 28th 1990, I like the chain the dog and the pyramid.': ToolCallPart(
         tool_name='final_result',
-        args=ArgsDict(
-            {
-                'name': 'Ben',
-                'dob': '1990-01-28',
-                'bio': 'Likes the chain the dog and the pyramid',
-            }
-        ),
+        args={
+            'name': 'Ben',
+            'dob': '1990-01-28',
+            'bio': 'Likes the chain the dog and the pyramid',
+        },
     ),
     'What is the capital of Italy? Answer with just the city.': 'Rome',
     'What is the capital of Italy? Answer with a paragraph.': (
         'The capital of Italy is Rome (Roma, in Italian), which has been a cultural and political center for centuries.'
         'Rome is known for its rich history, stunning architecture, and delicious cuisine.'
     ),
-    'Begin infinite retry loop!': ToolCallPart(tool_name='infinite_retry_tool', args=ArgsDict({})),
+    'Begin infinite retry loop!': ToolCallPart(tool_name='infinite_retry_tool', args={}),
     'Please generate 5 jokes.': ToolCallPart(
         tool_name='final_result',
-        args=ArgsDict({'response': []}),
+        args={'response': []},
     ),
     'SFO to ANC': ToolCallPart(
         tool_name='flight_search',
-        args=ArgsDict({'origin': 'SFO', 'destination': 'ANC'}),
+        args={'origin': 'SFO', 'destination': 'ANC'},
     ),
     'window seat with leg room': ToolCallPart(
         tool_name='final_result_SeatPreference',
-        args=ArgsDict({'row': 1, 'seat': 'A'}),
+        args={'row': 1, 'seat': 'A'},
     ),
     'Ask a simple question with a single correct answer.': 'What is the capital of France?',
     '<examples>\n  <question>What is the capital of France?</question>\n  <answer>Vichy</answer>\n</examples>': ToolCallPart(
         tool_name='final_result',
-        args=ArgsDict({'correct': False, 'comment': 'Vichy is no longer the capital of France.'}),
+        args={'correct': False, 'comment': 'Vichy is no longer the capital of France.'},
     ),
     '<examples>\n  <question>what is 1 + 1?</question>\n  <answer>2</answer>\n</examples>': ToolCallPart(
         tool_name='final_result',
-        args=ArgsDict({'correct': True, 'comment': 'Well done, 1 + 1 = 2'}),
+        args={'correct': True, 'comment': 'Well done, 1 + 1 = 2'},
     ),
 }
 
@@ -276,9 +271,9 @@ async def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelRes
     m = messages[-1].parts[-1]
     if isinstance(m, UserPromptPart):
         if m.content == 'Tell me a joke.' and any(t.name == 'joke_factory' for t in info.function_tools):
-            return ModelResponse(parts=[ToolCallPart(tool_name='joke_factory', args=ArgsDict({'count': 5}))])
+            return ModelResponse(parts=[ToolCallPart(tool_name='joke_factory', args={'count': 5})])
         elif m.content == 'Please generate 5 jokes.' and any(t.name == 'get_jokes' for t in info.function_tools):
-            return ModelResponse(parts=[ToolCallPart(tool_name='get_jokes', args=ArgsDict({'count': 5}))])
+            return ModelResponse(parts=[ToolCallPart(tool_name='get_jokes', args={'count': 5})])
         elif re.fullmatch(r'sql prompt \d+', m.content):
             return ModelResponse(parts=[TextPart('SELECT 1')])
         elif m.content.startswith('Write a welcome email for the user:'):
@@ -286,17 +281,15 @@ async def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelRes
                 parts=[
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsDict(
-                            {
-                                'subject': 'Welcome to our tech blog!',
-                                'body': 'Hello John, Welcome to our tech blog! ...',
-                            }
-                        ),
+                        args={
+                            'subject': 'Welcome to our tech blog!',
+                            'body': 'Hello John, Welcome to our tech blog! ...',
+                        },
                     )
                 ]
             )
         elif m.content.startswith('<examples>\n  <user>'):
-            return ModelResponse(parts=[ToolCallPart(tool_name='final_result_EmailOk', args=ArgsDict({}))])
+            return ModelResponse(parts=[ToolCallPart(tool_name='final_result_EmailOk', args={})])
         elif m.content == 'Ask a simple question with a single correct answer.' and len(messages) > 2:
             return ModelResponse(parts=[TextPart('what is 1 + 1?')])
         elif response := text_responses.get(m.content):
@@ -307,9 +300,9 @@ async def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelRes
 
     elif isinstance(m, ToolReturnPart) and m.tool_name == 'roulette_wheel':
         win = m.content == 'winner'
-        return ModelResponse(parts=[ToolCallPart(tool_name='final_result', args=ArgsDict({'response': win}))])
+        return ModelResponse(parts=[ToolCallPart(tool_name='final_result', args={'response': win})])
     elif isinstance(m, ToolReturnPart) and m.tool_name == 'roll_die':
-        return ModelResponse(parts=[ToolCallPart(tool_name='get_player_name', args=ArgsDict({}))])
+        return ModelResponse(parts=[ToolCallPart(tool_name='get_player_name', args={})])
     elif isinstance(m, ToolReturnPart) and m.tool_name == 'get_player_name':
         return ModelResponse(parts=[TextPart("Congratulations Anne, you guessed correctly! You're a winner!")])
     if (
@@ -317,32 +310,32 @@ async def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelRes
         and isinstance(m.content, str)
         and m.content.startswith("No user found with name 'Joh")
     ):
-        return ModelResponse(parts=[ToolCallPart(tool_name='get_user_by_name', args=ArgsDict({'name': 'John Doe'}))])
+        return ModelResponse(parts=[ToolCallPart(tool_name='get_user_by_name', args={'name': 'John Doe'})])
     elif isinstance(m, RetryPromptPart) and m.tool_name == 'infinite_retry_tool':
-        return ModelResponse(parts=[ToolCallPart(tool_name='infinite_retry_tool', args=ArgsDict({}))])
+        return ModelResponse(parts=[ToolCallPart(tool_name='infinite_retry_tool', args={})])
     elif isinstance(m, ToolReturnPart) and m.tool_name == 'get_user_by_name':
         args: dict[str, Any] = {
             'message': 'Hello John, would you be free for coffee sometime next week? Let me know what works for you!',
             'user_id': 123,
         }
-        return ModelResponse(parts=[ToolCallPart(tool_name='final_result', args=ArgsDict(args))])
+        return ModelResponse(parts=[ToolCallPart(tool_name='final_result', args=args)])
     elif isinstance(m, RetryPromptPart) and m.tool_name == 'calc_volume':
-        return ModelResponse(parts=[ToolCallPart(tool_name='calc_volume', args=ArgsDict({'size': 6}))])
+        return ModelResponse(parts=[ToolCallPart(tool_name='calc_volume', args={'size': 6})])
     elif isinstance(m, ToolReturnPart) and m.tool_name == 'customer_balance':
         args = {
             'support_advice': 'Hello John, your current account balance, including pending transactions, is $123.45.',
             'block_card': False,
             'risk': 1,
         }
-        return ModelResponse(parts=[ToolCallPart(tool_name='final_result', args=ArgsDict(args))])
+        return ModelResponse(parts=[ToolCallPart(tool_name='final_result', args=args)])
     elif isinstance(m, ToolReturnPart) and m.tool_name == 'joke_factory':
         return ModelResponse(parts=[TextPart('Did you hear about the toothpaste scandal? They called it Colgate.')])
     elif isinstance(m, ToolReturnPart) and m.tool_name == 'get_jokes':
         args = {'response': []}
-        return ModelResponse(parts=[ToolCallPart(tool_name='final_result', args=ArgsDict(args))])
+        return ModelResponse(parts=[ToolCallPart(tool_name='final_result', args=args)])
     elif isinstance(m, ToolReturnPart) and m.tool_name == 'flight_search':
         args = {'flight_number': m.content.flight_number}  # type: ignore
-        return ModelResponse(parts=[ToolCallPart(tool_name='final_result_FlightDetails', args=ArgsDict(args))])
+        return ModelResponse(parts=[ToolCallPart(tool_name='final_result_FlightDetails', args=args)])
     else:
         sys.stdout.write(str(debug.format(messages, info)))
         raise RuntimeError(f'Unexpected message: {m}')

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -130,12 +130,7 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary]) -> None:
                     },
                     {
                         'parts': [
-                            {
-                                'tool_name': 'my_ret',
-                                'args': {'args_dict': {'x': 0}},
-                                'tool_call_id': None,
-                                'part_kind': 'tool-call',
-                            }
+                            {'tool_name': 'my_ret', 'args': {'x': 0}, 'tool_call_id': None, 'part_kind': 'tool-call'}
                         ],
                         'model_name': 'test',
                         'timestamp': IsStr(regex=r'\d{4}-\d{2}-.+'),
@@ -209,13 +204,6 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary]) -> None:
                                                 'type': 'object',
                                                 'title': 'ToolCallPart',
                                                 'x-python-datatype': 'dataclass',
-                                                'properties': {
-                                                    'args': {
-                                                        'type': 'object',
-                                                        'title': 'ArgsDict',
-                                                        'x-python-datatype': 'dataclass',
-                                                    }
-                                                },
                                             },
                                         },
                                         'timestamp': {'type': 'string', 'format': 'date-time'},

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -9,8 +9,6 @@ from inline_snapshot import snapshot
 from pydantic_ai import UnexpectedModelBehavior
 from pydantic_ai._parts_manager import ModelResponsePartsManager
 from pydantic_ai.messages import (
-    ArgsDict,
-    ArgsJson,
     PartDeltaEvent,
     PartStartEvent,
     TextPart,
@@ -91,14 +89,12 @@ def test_handle_tool_call_deltas():
     assert event == snapshot(
         PartStartEvent(
             index=0,
-            part=ToolCallPart(
-                tool_name='tool', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call'
-            ),
+            part=ToolCallPart(tool_name='tool', args='{"arg1":', tool_call_id=None, part_kind='tool-call'),
             event_kind='part_start',
         )
     )
     assert manager.get_parts() == snapshot(
-        [ToolCallPart(tool_name='tool', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call')]
+        [ToolCallPart(tool_name='tool', args='{"arg1":', tool_call_id=None, part_kind='tool-call')]
     )
 
     event = manager.handle_tool_call_delta(vendor_part_id='first', tool_name='1', args=None, tool_call_id=None)
@@ -112,7 +108,7 @@ def test_handle_tool_call_deltas():
         )
     )
     assert manager.get_parts() == snapshot(
-        [ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call')]
+        [ToolCallPart(tool_name='tool1', args='{"arg1":', tool_call_id=None, part_kind='tool-call')]
     )
 
     event = manager.handle_tool_call_delta(vendor_part_id='first', tool_name=None, args='"value1"}', tool_call_id=None)
@@ -129,7 +125,7 @@ def test_handle_tool_call_deltas():
         [
             ToolCallPart(
                 tool_name='tool1',
-                args=ArgsJson(args_json='{"arg1":"value1"}'),
+                args='{"arg1":"value1"}',
                 tool_call_id=None,
                 part_kind='tool-call',
             )
@@ -146,7 +142,7 @@ def test_handle_tool_call_deltas_without_vendor_id():
         [
             ToolCallPart(
                 tool_name='tool1',
-                args=ArgsJson(args_json='{"arg1":"value1"}'),
+                args='{"arg1":"value1"}',
                 tool_call_id=None,
                 part_kind='tool-call',
             )
@@ -159,12 +155,8 @@ def test_handle_tool_call_deltas_without_vendor_id():
     manager.handle_tool_call_delta(vendor_part_id=None, tool_name='tool2', args='"value1"}', tool_call_id=None)
     assert manager.get_parts() == snapshot(
         [
-            ToolCallPart(
-                tool_name='tool2', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call'
-            ),
-            ToolCallPart(
-                tool_name='tool2', args=ArgsJson(args_json='"value1"}'), tool_call_id=None, part_kind='tool-call'
-            ),
+            ToolCallPart(tool_name='tool2', args='{"arg1":', tool_call_id=None, part_kind='tool-call'),
+            ToolCallPart(tool_name='tool2', args='"value1"}', tool_call_id=None, part_kind='tool-call'),
         ]
     )
 
@@ -177,9 +169,7 @@ def test_handle_tool_call_part():
     assert event == snapshot(
         PartStartEvent(
             index=0,
-            part=ToolCallPart(
-                tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call'
-            ),
+            part=ToolCallPart(tool_name='tool1', args='{"arg1":', tool_call_id=None, part_kind='tool-call'),
             event_kind='part_start',
         )
     )
@@ -187,17 +177,15 @@ def test_handle_tool_call_part():
     # Add a delta
     manager.handle_tool_call_delta(vendor_part_id='second', tool_name='tool1', args=None, tool_call_id=None)
     assert manager.get_parts() == snapshot(
-        [ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call')]
+        [ToolCallPart(tool_name='tool1', args='{"arg1":', tool_call_id=None, part_kind='tool-call')]
     )
 
     # Override it with handle_tool_call_part
     manager.handle_tool_call_part(vendor_part_id='second', tool_name='tool1', args='{}', tool_call_id=None)
     assert manager.get_parts() == snapshot(
         [
-            ToolCallPart(
-                tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id=None, part_kind='tool-call'
-            ),
-            ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{}'), tool_call_id=None, part_kind='tool-call'),
+            ToolCallPart(tool_name='tool1', args='{"arg1":', tool_call_id=None, part_kind='tool-call'),
+            ToolCallPart(tool_name='tool1', args='{}', tool_call_id=None, part_kind='tool-call'),
         ]
     )
 
@@ -215,11 +203,11 @@ def test_handle_tool_call_part():
         [
             ToolCallPart(
                 tool_name='tool1',
-                args=ArgsJson(args_json='{"arg1":"value1"}'),
+                args='{"arg1":"value1"}',
                 tool_call_id=None,
                 part_kind='tool-call',
             ),
-            ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{}'), tool_call_id=None, part_kind='tool-call'),
+            ToolCallPart(tool_name='tool1', args='{}', tool_call_id=None, part_kind='tool-call'),
         ]
     )
 
@@ -228,9 +216,7 @@ def test_handle_tool_call_part():
     assert event == snapshot(
         PartStartEvent(
             index=2,
-            part=ToolCallPart(
-                tool_name='tool1', args=ArgsJson(args_json='{}'), tool_call_id=None, part_kind='tool-call'
-            ),
+            part=ToolCallPart(tool_name='tool1', args='{}', tool_call_id=None, part_kind='tool-call'),
             event_kind='part_start',
         )
     )
@@ -238,12 +224,12 @@ def test_handle_tool_call_part():
         [
             ToolCallPart(
                 tool_name='tool1',
-                args=ArgsJson(args_json='{"arg1":"value1"}'),
+                args='{"arg1":"value1"}',
                 tool_call_id=None,
                 part_kind='tool-call',
             ),
-            ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{}'), tool_call_id=None, part_kind='tool-call'),
-            ToolCallPart(tool_name='tool1', args=ArgsJson(args_json='{}'), tool_call_id=None, part_kind='tool-call'),
+            ToolCallPart(tool_name='tool1', args='{}', tool_call_id=None, part_kind='tool-call'),
+            ToolCallPart(tool_name='tool1', args='{}', tool_call_id=None, part_kind='tool-call'),
         ]
     )
 
@@ -265,9 +251,7 @@ def test_handle_mixed_deltas_without_text_part_id(text_vendor_part_id: str | Non
     assert event == snapshot(
         PartStartEvent(
             index=1,
-            part=ToolCallPart(
-                tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id='abc', part_kind='tool-call'
-            ),
+            part=ToolCallPart(tool_name='tool1', args='{"arg1":', tool_call_id='abc', part_kind='tool-call'),
             event_kind='part_start',
         )
     )
@@ -284,9 +268,7 @@ def test_handle_mixed_deltas_without_text_part_id(text_vendor_part_id: str | Non
         assert manager.get_parts() == snapshot(
             [
                 TextPart(content='hello ', part_kind='text'),
-                ToolCallPart(
-                    tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id='abc', part_kind='tool-call'
-                ),
+                ToolCallPart(tool_name='tool1', args='{"arg1":', tool_call_id='abc', part_kind='tool-call'),
                 TextPart(content='world', part_kind='text'),
             ]
         )
@@ -299,9 +281,7 @@ def test_handle_mixed_deltas_without_text_part_id(text_vendor_part_id: str | Non
         assert manager.get_parts() == snapshot(
             [
                 TextPart(content='hello world', part_kind='text'),
-                ToolCallPart(
-                    tool_name='tool1', args=ArgsJson(args_json='{"arg1":'), tool_call_id='abc', part_kind='tool-call'
-                ),
+                ToolCallPart(tool_name='tool1', args='{"arg1":', tool_call_id='abc', part_kind='tool-call'),
             ]
         )
 
@@ -331,7 +311,7 @@ def test_tool_call_id_delta():
         [
             ToolCallPart(
                 tool_name='tool1',
-                args=ArgsJson(args_json='{"arg1":'),
+                args='{"arg1":',
                 tool_call_id=None,
                 part_kind='tool-call',
             )
@@ -343,7 +323,7 @@ def test_tool_call_id_delta():
         [
             ToolCallPart(
                 tool_name='tool1',
-                args=ArgsJson(args_json='{"arg1":"value1"}'),
+                args='{"arg1":"value1"}',
                 tool_call_id='id2',
                 part_kind='tool-call',
             )
@@ -364,7 +344,7 @@ def test_tool_call_id_delta_failure(apply_to_delta: bool):
         else [
             ToolCallPart(
                 tool_name='tool1',
-                args=ArgsJson(args_json='{"arg1":'),
+                args='{"arg1":',
                 tool_call_id='id1',
                 part_kind='tool-call',
             )
@@ -381,17 +361,17 @@ def test_tool_call_id_delta_failure(apply_to_delta: bool):
 @pytest.mark.parametrize(
     'args1,args2,result',
     [
-        ('{"arg1":', '"value1"}', ArgsJson(args_json='{"arg1":"value1"}')),
+        ('{"arg1":', '"value1"}', '{"arg1":"value1"}'),
         ('{"a":1}', {}, UnexpectedModelBehavior('Cannot apply dict deltas to non-dict tool arguments ')),
         ({}, '{"b":2}', UnexpectedModelBehavior('Cannot apply JSON deltas to non-JSON tool arguments ')),
-        ({'a': 1}, {'b': 2}, ArgsDict(args_dict={'a': 1, 'b': 2})),
+        ({'a': 1}, {'b': 2}, {'a': 1, 'b': 2}),
     ],
 )
 @pytest.mark.parametrize('apply_to_delta', [False, True])
 def test_apply_tool_delta_variants(
     args1: str | dict[str, Any],
     args2: str | dict[str, Any],
-    result: ArgsJson | ArgsDict | UnexpectedModelBehavior,
+    result: str | dict[str, Any] | UnexpectedModelBehavior,
     apply_to_delta: bool,
 ):
     tool_name = 'tool1'

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -11,8 +11,6 @@ from pydantic import BaseModel
 
 from pydantic_ai import Agent, UnexpectedModelBehavior, UserError, capture_run_messages
 from pydantic_ai.messages import (
-    ArgsDict,
-    ArgsJson,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -48,7 +46,7 @@ async def test_streamed_text_response():
             [
                 ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))]),
                 ModelResponse(
-                    parts=[ToolCallPart(tool_name='ret_a', args=ArgsDict(args_dict={'x': 'a'}))],
+                    parts=[ToolCallPart(tool_name='ret_a', args={'x': 'a'})],
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                 ),
@@ -73,7 +71,7 @@ async def test_streamed_text_response():
             [
                 ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))]),
                 ModelResponse(
-                    parts=[ToolCallPart(tool_name='ret_a', args=ArgsDict(args_dict={'x': 'a'}))],
+                    parts=[ToolCallPart(tool_name='ret_a', args={'x': 'a'})],
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                 ),
@@ -278,7 +276,7 @@ async def test_call_tool():
             [
                 ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
                 ModelResponse(
-                    parts=[ToolCallPart(tool_name='ret_a', args=ArgsJson(args_json='{"x": "hello"}'))],
+                    parts=[ToolCallPart(tool_name='ret_a', args='{"x": "hello"}')],
                     model_name='function:stream_structured_function',
                     timestamp=IsNow(tz=timezone.utc),
                 ),
@@ -292,7 +290,7 @@ async def test_call_tool():
             [
                 ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
                 ModelResponse(
-                    parts=[ToolCallPart(tool_name='ret_a', args=ArgsJson(args_json='{"x": "hello"}'))],
+                    parts=[ToolCallPart(tool_name='ret_a', args='{"x": "hello"}')],
                     model_name='function:stream_structured_function',
                     timestamp=IsNow(tz=timezone.utc),
                 ),
@@ -303,7 +301,7 @@ async def test_call_tool():
                     parts=[
                         ToolCallPart(
                             tool_name='final_result',
-                            args=ArgsJson(args_json='{"response": ["hello world", 2]}'),
+                            args='{"response": ["hello world", 2]}',
                         )
                     ],
                     model_name='function:stream_structured_function',
@@ -352,7 +350,7 @@ async def test_call_tool_wrong_name():
         [
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
-                parts=[ToolCallPart(tool_name='foobar', args=ArgsJson(args_json='{}'))],
+                parts=[ToolCallPart(tool_name='foobar', args='{}')],
                 model_name='function:stream_structured_function',
                 timestamp=IsNow(tz=timezone.utc),
             ),
@@ -412,9 +410,9 @@ async def test_early_strategy_stops_after_first_final_result():
             ModelRequest(parts=[UserPromptPart(content='test early strategy', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
                 parts=[
-                    ToolCallPart(tool_name='final_result', args=ArgsJson(args_json='{"value": "final"}')),
-                    ToolCallPart(tool_name='regular_tool', args=ArgsJson(args_json='{"x": 1}')),
-                    ToolCallPart(tool_name='another_tool', args=ArgsJson(args_json='{"y": 2}')),
+                    ToolCallPart(tool_name='final_result', args='{"value": "final"}'),
+                    ToolCallPart(tool_name='regular_tool', args='{"x": 1}'),
+                    ToolCallPart(tool_name='another_tool', args='{"y": 2}'),
                 ],
                 model_name='function:sf',
                 timestamp=IsNow(tz=timezone.utc),
@@ -465,8 +463,8 @@ async def test_early_strategy_uses_first_final_result():
             ),
             ModelResponse(
                 parts=[
-                    ToolCallPart(tool_name='final_result', args=ArgsJson(args_json='{"value": "first"}')),
-                    ToolCallPart(tool_name='final_result', args=ArgsJson(args_json='{"value": "second"}')),
+                    ToolCallPart(tool_name='final_result', args='{"value": "first"}'),
+                    ToolCallPart(tool_name='final_result', args='{"value": "second"}'),
                 ],
                 model_name='function:sf',
                 timestamp=IsNow(tz=timezone.utc),
@@ -524,11 +522,11 @@ async def test_exhaustive_strategy_executes_all_tools():
             ModelRequest(parts=[UserPromptPart(content='test exhaustive strategy', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
                 parts=[
-                    ToolCallPart(tool_name='final_result', args=ArgsJson(args_json='{"value": "first"}')),
-                    ToolCallPart(tool_name='regular_tool', args=ArgsJson(args_json='{"x": 42}')),
-                    ToolCallPart(tool_name='another_tool', args=ArgsJson(args_json='{"y": 2}')),
-                    ToolCallPart(tool_name='final_result', args=ArgsJson(args_json='{"value": "second"}')),
-                    ToolCallPart(tool_name='unknown_tool', args=ArgsJson(args_json='{"value": "???"}')),
+                    ToolCallPart(tool_name='final_result', args='{"value": "first"}'),
+                    ToolCallPart(tool_name='regular_tool', args='{"x": 42}'),
+                    ToolCallPart(tool_name='another_tool', args='{"y": 2}'),
+                    ToolCallPart(tool_name='final_result', args='{"value": "second"}'),
+                    ToolCallPart(tool_name='unknown_tool', args='{"value": "???"}'),
                 ],
                 model_name='function:sf',
                 timestamp=IsNow(tz=timezone.utc),
@@ -607,25 +605,25 @@ async def test_early_strategy_with_final_result_in_middle():
                 parts=[
                     ToolCallPart(
                         tool_name='regular_tool',
-                        args=ArgsJson(args_json='{"x": 1}'),
+                        args='{"x": 1}',
                         tool_call_id=None,
                         part_kind='tool-call',
                     ),
                     ToolCallPart(
                         tool_name='final_result',
-                        args=ArgsJson(args_json='{"value": "final"}'),
+                        args='{"value": "final"}',
                         tool_call_id=None,
                         part_kind='tool-call',
                     ),
                     ToolCallPart(
                         tool_name='another_tool',
-                        args=ArgsJson(args_json='{"y": 2}'),
+                        args='{"y": 2}',
                         tool_call_id=None,
                         part_kind='tool-call',
                     ),
                     ToolCallPart(
                         tool_name='unknown_tool',
-                        args=ArgsJson(args_json='{"value": "???"}'),
+                        args='{"value": "???"}',
                         tool_call_id=None,
                         part_kind='tool-call',
                     ),
@@ -702,13 +700,13 @@ async def test_early_strategy_does_not_apply_to_tool_calls_without_final_tool():
                 ]
             ),
             ModelResponse(
-                parts=[ToolCallPart(tool_name='regular_tool', args=ArgsDict(args_dict={'x': 0}))],
+                parts=[ToolCallPart(tool_name='regular_tool', args={'x': 0})],
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
             ),
             ModelRequest(parts=[ToolReturnPart(tool_name='regular_tool', content=0, timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
-                parts=[ToolCallPart(tool_name='final_result', args=ArgsDict(args_dict={'value': 'a'}))],
+                parts=[ToolCallPart(tool_name='final_result', args={'value': 'a'})],
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
             ),

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -11,7 +11,6 @@ from pydantic_core import PydanticSerializationError
 
 from pydantic_ai import Agent, RunContext, Tool, UserError
 from pydantic_ai.messages import (
-    ArgsDict,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -505,7 +504,7 @@ def test_dynamic_tool_use_messages():
     async def repeat_call_foobar(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if info.function_tools:
             tool = info.function_tools[0]
-            return ModelResponse(parts=[ToolCallPart.from_raw_args(tool.name, {'x': 42, 'y': 'a'})])
+            return ModelResponse(parts=[ToolCallPart(tool.name, {'x': 42, 'y': 'a'})])
         else:
             return ModelResponse(parts=[TextPart('done')])
 
@@ -649,10 +648,10 @@ def test_call_tool_without_unrequired_parameters(set_event_loop: None):
         if len(messages) == 1:
             return ModelResponse(
                 parts=[
-                    ToolCallPart(tool_name='my_tool', args=ArgsDict({'a': 13})),
-                    ToolCallPart(tool_name='my_tool', args=ArgsDict({'a': 13, 'b': 4})),
-                    ToolCallPart(tool_name='my_tool_plain', args=ArgsDict({'b': 17})),
-                    ToolCallPart(tool_name='my_tool_plain', args=ArgsDict({'a': 4, 'b': 17})),
+                    ToolCallPart(tool_name='my_tool', args={'a': 13}),
+                    ToolCallPart(tool_name='my_tool', args={'a': 13, 'b': 4}),
+                    ToolCallPart(tool_name='my_tool_plain', args={'b': 17}),
+                    ToolCallPart(tool_name='my_tool_plain', args={'a': 4, 'b': 17}),
                 ]
             )
         else:
@@ -678,10 +677,10 @@ def test_call_tool_without_unrequired_parameters(set_event_loop: None):
     tool_returns = [p.content for p in second_request.parts if isinstance(p, ToolReturnPart)]
     assert tool_call_args == snapshot(
         [
-            ArgsDict(args_dict={'a': 13}),
-            ArgsDict(args_dict={'a': 13, 'b': 4}),
-            ArgsDict(args_dict={'b': 17}),
-            ArgsDict(args_dict={'a': 4, 'b': 17}),
+            {'a': 13},
+            {'a': 13, 'b': 4},
+            {'b': 17},
+            {'a': 4, 'b': 17},
         ]
     )
     assert tool_returns == snapshot([15, 17, 51, 68])

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -8,7 +8,6 @@ from inline_snapshot import snapshot
 
 from pydantic_ai import Agent, RunContext, UsageLimitExceeded
 from pydantic_ai.messages import (
-    ArgsDict,
     ModelRequest,
     ModelResponse,
     ToolCallPart,
@@ -84,7 +83,7 @@ async def test_streamed_text_limits() -> None:
             [
                 ModelRequest(parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))]),
                 ModelResponse(
-                    parts=[ToolCallPart(tool_name='ret_a', args=ArgsDict(args_dict={'x': 'a'}))],
+                    parts=[ToolCallPart(tool_name='ret_a', args={'x': 'a'})],
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                 ),


### PR DESCRIPTION
Dropping `ArgsDict` and `ArgsJson` and just relying on `isinstance(args, dict)` and `isinstance(args, str)` instead of checking for the `ArgsDict` and `ArgsJson` types seems to clean things up a lot, and removes the need for the `from_raw_args` method on `ToolCallPart`.

Overall I think this change feels pretty good, _especially(!)_ the impact on the reprs of things containing args.

+269/-382 is nice as well