### PR TITLE
support MCP logging, increase minimum mcp version to 1.6.0

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -9,7 +9,7 @@ from types import TracebackType
 from typing import Any
 
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
-from mcp.types import JSONRPCMessage
+from mcp.types import JSONRPCMessage, LoggingLevel
 from typing_extensions import Self
 
 from pydantic_ai.tools import ToolDefinition
@@ -52,6 +52,11 @@ class MCPServer(ABC):
         raise NotImplementedError('MCP Server subclasses must implement this method.')
         yield
 
+    @abstractmethod
+    def _get_log_level(self) -> LoggingLevel | None:
+        """Get the log level for the MCP server."""
+        raise NotImplementedError('MCP Server subclasses must implement this method.')
+
     async def list_tools(self) -> list[ToolDefinition]:
         """Retrieve tools that are currently active on the server.
 
@@ -89,6 +94,8 @@ class MCPServer(ABC):
         self._client = await self._exit_stack.enter_async_context(client)
 
         await self._client.initialize()
+        if log_level := self._get_log_level():
+            await self._client.set_logging_level(log_level)
         self.is_running = True
         return self
 
@@ -150,6 +157,13 @@ class MCPServerStdio(MCPServer):
     By default the subprocess will not inherit any environment variables from the parent process.
     If you want to inherit the environment variables from the parent process, use `env=os.environ`.
     """
+    log_level: LoggingLevel | None = None
+    """The log level to enable set when connecting to the server, if any.
+
+    See <https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging#logging> for more details.
+
+    If `None`, no log level will be set.
+    """
 
     cwd: str | Path | None = None
     """The working directory to use when spawning the process."""
@@ -163,6 +177,9 @@ class MCPServerStdio(MCPServer):
         server = StdioServerParameters(command=self.command, args=list(self.args), env=self.env, cwd=self.cwd)
         async with stdio_client(server=server) as (read_stream, write_stream):
             yield read_stream, write_stream
+
+    def _get_log_level(self) -> LoggingLevel | None:
+        return self.log_level
 
 
 @dataclass
@@ -223,6 +240,13 @@ class MCPServerHTTP(MCPServer):
     If no new messages are received within this time, the connection will be considered stale
     and may be closed. Defaults to 5 minutes (300 seconds).
     """
+    log_level: LoggingLevel | None = None
+    """The log level to enable set when connecting to the server, if any.
+
+    See <https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging#logging> for more details.
+
+    If `None`, no log level will be set.
+    """
 
     @asynccontextmanager
     async def client_streams(
@@ -234,3 +258,6 @@ class MCPServerHTTP(MCPServer):
             url=self.url, headers=self.headers, timeout=self.timeout, sse_read_timeout=self.sse_read_timeout
         ) as (read_stream, write_stream):
             yield read_stream, write_stream
+
+    def _get_log_level(self) -> LoggingLevel | None:
+        return self.log_level

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -158,7 +158,7 @@ class MCPServerStdio(MCPServer):
     If you want to inherit the environment variables from the parent process, use `env=os.environ`.
     """
     log_level: LoggingLevel | None = None
-    """The log level to enable set when connecting to the server, if any.
+    """The log level to set when connecting to the server, if any.
 
     See <https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging#logging> for more details.
 
@@ -241,7 +241,7 @@ class MCPServerHTTP(MCPServer):
     and may be closed. Defaults to 5 minutes (300 seconds).
     """
     log_level: LoggingLevel | None = None
-    """The log level to enable set when connecting to the server, if any.
+    """The log level to set when connecting to the server, if any.
 
     See <https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging#logging> for more details.
 

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -69,7 +69,7 @@ tavily = ["tavily-python>=0.5.0"]
 # CLI
 cli = ["rich>=13", "prompt-toolkit>=3", "argcomplete>=3.5.0"]
 # MCP
-mcp = ["mcp>=1.5.0; python_version >= '3.10'"]
+mcp = ["mcp>=1.6.0; python_version >= '3.10'"]
 # Evals
 evals = ["pydantic-evals=={{ version }}"]
 

--- a/tests/mcp_server.py
+++ b/tests/mcp_server.py
@@ -1,5 +1,4 @@
 from mcp.server.fastmcp import Context, FastMCP
-from mcp.server.session import ServerSession
 
 mcp = FastMCP('PydanticAI MCP Server')
 log_level = 'unset'
@@ -19,7 +18,7 @@ async def celsius_to_fahrenheit(celsius: float) -> float:
 
 
 @mcp.tool()
-async def get_log_level(ctx: Context[ServerSession, None]) -> str:
+async def get_log_level(ctx: Context) -> str:  # type: ignore
     """Get the current log level.
 
     Returns:

--- a/tests/mcp_server.py
+++ b/tests/mcp_server.py
@@ -1,19 +1,42 @@
-from mcp.server.fastmcp import FastMCP
+import asyncio
 
-mcp = FastMCP('PydanticAI MCP Server')
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
 
-
-@mcp.tool()
-async def celsius_to_fahrenheit(celsius: float) -> float:
-    """Convert Celsius to Fahrenheit.
-
-    Args:
-        celsius: Temperature in Celsius
-
-    Returns:
-        Temperature in Fahrenheit
-    """
-    return (celsius * 9 / 5) + 32
+server = Server('test-server')
+log_level = 'unset'
 
 
-mcp.run()
+@server.call_tool()
+async def query_db(name: str, arguments: dict[str, float]) -> list[TextContent]:
+    if name == 'celsius_to_fahrenheit':
+        celsius = arguments['celsius']
+        return [TextContent(type='text', text=str((celsius * 9 / 5) + 32))]
+    elif name == 'get_log_level':
+        return [TextContent(type='text', text=log_level)]
+    else:
+        raise ValueError(f'Unknown tool: {name}')
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    return [
+        Tool(name='celsius_to_fahrenheit', description='Convert Celsius to Fahrenheit.', inputSchema={}),
+        Tool(name='get_log_level', description='', inputSchema={}),
+    ]
+
+
+@server.set_logging_level()
+async def set_logging_level(level: str) -> None:
+    global log_level
+    log_level = level
+
+
+async def run_stdio_server():
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+if __name__ == '__main__':
+    asyncio.run(run_stdio_server())

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -45,7 +45,7 @@ async def test_stdio_server_with_cwd():
     server = MCPServerStdio('python', ['mcp_server.py'], cwd=test_dir)
     async with server:
         tools = await server.list_tools()
-        assert len(tools) == 1
+        assert len(tools) == 2
 
 
 def test_sse_server():

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -51,6 +51,7 @@ async def test_stdio_server_with_cwd():
 def test_sse_server():
     sse_server = MCPServerHTTP(url='http://localhost:8000/sse')
     assert sse_server.url == 'http://localhost:8000/sse'
+    assert sse_server._get_log_level() is None  # pyright: ignore[reportPrivateUsage]
 
 
 def test_sse_server_with_header_and_timeout():
@@ -59,11 +60,13 @@ def test_sse_server_with_header_and_timeout():
         headers={'my-custom-header': 'my-header-value'},
         timeout=10,
         sse_read_timeout=100,
+        log_level='info',
     )
     assert sse_server.url == 'http://localhost:8000/sse'
     assert sse_server.headers is not None and sse_server.headers['my-custom-header'] == 'my-header-value'
     assert sse_server.timeout == 10
     assert sse_server.sse_read_timeout == 100
+    assert sse_server._get_log_level() == 'info'  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_agent_with_stdio_server(allow_model_requests: None, openai_api_key: str):

--- a/uv.lock
+++ b/uv.lock
@@ -2979,7 +2979,7 @@ requires-dist = [
     { name = "groq", marker = "extra == 'groq'", specifier = ">=0.15.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=3.11.0" },
-    { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=1.5.0" },
+    { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=1.6.0" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.2.5" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.74.0" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },


### PR DESCRIPTION
This isn't much use until @alexmojaki is able to get better logging instrumentation in logfire, but we may as well merge it.