### PR TITLE
fix: docs: replace single-quotes with double quotes for Windows compatility

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ PydanticAI has an excellent (but completely optional) integration with [Pydantic
 To use Logfire with PydanticAI, install `pydantic-ai` or `pydantic-ai-slim` with the `logfire` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai[logfire]'
+pip/uv-add "pydantic-ai[logfire]"
 ```
 
 From there, follow the [Logfire setup docs](logfire.md#using-logfire) to configure Logfire.
@@ -30,7 +30,7 @@ We distribute the [`pydantic_ai_examples`](https://github.com/pydantic/pydantic-
 To install examples, use the `examples` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai[examples]'
+pip/uv-add "pydantic-ai[examples]"
 ```
 
 To run the examples, follow instructions in the [examples docs](examples/index.md).
@@ -41,7 +41,7 @@ If you know which model you're going to use and want to avoid installing superfl
 For example, if you're using just [`OpenAIModel`][pydantic_ai.models.openai.OpenAIModel], you would run:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[openai]'
+pip/uv-add "pydantic-ai-slim[openai]"
 ```
 
 `pydantic-ai-slim` has the following optional groups:
@@ -61,5 +61,5 @@ See the [models](models.md) documentation for information on which optional depe
 You can also install dependencies for multiple models and use cases, for example:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[openai,vertexai,logfire]'
+pip/uv-add "pydantic-ai-slim[openai,vertexai,logfire]"
 ```


### PR DESCRIPTION
Ubuntu is indifferent whether we run `uv add 'pydantic-ai[option]' `or `"uv add 'pydantic-ai[option]"`, but Windows errors with this message:

```
error: Failed to parse: `'pydantic-ai[logfire]'`
  Caused by: Expected package name starting with an alphanumeric character, found `'`
'pydantic-ai[logfire]'
```

I'm on Windows 11 Version 24H2, x64 based-processor 
Using uv 0.6.6 (c1a0bb85e 2025-03-12) and python 3.12.9
If this is merged, here are other files that I can update: https://github.com/search?q=repo%3Apydantic%2Fpydantic-ai+path%3A%2F%5Edocs%5C%2F%2F+%27pydantic-ai&type=code