### PR TITLE
Rename HandleResponseNode to CallToolsNode

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -133,7 +133,7 @@ async def main():
                 kind='request',
             )
         ),
-        HandleResponseNode(
+        CallToolsNode(
             model_response=ModelResponse(
                 parts=[TextPart(content='Paris', part_kind='text')],
                 model_name='gpt-4o',
@@ -194,7 +194,7 @@ async def main():
                     kind='request',
                 )
             ),
-            HandleResponseNode(
+            CallToolsNode(
                 model_response=ModelResponse(
                     parts=[TextPart(content='Paris', part_kind='text')],
                     model_name='gpt-4o',
@@ -311,10 +311,10 @@ async def main():
                             output_messages.append(
                                 f'[Result] The model produced a final result (tool_name={event.tool_name})'
                             )
-            elif Agent.is_handle_response_node(node):
+            elif Agent.is_call_tools_node(node):
                 # A handle-response node => The model returned some data, potentially calls a tool
                 output_messages.append(
-                    '=== HandleResponseNode: streaming partial response & tool usage ==='
+                    '=== CallToolsNode: streaming partial response & tool usage ==='
                 )
                 async with node.stream(run.ctx) as handle_stream:
                     async for event in handle_stream:
@@ -343,7 +343,7 @@ if __name__ == '__main__':
         '[Request] Part 0 args_delta=ris","forecast_',
         '[Request] Part 0 args_delta=date":"2030-01-',
         '[Request] Part 0 args_delta=01"}',
-        '=== HandleResponseNode: streaming partial response & tool usage ===',
+        '=== CallToolsNode: streaming partial response & tool usage ===',
         '[Tools] The LLM calls tool=\'weather_forecast\' with args={"location":"Paris","forecast_date":"2030-01-01"} (tool_call_id=\'0001\')',
         "[Tools] Tool call '0001' returned => The forecast in Paris on 2030-01-01 is 24°C and sunny.",
         '=== ModelRequestNode: streaming partial request tokens ===',
@@ -352,7 +352,7 @@ if __name__ == '__main__':
         "[Request] Part 0 text delta: 'warm and sunny '",
         "[Request] Part 0 text delta: 'in Paris on '",
         "[Request] Part 0 text delta: 'Tuesday.'",
-        '=== HandleResponseNode: streaming partial response & tool usage ===',
+        '=== CallToolsNode: streaming partial response & tool usage ===',
         '=== Final Agent Output: It will be warm and sunny in Paris on Tuesday. ===',
     ]
     """

--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import version
 
-from .agent import Agent, EndStrategy, HandleResponseNode, ModelRequestNode, UserPromptNode, capture_run_messages
+from .agent import Agent, CallToolsNode, EndStrategy, ModelRequestNode, UserPromptNode, capture_run_messages
 from .exceptions import (
     AgentRunError,
     FallbackExceptionGroup,
@@ -18,7 +18,7 @@ __all__ = (
     # agent
     'Agent',
     'EndStrategy',
-    'HandleResponseNode',
+    'CallToolsNode',
     'ModelRequestNode',
     'UserPromptNode',
     'capture_run_messages',

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -42,7 +42,7 @@ from .tools import (
 # Re-exporting like this improves auto-import behavior in PyCharm
 capture_run_messages = _agent_graph.capture_run_messages
 EndStrategy = _agent_graph.EndStrategy
-HandleResponseNode = _agent_graph.HandleResponseNode
+CallToolsNode = _agent_graph.CallToolsNode
 ModelRequestNode = _agent_graph.ModelRequestNode
 UserPromptNode = _agent_graph.UserPromptNode
 
@@ -52,7 +52,7 @@ __all__ = (
     'AgentRunResult',
     'capture_run_messages',
     'EndStrategy',
-    'HandleResponseNode',
+    'CallToolsNode',
     'ModelRequestNode',
     'UserPromptNode',
 )
@@ -362,7 +362,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
                         kind='request',
                     )
                 ),
-                HandleResponseNode(
+                CallToolsNode(
                     model_response=ModelResponse(
                         parts=[TextPart(content='Paris', part_kind='text')],
                         model_name='gpt-4o',
@@ -1183,14 +1183,14 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         return isinstance(node, _agent_graph.ModelRequestNode)
 
     @staticmethod
-    def is_handle_response_node(
+    def is_call_tools_node(
         node: _agent_graph.AgentNode[T, S] | End[result.FinalResult[S]],
-    ) -> TypeGuard[_agent_graph.HandleResponseNode[T, S]]:
-        """Check if the node is a `HandleResponseNode`, narrowing the type if it is.
+    ) -> TypeGuard[_agent_graph.CallToolsNode[T, S]]:
+        """Check if the node is a `CallToolsNode`, narrowing the type if it is.
 
         This method preserves the generic parameters while narrowing the type, unlike a direct call to `isinstance`.
         """
-        return isinstance(node, _agent_graph.HandleResponseNode)
+        return isinstance(node, _agent_graph.CallToolsNode)
 
     @staticmethod
     def is_user_prompt_node(
@@ -1250,7 +1250,7 @@ class AgentRun(Generic[AgentDepsT, ResultDataT]):
                     kind='request',
                 )
             ),
-            HandleResponseNode(
+            CallToolsNode(
                 model_response=ModelResponse(
                     parts=[TextPart(content='Paris', part_kind='text')],
                     model_name='gpt-4o',
@@ -1374,7 +1374,7 @@ class AgentRun(Generic[AgentDepsT, ResultDataT]):
                             kind='request',
                         )
                     ),
-                    HandleResponseNode(
+                    CallToolsNode(
                         model_response=ModelResponse(
                             parts=[TextPart(content='Paris', part_kind='text')],
                             model_name='gpt-4o',


### PR DESCRIPTION
Rename the `HandleResponseNode` in the agent graph (exposed via Agent.iter) to the more specific/descriptive `CallToolsNode`. I'm not 100% confident we should even keep this around (rather than merging with ModelRequestNode), but I at least feel this is a better name.

Note that we may need to handle `response_format` structured output stuff in this node, but I'm okay with the potential confusingness that introduces, especially considering I think there's a chance that that _actually_ needs to be handled in `ModelRequestNode` anyway.

@Kludex was there some other renaming we wanted to do right now? Can't remember.