### PR TITLE
Add placeholder API key for OpenAI compatible models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -119,9 +119,9 @@ class OpenAIModel(Model):
         """
         self._model_name = model_name
         # This is a workaround for the OpenAI client requiring an API key, whilst locally served,
-        # openai compatible models do not always need an API key.
+        # openai compatible models do not always need an API key, but a placeholder (non-empty) key is required.
         if api_key is None and 'OPENAI_API_KEY' not in os.environ and base_url is not None and openai_client is None:
-            api_key = ''
+            api_key = 'mock-placeholder'
 
         if openai_client is not None:
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -121,7 +121,7 @@ class OpenAIModel(Model):
         # This is a workaround for the OpenAI client requiring an API key, whilst locally served,
         # openai compatible models do not always need an API key, but a placeholder (non-empty) key is required.
         if api_key is None and 'OPENAI_API_KEY' not in os.environ and base_url is not None and openai_client is None:
-            api_key = 'mock-placeholder'
+            api_key = 'api-key-not-set'
 
         if openai_client is not None:
             assert http_client is None, 'Cannot provide both `openai_client` and `http_client`'


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic-ai/issues/903

Add a placeholder API key to avoid the invalid bearer issue:

```py
httpx.LocalProtocolError: Illegal header value b'Bearer '
```