### PR TITLE
disable cohere with emscripten

### DIFF
--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 logfire = ["logfire>=3.11.0"]
 # Models
 openai = ["openai>=1.67.0"]
-cohere = ["cohere>=5.13.11"]
+cohere = ["cohere>=5.13.11; platform_system != 'Emscripten'"]
 vertexai = ["google-auth>=2.36.0", "requests>=2.32.3"]
 anthropic = ["anthropic>=0.49.0"]
 groq = ["groq>=0.15.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -2906,7 +2906,7 @@ cli = [
     { name = "rich" },
 ]
 cohere = [
-    { name = "cohere" },
+    { name = "cohere", marker = "sys_platform != 'emscripten'" },
 ]
 duckduckgo = [
     { name = "duckduckgo-search" },
@@ -2959,7 +2959,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.49.0" },
     { name = "argcomplete", marker = "extra == 'cli'", specifier = ">=3.5.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34.116" },
-    { name = "cohere", marker = "extra == 'cohere'", specifier = ">=5.13.11" },
+    { name = "cohere", marker = "sys_platform != 'emscripten' and extra == 'cohere'", specifier = ">=5.13.11" },
     { name = "duckduckgo-search", marker = "extra == 'duckduckgo'", specifier = ">=7.0.0" },
     { name = "eval-type-backport", specifier = ">=0.2.0" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
@rafidka FYI here we're stopping install cohere in the browser since two packages you depend on (at least) `fastavro` and `tokenizers` fail when installing in pyodide.

See [this pydantic.run](https://pydantic.run/store/9c44b96b2b9ac5f6) for an example.

Let us know if you want to make those dependencies optional in your package.