### PR TITLE
adding base_url to Mistral Provider

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -44,6 +44,7 @@ class MistralProvider(Provider[Mistral]):
         *,
         api_key: str | None = None,
         mistral_client: Mistral | None = None,
+        base_url: str | None = None,
         http_client: AsyncHTTPClient | None = None,
     ) -> None:
         """Create a new Mistral provider.
@@ -67,7 +68,7 @@ class MistralProvider(Provider[Mistral]):
                     'to use the Mistral provider.'
                 )
             elif http_client is not None:
-                self._client = Mistral(api_key=api_key, async_client=http_client)
+                self._client = Mistral(api_key=api_key, async_client=http_client, server_url=base_url)
             else:
                 http_client = cached_async_http_client(provider='mistral')
-                self._client = Mistral(api_key=api_key, async_client=http_client)
+                self._client = Mistral(api_key=api_key, async_client=http_client, server_url=base_url)


### PR DESCRIPTION
passing base_url to support mistral models that are hosted somewhere else (e.g. Azure)


I tested this and it works

```python 

from pydantic_ai import Agent
from pydantic_ai.models.mistral import MistralModel
from pydantic_ai.providers.mistral import MistralProvider

model = MistralModel(
    "mistral-small-2503",
    provider=MistralProvider(
        api_key=os.environ["AZURE_AI_API_KEY"], base_url=os.environ["AZURE_AI_ENDPOINT"]
    ),
)

agent = Agent(model)

```