### PR TITLE
change api_key check flow

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/groq.py
@@ -72,4 +72,6 @@ class GroqProvider(Provider[AsyncGroq]):
             elif http_client is not None:
                 self._client = AsyncGroq(base_url=self.base_url, api_key=api_key, http_client=http_client)
             else:
-                self._client = AsyncGroq(base_url=self.base_url, api_key=api_key, http_client=cached_async_http_client())
+                self._client = AsyncGroq(
+                    base_url=self.base_url, api_key=api_key, http_client=cached_async_http_client()
+                )

--- a/pydantic_ai_slim/pydantic_ai/providers/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/groq.py
@@ -57,17 +57,19 @@ class GroqProvider(Provider[AsyncGroq]):
                 client to use. If provided, `api_key` and `http_client` must be `None`.
             http_client: An existing `AsyncHTTPClient` to use for making HTTP requests.
         """
-        api_key = api_key or os.environ.get('GROQ_API_KEY')
-
-        if api_key is None and groq_client is None:
-            raise ValueError(
-                'Set the `GROQ_API_KEY` environment variable or pass it via `GroqProvider(api_key=...)`'
-                'to use the Groq provider.'
-            )
-
         if groq_client is not None:
+            assert http_client is None, 'Cannot provide both `groq_client` and `http_client`'
+            assert api_key is None, 'Cannot provide both `groq_client` and `api_key`'
             self._client = groq_client
-        elif http_client is not None:
-            self._client = AsyncGroq(base_url=self.base_url, api_key=api_key, http_client=http_client)
         else:
-            self._client = AsyncGroq(base_url=self.base_url, api_key=api_key, http_client=cached_async_http_client())
+            api_key = api_key or os.environ.get('GROQ_API_KEY')
+
+            if api_key is None:
+                raise ValueError(
+                    'Set the `GROQ_API_KEY` environment variable or pass it via `GroqProvider(api_key=...)`'
+                    'to use the Groq provider.'
+                )
+            elif http_client is not None:
+                self._client = AsyncGroq(base_url=self.base_url, api_key=api_key, http_client=http_client)
+            else:
+                self._client = AsyncGroq(base_url=self.base_url, api_key=api_key, http_client=cached_async_http_client())

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -55,19 +55,19 @@ class MistralProvider(Provider[Mistral]):
             mistral_client: An existing `Mistral` client to use, if provided, `api_key` and `http_client` must be `None`.
             http_client: An existing async client to use for making HTTP requests.
         """
-        api_key = api_key or os.environ.get('MISTRAL_API_KEY')
-
-        if api_key is None and mistral_client is None:
-            raise ValueError(
-                'Set the `MISTRAL_API_KEY` environment variable or pass it via `MistralProvider(api_key=...)`'
-                'to use the Mistral provider.'
-            )
-
         if mistral_client is not None:
             assert http_client is None, 'Cannot provide both `mistral_client` and `http_client`'
             assert api_key is None, 'Cannot provide both `mistral_client` and `api_key`'
             self._client = mistral_client
-        elif http_client is not None:
-            self._client = Mistral(api_key=api_key, async_client=http_client)
         else:
-            self._client = Mistral(api_key=api_key, async_client=cached_async_http_client())
+            api_key = api_key or os.environ.get('MISTRAL_API_KEY')
+
+            if api_key is None:
+                raise ValueError(
+                    'Set the `MISTRAL_API_KEY` environment variable or pass it via `MistralProvider(api_key=...)`'
+                    'to use the Mistral provider.'
+                )
+            elif http_client is not None:
+                self._client = Mistral(api_key=api_key, async_client=http_client)
+            else:
+                self._client = Mistral(api_key=api_key, async_client=cached_async_http_client())


### PR DESCRIPTION
This changes both Groq and Mistral api_key logic to follow the pattern used in Anthropic: `api_key` cannot be used together with a client, but it is okay to have them in the environment.