### PR TITLE
added documentation to visualize a graph within a jupyter-notebook

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -190,7 +190,8 @@ stateDiagram-v2
   Increment --> DivisibleBy5
 ```
 
-In order to visualize a graph within a `jupyter-notebook`, `IPython.display` needs to be used
+In order to visualize a graph within a `jupyter-notebook`, `IPython.display` needs to be used:
+
 ```python {title="jupyter_display_mermaid.py"  test="skip"}
 from graph_example import DivisibleBy5, fives_graph
 from IPython.display import Image, display

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -190,16 +190,13 @@ stateDiagram-v2
   Increment --> DivisibleBy5
 ```
 
-!!! tips
-    In order to visualize a graph within a `jupyter-notebook`, `IPython.display` needs to be used
-    ```python
-    from IPython.display import Image, display
-    display(
-        Image(
-            fives_graph.mermaid_image(start_node=DivisibleBy5)
-            )
-    )
-    ```
+In order to visualize a graph within a `jupyter-notebook`, `IPython.display` needs to be used
+```python {title="jupyter_display_mermaid.py"  test="skip"}
+from graph_example import DivisibleBy5, fives_graph
+from IPython.display import Image, display
+
+display(Image(fives_graph.mermaid_image(start_node=DivisibleBy5)))
+```
 
 ## Stateful Graphs
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -190,6 +190,17 @@ stateDiagram-v2
   Increment --> DivisibleBy5
 ```
 
+!!! tips
+    In order to visualize a graph within a `jupyter-notebook`, `IPython.display` needs to be used
+    ```python
+    from IPython.display import Image, display
+    display(
+        Image(
+            fives_graph.mermaid_image(start_node=DivisibleBy5)
+            )
+    )
+    ```
+
 ## Stateful Graphs
 
 The "state" concept in `pydantic-graph` provides an optional way to access and mutate an object (often a `dataclass` or Pydantic model) as nodes run in a graph. If you think of Graphs as a production line, then you state is the engine being passed along the line and built up by each node as the graph is run.


### PR DESCRIPTION
Hi,
I would like to make this addition to the documentation.
This is for displaying a graph within a `jupyter-notebook`.

<img width="1471" alt="Screen Shot 2025-01-26 at 9 29 07 AM" src="https://github.com/user-attachments/assets/63ca3147-b25e-496b-a383-3f324346c69a" />

`IPython.display` is a dependency of a jupyter-notebook (I installed it through ipykernel) so the requirements/UV/lock should not be changed (assuming the user is using a notebook, he will have IPython.display)

Fixes https://github.com/pydantic/pydantic-ai/issues/719