### PR TITLE
Support locally served models which do not require an api key

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -104,7 +104,7 @@ class OpenAIModel(Model):
         self.model_name: OpenAIModelName = model_name
         # This is a workaround for the OpenAI client requiring an API key, whilst locally served,
         # openai compatible models do not always need an API key.
-        if api_key is None and 'OPENAI_API_KEY' not in os.environ and base_url is not None:
+        if api_key is None and 'OPENAI_API_KEY' not in os.environ and base_url is not None and openai_client is None:
             api_key = ''
         elif openai_client is not None:
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from itertools import chain
-from typing import Literal, Union, cast, get_args, overload
+from typing import Literal, Union, cast, overload
 
 from httpx import AsyncClient as AsyncHTTPClient
 from typing_extensions import assert_never
@@ -102,15 +102,9 @@ class OpenAIModel(Model):
                 In the future, this may be inferred from the model name.
         """
         self.model_name: OpenAIModelName = model_name
-        # This is a workaround for the OpenAI client requiring an API key, but locally served,
-        # openai compatible models models not always needing an API key.
-        if (
-            api_key is None
-            and 'OPENAI_API_KEY' not in os.environ
-            and model_name not in get_args(ChatModel)
-            and openai_client is None
-        ):
-            assert base_url is not None, 'A base_url must be provided if not using an openai model'
+        # This is a workaround for the OpenAI client requiring an API key, whilst locally served,
+        # openai compatible models do not always need an API key.
+        if api_key is None and 'OPENAI_API_KEY' not in os.environ and base_url is not None:
             api_key = ''
         elif openai_client is not None:
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -106,7 +106,7 @@ class OpenAIModel(Model):
         # openai compatible models models not always needing an API key.
         if (
             api_key is None
-            and os.environ.get('OPENAI_API_KEY') is None
+            and 'OPENAI_API_KEY' not in os.environ
             and model_name not in get_args(ChatModel)
             and openai_client is None
         ):

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1,11 +1,12 @@
 from __future__ import annotations as _annotations
 
+import os
 from collections.abc import AsyncIterable, AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from itertools import chain
-from typing import Literal, Union, cast, overload
+from typing import Literal, Union, cast, get_args, overload
 
 from httpx import AsyncClient as AsyncHTTPClient
 from typing_extensions import assert_never
@@ -101,7 +102,17 @@ class OpenAIModel(Model):
                 In the future, this may be inferred from the model name.
         """
         self.model_name: OpenAIModelName = model_name
-        if openai_client is not None:
+        # # This is a workaround for the OpenAI client requiring an API key, but locally served,
+        # # openai compatible models models not always needing an API key.
+        if (
+            api_key is None
+            and os.environ.get('OPENAI_API_KEY') is None
+            and model_name not in get_args(ChatModel)
+            and openai_client is None
+        ):
+            assert base_url is not None, 'A base_url must be provided if not using an openai model'
+            api_key = ''
+        elif openai_client is not None:
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'
             assert base_url is None, 'Cannot provide both `openai_client` and `base_url`'
             assert api_key is None, 'Cannot provide both `openai_client` and `api_key`'

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -102,8 +102,8 @@ class OpenAIModel(Model):
                 In the future, this may be inferred from the model name.
         """
         self.model_name: OpenAIModelName = model_name
-        # # This is a workaround for the OpenAI client requiring an API key, but locally served,
-        # # openai compatible models models not always needing an API key.
+        # This is a workaround for the OpenAI client requiring an API key, but locally served,
+        # openai compatible models models not always needing an API key.
         if (
             api_key is None
             and os.environ.get('OPENAI_API_KEY') is None

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -29,7 +29,7 @@ from ..conftest import IsNow, try_import
 from .mock_async_stream import MockAsyncStream
 
 with try_import() as imports_successful:
-    from openai import NOT_GIVEN, AsyncOpenAI
+    from openai import NOT_GIVEN, AsyncOpenAI, OpenAIError
     from openai.types import chat
     from openai.types.chat.chat_completion import Choice
     from openai.types.chat.chat_completion_chunk import (
@@ -63,6 +63,19 @@ def test_init_with_base_url():
     assert m.client.api_key == 'foobar'
     assert m.name() == 'openai:gpt-4o'
     m.name()
+
+
+def test_init_with_non_openai_model():
+    m = OpenAIModel('llama3.2-vision:latest', base_url='https://example.com/v1/')
+    m.name()
+
+
+def test_init_of_openai_without_api_key_raises_error():
+    with pytest.raises(
+        OpenAIError,
+        match='^The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable$',
+    ):
+        OpenAIModel('gpt-4o')
 
 
 @dataclass


### PR DESCRIPTION
Adds check for a openai-api compatible model which do not require an API key, addressing https://github.com/pydantic/pydantic-ai/issues/812

Adds a tests for API key-less initialization of `OpenAIModel`.