### PR TITLE
Make `ToolDefinition.description` optional and fix Bedrock description handling

### DIFF
--- a/docs/direct.md
+++ b/docs/direct.md
@@ -66,7 +66,7 @@ async def main():
             function_tools=[
                 ToolDefinition(
                     name=Divide.__name__.lower(),
-                    description=Divide.__doc__ or '',
+                    description=Divide.__doc__,
                     parameters_json_schema=Divide.model_json_schema(),
                 )
             ],

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -591,7 +591,6 @@ print(test_model.last_model_request_parameters.function_tools)
 [
     ToolDefinition(
         name='greet',
-        description='',
         parameters_json_schema={
             'additionalProperties': False,
             'properties': {

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -451,7 +451,6 @@ print(test_model.last_model_request_parameters.function_tools)
 [
     ToolDefinition(
         name='foobar',
-        description='This is a Foobar',
         parameters_json_schema={
             'properties': {
                 'x': {'type': 'integer'},
@@ -462,6 +461,7 @@ print(test_model.last_model_request_parameters.function_tools)
             'title': 'Foobar',
             'type': 'object',
         },
+        description='This is a Foobar',
     )
 ]
 """

--- a/pydantic_ai_slim/pydantic_ai/_function_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_function_schema.py
@@ -35,7 +35,7 @@ class FunctionSchema:
     """Internal information about a function schema."""
 
     function: Callable[..., Any]
-    description: str
+    description: str | None
     validator: SchemaValidator
     json_schema: ObjectJsonSchema
     # if not None, the function takes a single by that name (besides potentially `info`)

--- a/pydantic_ai_slim/pydantic_ai/_griffe.py
+++ b/pydantic_ai_slim/pydantic_ai/_griffe.py
@@ -19,7 +19,7 @@ def doc_descriptions(
     sig: Signature,
     *,
     docstring_format: DocstringFormat,
-) -> tuple[str, dict[str, str]]:
+) -> tuple[str | None, dict[str, str]]:
     """Extract the function description and parameter descriptions from a function's docstring.
 
     The function parses the docstring using the specified format (or infers it if 'auto')
@@ -35,7 +35,7 @@ def doc_descriptions(
     """
     doc = func.__doc__
     if doc is None:
-        return '', {}
+        return None, {}
 
     # see https://github.com/mkdocstrings/griffe/issues/293
     parent = cast(GriffeObject, sig)

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -98,7 +98,7 @@ class MCPServer(ABC):
         return [
             tools.ToolDefinition(
                 name=self.get_prefixed_tool_name(tool.name),
-                description=tool.description or '',
+                description=tool.description,
                 parameters_json_schema=tool.inputSchema,
             )
             for tool in mcp_tools.tools

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -416,7 +416,7 @@ class AnthropicModel(Model):
     def _map_tool_definition(f: ToolDefinition) -> BetaToolParam:
         return {
             'name': f.name,
-            'description': f.description,
+            'description': f.description or '',
             'input_schema': f.parameters_json_schema,
         }
 

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -234,7 +234,7 @@ class BedrockConverseModel(Model):
             'inputSchema': {'json': f.parameters_json_schema},
         }
 
-        if f.description:
+        if f.description:  # pragma: no branch
             tool_spec['description'] = f.description
 
         return {'toolSpec': tool_spec}

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
         SystemContentBlockTypeDef,
         ToolChoiceTypeDef,
         ToolConfigurationTypeDef,
+        ToolSpecificationTypeDef,
         ToolTypeDef,
         VideoBlockTypeDef,
     )
@@ -228,13 +229,15 @@ class BedrockConverseModel(Model):
 
     @staticmethod
     def _map_tool_definition(f: ToolDefinition) -> ToolTypeDef:
-        return {
-            'toolSpec': {
-                'name': f.name,
-                'description': f.description,
-                'inputSchema': {'json': f.parameters_json_schema},
-            }
+        tool_spec: ToolSpecificationTypeDef = {
+            'name': f.name,
+            'inputSchema': {'json': f.parameters_json_schema},
         }
+
+        if f.description:
+            tool_spec['description'] = f.description
+
+        return {'toolSpec': tool_spec}
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -773,7 +773,7 @@ class _GeminiFunction(TypedDict):
 
 def _function_from_abstract_tool(tool: ToolDefinition) -> _GeminiFunction:
     json_schema = tool.parameters_json_schema
-    f = _GeminiFunction(name=tool.name, description=tool.description, parameters=json_schema)
+    f = _GeminiFunction(name=tool.name, description=tool.description or '', parameters=json_schema)
     return f
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -534,7 +534,7 @@ def _function_declaration_from_tool(tool: ToolDefinition) -> FunctionDeclaration
     json_schema = tool.parameters_json_schema
     f = FunctionDeclarationDict(
         name=tool.name,
-        description=tool.description,
+        description=tool.description or '',
         parameters=json_schema,  # type: ignore
     )
     return f

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -333,7 +333,7 @@ class GroqModel(Model):
             'type': 'function',
             'function': {
                 'name': f.name,
-                'description': f.description,
+                'description': f.description or '',
                 'parameters': f.parameters_json_schema,
             },
         }

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -306,7 +306,9 @@ class MistralModel(Model):
         )
         tools = [
             MistralTool(
-                function=MistralFunction(name=r.name, parameters=r.parameters_json_schema, description=r.description)
+                function=MistralFunction(
+                    name=r.name, parameters=r.parameters_json_schema, description=r.description or ''
+                )
             )
             for r in all_tools
         ]

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -469,7 +469,7 @@ class OpenAIModel(Model):
             'type': 'function',
             'function': {
                 'name': f.name,
-                'description': f.description,
+                'description': f.description or '',
                 'parameters': f.parameters_json_schema,
             },
         }

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -161,7 +161,7 @@ class Tool(Generic[AgentDepsT]):
     takes_ctx: bool
     max_retries: int | None
     name: str
-    description: str
+    description: str | None
     prepare: ToolPrepareFunc[AgentDepsT] | None
     docstring_format: DocstringFormat
     require_parameter_descriptions: bool
@@ -269,7 +269,7 @@ class Tool(Generic[AgentDepsT]):
         cls,
         function: Callable[..., Any],
         name: str,
-        description: str,
+        description: str | None,
         json_schema: JsonSchemaValue,
     ) -> Self:
         """Creates a Pydantic tool from a function and a JSON schema.
@@ -440,11 +440,11 @@ class ToolDefinition:
     name: str
     """The name of the tool."""
 
-    description: str
-    """The description of the tool."""
-
     parameters_json_schema: ObjectJsonSchema
     """The JSON schema for the tool's parameters."""
+
+    description: str | None = None
+    """The description of the tool."""
 
     outer_typed_dict_key: str | None = None
     """The key in the outer [TypedDict] that wraps an output tool.

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -1443,9 +1443,9 @@ async def test_bedrock_mistral_tool_result_format(bedrock_provider: BedrockProvi
 
 async def test_bedrock_anthropic_no_tool_choice(bedrock_provider: BedrockProvider):
     my_tool = ToolDefinition(
-        'my_tool',
-        'This is my tool',
-        {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
+        name='my_tool',
+        description='This is my tool',
+        parameters_json_schema={'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
     )
     mrp = ModelRequestParameters(output_mode='tool', function_tools=[my_tool], allow_text_output=False, output_tools=[])
 

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -83,14 +83,18 @@ async def test_model_tools(allow_model_requests: None):
     m = GeminiModel('gemini-1.5-flash', provider=GoogleGLAProvider(api_key='via-arg'))
     tools = [
         ToolDefinition(
-            'foo',
-            'This is foo',
-            {'type': 'object', 'title': 'Foo', 'properties': {'bar': {'type': 'number', 'title': 'Bar'}}},
+            name='foo',
+            description='This is foo',
+            parameters_json_schema={
+                'type': 'object',
+                'title': 'Foo',
+                'properties': {'bar': {'type': 'number', 'title': 'Bar'}},
+            },
         ),
         ToolDefinition(
-            'apple',
-            'This is apple',
-            {
+            name='apple',
+            description='This is apple',
+            parameters_json_schema={
                 'type': 'object',
                 'properties': {
                     'banana': {'type': 'array', 'title': 'Banana', 'items': {'type': 'number', 'title': 'Bar'}}
@@ -99,9 +103,14 @@ async def test_model_tools(allow_model_requests: None):
         ),
     ]
     output_tool = ToolDefinition(
-        'result',
-        'This is the tool for the final Result',
-        {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}, 'required': ['spam']},
+        name='result',
+        description='This is the tool for the final Result',
+        parameters_json_schema={
+            'type': 'object',
+            'title': 'Result',
+            'properties': {'spam': {'type': 'number'}},
+            'required': ['spam'],
+        },
     )
 
     mrp = ModelRequestParameters(
@@ -148,9 +157,9 @@ async def test_model_tools(allow_model_requests: None):
 async def test_require_response_tool(allow_model_requests: None):
     m = GeminiModel('gemini-1.5-flash', provider=GoogleGLAProvider(api_key='via-arg'))
     output_tool = ToolDefinition(
-        'result',
-        'This is the tool for the final Result',
-        {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
+        name='result',
+        description='This is the tool for the final Result',
+        parameters_json_schema={'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
     )
     mrp = ModelRequestParameters(
         function_tools=[],
@@ -235,9 +244,9 @@ async def test_json_def_replaced(allow_model_requests: None):
 
     m = GeminiModel('gemini-1.5-flash', provider=GoogleGLAProvider(api_key='via-arg'))
     output_tool = ToolDefinition(
-        'result',
-        'This is the tool for the final Result',
-        json_schema,
+        name='result',
+        description='This is the tool for the final Result',
+        parameters_json_schema=json_schema,
     )
     mrp = ModelRequestParameters(
         function_tools=[],
@@ -320,9 +329,9 @@ async def test_json_def_enum(allow_model_requests: None):
     )
     m = GeminiModel('gemini-1.5-flash', provider=GoogleGLAProvider(api_key='via-arg'))
     output_tool = ToolDefinition(
-        'result',
-        'This is the tool for the final Result',
-        json_schema,
+        name='result',
+        description='This is the tool for the final Result',
+        parameters_json_schema=json_schema,
     )
     mrp = ModelRequestParameters(
         function_tools=[],
@@ -368,9 +377,9 @@ async def test_json_def_replaced_any_of(allow_model_requests: None):
 
     m = GeminiModel('gemini-1.5-flash', provider=GoogleGLAProvider(api_key='via-arg'))
     output_tool = ToolDefinition(
-        'result',
-        'This is the tool for the final Result',
-        json_schema,
+        name='result',
+        description='This is the tool for the final Result',
+        parameters_json_schema=json_schema,
     )
     mrp = ModelRequestParameters(
         function_tools=[],
@@ -437,9 +446,9 @@ async def test_json_def_recursive(allow_model_requests: None):
 
     m = GeminiModel('gemini-1.5-flash', provider=GoogleGLAProvider(api_key='via-arg'))
     output_tool = ToolDefinition(
-        'result',
-        'This is the tool for the final Result',
-        json_schema,
+        name='result',
+        description='This is the tool for the final Result',
+        parameters_json_schema=json_schema,
     )
     with pytest.raises(UserError, match=r'Recursive `\$ref`s in JSON Schema are not supported by Gemini'):
         mrp = ModelRequestParameters(
@@ -476,9 +485,9 @@ async def test_json_def_date(allow_model_requests: None):
 
     m = GeminiModel('gemini-1.5-flash', provider=GoogleGLAProvider(api_key='via-arg'))
     output_tool = ToolDefinition(
-        'result',
-        'This is the tool for the final Result',
-        json_schema,
+        name='result',
+        description='This is the tool for the final Result',
+        parameters_json_schema=json_schema,
     )
     mrp = ModelRequestParameters(
         function_tools=[],

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -1913,9 +1913,9 @@ def test_openai_model_profile_from_provider():
 
 def test_model_profile_strict_not_supported():
     my_tool = ToolDefinition(
-        'my_tool',
-        'This is my tool',
-        {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
+        name='my_tool',
+        description='This is my tool',
+        parameters_json_schema={'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
         strict=True,
     )
 

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -473,9 +473,9 @@ async def test_openai_responses_model_instructions(allow_model_requests: None, o
 
 def test_model_profile_strict_not_supported():
     my_tool = ToolDefinition(
-        'my_tool',
-        'This is my tool',
-        {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
+        name='my_tool',
+        description='This is my tool',
+        parameters_json_schema={'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
         strict=True,
     )
 

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -54,9 +54,7 @@ async def test_model_request_tool_call():
         'test',
         [ModelRequest.user_text_prompt('x')],
         model_request_parameters=ModelRequestParameters(
-            function_tools=[
-                ToolDefinition(name='tool_name', description='', parameters_json_schema={'type': 'object'})
-            ],
+            function_tools=[ToolDefinition(name='tool_name', parameters_json_schema={'type': 'object'})],
             allow_text_output=False,
         ),
     )

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -280,7 +280,7 @@ def test_logfire(
                         'function_tools': [
                             {
                                 'name': 'my_ret',
-                                'description': '',
+                                'description': None,
                                 'parameters_json_schema': {
                                     'additionalProperties': False,
                                     'properties': {'x': {'type': 'integer'}},

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -24,7 +24,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.tools import RunContext
+from pydantic_ai.tools import RunContext, ToolDefinition
 from pydantic_ai.usage import Usage
 
 from .conftest import IsDatetime, IsNow, IsStr, try_import
@@ -59,8 +59,27 @@ async def test_stdio_server():
     async with server:
         tools = await server.list_tools()
         assert len(tools) == snapshot(13)
-        assert tools[0].name == 'celsius_to_fahrenheit'
-        assert tools[0].description.startswith('Convert Celsius to Fahrenheit.')
+        assert tools[0] == snapshot(
+            ToolDefinition(
+                name='celsius_to_fahrenheit',
+                parameters_json_schema={
+                    'properties': {'celsius': {'title': 'Celsius', 'type': 'number'}},
+                    'required': ['celsius'],
+                    'title': 'celsius_to_fahrenheitArguments',
+                    'type': 'object',
+                },
+                description="""\
+Convert Celsius to Fahrenheit.
+
+    Args:
+        celsius: Temperature in Celsius
+
+    Returns:
+        Temperature in Fahrenheit
+    \
+""",
+            )
+        )
 
         # Test calling the temperature conversion tool
         result = await server.call_tool('celsius_to_fahrenheit', {'celsius': 0})

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -24,7 +24,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.tools import RunContext, ToolDefinition
+from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import Usage
 
 from .conftest import IsDatetime, IsNow, IsStr, try_import
@@ -59,27 +59,9 @@ async def test_stdio_server():
     async with server:
         tools = await server.list_tools()
         assert len(tools) == snapshot(13)
-        assert tools[0] == snapshot(
-            ToolDefinition(
-                name='celsius_to_fahrenheit',
-                parameters_json_schema={
-                    'properties': {'celsius': {'title': 'Celsius', 'type': 'number'}},
-                    'required': ['celsius'],
-                    'title': 'celsius_to_fahrenheitArguments',
-                    'type': 'object',
-                },
-                description="""\
-Convert Celsius to Fahrenheit.
-
-    Args:
-        celsius: Temperature in Celsius
-
-    Returns:
-        Temperature in Fahrenheit
-    \
-""",
-            )
-        )
+        assert tools[0].name == 'celsius_to_fahrenheit'
+        assert isinstance(tools[0].description, str)
+        assert tools[0].description.startswith('Convert Celsius to Fahrenheit.')
 
         # Test calling the temperature conversion tool
         result = await server.call_tool('celsius_to_fahrenheit', {'celsius': 0})

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -107,11 +107,6 @@ def test_docstring_google(docstring_format: Literal['google', 'auto']):
             'strict': None,
         }
     )
-    keys = list(json_schema.keys())
-    # name should be the first key
-    assert keys[0] == 'name'
-    # description should be the second key
-    assert keys[1] == 'description'
 
 
 def sphinx_style_docstring(foo: int, /) -> str:  # pragma: no cover

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -439,7 +439,7 @@ def test_takes_model_and_int():
     assert json_schema == snapshot(
         {
             'name': 'takes_just_model',
-            'description': '',
+            'description': None,
             'parameters_json_schema': {
                 '$defs': {
                     'Foo': {
@@ -857,7 +857,7 @@ def test_json_schema_required_parameters():
     assert json_schema == snapshot(
         [
             {
-                'description': '',
+                'description': None,
                 'name': 'my_tool',
                 'outer_typed_dict_key': None,
                 'parameters_json_schema': {
@@ -869,7 +869,7 @@ def test_json_schema_required_parameters():
                 'strict': None,
             },
             {
-                'description': '',
+                'description': None,
                 'name': 'my_tool_plain',
                 'outer_typed_dict_key': None,
                 'parameters_json_schema': {
@@ -955,7 +955,7 @@ def test_schema_generator():
     assert json_schema == snapshot(
         [
             {
-                'description': '',
+                'description': None,
                 'name': 'my_tool_1',
                 'outer_typed_dict_key': None,
                 'parameters_json_schema': {
@@ -965,7 +965,7 @@ def test_schema_generator():
                 'strict': None,
             },
             {
-                'description': '',
+                'description': None,
                 'name': 'my_tool_2',
                 'outer_typed_dict_key': None,
                 'parameters_json_schema': {


### PR DESCRIPTION
Before merging this we should probably make the description field on `pydantic_ai.tools.ToolDefinition` optional, and handle `None` properly on every other model.