### PR TITLE
Match OpenAI models in strictness

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -630,7 +630,8 @@ class OpenAIResponsesModel(Model):
             'parameters': f.parameters_json_schema,
             'type': 'function',
             'description': f.description,
-            'strict': True,
+            # TODO(Marcelo): We should make this configurable, and if True, set `additionalProperties` to False.
+            'strict': False,
         }
 
     async def _map_message(self, messages: list[ModelMessage]) -> tuple[str, list[responses.ResponseInputItemParam]]:


### PR DESCRIPTION
The `OpenAIModel` is working with `strict=False`. We need to make this configurable. I'm just matching the behavior for now.