### PR TITLE
fix: missing graph extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 
-dependencies = ["pydantic-ai-slim[graph,openai,vertexai,groq,anthropic,mistral,cohere]==0.0.22"]
+dependencies = ["pydantic-ai-slim[openai,vertexai,groq,anthropic,mistral,cohere]==0.0.22"]
 
 [project.urls]
 Homepage = "https://ai.pydantic.dev"

--- a/uv.lock
+++ b/uv.lock
@@ -2557,7 +2557,7 @@ lint = [
 requires-dist = [
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=2.3" },
     { name = "pydantic-ai-examples", marker = "extra == 'examples'", editable = "examples" },
-    { name = "pydantic-ai-slim", extras = ["graph", "openai", "vertexai", "groq", "anthropic", "mistral", "cohere"], editable = "pydantic_ai_slim" },
+    { name = "pydantic-ai-slim", extras = ["openai", "vertexai", "groq", "anthropic", "mistral", "cohere"], editable = "pydantic_ai_slim" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Fix for
```
uv lock --upgrade
Resolved 125 packages in 2.03s
warning: The package `pydantic-ai-slim==0.0.22` does not have an extra named `graph`
Updated cohere v5.13.11 -> v5.13.12
Updated hypothesis v6.125.1 -> v6.125.2
```