### PR TITLE
Add dummy tool call id for models that doesn't return it

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -1,12 +1,14 @@
 from __future__ import annotations as _annotations
 
 import asyncio
+import random
 import time
 from collections.abc import AsyncIterable, AsyncIterator, Iterator
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, is_dataclass
 from datetime import datetime, timezone
 from functools import partial
+from string import ascii_letters, digits
 from types import GenericAlias
 from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, Union
 
@@ -199,6 +201,18 @@ def guard_tool_call_id(
     """Type guard that checks a `tool_call_id` is not None both for static typing and runtime."""
     assert t.tool_call_id is not None, f'{model_source} requires `tool_call_id` to be set: {t}'
     return t.tool_call_id
+
+
+def dummy_tool_call_id(*, length: int = 15) -> str:
+    """Generate a random tool call ID.
+
+    Args:
+        length: The length of the tool call ID to be appended to `fake_call_`. (default: 15)
+
+    Returns:
+        str: A random tool call ID. e.g. `fake_call_pgWoMcQp9F4V0qS`
+    """
+    return 'fake_call_' + ''.join(random.choices(ascii_letters + digits, k=length))
 
 
 class PeekableAsyncStream(Generic[T]):

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -512,6 +512,7 @@ def _process_response_from_parts(
         elif 'function_call' in part:
             items.append(
                 ToolCallPart(
+                    tool_call_id=_utils.dummy_tool_call_id(),
                     tool_name=part['function_call']['name'],
                     args=part['function_call']['args'],
                 )

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -331,7 +331,7 @@ class MistralModel(Model):
     @staticmethod
     def _map_mistral_to_pydantic_tool_call(tool_call: MistralToolCall) -> ToolCallPart:
         """Maps a MistralToolCall to a ToolCall."""
-        tool_call_id = tool_call.id or None
+        tool_call_id = tool_call.id or _utils.dummy_tool_call_id()
         func_call = tool_call.function
 
         return ToolCallPart(func_call.name, func_call.arguments, tool_call_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ import pytest
 from _pytest.assertion.rewrite import AssertionRewritingHook
 from typing_extensions import TypeAlias
 
+import pydantic_ai._utils
 import pydantic_ai.models
 
 __all__ = 'IsNow', 'IsFloat', 'TestEnv', 'ClientWithHandler', 'try_import'
@@ -179,3 +180,19 @@ def set_event_loop() -> Iterator[None]:
     asyncio.set_event_loop(new_loop)
     yield
     new_loop.close()
+
+
+@pytest.fixture
+def dummy_tool_call_id_mock(monkeypatch: pytest.MonkeyPatch) -> Callable[[], str]:
+    """Mock the dummy_tool_call_id function to return a fixed string."""
+
+    def _mock(*, length: int = 15) -> str:
+        return 'fake_call_123456789012345'
+
+    monkeypatch.setattr(
+        pydantic_ai._utils,
+        'dummy_tool_call_id',
+        _mock,
+    )
+
+    return _mock

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -487,7 +487,9 @@ async def test_text_success(get_gemini_client: GetGeminiClient):
     )
 
 
-async def test_request_structured_response(get_gemini_client: GetGeminiClient):
+async def test_request_structured_response(
+    get_gemini_client: GetGeminiClient, dummy_tool_call_id_mock: Callable[[], str]
+):
     response = gemini_response(
         _content_model_response(ModelResponse(parts=[ToolCallPart('final_result', {'response': [1, 2, 123]})]))
     )
@@ -505,6 +507,7 @@ async def test_request_structured_response(get_gemini_client: GetGeminiClient):
                     ToolCallPart(
                         tool_name='final_result',
                         args={'response': [1, 2, 123]},
+                        tool_call_id=dummy_tool_call_id_mock(),
                     )
                 ],
                 model_name='gemini-1.5-flash-123',
@@ -513,7 +516,10 @@ async def test_request_structured_response(get_gemini_client: GetGeminiClient):
             ModelRequest(
                 parts=[
                     ToolReturnPart(
-                        tool_name='final_result', content='Final result processed.', timestamp=IsNow(tz=timezone.utc)
+                        tool_name='final_result',
+                        content='Final result processed.',
+                        timestamp=IsNow(tz=timezone.utc),
+                        tool_call_id=dummy_tool_call_id_mock(),
                     )
                 ]
             ),
@@ -521,7 +527,7 @@ async def test_request_structured_response(get_gemini_client: GetGeminiClient):
     )
 
 
-async def test_request_tool_call(get_gemini_client: GetGeminiClient):
+async def test_request_tool_call(get_gemini_client: GetGeminiClient, dummy_tool_call_id_mock: Callable[[], str]):
     responses = [
         gemini_response(
             _content_model_response(ModelResponse(parts=[ToolCallPart('get_location', {'loc_name': 'San Fransisco'})]))
@@ -566,6 +572,7 @@ async def test_request_tool_call(get_gemini_client: GetGeminiClient):
                     ToolCallPart(
                         tool_name='get_location',
                         args={'loc_name': 'San Fransisco'},
+                        tool_call_id=dummy_tool_call_id_mock(),
                     )
                 ],
                 model_name='gemini-1.5-flash-123',
@@ -577,6 +584,7 @@ async def test_request_tool_call(get_gemini_client: GetGeminiClient):
                         content='Wrong location, please try again',
                         tool_name='get_location',
                         timestamp=IsNow(tz=timezone.utc),
+                        tool_call_id=dummy_tool_call_id_mock(),
                     )
                 ]
             ),
@@ -585,10 +593,12 @@ async def test_request_tool_call(get_gemini_client: GetGeminiClient):
                     ToolCallPart(
                         tool_name='get_location',
                         args={'loc_name': 'London'},
+                        tool_call_id=dummy_tool_call_id_mock(),
                     ),
                     ToolCallPart(
                         tool_name='get_location',
                         args={'loc_name': 'New York'},
+                        tool_call_id=dummy_tool_call_id_mock(),
                     ),
                 ],
                 model_name='gemini-1.5-flash-123',
@@ -597,10 +607,16 @@ async def test_request_tool_call(get_gemini_client: GetGeminiClient):
             ModelRequest(
                 parts=[
                     ToolReturnPart(
-                        tool_name='get_location', content='{"lat": 51, "lng": 0}', timestamp=IsNow(tz=timezone.utc)
+                        tool_name='get_location',
+                        content='{"lat": 51, "lng": 0}',
+                        timestamp=IsNow(tz=timezone.utc),
+                        tool_call_id=dummy_tool_call_id_mock(),
                     ),
                     ToolReturnPart(
-                        tool_name='get_location', content='{"lat": 41, "lng": -74}', timestamp=IsNow(tz=timezone.utc)
+                        tool_name='get_location',
+                        content='{"lat": 41, "lng": -74}',
+                        timestamp=IsNow(tz=timezone.utc),
+                        tool_call_id=dummy_tool_call_id_mock(),
                     ),
                 ]
             ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,13 @@ import pytest
 from inline_snapshot import snapshot
 
 from pydantic_ai import UserError
-from pydantic_ai._utils import UNSET, PeekableAsyncStream, check_object_json_schema, group_by_temporal
+from pydantic_ai._utils import (
+    UNSET,
+    PeekableAsyncStream,
+    check_object_json_schema,
+    dummy_tool_call_id,
+    group_by_temporal,
+)
 
 from .models.mock_async_stream import MockAsyncStream
 
@@ -80,3 +86,8 @@ def test_package_versions(capsys: pytest.CaptureFixture[str]):
             packages = sorted((package.metadata['Name'], package.version) for package in distributions())
             for name, version in packages:
                 print(f'{name:30} {version}')
+
+
+def test_dummy_tool_call_id():
+    assert len(dummy_tool_call_id().replace('fake_call_', '')) > 0
+    assert len(dummy_tool_call_id(length=10).replace('fake_call_', '')) == 10


### PR DESCRIPTION
Attempt to fix #895 

## Changes
- Added `dummy_tool_call_id` to `_utils.py`
- Used `dummy_tool_call_id` in `models/gemini.py` and `models/mistral.py`, where it was found that tool call id could be `None`:
- Updates test for Gemini after using `dummy_tool_call_id`. No tests were added since the updated tests already verify the usage of the dummy id.
- Added `test_request_tool_call_with_no_id_from_model` test for Mistral to test usage of `dummy_tool_call_id` when `MistralToolCall` has `id == None`.

