### PR TITLE
Add support for callable output tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -438,7 +438,7 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
         if output_schema is not None:
             for call, output_tool in output_schema.find_tool(tool_calls):
                 try:
-                    result_data = output_tool.validate(call)
+                    result_data = await output_tool.execute(call)
                     result_data = await _validate_output(result_data, ctx, call)
                 except _output.ToolRetryError as e:
                     # TODO: Should only increment retry stuff once per node execution, not for each tool call


### PR DESCRIPTION
Makes it possible to pass a call to `ToolOutput`, in which case the arguments provided by the model will be used to call that function, and that function's output is what will be returned from the agent run. (Fixes https://github.com/pydantic/pydantic-ai/issues/1189)

There are some additional things to do before this is ready:
* [ ] Handle the case where the function has an argument of type `RunContext`; this value should be injected, not obtained from the model.
* [ ] Tests
* [ ] Docs

Any concerns about the approach here would be appreciated.

Note — I think we also need to support multiple values of ToolOutput, at which point we may be able to refactor our union handling to make use of that under the hood for better consistency.

----

For context, I used this script to test:
```python
import logfire
from logfire import ConsoleOptions

from pydantic_ai import Agent, ToolOutput, ModelRetry

logfire.instrument_pydantic_ai()
logfire.configure(send_to_logfire=False, console=ConsoleOptions(verbose=True))


def my_int_tool(x: int) -> int:
    print(f'my_int_tool called with {x}')
    if x % 2 == 0:
        raise ModelRetry('Sorry, I meant an odd number')
    return x


my_agent = Agent(
    model='openai:gpt-4o',
    output_type=ToolOutput(call=my_int_tool),
    system_prompt='You are a helpful assistant.',
)


result = my_agent.run_sync('Please return any even number')
print(result.output)
```
and I see this output in the console:
```
18:12:10.734 my_agent run
18:12:10.735   chat gpt-4o
             │ model_request_parameters={
             │                              'function_tools': [],
             │                              'allow_text_output': False,
             │                              'output_tools': [{'name': 'final_result', 'description': 'The final response which ends this conversation', 'parameters_json_schema': {'additionalProperties': False, 'properties': {'x': {'title': 'X', 'type': 'integer'}}, 'required': ['x'], 'type': 'object'}, 'outer_typed_dict_key': None, 'strict': True}],
             │                          }
my_int_tool called with 2
18:12:12.829   chat gpt-4o
             │ model_request_parameters={
             │                              'function_tools': [],
             │                              'allow_text_output': False,
             │                              'output_tools': [{'name': 'final_result', 'description': 'The final response which ends this conversation', 'parameters_json_schema': {'additionalProperties': False, 'properties': {'x': {'title': 'X', 'type': 'integer'}}, 'required': ['x'], 'type': 'object'}, 'outer_typed_dict_key': None, 'strict': True}],
             │                          }
my_int_tool called with 3
3
```