### PR TITLE
Support for passing extra settings to OpenAI-like services (#1326)

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -165,6 +165,35 @@ agent = Agent(model)
 ...
 ```
 
+You can also create a custom model settings class to pass additional settings to the API:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIModel, OpenAIModelSettings
+from pydantic_ai.providers.openai import OpenAIProvider
+
+
+class CustomModelSettings(OpenAIModelSettings):
+    """Example of adding top_k parameter to model settings."""
+    top_k: int
+
+model = OpenAIModel(
+    'model_name',
+    provider=OpenAIProvider(
+        base_url='https://<openai-compatible-api-endpoint>.com', api_key='your-api-key'
+    ),
+)
+
+custom_model_settings = CustomModelSettings(
+    temperature=0.98,
+    top_p=0.37,
+    top_k=100,
+)
+
+agent = Agent(model, model_settings=custom_model_settings)
+...
+```
+
 You can also customize any provider with a custom `http_client`:
 
 ```python

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -283,6 +283,7 @@ class OpenAIModel(Model):
                 logit_bias=model_settings.get('logit_bias', NOT_GIVEN),
                 reasoning_effort=model_settings.get('openai_reasoning_effort', NOT_GIVEN),
                 user=model_settings.get('openai_user', NOT_GIVEN),
+                extra_body={k: v for k, v in model_settings.items() if k not in OpenAIModelSettings.__annotations__},
                 extra_headers={'User-Agent': get_user_agent()},
             )
         except APIStatusError as e:

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -175,6 +175,7 @@ async def test_request_simple_success(allow_model_requests: None):
             'messages': [{'content': 'hello', 'role': 'user'}],
             'model': 'gpt-4o',
             'n': 1,
+            'extra_body': {},
             'extra_headers': {'User-Agent': IsStr(regex=r'pydantic-ai\/.*')},
         },
         {
@@ -185,6 +186,7 @@ async def test_request_simple_success(allow_model_requests: None):
             ],
             'model': 'gpt-4o',
             'n': 1,
+            'extra_body': {},
             'extra_headers': {'User-Agent': IsStr(regex=r'pydantic-ai\/.*')},
         },
     ]
@@ -558,6 +560,7 @@ async def test_system_prompt_role(
             ],
             'model': 'gpt-4o',
             'n': 1,
+            'extra_body': {},
             'extra_headers': {'User-Agent': IsStr(regex=r'pydantic-ai\/.*')},
         }
     ]
@@ -634,6 +637,7 @@ async def test_image_url_input(allow_model_requests: None):
                     }
                 ],
                 'n': 1,
+                'extra_body': {},
                 'extra_headers': {'User-Agent': IsStr(regex=r'pydantic-ai\/.*')},
             }
         ]


### PR DESCRIPTION
Addresses #1326

This change allows developers to pass custom settings to alternate OpenAI-like services. Additional parameters not present in `OpenAIModelSettings` will be passed through the API's `extra_body` field.

Example:

```python
from pydantic_ai import Agent
from pydantic_ai.models.openai import OpenAIModel, OpenAIModelSettings
from pydantic_ai.providers.openai import OpenAIProvider


class CustomModelSettings(OpenAIModelSettings):
    """Example of adding top_k parameter to model settings."""
    top_k: int

model = OpenAIModel(
    'model_name',
    provider=OpenAIProvider(
        base_url='https://<openai-compatible-api-endpoint>.com', api_key='your-api-key'
    ),
)

custom_model_settings = CustomModelSettings(
    temperature=0.98,
    top_p=0.37,
    top_k=100,
)

agent = Agent(model, model_settings=custom_model_settings)
...
```
 