### PR TITLE
Remove redundant project_id validation in VertexAIModel to support cross-project service accounts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -148,11 +148,6 @@ class VertexAIModel(Model):
                 raise UserError(f'No project_id provided and none found in {creds_source}')
             project_id = creds_project_id
         else:
-            if creds_project_id is not None and self.project_id != creds_project_id:
-                raise UserError(
-                    f'The project_id you provided does not match the one from {creds_source}: '
-                    f'{self.project_id!r} != {creds_project_id!r}'
-                )
             project_id = self.project_id
 
         self.url = url = self.url_template.format(


### PR DESCRIPTION
**Changes**
This PR removes an unnecessary validation check in the VertexAIModel class that compared the provided project_id with the credentials' project ID. Previously, the code enforced that these values must match, which is not required in Google Cloud Platform (GCP) workflows.

**Rationale**
In GCP, it is valid and common to use a service account from one project to interact with resources in another project. For example:

- Centralized service account management in a "shared" project.

- Cross-project API access (e.g., Vertex AI models in a different project).

The removed validation check prevented this legitimate use case by raising an error when the provided project_id differed from the credentials' project ID. This change prioritizes the explicitly provided project_id parameter, aligning with GCP's flexibility.

**Impact**

- Users can now specify a project_id that differs from the service account's associated project.

- Enables cross-project resource access patterns without validation errors.

- Maintains backward compatibility — if no project_id is provided, credentials' project ID is still used as before.