### PR TITLE
Add `stop_sequences` to `ModelSettings`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -226,6 +226,7 @@ class AnthropicModel(Model):
                 tools=tools or NOT_GIVEN,
                 tool_choice=tool_choice or NOT_GIVEN,
                 stream=stream,
+                stop_sequences=model_settings.get('stop_sequences', NOT_GIVEN),
                 temperature=model_settings.get('temperature', NOT_GIVEN),
                 top_p=model_settings.get('top_p', NOT_GIVEN),
                 timeout=model_settings.get('timeout', NOT_GIVEN),

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -294,9 +294,8 @@ class BedrockConverseModel(Model):
             inference_config['temperature'] = temperature
         if top_p := model_settings.get('top_p'):
             inference_config['topP'] = top_p
-        # TODO(Marcelo): This is not included in model_settings yet.
-        # if stop_sequences := model_settings.get('stop_sequences'):
-        #     inference_config['stopSequences'] = stop_sequences
+        if stop_sequences := model_settings.get('stop_sequences'):
+            inference_config['stopSequences'] = stop_sequences
 
         return inference_config
 

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -118,7 +118,7 @@ class CohereModel(Model):
                 'cohere' or an instance of `Provider[AsyncClientV2]`. If not provided, a new provider will be
                 created using the other parameters.
         """
-        self._model_name: CohereModelName = model_name
+        self._model_name = model_name
 
         if isinstance(provider, str):
             provider = infer_provider(provider)
@@ -163,6 +163,7 @@ class CohereModel(Model):
                 messages=cohere_messages,
                 tools=tools or OMIT,
                 max_tokens=model_settings.get('max_tokens', OMIT),
+                stop_sequences=model_settings.get('stop_sequences', OMIT),
                 temperature=model_settings.get('temperature', OMIT),
                 p=model_settings.get('top_p', OMIT),
                 seed=model_settings.get('seed', OMIT),

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -216,6 +216,8 @@ class GeminiModel(Model):
                 generation_config['temperature'] = temperature
             if (top_p := model_settings.get('top_p')) is not None:
                 generation_config['top_p'] = top_p
+            if (stop_sequences := model_settings.get('stop_sequences')) is not None:
+                generation_config['stop_sequences'] = stop_sequences
             if (presence_penalty := model_settings.get('presence_penalty')) is not None:
                 generation_config['presence_penalty'] = presence_penalty
             if (frequency_penalty := model_settings.get('frequency_penalty')) is not None:
@@ -506,6 +508,7 @@ class _GeminiGenerationConfig(TypedDict, total=False):
     top_p: float
     presence_penalty: float
     frequency_penalty: float
+    stop_sequences: list[str]
 
 
 class _GeminiContent(TypedDict):

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -216,8 +216,6 @@ class GeminiModel(Model):
                 generation_config['temperature'] = temperature
             if (top_p := model_settings.get('top_p')) is not None:
                 generation_config['top_p'] = top_p
-            if (stop_sequences := model_settings.get('stop_sequences')) is not None:
-                generation_config['stop_sequences'] = stop_sequences
             if (presence_penalty := model_settings.get('presence_penalty')) is not None:
                 generation_config['presence_penalty'] = presence_penalty
             if (frequency_penalty := model_settings.get('frequency_penalty')) is not None:

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -208,6 +208,7 @@ class GroqModel(Model):
                 parallel_tool_calls=model_settings.get('parallel_tool_calls', NOT_GIVEN),
                 tools=tools or NOT_GIVEN,
                 tool_choice=tool_choice or NOT_GIVEN,
+                stop=model_settings.get('stop_sequences', NOT_GIVEN),
                 stream=stream,
                 max_tokens=model_settings.get('max_tokens', NOT_GIVEN),
                 temperature=model_settings.get('temperature', NOT_GIVEN),

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -199,6 +199,7 @@ class MistralModel(Model):
                 top_p=model_settings.get('top_p', 1),
                 timeout_ms=self._get_timeout_ms(model_settings.get('timeout')),
                 random_seed=model_settings.get('seed', UNSET),
+                stop=model_settings.get('stop_sequences', None),
             )
         except SDKError as e:
             if (status_code := e.status_code) >= 400:
@@ -236,6 +237,7 @@ class MistralModel(Model):
                 timeout_ms=self._get_timeout_ms(model_settings.get('timeout')),
                 presence_penalty=model_settings.get('presence_penalty'),
                 frequency_penalty=model_settings.get('frequency_penalty'),
+                stop=model_settings.get('stop_sequences', None),
             )
 
         elif model_request_parameters.result_tools:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -271,6 +271,7 @@ class OpenAIModel(Model):
                 tool_choice=tool_choice or NOT_GIVEN,
                 stream=stream,
                 stream_options={'include_usage': True} if stream else NOT_GIVEN,
+                stop=model_settings.get('stop_sequences', NOT_GIVEN),
                 max_completion_tokens=model_settings.get('max_tokens', NOT_GIVEN),
                 temperature=model_settings.get('temperature', NOT_GIVEN),
                 top_p=model_settings.get('top_p', NOT_GIVEN),
@@ -611,7 +612,7 @@ class OpenAIResponsesModel(Model):
                 truncation=model_settings.get('openai_truncation', NOT_GIVEN),
                 timeout=model_settings.get('timeout', NOT_GIVEN),
                 reasoning=reasoning,
-                user=model_settings.get('user', NOT_GIVEN),
+                user=model_settings.get('openai_user', NOT_GIVEN),
             )
         except APIStatusError as e:
             if (status_code := e.status_code) >= 400:

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -139,7 +139,6 @@ class ModelSettings(TypedDict, total=False):
     * Mistral
     * Groq
     * Cohere
-    * Gemini
     """
 
 

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -128,6 +128,20 @@ class ModelSettings(TypedDict, total=False):
     * Groq
     """
 
+    stop_sequences: list[str]
+    """Sequences that will cause the model to stop generating.
+
+    Supported by:
+
+    * OpenAI
+    * Anthropic
+    * Bedrock
+    * Mistral
+    * Groq
+    * Cohere
+    * Gemini
+    """
+
 
 def merge_model_settings(base: ModelSettings | None, overrides: ModelSettings | None) -> ModelSettings | None:
     """Merge two sets of model settings, preferring the overrides.

--- a/tests/cassettes/test_settings/test_stop_settings[anthropic].yaml
+++ b/tests/cassettes/test_settings/test_stop_settings[anthropic].yaml
@@ -1,0 +1,57 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '193'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 1024
+      messages:
+      - content:
+        - text: What is the capital of France?
+          type: text
+        role: user
+      model: claude-3-5-sonnet-latest
+      stop_sequences:
+      - Paris
+      stream: false
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '333'
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      content:
+      - text: 'The capital of France is '
+        type: text
+      id: msg_01FfkgikmbDFzn9XE1YYkJmA
+      model: claude-3-5-sonnet-20241022
+      role: assistant
+      stop_reason: stop_sequence
+      stop_sequence: Paris
+      type: message
+      usage:
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        input_tokens: 14
+        output_tokens: 6
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_settings/test_stop_settings[bedrock].yaml
+++ b/tests/cassettes/test_settings/test_stop_settings[bedrock].yaml
@@ -1,0 +1,43 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "What is the capital of France?"}]}], "system": [], "inferenceConfig":
+      {"stopSequences": ["Paris"]}}'
+    headers:
+      amz-sdk-invocation-id:
+      - !!binary |
+        YzVkZjljOTMtMDQ1Zi00NWE0LWJhY2YtMDAwMjdjYTg1NmRl
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      content-length:
+      - '152'
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-micro-v1%3A0/converse
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '209'
+      content-type:
+      - application/json
+    parsed_body:
+      metrics:
+        latencyMs: 179
+      output:
+        message:
+          content:
+          - text: The capital of France is Paris
+          role: assistant
+      stopReason: end_turn
+      usage:
+        inputTokens: 7
+        outputTokens: 6
+        totalTokens: 13
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_settings/test_stop_settings[cohere].yaml
+++ b/tests/cassettes/test_settings/test_stop_settings[cohere].yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '140'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the capital of France?
+        role: user
+      model: command-r-plus
+      stop_sequences:
+      - Paris
+      stream: false
+    uri: https://api.cohere.com/v2/chat
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-length:
+      - '280'
+      content-type:
+      - application/json
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 UTC
+      num_chars:
+      - '1200'
+      num_tokens:
+      - '12'
+      pragma:
+      - no-cache
+      vary:
+      - Origin
+    parsed_body:
+      finish_reason: STOP_SEQUENCE
+      id: 2ed6908c-e5cb-4063-b2a3-0ac4990d1b85
+      message:
+        content:
+        - text: The capital of France is
+          type: text
+        role: assistant
+      usage:
+        billed_units:
+          input_tokens: 7
+          output_tokens: 5
+        tokens:
+          input_tokens: 200
+          output_tokens: 7
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_settings/test_stop_settings[gemini].yaml
+++ b/tests/cassettes/test_settings/test_stop_settings[gemini].yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '154'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: What is the capital of France?
+        role: user
+      generation_config:
+        stop_sequences:
+        - Paris
+      safety_settings: null
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '416'
+      content-type:
+      - application/json; charset=UTF-8
+      server-timing:
+      - gfet4t7; dur=314
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    parsed_body:
+      candidates:
+      - content:
+          parts:
+          - text: ''
+          role: model
+        finishReason: STOP
+      modelVersion: gemini-1.5-flash
+      usageMetadata:
+        promptTokenCount: 7
+        promptTokensDetails:
+        - modality: TEXT
+          tokenCount: 7
+        totalTokenCount: 7
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_settings/test_stop_settings[groq].yaml
+++ b/tests/cassettes/test_settings/test_stop_settings[groq].yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '136'
+      content-type:
+      - application/json
+      host:
+      - api.groq.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the capital of France?
+        role: user
+      model: llama3-8b-8192
+      n: 1
+      stop:
+      - Paris
+      stream: false
+    uri: https://api.groq.com/openai/v1/chat/completions
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=86400
+      cache-control:
+      - private, max-age=0, no-store, no-cache, must-revalidate
+      connection:
+      - keep-alive
+      content-length:
+      - '562'
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin, Accept-Encoding
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        logprobs: null
+        message:
+          content: 'The capital of France is '
+          role: assistant
+      created: 1744190899
+      id: chatcmpl-9de98446-dccf-439b-bcb8-996ee77471d8
+      model: llama3-8b-8192
+      object: chat.completion
+      system_fingerprint: fp_dadc9d6142
+      usage:
+        completion_time: 0.006666667
+        completion_tokens: 8
+        prompt_time: 0.003914844
+        prompt_tokens: 17
+        queue_time: 0.5322581550000001
+        total_time: 0.010581511
+        total_tokens: 25
+      usage_breakdown:
+        models: null
+      x_groq:
+        id: req_01jrcy20hceg1t9cpsg7cmj7f9
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_settings/test_stop_settings[mistral].yaml
+++ b/tests/cassettes/test_settings/test_stop_settings[mistral].yaml
@@ -1,0 +1,69 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '153'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the capital of France?
+        role: user
+      model: ministral-8b-latest
+      n: 1
+      stop:
+      - Paris
+      stream: false
+      top_p: 1.0
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    headers:
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '322'
+      content-type:
+      - application/json
+      ratelimitbysize-limit:
+      - '500000'
+      ratelimitbysize-query-cost:
+      - '32008'
+      ratelimitbysize-remaining:
+      - '467992'
+      ratelimitbysize-reset:
+      - '42'
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        message:
+          content: 'The capital of France is '
+          role: assistant
+          tool_calls: null
+      created: 1744190898
+      id: 0bbc8cf8fc76455fae759fb9109f8547
+      model: ministral-8b-latest
+      object: chat.completion
+      usage:
+        completion_tokens: 6
+        prompt_tokens: 10
+        total_tokens: 16
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_settings/test_stop_settings[openai].yaml
+++ b/tests/cassettes/test_settings/test_stop_settings[openai].yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '129'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the capital of France?
+        role: user
+      model: o3-mini
+      n: 1
+      stop:
+      - Paris
+      stream: false
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '805'
+      content-type:
+      - application/json
+      openai-organization:
+      - pydantic-28gund
+      openai-processing-ms:
+      - '3852'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        message:
+          annotations: []
+          content: 'The capital of France is '
+          refusal: null
+          role: assistant
+      created: 1744190892
+      id: chatcmpl-BKM16LEJBCFN3jeeR1O8sFXn6OMZt
+      model: o3-mini-2025-01-31
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_617f206dd9
+      usage:
+        completion_tokens: 80
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 64
+          rejected_prediction_tokens: 0
+        prompt_tokens: 13
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 93
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,8 @@ from vcr import VCR
 
 import pydantic_ai.models
 from pydantic_ai.messages import BinaryContent
-from pydantic_ai.models import cached_async_http_client
+from pydantic_ai.models import Model, cached_async_http_client
+from pydantic_ai.providers.bedrock import BedrockProvider
 
 __all__ = 'IsDatetime', 'IsFloat', 'IsNow', 'IsStr', 'TestEnv', 'ClientWithHandler', 'try_import'
 
@@ -265,6 +266,74 @@ def co_api_key() -> str:
 @pytest.fixture(scope='session')
 def mistral_api_key() -> str:
     return os.getenv('MISTRAL_API_KEY', 'mock-api-key')
+
+
+@pytest.fixture(scope='session')
+def bedrock_provider():
+    import boto3
+
+    from pydantic_ai.providers.bedrock import BedrockProvider
+
+    bedrock_client = boto3.client(
+        'bedrock-runtime',
+        region_name=os.getenv('AWS_REGION', 'us-east-1'),
+        aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID', 'AKIA6666666666666666'),
+        aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY', '6666666666666666666666666666666666666666'),
+    )
+    yield BedrockProvider(bedrock_client=bedrock_client)
+    bedrock_client.close()
+
+
+@pytest.fixture()
+def model(
+    request: pytest.FixtureRequest,
+    openai_api_key: str,
+    anthropic_api_key: str,
+    mistral_api_key: str,
+    groq_api_key: str,
+    co_api_key: str,
+    gemini_api_key: str,
+    bedrock_provider: BedrockProvider,
+) -> Model:
+    try:
+        if request.param == 'openai':
+            from pydantic_ai.models.openai import OpenAIModel
+            from pydantic_ai.providers.openai import OpenAIProvider
+
+            return OpenAIModel('o3-mini', provider=OpenAIProvider(api_key=openai_api_key))
+        elif request.param == 'anthropic':
+            from pydantic_ai.models.anthropic import AnthropicModel
+            from pydantic_ai.providers.anthropic import AnthropicProvider
+
+            return AnthropicModel('claude-3-5-sonnet-latest', provider=AnthropicProvider(api_key=anthropic_api_key))
+        elif request.param == 'mistral':
+            from pydantic_ai.models.mistral import MistralModel
+            from pydantic_ai.providers.mistral import MistralProvider
+
+            return MistralModel('ministral-8b-latest', provider=MistralProvider(api_key=mistral_api_key))
+        elif request.param == 'groq':
+            from pydantic_ai.models.groq import GroqModel
+            from pydantic_ai.providers.groq import GroqProvider
+
+            return GroqModel('llama3-8b-8192', provider=GroqProvider(api_key=groq_api_key))
+        elif request.param == 'cohere':
+            from pydantic_ai.models.cohere import CohereModel
+            from pydantic_ai.providers.cohere import CohereProvider
+
+            return CohereModel('command-r-plus', provider=CohereProvider(api_key=co_api_key))
+        elif request.param == 'gemini':
+            from pydantic_ai.models.gemini import GeminiModel
+            from pydantic_ai.providers.google_gla import GoogleGLAProvider
+
+            return GeminiModel('gemini-1.5-flash', provider=GoogleGLAProvider(api_key=gemini_api_key))
+        elif request.param == 'bedrock':
+            from pydantic_ai.models.bedrock import BedrockConverseModel
+
+            return BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+        else:  # pragma: no cover
+            raise ValueError(f'Unknown model: {request.param}')
+    except ImportError:  # pragma: no cover
+        pytest.skip(f'{request.param} is not installed')
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,6 @@ from vcr import VCR
 import pydantic_ai.models
 from pydantic_ai.messages import BinaryContent
 from pydantic_ai.models import Model, cached_async_http_client
-from pydantic_ai.providers.bedrock import BedrockProvider
 
 __all__ = 'IsDatetime', 'IsFloat', 'IsNow', 'IsStr', 'TestEnv', 'ClientWithHandler', 'try_import'
 
@@ -31,6 +30,7 @@ __all__ = 'IsDatetime', 'IsFloat', 'IsNow', 'IsStr', 'TestEnv', 'ClientWithHandl
 pydantic_ai.models.ALLOW_MODEL_REQUESTS = False
 
 if TYPE_CHECKING:
+    from pydantic_ai.providers.bedrock import BedrockProvider
 
     def IsDatetime(*args: Any, **kwargs: Any) -> datetime: ...
     def IsFloat(*args: Any, **kwargs: Any) -> float: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,19 +269,22 @@ def mistral_api_key() -> str:
 
 
 @pytest.fixture(scope='session')
-def bedrock_provider():
-    import boto3
+def bedrock_provider():  # pragma: no cover
+    try:
+        import boto3
 
-    from pydantic_ai.providers.bedrock import BedrockProvider
+        from pydantic_ai.providers.bedrock import BedrockProvider
 
-    bedrock_client = boto3.client(
-        'bedrock-runtime',
-        region_name=os.getenv('AWS_REGION', 'us-east-1'),
-        aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID', 'AKIA6666666666666666'),
-        aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY', '6666666666666666666666666666666666666666'),
-    )
-    yield BedrockProvider(bedrock_client=bedrock_client)
-    bedrock_client.close()
+        bedrock_client = boto3.client(
+            'bedrock-runtime',
+            region_name=os.getenv('AWS_REGION', 'us-east-1'),
+            aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID', 'AKIA6666666666666666'),
+            aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY', '6666666666666666666666666666666666666666'),
+        )
+        yield BedrockProvider(bedrock_client=bedrock_client)
+        bedrock_client.close()
+    except ImportError:
+        pytest.skip('boto3 is not installed')
 
 
 @pytest.fixture()
@@ -294,7 +297,7 @@ def model(
     co_api_key: str,
     gemini_api_key: str,
     bedrock_provider: BedrockProvider,
-) -> Model:
+) -> Model:  # pragma: no cover
     try:
         if request.param == 'openai':
             from pydantic_ai.models.openai import OpenAIModel
@@ -330,9 +333,9 @@ def model(
             from pydantic_ai.models.bedrock import BedrockConverseModel
 
             return BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
-        else:  # pragma: no cover
+        else:
             raise ValueError(f'Unknown model: {request.param}')
-    except ImportError:  # pragma: no cover
+    except ImportError:
         pytest.skip(f'{request.param} is not installed')
 
 

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import datetime
-import os
 from typing import Any
 
 import pytest
@@ -35,8 +34,6 @@ from pydantic_ai.usage import Usage
 from ..conftest import IsDatetime, try_import
 
 with try_import() as imports_successful:
-    import boto3
-
     from pydantic_ai.models.bedrock import BedrockConverseModel
     from pydantic_ai.providers.bedrock import BedrockProvider
 
@@ -45,18 +42,6 @@ pytestmark = [
     pytest.mark.anyio,
     pytest.mark.vcr,
 ]
-
-
-@pytest.fixture
-def bedrock_provider():
-    bedrock_client = boto3.client(  # type: ignore[reportUnknownMemberType]
-        'bedrock-runtime',
-        region_name=os.getenv('AWS_REGION', 'us-east-1'),
-        aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID', 'AKIA6666666666666666'),
-        aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY', '6666666666666666666666666666666666666666'),
-    )
-    yield BedrockProvider(bedrock_client=bedrock_client)
-    bedrock_client.close()
 
 
 async def test_bedrock_model(allow_model_requests: None, bedrock_provider: BedrockProvider):


### PR DESCRIPTION
This PR only adds `stop_sequences` to `ModelSettings`.

- Closes https://github.com/pydantic/pydantic-ai/issues/1264

---

We need a smarter way to test a "thing" that affects all models without having to create a test on each `test_<model>` module.

Maybe we should have something like:

```py
async def test_stop_settings(allow_model_requests: None, model: Model) -> None:
    agent = Agent(model=model)
    result = await agent.run('What is the capital of France?')
    assert result.data == snapshot()
```

`model` would be a parametrized fixture on each provider. 

---

EDIT: I just added the above test. 🙏 