### PR TITLE
Document `InstrumentedModel`

### DIFF
--- a/docs/api/models/instrumented.md
+++ b/docs/api/models/instrumented.md
@@ -1,0 +1,3 @@
+# pydantic_ai.models.instrumented
+
+::: pydantic_ai.models.instrumented

--- a/docs/api/models/wrapper.md
+++ b/docs/api/models/wrapper.md
@@ -1,0 +1,3 @@
+# pydantic_ai.models.wrapper
+
+::: pydantic_ai.models.wrapper

--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -172,3 +172,14 @@ instrumentation_settings = InstrumentationSettings(
     event_logger_provider=EventLoggerProvider(),
 )
 ```
+
+## Instrumenting a specific `Model`
+
+```python {title="instrumented_model_example.py"}
+from pydantic_ai.models.instrumented import InstrumentedModel, InstrumentationSettings
+from pydantic_ai import Agent
+
+settings = InstrumentationSettings()
+model = InstrumentedModel('gpt-4o', settings)
+agent = Agent(model)
+```

--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -159,7 +159,7 @@ Note that the OpenTelemetry Semantic Conventions are still experimental and are 
 
 ## Setting OpenTelemetry SDK providers
 
-By default, the global `TracerProvider` and `EventLoggerProvider` are used. These are set automatically by `logfire.configure()`. They can also be set by the `set_tracer_provider` and `set_event_logger_provider` functions in the OpenTelemetry Python SDK. You can set custom providers with `InstrumentationSettings`:
+By default, the global `TracerProvider` and `EventLoggerProvider` are used. These are set automatically by `logfire.configure()`. They can also be set by the `set_tracer_provider` and `set_event_logger_provider` functions in the OpenTelemetry Python SDK. You can set custom providers with [`InstrumentationSettings`][pydantic_ai.models.instrumented.InstrumentationSettings].
 
 ```python {title="instrumentation_settings_providers.py"}
 from opentelemetry.sdk._events import EventLoggerProvider

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,10 +65,12 @@ nav:
       - api/models/gemini.md
       - api/models/vertexai.md
       - api/models/groq.md
+      - api/models/instrumented.md
       - api/models/mistral.md
       - api/models/test.md
       - api/models/function.md
       - api/models/fallback.md
+      - api/models/wrapper.md
       - api/providers.md
       - api/pydantic_graph/graph.md
       - api/pydantic_graph/nodes.md

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -195,6 +195,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
                 If this isn't set, then the last value set by
                 [`Agent.instrument_all()`][pydantic_ai.Agent.instrument_all]
                 will be used, which defaults to False.
+                See the [Debugging and Monitoring guide](https://ai.pydantic.dev/logfire/) for more info.
         """
         if model is None or defer_model_check:
             self.model = model

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -445,7 +445,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         usage_limits = usage_limits or _usage.UsageLimits()
 
         if isinstance(model_used, InstrumentedModel):
-            tracer = model_used.options.tracer
+            tracer = model_used.settings.tracer
         else:
             tracer = NoOpTracer()
         agent_name = self.name or 'agent'

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -52,7 +52,7 @@ class InstrumentationSettings:
 
     - `Agent(instrument=...)`
     - [`Agent.instrument_all()`][pydantic_ai.agent.Agent.instrument_all]
-    - `InstrumentedModel`
+    - [`InstrumentedModel`][pydantic_ai.models.instrumented.InstrumentedModel]
     """
 
     tracer: Tracer = field(repr=False)

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -53,6 +53,8 @@ class InstrumentationSettings:
     - `Agent(instrument=...)`
     - [`Agent.instrument_all()`][pydantic_ai.agent.Agent.instrument_all]
     - [`InstrumentedModel`][pydantic_ai.models.instrumented.InstrumentedModel]
+
+    See the [Debugging and Monitoring guide](https://ai.pydantic.dev/logfire/) for more info.
     """
 
     tracer: Tracer = field(repr=False)
@@ -94,7 +96,10 @@ GEN_AI_REQUEST_MODEL_ATTRIBUTE = 'gen_ai.request.model'
 
 @dataclass
 class InstrumentedModel(WrapperModel):
-    """Model which wraps another model so that requests are instrumented with OpenTelemetry."""
+    """Model which wraps another model so that requests are instrumented with OpenTelemetry.
+
+    See the [Debugging and Monitoring guide](https://ai.pydantic.dev/logfire/) for more info.
+    """
 
     settings: InstrumentationSettings
     """Configuration for instrumenting requests."""

--- a/pydantic_ai_slim/pydantic_ai/models/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/models/wrapper.py
@@ -13,9 +13,13 @@ from . import KnownModelName, Model, ModelRequestParameters, StreamedResponse, i
 
 @dataclass(init=False)
 class WrapperModel(Model):
-    """Model which wraps another model."""
+    """Model which wraps another model.
+
+    Does nothing on its own, used as a base class.
+    """
 
     wrapped: Model
+    """The underlying model being wrapped."""
 
     def __init__(self, wrapped: Model | KnownModelName):
         self.wrapped = infer_model(wrapped)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -230,14 +230,14 @@ def test_instrument_all():
     m = get_model()
     assert isinstance(m, InstrumentedModel)
     assert m.wrapped is model
-    assert m.options.event_mode == InstrumentationSettings().event_mode
+    assert m.settings.event_mode == InstrumentationSettings().event_mode
 
     options = InstrumentationSettings(event_mode='logs')
     Agent.instrument_all(options)
     m = get_model()
     assert isinstance(m, InstrumentedModel)
     assert m.wrapped is model
-    assert m.options is options
+    assert m.settings is options
 
     Agent.instrument_all(False)
     assert get_model() is model


### PR DESCRIPTION
and other related refinements to docs.

Also renames `InstrumentedModel.options` to `settings` to match the type name.

Closes https://github.com/pydantic/pydantic-ai/issues/1070