### PR TITLE
Support evaluator functions

### DIFF
--- a/examples/pydantic_ai_examples/evals/eval.py
+++ b/examples/pydantic_ai_examples/evals/eval.py
@@ -31,7 +31,7 @@ async def main():
     )
     dataset = TimeRangeDataset.from_file(
         Path(__file__).parent / 'test_cases.yaml',
-        custom_evaluator_types=(IsInstance, LlmJudge),
+        custom_evaluators=(IsInstance, LlmJudge),
     )
 
     class MyEvaluator(Evaluator[TimeRangeInputs, TimeRangeResponse]):

--- a/examples/pydantic_ai_examples/evals/models.py
+++ b/examples/pydantic_ai_examples/evals/models.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
         path = Path(__file__).parent / 'test_cases.yaml'
         if not path.exists():
             TimeRangeDataset(cases=[], evaluators=[LlmJudge(rubric='abc')]).to_file(
-                path, custom_evaluator_types=[LlmJudge, IsInstance]
+                path, custom_evaluators=[LlmJudge, IsInstance]
             )
 
     main()

--- a/pydantic_evals/pydantic_evals/evaluators/context.py
+++ b/pydantic_evals/pydantic_evals/evaluators/context.py
@@ -15,13 +15,13 @@ from ..otel._errors import SpanTreeRecordingError
 from ..otel.span_tree import SpanTree
 
 # ScoringContext needs to be covariant
-InputsT = TypeVar('InputsT', default=dict[str, Any], covariant=True)
+InputsT = TypeVar('InputsT', default=Any, covariant=True)
 """Type variable for the inputs to the task being evaluated."""
 
-OutputT = TypeVar('OutputT', default=dict[str, Any], covariant=True)
+OutputT = TypeVar('OutputT', default=Any, covariant=True)
 """Type variable for the output of the task being evaluated."""
 
-MetadataT = TypeVar('MetadataT', default=dict[str, Any], covariant=True)
+MetadataT = TypeVar('MetadataT', default=Any, covariant=True)
 """Type variable for the metadata associated with the task being evaluated."""
 
 

--- a/pydantic_evals/pydantic_evals/evaluators/function_evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/function_evaluator.py
@@ -1,0 +1,53 @@
+import inspect
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from inspect import iscoroutinefunction
+from typing import Any, Callable, Concatenate
+
+from typing_extensions import ParamSpec, TypeVar
+
+from pydantic_evals.evaluators import Evaluator, EvaluatorContext, EvaluatorOutput
+
+InputsT = TypeVar('InputsT', default=Any, contravariant=True)
+"""Type variable for the inputs type of the task being evaluated."""
+
+OutputT = TypeVar('OutputT', default=Any, contravariant=True)
+"""Type variable for the output type of the task being evaluated."""
+
+MetadataT = TypeVar('MetadataT', default=Any, contravariant=True)
+"""Type variable for the metadata type of the task being evaluated."""
+
+P = ParamSpec('P', default=...)
+
+
+def function_evaluator(
+    func: Callable[
+        Concatenate[EvaluatorContext[InputsT, OutputT, MetadataT], P], EvaluatorOutput | Awaitable[EvaluatorOutput]
+    ],
+) -> Callable[P, Evaluator[InputsT, OutputT, MetadataT]]:
+    """Decorator to create an Evaluator type from a function."""
+    params = inspect.signature(func).parameters
+    params = dict(list(params.items())[1:])  # remove first parameter
+
+    if iscoroutinefunction(func):
+
+        class MyEvaluator(Evaluator):  # type: ignore
+            async def evaluate(self, ctx: EvaluatorContext) -> EvaluatorOutput:
+                return await func(ctx, **self.__dict__)  # type: ignore
+    else:
+
+        class MyEvaluator(Evaluator):
+            def evaluate(self, ctx: EvaluatorContext) -> EvaluatorOutput:
+                return func(ctx, **self.__dict__)  # type: ignore
+
+    annotations = {}
+    for name, p in params.items():
+        annotations[name] = p.annotation
+        if p.default != inspect.Parameter.empty:
+            setattr(MyEvaluator, name, p.default)
+
+    MyEvaluator.__annotations__ = {name: p.annotation for name, p in params.items()}
+    MyEvaluator.__name__ = func.__name__
+    MyEvaluator.__qualname__ = f'evaluator({func.__qualname__})'
+    MyEvaluator = dataclass(MyEvaluator)
+    return MyEvaluator  # type: ignore

--- a/pydantic_evals/pydantic_evals/generation.py
+++ b/pydantic_evals/pydantic_evals/generation.py
@@ -15,7 +15,7 @@ from typing_extensions import TypeVar
 
 from pydantic_ai import Agent, models
 from pydantic_evals import Dataset
-from pydantic_evals.evaluators.evaluator import Evaluator
+from pydantic_evals.dataset import CustomEvaluator
 
 InputsT = TypeVar('InputsT', default=Any)
 """Generic type for the inputs to the task being evaluated."""
@@ -34,7 +34,7 @@ async def generate_dataset(
     inputs_type: type[InputsT],
     output_type: type[OutputT],
     metadata_type: type[MetadataT],
-    custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = (),
+    custom_evaluators: Sequence[CustomEvaluator[InputsT, OutputT, MetadataT]] = (),
     model: models.Model | models.KnownModelName = 'openai:gpt-4o',
     n_examples: int = 3,
     extra_instructions: str | None = None,
@@ -49,7 +49,7 @@ async def generate_dataset(
         inputs_type: The type of inputs for the dataset.
         output_type: The type of expected outputs for the dataset.
         metadata_type: The type of metadata for the dataset.
-        custom_evaluator_types: Optional sequence of custom evaluator classes to include in the schema.
+        custom_evaluators: Optional sequence of custom evaluator classes to include in the schema.
         model: The PydanticAI model to use for generation. Defaults to 'gpt-4o'.
         n_examples: Number of examples to generate. Defaults to 3.
         extra_instructions: Optional additional instructions to provide to the LLM.
@@ -61,7 +61,7 @@ async def generate_dataset(
         ValidationError: If the LLM's response cannot be parsed as a valid dataset.
     """
     dataset_type = Dataset[inputs_type, output_type, metadata_type]
-    result_schema = dataset_type.model_json_schema_with_evaluators(custom_evaluator_types)
+    result_schema = dataset_type.model_json_schema_with_evaluators(custom_evaluators)
 
     # TODO(DavidM): Update this once we add better response_format and/or ResultTool support to PydanticAI
     agent = Agent(
@@ -77,10 +77,10 @@ async def generate_dataset(
 
     result = await agent.run(extra_instructions or 'Please generate the object.')
     try:
-        result = dataset_type.from_text(result.data, fmt='json', custom_evaluator_types=custom_evaluator_types)
+        result = dataset_type.from_text(result.data, fmt='json', custom_evaluators=custom_evaluators)
     except ValidationError as e:
         print(f'Raw response from model:\n{result.data}')
         raise e
     if path is not None:
-        result.to_file(path, custom_evaluator_types=custom_evaluator_types)
+        result.to_file(path, custom_evaluators=custom_evaluators)
     return result

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -684,7 +684,7 @@ async def test_duplicate_evaluator_failure(example_dataset: Dataset[TaskInput, T
     SecondEvaluator.__name__ = FirstEvaluator.__name__
     with pytest.raises(ValueError) as exc_info:
         Dataset[TaskInput, TaskOutput, TaskMetadata].from_dict(
-            {'cases': []}, custom_evaluator_types=(FirstEvaluator, SecondEvaluator)
+            {'cases': []}, custom_evaluators=(FirstEvaluator, SecondEvaluator)
         )
     assert str(exc_info.value) == snapshot("Duplicate evaluator class name: 'FirstEvaluator'")
 


### PR DESCRIPTION
I think we don't want to merge this, but I'll note that this makes it possible to do:
```
from typing import Any

from pydantic_evals import Dataset
from pydantic_evals.evaluators import EvaluatorContext, EvaluatorOutput
from pydantic_evals.evaluators.function_evaluator import function_evaluator


@function_evaluator
def evaluate_case(ctx: EvaluatorContext, result: Any) -> EvaluatorOutput:
    return result

dataset_text = """
cases:
    - name: "case1"
      inputs: {"x": 1}
    - name: "case2"
      inputs: {"x": 2}
evaluators:
    - evaluate_case: 3
"""

dataset = Dataset[Any, Any, Any].from_text(dataset_text, custom_evaluators=(evaluate_case,))
print(dataset)
#> cases=[Case(name='case1', inputs={'x': 1}, metadata=None, expected_output=None, evaluators=[]), Case(name='case2', inputs={'x': 2}, metadata=None, expected_output=None, evaluators=[])] evaluators=[evaluator(evaluate_case)(result=3)]

dataset.add_evaluator(evaluate_case('abc'))
#> cases=[Case(name='case1', inputs={'x': 1}, metadata=None, expected_output=None, evaluators=[]), Case(name='case2', inputs={'x': 2}, metadata=None, expected_output=None, evaluators=[])] evaluators=[evaluator(evaluate_case)(result=3), evaluator(evaluate_case)(result='abc')]
```
without any type errors.

I think @alexmojaki preferred something in this direction; ultimately though I think it makes too many things fragile/harder to understand, yes it's perhaps a bit annoying to need the boilerplate of defining a dataclass to create an evaluator, but it has the upside of being easier to use in python and not-in-python (without partial), among other things.

I'll close this PR because I don't want to merge it but wanted to open for sharing, maybe @alexmojaki will see a way to improve it.