### PR TITLE
docs: Remove note about default event_mode changing

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -151,7 +151,7 @@ agent = Agent('openai:gpt-4o', instrument=instrumentation_settings)
 Agent.instrument_all(instrumentation_settings)
 ```
 
-For now, this won't look as good in the Logfire UI, but we're working on it. **Once the UI supports it, `event_mode='logs'` will become the default.**
+For now, this won't look as good in the Logfire UI, but we're working on it.
 
 If you have very long conversations, the `events` span attribute may be truncated. Using `event_mode='logs'` will help avoid this issue.
 


### PR DESCRIPTION
Based on https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1741904598954169?thread_ts=1741900243.954299&cid=C083V7PMHHA

It's become less clear if the default will actually change, and it's probably best not to push people in that direction prematurely.