### PR TITLE
Only run documentation build hooks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,11 @@ jobs:
 
         # always build docs to check it works without insiders packages
       - run: make docs
-        env:
-          CI_DOCS_BUID: 1
 
       - run: make docs-insiders
         if: github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main'
         env:
           PPPR_TOKEN: ${{ secrets.PPPR_TOKEN }}
-          CI_DOCS_BUID: 1
 
       - run: tree -sh site
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,14 @@ jobs:
 
         # always build docs to check it works without insiders packages
       - run: make docs
+        env:
+          CI_DOCS_BUID: 1
 
       - run: make docs-insiders
         if: github.event.pull_request.head.repo.full_name == github.repository || github.ref == 'refs/heads/main'
         env:
           PPPR_TOKEN: ${{ secrets.PPPR_TOKEN }}
+          CI_DOCS_BUID: 1
 
       - run: tree -sh site
       - uses: actions/setup-node@v4

--- a/docs/.hooks/algolia.py
+++ b/docs/.hooks/algolia.py
@@ -36,6 +36,10 @@ MAX_CONTENT_LENGTH = 90_000
 
 
 def on_page_content(html: str, page: Page, config: Config, files: Files) -> str:
+    if not os.getenv('CI_DOCS_BUILD'):
+        # Only run in CI
+        return html
+
     from bs4 import BeautifulSoup
 
     assert page.title is not None, 'Page title must not be None'

--- a/docs/.hooks/algolia.py
+++ b/docs/.hooks/algolia.py
@@ -36,8 +36,7 @@ MAX_CONTENT_LENGTH = 90_000
 
 
 def on_page_content(html: str, page: Page, config: Config, files: Files) -> str:
-    if not os.getenv('CI_DOCS_BUILD'):
-        # Only run in CI
+    if not os.getenv('CI'):
         return html
 
     from bs4 import BeautifulSoup

--- a/docs/.hooks/build_llms_txt.py
+++ b/docs/.hooks/build_llms_txt.py
@@ -17,8 +17,7 @@ def on_config(config: MkDocsConfig):
 
 
 def on_page_content(html: str, page: Page, config: MkDocsConfig, files: Files) -> str:
-    if not os.getenv('CI_DOCS_BUILD'):
-        # Only run in CI
+    if not os.getenv('CI'):
         return html
 
     soup = BeautifulSoup(html, 'html.parser')

--- a/docs/.hooks/build_llms_txt.py
+++ b/docs/.hooks/build_llms_txt.py
@@ -17,6 +17,10 @@ def on_config(config: MkDocsConfig):
 
 
 def on_page_content(html: str, page: Page, config: MkDocsConfig, files: Files) -> str:
+    if not os.getenv('CI_DOCS_BUILD'):
+        # Only run in CI
+        return html
+
     soup = BeautifulSoup(html, 'html.parser')
 
     # Clean up presentational and UI elements


### PR DESCRIPTION
Unfortunately there's no way to configure mkdocs differently if you are running `serve` (i.e. "dev" mode) or `build`.