### PR TITLE
feat: add timestamp field to SystemPromptPart class for consistency

### DIFF
--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -45,6 +45,7 @@ print(result.all_messages())
             SystemPromptPart(
                 content='Be a helpful assistant.',
                 dynamic_ref=None,
+                timestamp=datetime.datetime(...),
                 part_kind='system-prompt',
             ),
             UserPromptPart(
@@ -90,6 +91,7 @@ async def main():
                     SystemPromptPart(
                         content='Be a helpful assistant.',
                         dynamic_ref=None,
+                        timestamp=datetime.datetime(...),
                         part_kind='system-prompt',
                     ),
                     UserPromptPart(
@@ -119,6 +121,7 @@ async def main():
                     SystemPromptPart(
                         content='Be a helpful assistant.',
                         dynamic_ref=None,
+                        timestamp=datetime.datetime(...),
                         part_kind='system-prompt',
                     ),
                     UserPromptPart(
@@ -176,6 +179,7 @@ print(result2.all_messages())
             SystemPromptPart(
                 content='Be a helpful assistant.',
                 dynamic_ref=None,
+                timestamp=datetime.datetime(...),
                 part_kind='system-prompt',
             ),
             UserPromptPart(
@@ -301,6 +305,7 @@ print(result2.all_messages())
             SystemPromptPart(
                 content='Be a helpful assistant.',
                 dynamic_ref=None,
+                timestamp=datetime.datetime(...),
                 part_kind='system-prompt',
             ),
             UserPromptPart(

--- a/docs/testing-evals.md
+++ b/docs/testing-evals.md
@@ -130,6 +130,7 @@ async def test_forecast():
             parts=[
                 SystemPromptPart(
                     content='Providing a weather forecast at the locations the user provides.',
+                    timestamp=IsNow(tz=timezone.utc),
                 ),
                 UserPromptPart(
                     content='What will the weather be like in London on 2024-11-28?',

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -73,6 +73,7 @@ print(dice_result.all_messages())
             SystemPromptPart(
                 content="You're a dice game, you should roll the die and see if the number you get back matches the user's guess. If so, tell them they're a winner. Use the player's name in the response.",
                 dynamic_ref=None,
+                timestamp=datetime.datetime(...),
                 part_kind='system-prompt',
             ),
             UserPromptPart(

--- a/mcp-run-python/src/prepare_env.py
+++ b/mcp-run-python/src/prepare_env.py
@@ -64,7 +64,7 @@ async def prepare_env(files: list[File]) -> Success | Error:
 
         with _micropip_logging() as logs_filename:
             try:
-                await micropip.install(dependencies, keep_going=True)
+                await micropip.install(dependencies, keep_going=True)  # type: ignore
                 importlib.invalidate_caches()
             except Exception:
                 with open(logs_filename) as f:
@@ -126,9 +126,9 @@ def _add_extra_dependencies(dependencies: list[str]) -> list[str]:
 
 @contextmanager
 def _micropip_logging() -> Iterator[str]:
-    from micropip import logging as micropip_logging
+    from micropip import logging as micropip_logging  # type: ignore
 
-    micropip_logging.setup_logging()
+    micropip_logging.setup_logging()  # type: ignore
     logger = logging.getLogger('micropip')
     logger.handlers.clear()
     logger.setLevel(logging.INFO)

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -32,6 +32,9 @@ class SystemPromptPart:
     Only set if system prompt is dynamic, see [`system_prompt`][pydantic_ai.Agent.system_prompt] for more information.
     """
 
+    timestamp: datetime = field(default_factory=_now_utc)
+    """The timestamp of the prompt."""
+
     part_kind: Literal['system-prompt'] = 'system-prompt'
     """Part type identifier, this is available on all parts as a discriminator."""
 

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -254,7 +254,7 @@ async def test_request_tool_call(allow_model_requests: None):
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='this is the system prompt'),
+                    SystemPromptPart(content='this is the system prompt', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -73,7 +73,7 @@ async def test_bedrock_model(allow_model_requests: None, bedrock_provider: Bedro
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='You are a chatbot.'),
+                    SystemPromptPart(content='You are a chatbot.', timestamp=IsDatetime()),
                     UserPromptPart(
                         content='Hello!',
                         timestamp=IsDatetime(),
@@ -122,7 +122,7 @@ async def test_bedrock_model_structured_response(allow_model_requests: None, bed
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='You are a helpful chatbot.'),
+                    SystemPromptPart(content='You are a helpful chatbot.', timestamp=IsDatetime()),
                     UserPromptPart(
                         content='What was the temperature in London 1st January 2022?',
                         timestamp=IsDatetime(),
@@ -242,7 +242,10 @@ async def test_bedrock_model_retry(allow_model_requests: None, bedrock_provider:
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='You are a helpful chatbot.'),
+                    SystemPromptPart(
+                        content='You are a helpful chatbot.',
+                        timestamp=IsDatetime(),
+                    ),
                     UserPromptPart(
                         content='What is the capital of France?',
                         timestamp=IsDatetime(),

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -259,7 +259,7 @@ async def test_request_tool_call(allow_model_requests: None):
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='this is the system prompt'),
+                    SystemPromptPart(content='this is the system prompt', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -559,7 +559,7 @@ async def test_request_tool_call(get_gemini_client: GetGeminiClient):
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='this is the system prompt'),
+                    SystemPromptPart(content='this is the system prompt', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -273,7 +273,7 @@ async def test_request_tool_call(allow_model_requests: None):
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='this is the system prompt'),
+                    SystemPromptPart(content='this is the system prompt', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -504,7 +504,7 @@ async def test_request_result_type_with_arguments_str_response(allow_model_reque
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='System prompt value'),
+                    SystemPromptPart(content='System prompt value', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='User prompt value', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),
@@ -1070,7 +1070,7 @@ async def test_request_tool_call(allow_model_requests: None):
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='this is the system prompt'),
+                    SystemPromptPart(content='this is the system prompt', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),
@@ -1207,7 +1207,7 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='this is the system prompt'),
+                    SystemPromptPart(content='this is the system prompt', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),
@@ -1347,7 +1347,7 @@ async def test_stream_tool_call_with_return_type(allow_model_requests: None):
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='this is the system prompt'),
+                    SystemPromptPart(content='this is the system prompt', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='User prompt value', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),
@@ -1447,7 +1447,7 @@ async def test_stream_tool_call(allow_model_requests: None):
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='this is the system prompt'),
+                    SystemPromptPart(content='this is the system prompt', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='User prompt value', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),
@@ -1550,7 +1550,7 @@ async def test_stream_tool_call_with_retry(allow_model_requests: None):
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='this is the system prompt'),
+                    SystemPromptPart(content='this is the system prompt', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='User prompt value', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -339,7 +339,7 @@ def test_call_all():
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='foobar'),
+                    SystemPromptPart(content='foobar', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -322,7 +322,7 @@ async def test_request_tool_call(allow_model_requests: None):
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='this is the system prompt'),
+                    SystemPromptPart(content='this is the system prompt', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -514,7 +514,7 @@ def test_run_with_history_new():
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='Foobar'),
+                    SystemPromptPart(content='Foobar', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),
@@ -538,7 +538,7 @@ def test_run_with_history_new():
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='Foobar'),
+                    SystemPromptPart(content='Foobar', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),
@@ -586,7 +586,7 @@ def test_run_with_history_new():
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='Foobar'),
+                    SystemPromptPart(content='Foobar', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),
@@ -632,7 +632,7 @@ def test_run_with_history_new_structured():
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='Foobar'),
+                    SystemPromptPart(content='Foobar', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ]
             ),
@@ -670,7 +670,7 @@ def test_run_with_history_new_structured():
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='Foobar'),
+                    SystemPromptPart(content='Foobar', timestamp=IsNow(tz=timezone.utc)),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
                 ],
             ),
@@ -1374,8 +1374,10 @@ def test_dynamic_false_no_reevaluate():
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='Foobar', part_kind='system-prompt'),
-                    SystemPromptPart(content=dynamic_value, part_kind='system-prompt'),
+                    SystemPromptPart(content='Foobar', part_kind='system-prompt', timestamp=IsNow(tz=timezone.utc)),
+                    SystemPromptPart(
+                        content=dynamic_value, part_kind='system-prompt', timestamp=IsNow(tz=timezone.utc)
+                    ),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc), part_kind='user-prompt'),
                 ],
                 kind='request',
@@ -1397,10 +1399,11 @@ def test_dynamic_false_no_reevaluate():
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='Foobar', part_kind='system-prompt'),
+                    SystemPromptPart(content='Foobar', part_kind='system-prompt', timestamp=IsNow(tz=timezone.utc)),
                     SystemPromptPart(
                         content='A',  # Remains the same
                         part_kind='system-prompt',
+                        timestamp=IsNow(tz=timezone.utc),
                     ),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc), part_kind='user-prompt'),
                 ],
@@ -1446,11 +1449,12 @@ def test_dynamic_true_reevaluate_system_prompt():
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='Foobar', part_kind='system-prompt'),
+                    SystemPromptPart(content='Foobar', part_kind='system-prompt', timestamp=IsNow(tz=timezone.utc)),
                     SystemPromptPart(
                         content=dynamic_value,
                         part_kind='system-prompt',
                         dynamic_ref=func.__qualname__,
+                        timestamp=IsNow(tz=timezone.utc),
                     ),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc), part_kind='user-prompt'),
                 ],
@@ -1473,11 +1477,12 @@ def test_dynamic_true_reevaluate_system_prompt():
         [
             ModelRequest(
                 parts=[
-                    SystemPromptPart(content='Foobar', part_kind='system-prompt'),
+                    SystemPromptPart(content='Foobar', part_kind='system-prompt', timestamp=IsNow(tz=timezone.utc)),
                     SystemPromptPart(
                         content='B',
                         part_kind='system-prompt',
                         dynamic_ref=func.__qualname__,
+                        timestamp=IsNow(tz=timezone.utc),
                     ),
                     UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc), part_kind='user-prompt'),
                 ],


### PR DESCRIPTION
## Summary
This pull request adds a `timestamp` field to the `SystemPromptPart` class in the `messages.py` file to ensure consistency with other part types in the `ModelRequestPart` hierarchy. This ensures that all parts maintain an immutable timestamped sequence for chat history.

It solves this #1145 

## Changes
- Added `timestamp` field to `SystemPromptPart` class:
  ```python
  timestamp: datetime = field(default_factory=_now_utc)
  """The timestamp of the prompt."""
  ```
- Ensured the timestamp field uses the same `_now_utc` default factory method used in other part classes like `UserPromptPart`, `ToolReturnPart`, and `RetryPromptPart`.
