### PR TITLE
Add support for specifying tool name when using decorator.

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -922,6 +922,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         self,
         /,
         *,
+        name: str | None = None,
         retries: int | None = None,
         prepare: ToolPrepareFunc[AgentDepsT] | None = None,
         docstring_format: DocstringFormat = 'auto',
@@ -933,6 +934,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         func: ToolFuncContext[AgentDepsT, ToolParams] | None = None,
         /,
         *,
+        name: str | None = None,
         retries: int | None = None,
         prepare: ToolPrepareFunc[AgentDepsT] | None = None,
         docstring_format: DocstringFormat = 'auto',
@@ -969,6 +971,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
 
         Args:
             func: The tool function to register.
+            name: The name of the tool, defaults to the function name.
             retries: The number of retries to allow for this tool, defaults to the agent's default retries,
                 which defaults to 1.
             prepare: custom method to prepare the tool definition for each step, return `None` to omit this
@@ -984,13 +987,17 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
                 func_: ToolFuncContext[AgentDepsT, ToolParams],
             ) -> ToolFuncContext[AgentDepsT, ToolParams]:
                 # noinspection PyTypeChecker
-                self._register_function(func_, True, retries, prepare, docstring_format, require_parameter_descriptions)
+                self._register_function(
+                    func_, True, name, retries, prepare, docstring_format, require_parameter_descriptions
+                )
                 return func_
 
             return tool_decorator
         else:
             # noinspection PyTypeChecker
-            self._register_function(func, True, retries, prepare, docstring_format, require_parameter_descriptions)
+            self._register_function(
+                func, True, name, retries, prepare, docstring_format, require_parameter_descriptions
+            )
             return func
 
     @overload
@@ -1001,6 +1008,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         self,
         /,
         *,
+        name: str | None = None,
         retries: int | None = None,
         prepare: ToolPrepareFunc[AgentDepsT] | None = None,
         docstring_format: DocstringFormat = 'auto',
@@ -1012,6 +1020,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         func: ToolFuncPlain[ToolParams] | None = None,
         /,
         *,
+        name: str | None = None,
         retries: int | None = None,
         prepare: ToolPrepareFunc[AgentDepsT] | None = None,
         docstring_format: DocstringFormat = 'auto',
@@ -1048,6 +1057,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
 
         Args:
             func: The tool function to register.
+            name: The name of the tool, defaults to the function name.
             retries: The number of retries to allow for this tool, defaults to the agent's default retries,
                 which defaults to 1.
             prepare: custom method to prepare the tool definition for each step, return `None` to omit this
@@ -1062,19 +1072,22 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
             def tool_decorator(func_: ToolFuncPlain[ToolParams]) -> ToolFuncPlain[ToolParams]:
                 # noinspection PyTypeChecker
                 self._register_function(
-                    func_, False, retries, prepare, docstring_format, require_parameter_descriptions
+                    func_, False, name, retries, prepare, docstring_format, require_parameter_descriptions
                 )
                 return func_
 
             return tool_decorator
         else:
-            self._register_function(func, False, retries, prepare, docstring_format, require_parameter_descriptions)
+            self._register_function(
+                func, False, name, retries, prepare, docstring_format, require_parameter_descriptions
+            )
             return func
 
     def _register_function(
         self,
         func: ToolFuncEither[AgentDepsT, ToolParams],
         takes_ctx: bool,
+        name: str | None,
         retries: int | None,
         prepare: ToolPrepareFunc[AgentDepsT] | None,
         docstring_format: DocstringFormat,
@@ -1085,6 +1098,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         tool = Tool[AgentDepsT](
             func,
             takes_ctx=takes_ctx,
+            name=name,
             max_retries=retries_,
             prepare=prepare,
             docstring_format=docstring_format,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -500,6 +500,30 @@ def test_dynamic_tool_decorator():
     assert r.data == snapshot('success (no tool calls)')
 
 
+def test_plain_tool_name():
+    agent = Agent(FunctionModel(get_json_schema))
+
+    def mytool(arg: str) -> str:
+        return arg
+
+    agent.tool_plain(name='foo_tool')(mytool)
+    result = agent.run_sync('Hello')
+    json_schema = json.loads(result.data)
+    assert json_schema['name'] == 'foo_tool'
+
+
+def test_tool_name():
+    agent = Agent(FunctionModel(get_json_schema))
+
+    def mytool(ctx: RunContext, arg: str) -> str:
+        return arg
+
+    agent.tool(name='foo_tool')(mytool)
+    result = agent.run_sync('Hello')
+    json_schema = json.loads(result.data)
+    assert json_schema['name'] == 'foo_tool'
+
+
 def test_dynamic_tool_use_messages():
     async def repeat_call_foobar(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if info.function_tools:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -503,10 +503,9 @@ def test_dynamic_tool_decorator():
 def test_plain_tool_name():
     agent = Agent(FunctionModel(get_json_schema))
 
-    def mytool(arg: str) -> str:
-        return arg
+    def my_tool(arg: str) -> str: ...
 
-    agent.tool_plain(name='foo_tool')(mytool)
+    agent.tool_plain(name='foo_tool')(my_tool)
     result = agent.run_sync('Hello')
     json_schema = json.loads(result.data)
     assert json_schema['name'] == 'foo_tool'
@@ -515,10 +514,9 @@ def test_plain_tool_name():
 def test_tool_name():
     agent = Agent(FunctionModel(get_json_schema))
 
-    def mytool(ctx: RunContext, arg: str) -> str:
-        return arg
+    def my_tool(ctx: RunContext, arg: str) -> str: ...
 
-    agent.tool(name='foo_tool')(mytool)
+    agent.tool(name='foo_tool')(my_tool)
     result = agent.run_sync('Hello')
     json_schema = json.loads(result.data)
     assert json_schema['name'] == 'foo_tool'


### PR DESCRIPTION
The `Tool` class supports a name parameter, but none of the function decorators did. So this adds the name parameter to the decorators and passes it through.

I'm unsure whether a change this small deserves unit tests of its own, or how you want said tests structured. So I just threw in a couple. But feel free to request changes on the subject (or change yourself).