### PR TITLE
fix: Empty args with tool call args

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -333,7 +333,7 @@ class Tool(Generic[AgentDepsT]):
     ) -> _messages.ToolReturnPart | _messages.RetryPromptPart:
         try:
             if isinstance(message.args, str):
-                args_dict = self._validator.validate_json(message.args)
+                args_dict = self._validator.validate_json(message.args or '{}')
             else:
                 args_dict = self._validator.validate_python(message.args)
         except ValidationError as e:


### PR DESCRIPTION
Run into an error when tool has no args required, LLM(bedrock sonnet 3.7 in my case) will try to call with `''` (empty string)

```python
message = ToolCallPart(tool_name='check_credentials', args='', tool_call_id='tooluse_OEM3QMpuRzax_s7gZawcxw', part_kind='tool-call')
```

It may be relevant to each mod's implementation here, but we should allow empty args when calling tool as args: `args: str | dict[str, Any] | None`