### PR TITLE
(Temporarily) disable type checking for mcp-run-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ reportMissingTypeStubs = false
 reportUnnecessaryIsInstance = false
 reportUnnecessaryTypeIgnoreComment = true
 reportMissingModuleSource = false
-include = ["pydantic_ai_slim", "mcp-run-python", "pydantic_graph", "tests", "examples"]
+include = ["pydantic_ai_slim", "pydantic_graph", "tests", "examples"]
 venvPath = ".venv"
 # see https://github.com/microsoft/pyright/issues/7771 - we don't want to error on decorated functions in tests
 # which are not otherwise used


### PR DESCRIPTION
Doing this because right now if you run `make install  && make typecheck` you get:
```
PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright
pydantic-ai/mcp-run-python/src/prepare_env.py
  pydantic-ai/mcp-run-python/src/prepare_env.py:20:8 - error: Import "micropip" could not be resolved (reportMissingImports)
  pydantic-ai/mcp-run-python/src/prepare_env.py:67:23 - error: Type of "install" is unknown (reportUnknownMemberType)
  pydantic-ai/mcp-run-python/src/prepare_env.py:129:10 - error: Import "micropip" could not be resolved (reportMissingImports)
  pydantic-ai/mcp-run-python/src/prepare_env.py:129:37 - error: Type of "micropip_logging" is unknown (reportUnknownVariableType)
  pydantic-ai/mcp-run-python/src/prepare_env.py:131:5 - error: Type of "setup_logging" is unknown (reportUnknownMemberType)
5 errors, 0 warnings, 0 informations 
make: *** [typecheck-pyright] Error 1
```

@samuelcolvin I'm not sure how you want to handle type-checking for this or why it's working in CI but not locally (it looks like we don't run pyright in CI? And I guess mypy doesn't care? Not sure what's going on there.)

I am just disabling this for now because I'm not sure what exactly makes sense here, but we should reenable it soon.