### PR TITLE
Anthropic `stop_reason` `max_tokens` Catch

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -179,8 +179,6 @@ class AnthropicModel(Model):
                 )
             )
 
-            print('Got stop_reason max_tokens, retrying request with max_tokens retry prompt')
-
             return await self.request(messages, model_settings, model_request_parameters)
 
     @asynccontextmanager

--- a/tests/test_token_limits.py
+++ b/tests/test_token_limits.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from pydantic_ai.agent import Agent
+from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior
+from pydantic_ai.models import override_allow_model_requests
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai.tools import Tool
+
+# Configure comprehensive logging
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s %(name)s %(message)s')
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+# Force propagation to ensure logs are captured
+logger.propagate = True
+
+
+@pytest.mark.skipif(
+    not pytest.importorskip('anthropic', reason='anthropic package not installed'), reason='No anthropic package'
+)
+@pytest.mark.skipif(not pytest.importorskip('os').environ.get('ANTHROPIC_API_KEY'), reason='No API key')
+@pytest.mark.anyio
+async def test_real_agent_with_token_limited_tool():
+    """Test a real agent with Anthropic model and a token-limited tool.
+
+    This test is skipped unless:
+    1. The anthropic package is installed
+    2. ANTHROPIC_API_KEY is set in the environment
+
+    Run with:
+        ALLOW_MODEL_REQUESTS=true pytest tests/test_token_limits.py::test_real_agent_with_token_limited_tool -v
+    """
+    # Skip if Anthropic is not available
+    if not os.environ.get('ANTHROPIC_API_KEY'):
+        pytest.skip('ANTHROPIC_API_KEY not set')
+
+    allow_api = os.environ.get('ALLOW_MODEL_REQUESTS', 'false').lower() == 'true'
+    with override_allow_model_requests(allow_api):
+        # Track if the tool was ever called
+        tool_was_called = False
+
+        # Keep track of the poem content
+        current_poem_content = ''
+        verses_added = 0
+
+        # Define a tool that takes a large input
+        def write_very_large_content(file_path: str, file_contents: str, append: bool = False) -> str:
+            """Write the provided content to the specified file.
+
+            Args:
+                file_path: The path where the file should be written
+                file_contents: The content to write to the file.
+                append: If True, append to existing content instead of replacing it
+
+            Returns:
+                A confirmation message
+            """
+            nonlocal tool_was_called, current_poem_content, verses_added
+
+            tool_was_called = True
+            print(f'TOOL BODY CALLED: Writing {len(file_contents)} characters to {file_path} (append={append})')
+
+            # Check if we're appending or replacing
+            if append:
+                # Count the number of verses being added
+                new_verses = [v for v in file_contents.split('\n\n') if v.strip()]
+                verses_being_added = len(new_verses)
+
+                # Append the new content
+                current_poem_content += '\n\n' + file_contents if current_poem_content else file_contents
+                verses_added += verses_being_added
+
+                print(f'APPENDING: Added {verses_being_added} verses, total now {verses_added}')
+                return f'Successfully appended {len(file_contents)} characters. Total verses: {verses_added}'
+            else:
+                # For non-append operations, check for minimum requirements
+                verses = [v for v in file_contents.split('\n\n') if v.strip()]
+
+                print(f'REPLACING: Received poem with {len(verses)} verses and {len(file_contents)} characters')
+
+                # If all checks pass, replace the current content
+                current_poem_content = file_contents
+                verses_added = len(verses)
+                return f'Successfully wrote {len(file_contents)} characters to {file_path}'
+
+        # Create the tool with a low max_retries to speed up the test
+        write_tool = Tool(write_very_large_content, max_retries=5)
+
+        # Create an agent with an actual Anthropic model
+        agent = Agent(
+            model='anthropic:claude-3-5-haiku-latest',
+            tools=[write_tool],
+            system_prompt="""You must use the write_very_large_content tool to write a poem to poem.txt.
+If you hit token limits when trying to write a large poem all at once, use the append=True parameter to add verses one at a time.
+You have a max_tokens of 100 for any output.
+""",
+        )
+
+        try:
+            # Run the agent with a prompt that will require a large text response
+            result = await agent.run(
+                'Write a poem to poem.txt. The poem must be very long with at least 50 verses.',
+                model_settings=ModelSettings(max_tokens=100, temperature=0.0),
+            )
+            # Check if we successfully built a complete poem with at least 50 verses
+            total_verses = len([v for v in current_poem_content.split('\n\n') if v.strip()])
+            print(f'COMPLETED POEM: {total_verses} verses, {len(current_poem_content)} characters')
+
+            # If we got here with a complete poem, that's success!
+            if total_verses >= 50:
+                print('SUCCESS: Model adapted to token limits by using append=True')
+                assert verses_added >= 50, 'Should have added at least 50 verses in total'
+                assert tool_was_called, 'The tool should have been called'
+            else:
+                # We got here but without a complete poem
+                print(f'UNEXPECTED RESULT: Poem has only {total_verses} verses')
+                print(f'Tool was called: {tool_was_called}')
+                print(f'Result: {result.data}')
+                assert False, 'Expected either token limit error or completed poem with 50+ verses'
+        except ModelRetry as exc:
+            # This indicates our token limit detection is working properly
+            # The tool should now be configured to retry or use append=True
+            print(f'CAUGHT ModelRetry: {exc}')
+            print(f'Tool was called: {tool_was_called}')
+
+            # Basic verification that we got the expected token limit message
+            assert 'token limit' in str(exc).lower()
+            assert 'write_very_large_content' in str(exc)
+
+            # Test passed - the ModelRetry was correctly raised with a helpful message
+            # In a real-world scenario, this would be captured by the Agent's retry mechanism
+        except UnexpectedModelBehavior as exc:
+            # Verify the error contains our improved token limit message
+            error_msg = str(exc)
+            print(f'CAUGHT ERROR: {error_msg}')
+            print(f'Tool was called: {tool_was_called}')
+            print(f'Verses added so far: {verses_added}')
+
+            # Check if we made partial progress
+            if verses_added > 0:
+                print(f'PARTIAL SUCCESS: Model added {verses_added} verses using append=True before exceeding retries')
+
+            # Basic verification that we got the expected error message
+            assert 'exceeded max retries' in error_msg
+            assert 'token limit' in error_msg.lower() or 'max_tokens' in error_msg

--- a/tests/test_token_limits.py
+++ b/tests/test_token_limits.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 
 import pytest
@@ -8,13 +7,6 @@ import pytest
 from pydantic_ai import Agent
 from pydantic_ai.models import override_allow_model_requests
 from pydantic_ai.settings import ModelSettings
-
-# Configure comprehensive logging
-logging.basicConfig(level=logging.DEBUG)
-
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-logger.propagate = True
 
 
 @pytest.mark.skipif(not os.getenv('ANTHROPIC_API_KEY'), reason='ANTHROPIC_API_KEY not set')

--- a/tests/test_token_limits.py
+++ b/tests/test_token_limits.py
@@ -5,146 +5,52 @@ import os
 
 import pytest
 
-from pydantic_ai.agent import Agent
-from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior
+from pydantic_ai import Agent
 from pydantic_ai.models import override_allow_model_requests
 from pydantic_ai.settings import ModelSettings
-from pydantic_ai.tools import Tool
 
 # Configure comprehensive logging
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s %(name)s %(message)s')
+logging.basicConfig(level=logging.DEBUG)
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
-# Force propagation to ensure logs are captured
 logger.propagate = True
 
 
-@pytest.mark.skipif(
-    not pytest.importorskip('anthropic', reason='anthropic package not installed'), reason='No anthropic package'
-)
-@pytest.mark.skipif(not pytest.importorskip('os').environ.get('ANTHROPIC_API_KEY'), reason='No API key')
-@pytest.mark.anyio
-async def test_real_agent_with_token_limited_tool():
-    """Test a real agent with Anthropic model and a token-limited tool.
+@pytest.mark.skipif(not os.getenv('ANTHROPIC_API_KEY'), reason='ANTHROPIC_API_KEY not set')
+def test_real_agent_with_token_limited_tool():
+    """Test that the agent can handle token limits by retrying with smaller chunks."""
+    with override_allow_model_requests(allow_model_requests=True):
+        # Set a very low token limit to trigger max_tokens error
+        model_settings = ModelSettings(max_tokens=500)
 
-    This test is skipped unless:
-    1. The anthropic package is installed
-    2. ANTHROPIC_API_KEY is set in the environment
+        # Create an agent that requires a tool call for the result
+        agent = Agent(model='anthropic:claude-3-5-sonnet-latest', model_settings=model_settings, retries=5)
 
-    Run with:
-        ALLOW_MODEL_REQUESTS=true pytest tests/test_token_limits.py::test_real_agent_with_token_limited_tool -v
-    """
-    # Skip if Anthropic is not available
-    if not os.environ.get('ANTHROPIC_API_KEY'):
-        pytest.skip('ANTHROPIC_API_KEY not set')
+        poem_content: str = ''
 
-    allow_api = os.environ.get('ALLOW_MODEL_REQUESTS', 'false').lower() == 'true'
-    with override_allow_model_requests(allow_api):
-        # Track if the tool was ever called
-        tool_was_called = False
-
-        # Keep track of the poem content
-        current_poem_content = ''
-        verses_added = 0
-
-        # Define a tool that takes a large input
-        def write_very_large_content(file_path: str, file_contents: str, append: bool = False) -> str:
-            """Write the provided content to the specified file.
-
-            Args:
-                file_path: The path where the file should be written
-                file_contents: The content to write to the file.
-                append: If True, append to existing content instead of replacing it
-
-            Returns:
-                A confirmation message
-            """
-            nonlocal tool_was_called, current_poem_content, verses_added
-
-            tool_was_called = True
-            print(f'TOOL BODY CALLED: Writing {len(file_contents)} characters to {file_path} (append={append})')
-
-            # Check if we're appending or replacing
+        @agent.tool_plain(retries=5)
+        def write_poem(content: str, filename: str, append: bool = False) -> str:
+            """Write a poem to a file. If append is True, append to the existing content. Otherwise, overwrite the existing content."""
+            nonlocal poem_content
             if append:
-                # Count the number of verses being added
-                new_verses = [v for v in file_contents.split('\n\n') if v.strip()]
-                verses_being_added = len(new_verses)
-
-                # Append the new content
-                current_poem_content += '\n\n' + file_contents if current_poem_content else file_contents
-                verses_added += verses_being_added
-
-                print(f'APPENDING: Added {verses_being_added} verses, total now {verses_added}')
-                return f'Successfully appended {len(file_contents)} characters. Total verses: {verses_added}'
+                poem_content += content
+                print(f'Appending to {filename}: {content}')
             else:
-                # For non-append operations, check for minimum requirements
-                verses = [v for v in file_contents.split('\n\n') if v.strip()]
+                poem_content = content
+                print(f'Overwriting {filename}: {content}')
+            return poem_content
 
-                print(f'REPLACING: Received poem with {len(verses)} verses and {len(file_contents)} characters')
-
-                # If all checks pass, replace the current content
-                current_poem_content = file_contents
-                verses_added = len(verses)
-                return f'Successfully wrote {len(file_contents)} characters to {file_path}'
-
-        # Create the tool with a low max_retries to speed up the test
-        write_tool = Tool(write_very_large_content, max_retries=5)
-
-        # Create an agent with an actual Anthropic model
-        agent = Agent(
-            model='anthropic:claude-3-5-haiku-latest',
-            tools=[write_tool],
-            system_prompt="""You must use the write_very_large_content tool to write a poem to poem.txt.
-If you hit token limits when trying to write a large poem all at once, use the append=True parameter to add verses one at a time.
-You have a max_tokens of 100 for any output.
-""",
+        # Don't use capture_run_messages, just run directly
+        _ = agent.run_sync(
+            'Write a very long poem using the `write_poem` tool to write to poem.txt. '
+            'The poem should be at least 500 words long. '
+            'Use the write_poem tool to write the poem to poem.txt.'
         )
 
-        try:
-            # Run the agent with a prompt that will require a large text response
-            result = await agent.run(
-                'Write a poem to poem.txt. The poem must be very long with at least 50 verses.',
-                model_settings=ModelSettings(max_tokens=100, temperature=0.0),
-            )
-            # Check if we successfully built a complete poem with at least 50 verses
-            total_verses = len([v for v in current_poem_content.split('\n\n') if v.strip()])
-            print(f'COMPLETED POEM: {total_verses} verses, {len(current_poem_content)} characters')
+        # Verify that the final poem meets the length requirement
+        words = poem_content.split()
+        assert len(words) >= 500, f'Expected at least 500 words, got {len(words)}'
 
-            # If we got here with a complete poem, that's success!
-            if total_verses >= 50:
-                print('SUCCESS: Model adapted to token limits by using append=True')
-                assert verses_added >= 50, 'Should have added at least 50 verses in total'
-                assert tool_was_called, 'The tool should have been called'
-            else:
-                # We got here but without a complete poem
-                print(f'UNEXPECTED RESULT: Poem has only {total_verses} verses')
-                print(f'Tool was called: {tool_was_called}')
-                print(f'Result: {result.data}')
-                assert False, 'Expected either token limit error or completed poem with 50+ verses'
-        except ModelRetry as exc:
-            # This indicates our token limit detection is working properly
-            # The tool should now be configured to retry or use append=True
-            print(f'CAUGHT ModelRetry: {exc}')
-            print(f'Tool was called: {tool_was_called}')
-
-            # Basic verification that we got the expected token limit message
-            assert 'token limit' in str(exc).lower()
-            assert 'write_very_large_content' in str(exc)
-
-            # Test passed - the ModelRetry was correctly raised with a helpful message
-            # In a real-world scenario, this would be captured by the Agent's retry mechanism
-        except UnexpectedModelBehavior as exc:
-            # Verify the error contains our improved token limit message
-            error_msg = str(exc)
-            print(f'CAUGHT ERROR: {error_msg}')
-            print(f'Tool was called: {tool_was_called}')
-            print(f'Verses added so far: {verses_added}')
-
-            # Check if we made partial progress
-            if verses_added > 0:
-                print(f'PARTIAL SUCCESS: Model added {verses_added} verses using append=True before exceeding retries')
-
-            # Basic verification that we got the expected error message
-            assert 'exceeded max retries' in error_msg
-            assert 'token limit' in error_msg.lower() or 'max_tokens' in error_msg
+        # Check that multiple tool calls were made (splitting the poem into chunks)
+        assert '\n\n' in poem_content, 'Expected poem to have multiple chunks with line breaks'


### PR DESCRIPTION
The test in this PR fails on the current branch, timing out because the model attempts a retry with incorrect information as to why the previous tool call failed. The first `ToolCallPart` is constructed from an `AnthropicResponse` that gives a `stop_reason` as `max_tokens`; the model hit the generation limit. If this happens during a tool call PydanticAI currently tries to process the arguments anyway even if the tool call was incomplete. This leads to a `ValidationError` on the input arguments leading to a `RetryPromptPart` that incorrectly tells the model it left out the input argument that got clipped. It tries again, fails, retries, and goes until "Tool exceed max retries". 

The current structure of the code makes it difficult to handle this in a particularly graceful way (from my limited perspective right now). The core changes in this PR allow this particular `stop_reason` to be caught, a custom error message to be sent back to the model, and the model to try again with this knowledge.

While I primarily did this for my own use case, I would love some feedback on how this can be better generalized and improved such that it can be merged for others to use as well. 