### PR TITLE
Set `use_attribute_docstrings=True` by default on tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_pydantic.py
+++ b/pydantic_ai_slim/pydantic_ai/_pydantic.py
@@ -58,7 +58,7 @@ def function_schema(  # noqa: C901
     Returns:
         A `FunctionSchema` instance.
     """
-    config = ConfigDict(title=function.__name__)
+    config = ConfigDict(title=function.__name__, use_attribute_docstrings=True)
     config_wrapper = ConfigWrapper(config)
     gen_schema = _generate_schema.GenerateSchema(config_wrapper)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -932,8 +932,7 @@ def test_tool_parameters_with_attribute_docstrings():
         """The second parameter"""
 
     @agent.tool_plain
-    def get_score(data: Data) -> int:
-        return data['a'] + data['b']
+    def get_score(data: Data) -> int: ...
 
     result = agent.run_sync('Hello')
     json_schema = json.loads(result.output)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -9,16 +9,10 @@ from inline_snapshot import snapshot
 from pydantic import BaseModel, Field, WithJsonSchema
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
 from pydantic_core import PydanticSerializationError, core_schema
+from typing_extensions import TypedDict
 
 from pydantic_ai import Agent, RunContext, Tool, ToolOutput, UserError
-from pydantic_ai.messages import (
-    ModelMessage,
-    ModelRequest,
-    ModelResponse,
-    TextPart,
-    ToolCallPart,
-    ToolReturnPart,
-)
+from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
@@ -925,4 +919,39 @@ def test_schema_generator():
                 'strict': None,
             },
         ]
+    )
+
+
+def test_tool_parameters_with_attribute_docstrings():
+    agent = Agent(FunctionModel(get_json_schema))
+
+    class Data(TypedDict):
+        a: int
+        """The first parameter"""
+        b: int
+        """The second parameter"""
+
+    @agent.tool_plain
+    def get_score(data: Data) -> int:
+        return data['a'] + data['b']
+
+    result = agent.run_sync('Hello')
+    json_schema = json.loads(result.output)
+    assert json_schema == snapshot(
+        {
+            'name': 'get_score',
+            'description': None,
+            'parameters_json_schema': {
+                'additionalProperties': False,
+                'properties': {
+                    'a': {'description': 'The first parameter', 'type': 'integer'},
+                    'b': {'description': 'The second parameter', 'type': 'integer'},
+                },
+                'required': ['a', 'b'],
+                'title': 'Data',
+                'type': 'object',
+            },
+            'outer_typed_dict_key': None,
+            'strict': None,
+        }
     )


### PR DESCRIPTION
It's annoying this is not by default.