### PR TITLE
Fixed DuplicateTableError for sql gen example

### DIFF
--- a/examples/pydantic_ai_examples/sql_gen.py
+++ b/examples/pydantic_ai_examples/sql_gen.py
@@ -171,7 +171,7 @@ async def database_connect(server_dsn: str, database: str) -> AsyncGenerator[Any
                     await conn.execute(
                         "CREATE TYPE log_level AS ENUM ('debug', 'info', 'warning', 'error', 'critical')"
                     )
-                await conn.execute(DB_SCHEMA)
+                    await conn.execute(DB_SCHEMA)
         yield conn
     finally:
         await conn.close()


### PR DESCRIPTION
This change fixes the error `asyncpg.exceptions.DuplicateTableError: relation "records" already exists` you would get when running the script more than once without tearing down the database