### PR TITLE
Add option to not reflect on tool calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -124,6 +124,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
     """
 
     _deps_type: type[AgentDepsT] = dataclasses.field(repr=False)
+    _reflect_on_tool_call: bool = dataclasses.field(repr=False)
     _result_tool_name: str = dataclasses.field(repr=False)
     _result_tool_description: str | None = dataclasses.field(repr=False)
     _result_schema: _result.ResultSchema[ResultDataT] | None = dataclasses.field(repr=False)
@@ -155,6 +156,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         tools: Sequence[Tool[AgentDepsT] | ToolFuncEither[AgentDepsT, ...]] = (),
         defer_model_check: bool = False,
         end_strategy: EndStrategy = 'early',
+        reflect_on_tool_call: bool = True,
     ):
         """Create an agent.
 
@@ -184,6 +186,9 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
                 [override the model][pydantic_ai.Agent.override] for testing.
             end_strategy: Strategy for handling tool calls that are requested alongside a final result.
                 See [`EndStrategy`][pydantic_ai.agent.EndStrategy] for more information.
+            reflect_on_tool_call: Whether to generate a final response with an LLM call after tool calls.
+                When set to `False`, the agent will return tool call results directly without generating
+                a final reflection response. Defaults to `True`.
         """
         if model is None or defer_model_check:
             self.model = model
@@ -212,6 +217,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
 
         self._default_retries = retries
         self._max_result_retries = result_retries if result_retries is not None else retries
+        self._reflect_on_tool_call = reflect_on_tool_call
         for tool in tools:
             if isinstance(tool, Tool):
                 self._register_tool(tool)
@@ -319,7 +325,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         result_type: type[RunResultDataT] | None = None,
         message_history: list[_messages.ModelMessage] | None = None,
         model: models.Model | models.KnownModelName | None = None,
-        deps: AgentDepsT = None,
+        deps: AgentDepsT | None = None,
         model_settings: ModelSettings | None = None,
         usage_limits: _usage.UsageLimits | None = None,
         usage: _usage.Usage | None = None,
@@ -433,21 +439,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
             model_name=model_used.model_name if model_used else 'no-model',
             agent_name=self.name or 'agent',
         )
-        graph_deps = _agent_graph.GraphAgentDeps[AgentDepsT, RunResultDataT](
-            user_deps=deps,
-            prompt=user_prompt,
-            new_message_index=new_message_index,
-            model=model_used,
-            model_settings=model_settings,
-            usage_limits=usage_limits,
-            max_result_retries=self._max_result_retries,
-            end_strategy=self.end_strategy,
-            result_schema=result_schema,
-            result_tools=self._result_schema.tool_defs() if self._result_schema else [],
-            result_validators=result_validators,
-            function_tools=self._function_tools,
-            run_span=run_span,
-        )
+        graph_deps = self._build_graph_deps(deps, user_prompt, new_message_index, model_used, model_settings, usage_limits, result_schema, result_validators, self._function_tools, run_span)
         start_node = _agent_graph.UserPromptNode[AgentDepsT](
             user_prompt=user_prompt,
             system_prompts=self._system_prompts,
@@ -1132,6 +1124,33 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
             return some_deps.value
         else:
             return deps
+
+    def _build_graph_deps(self, 
+        deps: AgentDepsT | None, 
+        user_prompt: str | Sequence[_messages.UserContent], 
+        new_message_index: int, 
+        model_used: models.Model, 
+        model_settings: ModelSettings | None, 
+        usage_limits: _usage.UsageLimits | None, 
+        result_schema: _result.ResultSchema[RunResultDataT] | None, 
+        result_validators: list[_result.ResultValidator[AgentDepsT, RunResultDataT]] | None, 
+        run_span: logfire_api.LogfireSpan) -> _agent_graph.GraphAgentDeps[AgentDepsT, RunResultDataT]:
+        return _agent_graph.GraphAgentDeps[AgentDepsT, RunResultDataT](
+            user_deps=deps,
+            prompt=user_prompt,
+            new_message_index=new_message_index,
+            model=model_used,
+            model_settings=model_settings,
+            usage_limits=usage_limits,
+            max_result_retries=self._max_result_retries,
+            end_strategy=self.end_strategy,
+            result_schema=result_schema,
+            result_tools=self._result_schema.tool_defs() if self._result_schema else [],
+            result_validators=result_validators,
+            function_tools=self._function_tools,
+            reflect_on_tool_call=self._reflect_on_tool_call,
+            run_span=run_span,
+        )
 
     def _infer_name(self, function_frame: FrameType | None) -> None:
         """Infer the agent name from the call frame.


### PR DESCRIPTION
I was struggling to make agents that require no reflection on tool calls and was managed to create working version of reflect_on_tool_use param like in Autogen. More info here: https://github.com/pydantic/pydantic-ai/issues/1024

I added check if param set to False there will be no call to model in this case