### PR TITLE
fix: bedrock has incorrect environment variable to set region

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -647,12 +647,12 @@ To use [AWS Bedrock](https://aws.amazon.com/bedrock/), you'll need an AWS accoun
 
 ### Environment variables
 
-You can set your AWS credentials as environment variables:
+You can set your AWS credentials as environment variables ([among other options](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables):
 
 ```bash
 export AWS_ACCESS_KEY_ID='your-access-key'
 export AWS_SECRET_ACCESS_KEY='your-secret-key'
-export AWS_REGION='us-east-1'  # or your preferred region
+export AWS_DEFAULT_REGION='us-east-1'  # or your preferred region
 ```
 
 You can then use [`BedrockConverseModel`][pydantic_ai.models.bedrock.BedrockConverseModel] by name:


### PR DESCRIPTION
The docs suggest using `AWS_REGION` however according to the boto docs and our testing, the correct name is `AWS_DEFAULT_REGION`

This just updates the docs, along with a pointer to the full list of possible environment variables.