### PR TITLE
Add Ability to Specify Gemini Safety Settings

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -226,6 +226,29 @@ print(result_sync.data)
 #> Rome
 ```
 
+For Gemini models, safety settings for requests can be specified via [`GeminiModelSettings`][pydantic_ai.models.gemini.GeminiModelSettings]. For example:
+```py
+from pydantic_ai import Agent
+from pydantic_ai.models.gemini import GeminiModel, GeminiModelSettings
+
+agent = Agent('google-gla:gemini-1.5-flash')
+
+result = agent.run_sync(
+    'Write a list of 5 very rude things that I might say to the universe after stubbing my toe in the dark:',
+    model_settings=GeminiModelSettings(
+        temperature = 0.0, # general model settings can also be specified
+        gemini_safety_settings=[
+            {'category': 'HARM_CATEGORY_HARASSMENT', 'threshold': 'BLOCK_LOW_AND_ABOVE'},
+            {'category': 'HARM_CATEGORY_HATE_SPEECH', 'threshold': 'BLOCK_LOW_AND_ABOVE'}
+        ],
+    ),
+)
+print(result.data)
+#> raises an UnexpectedModelBehavior since safety thresholds exceeded (note: returns a normal response if within thresholds)
+```
+
+Credit for the above prompt goes to Hussain Chinoy and Google.
+
 ## Runs vs. Conversations
 
 An agent **run** might represent an entire conversation — there's no limit to how many messages can be exchanged in a single run. However, a **conversation** might also be composed of multiple runs, especially if you need to maintain state between separate interactions or API calls.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -244,8 +244,6 @@ except UnexpectedModelBehavior as e:
 1. This error is raised because the safety thresholds were exceeded.
 Generally, `result` would contain a normal `ModelResponse`.
 
-Credit for the above prompt goes to Hussain Chinoy and Google.
-
 ## Runs vs. Conversations
 
 An agent **run** might represent an entire conversation — there's no limit to how many messages can be exchanged in a single run. However, a **conversation** might also be composed of multiple runs, especially if you need to maintain state between separate interactions or API calls.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -211,7 +211,7 @@ If you wish to further customize model behavior, you can use a subclass of [`Mod
 For example:
 
 ```py
-from pydantic_ai import Agent
+from pydantic_ai import Agent, UnexpectedModelBehavior
 from pydantic_ai.models.gemini import GeminiModelSettings
 
 agent = Agent('google-gla:gemini-1.5-flash')
@@ -233,12 +233,16 @@ try:
             ],
         ),
     )
-except Exception as e:
-    print(repr(e))
-    #> UnexpectedModelBehavior('Safety settings triggered')
-
-# Note: Result will return a normal response if within safety thresholds. Otherwise, will raise error like above.
+except UnexpectedModelBehavior as e:
+    print(e)  # (1)!
+    """
+    Safety settings triggered, body:
+    <safety settings details>
+    """
 ```
+
+1. This error is raised because the safety thresholds were exceeded.
+Generally, `result` would contain a normal `ModelResponse`.
 
 Credit for the above prompt goes to Hussain Chinoy and Google.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -220,10 +220,16 @@ try:
     result = agent.run_sync(
         'Write a list of 5 very rude things that I might say to the universe after stubbing my toe in the dark:',
         model_settings=GeminiModelSettings(
-            temperature = 0.0, # general model settings can also be specified
+            temperature=0.0,  # general model settings can also be specified
             gemini_safety_settings=[
-                {'category': 'HARM_CATEGORY_HARASSMENT', 'threshold': 'BLOCK_LOW_AND_ABOVE'},
-                {'category': 'HARM_CATEGORY_HATE_SPEECH', 'threshold': 'BLOCK_LOW_AND_ABOVE'}
+                {
+                    'category': 'HARM_CATEGORY_HARASSMENT',
+                    'threshold': 'BLOCK_LOW_AND_ABOVE',
+                },
+                {
+                    'category': 'HARM_CATEGORY_HATE_SPEECH',
+                    'threshold': 'BLOCK_LOW_AND_ABOVE',
+                },
             ],
         ),
     )

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -206,45 +206,32 @@ print(result_sync.data)
 
 ### Model specific settings
 
-<!-- TODO: replace this with the gemini safety settings example once added via https://github.com/pydantic/pydantic-ai/issues/373 -->
-
-If you wish to further customize model behavior, you can use a subclass of [`ModelSettings`][pydantic_ai.settings.ModelSettings], like [`AnthropicModelSettings`][pydantic_ai.models.anthropic.AnthropicModelSettings], associated with your model of choice.
+If you wish to further customize model behavior, you can use a subclass of [`ModelSettings`][pydantic_ai.settings.ModelSettings], like [`GeminiModelSettings`][pydantic_ai.models.gemini.GeminiModelSettings], associated with your model of choice.
 
 For example:
 
 ```py
 from pydantic_ai import Agent
-from pydantic_ai.models.anthropic import AnthropicModelSettings
-
-agent = Agent('anthropic:claude-3-5-sonnet-latest')
-
-result_sync = agent.run_sync(
-    'What is the capital of Italy?',
-    model_settings=AnthropicModelSettings(anthropic_metadata={'user_id': 'my_user_id'}),
-)
-print(result_sync.data)
-#> Rome
-```
-
-For Gemini models, safety settings for requests can be specified via [`GeminiModelSettings`][pydantic_ai.models.gemini.GeminiModelSettings]. For example:
-```py
-from pydantic_ai import Agent
-from pydantic_ai.models.gemini import GeminiModel, GeminiModelSettings
+from pydantic_ai.models.gemini import GeminiModelSettings
 
 agent = Agent('google-gla:gemini-1.5-flash')
 
-result = agent.run_sync(
-    'Write a list of 5 very rude things that I might say to the universe after stubbing my toe in the dark:',
-    model_settings=GeminiModelSettings(
-        temperature = 0.0, # general model settings can also be specified
-        gemini_safety_settings=[
-            {'category': 'HARM_CATEGORY_HARASSMENT', 'threshold': 'BLOCK_LOW_AND_ABOVE'},
-            {'category': 'HARM_CATEGORY_HATE_SPEECH', 'threshold': 'BLOCK_LOW_AND_ABOVE'}
-        ],
-    ),
-)
-print(result.data)
-#> raises an UnexpectedModelBehavior since safety thresholds exceeded (note: returns a normal response if within thresholds)
+try:
+    result = agent.run_sync(
+        'Write a list of 5 very rude things that I might say to the universe after stubbing my toe in the dark:',
+        model_settings=GeminiModelSettings(
+            temperature = 0.0, # general model settings can also be specified
+            gemini_safety_settings=[
+                {'category': 'HARM_CATEGORY_HARASSMENT', 'threshold': 'BLOCK_LOW_AND_ABOVE'},
+                {'category': 'HARM_CATEGORY_HATE_SPEECH', 'threshold': 'BLOCK_LOW_AND_ABOVE'}
+            ],
+        ),
+    )
+except Exception as e:
+    print(repr(e))
+    #> UnexpectedModelBehavior('Safety settings triggered')
+
+# Note: Result will return a normal response if within safety thresholds. Otherwise, will raise error like above.
 ```
 
 Credit for the above prompt goes to Hussain Chinoy and Google.

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -52,7 +52,7 @@ class GeminiModelSettings(ModelSettings):
     """Settings used for a Gemini model request."""
 
     # This class is a placeholder for any future gemini-specific settings
-    gemini_safety_settings: list[GeminiSafetySettings]  # are duplicates a problem?
+    gemini_safety_settings: list[GeminiSafetySettings]
 
 
 @dataclass(init=False)
@@ -610,7 +610,7 @@ class _GeminiCandidates(TypedDict):
     """See <https://ai.google.dev/api/generate-content#v1beta.Candidate>."""
 
     content: _GeminiContent
-    finish_reason: NotRequired[Annotated[Literal['STOP', 'MAX_TOKENS'], pydantic.Field(alias='finishReason')]]
+    finish_reason: NotRequired[Annotated[Literal['STOP', 'MAX_TOKENS', 'SAFETY'], pydantic.Field(alias='finishReason')]]
     """
     See <https://ai.google.dev/api/generate-content#FinishReason>, lots of other values are possible,
     but let's wait until we see them and know what they mean to add them here.
@@ -658,6 +658,7 @@ class _GeminiSafetyRating(TypedDict):
         'HARM_CATEGORY_CIVIC_INTEGRITY',
     ]
     probability: Literal['NEGLIGIBLE', 'LOW', 'MEDIUM', 'HIGH']
+    blocked: NotRequired[bool]
 
 
 class _GeminiPromptFeedback(TypedDict):

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -268,11 +268,7 @@ class GeminiAgentModel(AgentModel):
             )
             if responses:
                 last = responses[-1]
-                if (
-                    last['candidates']
-                    and ('content' in last['candidates'][0])
-                    and last['candidates'][0]['content']['parts']
-                ):
+               if last['candidates'] and last['candidates'][0].get('content', {}).get('parts'):
                     start_response = last
                     break
 

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -268,7 +268,7 @@ class GeminiAgentModel(AgentModel):
             )
             if responses:
                 last = responses[-1]
-               if last['candidates'] and last['candidates'][0].get('content', {}).get('parts'):
+                if last['candidates'] and last['candidates'][0].get('content', {}).get('parts'):
                     start_response = last
                     break
 

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -408,9 +408,10 @@ class _GeminiRequest(TypedDict):
 
 
 class GeminiSafetySettings(TypedDict):
-    """Individual safety settings fields for Gemini.
+    """Safety settings options for Gemini model request.
 
-    See <https://ai.google.dev/gemini-api/docs/safety-settings> for API docs.
+    See [Gemini API docs](https://ai.google.dev/gemini-api/docs/safety-settings) for safety category and threshold descriptions.
+    For an example on how to use `GeminiSafetySettings`, see [here](../../agents.md#model-specific-settings).
     """
 
     category: Literal[
@@ -422,8 +423,9 @@ class GeminiSafetySettings(TypedDict):
         'HARM_CATEGORY_CIVIC_INTEGRITY',
     ]
     """
-    See <https://ai.google.dev/api/generate-content#v1beta.HarmCategory> for HarmCategory API docs.
+    Safety settings category.
     """
+
     threshold: Literal[
         'HARM_BLOCK_THRESHOLD_UNSPECIFIED',
         'BLOCK_LOW_AND_ABOVE',
@@ -433,10 +435,7 @@ class GeminiSafetySettings(TypedDict):
         'OFF',
     ]
     """
-    See <https://ai.google.dev/api/generate-content#HarmBlockThreshold> for HarmBlockThreshold API docs.
-
-    Note: there are some restrictions on who has access to BLOCK_NONE and OFF.
-    See <https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-filters> for more details.
+    Safety settings threshold.
     """
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,6 +17,7 @@ from pytest_examples import CodeExample, EvalExample, find_examples
 from pytest_mock import MockerFixture
 
 from pydantic_ai._utils import group_by_temporal
+from pydantic_ai.exceptions import UnexpectedModelBehavior
 from pydantic_ai.messages import (
     ModelMessage,
     ModelResponse,
@@ -288,6 +289,8 @@ async def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelRes
                     )
                 ]
             )
+        elif m.content.startswith('Write a list of 5 very rude things that I might say'):
+            raise UnexpectedModelBehavior('Safety settings triggered', body='<safety settings details>')
         elif m.content.startswith('<examples>\n  <user>'):
             return ModelResponse(parts=[ToolCallPart(tool_name='final_result_EmailOk', args={})])
         elif m.content == 'Ask a simple question with a single correct answer.' and len(messages) > 2:


### PR DESCRIPTION
fix #373

Add ability to specify Gemini safety settings when doing an agent run. This addition allows you to specify safety categories and thresholds via the `model_settings` field. Valid settings are based on the [Gemini API docs](https://ai.google.dev/gemini-api/docs/safety-settings#safety-filters). This should hopefully add flexibility to deal with Gemini's safety guardrails as needed, aligning with what one is able to [currently do](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-filters) in the vertexai package. 

Example Code:

```py
from pydantic_ai import Agent
from pydantic_ai.models.gemini import GeminiModel, GeminiModelSettings

GEMINI_API_KEY = '<api key here>'

model = GeminiModel('gemini-1.5-flash', api_key=GEMINI_API_KEY)
agent = Agent(model, system_prompt='Be concise, reply with one sentence.')

result = agent.run_sync(
    'Write a list of 3 mean things that I might say to Paddington after he steals my marmalade:',
    model_settings=GeminiModelSettings(
        gemini_safety_settings=[
            {'category': 'HARM_CATEGORY_HARASSMENT', 'threshold': 'BLOCK_LOW_AND_ABOVE'},
            {'category': 'HARM_CATEGORY_HATE_SPEECH', 'threshold': 'BLOCK_LOW_AND_ABOVE'},
            {'category': 'HARM_CATEGORY_DANGEROUS_CONTENT', 'threshold': 'BLOCK_LOW_AND_ABOVE'},
        ],
    ),
)
```

Thanks @Credit for the above prompt goes to @ghchinoy for the example prompt!