### PR TITLE
Add expected output to logfire attributes for the evals task span

### DIFF
--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -871,11 +871,12 @@ async def _run_task_and_evaluators(
         A ReportCase containing the evaluation results.
     """
     with _logfire.span(
-        '{task_name}: {case_name}',
+        'case: {case_name}',
         task_name=get_unwrapped_function_name(task),
         case_name=case.name,
         inputs=case.inputs,
         metadata=case.metadata,
+        expected_output=case.expected_output,
     ) as case_span:
         t0 = time.time()
         scoring_context = await _run_task(task, case)


### PR DESCRIPTION
(Also update the span name to just say "case" rather than the actual task name, which will be visible from the parent span, and is still an attribute.)