### PR TITLE
Add reference field to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -20,3 +20,10 @@ body:
         * Reference to other projects that have a similar feature
     validations:
       required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: |
+        Please add any links or references that might help us understand your feature request better. 📚


### PR DESCRIPTION
I don't know why, but it seems that I don't see many links in the issues created here.