### PR TITLE
Using `model_name` and `system` model properties

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -377,7 +377,7 @@ pip/uv-add 'pydantic-ai-slim[mistral]'
 
 To use [Mistral](https://mistral.ai) through their API, go to [console.mistral.ai/api-keys/](https://console.mistral.ai/api-keys/) and follow your nose until you find the place to generate an API key.
 
-[`NamedMistralModels`][pydantic_ai.models.mistral.NamedMistralModels] contains a list of the most popular Mistral models.
+[`MistralModelName`][pydantic_ai.models.mistral.MistralModelName] contains a list of the most popular Mistral models.
 
 ### Environment variable
 
@@ -434,7 +434,7 @@ pip/uv-add 'pydantic-ai-slim[cohere]'
 
 To use [Cohere](https://cohere.com/) through their API, go to [dashboard.cohere.com/api-keys](https://dashboard.cohere.com/api-keys) and follow your nose until you find the place to generate an API key.
 
-[`NamedCohereModels`][pydantic_ai.models.cohere.NamedCohereModels] contains a list of the most popular Cohere models.
+[`CohereModelName`][pydantic_ai.models.cohere.CohereModelName] contains a list of the most popular Cohere models.
 
 ### Environment variable
 

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -309,7 +309,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
             '{agent_name} run {prompt=}',
             prompt=user_prompt,
             agent=self,
-            model_name=model_used.name() if model_used else 'no-model',
+            model_name=model_used.model_name if model_used else 'no-model',
             agent_name=self.name or 'agent',
         ) as run_span:
             # Build the deps object for the graph
@@ -554,7 +554,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
             '{agent_name} run stream {prompt=}',
             prompt=user_prompt,
             agent=self,
-            model_name=model_used.name(),
+            model_name=model_used.model_name if model_used else 'no-model',
             agent_name=self.name or 'agent',
         ) as run_span:
             # Build the deps object for the graph

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -173,9 +173,7 @@ class ModelRequestParameters:
 class Model(ABC):
     """Abstract class for a model."""
 
-    @abstractmethod
-    def name(self) -> str:
-        raise NotImplementedError()
+    _model_name: str
 
     @abstractmethod
     async def request(
@@ -200,6 +198,11 @@ class Model(ABC):
         # yield is required to make this a generator for type checking
         # noinspection PyUnreachableCode
         yield  # pragma: no cover
+
+    @property
+    def model_name(self) -> str:
+        """The model name."""
+        return self._model_name
 
 
 @dataclass
@@ -311,26 +314,26 @@ def infer_model(model: Model | KnownModelName) -> Model:
     elif model.startswith('google-gla'):
         from .gemini import GeminiModel
 
-        return GeminiModel(model[11:])  # pyright: ignore[reportArgumentType]
+        return GeminiModel(model[11:])
     # backwards compatibility with old model names (ex, gemini-1.5-flash -> google-gla:gemini-1.5-flash)
     elif model.startswith('gemini'):
         from .gemini import GeminiModel
 
         # noinspection PyTypeChecker
-        return GeminiModel(model)  # pyright: ignore[reportArgumentType]
+        return GeminiModel(model)
     elif model.startswith('groq:'):
         from .groq import GroqModel
 
-        return GroqModel(model[5:])  # pyright: ignore[reportArgumentType]
+        return GroqModel(model[5:])
     elif model.startswith('google-vertex'):
         from .vertexai import VertexAIModel
 
-        return VertexAIModel(model[14:])  # pyright: ignore[reportArgumentType]
+        return VertexAIModel(model[14:])
     # backwards compatibility with old model names (ex, vertexai:gemini-1.5-flash -> google-vertex:gemini-1.5-flash)
     elif model.startswith('vertexai:'):
         from .vertexai import VertexAIModel
 
-        return VertexAIModel(model[9:])  # pyright: ignore[reportArgumentType]
+        return VertexAIModel(model[9:])
     elif model.startswith('mistral:'):
         from .mistral import MistralModel
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -174,6 +174,7 @@ class Model(ABC):
     """Abstract class for a model."""
 
     _model_name: str
+    _system: str | None
 
     @abstractmethod
     async def request(
@@ -203,6 +204,11 @@ class Model(ABC):
     def model_name(self) -> str:
         """The model name."""
         return self._model_name
+
+    @property
+    def system(self) -> str | None:
+        """The system / model provider, ex: openai."""
+        return self._system
 
 
 @dataclass

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -68,14 +68,14 @@ LatestAnthropicModelNames = Literal[
     'claude-3-5-sonnet-latest',
     'claude-3-opus-latest',
 ]
-"""Latest named Anthropic models."""
+"""Latest Anthropic models."""
 
 AnthropicModelName = Union[str, LatestAnthropicModelNames]
 """Possible Anthropic model names.
 
 Since Anthropic supports a variety of date-stamped models, we explicitly list the latest models but
 allow any name in the type hints.
-Since [the Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models) for a full list.
+See [the Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models) for a full list.
 """
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -103,8 +103,8 @@ class AnthropicModel(Model):
 
     client: AsyncAnthropic = field(repr=False)
 
-    _model_name: AnthropicModelName
-    _system: str | None = 'anthropic'
+    _model_name: AnthropicModelName = field(repr=False)
+    _system: str | None = field(default='anthropic', repr=False)
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -101,8 +101,10 @@ class AnthropicModel(Model):
         We anticipate adding support for streaming responses in a near-term future release.
     """
 
-    _model_name: AnthropicModelName
     client: AsyncAnthropic = field(repr=False)
+
+    _model_name: AnthropicModelName
+    _system: str | None = 'anthropic'
 
     def __init__(
         self,
@@ -133,9 +135,6 @@ class AnthropicModel(Model):
             self.client = AsyncAnthropic(api_key=api_key, http_client=http_client)
         else:
             self.client = AsyncAnthropic(api_key=api_key, http_client=cached_async_http_client())
-
-    def name(self) -> str:
-        return f'anthropic:{self._model_name}'
 
     async def request(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -90,8 +90,8 @@ class CohereModel(Model):
 
     client: AsyncClientV2 = field(repr=False)
 
-    _model_name: CohereModelName
-    _system: str | None = 'cohere'
+    _model_name: CohereModelName = field(repr=False)
+    _system: str | None = field(default='cohere', repr=False)
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -67,9 +67,15 @@ LatestCohereModelNames = Literal[
     'command-r-plus-08-2024',
     'command-r7b-12-2024',
 ]
-"""Latest / most popular named Cohere models."""
+"""Latest Cohere models."""
 
 CohereModelName = Union[str, LatestCohereModelNames]
+"""Possible Cohere model names.
+
+Since Cohere supports a variety of date-stamped models, we explicitly list the latest models but
+allow any name in the type hints.
+See [Cohere's docs](https://docs.cohere.com/v2/docs/models) for a list of all available models.
+"""
 
 
 class CohereModelSettings(ModelSettings):

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -88,8 +88,10 @@ class CohereModel(Model):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    _model_name: CohereModelName
     client: AsyncClientV2 = field(repr=False)
+
+    _model_name: CohereModelName
+    _system: str | None = 'cohere'
 
     def __init__(
         self,
@@ -117,9 +119,6 @@ class CohereModel(Model):
             self.client = cohere_client
         else:
             self.client = AsyncClientV2(api_key=api_key, httpx_client=http_client)  # type: ignore
-
-    def name(self) -> str:
-        return f'cohere:{self._model_name}'
 
     async def request(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -88,7 +88,7 @@ class CohereModel(Model):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    model_name: CohereModelName
+    _model_name: CohereModelName
     client: AsyncClientV2 = field(repr=False)
 
     def __init__(
@@ -110,7 +110,7 @@ class CohereModel(Model):
                 `api_key` and `http_client` must be `None`.
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
         """
-        self.model_name: CohereModelName = model_name
+        self._model_name: CohereModelName = model_name
         if cohere_client is not None:
             assert http_client is None, 'Cannot provide both `cohere_client` and `http_client`'
             assert api_key is None, 'Cannot provide both `cohere_client` and `api_key`'
@@ -119,7 +119,7 @@ class CohereModel(Model):
             self.client = AsyncClientV2(api_key=api_key, httpx_client=http_client)  # type: ignore
 
     def name(self) -> str:
-        return f'cohere:{self.model_name}'
+        return f'cohere:{self._model_name}'
 
     async def request(
         self,
@@ -140,7 +140,7 @@ class CohereModel(Model):
         tools = self._get_tools(model_request_parameters)
         cohere_messages = list(chain(*(self._map_message(m) for m in messages)))
         return await self.client.chat(
-            model=self.model_name,
+            model=self._model_name,
             messages=cohere_messages,
             tools=tools or OMIT,
             max_tokens=model_settings.get('max_tokens', OMIT),
@@ -168,7 +168,7 @@ class CohereModel(Model):
                         tool_call_id=c.id,
                     )
                 )
-        return ModelResponse(parts=parts, model_name=self.model_name)
+        return ModelResponse(parts=parts, model_name=self._model_name)
 
     def _map_message(self, message: ModelMessage) -> Iterable[ChatMessageV2]:
         """Just maps a `pydantic_ai.Message` to a `cohere.ChatMessageV2`."""

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -52,7 +52,7 @@ except ImportError as _import_error:
         "you can use the `cohere` optional group — `pip install 'pydantic-ai-slim[cohere]'`"
     ) from _import_error
 
-NamedCohereModels = Literal[
+LatestCohereModelNames = Literal[
     'c4ai-aya-expanse-32b',
     'c4ai-aya-expanse-8b',
     'command',
@@ -69,7 +69,7 @@ NamedCohereModels = Literal[
 ]
 """Latest / most popular named Cohere models."""
 
-CohereModelName = Union[NamedCohereModels, str]
+CohereModelName = Union[str, LatestCohereModelNames]
 
 
 class CohereModelSettings(ModelSettings):

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -39,7 +39,9 @@ class FunctionModel(Model):
 
     function: FunctionDef | None = None
     stream_function: StreamFunctionDef | None = None
+
     _model_name: str
+    _system: str | None = None
 
     @overload
     def __init__(self, function: FunctionDef) -> None: ...
@@ -66,10 +68,7 @@ class FunctionModel(Model):
 
         function_name = self.function.__name__ if self.function is not None else ''
         stream_function_name = self.stream_function.__name__ if self.stream_function is not None else ''
-        self._model_name = f'{function_name}:{stream_function_name}'
-
-    def name(self) -> str:
-        return f'function:{self._model_name}'
+        self._model_name = f'function:{function_name}:{stream_function_name}'
 
     async def request(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -39,6 +39,7 @@ class FunctionModel(Model):
 
     function: FunctionDef | None = None
     stream_function: StreamFunctionDef | None = None
+    _model_name: str
 
     @overload
     def __init__(self, function: FunctionDef) -> None: ...
@@ -63,10 +64,12 @@ class FunctionModel(Model):
         self.function = function
         self.stream_function = stream_function
 
-    def name(self) -> str:
         function_name = self.function.__name__ if self.function is not None else ''
         stream_function_name = self.stream_function.__name__ if self.stream_function is not None else ''
-        return f'function:{function_name}:{stream_function_name}'
+        self._model_name = f'{function_name}:{stream_function_name}'
+
+    def name(self) -> str:
+        return f'function:{self._model_name}'
 
     async def request(
         self,
@@ -82,7 +85,6 @@ class FunctionModel(Model):
         )
 
         assert self.function is not None, 'FunctionModel must receive a `function` to support non-streamed requests'
-        model_name = f'function:{self.function.__name__}'
 
         if inspect.iscoroutinefunction(self.function):
             response = await self.function(messages, agent_info)
@@ -90,7 +92,7 @@ class FunctionModel(Model):
             response_ = await _utils.run_in_executor(self.function, messages, agent_info)
             assert isinstance(response_, ModelResponse), response_
             response = response_
-        response.model_name = model_name
+        response.model_name = f'function:{self.function.__name__}'
         # TODO is `messages` right here? Should it just be new messages?
         return response, _estimate_usage(chain(messages, [response]))
 
@@ -111,7 +113,6 @@ class FunctionModel(Model):
         assert (
             self.stream_function is not None
         ), 'FunctionModel must receive a `stream_function` to support streamed requests'
-        model_name = f'function:{self.stream_function.__name__}'
 
         response_stream = PeekableAsyncStream(self.stream_function(messages, agent_info))
 
@@ -119,7 +120,7 @@ class FunctionModel(Model):
         if isinstance(first, _utils.Unset):
             raise ValueError('Stream function must return at least one item')
 
-        yield FunctionStreamedResponse(_model_name=model_name, _iter=response_stream)
+        yield FunctionStreamedResponse(_model_name=f'function:{self.stream_function.__name__}', _iter=response_stream)
 
 
 @dataclass(frozen=True)

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -40,8 +40,8 @@ class FunctionModel(Model):
     function: FunctionDef | None = None
     stream_function: StreamFunctionDef | None = None
 
-    _model_name: str
-    _system: str | None = None
+    _model_name: str = field(repr=False)
+    _system: str | None = field(default=None, repr=False)
 
     @overload
     def __init__(self, function: FunctionDef) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -72,12 +72,12 @@ class GeminiModel(Model):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    http_client: AsyncHTTPClient
+    http_client: AsyncHTTPClient = field(repr=False)
 
-    _model_name: GeminiModelName
-    _system: str | None = 'google-gla'
-    _auth: AuthProtocol | None
-    _url: str | None
+    _model_name: GeminiModelName = field(repr=False)
+    _auth: AuthProtocol | None = field(repr=False)
+    _url: str | None = field(repr=False)
+    _system: str | None = field(default='google-gla', repr=False)
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -72,9 +72,10 @@ class GeminiModel(Model):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    _model_name: GeminiModelName
     http_client: AsyncHTTPClient
 
+    _model_name: GeminiModelName
+    _system: str | None = 'google-gla'
     _auth: AuthProtocol | None
     _url: str | None
 
@@ -116,9 +117,6 @@ class GeminiModel(Model):
     def url(self) -> str:
         assert self._url is not None, 'URL not initialized'
         return self._url
-
-    def name(self) -> str:
-        return f'google-gla:{self._model_name}'
 
     async def request(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -48,12 +48,15 @@ LatestGeminiModelNames = Literal[
     'gemini-2.0-flash-thinking-exp-01-21',
     'gemini-exp-1206',
 ]
-"""Named Gemini models.
-
-See [the Gemini API docs](https://ai.google.dev/gemini-api/docs/models/gemini#model-variations) for a full list.
-"""
+"""Latest Gemini models."""
 
 GeminiModelName = Union[str, LatestGeminiModelNames]
+"""Possible Gemini model names.
+
+Since Gemini supports a variety of date-stamped models, we explicitly list the latest models but
+allow any name in the type hints.
+See [the Gemini API docs](https://ai.google.dev/gemini-api/docs/models/gemini#model-variations) for a full list.
+"""
 
 
 class GeminiModelSettings(ModelSettings):

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -39,7 +39,7 @@ from . import (
     get_user_agent,
 )
 
-KnownGeminiModels = Literal[
+LatestGeminiModelNames = Literal[
     'gemini-1.5-flash',
     'gemini-1.5-flash-8b',
     'gemini-1.5-pro',
@@ -53,7 +53,7 @@ KnownGeminiModels = Literal[
 See [the Gemini API docs](https://ai.google.dev/gemini-api/docs/models/gemini#model-variations) for a full list.
 """
 
-GeminiModelName = Union[str, KnownGeminiModels]
+GeminiModelName = Union[str, LatestGeminiModelNames]
 
 
 class GeminiModelSettings(ModelSettings):

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -58,12 +58,16 @@ LatestGroqModelNames = Literal[
     'mixtral-8x7b-32768',
     'gemma2-9b-it',
 ]
-"""Named Groq models.
-
-See [the Groq docs](https://console.groq.com/docs/models) for a full list.
-"""
+"""Latest Groq models."""
 
 GroqModelName = Union[str, LatestGroqModelNames]
+"""
+Possible Groq model names.
+
+Since Groq supports a variety of date-stamped models, we explicitly list the latest models but
+allow any name in the type hints.
+See [the Groq docs](https://console.groq.com/docs/models) for a full list.
+"""
 
 
 class GroqModelSettings(ModelSettings):

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -45,7 +45,7 @@ except ImportError as _import_error:
         "you can use the `groq` optional group — `pip install 'pydantic-ai-slim[groq]'`"
     ) from _import_error
 
-KnownGroqModels = Literal[
+LatestGroqModelNames = Literal[
     'llama-3.3-70b-versatile',
     'llama-3.3-70b-specdec',
     'llama-3.1-8b-instant',
@@ -63,7 +63,7 @@ KnownGroqModels = Literal[
 See [the Groq docs](https://console.groq.com/docs/models) for a full list.
 """
 
-GroqModelName = Union[str, KnownGroqModels]
+GroqModelName = Union[str, LatestGroqModelNames]
 
 
 class GroqModelSettings(ModelSettings):

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -81,8 +81,10 @@ class GroqModel(Model):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    _model_name: GroqModelName
     client: AsyncGroq = field(repr=False)
+
+    _model_name: GroqModelName
+    _system: str | None = 'groq'
 
     def __init__(
         self,
@@ -113,9 +115,6 @@ class GroqModel(Model):
             self.client = AsyncGroq(api_key=api_key, http_client=http_client)
         else:
             self.client = AsyncGroq(api_key=api_key, http_client=cached_async_http_client())
-
-    def name(self) -> str:
-        return f'groq:{self._model_name}'
 
     async def request(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -83,8 +83,8 @@ class GroqModel(Model):
 
     client: AsyncGroq = field(repr=False)
 
-    _model_name: GroqModelName
-    _system: str | None = 'groq'
+    _model_name: GroqModelName = field(repr=False)
+    _system: str | None = field(default='groq', repr=False)
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -99,7 +99,7 @@ class MistralModel(Model):
     [API Documentation](https://docs.mistral.ai/)
     """
 
-    model_name: MistralModelName
+    _model_name: MistralModelName
     client: Mistral = field(repr=False)
     json_mode_schema_prompt: str = """Answer in JSON Object, respect the format:\n```\n{schema}\n```\n"""
 
@@ -121,7 +121,7 @@ class MistralModel(Model):
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
             json_mode_schema_prompt: The prompt to show when the model expects a JSON object as input.
         """
-        self.model_name = model_name
+        self._model_name = model_name
         self.json_mode_schema_prompt = json_mode_schema_prompt
 
         if client is not None:
@@ -133,7 +133,7 @@ class MistralModel(Model):
             self.client = Mistral(api_key=api_key, async_client=http_client or cached_async_http_client())
 
     def name(self) -> str:
-        return f'mistral:{self.model_name}'
+        return f'mistral:{self._model_name}'
 
     async def request(
         self,
@@ -171,7 +171,7 @@ class MistralModel(Model):
     ) -> MistralChatCompletionResponse:
         """Make a non-streaming request to the model."""
         response = await self.client.chat.complete_async(
-            model=str(self.model_name),
+            model=str(self._model_name),
             messages=list(chain(*(self._map_message(m) for m in messages))),
             n=1,
             tools=self._map_function_and_result_tools_definition(model_request_parameters) or UNSET,
@@ -203,7 +203,7 @@ class MistralModel(Model):
         ):
             # Function Calling
             response = await self.client.chat.stream_async(
-                model=str(self.model_name),
+                model=str(self._model_name),
                 messages=mistral_messages,
                 n=1,
                 tools=self._map_function_and_result_tools_definition(model_request_parameters) or UNSET,
@@ -223,7 +223,7 @@ class MistralModel(Model):
             mistral_messages.append(user_output_format_message)
 
             response = await self.client.chat.stream_async(
-                model=str(self.model_name),
+                model=str(self._model_name),
                 messages=mistral_messages,
                 response_format={'type': 'json_object'},
                 stream=True,
@@ -232,7 +232,7 @@ class MistralModel(Model):
         else:
             # Stream Mode
             response = await self.client.chat.stream_async(
-                model=str(self.model_name),
+                model=str(self._model_name),
                 messages=mistral_messages,
                 stream=True,
             )
@@ -294,7 +294,7 @@ class MistralModel(Model):
                 tool = self._map_mistral_to_pydantic_tool_call(tool_call=tool_call)
                 parts.append(tool)
 
-        return ModelResponse(parts, model_name=self.model_name, timestamp=timestamp)
+        return ModelResponse(parts, model_name=self._model_name, timestamp=timestamp)
 
     async def _process_streamed_response(
         self,
@@ -314,7 +314,7 @@ class MistralModel(Model):
 
         return MistralStreamedResponse(
             _response=peekable_response,
-            _model_name=self.model_name,
+            _model_name=self._model_name,
             _timestamp=timestamp,
             _result_tools={c.name: c for c in result_tools},
         )

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -99,9 +99,11 @@ class MistralModel(Model):
     [API Documentation](https://docs.mistral.ai/)
     """
 
-    _model_name: MistralModelName
     client: Mistral = field(repr=False)
     json_mode_schema_prompt: str = """Answer in JSON Object, respect the format:\n```\n{schema}\n```\n"""
+
+    _model_name: MistralModelName
+    _system: str | None = 'mistral'
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -70,12 +70,12 @@ except ImportError as e:
         "you can use the `mistral` optional group — `pip install 'pydantic-ai-slim[mistral]'`"
     ) from e
 
-NamedMistralModels = Literal[
+LatestMistralModelNames = Literal[
     'mistral-large-latest', 'mistral-small-latest', 'codestral-latest', 'mistral-moderation-latest'
 ]
 """Latest / most popular named Mistral models."""
 
-MistralModelName = Union[NamedMistralModels, str]
+MistralModelName = Union[str, LatestMistralModelNames]
 """Possible Mistral model names.
 
 Since Mistral supports a variety of date-stamped models, we explicitly list the most popular models but

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -102,8 +102,8 @@ class MistralModel(Model):
     client: Mistral = field(repr=False)
     json_mode_schema_prompt: str = """Answer in JSON Object, respect the format:\n```\n{schema}\n```\n"""
 
-    _model_name: MistralModelName
-    _system: str | None = 'mistral'
+    _model_name: MistralModelName = field(repr=False)
+    _system: str | None = field(default='mistral', repr=False)
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -73,7 +73,7 @@ except ImportError as e:
 LatestMistralModelNames = Literal[
     'mistral-large-latest', 'mistral-small-latest', 'codestral-latest', 'mistral-moderation-latest'
 ]
-"""Latest / most popular named Mistral models."""
+"""Latest  Mistral models."""
 
 MistralModelName = Union[str, LatestMistralModelNames]
 """Possible Mistral model names.

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -75,9 +75,11 @@ class OpenAIModel(Model):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    _model_name: OpenAIModelName
     client: AsyncOpenAI = field(repr=False)
     system_prompt_role: OpenAISystemPromptRole | None = field(default=None)
+
+    _model_name: OpenAIModelName
+    _system: str | None
 
     def __init__(
         self,
@@ -88,6 +90,7 @@ class OpenAIModel(Model):
         openai_client: AsyncOpenAI | None = None,
         http_client: AsyncHTTPClient | None = None,
         system_prompt_role: OpenAISystemPromptRole | None = None,
+        system: str | None = 'openai',
     ):
         """Initialize an OpenAI model.
 
@@ -105,6 +108,8 @@ class OpenAIModel(Model):
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
             system_prompt_role: The role to use for the system prompt message. If not provided, defaults to `'system'`.
                 In the future, this may be inferred from the model name.
+            system: The model provider used, defaults to `openai`. This is for observability purposes, you must
+                customize the `base_url` and `api_key` to use a different provider.
         """
         self._model_name = model_name
         # This is a workaround for the OpenAI client requiring an API key, whilst locally served,
@@ -121,6 +126,7 @@ class OpenAIModel(Model):
         else:
             self.client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=cached_async_http_client())
         self.system_prompt_role = system_prompt_role
+        self._system = system
 
     def name(self) -> str:
         return f'openai:{self._model_name}'

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -78,8 +78,8 @@ class OpenAIModel(Model):
     client: AsyncOpenAI = field(repr=False)
     system_prompt_role: OpenAISystemPromptRole | None = field(default=None)
 
-    _model_name: OpenAIModelName
-    _system: str | None
+    _model_name: OpenAIModelName = field(repr=False)
+    _system: str | None = field(repr=False)
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -48,8 +48,14 @@ except ImportError as _import_error:
 
 OpenAIModelName = Union[str, ChatModel]
 """
+Possible OpenAI model names.
+
+Since OpenAI supports a variety of date-stamped models, we explicitly list the latest models but
+allow any name in the type hints.
+See [the OpenAI docs](https://platform.openai.com/docs/models) for a full list.
+
 Using this more broad type for the model name instead of the ChatModel definition
-allows this model to be used more easily with other model types (ie, Ollama, Deepseek)
+allows this model to be used more easily with other model types (ie, Ollama, Deepseek).
 """
 
 OpenAISystemPromptRole = Literal['system', 'developer', 'user']

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -46,7 +46,7 @@ except ImportError as _import_error:
         "you can use the `openai` optional group — `pip install 'pydantic-ai-slim[openai]'`"
     ) from _import_error
 
-OpenAIModelName = Union[ChatModel, str]
+OpenAIModelName = Union[str, ChatModel]
 """
 Using this more broad type for the model name instead of the ChatModel definition
 allows this model to be used more easily with other model types (ie, Ollama, Deepseek)

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -78,8 +78,8 @@ class TestModel(Model):
 
     This is set when a request is made, so will reflect the function tools from the last step of the last run.
     """
-    _model_name: str = 'test'
-    _system: str | None = None
+    _model_name: str = field(default='test', repr=False)
+    _system: str | None = field(default=None, repr=False)
 
     async def request(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -78,6 +78,7 @@ class TestModel(Model):
 
     This is set when a request is made, so will reflect the function tools from the last step of the last run.
     """
+    _model_name: str = 'test'
 
     def name(self) -> str:
         return 'test'
@@ -104,7 +105,9 @@ class TestModel(Model):
         self.last_model_request_parameters = model_request_parameters
 
         model_response = self._request(messages, model_settings, model_request_parameters)
-        yield TestStreamedResponse(_model_name=self.name(), _structured_response=model_response, _messages=messages)
+        yield TestStreamedResponse(
+            _model_name=self._model_name, _structured_response=model_response, _messages=messages
+        )
 
     def gen_tool_args(self, tool_def: ToolDefinition) -> Any:
         return _JsonSchemaTestData(tool_def.parameters_json_schema, self.seed).generate()
@@ -155,7 +158,7 @@ class TestModel(Model):
         if tool_calls and not any(isinstance(m, ModelResponse) for m in messages):
             return ModelResponse(
                 parts=[ToolCallPart(name, self.gen_tool_args(args)) for name, args in tool_calls],
-                model_name=self.name(),
+                model_name=self._model_name,
             )
 
         if messages:
@@ -184,7 +187,7 @@ class TestModel(Model):
                             if tool.name in new_retry_names
                         ]
                     )
-                return ModelResponse(parts=retry_parts, model_name=self.name())
+                return ModelResponse(parts=retry_parts, model_name=self._model_name)
 
         if isinstance(result, _TextResult):
             if (response_text := result.value) is None:
@@ -197,21 +200,23 @@ class TestModel(Model):
                                 output[part.tool_name] = part.content
                 if output:
                     return ModelResponse(
-                        parts=[TextPart(pydantic_core.to_json(output).decode())], model_name=self.name()
+                        parts=[TextPart(pydantic_core.to_json(output).decode())], model_name=self._model_name
                     )
                 else:
-                    return ModelResponse(parts=[TextPart('success (no tool calls)')], model_name=self.name())
+                    return ModelResponse(parts=[TextPart('success (no tool calls)')], model_name=self._model_name)
             else:
-                return ModelResponse(parts=[TextPart(response_text)], model_name=self.name())
+                return ModelResponse(parts=[TextPart(response_text)], model_name=self._model_name)
         else:
             assert result_tools, 'No result tools provided'
             custom_result_args = result.value
             result_tool = result_tools[self.seed % len(result_tools)]
             if custom_result_args is not None:
-                return ModelResponse(parts=[ToolCallPart(result_tool.name, custom_result_args)], model_name=self.name())
+                return ModelResponse(
+                    parts=[ToolCallPart(result_tool.name, custom_result_args)], model_name=self._model_name
+                )
             else:
                 response_args = self.gen_tool_args(result_tool)
-                return ModelResponse(parts=[ToolCallPart(result_tool.name, response_args)], model_name=self.name())
+                return ModelResponse(parts=[ToolCallPart(result_tool.name, response_args)], model_name=self._model_name)
 
 
 @dataclass

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -79,9 +79,7 @@ class TestModel(Model):
     This is set when a request is made, so will reflect the function tools from the last step of the last run.
     """
     _model_name: str = 'test'
-
-    def name(self) -> str:
-        return 'test'
+    _system: str | None = None
 
     async def request(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -65,8 +65,8 @@ class VertexAIModel(GeminiModel):
     model_publisher: Literal['google']
     url_template: str
 
-    _model_name: GeminiModelName
-    _system: str | None = 'google-vertex'
+    _model_name: GeminiModelName = field(repr=False)
+    _system: str | None = field(default='google-vertex', repr=False)
 
     # TODO __init__ can be removed once we drop 3.9 and we can set kw_only correctly on the dataclass
     def __init__(

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -59,6 +59,7 @@ The template is used thus:
 class VertexAIModel(GeminiModel):
     """A model that uses Gemini via the `*-aiplatform.googleapis.com` VertexAI API."""
 
+    _model_name: GeminiModelName
     service_account_file: Path | str | None
     project_id: str | None
     region: VertexAiRegion
@@ -95,7 +96,7 @@ class VertexAIModel(GeminiModel):
                 [`VERTEX_AI_URL_TEMPLATE` docs][pydantic_ai.models.vertexai.VERTEX_AI_URL_TEMPLATE]
                 for more information.
         """
-        self.model_name = model_name
+        self._model_name = model_name
         self.service_account_file = service_account_file
         self.project_id = project_id
         self.region = region
@@ -134,12 +135,12 @@ class VertexAIModel(GeminiModel):
             region=self.region,
             project_id=project_id,
             model_publisher=self.model_publisher,
-            model=self.model_name,
+            model=self._model_name,
         )
         self._auth = BearerTokenAuth(creds)
 
     def name(self) -> str:
-        return f'google-vertex:{self.model_name}'
+        return f'google-vertex:{self._model_name}'
 
     async def request(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -59,12 +59,14 @@ The template is used thus:
 class VertexAIModel(GeminiModel):
     """A model that uses Gemini via the `*-aiplatform.googleapis.com` VertexAI API."""
 
-    _model_name: GeminiModelName
     service_account_file: Path | str | None
     project_id: str | None
     region: VertexAiRegion
     model_publisher: Literal['google']
     url_template: str
+
+    _model_name: GeminiModelName
+    _system: str | None = 'google-vertex'
 
     # TODO __init__ can be removed once we drop 3.9 and we can set kw_only correctly on the dataclass
     def __init__(
@@ -138,9 +140,6 @@ class VertexAIModel(GeminiModel):
             model=self._model_name,
         )
         self._auth = BearerTokenAuth(creds)
-
-    def name(self) -> str:
-        return f'google-vertex:{self._model_name}'
 
     async def request(
         self,

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -60,7 +60,8 @@ T = TypeVar('T')
 def test_init():
     m = AnthropicModel('claude-3-5-haiku-latest', api_key='foobar')
     assert m.client.api_key == 'foobar'
-    assert m.name() == 'anthropic:claude-3-5-haiku-latest'
+    assert m.model_name == 'claude-3-5-haiku-latest'
+    assert m.system == 'anthropic'
 
 
 @dataclass

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -44,7 +44,8 @@ pytestmark = [
 
 def test_init():
     m = CohereModel('command-r7b-12-2024', api_key='foobar')
-    assert m.name() == 'cohere:command-r7b-12-2024'
+    assert m.model_name == 'command-r7b-12-2024'
+    assert m.system == 'cohere'
 
 
 @dataclass

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -52,7 +52,8 @@ pytestmark = [
 def test_init():
     m = GroqModel('llama-3.3-70b-versatile', api_key='foobar')
     assert m.client.api_key == 'foobar'
-    assert m.name() == 'groq:llama-3.3-70b-versatile'
+    assert m.model_name == 'llama-3.3-70b-versatile'
+    assert m.system == 'groq'
 
 
 @dataclass

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -79,7 +79,7 @@ def test_infer_model(
 
     m = infer_model(model_name)  # pyright: ignore[reportArgumentType]
     assert isinstance(m, expected_model)
-    assert m.name() == expected_model_name
+    assert m.model_name == expected_model_name
 
     m2 = infer_model(m)
     assert m2 is m

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -8,66 +8,81 @@ from pydantic_ai.models import infer_model
 from ..conftest import TestEnv
 
 TEST_CASES = [
-    ('OPENAI_API_KEY', 'openai:gpt-3.5-turbo', 'openai:gpt-3.5-turbo', 'openai', 'OpenAIModel'),
-    ('OPENAI_API_KEY', 'gpt-3.5-turbo', 'openai:gpt-3.5-turbo', 'openai', 'OpenAIModel'),
-    ('OPENAI_API_KEY', 'o1', 'openai:o1', 'openai', 'OpenAIModel'),
-    ('GEMINI_API_KEY', 'google-gla:gemini-1.5-flash', 'google-gla:gemini-1.5-flash', 'gemini', 'GeminiModel'),
-    ('GEMINI_API_KEY', 'gemini-1.5-flash', 'google-gla:gemini-1.5-flash', 'gemini', 'GeminiModel'),
+    ('OPENAI_API_KEY', 'openai:gpt-3.5-turbo', 'gpt-3.5-turbo', 'openai', 'openai', 'OpenAIModel'),
+    ('OPENAI_API_KEY', 'gpt-3.5-turbo', 'gpt-3.5-turbo', 'openai', 'openai', 'OpenAIModel'),
+    ('OPENAI_API_KEY', 'o1', 'o1', 'openai', 'openai', 'OpenAIModel'),
+    ('GEMINI_API_KEY', 'google-gla:gemini-1.5-flash', 'gemini-1.5-flash', 'google-gla', 'gemini', 'GeminiModel'),
+    ('GEMINI_API_KEY', 'gemini-1.5-flash', 'gemini-1.5-flash', 'google-gla', 'gemini', 'GeminiModel'),
     (
         'GEMINI_API_KEY',
         'google-vertex:gemini-1.5-flash',
-        'google-vertex:gemini-1.5-flash',
+        'gemini-1.5-flash',
+        'google-vertex',
         'vertexai',
         'VertexAIModel',
     ),
     (
         'GEMINI_API_KEY',
         'vertexai:gemini-1.5-flash',
-        'google-vertex:gemini-1.5-flash',
+        'gemini-1.5-flash',
+        'google-vertex',
         'vertexai',
         'VertexAIModel',
     ),
     (
         'ANTHROPIC_API_KEY',
         'anthropic:claude-3-5-haiku-latest',
-        'anthropic:claude-3-5-haiku-latest',
+        'claude-3-5-haiku-latest',
+        'anthropic',
         'anthropic',
         'AnthropicModel',
     ),
     (
         'ANTHROPIC_API_KEY',
         'claude-3-5-haiku-latest',
-        'anthropic:claude-3-5-haiku-latest',
+        'claude-3-5-haiku-latest',
+        'anthropic',
         'anthropic',
         'AnthropicModel',
     ),
     (
         'GROQ_API_KEY',
         'groq:llama-3.3-70b-versatile',
-        'groq:llama-3.3-70b-versatile',
+        'llama-3.3-70b-versatile',
+        'groq',
         'groq',
         'GroqModel',
     ),
     (
         'MISTRAL_API_KEY',
         'mistral:mistral-small-latest',
-        'mistral:mistral-small-latest',
+        'mistral-small-latest',
+        'mistral',
         'mistral',
         'MistralModel',
     ),
     (
         'CO_API_KEY',
         'cohere:command',
-        'cohere:command',
+        'command',
+        'cohere',
         'cohere',
         'CohereModel',
     ),
 ]
 
 
-@pytest.mark.parametrize('mock_api_key, model_name, expected_model_name, module_name, model_class_name', TEST_CASES)
+@pytest.mark.parametrize(
+    'mock_api_key, model_name, expected_model_name, expected_system, module_name, model_class_name', TEST_CASES
+)
 def test_infer_model(
-    env: TestEnv, mock_api_key: str, model_name: str, expected_model_name: str, module_name: str, model_class_name: str
+    env: TestEnv,
+    mock_api_key: str,
+    model_name: str,
+    expected_model_name: str,
+    expected_system: str,
+    module_name: str,
+    model_class_name: str,
 ):
     try:
         model_module = import_module(f'pydantic_ai.models.{module_name}')
@@ -80,6 +95,7 @@ def test_infer_model(
     m = infer_model(model_name)  # pyright: ignore[reportArgumentType]
     assert isinstance(m, expected_model)
     assert m.model_name == expected_model_name
+    assert m.system == expected_system
 
     m2 = infer_model(m)
     assert m2 is m

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -41,13 +41,13 @@ async def stream_hello(_messages: list[ModelMessage], _agent_info: AgentInfo) ->
 
 def test_init() -> None:
     m = FunctionModel(function=hello)
-    assert m.name() == 'function:hello:'
+    assert m.model_name == 'function:hello:'
 
     m1 = FunctionModel(stream_function=stream_hello)
-    assert m1.name() == 'function::stream_hello'
+    assert m1.model_name == 'function::stream_hello'
 
     m2 = FunctionModel(function=hello, stream_function=stream_hello)
-    assert m2.name() == 'function:hello:stream_hello'
+    assert m2.model_name == 'function:hello:stream_hello'
 
 
 async def return_last(messages: list[ModelMessage], _: AgentInfo) -> ModelResponse:

--- a/tests/models/test_vertexai.py
+++ b/tests/models/test_vertexai.py
@@ -40,7 +40,8 @@ async def test_init_service_account(tmp_path: Path, allow_model_requests: None):
         'publishers/google/models/gemini-1.5-flash:'
     )
     assert model.auth is not None
-    assert model.name() == snapshot('google-vertex:gemini-1.5-flash')
+    assert model.model_name == snapshot('gemini-1.5-flash')
+    assert model.system == snapshot('google-vertex')
 
 
 class NoOpCredentials:
@@ -67,7 +68,8 @@ async def test_init_env(mocker: MockerFixture, allow_model_requests: None):
         'publishers/google/models/gemini-1.5-flash:'
     )
     assert model.auth is not None
-    assert model.name() == snapshot('google-vertex:gemini-1.5-flash')
+    assert model.model_name == snapshot('gemini-1.5-flash')
+    assert model.system == snapshot('google-vertex')
 
     await model.ainit()
     assert model.url is not None

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -103,6 +103,8 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary]) -> None:
                         'custom_result_args': None,
                         'seed': 0,
                         'last_model_request_parameters': None,
+                        '_model_name': 'test',
+                        '_system': None,
                     },
                     'name': 'my_agent',
                     'end_strategy': 'early',

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -103,8 +103,6 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary]) -> None:
                         'custom_result_args': None,
                         'seed': 0,
                         'last_model_request_parameters': None,
-                        '_model_name': 'test',
-                        '_system': None,
                     },
                     'name': 'my_agent',
                     'end_strategy': 'early',


### PR DESCRIPTION
Better aligns with information needed in https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/

* Removes `name` abstractmethod
* Adds `model_name` property to correspond to [`genai.request.model`](https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/#gen-ai-request-model) - note, we pass this through to `ModelResponse`, which covers the [`genai.response.model`](https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/#gen-ai-response-model) case
* Adds `system` property to correspond to [`genai.system`](https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/#gen-ai-system)
* Unifies naming pattern for `XModelName = Union[str, LatestXModelNames]`