### PR TITLE
Fix OpenAI Model for working with local Ollama without passing an API key

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -122,7 +122,8 @@ class OpenAIModel(Model):
         # openai compatible models do not always need an API key.
         if api_key is None and 'OPENAI_API_KEY' not in os.environ and base_url is not None and openai_client is None:
             api_key = ''
-        elif openai_client is not None:
+
+        if openai_client is not None:
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'
             assert base_url is None, 'Cannot provide both `openai_client` and `base_url`'
             assert api_key is None, 'Cannot provide both `openai_client` and `api_key`'

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -65,6 +65,11 @@ def test_init_with_base_url():
     m.name()
 
 
+def test_init_with_no_api_key_will_still_setup_client():
+    m = OpenAIModel('llama3.2', base_url='http://localhost:19434/v1')
+    assert str(m.client.base_url) == 'http://localhost:19434/v1/'
+
+
 def test_init_with_non_openai_model():
     m = OpenAIModel('llama3.2-vision:latest', base_url='https://example.com/v1/')
     m.name()


### PR DESCRIPTION
If you do not pass an API key to the init of the OpenAIModel it results in self.client being None.  This is a quick fix for that.