### PR TITLE
deprecate mcp-run-python NPX package

### DIFF
--- a/mcp-run-python/README.md
+++ b/mcp-run-python/README.md
@@ -1,17 +1,3 @@
 # MCP Run Python
 
-[Model Context Protocol](https://modelcontextprotocol.io/) server to run Python code in a sandbox.
-
-The code is executed using [pyodide](https://pyodide.org) in node and is therefore isolated from
-the rest of the operating system.
-
-The server can be run with just npx thus:
-
-```bash
-npx @pydantic/mcp-run-python [stdio|sse]
-```
-
-where:
-
-- `stdio` runs the server with the [Stdio MCP transport](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#stdio) — suitable for running the process as a subprocess locally
-- and `sse` runs the server with the [SSE MCP transport](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#http-with-sse) — running the server as an HTTP server to connect locally or remotely
+**Deprecated**: See the JSR package <https://jsr.io/@pydantic/mcp-run-python> instead.

--- a/mcp-run-python/package-lock.json
+++ b/mcp-run-python/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/mcp-run-python",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/mcp-run-python",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.7.0",

--- a/mcp-run-python/package.json
+++ b/mcp-run-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/mcp-run-python",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "MCP server to run Python code in a sandbox.",
   "author": "Samuel Colvin",
   "homepage": "https://github.com/pydantic/pydantic-ai/tree/main/mcp-run-python",

--- a/mcp-run-python/src/index.ts
+++ b/mcp-run-python/src/index.ts
@@ -8,6 +8,9 @@ import { z } from 'zod'
 import { runCode, asXml } from './runCode.js'
 
 export async function main() {
+  console.error(`
+NOTE: This package is deprecated, use the JSR package https://jsr.io/@pydantic/mcp-run-python instead.
+`)
   const args = process.argv.slice(2)
   if (args.length === 1 && args[0] === 'stdio') {
     await runStdio()
@@ -16,7 +19,6 @@ export async function main() {
   } else if (args.length === 1 && args[0] === 'warmup') {
     await warmup()
   } else {
-    console.error('Usage: npx @pydantic/mcp-run-python [stdio|sse|warmup]')
     process.exit(1)
   }
 }


### PR DESCRIPTION
In favour of JSR package, see #1340.

This has been released.