### PR TITLE
Switch CLI to `clai`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,13 @@ repos:
         types_or: [javascript, ts, json]
         files: '^mcp-run-python/'
         pass_filenames: false
+      - id: clai-help
+        name: clai help output
+        entry: uv
+        args: [run, pytest, 'clai/update_readme.py']
+        language: system
+        types_or: [python, markdown]
+        pass_filenames: false
       - id: typecheck
         name: Typecheck
         entry: make

--- a/clai/README.md
+++ b/clai/README.md
@@ -1,6 +1,14 @@
 # clai
 
-PydanticAI CLI: command line interface to chat to LLMs.
+[![CI](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
+[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic-ai.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic-ai)
+[![PyPI](https://img.shields.io/pypi/v/clai.svg)](https://pypi.python.org/pypi/clai)
+[![versions](https://img.shields.io/pypi/pyversions/clai.svg)](https://github.com/pydantic/pydantic-ai)
+[![license](https://img.shields.io/github/license/pydantic/pydantic-ai.svg?v)](https://github.com/pydantic/pydantic-ai/blob/main/LICENSE)
+
+(pronounced "clay")
+
+Command line interface to chat to LLMs, part of the [PydanticAI project](https://github.com/pydantic/pydantic-ai).
 
 ## Usage
 
@@ -10,7 +18,7 @@ uvx clai
 
 Or,
 
-```
+```bash
 pip install clai
 clai
 ```

--- a/clai/README.md
+++ b/clai/README.md
@@ -18,12 +18,13 @@ clai
 ## Help
 
 ```
-usage: clai [-h] [-m [MODEL]] [-l] [-t [CODE_THEME]] [--no-stream] [--version] [prompt]
+usage: clai [-h] [-m [MODEL]] [-l] [-t [CODE_THEME]] [--no-stream] [--version]
+            [prompt]
 
-PydanticAI CLI v0.1.1.dev5+4d261d50
+PydanticAI CLI v...
 
-Special prompt:
-* `/exit` - exit the interactive mode
+Special prompts:
+* `/exit` - exit the interactive mode (ctrl-c and ctrl-d also work)
 * `/markdown` - show the last markdown output of the last question
 * `/multiline` - toggle multiline mode
 
@@ -37,6 +38,6 @@ options:
   -l, --list-models     List all available models and exit
   -t [CODE_THEME], --code-theme [CODE_THEME]
                         Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.
-  --no-stream           Whether to stream responses from the model
+  --no-stream           Disable streaming from the model
   --version             Show version and exit
 ```

--- a/clai/README.md
+++ b/clai/README.md
@@ -1,0 +1,42 @@
+# clai
+
+PydanticAI CLI: command line interface to chat to LLMs.
+
+## Usage
+
+```bash
+uvx clai
+```
+
+Or,
+
+```
+pip install clai
+clai
+```
+
+## Help
+
+```
+usage: clai [-h] [-m [MODEL]] [-l] [-t [CODE_THEME]] [--no-stream] [--version] [prompt]
+
+PydanticAI CLI v0.1.1.dev5+4d261d50
+
+Special prompt:
+* `/exit` - exit the interactive mode
+* `/markdown` - show the last markdown output of the last question
+* `/multiline` - toggle multiline mode
+
+positional arguments:
+  prompt                AI Prompt, if omitted fall into interactive mode
+
+options:
+  -h, --help            show this help message and exit
+  -m [MODEL], --model [MODEL]
+                        Model to use, in format "<provider>:<model>" e.g. "openai:gpt-4o" or "anthropic:claude-3-7-sonnet-latest". Defaults to "openai:gpt-4o".
+  -l, --list-models     List all available models and exit
+  -t [CODE_THEME], --code-theme [CODE_THEME]
+                        Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.
+  --no-stream           Whether to stream responses from the model
+  --version             Show version and exit
+```

--- a/clai/README.md
+++ b/clai/README.md
@@ -18,8 +18,7 @@ clai
 ## Help
 
 ```
-usage: clai [-h] [-m [MODEL]] [-l] [-t [CODE_THEME]] [--no-stream] [--version]
-            [prompt]
+usage: clai [-h] [-m [MODEL]] [-l] [-t [CODE_THEME]] [--no-stream] [--version] [prompt]
 
 PydanticAI CLI v...
 

--- a/clai/README.md
+++ b/clai/README.md
@@ -12,16 +12,43 @@ Command line interface to chat to LLMs, part of the [PydanticAI project](https:/
 
 ## Usage
 
+<!-- Keep this in sync with docs/cli.md -->
+
+You'll need to set an environment variable depending on the provider you intend to use.
+
+E.g. if you're using OpenAI, set the `OPENAI_API_KEY` environment variable:
+
+```bash
+export OPENAI_API_KEY='your-api-key-here'
+```
+
+Then with [`uvx`](https://docs.astral.sh/uv/guides/tools/), run:
+
 ```bash
 uvx clai
 ```
 
-Or,
+Or to install `clai` globally [with `uv`](https://docs.astral.sh/uv/guides/tools/#installing-tools), run:
+
+```bash
+uv tool install clai
+...
+clai
+```
+
+Or with `pip`, run:
 
 ```bash
 pip install clai
+...
 clai
 ```
+
+Either way, running `clai` will start an interactive session where you can chat with the AI model. Special commands available in interactive mode:
+
+- `/exit`: Exit the session
+- `/markdown`: Show the last response in markdown format
+- `/multiline`: Toggle multiline input mode (use Ctrl+D to submit)
 
 ## Help
 

--- a/clai/clai/__init__.py
+++ b/clai/clai/__init__.py
@@ -1,0 +1,11 @@
+from importlib.metadata import version as _metadata_version
+
+from pydantic_ai import _cli
+
+__all__ = '__version__', 'cli'
+__version__ = _metadata_version('clai')
+
+
+def cli():
+    """Run the clai CLI and exit."""
+    _cli.cli_exit('clai')

--- a/clai/clai/__main__.py
+++ b/clai/clai/__main__.py
@@ -1,0 +1,6 @@
+"""This means `python -m clai` should run the CLI."""
+
+from pydantic_ai import _cli
+
+if __name__ == '__main__':
+    _cli.cli_exit('clai')

--- a/clai/pyproject.toml
+++ b/clai/pyproject.toml
@@ -12,7 +12,7 @@ bump = true
 
 [project]
 name = "clai"
-dynamic = ["version", "dependencies", "optional-dependencies"]
+dynamic = ["version", "dependencies"]
 description = "PydanticAI CLI: command line interface to chat to LLMs"
 authors = [
   { name = "Samuel Colvin", email = "samuel@pydantic.dev" },

--- a/clai/pyproject.toml
+++ b/clai/pyproject.toml
@@ -11,9 +11,9 @@ style = "pep440"
 bump = true
 
 [project]
-name = "pydantic-ai-slim"
+name = "clai"
 dynamic = ["version", "dependencies", "optional-dependencies"]
-description = "Agent Framework / shim to use Pydantic with LLMs, slim package"
+description = "PydanticAI CLI: command line interface to chat to LLMs"
 authors = [
   { name = "Samuel Colvin", email = "samuel@pydantic.dev" },
   { name = "Marcelo Trylesinski", email = "marcelotryle@gmail.com" },
@@ -47,61 +47,17 @@ requires-python = ">=3.9"
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning]
 dependencies = [
-    "eval-type-backport>=0.2.0",
-    "griffe>=1.3.2",
-    "httpx>=0.27",
-    "pydantic>=2.10",
-    "pydantic-graph=={{ version }}",
-    "exceptiongroup; python_version < '3.11'",
-    "opentelemetry-api>=1.28.0",
-    "typing-inspection>=0.4.0",
-]
-
-[tool.hatch.metadata.hooks.uv-dynamic-versioning.optional-dependencies]
-# WARNING if you add optional groups, please update docs/install.md
-logfire = ["logfire>=3.11.0"]
-# Models
-openai = ["openai>=1.75.0"]
-cohere = ["cohere>=5.13.11; platform_system != 'Emscripten'"]
-vertexai = ["google-auth>=2.36.0", "requests>=2.32.2"]
-anthropic = ["anthropic>=0.49.0"]
-groq = ["groq>=0.15.0"]
-mistral = ["mistralai>=1.2.5"]
-bedrock = ["boto3>=1.35.74"]
-# Tools
-duckduckgo = ["duckduckgo-search>=7.0.0"]
-tavily = ["tavily-python>=0.5.0"]
-# CLI
-cli = ["rich>=13", "prompt-toolkit>=3", "argcomplete>=3.5.0"]
-# MCP
-mcp = ["mcp>=1.6.0; python_version >= '3.10'"]
-# Evals
-evals = ["pydantic-evals=={{ version }}"]
-
-[dependency-groups]
-dev = [
-    "anyio>=4.5.0",
-    "devtools>=0.12.2",
-    "coverage[toml]>=7.6.2",
-    "dirty-equals>=0.9.0",
-    "inline-snapshot>=0.19.3",
-    "pytest>=8.3.3",
-    "pytest-examples>=0.0.14",
-    "pytest-mock>=3.14.0",
-    "pytest-pretty>=1.2.0",
-    "pytest-recording>=0.13.2",
-    "diff-cover>=9.2.0",
-    "boto3-stubs[bedrock-runtime]",
+    "pydantic-ai=={{ version }}",
 ]
 
 [tool.hatch.metadata]
 allow-direct-references = true
 
 [project.scripts]
-pai = "pydantic_ai._cli:cli_exit"  # TODO remove this when clai has been out for a while
+clai = "clai:cli"
 
 [tool.hatch.build.targets.wheel]
-packages = ["pydantic_ai"]
+packages = ["clai"]
 
 [tool.uv.sources]
-pydantic-graph = { workspace = true }
+pydantic-ai = { workspace = true }

--- a/clai/update_readme.py
+++ b/clai/update_readme.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 from pathlib import Path
@@ -10,6 +11,7 @@ from pydantic_ai._cli import cli
 @pytest.mark.skipif(sys.version_info >= (3, 13), reason='slightly different output with 3.13')
 def test_cli_help(capfd: pytest.CaptureFixture[str]):
     """Check README.md help output matches `clai --help`."""
+    os.environ['COLUMNS'] = '150'
     with pytest.raises(SystemExit):
         cli(['--help'], prog_name='clai')
 

--- a/clai/update_readme.py
+++ b/clai/update_readme.py
@@ -11,15 +11,18 @@ from pydantic_ai._cli import cli
 def test_cli_help(capfd: pytest.CaptureFixture[str]):
     """Check README.md help output matches `clai --help`."""
     with pytest.raises(SystemExit):
-        cli(['--help'])
+        cli(['--help'], prog_name='clai')
 
-    help_output = capfd.readouterr().out
+    help_output = capfd.readouterr().out.strip()
+    # TODO change when we reach v1
+    help_output = re.sub(r'(PydanticAI CLI v).+', r'\1...', help_output)
 
     this_dir = Path(__file__).parent
     readme = this_dir / 'README.md'
     content = readme.read_text()
 
-    new_content = re.sub('^(## Help\n+```).+?```', content, rf'\1{help_output}```', flags=re.M | re.S)
+    new_content, count = re.subn('^(## Help\n+```).+?```', rf'\1\n{help_output}\n```', content, flags=re.M | re.S)
+    assert count, 'help section not found'
     if new_content != content:
         readme.write_text(new_content)
-        pytest.fail('help output updated')
+        pytest.fail('`clai --help` output changed.')

--- a/clai/update_readme.py
+++ b/clai/update_readme.py
@@ -1,0 +1,25 @@
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from pydantic_ai._cli import cli
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason='slightly different output with 3.13')
+def test_cli_help(capfd: pytest.CaptureFixture[str]):
+    """Check README.md help output matches `clai --help`."""
+    with pytest.raises(SystemExit):
+        cli(['--help'])
+
+    help_output = capfd.readouterr().out
+
+    this_dir = Path(__file__).parent
+    readme = this_dir / 'README.md'
+    content = readme.read_text()
+
+    new_content = re.sub('^(## Help\n+```).+?```', content, rf'\1{help_output}```', flags=re.M | re.S)
+    if new_content != content:
+        readme.write_text(new_content)
+        pytest.fail('help output updated')

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,42 +1,32 @@
 # Command Line Interface (CLI)
 
-**PydanticAI** comes with a simple reference CLI application which you can use to interact with various LLMs directly from the command line.
+**PydanticAI** comes with a CLI which you can use to interact with various LLMs from the command line.
 It provides a convenient way to chat with language models and quickly get answers right in the terminal.
 
 We originally developed this CLI for our own use, but found ourselves using it so frequently that we decided to share it as part of the PydanticAI package.
 
 We plan to continue adding new features, such as interaction with MCP servers, access to tools, and more.
 
-## Installation
-
-To use the CLI, you need to either install [`pydantic-ai`](install.md), or install
-[`pydantic-ai-slim`](install.md#slim-install) with the `cli` optional group:
-
-```bash
-pip/uv-add "pydantic-ai[cli]"
-```
-
-To enable command-line argument autocompletion, run:
-
-```bash
-register-python-argcomplete pai >> ~/.bashrc  # for bash
-register-python-argcomplete pai >> ~/.zshrc   # for zsh
-```
-
 ## Usage
 
 You'll need to set an environment variable depending on the provider you intend to use.
 
-If using OpenAI, set the `OPENAI_API_KEY` environment variable:
+E.g. if using OpenAI, set the `OPENAI_API_KEY` environment variable:
 
 ```bash
 export OPENAI_API_KEY='your-api-key-here'
 ```
 
-Then simply run:
+Then with `uvx` (part of [uv](https://docs.astral.sh/uv/)) installed, simply run:
 
 ```bash
-pai
+uvx clai
+```
+
+You can also install `clai` globally with:
+
+```bash
+uv tool install clai
 ```
 
 This will start an interactive session where you can chat with the AI model. Special commands available in interactive mode:
@@ -45,18 +35,20 @@ This will start an interactive session where you can chat with the AI model. Spe
 - `/markdown`: Show the last response in markdown format
 - `/multiline`: Toggle multiline input mode (use Ctrl+D to submit)
 
+### Help
+
+To get help on the CLI, use the `--help` flag:
+
+```bash
+uvx clai --help
+```
+
 ### Choose a model
 
 You can specify which model to use with the `--model` flag:
 
 ```bash
-$ pai --model=openai:gpt-4 "What's the capital of France?"
+uvx clai --model anthropic:claude-3-7-sonnet-latest
 ```
 
-### Usage with `uvx`
-
-If you have [uv](https://docs.astral.sh/uv/) installed, the quickest way to run the CLI is with `uvx`:
-
-```bash
-uvx --from pydantic-ai pai
-```
+(a full list of models available can be printed with `uvx clai --list-models`)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # Command Line Interface (CLI)
 
-**PydanticAI** comes with a CLI which you can use to interact with various LLMs from the command line.
+**PydanticAI** comes with a CLI, `clai` (pronounced "clay") which you can use to interact with various LLMs from the command line.
 It provides a convenient way to chat with language models and quickly get answers right in the terminal.
 
 We originally developed this CLI for our own use, but found ourselves using it so frequently that we decided to share it as part of the PydanticAI package.
@@ -29,7 +29,13 @@ You can also install `clai` globally with:
 uv tool install clai
 ```
 
-This will start an interactive session where you can chat with the AI model. Special commands available in interactive mode:
+If you're using `pip`, install `clai` with:
+
+```bash
+pip install clai
+```
+
+Either way, running `clai` will start an interactive session where you can chat with the AI model. Special commands available in interactive mode:
 
 - `/exit`: Exit the session
 - `/markdown`: Show the last response in markdown format

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,30 +9,36 @@ We plan to continue adding new features, such as interaction with MCP servers, a
 
 ## Usage
 
+<!-- Keep this in sync with clai/README.md -->
+
 You'll need to set an environment variable depending on the provider you intend to use.
 
-E.g. if using OpenAI, set the `OPENAI_API_KEY` environment variable:
+E.g. if you're using OpenAI, set the `OPENAI_API_KEY` environment variable:
 
 ```bash
 export OPENAI_API_KEY='your-api-key-here'
 ```
 
-Then with `uvx` (part of [uv](https://docs.astral.sh/uv/)) installed, simply run:
+Then with [`uvx`](https://docs.astral.sh/uv/guides/tools/), run:
 
 ```bash
 uvx clai
 ```
 
-You can also install `clai` globally with:
+Or to install `clai` globally [with `uv`](https://docs.astral.sh/uv/guides/tools/#installing-tools), run:
 
 ```bash
 uv tool install clai
+...
+clai
 ```
 
-If you're using `pip`, install `clai` with:
+Or with `pip`, run:
 
 ```bash
 pip install clai
+...
+clai
 ```
 
 Either way, running `clai` will start an interactive session where you can chat with the AI model. Special commands available in interactive mode:

--- a/pydantic_ai_slim/README.md
+++ b/pydantic_ai_slim/README.md
@@ -2,8 +2,8 @@
 
 [![CI](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/pydantic/pydantic-ai/actions/workflows/ci.yml?query=branch%3Amain)
 [![Coverage](https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic-ai.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic-ai)
-[![PyPI](https://img.shields.io/pypi/v/pydantic-ai.svg)](https://pypi.python.org/pypi/pydantic-ai)
-[![versions](https://img.shields.io/pypi/pyversions/pydantic-ai.svg)](https://github.com/pydantic/pydantic-ai)
+[![PyPI](https://img.shields.io/pypi/v/pydantic-ai-slim.svg)](https://pypi.python.org/pypi/pydantic-ai-slim)
+[![versions](https://img.shields.io/pypi/pyversions/pydantic-ai-slim.svg)](https://github.com/pydantic/pydantic-ai)
 [![license](https://img.shields.io/github/license/pydantic/pydantic-ai.svg?v)](https://github.com/pydantic/pydantic-ai/blob/main/LICENSE)
 
 PydanticAI core logic with minimal required dependencies.

--- a/pydantic_ai_slim/pydantic_ai/__main__.py
+++ b/pydantic_ai_slim/pydantic_ai/__main__.py
@@ -1,6 +1,6 @@
 """This means `python -m pydantic_ai` should run the CLI."""
 
-from ._cli import app
+from ._cli import cli_exit
 
 if __name__ == '__main__':
-    app()
+    cli_exit()

--- a/pydantic_ai_slim/pydantic_ai/_cli.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli.py
@@ -7,16 +7,16 @@ from asyncio import CancelledError
 from collections.abc import Sequence
 from contextlib import ExitStack
 from datetime import datetime, timezone
-from importlib.metadata import version
 from pathlib import Path
 from typing import Any, cast
 
 from typing_inspection.introspection import get_literal_values
 
-from pydantic_ai.agent import Agent
-from pydantic_ai.exceptions import UserError
-from pydantic_ai.messages import ModelMessage
-from pydantic_ai.models import KnownModelName, infer_model
+from . import __version__
+from .agent import Agent
+from .exceptions import UserError
+from .messages import ModelMessage
+from .models import KnownModelName, infer_model
 
 try:
     import argcomplete
@@ -39,7 +39,7 @@ except ImportError as _import_error:
     ) from _import_error
 
 
-__version__ = version('pydantic-ai-slim')
+__all__ = 'cli', 'cli_exit'
 
 
 class SimpleCodeBlock(CodeBlock):
@@ -83,14 +83,20 @@ The current date and time is {datetime.now()} {tzname}.
 The user is running {sys.platform}."""
 
 
-def cli(args_list: Sequence[str] | None = None) -> int:
+def cli_exit(prog_name: str = 'pai'):  # pragma: no cover
+    """Run the CLI and exit."""
+    sys.exit(cli(prog_name=prog_name))
+
+
+def cli(args_list: Sequence[str] | None = None, prog_name: str = 'pai') -> int:
+    """Run the CLI and return the exit code for the process."""
     parser = argparse.ArgumentParser(
-        prog='pai',
+        prog=prog_name,
         description=f"""\
 PydanticAI CLI v{__version__}\n\n
 
-Special prompt:
-* `/exit` - exit the interactive mode
+Special prompts:
+* `/exit` - exit the interactive mode (ctrl-c and ctrl-d also work)
 * `/markdown` - show the last markdown output of the last question
 * `/multiline` - toggle multiline mode
 """,
@@ -101,7 +107,7 @@ Special prompt:
         '-m',
         '--model',
         nargs='?',
-        help='Model to use, in format "<provider>:<model>" e.g. "openai:gpt-4o". Defaults to "openai:gpt-4o".',
+        help='Model to use, in format "<provider>:<model>" e.g. "openai:gpt-4o" or "anthropic:claude-3-7-sonnet-latest". Defaults to "openai:gpt-4o".',
         default='openai:gpt-4o',
     )
     # we don't want to autocomplete or list models that don't include the provider,
@@ -118,10 +124,10 @@ Special prompt:
         '-t',
         '--code-theme',
         nargs='?',
-        help='Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "monokai".',
-        default='monokai',
+        help='Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.',
+        default='dark',
     )
-    parser.add_argument('--no-stream', action='store_true', help='Whether to stream responses from the model')
+    parser.add_argument('--no-stream', action='store_true', help='Disable streaming from the model')
     parser.add_argument('--version', action='store_true', help='Show version and exit')
 
     argcomplete.autocomplete(parser)
@@ -129,7 +135,8 @@ Special prompt:
 
     console = Console()
     console.print(
-        f'[green]pai - PydanticAI CLI v{__version__} using[/green] [magenta]{args.model}[/magenta]', highlight=False
+        f'[green]{prog_name} - PydanticAI CLI v{__version__} using[/green] [magenta]{args.model}[/magenta]',
+        highlight=False,
     )
     if args.version:
         return 0
@@ -160,23 +167,25 @@ Special prompt:
             pass
         return 0
 
-    history = Path.home() / '.pai-prompt-history.txt'
+    history = Path.home() / f'.{prog_name}-prompt-history.txt'
     # doing this instead of `PromptSession[Any](history=` allows mocking of PromptSession in tests
     session: PromptSession[Any] = PromptSession(history=FileHistory(str(history)))
     try:
-        return asyncio.run(run_chat(session, stream, cli_agent, console, code_theme))
+        return asyncio.run(run_chat(session, stream, cli_agent, console, code_theme, prog_name))
     except KeyboardInterrupt:  # pragma: no cover
         return 0
 
 
-async def run_chat(session: PromptSession[Any], stream: bool, agent: Agent, console: Console, code_theme: str) -> int:
+async def run_chat(
+    session: PromptSession[Any], stream: bool, agent: Agent, console: Console, code_theme: str, prog_name: str
+) -> int:
     multiline = False
     messages: list[ModelMessage] = []
 
     while True:
         try:
             auto_suggest = CustomAutoSuggest(['/markdown', '/multiline', '/exit'])
-            text = await session.prompt_async('pai ➤ ', auto_suggest=auto_suggest, multiline=multiline)
+            text = await session.prompt_async(f'{prog_name} ➤ ', auto_suggest=auto_suggest, multiline=multiline)
         except (KeyboardInterrupt, EOFError):  # pragma: no cover
             return 0
 
@@ -214,14 +223,14 @@ async def ask_agent(
 
     with status, ExitStack() as stack:
         async with agent.iter(prompt, message_history=messages) as agent_run:
-            live = Live('', refresh_per_second=15, console=console, vertical_overflow='visible')
+            live = Live('', refresh_per_second=15, console=console, vertical_overflow='ellipsis')
             async for node in agent_run:
                 if Agent.is_model_request_node(node):
                     async with node.stream(agent_run.ctx) as handle_stream:
                         status.stop()  # stopping multiple times is idempotent
                         stack.enter_context(live)  # entering multiple times is idempotent
 
-                        async for content in handle_stream.stream_output():
+                        async for content in handle_stream.stream_output(debounce_by=None):
                             live.update(Markdown(content, code_theme=code_theme))
 
         assert agent_run.result is not None
@@ -282,7 +291,3 @@ def handle_slash_command(
     else:
         console.print(f'[red]Unknown command[/red] [magenta]`{ident_prompt}`[/magenta]')
     return None, multiline
-
-
-def app():  # pragma: no cover
-    sys.exit(cli())

--- a/pydantic_ai_slim/pydantic_ai/_cli.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli.py
@@ -88,7 +88,7 @@ def cli_exit(prog_name: str = 'pai'):  # pragma: no cover
     sys.exit(cli(prog_name=prog_name))
 
 
-def cli(args_list: Sequence[str] | None = None, prog_name: str = 'pai') -> int:
+def cli(args_list: Sequence[str] | None = None, *, prog_name: str = 'pai') -> int:
     """Run the CLI and return the exit code for the process."""
     parser = argparse.ArgumentParser(
         prog=prog_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,14 +60,13 @@ Documentation = "https://ai.pydantic.dev"
 Changelog = "https://github.com/pydantic/pydantic-ai/releases"
 
 [project.scripts]
-pai = "pydantic_ai._cli:app"
+pai = "pydantic_ai._cli:cli_exit"  # TODO remove this when clai has been out for a while
 
 [tool.uv.sources]
 pydantic-ai-slim = { workspace = true }
 pydantic-evals = { workspace = true }
 pydantic-graph = { workspace = true }
 pydantic-ai-examples = { workspace = true }
-mcp-run-python = { workspace = true }
 
 [tool.uv.workspace]
 members = [
@@ -75,6 +74,7 @@ members = [
     "pydantic_evals",
     "pydantic_graph",
     "mcp-run-python",
+    "clai",
     "examples",
 ]
 
@@ -106,6 +106,7 @@ include = [
     "pydantic_graph/**/*.py",
     "mcp-run-python/**/*.py",
     "examples/**/*.py",
+    "clai/**/*.py",
     "tests/**/*.py",
     "docs/**/*.py",
 ]
@@ -163,6 +164,7 @@ include = [
     "mcp-run-python",
     "tests",
     "examples",
+    "clai",
 ]
 venvPath = ".venv"
 # see https://github.com/microsoft/pyright/issues/7771 - we don't want to error on decorated functions in tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from io import StringIO
 from typing import Any
 
@@ -29,40 +27,6 @@ pytestmark = pytest.mark.skipif(not imports_successful(), reason='install cli ex
 def test_cli_version(capfd: CaptureFixture[str]):
     assert cli(['--version']) == 0
     assert capfd.readouterr().out.startswith('pai - PydanticAI CLI')
-
-
-@pytest.mark.skipif(not os.getenv('CI', False), reason="Marcelo can't make this test pass locally")
-@pytest.mark.skipif(sys.version_info >= (3, 13), reason='slightly different output with 3.13')
-def test_cli_help(capfd: CaptureFixture[str]):
-    with pytest.raises(SystemExit) as exc:
-        cli(['--help'])
-    assert exc.value.code == 0
-
-    assert capfd.readouterr().out.splitlines() == snapshot(
-        [
-            'usage: pai [-h] [-m [MODEL]] [-l] [-t [CODE_THEME]] [--no-stream] [--version] [prompt]',
-            '',
-            IsStr(),
-            '',
-            'Special prompt:',
-            '* `/exit` - exit the interactive mode',
-            '* `/markdown` - show the last markdown output of the last question',
-            '* `/multiline` - toggle multiline mode',
-            '',
-            'positional arguments:',
-            '  prompt                AI Prompt, if omitted fall into interactive mode',
-            '',
-            IsStr(),
-            '  -h, --help            show this help message and exit',
-            '  -m [MODEL], --model [MODEL]',
-            '                        Model to use, in format "<provider>:<model>" e.g. "openai:gpt-4o". Defaults to "openai:gpt-4o".',
-            '  -l, --list-models     List all available models and exit',
-            '  -t [CODE_THEME], --code-theme [CODE_THEME]',
-            '                        Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "monokai".',
-            '  --no-stream           Whether to stream responses from the model',
-            '  --version             Show version and exit',
-        ]
-    )
 
 
 def test_invalid_model(capfd: CaptureFixture[str]):
@@ -169,7 +133,7 @@ def test_code_theme_unset(mocker: MockerFixture, env: TestEnv):
     mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
     cli([])
     mock_run_chat.assert_awaited_once_with(
-        IsInstance(PromptSession), True, IsInstance(Agent), IsInstance(Console), 'monokai'
+        IsInstance(PromptSession), True, IsInstance(Agent), IsInstance(Console), 'monokai', 'pai'
     )
 
 
@@ -178,7 +142,7 @@ def test_code_theme_light(mocker: MockerFixture, env: TestEnv):
     mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
     cli(['--code-theme=light'])
     mock_run_chat.assert_awaited_once_with(
-        IsInstance(PromptSession), True, IsInstance(Agent), IsInstance(Console), 'default'
+        IsInstance(PromptSession), True, IsInstance(Agent), IsInstance(Console), 'default', 'pai'
     )
 
 
@@ -187,5 +151,5 @@ def test_code_theme_dark(mocker: MockerFixture, env: TestEnv):
     mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
     cli(['--code-theme=dark'])
     mock_run_chat.assert_awaited_once_with(
-        IsInstance(PromptSession), True, IsInstance(Agent), IsInstance(Console), 'monokai'
+        IsInstance(PromptSession), True, IsInstance(Agent), IsInstance(Console), 'monokai', 'pai'
     )

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ resolution-markers = [
 
 [manifest]
 members = [
+    "clai",
     "mcp-run-python",
     "pydantic-ai",
     "pydantic-ai-examples",
@@ -673,6 +674,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/2d/a9790237cb4d01a6d57afadc8573c8b73c609ade20b80f4cda30802009ee/charset_normalizer-3.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:49402233c892a461407c512a19435d1ce275543138294f7ef013f0b63d5d3765", size = 102811 },
     { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767 },
 ]
+
+[[package]]
+name = "clai"
+source = { editable = "clai" }
+dependencies = [
+    { name = "pydantic-ai" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pydantic-ai", editable = "." }]
 
 [[package]]
 name = "click"


### PR DESCRIPTION
Thanks to @apockill kindly donating us the `clai` PyPI package name, we now have a much shorter name for a CLI, which will allow users to do:

```
uvx clai
```

TODO:
* [x] check the clai PyPI package is configured for auto-release
* [x] update docs