### PR TITLE
Fix CI by removing references to shutdown groq models

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -352,7 +352,7 @@ You can then use [`GroqModel`][pydantic_ai.models.groq.GroqModel] by name:
 ```python {title="groq_model_by_name.py"}
 from pydantic_ai import Agent
 
-agent = Agent('groq:llama-3.1-70b-versatile')
+agent = Agent('groq:llama-3.3-70b-versatile')
 ...
 ```
 
@@ -362,7 +362,7 @@ Or initialise the model directly with just the model name:
 from pydantic_ai import Agent
 from pydantic_ai.models.groq import GroqModel
 
-model = GroqModel('llama-3.1-70b-versatile')
+model = GroqModel('llama-3.3-70b-versatile')
 agent = Agent(model)
 ...
 ```
@@ -375,7 +375,7 @@ If you don't want to or can't set the environment variable, you can pass it at r
 from pydantic_ai import Agent
 from pydantic_ai.models.groq import GroqModel
 
-model = GroqModel('llama-3.1-70b-versatile', api_key='your-api-key')
+model = GroqModel('llama-3.3-70b-versatile', api_key='your-api-key')
 agent = Agent(model)
 ...
 ```

--- a/examples/pydantic_ai_examples/roulette_wheel.py
+++ b/examples/pydantic_ai_examples/roulette_wheel.py
@@ -21,7 +21,7 @@ class Deps:
 
 # Create the agent with proper typing
 roulette_agent = Agent(
-    'groq:llama-3.1-70b-versatile',
+    'groq:llama-3.3-70b-versatile',
     deps_type=Deps,
     retries=3,
     result_type=bool,

--- a/examples/pydantic_ai_examples/stream_markdown.py
+++ b/examples/pydantic_ai_examples/stream_markdown.py
@@ -27,7 +27,7 @@ agent = Agent()
 models: list[tuple[KnownModelName, str]] = [
     ('google-gla:gemini-1.5-flash', 'GEMINI_API_KEY'),
     ('openai:gpt-4o-mini', 'OPENAI_API_KEY'),
-    ('groq:llama-3.1-70b-versatile', 'GROQ_API_KEY'),
+    ('groq:llama-3.3-70b-versatile', 'GROQ_API_KEY'),
 ]
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -36,7 +36,7 @@ KnownModelName = Literal[
     'openai:o1',
     'openai:gpt-3.5-turbo',
     'groq:llama-3.3-70b-versatile',
-    'groq:llama-3.1-70b-versatile',
+    'groq:llama-3.3-70b-versatile',
     'groq:llama3-groq-70b-8192-tool-use-preview',
     'groq:llama3-groq-8b-8192-tool-use-preview',
     'groq:llama-3.1-70b-specdec',

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -47,10 +47,7 @@ except ImportError as _import_error:
 
 GroqModelName = Literal[
     'llama-3.3-70b-versatile',
-    'llama-3.1-70b-versatile',
-    'llama3-groq-70b-8192-tool-use-preview',
-    'llama3-groq-8b-8192-tool-use-preview',
-    'llama-3.1-70b-specdec',
+    'llama-3.3-70b-specdec',
     'llama-3.1-8b-instant',
     'llama-3.2-1b-preview',
     'llama-3.2-3b-preview',
@@ -60,7 +57,6 @@ GroqModelName = Literal[
     'llama3-8b-8192',
     'mixtral-8x7b-32768',
     'gemma2-9b-it',
-    'gemma-7b-it',
 ]
 """Named Groq models.
 

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -50,9 +50,9 @@ pytestmark = [
 
 
 def test_init():
-    m = GroqModel('llama-3.1-70b-versatile', api_key='foobar')
+    m = GroqModel('llama-3.3-70b-versatile', api_key='foobar')
     assert m.client.api_key == 'foobar'
-    assert m.name() == 'groq:llama-3.1-70b-versatile'
+    assert m.name() == 'groq:llama-3.3-70b-versatile'
 
 
 @dataclass
@@ -102,7 +102,7 @@ def completion_message(message: ChatCompletionMessage, *, usage: CompletionUsage
         id='123',
         choices=[Choice(finish_reason='stop', index=0, message=message)],
         created=1704067200,  # 2024-01-01
-        model='llama-3.1-70b-versatile',
+        model='llama-3.3-70b-versatile',
         object='chat.completion',
         usage=usage,
     )
@@ -111,7 +111,7 @@ def completion_message(message: ChatCompletionMessage, *, usage: CompletionUsage
 async def test_request_simple_success(allow_model_requests: None):
     c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
     mock_client = MockGroq.create_mock(c)
-    m = GroqModel('llama-3.1-70b-versatile', groq_client=mock_client)
+    m = GroqModel('llama-3.3-70b-versatile', groq_client=mock_client)
     agent = Agent(m)
 
     result = await agent.run('hello')
@@ -129,13 +129,13 @@ async def test_request_simple_success(allow_model_requests: None):
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
                 parts=[TextPart(content='world')],
-                model_name='llama-3.1-70b-versatile',
+                model_name='llama-3.3-70b-versatile',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
             ),
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
                 parts=[TextPart(content='world')],
-                model_name='llama-3.1-70b-versatile',
+                model_name='llama-3.3-70b-versatile',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
             ),
         ]
@@ -148,7 +148,7 @@ async def test_request_simple_usage(allow_model_requests: None):
         usage=CompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
     )
     mock_client = MockGroq.create_mock(c)
-    m = GroqModel('llama-3.1-70b-versatile', groq_client=mock_client)
+    m = GroqModel('llama-3.3-70b-versatile', groq_client=mock_client)
     agent = Agent(m)
 
     result = await agent.run('Hello')
@@ -170,7 +170,7 @@ async def test_request_structured_response(allow_model_requests: None):
         )
     )
     mock_client = MockGroq.create_mock(c)
-    m = GroqModel('llama-3.1-70b-versatile', groq_client=mock_client)
+    m = GroqModel('llama-3.3-70b-versatile', groq_client=mock_client)
     agent = Agent(m, result_type=list[int])
 
     result = await agent.run('Hello')
@@ -186,7 +186,7 @@ async def test_request_structured_response(allow_model_requests: None):
                         tool_call_id='123',
                     )
                 ],
-                model_name='llama-3.1-70b-versatile',
+                model_name='llama-3.3-70b-versatile',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
             ),
             ModelRequest(
@@ -244,7 +244,7 @@ async def test_request_tool_call(allow_model_requests: None):
         completion_message(ChatCompletionMessage(content='final response', role='assistant')),
     ]
     mock_client = MockGroq.create_mock(responses)
-    m = GroqModel('llama-3.1-70b-versatile', groq_client=mock_client)
+    m = GroqModel('llama-3.3-70b-versatile', groq_client=mock_client)
     agent = Agent(m, system_prompt='this is the system prompt')
 
     @agent.tool_plain
@@ -272,7 +272,7 @@ async def test_request_tool_call(allow_model_requests: None):
                         tool_call_id='1',
                     )
                 ],
-                model_name='llama-3.1-70b-versatile',
+                model_name='llama-3.3-70b-versatile',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
             ),
             ModelRequest(
@@ -293,7 +293,7 @@ async def test_request_tool_call(allow_model_requests: None):
                         tool_call_id='2',
                     )
                 ],
-                model_name='llama-3.1-70b-versatile',
+                model_name='llama-3.3-70b-versatile',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
             ),
             ModelRequest(
@@ -308,7 +308,7 @@ async def test_request_tool_call(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[TextPart(content='final response')],
-                model_name='llama-3.1-70b-versatile',
+                model_name='llama-3.3-70b-versatile',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
             ),
         ]
@@ -326,7 +326,7 @@ def chunk(delta: list[ChoiceDelta], finish_reason: FinishReason | None = None) -
         ],
         created=1704067200,  # 2024-01-01
         x_groq=None,
-        model='llama-3.1-70b-versatile',
+        model='llama-3.3-70b-versatile',
         object='chat.completion.chunk',
         usage=CompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
     )
@@ -339,7 +339,7 @@ def text_chunk(text: str, finish_reason: FinishReason | None = None) -> chat.Cha
 async def test_stream_text(allow_model_requests: None):
     stream = text_chunk('hello '), text_chunk('world'), chunk([])
     mock_client = MockGroq.create_mock_stream(stream)
-    m = GroqModel('llama-3.1-70b-versatile', groq_client=mock_client)
+    m = GroqModel('llama-3.3-70b-versatile', groq_client=mock_client)
     agent = Agent(m)
 
     async with agent.run_stream('') as result:
@@ -351,7 +351,7 @@ async def test_stream_text(allow_model_requests: None):
 async def test_stream_text_finish_reason(allow_model_requests: None):
     stream = text_chunk('hello '), text_chunk('world'), text_chunk('.', finish_reason='stop')
     mock_client = MockGroq.create_mock_stream(stream)
-    m = GroqModel('llama-3.1-70b-versatile', groq_client=mock_client)
+    m = GroqModel('llama-3.3-70b-versatile', groq_client=mock_client)
     agent = Agent(m)
 
     async with agent.run_stream('') as result:
@@ -398,7 +398,7 @@ async def test_stream_structured(allow_model_requests: None):
         chunk([]),
     )
     mock_client = MockGroq.create_mock_stream(stream)
-    m = GroqModel('llama-3.1-70b-versatile', groq_client=mock_client)
+    m = GroqModel('llama-3.3-70b-versatile', groq_client=mock_client)
     agent = Agent(m, result_type=MyTypedDict)
 
     async with agent.run_stream('') as result:
@@ -424,7 +424,7 @@ async def test_stream_structured(allow_model_requests: None):
                         args='{"first": "One", "second": "Two"}',
                     )
                 ],
-                model_name='llama-3.1-70b-versatile',
+                model_name='llama-3.3-70b-versatile',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
             ),
             ModelRequest(
@@ -449,7 +449,7 @@ async def test_stream_structured_finish_reason(allow_model_requests: None):
         struc_chunk(None, None, finish_reason='stop'),
     )
     mock_client = MockGroq.create_mock_stream(stream)
-    m = GroqModel('llama-3.1-70b-versatile', groq_client=mock_client)
+    m = GroqModel('llama-3.3-70b-versatile', groq_client=mock_client)
     agent = Agent(m, result_type=MyTypedDict)
 
     async with agent.run_stream('') as result:
@@ -469,7 +469,7 @@ async def test_stream_structured_finish_reason(allow_model_requests: None):
 async def test_no_content(allow_model_requests: None):
     stream = chunk([ChoiceDelta()]), chunk([ChoiceDelta()])
     mock_client = MockGroq.create_mock_stream(stream)
-    m = GroqModel('llama-3.1-70b-versatile', groq_client=mock_client)
+    m = GroqModel('llama-3.3-70b-versatile', groq_client=mock_client)
     agent = Agent(m, result_type=MyTypedDict)
 
     with pytest.raises(UnexpectedModelBehavior, match='Received empty model response'):
@@ -480,7 +480,7 @@ async def test_no_content(allow_model_requests: None):
 async def test_no_delta(allow_model_requests: None):
     stream = chunk([]), text_chunk('hello '), text_chunk('world')
     mock_client = MockGroq.create_mock_stream(stream)
-    m = GroqModel('llama-3.1-70b-versatile', groq_client=mock_client)
+    m = GroqModel('llama-3.3-70b-versatile', groq_client=mock_client)
     agent = Agent(m)
 
     async with agent.run_stream('') as result:

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -45,7 +45,7 @@ def vertexai(http_client: httpx.AsyncClient, tmp_path: Path) -> Model:
 def groq(http_client: httpx.AsyncClient, _tmp_path: Path) -> Model:
     from pydantic_ai.models.groq import GroqModel
 
-    return GroqModel('llama-3.1-70b-versatile', http_client=http_client)
+    return GroqModel('llama-3.3-70b-versatile', http_client=http_client)
 
 
 def anthropic(http_client: httpx.AsyncClient, _tmp_path: Path) -> Model:


### PR DESCRIPTION
As noted here https://console.groq.com/docs/deprecations `llama-3.1-70b-versatile` was shut down two days ago, and this appears to be causing our CI to fail.

That page specifically says you should change from `llama-3.1-70b-versatile` to `llama-3.3-70b-versatile` everywhere in the codebase. I also removed references to the other models listed as shut down in the groq docs.

I also noticed that for some models we allow `str` as a fallback on the model name type, but for Gemini and Groq we don't. I'm not sure if that was intentional so I didn't change it in this PR, but I feel like we should be consistent and always allow `str` or never (and presumably always, since I believe we did that to be more future-compatible with OpenAI and Anthropic).