### PR TITLE
BREAKING CHANGE (minor) move `format_as_xml`

### DIFF
--- a/docs/evals.md
+++ b/docs/evals.md
@@ -163,8 +163,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from pydantic_ai import Agent
-from pydantic_ai.format_as_xml import format_as_xml
+from pydantic_ai import Agent, format_as_xml
 from pydantic_evals import Case, Dataset
 from pydantic_evals.evaluators import IsInstance, LLMJudge
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -661,8 +661,7 @@ Instead of running the entire graph in a single process invocation, we run the g
         GraphRunContext,
     )
 
-    from pydantic_ai import Agent
-    from pydantic_ai import format_as_xml
+    from pydantic_ai import Agent, format_as_xml
     from pydantic_ai.messages import ModelMessage
 
     ask_agent = Agent('openai:gpt-4o', output_type=str, instrument=True)

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -359,8 +359,7 @@ from dataclasses import dataclass, field
 
 from pydantic import BaseModel, EmailStr
 
-from pydantic_ai import Agent
-from pydantic_ai.format_as_xml import format_as_xml
+from pydantic_ai import Agent, format_as_xml
 from pydantic_ai.messages import ModelMessage
 from pydantic_graph import BaseNode, End, Graph, GraphRunContext
 
@@ -663,7 +662,7 @@ Instead of running the entire graph in a single process invocation, we run the g
     )
 
     from pydantic_ai import Agent
-    from pydantic_ai.format_as_xml import format_as_xml
+    from pydantic_ai import format_as_xml
     from pydantic_ai.messages import ModelMessage
 
     ask_agent = Agent('openai:gpt-4o', output_type=str, instrument=True)

--- a/examples/pydantic_ai_examples/question_graph.py
+++ b/examples/pydantic_ai_examples/question_graph.py
@@ -20,8 +20,7 @@ from pydantic_graph import (
 )
 from pydantic_graph.persistence.file import FileStatePersistence
 
-from pydantic_ai import Agent
-from pydantic_ai.format_as_xml import format_as_xml
+from pydantic_ai import Agent, format_as_xml
 from pydantic_ai.messages import ModelMessage
 
 # 'if-token-present' means nothing will be sent (and the example will work) if you don't have logfire configured

--- a/examples/pydantic_ai_examples/sql_gen.py
+++ b/examples/pydantic_ai_examples/sql_gen.py
@@ -25,8 +25,7 @@ from devtools import debug
 from pydantic import BaseModel, Field
 from typing_extensions import TypeAlias
 
-from pydantic_ai import Agent, ModelRetry, RunContext
-from pydantic_ai.format_as_xml import format_as_xml
+from pydantic_ai import Agent, ModelRetry, RunContext, format_as_xml
 
 # 'if-token-present' means nothing will be sent (and the example will work) if you don't have logfire configured
 logfire.configure(send_to_logfire='if-token-present')

--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -1,4 +1,4 @@
-from importlib.metadata import version
+from importlib.metadata import version as _metadata_version
 
 from .agent import Agent, CallToolsNode, EndStrategy, ModelRequestNode, UserPromptNode, capture_run_messages
 from .exceptions import (
@@ -10,6 +10,7 @@ from .exceptions import (
     UsageLimitExceeded,
     UserError,
 )
+from .format_prompt import format_as_xml
 from .messages import AudioUrl, BinaryContent, DocumentUrl, ImageUrl, VideoUrl
 from .result import ToolOutput
 from .tools import RunContext, Tool
@@ -42,5 +43,7 @@ __all__ = (
     'RunContext',
     # result
     'ToolOutput',
+    # format_prompt
+    'format_as_xml',
 )
-__version__ = version('pydantic_ai_slim')
+__version__ = _metadata_version('pydantic_ai_slim')

--- a/pydantic_ai_slim/pydantic_ai/format_as_xml.py
+++ b/pydantic_ai_slim/pydantic_ai/format_as_xml.py
@@ -1,0 +1,9 @@
+from typing_extensions import deprecated
+
+from .format_prompt import format_as_xml as _format_as_xml
+
+
+@deprecated('`format_as_xml` has moved, import it via `from pydantic_ai import format_as_xml`')
+def format_as_xml(prompt: str) -> str:
+    """`format_as_xml` has moved, import it via `from pydantic_ai import format_as_xml` instead."""
+    return _format_as_xml(prompt)

--- a/pydantic_ai_slim/pydantic_ai/format_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/format_prompt.py
@@ -42,7 +42,7 @@ def format_as_xml(
 
     Example:
     ```python {title="format_as_xml_example.py" lint="skip"}
-    from pydantic_ai.format_as_xml import format_as_xml
+    from pydantic_ai import format_as_xml
 
     print(format_as_xml({'name': 'John', 'height': 6, 'weight': 200}, root_tag='user'))
     '''

--- a/tests/test_format_as_xml.py
+++ b/tests/test_format_as_xml.py
@@ -6,7 +6,7 @@ import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel
 
-from pydantic_ai.format_as_xml import format_as_xml
+from pydantic_ai import format_as_xml
 
 
 @dataclass


### PR DESCRIPTION
It was ugly and confusing have to do

```py
from pydantic_ai.format_as_xml import format_as_xml
```

This allows root import (`from pydantic_aiimport format_as_xml`) and makes it easy to extend functionality with other methods in future.