### PR TITLE
Add support for the use of response_format to force a particular json schema for the response

### DIFF
--- a/examples/pydantic_ai_examples/flight_booking.py
+++ b/examples/pydantic_ai_examples/flight_booking.py
@@ -105,7 +105,9 @@ class Failed(BaseModel):
 
 
 # This agent is responsible for extracting the user's seat selection
-seat_preference_agent = Agent[None, SeatPreference | Failed](
+seat_preference_agent = Agent[
+    None, SeatPreference | Failed
+](
     'openai:gpt-4o',
     result_type=SeatPreference | Failed,  # type: ignore
     system_prompt=(

--- a/examples/pydantic_ai_examples/rag.py
+++ b/examples/pydantic_ai_examples/rag.py
@@ -67,9 +67,9 @@ async def retrieve(context: RunContext[Deps], search_query: str) -> str:
             model='text-embedding-3-small',
         )
 
-    assert len(embedding.data) == 1, (
-        f'Expected 1 embedding, got {len(embedding.data)}, doc query: {search_query!r}'
-    )
+    assert (
+        len(embedding.data) == 1
+    ), f'Expected 1 embedding, got {len(embedding.data)}, doc query: {search_query!r}'
     embedding = embedding.data[0].embedding
     embedding_json = pydantic_core.to_json(embedding).decode()
     rows = await context.deps.pool.fetch(
@@ -149,9 +149,9 @@ async def insert_doc_section(
                 input=section.embedding_content(),
                 model='text-embedding-3-small',
             )
-        assert len(embedding.data) == 1, (
-            f'Expected 1 embedding, got {len(embedding.data)}, doc section: {section}'
-        )
+        assert (
+            len(embedding.data) == 1
+        ), f'Expected 1 embedding, got {len(embedding.data)}, doc section: {section}'
         embedding = embedding.data[0].embedding
         embedding_json = pydantic_core.to_json(embedding).decode()
         await pool.execute(

--- a/pydantic_ai_slim/pydantic_ai/_result.py
+++ b/pydantic_ai_slim/pydantic_ai/_result.py
@@ -83,6 +83,7 @@ class ResultSchema(Generic[ResultDataT]):
     Similar to `Tool` but for the final result of running an agent.
     """
 
+    structured_output_validator: TypeAdapter[ResultDataT]
     tools: dict[str, ResultTool[ResultDataT]]
     allow_text_result: bool
 

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -109,9 +109,9 @@ class FunctionModel(Model):
             model_settings,
         )
 
-        assert self.stream_function is not None, (
-            'FunctionModel must receive a `stream_function` to support streamed requests'
-        )
+        assert (
+            self.stream_function is not None
+        ), 'FunctionModel must receive a `stream_function` to support streamed requests'
 
         response_stream = PeekableAsyncStream(self.stream_function(messages, agent_info))
 

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -202,6 +202,7 @@ class GroqModel(Model):
             tools=tools or NOT_GIVEN,
             tool_choice=tool_choice or NOT_GIVEN,
             stream=stream,
+            response_format=response_format,
             max_tokens=model_settings.get('max_tokens', NOT_GIVEN),
             temperature=model_settings.get('temperature', NOT_GIVEN),
             top_p=model_settings.get('top_p', NOT_GIVEN),

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -130,15 +130,15 @@ class TestModel(Model):
 
     def _get_result(self, model_request_parameters: ModelRequestParameters) -> _TextResult | _FunctionToolResult:
         if self.custom_result_text is not None:
-            assert model_request_parameters.allow_text_result, (
-                'Plain response not allowed, but `custom_result_text` is set.'
-            )
+            assert (
+                model_request_parameters.allow_text_result
+            ), 'Plain response not allowed, but `custom_result_text` is set.'
             assert self.custom_result_args is None, 'Cannot set both `custom_result_text` and `custom_result_args`.'
             return _TextResult(self.custom_result_text)
         elif self.custom_result_args is not None:
-            assert model_request_parameters.result_tools is not None, (
-                'No result tools provided, but `custom_result_args` is set.'
-            )
+            assert (
+                model_request_parameters.result_tools is not None
+            ), 'No result tools provided, but `custom_result_args` is set.'
             result_tool = model_request_parameters.result_tools[0]
 
             if k := result_tool.outer_typed_dict_key:

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -351,7 +351,7 @@ class FinalResult(Generic[ResultDataT]):
     data: ResultDataT
     """The final result data."""
     tool_name: str | None
-    """Name of the final result tool; `None` if the result came from unstructured text content."""
+    """Name of the final result tool; `None` if the result did not come from a tool call."""
 
 
 def _get_usage_checking_stream_response(

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -92,6 +92,7 @@ class ModelSettings(TypedDict, total=False):
     Supported by:
 
     * OpenAI
+    * Gemini
     * Groq
     * Cohere
     * Mistral
@@ -129,6 +130,24 @@ class ModelSettings(TypedDict, total=False):
     * OpenAI
     * Groq
     """
+
+    force_response_format: bool
+    """Whether to force a specific response format from the model.
+
+    TODO: Add a description of what this means and the pros/cons of using this.
+    Pros: Works better than tool calling with many "dumber" models
+    Cons: Forces the model to generate structured output, so the agent cannot make use of data retrieval tool calls
+    before generating a final response.
+    # TODO: Explain that this can be set on the model if you know you want to the agent in a way that doesn't require tool calls
+
+    Supported by:
+
+    * Cohere
+    * Gemini
+    * Groq
+    * OpenAI
+    """
+    # TODO: I think Mistral should support this too, but need to confirm; that model is implemented quite differently
 
 
 def merge_model_settings(base: ModelSettings | None, overrides: ModelSettings | None) -> ModelSettings | None:


### PR DESCRIPTION
Initial work on adding support for structured output via the `response_format` argument in OpenAI chat completion requests (and similar for other models). Uses `model_settings` to achieve this.

This is only partially implemented right now but I'm opening the PR as a way to ensure I (or someone else) don't forget to get this across the line ASAP.

#582 