### PR TITLE
Raise UserError when tool system_prompt returns a None

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -190,9 +190,9 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
                             # Look up the runner by its ref
                             if runner := self.system_prompt_dynamic_functions.get(part.dynamic_ref):
                                 updated_part_content = await runner.run(run_context)
-                                if updated_part_content is None:
+                                if updated_part_content is None:  # type: ignore[comparison-overlap]
                                     raise exceptions.UserError(
-                                        f"system prompt function {runner.function} returned None"
+                                        f'system prompt function {runner.function} returned None'
                                     )
                                 if not isinstance(updated_part_content, str):
                                     updated_part_content = str(updated_part_content)
@@ -205,10 +205,8 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
         messages: list[_messages.ModelRequestPart] = [_messages.SystemPromptPart(p) for p in self.system_prompts]
         for sys_prompt_runner in self.system_prompt_functions:
             prompt = await sys_prompt_runner.run(run_context)
-            if prompt is None:
-                raise exceptions.UserError(
-                    f"system prompt function {sys_prompt_runner.function} returned None"
-                )
+            if prompt is None:  # type: ignore[comparison-overlap]
+                raise exceptions.UserError(f'system prompt function {sys_prompt_runner.function} returned None')
             if not isinstance(prompt, str):
                 prompt = str(prompt)
             if sys_prompt_runner.dynamic:

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -190,6 +190,12 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
                             # Look up the runner by its ref
                             if runner := self.system_prompt_dynamic_functions.get(part.dynamic_ref):
                                 updated_part_content = await runner.run(run_context)
+                                if updated_part_content is None:
+                                    raise exceptions.UserError(
+                                        f"system prompt function {runner.function} returned None"
+                                    )
+                                if not isinstance(updated_part_content, str):
+                                    updated_part_content = str(updated_part_content)
                                 msg.parts[i] = _messages.SystemPromptPart(
                                     updated_part_content, dynamic_ref=part.dynamic_ref
                                 )
@@ -199,6 +205,12 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
         messages: list[_messages.ModelRequestPart] = [_messages.SystemPromptPart(p) for p in self.system_prompts]
         for sys_prompt_runner in self.system_prompt_functions:
             prompt = await sys_prompt_runner.run(run_context)
+            if prompt is None:
+                raise exceptions.UserError(
+                    f"system prompt function {sys_prompt_runner.function} returned None"
+                )
+            if not isinstance(prompt, str):
+                prompt = str(prompt)
             if sys_prompt_runner.dynamic:
                 messages.append(_messages.SystemPromptPart(prompt, dynamic_ref=sys_prompt_runner.function.__qualname__))
             else:

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -190,12 +190,7 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
                             # Look up the runner by its ref
                             if runner := self.system_prompt_dynamic_functions.get(part.dynamic_ref):
                                 updated_part_content = await runner.run(run_context)
-                                if updated_part_content is None:  # type: ignore[comparison-overlap]
-                                    raise exceptions.UserError(
-                                        f'system prompt function {runner.function} returned None'
-                                    )
-                                if not isinstance(updated_part_content, str):
-                                    updated_part_content = str(updated_part_content)
+
                                 msg.parts[i] = _messages.SystemPromptPart(
                                     updated_part_content, dynamic_ref=part.dynamic_ref
                                 )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1384,6 +1384,15 @@ def test_system_prompt_egde_cases(dynamic: bool, return_value: Any, valid: bool)
         with pytest.raises(UserError, match=f'returned {return_value}'):
             agent.run_sync('Hello')
 
+    if dynamic:
+        if return_value is None:
+            return_value = ''
+            res = agent.run_sync('Hello')
+        else:
+            return_value = None
+            with pytest.raises(UserError, match=f'returned {return_value}'):
+                agent.run_sync('Hello')
+
 
 def test_dynamic_false_no_reevaluate():
     """When dynamic is false (default), the system prompt is not reevaluated

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1352,14 +1352,17 @@ def test_double_capture_run_messages() -> None:
         ]
     )
 
-@pytest.mark.parametrize('return_value,valid', [
-    ('', True),  
-    (None, False),
-    (5, True),  ## TODO - decide if this is valid
- ]
+
+@pytest.mark.parametrize(
+    'return_value,valid',
+    [
+        ('', True),
+        (None, False),
+        (5, True),  ## TODO - decide if this is valid
+    ],
 )
 @pytest.mark.parametrize('dynamic', [True, False])
-def test_system_prompt_egde_cases(dynamic: bool, return_value: str, valid: bool):
+def test_system_prompt_egde_cases(dynamic: bool, return_value: Any, valid: bool):
     """Tests edge cases for system prompt.
     i.e: SystemPromptPart(
             content="A",       <--- Remains the same when `message_history` is passed.
@@ -1380,6 +1383,7 @@ def test_system_prompt_egde_cases(dynamic: bool, return_value: str, valid: bool)
     else:
         with pytest.raises(UserError, match=f'returned {return_value}'):
             agent.run_sync('Hello')
+
 
 def test_dynamic_false_no_reevaluate():
     """When dynamic is false (default), the system prompt is not reevaluated


### PR DESCRIPTION
Previously

```python
@agent.system_prompt
async def func():
    return None
```

would raise an error at time of model calling

This PR checks defensively checks what is being returned, and will raise a hopefully more informative UserError. Note this all requires a type check override, since returning None is forbidden. However, if we treat user code as input then it's possible to violate at runtime.

Also include a unit test, and for an additional ultra-edgy case of returning a non-string from system_prompt

Fixes #1057
