### PR TITLE
fix: ModuleNotFoundError for mypy_boto3_bedrock_runtime

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Generic, Literal, Union, cast, overload
 
 import anyio
 import anyio.to_thread
-from mypy_boto3_bedrock_runtime.type_defs import ImageBlockTypeDef
 from typing_extensions import ParamSpec, assert_never
 
 from pydantic_ai import _utils, result
@@ -50,6 +49,7 @@ if TYPE_CHECKING:
         MessageUnionTypeDef,
         ToolChoiceTypeDef,
         ToolTypeDef,
+        ImageBlockTypeDef,
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -45,11 +45,11 @@ if TYPE_CHECKING:
         ConverseResponseTypeDef,
         ConverseStreamMetadataEventTypeDef,
         ConverseStreamOutputTypeDef,
+        ImageBlockTypeDef,
         InferenceConfigurationTypeDef,
         MessageUnionTypeDef,
         ToolChoiceTypeDef,
         ToolTypeDef,
-        ImageBlockTypeDef,
     )
 
 


### PR DESCRIPTION
This causes `ModuleNotFoundError: No module named 'mypy_boto3_bedrock_runtime'` when `from pydantic_ai.models.bedrock import BedrockConverseModel`