### PR TITLE
Various minor fixes

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -282,7 +282,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         result_schema: _result.ResultSchema[RunResultDataT] | None = self._prepare_result_schema(result_type)
 
         # Build the graph
-        graph = _agent_graph.build_agent_graph(self.name, self._deps_type, result_type or self.result_type)
+        graph = self._build_graph(result_type)
 
         # Build the initial state
         state = _agent_graph.GraphAgentState(

--- a/pydantic_graph/pydantic_graph/graph.py
+++ b/pydantic_graph/pydantic_graph/graph.py
@@ -181,22 +181,22 @@ class Graph(Generic[StateT, DepsT, RunEndT]):
                         start=start_node,
                     )
                 )
-        while True:
-            next_node = await self.next(start_node, history, state=state, deps=deps, infer_name=False)
-            if isinstance(next_node, End):
-                history.append(EndStep(result=next_node))
-                if run_span is not None:
-                    run_span.set_attribute('history', history)
-                return next_node.data, history
-            elif isinstance(next_node, BaseNode):
-                start_node = next_node
-            else:
-                if TYPE_CHECKING:
-                    typing_extensions.assert_never(next_node)
-                else:
-                    raise exceptions.GraphRuntimeError(
-                        f'Invalid node return type: `{type(next_node).__name__}`. Expected `BaseNode` or `End`.'
-                    )
+
+            next_node = start_node
+            while True:
+                next_node = await self.next(next_node, history, state=state, deps=deps, infer_name=False)
+                if isinstance(next_node, End):
+                    history.append(EndStep(result=next_node))
+                    if run_span is not None:
+                        run_span.set_attribute('history', history)
+                    return next_node.data, history
+                elif not isinstance(next_node, BaseNode):
+                    if TYPE_CHECKING:
+                        typing_extensions.assert_never(next_node)
+                    else:
+                        raise exceptions.GraphRuntimeError(
+                            f'Invalid node return type: `{type(next_node).__name__}`. Expected `BaseNode` or `End`.'
+                        )
 
     def run_sync(
         self: Graph[StateT, DepsT, T],


### PR DESCRIPTION
* Use the `_build_graph` method for building the agent graph in the Agent class, rather than a direct call to the agent graph function
* Fix the fact that we were closing the `run_span` right away when graph runs were auto-instrumented.
* Tweak the implementation of the `Graph.run` loop so that we don't modify the value of `start_node`, which is a bit confusing, and allows us to remove a branch from the conditional. The remaining code is closer to what I'd expect a user to make use of (though I still want to simplify further, as demonstrated in #833)