### PR TITLE
Remove stale `name` methods from openai and mistral models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -134,9 +134,6 @@ class MistralModel(Model):
             api_key = os.getenv('MISTRAL_API_KEY') if api_key is None else api_key
             self.client = Mistral(api_key=api_key, async_client=http_client or cached_async_http_client())
 
-    def name(self) -> str:
-        return f'mistral:{self._model_name}'
-
     async def request(
         self,
         messages: list[ModelMessage],

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -135,9 +135,6 @@ class OpenAIModel(Model):
         self.system_prompt_role = system_prompt_role
         self._system = system
 
-    def name(self) -> str:
-        return f'openai:{self._model_name}'
-
     async def request(
         self,
         messages: list[ModelMessage],

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -176,7 +176,7 @@ def func_chunk(
 
 def test_init():
     m = MistralModel('mistral-large-latest', api_key='foobar')
-    assert m.name() == 'mistral:mistral-large-latest'
+    assert m.model_name == 'mistral-large-latest'
 
 
 #####################

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -54,15 +54,14 @@ def test_init():
     m = OpenAIModel('gpt-4o', api_key='foobar')
     assert str(m.client.base_url) == 'https://api.openai.com/v1/'
     assert m.client.api_key == 'foobar'
-    assert m.name() == 'openai:gpt-4o'
+    assert m.model_name == 'gpt-4o'
 
 
 def test_init_with_base_url():
     m = OpenAIModel('gpt-4o', base_url='https://example.com/v1', api_key='foobar')
     assert str(m.client.base_url) == 'https://example.com/v1/'
     assert m.client.api_key == 'foobar'
-    assert m.name() == 'openai:gpt-4o'
-    m.name()
+    assert m.model_name == 'gpt-4o'
 
 
 def test_init_with_no_api_key_will_still_setup_client():
@@ -72,7 +71,7 @@ def test_init_with_no_api_key_will_still_setup_client():
 
 def test_init_with_non_openai_model():
     m = OpenAIModel('llama3.2-vision:latest', base_url='https://example.com/v1/')
-    m.name()
+    assert m.model_name == 'llama3.2-vision:latest'
 
 
 def test_init_of_openai_without_api_key_raises_error(env: TestEnv):


### PR DESCRIPTION
Remove stale `name` methods missed in https://github.com/pydantic/pydantic-ai/pull/865