### PR TITLE
Allow additional properties in the JSON schemas used for tools with Gemini

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -818,10 +818,6 @@ class _GeminiJsonSchema:
                 schema['description'] = f'Format: {fmt}'
 
     def _object(self, schema: dict[str, Any], refs_stack: tuple[str, ...]) -> None:
-        ad_props = schema.pop('additionalProperties', None)
-        if ad_props:
-            raise UserError('Additional properties in JSON Schema are not supported by Gemini')
-
         if properties := schema.get('properties'):  # pragma: no branch
             for value in properties.values():
                 self._simplify(value, refs_stack)


### PR DESCRIPTION
I'm not getting API response errors using `gemini-2.0-flash-exp` or `gemini-2.5-pro-exp-03-25` when making requests with schemas that currently hit this error. So I guess Google has loosened their schema restrictions.

Admittedly, even with some fairly extensive prompting requesting it make _use_ of the additionalProperties I can't get it to, but I don't see much benefit to us making this an error now — maybe one day in the not-distant future, Google will release models that do this properly.

I could see an argument for keeping this as an error if we wanted to as a way to discourage users from using these types with gemini, but my feeling is it's better to not be an error and just classify it as a misbehavior of Gemini. Like, you might want to e.g. fall back to gemini from openai or anthropic, and those models might generate the additionalProperties in a useful way, but being able to fall back without erroring is still worth something.