### PR TITLE
Disable running gemini tests in test_live.py

### DIFF
--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -68,7 +68,7 @@ def mistral(http_client: httpx.AsyncClient, _tmp_path: Path) -> Model:
 
 params = [
     pytest.param(openai, id='openai'),
-    pytest.param(gemini, id='gemini'),
+    pytest.param(gemini, marks=pytest.mark.skip(reason='API seems very flaky'), id='gemini'),
     pytest.param(vertexai, id='vertexai'),
     pytest.param(groq, id='groq'),
     pytest.param(anthropic, id='anthropic'),


### PR DESCRIPTION
We can try undoing this at some point in the future when we think the API might be more reliable.