### PR TITLE
Make use of `typing-inspection`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_pydantic.py
+++ b/pydantic_ai_slim/pydantic_ai/_pydantic.py
@@ -6,7 +6,7 @@ This module has to use numerous internal Pydantic APIs and is therefore brittle 
 from __future__ import annotations as _annotations
 
 from inspect import Parameter, signature
-from typing import TYPE_CHECKING, Any, Callable, TypedDict, cast, get_origin
+from typing import TYPE_CHECKING, Any, Callable, TypedDict, cast
 
 from pydantic import ConfigDict
 from pydantic._internal import _decorators, _generate_schema, _typing_extra
@@ -15,6 +15,7 @@ from pydantic.fields import FieldInfo
 from pydantic.json_schema import GenerateJsonSchema
 from pydantic.plugin._schema_validator import create_schema_validator
 from pydantic_core import SchemaValidator, core_schema
+from typing_extensions import get_origin
 
 from ._griffe import doc_descriptions
 from ._utils import check_object_json_schema, is_model_like
@@ -223,8 +224,7 @@ def _build_schema(
 
 
 def _is_call_ctx(annotation: Any) -> bool:
+    """Return whether the annotation is the `RunContext` class, parameterized or not."""
     from .tools import RunContext
 
-    return annotation is RunContext or (
-        _typing_extra.is_generic_alias(annotation) and get_origin(annotation) is RunContext
-    )
+    return annotation is RunContext or get_origin(annotation) is RunContext

--- a/pydantic_ai_slim/pydantic_ai/_result.py
+++ b/pydantic_ai_slim/pydantic_ai/_result.py
@@ -1,14 +1,14 @@
 from __future__ import annotations as _annotations
 
 import inspect
-import sys
-import types
 from collections.abc import Awaitable, Iterable, Iterator
 from dataclasses import dataclass, field
-from typing import Any, Callable, Generic, Literal, Union, cast, get_args, get_origin
+from typing import Any, Callable, Generic, Literal, Union, cast
 
 from pydantic import TypeAdapter, ValidationError
-from typing_extensions import TypeAliasType, TypedDict, TypeVar
+from typing_extensions import TypedDict, TypeVar, get_args, get_origin
+from typing_inspection import typing_objects
+from typing_inspection.introspection import is_union_origin
 
 from . import _utils, messages as _messages
 from .exceptions import ModelRetry
@@ -248,23 +248,12 @@ def extract_str_from_union(response_type: Any) -> _utils.Option[Any]:
 
 
 def get_union_args(tp: Any) -> tuple[Any, ...]:
-    """Extract the arguments of a Union type if `response_type` is a union, otherwise return an empty union."""
-    if isinstance(tp, TypeAliasType):
+    """Extract the arguments of a Union type if `response_type` is a union, otherwise return an empty tuple."""
+    if typing_objects.is_typealiastype(tp):
         tp = tp.__value__
 
     origin = get_origin(tp)
-    if origin_is_union(origin):
+    if is_union_origin(origin):
         return get_args(tp)
     else:
         return ()
-
-
-if sys.version_info < (3, 10):
-
-    def origin_is_union(tp: type[Any] | None) -> bool:
-        return tp is Union
-
-else:
-
-    def origin_is_union(tp: type[Any] | None) -> bool:
-        return tp is Union or tp is types.UnionType

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pydantic-graph==0.0.30",
     "exceptiongroup; python_version < '3.11'",
     "opentelemetry-api>=1.28.0",
+    "typing-inspection>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/pydantic_graph/pydantic_graph/graph.py
+++ b/pydantic_graph/pydantic_graph/graph.py
@@ -13,6 +13,7 @@ import logfire_api
 import pydantic
 import typing_extensions
 from logfire_api import LogfireSpan
+from typing_inspection import typing_objects
 
 from . import _utils, exceptions, mermaid
 from .nodes import BaseNode, DepsT, End, GraphRunContext, NodeDef, RunEndT
@@ -506,7 +507,7 @@ class Graph(Generic[StateT, DepsT, RunEndT]):
                     args = typing_extensions.get_args(base)
                     if len(args) == 3:
                         t = args[2]
-                        if not _utils.is_never(t):
+                        if not typing_objects.is_never(t):
                             return t
                     # break the inner (bases) loop
                     break

--- a/pydantic_graph/pydantic_graph/nodes.py
+++ b/pydantic_graph/pydantic_graph/nodes.py
@@ -3,9 +3,9 @@ from __future__ import annotations as _annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, is_dataclass
 from functools import cache
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, get_type_hints
 
-from typing_extensions import Never, TypeVar
+from typing_extensions import Never, TypeVar, get_origin
 
 from . import _utils, exceptions
 

--- a/pydantic_graph/pyproject.toml
+++ b/pydantic_graph/pyproject.toml
@@ -31,7 +31,12 @@ classifiers = [
     "Topic :: Internet",
 ]
 requires-python = ">=3.9"
-dependencies = ["httpx>=0.27", "logfire-api>=1.2.0", "pydantic>=2.10"]
+dependencies = [
+    "httpx>=0.27",
+    "logfire-api>=1.2.0",
+    "pydantic>=2.10",
+    "typing-inspection>=0.4.0",
+]
 
 [project.urls]
 Homepage = "https://ai.pydantic.dev/graph/tree/main/pydantic_graph"

--- a/tests/models/test_model_names.py
+++ b/tests/models/test_model_names.py
@@ -1,7 +1,8 @@
 from collections.abc import Iterator
-from typing import Any, get_args
+from typing import Any
 
 import pytest
+from typing_extensions import get_args
 
 from pydantic_ai.models import KnownModelName
 

--- a/uv.lock
+++ b/uv.lock
@@ -2718,6 +2718,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pydantic-graph" },
+    { name = "typing-inspection" },
 ]
 
 [package.optional-dependencies]
@@ -2786,6 +2787,7 @@ requires-dist = [
     { name = "pydantic-graph", editable = "pydantic_graph" },
     { name = "requests", marker = "extra == 'vertexai'", specifier = ">=2.32.3" },
     { name = "tavily-python", marker = "extra == 'tavily'", specifier = ">=0.5.0" },
+    { name = "typing-inspection", specifier = ">=0.4.0" },
 ]
 provides-extras = ["logfire", "openai", "cohere", "vertexai", "anthropic", "groq", "mistral", "duckduckgo", "tavily"]
 
@@ -2909,6 +2911,7 @@ dependencies = [
     { name = "httpx" },
     { name = "logfire-api" },
     { name = "pydantic" },
+    { name = "typing-inspection" },
 ]
 
 [package.metadata]
@@ -2916,6 +2919,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "logfire-api", specifier = ">=1.2.0" },
     { name = "pydantic", specifier = ">=2.10" },
+    { name = "typing-inspection", specifier = ">=0.4.0" },
 ]
 
 [[package]]
@@ -3586,6 +3590,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827 },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125 },
 ]
 
 [[package]]


### PR DESCRIPTION
This is a first step in using `typing-inspection`. More logic could be incorporated into the library (e.g. when unpacking PEP 695 type aliases, we need to take parameterized forms into account, etc) but this requires a proper design first.