### PR TITLE
Store additional usage details from Anthropic

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -409,13 +409,25 @@ def _map_usage(message: AnthropicMessage | RawMessageStreamEvent) -> usage.Usage
     if response_usage is None:
         return usage.Usage()
 
+    # Usage coming from the RawMessageDeltaEvent doesn't have input token data, hence these getattr calls
     request_tokens = getattr(response_usage, 'input_tokens', None)
+    cache_creation_request_tokens = getattr(response_usage, 'cache_creation_input_tokens', None)
+    cache_read_request_tokens = getattr(response_usage, 'cache_read_input_tokens', None)
+    details: dict[str, int] = {}
+    # Tokens are only counted once between input_tokens, cache_creation_input_tokens, and cache_read_input_tokens
+    # This approach maintains request_tokens as the count of all input tokens, with cached counts as details
+    if isinstance(cache_creation_request_tokens, int):
+        request_tokens = (request_tokens or 0) + cache_creation_request_tokens
+        details['cache_creation_input_tokens'] = cache_creation_request_tokens
+    if isinstance(cache_read_request_tokens, int):
+        request_tokens = (request_tokens or 0) + cache_read_request_tokens
+        details['cache_read_input_tokens'] = cache_read_request_tokens
 
     return usage.Usage(
-        # Usage coming from the RawMessageDeltaEvent doesn't have input token data, hence this getattr
         request_tokens=request_tokens,
         response_tokens=response_usage.output_tokens,
         total_tokens=(request_tokens or 0) + response_usage.output_tokens,
+        details=details,
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -409,25 +409,29 @@ def _map_usage(message: AnthropicMessage | RawMessageStreamEvent) -> usage.Usage
     if response_usage is None:
         return usage.Usage()
 
+    # Store all integer-typed usage values in the details dict
+    response_usage_dict = response_usage.model_dump()
+    details: dict[str, int] = {}
+    for key, value in response_usage_dict.items():
+        if isinstance(value, int):
+            details[key] = value
+
     # Usage coming from the RawMessageDeltaEvent doesn't have input token data, hence these getattr calls
     request_tokens = getattr(response_usage, 'input_tokens', None)
     cache_creation_request_tokens = getattr(response_usage, 'cache_creation_input_tokens', None)
     cache_read_request_tokens = getattr(response_usage, 'cache_read_input_tokens', None)
-    details: dict[str, int] = {}
     # Tokens are only counted once between input_tokens, cache_creation_input_tokens, and cache_read_input_tokens
     # This approach maintains request_tokens as the count of all input tokens, with cached counts as details
     if isinstance(cache_creation_request_tokens, int):
         request_tokens = (request_tokens or 0) + cache_creation_request_tokens
-        details['cache_creation_input_tokens'] = cache_creation_request_tokens
     if isinstance(cache_read_request_tokens, int):
         request_tokens = (request_tokens or 0) + cache_read_request_tokens
-        details['cache_read_input_tokens'] = cache_read_request_tokens
 
     return usage.Usage(
         request_tokens=request_tokens,
         response_tokens=response_usage.output_tokens,
         total_tokens=(request_tokens or 0) + response_usage.output_tokens,
-        details=details,
+        details=details or None,
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -426,7 +426,7 @@ def _map_usage(message: AnthropicMessage | RawMessageStreamEvent) -> usage.Usage
     )
 
     return usage.Usage(
-        request_tokens=request_tokens,
+        request_tokens=request_tokens or None,
         response_tokens=response_usage.output_tokens,
         total_tokens=request_tokens + response_usage.output_tokens,
         details=details or None,

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from datetime import timezone
 from functools import cached_property
 from typing import Any, TypeVar, Union, cast
+from unittest.mock import ANY
 
 import httpx
 import pytest
@@ -141,14 +142,17 @@ async def test_sync_request_text_response(allow_model_requests: None):
 
     result = await agent.run('hello')
     assert result.output == 'world'
-    assert result.usage() == snapshot(Usage(requests=1, request_tokens=5, response_tokens=10, total_tokens=15))
-
+    assert result.usage() == snapshot(
+        Usage(requests=1, request_tokens=5, response_tokens=10, total_tokens=15, details=ANY)
+    )
     # reset the index so we get the same response again
     mock_client.index = 0  # type: ignore
 
     result = await agent.run('hello', message_history=result.new_messages())
     assert result.output == 'world'
-    assert result.usage() == snapshot(Usage(requests=1, request_tokens=5, response_tokens=10, total_tokens=15))
+    assert result.usage() == snapshot(
+        Usage(requests=1, request_tokens=5, response_tokens=10, total_tokens=15, details=ANY)
+    )
     assert result.all_messages() == snapshot(
         [
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
@@ -189,10 +193,7 @@ async def test_async_request_prompt_caching(allow_model_requests: None):
             request_tokens=13,
             response_tokens=5,
             total_tokens=18,
-            details={
-                'cache_creation_input_tokens': 4,
-                'cache_read_input_tokens': 6,
-            },
+            details=ANY,
         )
     )
 
@@ -208,7 +209,9 @@ async def test_async_request_text_response(allow_model_requests: None):
 
     result = await agent.run('hello')
     assert result.output == 'world'
-    assert result.usage() == snapshot(Usage(requests=1, request_tokens=3, response_tokens=5, total_tokens=8))
+    assert result.usage() == snapshot(
+        Usage(requests=1, request_tokens=3, response_tokens=5, total_tokens=8, details=ANY)
+    )
 
 
 async def test_request_structured_response(allow_model_requests: None):
@@ -581,7 +584,9 @@ async def test_stream_structured(allow_model_requests: None):
             ]
         )
         assert result.is_complete
-        assert result.usage() == snapshot(Usage(requests=2, request_tokens=20, response_tokens=5, total_tokens=25))
+        assert result.usage() == snapshot(
+            Usage(requests=2, request_tokens=20, response_tokens=5, total_tokens=25, details=ANY)
+        )
         assert tool_called
 
 

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field
 from datetime import timezone
 from functools import cached_property
 from typing import Any, TypeVar, Union, cast
-from unittest.mock import ANY
 
 import httpx
 import pytest
@@ -143,7 +142,13 @@ async def test_sync_request_text_response(allow_model_requests: None):
     result = await agent.run('hello')
     assert result.output == 'world'
     assert result.usage() == snapshot(
-        Usage(requests=1, request_tokens=5, response_tokens=10, total_tokens=15, details=ANY)
+        Usage(
+            requests=1,
+            request_tokens=5,
+            response_tokens=10,
+            total_tokens=15,
+            details={'input_tokens': 5, 'output_tokens': 10},
+        )
     )
     # reset the index so we get the same response again
     mock_client.index = 0  # type: ignore
@@ -151,7 +156,13 @@ async def test_sync_request_text_response(allow_model_requests: None):
     result = await agent.run('hello', message_history=result.new_messages())
     assert result.output == 'world'
     assert result.usage() == snapshot(
-        Usage(requests=1, request_tokens=5, response_tokens=10, total_tokens=15, details=ANY)
+        Usage(
+            requests=1,
+            request_tokens=5,
+            response_tokens=10,
+            total_tokens=15,
+            details={'input_tokens': 5, 'output_tokens': 10},
+        )
     )
     assert result.all_messages() == snapshot(
         [
@@ -193,7 +204,12 @@ async def test_async_request_prompt_caching(allow_model_requests: None):
             request_tokens=13,
             response_tokens=5,
             total_tokens=18,
-            details=ANY,
+            details={
+                'input_tokens': 3,
+                'output_tokens': 5,
+                'cache_creation_input_tokens': 4,
+                'cache_read_input_tokens': 6,
+            },
         )
     )
 
@@ -210,7 +226,13 @@ async def test_async_request_text_response(allow_model_requests: None):
     result = await agent.run('hello')
     assert result.output == 'world'
     assert result.usage() == snapshot(
-        Usage(requests=1, request_tokens=3, response_tokens=5, total_tokens=8, details=ANY)
+        Usage(
+            requests=1,
+            request_tokens=3,
+            response_tokens=5,
+            total_tokens=8,
+            details={'input_tokens': 3, 'output_tokens': 5},
+        )
     )
 
 
@@ -585,7 +607,13 @@ async def test_stream_structured(allow_model_requests: None):
         )
         assert result.is_complete
         assert result.usage() == snapshot(
-            Usage(requests=2, request_tokens=20, response_tokens=5, total_tokens=25, details=ANY)
+            Usage(
+                requests=2,
+                request_tokens=20,
+                response_tokens=5,
+                total_tokens=25,
+                details={'input_tokens': 20, 'output_tokens': 5},
+            )
         )
         assert tool_called
 


### PR DESCRIPTION
This change handles the two additional usage fields returned by Anthropic: `cache_creation_input_tokens` and `cache_read_input_tokens`. When prompt caching is not enabled, this change has no impact.

Currently, the providers/models system is very flexible, which has made it easy to enable Anthropic's prompt caching by providing a custom client or provider, but this part of the code `_map_usage` is not nicely overridable, so updating it to handle the full usage object properly.

This, or a similar, change, will be need to support prompt caching natively too, once someone gets to that.