### PR TITLE
Fix for Bedrock Parallel Tool Call User message issue for certain models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -391,7 +391,6 @@ class BedrockConverseModel(Model):
                         tool_results: list[dict[str, typing.Any]] = []
                         while i < len(parts) and isinstance(parts[i], ToolReturnPart):
                             tr_part = typing.cast(ToolReturnPart, parts[i])
-                            # Remove unnecessary None check, tool_call_id is always str
                             tool_results.append(
                                 {
                                     'toolResult': {

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -411,6 +411,7 @@ class BedrockConverseModel(Model):
                             )
                         )
                     elif isinstance(part, RetryPromptPart):
+                        # TODO(Marcelo): We need to add a test here.
                         if part.tool_name is None:  # pragma: no cover
                             bedrock_messages.append({'role': 'user', 'content': [{'text': part.model_response()}]})
                         else:

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -170,7 +170,7 @@ class BedrockModelSettings(ModelSettings, total=False):
 class BedrockConverseModel(Model):
     """A model that uses the Bedrock Converse API."""
 
-    client: Any  # Use Any at runtime, BedrockRuntimeClient for type checking
+    client: BedrockRuntimeClient
 
     _model_name: BedrockModelName = field(repr=False)
     _system: str = field(default='bedrock', repr=False)
@@ -205,7 +205,7 @@ class BedrockConverseModel(Model):
 
         if isinstance(provider, str):
             provider = infer_provider(provider)
-        self.client = cast('BedrockRuntimeClient', provider.client)  # Use string for cast
+        self.client = cast('BedrockRuntimeClient', provider.client)
 
     def _get_tools(self, model_request_parameters: ModelRequestParameters) -> list[ToolTypeDef]:
         tools = [self._map_tool_definition(r) for r in model_request_parameters.function_tools]


### PR DESCRIPTION
Enhance message mapping: group consecutive ToolReturnPart objects into a single user message for Bedrock models. NOTE: Was previously breaking when the LLM was attempting to call multiple tools in one request. This is because the code was appending multiple user messages in a row, one for each tool call response. Which breaks the subsequent user/assistant messages required for Nova and Claude models

I believe this behavior should be controlled by the model type at some point?