### PR TITLE
Make it possible to override JSON schema generation for tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_pydantic.py
+++ b/pydantic_ai_slim/pydantic_ai/_pydantic.py
@@ -44,6 +44,7 @@ def function_schema(  # noqa: C901
     takes_ctx: bool,
     docstring_format: DocstringFormat,
     require_parameter_descriptions: bool,
+    schema_generator: type[GenerateJsonSchema],
 ) -> FunctionSchema:
     """Build a Pydantic validator and JSON schema from a tool function.
 
@@ -52,6 +53,7 @@ def function_schema(  # noqa: C901
         takes_ctx: Whether the function takes a `RunContext` first argument.
         docstring_format: The docstring format to use.
         require_parameter_descriptions: Whether to require descriptions for all tool function parameters.
+        schema_generator: The JSON schema generator class to use.
 
     Returns:
         A `FunctionSchema` instance.
@@ -150,13 +152,16 @@ def function_schema(  # noqa: C901
     )
     # PluggableSchemaValidator is api compatible with SchemaValidator
     schema_validator = cast(SchemaValidator, schema_validator)
-    json_schema = GenerateJsonSchema().generate(schema)
+    json_schema = schema_generator().generate(schema)
 
     # workaround for https://github.com/pydantic/pydantic/issues/10785
-    # if we build a custom TypeDict schema (matches when `single_arg_name is None`), we manually set
+    # if we build a custom TypedDict schema (matches when `single_arg_name is None`), we manually set
     # `additionalProperties` in the JSON Schema
     if single_arg_name is None:
-        json_schema['additionalProperties'] = bool(var_kwargs_schema)
+        if schema_generator is GenerateJsonSchema:
+            # If you are overriding the GenerateJsonSchema, you should handle this yourself
+            # TODO: It might make sense to instead use a custom subclass of GenerateJsonSchema that does this..
+            json_schema['additionalProperties'] = bool(var_kwargs_schema)
     elif not description:
         # if the tool description is not set, and we have a single parameter, take the description from that
         # and set it on the tool


### PR DESCRIPTION
In some cases you might want to have a bit more control over the generated JSON schema; see discussion in this thread https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1741204403143859.

I'll note there's a couple comments in the PR currently that should be considered before merging/not.