### PR TITLE
Improve serialization of LLMJudge and custom evaluators

### DIFF
--- a/docs/api/pydantic_evals/evaluators.md
+++ b/docs/api/pydantic_evals/evaluators.md
@@ -1,3 +1,5 @@
 # `pydantic_evals.evaluators`
 
 ::: pydantic_evals.evaluators
+
+::: pydantic_evals.evaluators.llm_as_a_judge

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -150,7 +150,7 @@ class OpenAIModel(Model):
     """
 
     client: AsyncOpenAI = field(repr=False)
-    system_prompt_role: OpenAISystemPromptRole | None = field(default=None)
+    system_prompt_role: OpenAISystemPromptRole | None = field(default=None, repr=False)
 
     _model_name: OpenAIModelName = field(repr=False)
     _system: str = field(default='openai', repr=False)

--- a/tests/evals/test_evaluator_common.py
+++ b/tests/evals/test_evaluator_common.py
@@ -222,10 +222,10 @@ async def test_llm_judge_evaluator(mocker: MockerFixture):
     assert result.value is True
     assert result.reason == 'Test passed'
 
-    mock_judge_output.assert_called_once_with('Hello world', 'Content contains a greeting', 'openai:gpt-4o')
+    mock_judge_output.assert_called_once_with('Hello world', 'Content contains a greeting', None)
 
     # Test with input
-    evaluator = LLMJudge(rubric='Output contains input', include_input=True)
+    evaluator = LLMJudge(rubric='Output contains input', include_input=True, model='openai:gpt-4o')
     result = await evaluator.evaluate(ctx)
     assert isinstance(result, EvaluationReason)
     assert result.value is True


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic-ai/issues/1345

Makes it so that we never fail serialization of an evaluator so it can be included in the description.

Specifically for `LLMJudge`, it always serializes models based on their system and name, even if they are custom. This won't be idempotent if you try to serialize-then-deserialize, but it will behave nicely if you are _just_ serializing (e.g. when generating the evaluation source info for inclusion in the otel spans).

It also modifies `LLMJudge` so that not passing a model leaves it as `None` rather than defaulting specifically to `'openai:gpt-4o'`, and exposes a function you can call to change the (global) default model to use for llm judging.

While I could imagine wanting to be able to serialize references to a user-managed model registry, and won't be surprised if we eventually (even in the near future) end up wanting to add that functionality, I think this will handle most usage and for now I think it's good enough.