### PR TITLE
docs: Explain tool execution, validation, and retries

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -467,3 +467,23 @@ print(test_model.last_model_request_parameters.function_tools)
 ```
 
 _(This example is complete, it can be run "as is")_
+
+
+## Tool Execution and Retries {#tool-retries}
+
+When a tool is executed, its arguments (provided by the LLM) are first validated against the function's signature using Pydantic. If validation fails (e.g., due to incorrect types or missing required arguments), a `ValidationError` is raised, and the framework automatically generates a [`RetryPromptPart`][pydantic_ai.messages.RetryPromptPart] containing the validation details. This prompt is sent back to the LLM, informing it of the error and allowing it to correct the parameters and retry the tool call.
+
+Beyond automatic validation errors, the tool's own internal logic can also explicitly request a retry by raising the [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] exception. This is useful for situations where the parameters were technically valid, but an issue occurred during execution (like a transient network error, or the tool determining the initial attempt needs modification).
+
+```python
+from pydantic_ai import ModelRetry
+
+
+def my_flaky_tool(query: str) -> str:
+    if query == 'bad':
+        # Tell the LLM the query was bad and it should try again
+        raise ModelRetry("The query 'bad' is not allowed. Please provide a different query.")
+    # ... process query ...
+    return 'Success!'
+```
+Raising `ModelRetry` also generates a `RetryPromptPart` containing the exception message, which is sent back to the LLM to guide its next attempt. Both `ValidationError` and `ModelRetry` respect the `retries` setting configured on the `Tool` or `Agent`.


### PR DESCRIPTION
This PR adds a new section to the `docs/tools.md` documentation explaining the process of tool execution, validation, and retries within PydanticAI.

**Justification:** Currently, information about how tool execution errors (like `ValidationError`) and explicit retries (`ModelRetry`) are handled is not easily discoverable via documentation search. I personally was looking for this information in the tools section of the documentation and couldn't find it even after a few tries (yes, I'm stupid). Adding this dedicated section aims to improve findability and provide users with a clearer understanding of how tools handle errors and retries during execution.

**Key points covered:**
- How tool arguments provided by the LLM are validated against the function signature using Pydantic.
- The automatic generation of `RetryPromptPart` when a `ValidationError` occurs, allowing the LLM to correct parameters.
- Introduction of the `ModelRetry` exception for tools to explicitly request a retry from their internal logic (e.g., for transient errors or invalid inputs not caught by type validation).
- Clarification that both `ValidationError` and `ModelRetry` respect the configured `retries` setting.