### PR TITLE
docs: add Marimo to nest-asyncio environments

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,7 +12,7 @@ import nest_asyncio
 
 nest_asyncio.apply()
 ```
-Note: This fix also applies to Google Colab.
+Note: This fix also applies to Google Colab and [Marimo](https://github.com/marimo-team/marimo).
 
 ## API Key Configuration
 


### PR DESCRIPTION
Hi,

While testing pydantic-ai in the Marimo reactive notebook framework ([Github](https://github.com/marimo-team/marimo) | [Website](https://marimo.io/)), I ran into the `RuntimeError: This event loop is already running` error:
![CleanShot 2025-04-10 at 20 25 26@2x](https://github.com/user-attachments/assets/090a412c-7f82-466b-ae87-d4fa9a4b856c)

I resolved it by using `nest_asyncio.apply()`:
![CleanShot 2025-04-10 at 20 26 11@2x](https://github.com/user-attachments/assets/32f1b57a-34f3-466b-9496-a0ec4bc81fd8)

I thought it might be helpful to add Marimo to the troubleshoot as a known environment where this solution works.