### PR TITLE
add `user` mapping in openai chat completion

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -288,6 +288,7 @@ class OpenAIModel(Model):
                 frequency_penalty=model_settings.get('frequency_penalty', NOT_GIVEN),
                 logit_bias=model_settings.get('logit_bias', NOT_GIVEN),
                 reasoning_effort=model_settings.get('openai_reasoning_effort', NOT_GIVEN),
+                user=model_settings.get('user', NOT_GIVEN)
             )
         except APIStatusError as e:
             if (status_code := e.status_code) >= 400:


### PR DESCRIPTION
Added the fix as documented in issue :
https://github.com/pydantic/pydantic-ai/issues/1156

This pull request includes a small change to the `pydantic_ai_slim/pydantic_ai/models/openai.py` file. The change adds a new parameter to the `_completions_create` method to include the `user` setting from `model_settings`.

* [`pydantic_ai_slim/pydantic_ai/models/openai.py`](diffhunk://#diff-b1c6daf2aed6a2c661aefda51026b68403994823f2d401706e2ebe99b48b75fbR291): Added the `user` parameter to the `_completions_create` method to include it in the model settings.

Following the changes we can pass on the `user` field as part of model setting and pass the model setting in the agent 

Example : 

```python
openai_model_settings = OpenAIModelSettings()
openai_model_settings["user"] = current_user

result = agent.run_sync(user_prompt='<USER PROMPT>',
                        model_settings=openai_model_settings,)
```

