### PR TITLE
fix: stream error when break early

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,9 +35,9 @@ async def test_group_by_temporal(interval: float | None, expected: list[list[int
         yield 3
         await asyncio.sleep(0.02)
 
-    async with group_by_temporal(yield_groups(), soft_max_interval=interval) as groups_iter:
-        groups: list[list[int]] = [g async for g in groups_iter]
-        assert groups == expected
+    groups_iter = group_by_temporal(yield_groups(), soft_max_interval=interval)
+    groups: list[list[int]] = [g async for g in groups_iter]
+    assert groups == expected
 
 
 def test_check_object_json_schema():


### PR DESCRIPTION
Closes: #1516

refactor `group_by_temporal` to avoid using task.

> Warning: seems don't work yet.
