### PR TITLE
Make it easier to override the base_url for Google models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/google_gla.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_gla.py
@@ -39,7 +39,13 @@ class GoogleGLAProvider(Provider[httpx.AsyncClient]):
                 'to use the Google GLA provider.'
             )
 
-        self._client = http_client or cached_async_http_client(provider='google-gla')
-        self._client.base_url = self.base_url
+        if http_client is not None:
+            self._client = http_client
+            if str(http_client.base_url) == '':
+                self._client.base_url = self.base_url
+        else:
+            self._client = cached_async_http_client(provider='google-gla')
+            self._client.base_url = self.base_url
+
         # https://cloud.google.com/docs/authentication/api-keys-use#using-with-rest
         self._client.headers['X-Goog-Api-Key'] = api_key

--- a/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
@@ -97,15 +97,21 @@ class GoogleVertexProvider(Provider[httpx.AsyncClient]):
         if service_account_file and service_account_info:
             raise ValueError('Only one of `service_account_file` or `service_account_info` can be provided.')
 
-        self._client = http_client or cached_async_http_client(provider='google-vertex')
         self.service_account_file = service_account_file
         self.service_account_info = service_account_info
         self.project_id = project_id
         self.region = region
         self.model_publisher = model_publisher
 
+        if http_client is not None:
+            self._client = http_client
+            if str(http_client.base_url) == '':
+                self._client.base_url = self.base_url
+        else:
+            self._client = cached_async_http_client(provider='google-vertex')
+            self._client.base_url = self.base_url
+
         self._client.auth = _VertexAIAuth(service_account_file, service_account_info, project_id, region)
-        self._client.base_url = self.base_url
 
 
 class _VertexAIAuth(httpx.Auth):


### PR DESCRIPTION
Makes it so that if you provide an http_client to the GoogleGLAProvider or the GoogleVertexProvider that has a base_url set, it will be used. This is useful if working with, e.g., AI gateways.

Reported here: https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1743795211655169 / related to #1381 