### PR TITLE
Make tests work after running make install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ examples/pydantic_ai_examples/.chat_app_messages.sqlite
 /question_graph_history.json
 /docs-site/.wrangler/
 /CLAUDE.md
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,12 @@
 .pre-commit: ## Check that pre-commit is installed
 	@pre-commit -V || echo 'Please install pre-commit: https://pre-commit.com/'
 
+.PHONY: .deno
+.deno: ## Check that deno is installed
+	@deno --version > /dev/null 2>&1 || (printf "\033[0;31m✖ Error: deno is not installed, but is needed for mcp-run-python\033[0m\n    Please install deno: https://docs.deno.com/runtime/getting_started/installation/\n" && exit 1)
+
 .PHONY: install
-install: .uv .pre-commit ## Install the package, dependencies, and pre-commit for local development
+install: .uv .pre-commit .deno ## Install the package, dependencies, and pre-commit for local development
 	uv sync --frozen --all-extras --all-packages --group lint --group docs
 	pre-commit install --install-hooks
 

--- a/tests/providers/test_google_vertex.py
+++ b/tests/providers/test_google_vertex.py
@@ -159,6 +159,9 @@ def vertex_provider_auth(mocker: MockerFixture) -> None:
     mocker.patch('pydantic_ai.providers.google_vertex.google.auth.default', return_value=return_value)
 
 
+@pytest.mark.skipif(
+    not os.getenv('CI', False), reason='Requires properly configured local google vertex config to pass'
+)
 @pytest.mark.vcr()
 async def test_vertexai_provider(allow_model_requests: None):
     m = GeminiModel('gemini-2.0-flash', provider='google-vertex')


### PR DESCRIPTION
* Fixes that running `make install` doesn't install deno, but deno is required for `make test` to pass.
* Skips the google vertex outside CI, where your local gcloud configuration can make the test fail