### PR TITLE
Make agent and graph runs serializable again

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -291,13 +291,4 @@ class PeekableAsyncStream(Generic[T]):
 
 
 def get_traceparent(x: AgentRun | AgentRunResult | GraphRun | GraphRunResult) -> str:
-    import logfire
-    import logfire_api
-    from logfire.experimental.annotations import get_traceparent
-
-    span: AbstractSpan | None = x._span(required=False)  # type: ignore[reportPrivateUsage]
-    if not span:  # pragma: no cover
-        return ''
-    if isinstance(span, logfire_api.LogfireSpan):  # pragma: no cover
-        assert isinstance(span, logfire.LogfireSpan)
-    return get_traceparent(span)
+    return x._traceparent(required=False) or ''  # type: ignore[reportPrivateUsage]

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -1728,7 +1728,7 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
             graph_run_result.output.tool_name,
             graph_run_result.state,
             self._graph_run.deps.new_message_index,
-            self._graph_run._span(required=False),  # type: ignore[reportPrivateUsage]
+            self._traceparent(required=False),
         )
 
     def __aiter__(

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -27,7 +27,6 @@ from . import (
     result,
     usage as _usage,
 )
-from ._utils import AbstractSpan
 from .models.instrumented import InstrumentationSettings, InstrumentedModel
 from .result import FinalResult, OutputDataT, StreamedRunResult, ToolOutput
 from .settings import ModelSettings, merge_model_settings
@@ -1683,14 +1682,14 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
     ]
 
     @overload
-    def _span(self, *, required: Literal[False]) -> AbstractSpan | None: ...
+    def _traceparent(self, *, required: Literal[False]) -> str | None: ...
     @overload
-    def _span(self) -> AbstractSpan: ...
-    def _span(self, *, required: bool = True) -> AbstractSpan | None:
-        span = self._graph_run._span(required=False)  # type: ignore[reportPrivateUsage]
-        if span is None and required:  # pragma: no cover
-            raise AttributeError('Span is not available for this agent run')
-        return span
+    def _traceparent(self) -> str: ...
+    def _traceparent(self, *, required: bool = True) -> str | None:
+        traceparent = self._graph_run._traceparent(required=False)  # type: ignore[reportPrivateUsage]
+        if traceparent is None and required:  # pragma: no cover
+            raise AttributeError('No span was created for this agent run')
+        return traceparent
 
     @property
     def ctx(self) -> GraphRunContext[_agent_graph.GraphAgentState, _agent_graph.GraphAgentDeps[AgentDepsT, Any]]:
@@ -1847,16 +1846,16 @@ class AgentRunResult(Generic[OutputDataT]):
     _output_tool_name: str | None = dataclasses.field(repr=False)
     _state: _agent_graph.GraphAgentState = dataclasses.field(repr=False)
     _new_message_index: int = dataclasses.field(repr=False)
-    _span_value: AbstractSpan | None = dataclasses.field(repr=False)
+    _traceparent_value: str | None = dataclasses.field(repr=False)
 
     @overload
-    def _span(self, *, required: Literal[False]) -> AbstractSpan | None: ...
+    def _traceparent(self, *, required: Literal[False]) -> str | None: ...
     @overload
-    def _span(self) -> AbstractSpan: ...
-    def _span(self, *, required: bool = True) -> AbstractSpan | None:
-        if self._span_value is None and required:  # pragma: no cover
-            raise AttributeError('Span is not available for this agent run')
-        return self._span_value
+    def _traceparent(self) -> str: ...
+    def _traceparent(self, *, required: bool = True) -> str | None:
+        if self._traceparent_value is None and required:  # pragma: no cover
+            raise AttributeError('No span was created for this agent run')
+        return self._traceparent_value
 
     @property
     @deprecated('`result.data` is deprecated, use `result.output` instead.')

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -3,15 +3,46 @@ from __future__ import annotations as _annotations
 import asyncio
 import types
 from functools import partial
-from typing import Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from logfire_api import LogfireSpan
-from opentelemetry.trace import Span
 from typing_extensions import ParamSpec, TypeAlias, TypeIs, get_args, get_origin
 from typing_inspection import typing_objects
 from typing_inspection.introspection import is_union_origin
 
+if TYPE_CHECKING:
+    from opentelemetry.trace import Span
+
+
 AbstractSpan: TypeAlias = 'LogfireSpan | Span'
+
+try:
+    from opentelemetry.trace import Span, set_span_in_context
+    from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+    TRACEPARENT_PROPAGATOR = TraceContextTextMapPropagator()
+    TRACEPARENT_NAME = 'traceparent'
+    assert TRACEPARENT_NAME in TRACEPARENT_PROPAGATOR.fields
+
+    # Logic taken from logfire.experimental.annotations
+    def get_traceparent(span: AbstractSpan) -> str | None:
+        """Get a string representing the span context to use for annotating spans."""
+        real_span: Span
+        if isinstance(span, Span):
+            real_span = span
+        else:
+            real_span = span._span
+            assert real_span
+        context = set_span_in_context(real_span)
+        carrier: dict[str, Any] = {}
+        TRACEPARENT_PROPAGATOR.inject(carrier, context)
+        return carrier.get(TRACEPARENT_NAME, '')
+
+except ImportError:
+
+    def get_traceparent(span: AbstractSpan) -> str | None:
+        # Opentelemetry wasn't installed, so we can't get the traceparent
+        return None
 
 
 def get_event_loop():

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -38,7 +38,7 @@ try:
         TRACEPARENT_PROPAGATOR.inject(carrier, context)
         return carrier.get(TRACEPARENT_NAME, '')
 
-except ImportError:
+except ImportError:  # pragma: no cover
 
     def get_traceparent(span: AbstractSpan) -> str | None:
         # Opentelemetry wasn't installed, so we can't get the traceparent


### PR DESCRIPTION
Closes #1533 #1525

Note: You probably don't want to be returning an AgentRun or GraphRun from a tool call, and should _instead_ be returning the `result.output` rather than the original `result`. But we can at least resolve the existing regression, and arguably this is better anyway because it allows you to serialize/deserialize without losing the relevant information about the traceparent.

Tried to keep things as private as possible so that we can revert/change this decision in the future if/when necessary.