### PR TITLE
Add `max_results` parameter to DuckDuckGo search tool

### DIFF
--- a/docs/common_tools.md
+++ b/docs/common_tools.md
@@ -22,7 +22,7 @@ Here's an example of how you can use the DuckDuckGo search tool with an agent:
 
 ```py {title="main.py" test="skip"}
 from pydantic_ai import Agent
-from pydantic_ai.toolsets.duckduckgo import duckduckgo_search_tool
+from pydantic_ai.common_tools.duckduckgo import duckduckgo_search_tool
 
 agent = Agent(
     'openai:o3-mini',

--- a/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
@@ -63,7 +63,12 @@ class DuckDuckGoSearchTool:
 
 
 def duckduckgo_search_tool(duckduckgo_client: DDGS | None = None, max_results: int | None = None):
-    """Creates a DuckDuckGo search tool."""
+    """Creates a DuckDuckGo search tool.
+
+    Args:
+        duckduckgo_client: The DuckDuckGo search client.
+        max_results: The maximum number of results. If None, returns results only from the first response.
+    """
     return Tool(
         DuckDuckGoSearchTool(client=duckduckgo_client or DDGS(), max_results=max_results).__call__,
         name='duckduckgo_search',

--- a/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
@@ -41,10 +41,7 @@ class DuckDuckGoSearchTool:
     """The DuckDuckGo search client."""
 
     max_results: int | None = None
-    """The maximum number of results.
-
-    If None, returns results only from the first response.
-    """
+    """The maximum number of results. If None, returns results only from the first response."""
 
     async def __call__(self, query: str) -> list[DuckDuckGoResult]:
         """Searches DuckDuckGo for the given query and returns the results.

--- a/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
@@ -1,3 +1,4 @@
+import functools
 from dataclasses import dataclass
 from typing import TypedDict
 
@@ -38,22 +39,24 @@ class DuckDuckGoSearchTool:
 
     client: DDGS
     """The DuckDuckGo search client."""
+
     max_results: int | None = None
-    """The maximum number of results to return. If None, returns results only from the first response."""
+    """The maximum number of results.
+
+    If None, returns results only from the first response.
+    """
 
     async def __call__(self, query: str) -> list[DuckDuckGoResult]:
         """Searches DuckDuckGo for the given query and returns the results.
 
         Args:
-            query: The query to search for.
+            query: The search query.
 
         Returns:
             The search results.
         """
-        # Pass all required positional arguments in order: keywords, region, safesearch, timelimit, backend, max_results
-        results = await anyio.to_thread.run_sync(
-            self.client.text, query, 'wt-wt', 'moderate', None, 'auto', self.max_results
-        )
+        search = functools.partial(self.client.text, max_results=self.max_results)
+        results = await anyio.to_thread.run_sync(search, query)
         if len(results) == 0:
             raise RuntimeError('No search results found.')
         return duckduckgo_ta.validate_python(results)
@@ -64,5 +67,5 @@ def duckduckgo_search_tool(duckduckgo_client: DDGS | None = None, max_results: i
     return Tool(
         DuckDuckGoSearchTool(client=duckduckgo_client or DDGS(), max_results=max_results).__call__,
         name='duckduckgo_search',
-        description='Searches DuckDuckGo for the given query and returns the results. You can specify max_results to control the number of results (if None, returns results only from the first response).',
+        description='Searches DuckDuckGo for the given query and returns the results.',
     )

--- a/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
@@ -47,7 +47,7 @@ class DuckDuckGoSearchTool:
         """Searches DuckDuckGo for the given query and returns the results.
 
         Args:
-            query: The search query.
+            query: The query to search for.
 
         Returns:
             The search results.


### PR DESCRIPTION
I added `max_results` to `duckduckgo_search_tool` and not `DuckDuckGoSearchTool.__call__` because that's what the LLM sees and it's probably better not to give it the option to set `max_results`