### PR TITLE
feat: support for customizing “tool_choice” in OpenAI

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -186,7 +186,9 @@ class OpenAIAgentModel(AgentModel):
         self, messages: list[ModelMessage], stream: bool, model_settings: OpenAIModelSettings
     ) -> chat.ChatCompletion | AsyncStream[ChatCompletionChunk]:
         # standalone function to make it easier to override
-        if not self.tools:
+        if tool_choice := model_settings.get('tool_choice'):
+            pass
+        elif not self.tools:
             tool_choice: Literal['none', 'required', 'auto'] | None = None
         elif not self.allow_text_result:
             tool_choice = 'required'


### PR DESCRIPTION
1016c92 feat: support for customizing “tool_choice” in OpenAI

commit 1016c92c738b9efc9cb9f1dd2d43ac1f8767cf21
Author: Sébastien Han <seb@redhat.com>
Date:   Mon Jan 27 16:52:45 2025 +0100

    feat: support for customizing “tool_choice” in OpenAI
    
    The ModelSettings class uses a TypedDict as its underlying type, providing
    flexibility to add options beyond the predefined attributes.
    
    Before generating chat completions, the code now checks if tool_choice is set
    in ModelSettings and applies it accordingly.
    
    Fixes: https://github.com/pydantic/pydantic-ai/issues/224
    Signed-off-by: Sébastien Han <seb@redhat.com>

Fixes: https://github.com/pydantic/pydantic-ai/issues/224