### PR TITLE
fix: no args tool call with bedrock model

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -536,7 +536,7 @@ class BedrockStreamedResponse(StreamedResponse):
                     maybe_event = self._parts_manager.handle_tool_call_delta(
                         vendor_part_id=index,
                         tool_name=tool_use.get('name'),
-                        args=tool_use.get('input'),
+                        args=tool_use.get('input') or None,  # args might be `''`, will cause json decode error
                         tool_call_id=tool_id,
                     )
                     if maybe_event:


### PR DESCRIPTION
Related: https://github.com/pydantic/pydantic-ai/pull/1407

This only happens when streaming nodes, since we are parsing parts on-the-fly

reproduce:

```python
from pydantic_ai import Agent

agent = Agent(
    model="bedrock:us.anthropic.claude-3-7-sonnet-20250219-v1:0"
)


prompt = """
call check_credentials
"""

@agent.tool_plain
def check_credentials() -> None:
    """say_hello"""
    print("hello")


@agent.tool_plain
def write_html(content: str) -> None:
    """Write a html file"""
    return
from pydantic_ai import Agent
from pydantic_ai.messages import (
    FinalResultEvent,
    FunctionToolCallEvent,
    FunctionToolResultEvent,
    PartDeltaEvent,
    PartStartEvent,
    TextPartDelta,
    ToolCallPartDelta,
)
from pydantic_ai.tools import RunContext
async def main():
    output_messages: list[str] = []

    async with agent.iter(prompt) as run:
        async for node in run:
            if Agent.is_user_prompt_node(node):
                # A user prompt node => The user has provided input
                output_messages.append(f'=== UserPromptNode: {node.user_prompt} ===')
            elif Agent.is_model_request_node(node):
                # A model request node => We can stream tokens from the model's request
                output_messages.append(
                    '=== ModelRequestNode: streaming partial request tokens ==='
                )
                async with node.stream(run.ctx) as request_stream:
                    async for event in request_stream:
                        if isinstance(event, PartStartEvent):
                            output_messages.append(
                                f'[Request] Starting part {event.index}: {event.part!r}'
                            )
                        elif isinstance(event, PartDeltaEvent):
                            if isinstance(event.delta, TextPartDelta):
                                output_messages.append(
                                    f'[Request] Part {event.index} text delta: {event.delta.content_delta!r}'
                                )
                            elif isinstance(event.delta, ToolCallPartDelta):
                                output_messages.append(
                                    f'[Request] Part {event.index} args_delta={event.delta.args_delta}'
                                )
                        elif isinstance(event, FinalResultEvent):
                            output_messages.append(
                                f'[Result] The model produced a final result (tool_name={event.tool_name})'
                            )
            elif Agent.is_call_tools_node(node):
                # A handle-response node => The model returned some data, potentially calls a tool
                output_messages.append(
                    '=== CallToolsNode: streaming partial response & tool usage ==='
                )
                async with node.stream(run.ctx) as handle_stream:
                    async for event in handle_stream:
                        if isinstance(event, FunctionToolCallEvent):
                            output_messages.append(
                                f'[Tools] The LLM calls tool={event.part.tool_name!r} with args={event.part.args} (tool_call_id={event.part.tool_call_id!r})'
                            )
                        elif isinstance(event, FunctionToolResultEvent):
                            output_messages.append(
                                f'[Tools] Tool call {event.tool_call_id!r} returned => {event.result.content}'
                            )
            elif Agent.is_end_node(node):
                assert run.result.data == node.data.data
                # Once an End node is reached, the agent run is complete
                output_messages.append(f'=== Final Agent Output: {run.result.data} ===')

    print(output_messages)

if __name__ == "__main__":
    import asyncio

    asyncio.run(main())

```

Bedrock events

```bash
{'messageStart': {'role': 'assistant'}}
{'contentBlockDelta': {'delta': {'text': 'I'}, 'contentBlockIndex': 0}}
{'contentBlockDelta': {'delta': {'text': "'ll call the check_credentials function for"}, 'contentBlockIndex': 0}}
{'contentBlockDelta': {'delta': {'text': ' you.'}, 'contentBlockIndex': 0}}
{'contentBlockStop': {'contentBlockIndex': 0}}
{'contentBlockStart': {'start': {'toolUse': {'toolUseId': 'tooluse_lEptOS8HS1SEtTnOj2G2cw', 'name': 'check_credentials'}}, 'contentBlockIndex': 1}}
{'contentBlockDelta': {'delta': {'toolUse': {'input': ''}}, 'contentBlockIndex': 1}}
{'contentBlockStop': {'contentBlockIndex': 1}}
{'messageStop': {'stopReason': 'tool_use'}}
{'metadata': {'usage': {'inputTokens': 429, 'outputTokens': 48, 'totalTokens': 477}, 'metrics': {'latencyMs': 2001}}}
Traceback (most recent call last):
  File "/Users/jizhongsheng/zerolab/lightblue/main.py", line 91, in <module>
    asyncio.run(main())
  File "/Users/jizhongsheng/miniconda3/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/miniconda3/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/miniconda3/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/zerolab/lightblue/main.py", line 47, in main
    async with node.stream(run.ctx) as request_stream:
               ^^^^^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/miniconda3/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/zerolab/lightblue/.venv/lib/python3.12/site-packages/pydantic_ai/_agent_graph.py", line 271, in stream
    async with self._stream(ctx) as streamed_response:
               ^^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/miniconda3/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/zerolab/lightblue/.venv/lib/python3.12/site-packages/pydantic_ai/_agent_graph.py", line 293, in _stream
    async with ctx.deps.model.request_stream(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/miniconda3/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/zerolab/lightblue/lightblue_ai/models/bedrock.py", line 200, in request_stream
    response = await self._messages_create(messages, True, model_settings, model_request_parameters)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/zerolab/lightblue/lightblue_ai/models/bedrock.py", line 262, in _messages_create
    system_prompt, bedrock_messages = await self._map_messages(messages)
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/zerolab/lightblue/lightblue_ai/models/bedrock.py", line 388, in _map_messages
    content.append(self._map_tool_call(item))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/zerolab/lightblue/lightblue_ai/models/bedrock.py", line 438, in _map_tool_call
    "toolUse": {"toolUseId": _utils.guard_tool_call_id(t=t), "name": t.tool_name, "input": t.args_as_dict()}
                                                                                           ^^^^^^^^^^^^^^^^
  File "/Users/jizhongsheng/zerolab/lightblue/.venv/lib/python3.12/site-packages/pydantic_ai/messages.py", line 428, in args_as_dict
    args = pydantic_core.from_json(self.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: EOF while parsing a value at line 1 column 0
```