### PR TITLE
docs: Add missing blank line between code block and list

### DIFF
--- a/docs/evals.md
+++ b/docs/evals.md
@@ -82,6 +82,7 @@ class MyEvaluator(Evaluator):
 
 dataset.add_evaluator(MyEvaluator())
 ```
+
 1. You can add built-in evaluators to a dataset using the [`add_evaluator`][pydantic_evals.Dataset.add_evaluator] method.
 2. This custom evaluator returns a simple score based on whether the output matches the expected output.
 


### PR DESCRIPTION
This was preventing the list from being rendered correctly, in turn preventing code annotations to work in the code block above.

I might have spotted other places with this issue in the past, not sure where, but grepping for `# \(\d+\)!` on the docs wouldn't be hard.