### PR TITLE
fix: replace single-quotes with double quotes in install command for Windows compatility

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,7 +13,7 @@ To use the CLI, you need to either install [`pydantic-ai`](install.md), or insta
 [`pydantic-ai-slim`](install.md#slim-install) with the `cli` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai[cli]'
+pip/uv-add "pydantic-ai[cli]"
 ```
 
 To enable command-line argument autocompletion, run:

--- a/docs/common_tools.md
+++ b/docs/common_tools.md
@@ -13,7 +13,7 @@ To use [`duckduckgo_search_tool`][pydantic_ai.common_tools.duckduckgo.duckduckgo
 [`pydantic-ai-slim`](install.md#slim-install) with the `duckduckgo` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[duckduckgo]'
+pip/uv-add "pydantic-ai-slim[duckduckgo]"
 ```
 
 ### Usage
@@ -96,7 +96,7 @@ To use [`tavily_search_tool`][pydantic_ai.common_tools.tavily.tavily_search_tool
 [`pydantic-ai-slim`](install.md#slim-install) with the `tavily` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[tavily]'
+pip/uv-add "pydantic-ai-slim[tavily]"
 ```
 
 ### Usage

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -13,7 +13,7 @@ Either way you'll need to install extra dependencies to run some examples, you j
 If you've installed `pydantic-ai` via pip/uv, you can install the extra dependencies with:
 
 ```bash
-pip/uv-add 'pydantic-ai[examples]'
+pip/uv-add "pydantic-ai[examples]"
 ```
 
 If you clone the repo, you should instead use `uv sync --extra examples` to install extra dependencies.
@@ -54,7 +54,7 @@ If you like one-liners and you're using uv, you can run a pydantic-ai example wi
 
 ```bash
 OPENAI_API_KEY='your-api-key' \
-  uv run --with 'pydantic-ai[examples]' \
+  uv run --with "pydantic-ai[examples]" \
   -m pydantic_ai_examples.pydantic_model
 ```
 

--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -32,7 +32,7 @@ Here's an example showing details of running the [Weather Agent](examples/weathe
 To use logfire, you'll need a logfire [account](https://logfire.pydantic.dev), and logfire installed:
 
 ```bash
-pip/uv-add 'pydantic-ai[logfire]'
+pip/uv-add "pydantic-ai[logfire]"
 ```
 
 Then authenticate your local environment with logfire:

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -8,7 +8,7 @@ to use their tools.
 You need to either install [`pydantic-ai`](../install.md), or[`pydantic-ai-slim`](../install.md#slim-install) with the `mcp` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[mcp]'
+pip/uv-add "pydantic-ai-slim[mcp]"
 ```
 
 !!! note

--- a/docs/models.md
+++ b/docs/models.md
@@ -47,7 +47,7 @@ connection and authentication to the underlying service.
 To use OpenAI models, you need to either install [`pydantic-ai`](install.md), or install [`pydantic-ai-slim`](install.md#slim-install) with the `openai` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[openai]'
+pip/uv-add "pydantic-ai-slim[openai]"
 ```
 
 ### Configuration
@@ -135,7 +135,7 @@ agent = Agent(model)
 To use [`AnthropicModel`][pydantic_ai.models.anthropic.AnthropicModel] models, you need to either install [`pydantic-ai`](install.md), or install [`pydantic-ai-slim`](install.md#slim-install) with the `anthropic` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[anthropic]'
+pip/uv-add "pydantic-ai-slim[anthropic]"
 ```
 
 ### Configuration
@@ -298,7 +298,7 @@ To use the `google-vertex` provider with [`GeminiModel`][pydantic_ai.models.gemi
 [`pydantic-ai`](install.md), or install [`pydantic-ai-slim`](install.md#slim-install) with the `vertexai` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[vertexai]'
+pip/uv-add "pydantic-ai-slim[vertexai]"
 ```
 
 ### Configuration
@@ -420,7 +420,7 @@ agent = Agent(model)
 To use [`GroqModel`][pydantic_ai.models.groq.GroqModel], you need to either install [`pydantic-ai`](install.md), or install [`pydantic-ai-slim`](install.md#slim-install) with the `groq` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[groq]'
+pip/uv-add "pydantic-ai-slim[groq]"
 ```
 
 ### Configuration
@@ -500,7 +500,7 @@ agent = Agent(model)
 To use [`MistralModel`][pydantic_ai.models.mistral.MistralModel], you need to either install [`pydantic-ai`](install.md), or install [`pydantic-ai-slim`](install.md#slim-install) with the `mistral` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[mistral]'
+pip/uv-add "pydantic-ai-slim[mistral]"
 ```
 
 ### Configuration
@@ -579,7 +579,7 @@ agent = Agent(model)
 To use [`CohereModel`][pydantic_ai.models.cohere.CohereModel], you need to either install [`pydantic-ai`](install.md), or install [`pydantic-ai-slim`](install.md#slim-install) with the `cohere` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[cohere]'
+pip/uv-add "pydantic-ai-slim[cohere]"
 ```
 
 ### Configuration
@@ -636,7 +636,7 @@ agent = Agent(model)
 To use [`BedrockConverseModel`][pydantic_ai.models.bedrock.BedrockConverseModel], you need to either install [`pydantic-ai`](install.md), or install [`pydantic-ai-slim`](install.md#slim-install) with the `bedrock` optional group:
 
 ```bash
-pip/uv-add 'pydantic-ai-slim[bedrock]'
+pip/uv-add "pydantic-ai-slim[bedrock]"
 ```
 
 ### Configuration

--- a/pydantic_ai_slim/pydantic_ai/_cli.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli.py
@@ -31,7 +31,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install `rich`, `prompt-toolkit` and `argcomplete` to use the PydanticAI CLI, '
-        "you can use the `cli` optional group — `pip install 'pydantic-ai-slim[cli]'`"
+        'you can use the `cli` optional group — `pip install "pydantic-ai-slim[cli]"`'
     ) from _import_error
 
 from pydantic_ai.agent import Agent

--- a/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
@@ -13,7 +13,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install `duckduckgo-search` to use the DuckDuckGo search tool, '
-        "you can use the `duckduckgo` optional group — `pip install 'pydantic-ai-slim[duckduckgo]'`"
+        'you can use the `duckduckgo` optional group — `pip install "pydantic-ai-slim[duckduckgo]"`'
     ) from _import_error
 
 __all__ = ('duckduckgo_search_tool',)

--- a/pydantic_ai_slim/pydantic_ai/common_tools/tavily.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/tavily.py
@@ -11,7 +11,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install `tavily-python` to use the Tavily search tool, '
-        "you can use the `tavily` optional group — `pip install 'pydantic-ai-slim[tavily]'`"
+        'you can use the `tavily` optional group — `pip install "pydantic-ai-slim[tavily]"`'
     ) from _import_error
 
 __all__ = ('tavily_search_tool',)

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -21,7 +21,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install the `mcp` package to use the MCP server, '
-        "you can use the `mcp` optional group — `pip install 'pydantic-ai-slim[mcp]'`"
+        'you can use the `mcp` optional group — `pip install "pydantic-ai-slim[mcp]"`'
     ) from _import_error
 
 __all__ = 'MCPServer', 'MCPServerStdio', 'MCPServerHTTP'

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -65,7 +65,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install `anthropic` to use the Anthropic model, '
-        "you can use the `anthropic` optional group — `pip install 'pydantic-ai-slim[anthropic]'`"
+        'you can use the `anthropic` optional group — `pip install "pydantic-ai-slim[anthropic]"`'
     ) from _import_error
 
 LatestAnthropicModelNames = Literal[

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -50,7 +50,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install `cohere` to use the Cohere model, '
-        "you can use the `cohere` optional group — `pip install 'pydantic-ai-slim[cohere]'`"
+        'you can use the `cohere` optional group — `pip install "pydantic-ai-slim[cohere]"`'
     ) from _import_error
 
 LatestCohereModelNames = Literal[

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -41,7 +41,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install `groq` to use the Groq model, '
-        "you can use the `groq` optional group — `pip install 'pydantic-ai-slim[groq]'`"
+        'you can use the `groq` optional group — `pip install "pydantic-ai-slim[groq]"`'
     ) from _import_error
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -75,7 +75,7 @@ try:
 except ImportError as e:
     raise ImportError(
         'Please install `mistral` to use the Mistral model, '
-        "you can use the `mistral` optional group — `pip install 'pydantic-ai-slim[mistral]'`"
+        'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
     ) from e
 
 LatestMistralModelNames = Literal[

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -57,7 +57,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install `openai` to use the OpenAI model, '
-        "you can use the `openai` optional group — `pip install 'pydantic-ai-slim[openai]'`"
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
 
 OpenAIModelName = Union[str, ChatModel]

--- a/pydantic_ai_slim/pydantic_ai/models/vertexai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/vertexai.py
@@ -27,7 +27,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install `google-auth` to use the VertexAI model, '
-        "you can use the `vertexai` optional group — `pip install 'pydantic-ai-slim[vertexai]'`"
+        'you can use the `vertexai` optional group — `pip install "pydantic-ai-slim[vertexai]"`'
     ) from _import_error
 
 VERTEX_AI_URL_TEMPLATE = (

--- a/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
@@ -12,7 +12,7 @@ try:
 except ImportError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `anthropic` package to use the Anthropic provider, '
-        "you can use the `anthropic` optional group — `pip install 'pydantic-ai-slim[anthropic]'`"
+        'you can use the `anthropic` optional group — `pip install "pydantic-ai-slim[anthropic]"`'
     ) from _import_error
 
 

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -13,7 +13,7 @@ try:
 except ImportError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Azure provider, '
-        "you can use the `openai` optional group — `pip install 'pydantic-ai-slim[openai]'`"
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
 
 

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -11,7 +11,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install the `boto3` package to use the Bedrock provider, '
-        "you can use the `bedrock` optional group — `pip install 'pydantic-ai-slim[bedrock]'`"
+        'you can use the `bedrock` optional group — `pip install "pydantic-ai-slim[bedrock]"`'
     ) from _import_error
 
 

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -13,7 +13,7 @@ try:
 except ImportError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the DeepSeek provider, '
-        "you can use the `openai` optional group — `pip install 'pydantic-ai-slim[openai]'`"
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
 
 from . import Provider

--- a/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
@@ -22,7 +22,7 @@ try:
 except ImportError as _import_error:
     raise ImportError(
         'Please install the `google-auth` package to use the Google Vertex AI provider, '
-        "you can use the `vertexai` optional group — `pip install 'pydantic-ai-slim[vertexai]'`"
+        'you can use the `vertexai` optional group — `pip install "pydantic-ai-slim[vertexai]"`'
     ) from _import_error
 
 

--- a/pydantic_ai_slim/pydantic_ai/providers/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/groq.py
@@ -12,7 +12,7 @@ try:
 except ImportError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `groq` package to use the Groq provider, '
-        "you can use the `groq` optional group — `pip install 'pydantic-ai-slim[groq]'`"
+        'you can use the `groq` optional group — `pip install "pydantic-ai-slim[groq]"`'
     ) from _import_error
 
 

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -12,7 +12,7 @@ try:
 except ImportError as e:  # pragma: no cover
     raise ImportError(
         'Please install the `mistral` package to use the Mistral provider, '
-        "you can use the `mistral` optional group — `pip install 'pydantic-ai-slim[mistral]'`"
+        'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
     ) from e
 
 

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -11,7 +11,7 @@ try:
 except ImportError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the OpenAI provider, '
-        "you can use the `openai` optional group — `pip install 'pydantic-ai-slim[openai]'`"
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
     ) from _import_error
 
 


### PR DESCRIPTION
Same as #1181 for the rest of the installation commands

> Ubuntu is indifferent whether we run `uv add 'pydantic-ai[option]' `or `"uv add 'pydantic-ai[option]"`, but Windows errors with this message:

```bat
rem with uv
ERROR: Invalid requirement: "'pydantic-ai-slim[openai]'": Expected package name at the start of dependency specifier
    'pydantic-ai-slim[openai]'
   ^

rem with pip
error: Failed to parse: `'pydantic-ai[logfire]'`
  Caused by: Expected package name starting with an alphanumeric character, found `'`
'pydantic-ai[logfire]'
^
```