### PR TITLE
Revert "Use `get_running_loop` instead of `get_event_loop`"

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -13,7 +13,7 @@ from pydantic.json_schema import GenerateJsonSchema
 from typing_extensions import TypeGuard, TypeVar, deprecated
 
 from pydantic_graph import End, Graph, GraphRun, GraphRunContext
-from pydantic_graph._utils import run_until_complete
+from pydantic_graph._utils import get_event_loop
 
 from . import (
     _agent_graph,
@@ -567,7 +567,7 @@ class Agent(Generic[AgentDepsT, ResultDataT]):
         """
         if infer_name and self.name is None:
             self._infer_name(inspect.currentframe())
-        return run_until_complete(
+        return get_event_loop().run_until_complete(
             self.run(
                 user_prompt,
                 result_type=result_type,

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -1,15 +1,22 @@
 from __future__ import annotations as _annotations
 
 import asyncio
-import sys
 import types
-from collections.abc import Coroutine
 from functools import partial
 from typing import Any, Callable, TypeVar
 
 from typing_extensions import ParamSpec, TypeIs, get_args, get_origin
 from typing_inspection import typing_objects
 from typing_inspection.introspection import is_union_origin
+
+
+def get_event_loop():
+    try:
+        event_loop = asyncio.get_event_loop()
+    except RuntimeError:
+        event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(event_loop)
+    return event_loop
 
 
 def get_union_args(tp: Any) -> tuple[Any, ...]:
@@ -93,15 +100,3 @@ async def run_in_executor(func: Callable[_P, _R], *args: _P.args, **kwargs: _P.k
         return await asyncio.get_running_loop().run_in_executor(None, partial(func, *args, **kwargs))
     else:
         return await asyncio.get_running_loop().run_in_executor(None, func, *args)  # type: ignore
-
-
-def run_until_complete(coro: Coroutine[None, None, _R]) -> _R:
-    if sys.version_info < (3, 11):
-        try:
-            loop = asyncio.new_event_loop()
-            return loop.run_until_complete(coro)
-        finally:
-            loop.close()
-    else:
-        with asyncio.runners.Runner(loop_factory=asyncio.new_event_loop) as runner:
-            return runner.run(coro)

--- a/pydantic_graph/pydantic_graph/graph.py
+++ b/pydantic_graph/pydantic_graph/graph.py
@@ -202,7 +202,7 @@ class Graph(Generic[StateT, DepsT, RunEndT]):
         if infer_name and self.name is None:
             self._infer_name(inspect.currentframe())
 
-        return _utils.run_until_complete(
+        return _utils.get_event_loop().run_until_complete(
             self.run(start_node, state=state, deps=deps, persistence=persistence, infer_name=False)
         )
 

--- a/tests/graph/test_utils.py
+++ b/tests/graph/test_utils.py
@@ -1,19 +1,12 @@
 from threading import Thread
 
-from pydantic_graph._utils import run_until_complete
+from pydantic_graph._utils import get_event_loop
 
 
-def test_run_until_complete_in_main_thread():
-    async def run(): ...
-
-    run_until_complete(run())
-
-
-def test_run_until_complete_in_thread():
-    async def run(): ...
-
+def test_get_event_loop_in_thread():
     def get_and_close_event_loop():
-        run_until_complete(run())
+        event_loop = get_event_loop()
+        event_loop.close()
 
     thread = Thread(target=get_and_close_event_loop)
     thread.start()


### PR DESCRIPTION
Reverts pydantic/pydantic-ai#1204

It seems I made a mistake when trying to solve the deprecation warning. Let me first revert it.

This PR solves the comments at the end of https://github.com/pydantic/pydantic-ai/issues/748.