### PR TITLE
Add openai strict mode support for mcp

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -64,6 +64,7 @@ class MCPServer(ABC):
                 name=tool.name,
                 description=tool.description or '',
                 parameters_json_schema=tool.inputSchema,
+                strict=self.strict,
             )
             for tool in tools.tools
         ]
@@ -150,6 +151,12 @@ class MCPServerStdio(MCPServer):
     If you want to inherit the environment variables from the parent process, use `env=os.environ`.
     """
 
+    strict: bool | None = None
+    """Whether to enforce (vendor-specific) strict JSON schema validation for tool calls.
+
+    See [`ToolDefinition`][pydantic_ai.tools.ToolDefinition] for more info.
+    """
+
     @asynccontextmanager
     async def client_streams(
         self,
@@ -218,6 +225,12 @@ class MCPServerHTTP(MCPServer):
     This timeout applies to the long-lived SSE connection after it's established.
     If no new messages are received within this time, the connection will be considered stale
     and may be closed. Defaults to 5 minutes (300 seconds).
+    """
+
+    strict: bool | None = None
+    """Whether to enforce (vendor-specific) strict JSON schema validation for tool calls.
+
+    See [`ToolDefinition`][pydantic_ai.tools.ToolDefinition] for more info.
     """
 
     @asynccontextmanager

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -34,6 +34,7 @@ class MCPServer(ABC):
     """
 
     is_running: bool = False
+    strict: bool | None = None
 
     _client: ClientSession
     _read_stream: MemoryObjectReceiveStream[JSONRPCMessage | Exception]


### PR DESCRIPTION
As a follow up of https://github.com/pydantic/pydantic-ai/pull/1304 , i wonder if this is the right way of supporting strict mode for MCP.