### PR TITLE
add tool name filtering to mcp server implementation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -35,6 +35,8 @@ class MCPServer(ABC):
 
     is_running: bool = False
 
+    allowed_tools: list[str] | None = None
+
     _client: ClientSession
     _read_stream: MemoryObjectReceiveStream[JSONRPCMessage | Exception]
     _write_stream: MemoryObjectSendStream[JSONRPCMessage]
@@ -66,6 +68,7 @@ class MCPServer(ABC):
                 parameters_json_schema=tool.inputSchema,
             )
             for tool in tools.tools
+            if self.allowed_tools is None or tool.name in self.allowed_tools
         ]
 
     async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> CallToolResult:
@@ -78,6 +81,9 @@ class MCPServer(ABC):
         Returns:
             The result of the tool call.
         """
+        if self.allowed_tools is not None and tool_name not in self.allowed_tools:
+            raise ValueError(f'Tool {tool_name} is not in the list of allowed_tools')
+
         return await self._client.call_tool(tool_name, arguments)
 
     async def __aenter__(self) -> Self:
@@ -139,6 +145,9 @@ class MCPServerStdio(MCPServer):
     If you want to inherit the environment variables from the parent process, use `env=os.environ`.
     """
 
+    allowed_tools: list[str] | None = None
+    """A list of tool names that can be called on this mcp server"""
+
     @asynccontextmanager
     async def client_streams(
         self,
@@ -187,6 +196,9 @@ class MCPServerHTTP(MCPServer):
 
     For example for a server running locally, this might be `http://localhost:3001/sse`.
     """
+
+    allowed_tools: list[str] | None = None
+    """A list of tool names that can be called on this mcp server"""
 
     @asynccontextmanager
     async def client_streams(

--- a/uv.lock
+++ b/uv.lock
@@ -2964,7 +2964,7 @@ requires-dist = [
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=2.3" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=1.4.1" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.2.5" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.66.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.67.0" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },
     { name = "prompt-toolkit", marker = "extra == 'cli'", specifier = ">=3" },
     { name = "pydantic", specifier = ">=2.10" },


### PR DESCRIPTION
adds the ability to set a list of allowed tools when creating an MCPServer instance, such that list_tools and call_tool will be checked against the list of allowed tools if its set.
#1219 