### PR TITLE
InstrumentedModel and FallbackModel fixes

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -262,8 +262,11 @@ class Model(ABC):
 
     @property
     @abstractmethod
-    def system(self) -> str | None:
-        """The system / model provider, ex: openai."""
+    def system(self) -> str:
+        """The system / model provider, ex: openai.
+
+        Use to populate the `gen_ai.system` OpenTelemetry semantic convention attribute.
+        """
         raise NotImplementedError()
 
     @property

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -265,7 +265,10 @@ class Model(ABC):
     def system(self) -> str:
         """The system / model provider, ex: openai.
 
-        Use to populate the `gen_ai.system` OpenTelemetry semantic convention attribute.
+        Use to populate the `gen_ai.system` OpenTelemetry semantic convention attribute,
+        so should use well-known values listed in
+        https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/#gen-ai-system
+        when applicable.
         """
         raise NotImplementedError()
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -115,7 +115,7 @@ class AnthropicModel(Model):
     client: AsyncAnthropic = field(repr=False)
 
     _model_name: AnthropicModelName = field(repr=False)
-    _system: str | None = field(default='anthropic', repr=False)
+    _system: str = field(default='anthropic', repr=False)
 
     def __init__(
         self,
@@ -183,7 +183,7 @@ class AnthropicModel(Model):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         """The system / model provider."""
         return self._system
 

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -119,7 +119,7 @@ class BedrockConverseModel(Model):
     client: BedrockRuntimeClient
 
     _model_name: BedrockModelName = field(repr=False)
-    _system: str | None = field(default='bedrock', repr=False)
+    _system: str = field(default='bedrock', repr=False)
 
     @property
     def model_name(self) -> str:
@@ -127,7 +127,7 @@ class BedrockConverseModel(Model):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         """The system / model provider, ex: openai."""
         return self._system
 

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -98,7 +98,7 @@ class CohereModel(Model):
     client: AsyncClientV2 = field(repr=False)
 
     _model_name: CohereModelName = field(repr=False)
-    _system: str | None = field(default='cohere', repr=False)
+    _system: str = field(default='cohere', repr=False)
 
     def __init__(
         self,
@@ -148,7 +148,7 @@ class CohereModel(Model):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         """The system / model provider."""
         return self._system
 

--- a/pydantic_ai_slim/pydantic_ai/models/fallback.py
+++ b/pydantic_ai_slim/pydantic_ai/models/fallback.py
@@ -44,7 +44,6 @@ class FallbackModel(Model):
             fallback_on: A callable or tuple of exceptions that should trigger a fallback.
         """
         self.models = [infer_model(default_model), *[infer_model(m) for m in fallback_models]]
-        self._model_name = f'FallBackModel[{", ".join(model.model_name for model in self.models)}]'
 
         if isinstance(fallback_on, tuple):
             self._fallback_on = _default_fallback_condition_factory(fallback_on)
@@ -111,11 +110,11 @@ class FallbackModel(Model):
     @property
     def model_name(self) -> str:
         """The model name."""
-        return self._model_name
+        return f'fallback:{", ".join(model.model_name for model in self.models)}'
 
     @property
     def system(self) -> str:
-        return 'fallback'
+        return f'fallback:{", ".join(model.system for model in self.models)}'
 
     @property
     def base_url(self) -> str | None:

--- a/pydantic_ai_slim/pydantic_ai/models/fallback.py
+++ b/pydantic_ai_slim/pydantic_ai/models/fallback.py
@@ -104,9 +104,8 @@ class FallbackModel(Model):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
-        """The system / model provider, n/a for fallback models."""
-        return None
+    def system(self) -> str:
+        return 'fallback'
 
     @property
     def base_url(self) -> str | None:

--- a/pydantic_ai_slim/pydantic_ai/models/fallback.py
+++ b/pydantic_ai_slim/pydantic_ai/models/fallback.py
@@ -110,11 +110,11 @@ class FallbackModel(Model):
     @property
     def model_name(self) -> str:
         """The model name."""
-        return f'fallback:{", ".join(model.model_name for model in self.models)}'
+        return f'fallback:{",".join(model.model_name for model in self.models)}'
 
     @property
     def system(self) -> str:
-        return f'fallback:{", ".join(model.system for model in self.models)}'
+        return f'fallback:{",".join(model.system for model in self.models)}'
 
     @property
     def base_url(self) -> str | None:

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -45,7 +45,7 @@ class FunctionModel(Model):
     stream_function: StreamFunctionDef | None = None
 
     _model_name: str = field(repr=False)
-    _system: str | None = field(default=None, repr=False)
+    _system: str = field(default='function', repr=False)
 
     @overload
     def __init__(self, function: FunctionDef, *, model_name: str | None = None) -> None: ...
@@ -140,7 +140,7 @@ class FunctionModel(Model):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         """The system / model provider."""
         return self._system
 

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -91,7 +91,7 @@ class GeminiModel(Model):
     _provider: Literal['google-gla', 'google-vertex'] | Provider[AsyncHTTPClient] | None = field(repr=False)
     _auth: AuthProtocol | None = field(repr=False)
     _url: str | None = field(repr=False)
-    _system: str | None = field(default='google-gla', repr=False)
+    _system: str = field(default='gemini', repr=False)
 
     @overload
     def __init__(
@@ -197,7 +197,7 @@ class GeminiModel(Model):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         """The system / model provider."""
         return self._system
 

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -88,7 +88,7 @@ class GroqModel(Model):
     client: AsyncGroq = field(repr=False)
 
     _model_name: GroqModelName = field(repr=False)
-    _system: str | None = field(default='groq', repr=False)
+    _system: str = field(default='groq', repr=False)
 
     @overload
     def __init__(
@@ -186,7 +186,7 @@ class GroqModel(Model):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         """The system / model provider."""
         return self._system
 

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -175,11 +175,7 @@ class InstrumentedModel(WrapperModel):
                         )
                     )
                 new_attributes: dict[str, AttributeValue] = usage.opentelemetry_attributes()  # type: ignore
-                if model_used := getattr(response, 'model_used', None):
-                    # FallbackModel sets model_used on the response so that we can report the attributes
-                    # of the model that was actually used.
-                    new_attributes.update(self.model_attributes(model_used))
-                    attributes.update(new_attributes)
+                attributes.update(getattr(span, 'attributes', {}))
                 request_model = attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]
                 new_attributes['gen_ai.response.model'] = response.model_name or request_model
                 span.set_attributes(new_attributes)

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -213,10 +213,8 @@ class InstrumentedModel(WrapperModel):
 
     @staticmethod
     def model_attributes(model: Model):
-        system = getattr(model, 'system', '') or model.__class__.__name__.removesuffix('Model').lower()
-        system = {'google-gla': 'gemini', 'google-vertex': 'vertex_ai', 'mistral': 'mistral_ai'}.get(system, system)
         attributes: dict[str, AttributeValue] = {
-            GEN_AI_SYSTEM_ATTRIBUTE: system,
+            GEN_AI_SYSTEM_ATTRIBUTE: model.system,
             GEN_AI_REQUEST_MODEL_ATTRIBUTE: model.model_name,
         }
         if base_url := model.base_url:

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -110,7 +110,7 @@ class MistralModel(Model):
     json_mode_schema_prompt: str = """Answer in JSON Object, respect the format:\n```\n{schema}\n```\n"""
 
     _model_name: MistralModelName = field(repr=False)
-    _system: str | None = field(default='mistral', repr=False)
+    _system: str = field(default='mistral_ai', repr=False)
 
     def __init__(
         self,
@@ -179,7 +179,7 @@ class MistralModel(Model):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         """The system / model provider."""
         return self._system
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -108,6 +108,7 @@ class OpenAIModel(Model):
         *,
         provider: Literal['openai', 'deepseek', 'azure'] | Provider[AsyncOpenAI] = 'openai',
         system_prompt_role: OpenAISystemPromptRole | None = None,
+        system: str = 'openai',
     ) -> None: ...
 
     @deprecated('Use the `provider` parameter instead of `base_url`, `api_key`, `openai_client` and `http_client`.')
@@ -122,6 +123,7 @@ class OpenAIModel(Model):
         openai_client: AsyncOpenAI | None = None,
         http_client: AsyncHTTPClient | None = None,
         system_prompt_role: OpenAISystemPromptRole | None = None,
+        system: str = 'openai',
     ) -> None: ...
 
     def __init__(
@@ -134,6 +136,7 @@ class OpenAIModel(Model):
         openai_client: AsyncOpenAI | None = None,
         http_client: AsyncHTTPClient | None = None,
         system_prompt_role: OpenAISystemPromptRole | None = None,
+        system: str = 'openai',
     ):
         """Initialize an OpenAI model.
 
@@ -152,6 +155,8 @@ class OpenAIModel(Model):
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
             system_prompt_role: The role to use for the system prompt message. If not provided, defaults to `'system'`.
                 In the future, this may be inferred from the model name.
+            system: The model provider used, defaults to `openai`. This is for observability purposes, you must
+                customize the `base_url` and `api_key` to use a different provider.
         """
         self._model_name = model_name
 
@@ -181,6 +186,7 @@ class OpenAIModel(Model):
             else:
                 self.client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=cached_async_http_client())
         self.system_prompt_role = system_prompt_role
+        self._system = system
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -99,7 +99,7 @@ class OpenAIModel(Model):
     system_prompt_role: OpenAISystemPromptRole | None = field(default=None)
 
     _model_name: OpenAIModelName = field(repr=False)
-    _system: str | None = field(repr=False)
+    _system: str = field(repr=False)
 
     @overload
     def __init__(
@@ -108,7 +108,6 @@ class OpenAIModel(Model):
         *,
         provider: Literal['openai', 'deepseek', 'azure'] | Provider[AsyncOpenAI] = 'openai',
         system_prompt_role: OpenAISystemPromptRole | None = None,
-        system: str | None = 'openai',
     ) -> None: ...
 
     @deprecated('Use the `provider` parameter instead of `base_url`, `api_key`, `openai_client` and `http_client`.')
@@ -123,7 +122,6 @@ class OpenAIModel(Model):
         openai_client: AsyncOpenAI | None = None,
         http_client: AsyncHTTPClient | None = None,
         system_prompt_role: OpenAISystemPromptRole | None = None,
-        system: str | None = 'openai',
     ) -> None: ...
 
     def __init__(
@@ -136,7 +134,6 @@ class OpenAIModel(Model):
         openai_client: AsyncOpenAI | None = None,
         http_client: AsyncHTTPClient | None = None,
         system_prompt_role: OpenAISystemPromptRole | None = None,
-        system: str | None = 'openai',
     ):
         """Initialize an OpenAI model.
 
@@ -155,8 +152,6 @@ class OpenAIModel(Model):
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
             system_prompt_role: The role to use for the system prompt message. If not provided, defaults to `'system'`.
                 In the future, this may be inferred from the model name.
-            system: The model provider used, defaults to `openai`. This is for observability purposes, you must
-                customize the `base_url` and `api_key` to use a different provider.
         """
         self._model_name = model_name
 
@@ -186,7 +181,6 @@ class OpenAIModel(Model):
             else:
                 self.client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=cached_async_http_client())
         self.system_prompt_role = system_prompt_role
-        self._system = system
 
     @property
     def base_url(self) -> str:
@@ -224,7 +218,7 @@ class OpenAIModel(Model):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         """The system / model provider."""
         return self._system
 

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -79,7 +79,7 @@ class TestModel(Model):
     This is set when a request is made, so will reflect the function tools from the last step of the last run.
     """
     _model_name: str = field(default='test', repr=False)
-    _system: str | None = field(default=None, repr=False)
+    _system: str = field(default='test', repr=False)
 
     async def request(
         self,
@@ -113,7 +113,7 @@ class TestModel(Model):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         """The system / model provider."""
         return self._system
 

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -69,7 +69,7 @@ class VertexAIModel(GeminiModel):
     url_template: str
 
     _model_name: GeminiModelName = field(repr=False)
-    _system: str | None = field(default='google-vertex', repr=False)
+    _system: str = field(default='vertex_ai', repr=False)
 
     # TODO __init__ can be removed once we drop 3.9 and we can set kw_only correctly on the dataclass
     def __init__(
@@ -175,7 +175,7 @@ class VertexAIModel(GeminiModel):
         return self._model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         """The system / model provider."""
         return self._system
 

--- a/pydantic_ai_slim/pydantic_ai/models/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/models/wrapper.py
@@ -38,7 +38,7 @@ class WrapperModel(Model):
         return self.wrapped.model_name
 
     @property
-    def system(self) -> str | None:
+    def system(self) -> str:
         return self.wrapped.system
 
     def __getattr__(self, item: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,17 +45,6 @@ else:
         return _IsNow(*args, **kwargs)
 
 
-try:
-    from logfire.testing import CaptureLogfire
-except ImportError:
-    pass
-else:
-
-    @pytest.fixture(autouse=True)
-    def logfire_disable(capfire: CaptureLogfire):
-        pass
-
-
 class TestEnv:
     __test__ = False
 

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -44,7 +44,7 @@ def test_init() -> None:
     assert fallback_model.model_name == snapshot(
         'FallBackModel[function:failure_response:, function:success_response:]'
     )
-    assert fallback_model.system is None
+    assert fallback_model.system == 'fallback'
     assert fallback_model.base_url is None
 
 

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -41,10 +41,8 @@ failure_model = FunctionModel(failure_response)
 
 def test_init() -> None:
     fallback_model = FallbackModel(failure_model, success_model)
-    assert fallback_model.model_name == snapshot(
-        'FallBackModel[function:failure_response:, function:success_response:]'
-    )
-    assert fallback_model.system == 'fallback'
+    assert fallback_model.model_name == snapshot('fallback:function:failure_response:,function:success_response:')
+    assert fallback_model.system == 'fallback:function,function'
     assert fallback_model.base_url is None
 
 
@@ -139,7 +137,7 @@ def test_first_failed_instrumented(capfire: CaptureLogfire) -> None:
                 'attributes': {
                     'gen_ai.operation.name': 'chat',
                     'logfire.span_type': 'span',
-                    'logfire.msg': 'chat FallBackModel[function:failure_response:, function:success_response:]',
+                    'logfire.msg': 'chat fallback:function:failure_response:,function:success_response:',
                     'gen_ai.usage.input_tokens': 51,
                     'gen_ai.usage.output_tokens': 1,
                     'gen_ai.system': 'function',
@@ -172,7 +170,7 @@ def test_first_failed_instrumented(capfire: CaptureLogfire) -> None:
                 'start_time': 1000000000,
                 'end_time': 6000000000,
                 'attributes': {
-                    'model_name': 'FallBackModel[function:failure_response:, function:success_response:]',
+                    'model_name': 'fallback:function:failure_response:,function:success_response:',
                     'agent_name': 'agent',
                     'logfire.msg': 'agent run',
                     'logfire.span_type': 'span',

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -57,7 +57,7 @@ TEST_CASES = [
         'MISTRAL_API_KEY',
         'mistral:mistral-small-latest',
         'mistral-small-latest',
-        'mistral',
+        'mistral_ai',
         'mistral',
         'MistralModel',
     ),

--- a/tests/models/test_vertexai.py
+++ b/tests/models/test_vertexai.py
@@ -44,7 +44,7 @@ async def test_init_service_account(tmp_path: Path, allow_model_requests: None):
     )
     assert model.auth is not None
     assert model.model_name == snapshot('gemini-1.5-flash')
-    assert model.system == snapshot('google-vertex')
+    assert model.system == snapshot('vertex_ai')
 
 
 class NoOpCredentials:
@@ -72,7 +72,7 @@ async def test_init_env(mocker: MockerFixture, allow_model_requests: None):
     )
     assert model.auth is not None
     assert model.model_name == snapshot('gemini-1.5-flash')
-    assert model.system == snapshot('google-vertex')
+    assert model.system == snapshot('vertex_ai')
 
     await model.ainit()
     assert model.base_url is not None


### PR DESCRIPTION
- Fixes `TypeError: cannot pickle '_thread.RLock' object` error reported in https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1741909209116159 by no longer setting `model_used` on `ModelResponse`.
- Makes `Model.system` non-optional, because `gen_ai.system` is an important attribute and OTel doesn't support null attribute values.
- Ensures that `Model.system` directly returns value used for `gen_ai.system` to help with https://github.com/pydantic/pydantic-ai/pull/1076#discussion_r1985236799. @Kludex we still need to do something about bedrock, azure, and maybe others, but I've stuffed too much in here already.