### PR TITLE
Fix bug related to Azure `OpenAI` model streaming response

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -353,10 +353,7 @@ class OpenAIStreamedResponse(StreamedResponse):
                 continue
 
             # Handle the text part of the response
-            if (
-                    (delta := choice.delta) is not None
-                    and (content := delta.content) is not None
-            ):
+            if (delta := choice.delta) is not None and (content := delta.content) is not None:
                 yield self._parts_manager.handle_text_delta(vendor_part_id="content", content=content)
 
             for dtc in choice.delta.tool_calls or []:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -354,7 +354,7 @@ class OpenAIStreamedResponse(StreamedResponse):
 
             # Handle the text part of the response
             if (delta := choice.delta) is not None and (content := delta.content) is not None:
-                yield self._parts_manager.handle_text_delta(vendor_part_id="content", content=content)
+                yield self._parts_manager.handle_text_delta(vendor_part_id='content', content=content)
 
             for dtc in choice.delta.tool_calls or []:
                 maybe_event = self._parts_manager.handle_tool_call_delta(

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -353,9 +353,11 @@ class OpenAIStreamedResponse(StreamedResponse):
                 continue
 
             # Handle the text part of the response
-            content = choice.delta.content
-            if content is not None:
-                yield self._parts_manager.handle_text_delta(vendor_part_id='content', content=content)
+            if (
+                    (delta := choice.delta) is not None
+                    and (content := delta.content) is not None
+            ):
+                yield self._parts_manager.handle_text_delta(vendor_part_id="content", content=content)
 
             for dtc in choice.delta.tool_calls or []:
                 maybe_event = self._parts_manager.handle_tool_call_delta(


### PR DESCRIPTION
Solves: https://github.com/pydantic/pydantic-ai/issues/797

This PR fixes an issue happening with Azure OpenAI streaming Response causing the raise of an AttributeError

As stated on the [issue](https://github.com/pydantic/pydantic-ai/issues/797), _the error occurs in pydantic-ai's OpenAI model implementation where it assumes every delta in the streaming response contains a content field. However, with Azure OpenAI's API, some deltas (like role initialization) may not include content, resulting in choice.delta.content being None._