### PR TITLE
Record agent run attributes in case of streaming and exception

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar
 from dataclasses import field
 from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, Union, cast
 
-from opentelemetry.trace import Span, Tracer
+from opentelemetry.trace import Tracer
 from typing_extensions import TypeGuard, TypeVar, assert_never
 
 from pydantic_graph import BaseNode, Graph, GraphRunContext
@@ -93,7 +93,6 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     function_tools: dict[str, Tool[DepsT]] = dataclasses.field(repr=False)
     mcp_servers: Sequence[MCPServer] = dataclasses.field(repr=False)
 
-    run_span: Span
     tracer: Tracer
 
 

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -692,28 +692,29 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         finally:
             try:
                 if run_span.is_recording():
-                    run_span.set_attributes(
-                        {
-                            **usage.opentelemetry_attributes(),
-                            'all_messages_events': json.dumps(
-                                [
-                                    InstrumentedModel.event_to_dict(e)
-                                    for e in InstrumentedModel.messages_to_otel_events(state.message_history)
-                                ]
-                            ),
-                            'logfire.json_schema': json.dumps(
-                                {
-                                    'type': 'object',
-                                    'properties': {
-                                        'all_messages_events': {'type': 'array'},
-                                        'final_result': {'type': 'object'},
-                                    },
-                                }
-                            ),
-                        }
-                    )
+                    run_span.set_attributes(self._run_span_end_attributes(state, usage))
             finally:
                 run_span.end()
+
+    def _run_span_end_attributes(self, state: _agent_graph.GraphAgentState, usage: _usage.Usage):
+        return {
+            **usage.opentelemetry_attributes(),
+            'all_messages_events': json.dumps(
+                [
+                    InstrumentedModel.event_to_dict(e)
+                    for e in InstrumentedModel.messages_to_otel_events(state.message_history)
+                ]
+            ),
+            'logfire.json_schema': json.dumps(
+                {
+                    'type': 'object',
+                    'properties': {
+                        'all_messages_events': {'type': 'array'},
+                        'final_result': {'type': 'object'},
+                    },
+                }
+            ),
+        }
 
     @overload
     def run_sync(

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 import dataclasses
 import inspect
+import json
 import warnings
 from collections.abc import AsyncIterator, Awaitable, Iterator, Sequence
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager, contextmanager
@@ -600,9 +601,10 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         )
 
         # Build the initial state
+        usage = usage or _usage.Usage()
         state = _agent_graph.GraphAgentState(
             message_history=message_history[:] if message_history else [],
-            usage=usage or _usage.Usage(),
+            usage=usage,
             retries=0,
             run_step=0,
         )
@@ -669,14 +671,50 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             system_prompt_dynamic_functions=self._system_prompt_dynamic_functions,
         )
 
-        async with graph.iter(
-            start_node,
-            state=state,
-            deps=graph_deps,
-            span=use_span(run_span, end_on_exit=True) if run_span.is_recording() else None,
-            infer_name=False,
-        ) as graph_run:
-            yield AgentRun(graph_run)
+        try:
+            async with graph.iter(
+                start_node,
+                state=state,
+                deps=graph_deps,
+                span=use_span(run_span) if run_span.is_recording() else None,
+                infer_name=False,
+            ) as graph_run:
+                agent_run = AgentRun(graph_run)
+                yield agent_run
+                if (final_result := agent_run.result) is not None and run_span.is_recording():
+                    run_span.set_attribute(
+                        'final_result',
+                        (
+                            final_result.output
+                            if isinstance(final_result.output, str)
+                            else json.dumps(InstrumentedModel.serialize_any(final_result.output))
+                        ),
+                    )
+        finally:
+            try:
+                if run_span.is_recording():
+                    run_span.set_attributes(
+                        {
+                            **usage.opentelemetry_attributes(),
+                            'all_messages_events': json.dumps(
+                                [
+                                    InstrumentedModel.event_to_dict(e)
+                                    for e in InstrumentedModel.messages_to_otel_events(state.message_history)
+                                ]
+                            ),
+                            'logfire.json_schema': json.dumps(
+                                {
+                                    'type': 'object',
+                                    'properties': {
+                                        'all_messages_events': {'type': 'array'},
+                                        'final_result': {'type': 'object'},
+                                    },
+                                }
+                            ),
+                        }
+                    )
+            finally:
+                run_span.end()
 
     @overload
     def run_sync(

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -658,7 +658,6 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             output_validators=output_validators,
             function_tools=self._function_tools,
             mcp_servers=self._mcp_servers,
-            run_span=run_span,
             tracer=tracer,
             get_instructions=get_instructions,
         )

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -240,6 +240,82 @@ def test_all_failed() -> None:
     assert exceptions[0].body == {'error': 'test error'}
 
 
+@pytest.mark.skipif(not logfire_imports_successful(), reason='logfire not installed')
+def test_all_failed_instrumented(capfire: CaptureLogfire) -> None:
+    fallback_model = FallbackModel(failure_model, failure_model)
+    agent = Agent(model=fallback_model, instrument=True)
+    with pytest.raises(ExceptionGroup) as exc_info:
+        agent.run_sync('hello')
+    assert 'All models from FallbackModel failed' in exc_info.value.args[0]
+    exceptions = exc_info.value.exceptions
+    assert len(exceptions) == 2
+    assert isinstance(exceptions[0], ModelHTTPError)
+    assert exceptions[0].status_code == 500
+    assert exceptions[0].model_name == 'test-function-model'
+    assert exceptions[0].body == {'error': 'test error'}
+    assert capfire.exporter.exported_spans_as_dict() == snapshot(
+        [
+            {
+                'name': 'chat fallback:function:failure_response:,function:failure_response:',
+                'context': {'trace_id': 1, 'span_id': 3, 'is_remote': False},
+                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'start_time': 2000000000,
+                'end_time': 4000000000,
+                'attributes': {
+                    'gen_ai.operation.name': 'chat',
+                    'gen_ai.system': 'fallback:function,function',
+                    'gen_ai.request.model': 'fallback:function:failure_response:,function:failure_response:',
+                    'model_request_parameters': '{"function_tools": [], "allow_text_output": true, "output_tools": []}',
+                    'logfire.json_schema': '{"type": "object", "properties": {"model_request_parameters": {"type": "object"}}}',
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'chat fallback:function:failure_response:,function:failure_response:',
+                    'logfire.level_num': 17,
+                },
+                'events': [
+                    {
+                        'name': 'exception',
+                        'timestamp': 3000000000,
+                        'attributes': {
+                            'exception.type': 'pydantic_ai.exceptions.FallbackExceptionGroup',
+                            'exception.message': 'All models from FallbackModel failed (2 sub-exceptions)',
+                            'exception.stacktrace': '+------------------------------------',
+                            'exception.escaped': 'False',
+                        },
+                    }
+                ],
+            },
+            {
+                'name': 'agent run',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 6000000000,
+                'attributes': {
+                    'model_name': 'fallback:function:failure_response:,function:failure_response:',
+                    'agent_name': 'agent',
+                    'logfire.msg': 'agent run',
+                    'logfire.span_type': 'span',
+                    'all_messages_events': '[{"content": "hello", "role": "user", "gen_ai.message.index": 0, "event.name": "gen_ai.user.message"}]',
+                    'logfire.json_schema': '{"type": "object", "properties": {"all_messages_events": {"type": "array"}, "final_result": {"type": "object"}}}',
+                    'logfire.level_num': 17,
+                },
+                'events': [
+                    {
+                        'name': 'exception',
+                        'timestamp': 5000000000,
+                        'attributes': {
+                            'exception.type': 'pydantic_ai.exceptions.FallbackExceptionGroup',
+                            'exception.message': 'All models from FallbackModel failed (2 sub-exceptions)',
+                            'exception.stacktrace': '+------------------------------------',
+                            'exception.escaped': 'False',
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+
+
 async def success_response_stream(_model_messages: list[ModelMessage], _agent_info: AgentInfo) -> AsyncIterator[str]:
     yield 'hello '
     yield 'world'

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -216,6 +216,10 @@ async def test_first_failed_instrumented_stream(capfire: CaptureLogfire) -> None
                     'agent_name': 'agent',
                     'logfire.msg': 'agent run',
                     'logfire.span_type': 'span',
+                    'gen_ai.usage.input_tokens': 50,
+                    'gen_ai.usage.output_tokens': 2,
+                    'all_messages_events': '[{"content": "input", "role": "user", "gen_ai.message.index": 0, "event.name": "gen_ai.user.message"}, {"role": "assistant", "content": "hello world", "gen_ai.message.index": 1, "event.name": "gen_ai.assistant.message"}]',
+                    'logfire.json_schema': '{"type": "object", "properties": {"all_messages_events": {"type": "array"}, "final_result": {"type": "object"}}}',
                 },
             },
         ]

--- a/uv.lock
+++ b/uv.lock
@@ -1325,17 +1325,18 @@ wheels = [
 
 [[package]]
 name = "inline-snapshot"
-version = "0.20.2"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asttokens" },
     { name = "executing" },
+    { name = "pytest" },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/1d/eb7aca1df3900f4d27f55c55e7aa9464ab9b1f2d2a7150f66cf82ca0ba2b/inline_snapshot-0.20.2.tar.gz", hash = "sha256:c276a2e018575d50e720e9b79b70f7030d292120f96e6be2e138a87a5a6d096b", size = 91060 }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/a3/9e78da370d20b896861cd5db3fa6fde89348b700ec144d8c1457c18ea113/inline_snapshot-0.23.0.tar.gz", hash = "sha256:872d027b1eae4e3e3b4028e0d46128bafbf62889a2424a2667dbe4b69cb1ffdf", size = 259375 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/d7/e9fdfdd574290c6f093f7a3c6b9968b1c6f99da4cdc41e6a790ddd51782c/inline_snapshot-0.20.2-py3-none-any.whl", hash = "sha256:52507d2976ea80abdcf72a89d31d0fda9a46f37cbae3ee1dcb67c9324b34ef44", size = 47844 },
+    { url = "https://files.pythonhosted.org/packages/71/ab/4ad6bb9808f242e659ca8437ee475efaa201f18ff20a0dd5553280c85ae5/inline_snapshot-0.23.0-py3-none-any.whl", hash = "sha256:b1a5feab675aee8d03a51f1b6291f412100ce750d846c2d58eab16c90ee2c4dd", size = 50119 },
 ]
 
 [[package]]


### PR DESCRIPTION
If `agent.run` failed with an exception or `agent.run_stream` was used, attributes like `all_messages_events` weren't recorded on the run span.