### PR TITLE
gemini: move `list` type inside the `Annotated` on `function_declarations` field

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -641,7 +641,7 @@ class _GeminiTextContent(TypedDict):
 
 
 class _GeminiTools(TypedDict):
-    function_declarations: list[Annotated[_GeminiFunction, pydantic.Field(alias='functionDeclarations')]]
+    function_declarations: Annotated[list[_GeminiFunction], pydantic.Field(alias='functionDeclarations')]
 
 
 class _GeminiFunction(TypedDict):


### PR DESCRIPTION
This PR fixes #1569 by changing the function declaration key in the API request from `function_declarations` to `functionDeclarations`.

@DouewM, I've verified that the correct key appears by running the little script in #1569 but didn't add an explicit test.