### PR TITLE
workaround for the OpenAI client requiring a user field

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -129,7 +129,7 @@ class OpenAIModel(Model):
             system: The model provider used, defaults to `openai`. This is for observability purposes, you must
                 customize the `base_url` and `api_key` to use a different provider.
         """
-        self.user = user    # this is a workaround for the OpenAI client requiring a user field
+        self.user = user
         self._model_name = model_name
         # This is a workaround for the OpenAI client requiring an API key, whilst locally served,
         # openai compatible models do not always need an API key, but a placeholder (non-empty) key is required.

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -128,6 +128,7 @@ class OpenAIModel(Model):
                 In the future, this may be inferred from the model name.
             system: The model provider used, defaults to `openai`. This is for observability purposes, you must
                 customize the `base_url` and `api_key` to use a different provider.
+            user: The user to associate with the request. If not provided, defaults to `None`.
         """
         self.user = user
         self._model_name = model_name

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -108,6 +108,7 @@ class OpenAIModel(Model):
         http_client: AsyncHTTPClient | None = None,
         system_prompt_role: OpenAISystemPromptRole | None = None,
         system: str | None = 'openai',
+        user: str | None = None,
     ):
         """Initialize an OpenAI model.
 
@@ -128,6 +129,7 @@ class OpenAIModel(Model):
             system: The model provider used, defaults to `openai`. This is for observability purposes, you must
                 customize the `base_url` and `api_key` to use a different provider.
         """
+        self.user = user    # this is a workaround for the OpenAI client requiring a user field
         self._model_name = model_name
         # This is a workaround for the OpenAI client requiring an API key, whilst locally served,
         # openai compatible models do not always need an API key, but a placeholder (non-empty) key is required.
@@ -243,6 +245,7 @@ class OpenAIModel(Model):
                 frequency_penalty=model_settings.get('frequency_penalty', NOT_GIVEN),
                 logit_bias=model_settings.get('logit_bias', NOT_GIVEN),
                 reasoning_effort=model_settings.get('openai_reasoning_effort', NOT_GIVEN),
+                user=self.user or NOT_GIVEN,
             )
         except APIStatusError as e:
             if (status_code := e.status_code) >= 400:


### PR DESCRIPTION
Add use of `user=` field for OpenAPI method `self.client.chat.completions.create`. This field in use for user JSON Object:

- The user object should contain your appkey, session_id, and user information.
- The appkey is a required field to identify your application.
- session_id - Optional parameter (include if you want to maintain conversational history)
- user - Optional parameter (id). Used to identify the user making the request

without it calls to OpenAI API doesn't work in enterprise environments where API calls are billed per application or user use (for example all corporate APIs via AzureOpenAI).

This patch will open use of pydantic_ai for many environments and users.

Example of use:
```python
client = AsyncAzureOpenAI(
    azure_endpoint=open_ai_endpoint,
    api_version='2024-12-01-preview',
    api_key=APIKey.check_and_refresh()
)
model = OpenAIModel('gpt-4o', openai_client=client, user=f'{{"appkey": "{deployment_name}"}}')
agent = Agent(model, system_prompt='Be concise, reply with one sentence.')
result = agent.run_sync('Where does "hello world" come from?')
print(result.data)
```

Changes added to pydantic-ai/pydantic_ai_slim/pydantic_ai/models/openai.py:
- ability to init object of class OpenAIModel(Model) with optional `user=value` parameter
- call to `self.client.chat.completions.create` with `user=value` parameter if entered during init
