### PR TITLE
fix OpenAI env var tests following

### DIFF
--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -25,7 +25,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.result import Usage
 from pydantic_ai.settings import ModelSettings
 
-from ..conftest import IsNow, try_import
+from ..conftest import IsNow, TestEnv, try_import
 from .mock_async_stream import MockAsyncStream
 
 with try_import() as imports_successful:
@@ -70,7 +70,8 @@ def test_init_with_non_openai_model():
     m.name()
 
 
-def test_init_of_openai_without_api_key_raises_error():
+def test_init_of_openai_without_api_key_raises_error(env: TestEnv):
+    env.remove('OPENAI_API_KEY')
     with pytest.raises(
         OpenAIError,
         match='^The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable$',

--- a/uv.lock
+++ b/uv.lock
@@ -2674,7 +2674,7 @@ requires-dist = [
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=2.3" },
     { name = "logfire-api", specifier = ">=1.2.0" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.2.5" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.59.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.61.0" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-graph", editable = "pydantic_graph" },
     { name = "requests", marker = "extra == 'vertexai'", specifier = ">=2.32.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -2674,7 +2674,7 @@ requires-dist = [
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=2.3" },
     { name = "logfire-api", specifier = ">=1.2.0" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.2.5" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.61.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.59.0" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-graph", editable = "pydantic_graph" },
     { name = "requests", marker = "extra == 'vertexai'", specifier = ">=2.32.3" },


### PR DESCRIPTION
My mistake, I missed that #814 was not correctly making sure the `OPENAI_API_KEY` env var was unset for this test.