### PR TITLE
Fix bug with JSON schema generation when using InstrumentedModel

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -146,6 +146,9 @@ class InstrumentedModel(WrapperModel):
                 if response_stream:
                     finish(response_stream.get(), response_stream.usage())
 
+    def customize_request_parameters(self, model_request_parameters: ModelRequestParameters) -> ModelRequestParameters:
+        return self.wrapped.customize_request_parameters(model_request_parameters)
+
     @contextmanager
     def _instrument(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -146,9 +146,6 @@ class InstrumentedModel(WrapperModel):
                 if response_stream:
                     finish(response_stream.get(), response_stream.usage())
 
-    def customize_request_parameters(self, model_request_parameters: ModelRequestParameters) -> ModelRequestParameters:
-        return self.wrapped.customize_request_parameters(model_request_parameters)
-
     @contextmanager
     def _instrument(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/models/wrapper.py
@@ -37,6 +37,9 @@ class WrapperModel(Model):
         async with self.wrapped.request_stream(messages, model_settings, model_request_parameters) as response_stream:
             yield response_stream
 
+    def customize_request_parameters(self, model_request_parameters: ModelRequestParameters) -> ModelRequestParameters:
+        return self.wrapped.customize_request_parameters(model_request_parameters)
+
     @property
     def model_name(self) -> str:
         return self.wrapped.model_name


### PR DESCRIPTION
After adding the `pydantic_ai.models.Model.customize_request_parameters` method, I missed adding it to the `WrappedModel`, which caused that method to not be called when using `InstrumentedModel`.

Closes #1398