### PR TITLE
Add `pytest-recording`/`vcr` and use it for a test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ testcov: test ## Run tests and generate a coverage report
 update-examples: ## Update documentation examples
 	uv run -m pytest --update-examples tests/test_examples.py
 
+.PHONY: update-vcr-tests
+update-vcr-tests: ## Update tests using VCR that hit LLM APIs; note you'll need to set API keys as appropriate
+	uv run -m pytest --record-mode=rewrite tests
+
 # `--no-strict` so you can build the docs without insiders packages
 .PHONY: docs
 docs: ## Build the documentation

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "pytest-examples>=0.0.14",
     "pytest-mock>=3.14.0",
     "pytest-pretty>=1.2.0",
+    "pytest-recording>=0.13.2",
     "diff-cover>=9.2.0",
 ]
 

--- a/tests/json_body_serializer.py
+++ b/tests/json_body_serializer.py
@@ -1,0 +1,77 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+import json
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from yaml import Dumper, Loader
+else:
+    try:
+        from yaml import CDumper as Dumper, CLoader as Loader
+    except ImportError:
+        from yaml import Dumper, Loader
+
+FILTERED_HEADER_PREFIXES = ['anthropic-', 'cf-', 'x-']
+FILTERED_HEADERS = {'authorization', 'date', 'request-id', 'server', 'user-agent', 'via'}
+
+
+class LiteralDumper(Dumper):
+    """
+    A custom dumper that will represent multi-line strings using literal style.
+    """
+
+
+def str_presenter(dumper: Dumper, data: str):
+    """If the string contains newlines, represent it as a literal block."""
+    if '\n' in data:
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+
+
+# Register the custom presenter on our dumper
+LiteralDumper.add_representer(str, str_presenter)
+
+
+def deserialize(cassette_string: str):
+    cassette_dict = yaml.load(cassette_string, Loader=Loader)
+    for interaction in cassette_dict['interactions']:
+        for kind, data in interaction.items():
+            parsed_body = data.pop('parsed_body', None)
+            if parsed_body is not None:
+                dumped_body = json.dumps(parsed_body)
+                data['body'] = {'string': dumped_body} if kind == 'response' else dumped_body
+    return cassette_dict
+
+
+def serialize(cassette_dict: Any):
+    for interaction in cassette_dict['interactions']:
+        for _kind, data in interaction.items():
+            headers: dict[str, list[str]] = data.get('headers', {})
+            # make headers lowercase
+            headers = {k.lower(): v for k, v in headers.items()}
+            # filter headers by name
+            headers = {k: v for k, v in headers.items() if k not in FILTERED_HEADERS}
+            # filter headers by prefix
+            headers = {
+                k: v for k, v in headers.items() if not any(k.startswith(prefix) for prefix in FILTERED_HEADER_PREFIXES)
+            }
+            # update headers on source object
+            data['headers'] = headers
+
+            content_type = headers.get('content-type', None)
+            if content_type != ['application/json']:
+                continue
+
+            # Parse the body as JSON
+            body: Any = data.get('body', None)
+            assert body is not None, data
+            if isinstance(body, dict):
+                # Responses will have the body under a field called 'string'
+                body = body.get('string')
+            if body is not None:
+                data['parsed_body'] = json.loads(body)
+                del data['body']
+
+    # Use our custom dumper
+    return yaml.dump(cassette_dict, Dumper=LiteralDumper, allow_unicode=True, width=120)

--- a/tests/models/cassettes/test_anthropic/test_multiple_parallel_tool_calls.yaml
+++ b/tests/models/cassettes/test_anthropic/test_multiple_parallel_tool_calls.yaml
@@ -1,0 +1,212 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '793'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 1024
+      messages:
+      - content:
+        - text: Alice, Bob, Charlie and Daisy are a family. Who is the youngest?
+          type: text
+        role: user
+      model: claude-3-5-haiku-latest
+      stream: false
+      system: "\n    Use the `retrieve_entity_info` tool to get information about a specific person.\n    If you need to use
+        `retrieve_entity_info` to get information about multiple people, try\n    to call them in parallel as much as possible.\n
+        \   Think step by step and then provide a single most probable concise answer.\n    "
+      tool_choice:
+        type: auto
+      tools:
+      - description: Get the knowledge about the given entity.
+        input_schema:
+          additionalProperties: false
+          properties:
+            name:
+              title: Name
+              type: string
+          required:
+          - name
+          type: object
+        name: retrieve_entity_info
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '835'
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      content:
+      - text: Let me retrieve the information about each family member to determine their ages.
+        type: text
+      - id: toolu_01B6ALG3PUWnoTbSG77WfHsW
+        input:
+          name: Alice
+        name: retrieve_entity_info
+        type: tool_use
+      - id: toolu_018ar6FXUarSmz9v81ajKN5q
+        input:
+          name: Bob
+        name: retrieve_entity_info
+        type: tool_use
+      - id: toolu_01DQDAMdPsj6Seitxpc29HZF
+        input:
+          name: Charlie
+        name: retrieve_entity_info
+        type: tool_use
+      - id: toolu_01Vzma2bAahRtnZi69djzStJ
+        input:
+          name: Daisy
+        name: retrieve_entity_info
+        type: tool_use
+      id: msg_01B6EyfNCSVqtFxbXvfmQXaX
+      model: claude-3-5-haiku-20241022
+      role: assistant
+      stop_reason: tool_use
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        input_tokens: 429
+        output_tokens: 186
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1928'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 1024
+      messages:
+      - content:
+        - text: Alice, Bob, Charlie and Daisy are a family. Who is the youngest?
+          type: text
+        role: user
+      - content:
+        - text: Let me retrieve the information about each family member to determine their ages.
+          type: text
+        - id: toolu_01B6ALG3PUWnoTbSG77WfHsW
+          input:
+            name: Alice
+          name: retrieve_entity_info
+          type: tool_use
+        - id: toolu_018ar6FXUarSmz9v81ajKN5q
+          input:
+            name: Bob
+          name: retrieve_entity_info
+          type: tool_use
+        - id: toolu_01DQDAMdPsj6Seitxpc29HZF
+          input:
+            name: Charlie
+          name: retrieve_entity_info
+          type: tool_use
+        - id: toolu_01Vzma2bAahRtnZi69djzStJ
+          input:
+            name: Daisy
+          name: retrieve_entity_info
+          type: tool_use
+        role: assistant
+      - content:
+        - content: alice is bob's wife
+          is_error: false
+          tool_use_id: toolu_01B6ALG3PUWnoTbSG77WfHsW
+          type: tool_result
+        - content: bob is alice's husband
+          is_error: false
+          tool_use_id: toolu_018ar6FXUarSmz9v81ajKN5q
+          type: tool_result
+        - content: charlie is alice's son
+          is_error: false
+          tool_use_id: toolu_01DQDAMdPsj6Seitxpc29HZF
+          type: tool_result
+        - content: daisy is bob's daughter and charlie's younger sister
+          is_error: false
+          tool_use_id: toolu_01Vzma2bAahRtnZi69djzStJ
+          type: tool_result
+        role: user
+      model: claude-3-5-haiku-latest
+      stream: false
+      system: "\n    Use the `retrieve_entity_info` tool to get information about a specific person.\n    If you need to use
+        `retrieve_entity_info` to get information about multiple people, try\n    to call them in parallel as much as possible.\n
+        \   Think step by step and then provide a single most probable concise answer.\n    "
+      tool_choice:
+        type: auto
+      tools:
+      - description: Get the knowledge about the given entity.
+        input_schema:
+          additionalProperties: false
+          properties:
+            name:
+              title: Name
+              type: string
+          required:
+          - name
+          type: object
+        name: retrieve_entity_info
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '618'
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      content:
+      - text: |-
+          Based on the retrieved information, we can see the family relationships:
+          - Alice and Bob are married
+          - Charlie is their son
+          - Daisy is their daughter and Charlie's younger sister
+
+          Since Daisy is described as Charlie's younger sister, Daisy is the youngest in this family.
+
+          The answer is: Daisy is the youngest.
+        type: text
+      id: msg_018ApbFsve4yLKjivLPAzqvA
+      model: claude-3-5-haiku-20241022
+      role: assistant
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        input_tokens: 761
+        output_tokens: 78
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -24,7 +24,6 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from pydantic_ai.models import cached_async_http_client
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.result import Usage
@@ -848,7 +847,7 @@ def test_run_sync_multiple():
 
     @agent.tool_plain
     async def make_request() -> str:
-        async with cached_async_http_client() as client:
+        async with httpx.AsyncClient() as client:
             # use this as I suspect it's about the fastest globally available endpoint
             try:
                 response = await client.get('https://cloudflare.com/cdn-cgi/trace')

--- a/tests/test_json_body_serializer.py
+++ b/tests/test_json_body_serializer.py
@@ -1,0 +1,177 @@
+from typing import Any
+
+import pytest
+import yaml
+
+from .json_body_serializer import deserialize, serialize
+
+
+@pytest.fixture
+def cassette_dict_base():
+    """
+    A fixture providing a base cassette dictionary with:
+    - A request containing a multi-line JSON string in `body`.
+    - A response containing a multi-line JSON string in `body['string']`.
+    - Various headers to test filtering & lowercasing.
+    """
+    return {
+        'interactions': [
+            {
+                'request': {
+                    'headers': {
+                        'Content-Type': ['application/json'],
+                        'Authorization': ['some-token'],  # Should be filtered out
+                        'X-Test': ['some-token'],  # Should be filtered out
+                        'Other-Header': ['test-value'],  # Should remain, but become lowercase (other-header)
+                    },
+                    'body': '{"message": "line1\\nline2"}',  # multi-line JSON
+                },
+            },
+            {
+                'response': {
+                    'headers': {
+                        'Content-Type': ['application/json'],
+                        'Date': ['some-date-string'],  # Should be filtered out
+                    },
+                    'body': {'string': '{"response": "line3\\nline4"}'},
+                },
+            },
+        ]
+    }
+
+
+def test_filtered_headers_removed(cassette_dict_base: dict[str, Any]):
+    """
+    Ensure that headers in FILTERED_HEADERS (e.g. 'Authorization', 'Date', etc.)
+    are removed from the serialized output.
+    """
+    output = serialize(cassette_dict_base).lower()
+
+    assert 'authorization:' not in output, "Expected 'Authorization' to be filtered out."
+    assert 'date:' not in output, "Expected 'Date' to be filtered out."
+    assert 'x-test:' not in output, "Expected 'X-Test' to be filtered out."
+
+
+def test_headers_are_lowercased(cassette_dict_base: dict[str, Any]):
+    """
+    Ensure that the remaining headers are written in all-lowercase form.
+    """
+    output = serialize(cassette_dict_base)
+
+    # 'Other-Header' should appear as 'other-header:' in the YAML
+    assert 'other-header:' in output.lower(), "Expected 'Other-Header' to become 'other-header' in the serialized YAML."
+    # Ensure we don't see the uppercase form
+    assert 'Other-Header:' not in output, (
+        f'Found uppercase header name in the serialized YAML; expected it to be lowercase.\nOutput:\n{output}'
+    )
+
+
+def test_multiline_strings_are_literal(cassette_dict_base: dict[str, Any]):
+    """
+    Ensure that multi-line JSON strings are emitted as literal blocks in YAML.
+    """
+    output = serialize(cassette_dict_base)
+
+    # The custom LiteralDumper uses style='|' when it finds '\n' in a string.
+    # Often you'll see '|\n' or '|-' in the YAML depending on your exact presenter.
+    assert '|\n' in output or '|-' in output, (
+        "Expected multi-line string to be represented in literal style ('|' or '|-'), "
+        "but didn't find it.\n\nSerialized output:\n" + output
+    )
+
+
+def test_serialization_includes_parsed_body_excludes_body(cassette_dict_base: dict[str, Any]):
+    """
+    After calling `serialize(...)`, the in-memory dict is transformed such that
+    JSON content is moved into `parsed_body` (and `body` is removed) for readability.
+    We then confirm the *YAML text* also contains `parsed_body`.
+    """
+    output_yaml = serialize(cassette_dict_base)
+
+    # 1) Check the YAML text for "parsed_body" key
+    assert 'parsed_body:' in output_yaml, (
+        f"Expected the YAML output to contain 'parsed_body' for JSON content.\nGot:\n{output_yaml}"
+    )
+
+    # 2) Double-check by parsing the YAML text back into a dict (just to confirm structure)
+    parsed = yaml.safe_load(output_yaml)
+    interactions = parsed.get('interactions', [])
+    assert len(interactions) == 2, 'Expected two interactions in the serialized output.'
+
+    # request
+    req = interactions[0]['request']
+    assert 'parsed_body' in req, "Expected 'parsed_body' to be present for the request in the YAML dictionary."
+    assert 'body' not in req, "Expected 'body' to be removed from the request after serialization."
+    # response
+    resp = interactions[1]['response']
+    assert 'parsed_body' in resp, "Expected 'parsed_body' to be present for the response in the YAML dictionary."
+    assert 'body' not in resp, "Expected 'body' to be removed from the response after serialization."
+
+
+def test_deserialization_restores_body_removes_parsed_body(cassette_dict_base: dict[str, Any]):
+    """
+    After we deserialize the YAML, we want `body` to be restored for VCR usage,
+    and `parsed_body` should be removed.
+    """
+    # First, get the YAML
+    output_yaml = serialize(cassette_dict_base)
+
+    # Now, deserialize it
+    deserialized = deserialize(output_yaml)
+    interactions = deserialized.get('interactions', [])
+
+    assert len(interactions) == 2, 'Expected exactly two interactions after deserialization.'
+
+    # Check request
+    req = interactions[0]['request']
+    assert 'parsed_body' not in req, "Expected 'parsed_body' to NOT be present in the request after deserialization."
+    assert 'body' in req, "Expected 'body' to be restored in the request after deserialization."
+    # The original code for a request sets `body` to a string
+    assert req['body'] == '{"message": "line1\\nline2"}', (
+        'Expected the request body to contain the JSON string from parsed_body.'
+    )
+
+    # Check response
+    resp = interactions[1]['response']
+    assert 'parsed_body' not in resp, "Expected 'parsed_body' to NOT be present in the response after deserialization."
+    assert 'body' in resp, "Expected 'body' to be restored in the response after deserialization."
+    # The original code for a response sets `body` to a dict with {'string': ...}
+    assert resp['body'] == {'string': '{"response": "line3\\nline4"}'}, (
+        "Expected the response body to be a dict with 'string' after deserialization."
+    )
+
+
+def test_round_trip_data_integrity(cassette_dict_base: dict[str, Any]):
+    """
+    Checks that going from an original cassette_dict -> serialize -> deserialize
+    yields the data structure that VCR needs (i.e., final form has 'body',
+    not 'parsed_body'), while still having the original JSON strings.
+    """
+    # Original dictionary:
+    original_request_body = cassette_dict_base['interactions'][0]['request']['body']
+    original_response_body = cassette_dict_base['interactions'][1]['response']['body']['string']
+
+    # Serialize -> Deserialize
+    output_yaml = serialize(cassette_dict_base)
+    deserialized = deserialize(output_yaml)
+
+    # Final data structure should have 'body' again
+    interactions = deserialized.get('interactions', [])
+    assert len(interactions) == 2
+
+    req: Any = interactions[0]['request']
+    resp: Any = interactions[1]['response']
+
+    # Ensure the final request body matches the original
+    assert req['body'] == original_request_body, (
+        'The final request body after round-trip should match the original JSON string.'
+    )
+
+    # Ensure the final response body['string'] matches the original
+    assert resp['body'] == {'string': original_response_body}, (
+        'The final response body after round-trip should match the original JSON string.'
+    )
+
+    # No 'parsed_body' in the final dictionary
+    assert 'parsed_body' not in req
+    assert 'parsed_body' not in resp

--- a/uv.lock
+++ b/uv.lock
@@ -2,12 +2,18 @@ version = 1
 revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-    "python_full_version >= '3.9.17' and python_full_version < '3.10'",
-    "python_full_version < '3.9.17'",
+    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.10.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.10.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '3.9.17' and python_full_version < '3.10' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.9.17' and python_full_version < '3.10' and platform_python_implementation != 'PyPy'",
+    "python_full_version < '3.9.17' and platform_python_implementation == 'PyPy'",
+    "python_full_version < '3.9.17' and platform_python_implementation != 'PyPy'",
 ]
 
 [manifest]
@@ -156,7 +162,8 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "requests" },
-    { name = "urllib3" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/fb/28e33a25bf40d9745875d4c8309178a9e5903b39525916dd45fa1a4b6ade/algoliasearch-4.13.2.tar.gz", hash = "sha256:b2c0bfe2a06327d90e889b9ff310077bf686b6ae5c6a3b09cfd31b2ae7bcd99d", size = 338503 }
 wheels = [
@@ -632,7 +639,8 @@ dependencies = [
     { name = "pydantic-core" },
     { name = "requests" },
     { name = "tokenizers" },
-    { name = "types-requests" },
+    { name = "types-requests", version = "2.31.0.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "types-requests", version = "2.32.0.20241016", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/48/795c53b25b08ec353cc4f48dc5c199ac4615b3c331e716ac50c7cb07034c/cohere-5.13.12.tar.gz", hash = "sha256:97bb9ac107e580780b941acbabd3aa5e71960e6835398292c46aaa8a0a4cab88", size = 132860 }
@@ -777,7 +785,8 @@ name = "diff-cover"
 version = "9.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.9.17'",
+    "python_full_version < '3.9.17' and platform_python_implementation == 'PyPy'",
+    "python_full_version < '3.9.17' and platform_python_implementation != 'PyPy'",
 ]
 dependencies = [
     { name = "chardet", marker = "python_full_version < '3.9.17'" },
@@ -795,11 +804,16 @@ name = "diff-cover"
 version = "9.2.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-    "python_full_version >= '3.9.17' and python_full_version < '3.10'",
+    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.10.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.10.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '3.9.17' and python_full_version < '3.10' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.9.17' and python_full_version < '3.10' and platform_python_implementation != 'PyPy'",
 ]
 dependencies = [
     { name = "chardet", marker = "python_full_version >= '3.9.17'" },
@@ -1089,7 +1103,7 @@ dependencies = [
     { name = "tomlkit", marker = "python_full_version >= '3.10'" },
     { name = "typer", marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
-    { name = "urllib3", marker = "python_full_version >= '3.10' and sys_platform == 'emscripten'" },
+    { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform == 'emscripten'" },
     { name = "uvicorn", marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
 ]
 wheels = [
@@ -2606,6 +2620,7 @@ dev = [
     { name = "pytest-examples" },
     { name = "pytest-mock" },
     { name = "pytest-pretty" },
+    { name = "pytest-recording" },
 ]
 
 [package.metadata]
@@ -2639,6 +2654,7 @@ dev = [
     { name = "pytest-examples", specifier = ">=0.0.14" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-pretty", specifier = ">=1.2.0" },
+    { name = "pytest-recording", specifier = ">=0.13.2" },
 ]
 
 [[package]]
@@ -2856,6 +2872,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-recording"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "vcrpy", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and platform_python_implementation == 'PyPy'" },
+    { name = "vcrpy", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/2a/ea6b8036ae01979eae02d8ad5a7da14dec90d9176b613e49fb8d134c78fc/pytest_recording-0.13.2.tar.gz", hash = "sha256:000c3babbb466681457fd65b723427c1779a0c6c17d9e381c3142a701e124877", size = 25270 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/52/8e67a969e9fad3fa5ec4eab9f2a7348ff04692065c7deda21d76e9112703/pytest_recording-0.13.2-py3-none-any.whl", hash = "sha256:3820fe5743d1ac46e807989e11d073cb776a60bdc544cf43ebca454051b22d13", size = 12783 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3043,7 +3073,8 @@ dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
     { name = "idna" },
-    { name = "urllib3" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
 wheels = [
@@ -3285,14 +3316,51 @@ wheels = [
 
 [[package]]
 name = "types-requests"
+version = "2.31.0.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9.17' and python_full_version < '3.10' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.9.17' and python_full_version < '3.10' and platform_python_implementation != 'PyPy'",
+    "python_full_version < '3.9.17' and platform_python_implementation == 'PyPy'",
+    "python_full_version < '3.9.17' and platform_python_implementation != 'PyPy'",
+]
+dependencies = [
+    { name = "types-urllib3", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/b8/c1e8d39996b4929b918aba10dba5de07a8b3f4c8487bb61bb79882544e69/types-requests-2.31.0.6.tar.gz", hash = "sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0", size = 15535 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/a1/6f8dc74d9069e790d604ddae70cb46dcbac668f1bb08136e7b0f2f5cd3bf/types_requests-2.31.0.6-py3-none-any.whl", hash = "sha256:a2db9cb228a81da8348b49ad6db3f5519452dd20a9c1e1a868c83c5fe88fd1a9", size = 14516 },
+]
+
+[[package]]
+name = "types-requests"
 version = "2.32.0.20241016"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.10.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.10.*' and platform_python_implementation != 'PyPy'",
+]
 dependencies = [
-    { name = "urllib3" },
+    { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/3c/4f2a430c01a22abd49a583b6b944173e39e7d01b688190a5618bd59a2e22/types-requests-2.32.0.20241016.tar.gz", hash = "sha256:0d9cad2f27515d0e3e3da7134a1b6f28fb97129d86b867f24d9c726452634d95", size = 18065 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/01/485b3026ff90e5190b5e24f1711522e06c79f4a56c8f4b95848ac072e20f/types_requests-2.32.0.20241016-py3-none-any.whl", hash = "sha256:4195d62d6d3e043a4eaaf08ff8a62184584d2e8684e9d2aa178c7915a7da3747", size = 15836 },
+]
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", size = 11239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", size = 15377 },
 ]
 
 [[package]]
@@ -3328,8 +3396,33 @@ wheels = [
 
 [[package]]
 name = "urllib3"
+version = "1.26.20"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9.17' and python_full_version < '3.10' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.9.17' and python_full_version < '3.10' and platform_python_implementation != 'PyPy'",
+    "python_full_version < '3.9.17' and platform_python_implementation == 'PyPy'",
+    "python_full_version < '3.9.17' and platform_python_implementation != 'PyPy'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225 },
+]
+
+[[package]]
+name = "urllib3"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.10.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.10.*' and platform_python_implementation != 'PyPy'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
@@ -3347,6 +3440,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4", size = 62315 },
+]
+
+[[package]]
+name = "vcrpy"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.11.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.10.*' and platform_python_implementation == 'PyPy'",
+]
+dependencies = [
+    { name = "pyyaml", marker = "python_full_version >= '3.10' and platform_python_implementation == 'PyPy'" },
+    { name = "wrapt", marker = "python_full_version >= '3.10' and platform_python_implementation == 'PyPy'" },
+    { name = "yarl", marker = "python_full_version >= '3.10' and platform_python_implementation == 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ea/a166a3cce4ac5958ba9bbd9768acdb1ba38ae17ff7986da09fa5b9dbc633/vcrpy-5.1.0.tar.gz", hash = "sha256:bbf1532f2618a04f11bce2a99af3a9647a32c880957293ff91e0a5f187b6b3d2", size = 84576 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/5b/3f70bcb279ad30026cc4f1df0a0491a0205a24dddd88301f396c485de9e7/vcrpy-5.1.0-py2.py3-none-any.whl", hash = "sha256:605e7b7a63dcd940db1df3ab2697ca7faf0e835c0852882142bafb19649d599e", size = 41969 },
+]
+
+[[package]]
+name = "vcrpy"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.10.*' and platform_python_implementation != 'PyPy'",
+    "python_full_version >= '3.9.17' and python_full_version < '3.10' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.9.17' and python_full_version < '3.10' and platform_python_implementation != 'PyPy'",
+    "python_full_version < '3.9.17' and platform_python_implementation == 'PyPy'",
+    "python_full_version < '3.9.17' and platform_python_implementation != 'PyPy'",
+]
+dependencies = [
+    { name = "pyyaml", marker = "python_full_version < '3.10' or platform_python_implementation != 'PyPy'" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and platform_python_implementation != 'PyPy'" },
+    { name = "wrapt", marker = "python_full_version < '3.10' or platform_python_implementation != 'PyPy'" },
+    { name = "yarl", marker = "python_full_version < '3.10' or platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/d3/856e06184d4572aada1dd559ddec3bedc46df1f2edc5ab2c91121a2cccdb/vcrpy-7.0.0.tar.gz", hash = "sha256:176391ad0425edde1680c5b20738ea3dc7fb942520a48d2993448050986b3a50", size = 85502 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/5d/1f15b252890c968d42b348d1e9b0aa12d5bf3e776704178ec37cceccdb63/vcrpy-7.0.0-py2.py3-none-any.whl", hash = "sha256:55791e26c18daa363435054d8b35bd41a4ac441b6676167635d1b37a71dbe124", size = 42321 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the `pytest-recording` package and uses it in a test of the anthropic API.

I think using this approach to test the LLM APIs will make it a lot easier to convert user-reported issues into tests, and maintain our implementation as time goes on.

It also makes it easier to see exactly what's happening in terms of requests/responses when developing new features.

(Requested by @Kludex, but after working on it and using it I feel like it is a big win.)

Note that this does NOT invalidate the benefits of `FunctionModel`, though I think we should also implement something like a `RecordingModel` that is analogous to `InstrumentedModel` that records the `pydantic_ai`-format inputs/outputs. That _also_ would not completely remove the value of `FunctionModel` or `TestModel` (since you wouldn't be able to have dynamic logic), but it _would_ make it a lot easier to create tests where dynamic logic isn't necessary (i.e., most uses of `FunctionModel` today) by just running a request against a real api (e.g. OpenAI) and recording the (non-vendor-specific) request/response structs that `pydantic_ai` sees. (Basically — this is just code-genning a FunctionModel after recording a real LLM API interaction.) But either way that doesn't need to be done now, and the `vcr` usage added in this PR is still useful (extremely useful, imo) even if we _do_ have a `RecordingModel` or similar, since the `vcr` usage allows us to be confident that we are really testing the network requests all the way end-to-end.