### PR TITLE
Pass non-annotated settings to OpenAI API

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -83,6 +83,14 @@ class OpenAIModelSettings(ModelSettings):
     """
 
 
+def non_annotated(model_settings: dict) -> dict:
+    '''
+    Extract non annotated key-value pairs from model_settings.
+    '''
+    return {k: v for (k, v) in model_settings.items()\
+            if k not in OpenAIModelSettings.__annotations__}
+
+
 @dataclass(init=False)
 class OpenAIModel(Model):
     """A model that uses the OpenAI API.
@@ -243,6 +251,7 @@ class OpenAIModel(Model):
                 frequency_penalty=model_settings.get('frequency_penalty', NOT_GIVEN),
                 logit_bias=model_settings.get('logit_bias', NOT_GIVEN),
                 reasoning_effort=model_settings.get('openai_reasoning_effort', NOT_GIVEN),
+                **non_annotated(model_settings)
             )
         except APIStatusError as e:
             if (status_code := e.status_code) >= 400:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterable, AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Literal, Union, cast, overload
+from typing import Any, Literal, Union, cast, overload
 
 from httpx import AsyncClient as AsyncHTTPClient
 from typing_extensions import assert_never
@@ -83,12 +83,9 @@ class OpenAIModelSettings(ModelSettings):
     """
 
 
-def non_annotated(model_settings: dict) -> dict:
-    '''
-    Extract non annotated key-value pairs from model_settings.
-    '''
-    return {k: v for (k, v) in model_settings.items()\
-            if k not in OpenAIModelSettings.__annotations__}
+def non_annotated(model_settings: ModelSettings) -> dict[str, Any]:
+    """Extract non annotated key-value pairs from model_settings."""
+    return {k: v for (k, v) in model_settings.items() if k not in OpenAIModelSettings.__annotations__}
 
 
 @dataclass(init=False)
@@ -251,7 +248,7 @@ class OpenAIModel(Model):
                 frequency_penalty=model_settings.get('frequency_penalty', NOT_GIVEN),
                 logit_bias=model_settings.get('logit_bias', NOT_GIVEN),
                 reasoning_effort=model_settings.get('openai_reasoning_effort', NOT_GIVEN),
-                **non_annotated(model_settings)
+                **non_annotated(model_settings),
             )
         except APIStatusError as e:
             if (status_code := e.status_code) >= 400:


### PR DESCRIPTION
Let non-annotated settings(settings for other OpenAI API compatible models, some are listed in https://github.com/pydantic/pydantic-ai/issues/856#issuecomment-2661447913 ) provided in model_settings be passed through to the OpenAI API call.