### PR TITLE
Support structured and manual JSON output_type modes in addition to tool calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -12,7 +12,7 @@ from .exceptions import (
 )
 from .format_prompt import format_as_xml
 from .messages import AudioUrl, BinaryContent, DocumentUrl, ImageUrl, VideoUrl
-from .result import ToolOutput
+from .result import StructuredOutput, ToolOutput
 from .tools import RunContext, Tool
 
 __all__ = (
@@ -43,6 +43,7 @@ __all__ = (
     'RunContext',
     # result
     'ToolOutput',
+    'StructuredOutput',
     # format_prompt
     'format_as_xml',
 )

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -24,7 +24,7 @@ from . import (
     result,
     usage as _usage,
 )
-from .result import OutputDataT, ToolOutput
+from .result import OutputDataT, StructuredOutput, ToolOutput
 from .settings import ModelSettings, merge_model_settings
 from .tools import RunContext, Tool, ToolDefinition
 
@@ -124,9 +124,6 @@ def is_agent_node(
 @dataclasses.dataclass
 class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
     user_prompt: str | Sequence[_messages.UserContent] | None
-
-    instructions: str | None
-    instructions_functions: list[_system_prompt.SystemPromptRunner[DepsT]]
 
     system_prompts: tuple[str, ...]
     system_prompt_functions: list[_system_prompt.SystemPromptRunner[DepsT]]
@@ -244,6 +241,8 @@ async def _prepare_request_parameters(
         function_tools=function_tool_defs,
         allow_text_output=allow_text_output(output_schema),
         output_tools=output_schema.tool_defs() if output_schema is not None else [],
+        output_schema=output_schema.json_schema if output_schema is not None else None,
+        preferred_output_mode=output_schema.preferred_mode if output_schema is not None else None,
     )
 
 
@@ -396,7 +395,7 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
         async for _event in stream:
             pass
 
-    async def _run_stream(
+    async def _run_stream(  # noqa: C901
         self, ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]]
     ) -> AsyncIterator[_messages.HandleResponseEvent]:
         if self._events_iterator is None:
@@ -404,12 +403,16 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
 
             async def _run_stream() -> AsyncIterator[_messages.HandleResponseEvent]:
                 texts: list[str] = []
+                structured_outputs: list[str] = []
                 tool_calls: list[_messages.ToolCallPart] = []
                 for part in self.model_response.parts:
                     if isinstance(part, _messages.TextPart):
                         # ignore empty content for text parts, see #437
                         if part.content:
                             texts.append(part.content)
+                    elif isinstance(part, _messages.StructuredOutputPart):
+                        if part.content:
+                            structured_outputs.append(part.content)
                     elif isinstance(part, _messages.ToolCallPart):
                         tool_calls.append(part)
                     else:
@@ -422,6 +425,9 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                 if tool_calls:
                     async for event in self._handle_tool_calls(ctx, tool_calls):
                         yield event
+                elif structured_outputs:
+                    # No events are emitted during the handling of structured outputs, so we don't need to yield anything
+                    self._next_node = await self._handle_structured_outputs(ctx, structured_outputs)
                 elif texts:
                     # No events are emitted during the handling of text responses, so we don't need to yield anything
                     self._next_node = await self._handle_text_response(ctx, texts)
@@ -534,6 +540,27 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                     ]
                 )
             )
+
+    async def _handle_structured_outputs(
+        self,
+        ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]],
+        structured_outputs: list[str],
+    ) -> ModelRequestNode[DepsT, NodeRunEndT] | End[result.FinalResult[NodeRunEndT]]:
+        if len(structured_outputs) != 1:
+            raise exceptions.UnexpectedModelBehavior('Received multiple structured outputs in a single response')
+        output_schema = ctx.deps.output_schema
+        if not output_schema:
+            raise exceptions.UnexpectedModelBehavior('Must specify a non-str result_type when using structured outputs')
+
+        structured_output = structured_outputs[0]
+        try:
+            result_data = output_schema.validate(structured_output)
+            result_data = await _validate_output(result_data, ctx, None)
+        except _output.ToolRetryError as e:
+            ctx.state.increment_retries(ctx.deps.max_result_retries)
+            return ModelRequestNode[DepsT, NodeRunEndT](_messages.ModelRequest(parts=[e.tool_retry]))
+        else:
+            return self._handle_final_result(ctx, result.FinalResult(result_data, None, None), [])
 
 
 def build_run_context(ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, Any]]) -> RunContext[DepsT]:
@@ -829,7 +856,9 @@ def get_captured_run_messages() -> _RunMessages:
 
 
 def build_agent_graph(
-    name: str | None, deps_type: type[DepsT], output_type: type[OutputT] | ToolOutput[OutputT]
+    name: str | None,
+    deps_type: type[DepsT],
+    output_type: type[OutputT] | ToolOutput[OutputT] | StructuredOutput[OutputT],
 ) -> Graph[GraphAgentState, GraphAgentDeps[DepsT, result.FinalResult[OutputT]], result.FinalResult[OutputT]]:
     """Build the execution [Graph][pydantic_graph.Graph] for a given agent."""
     nodes = (

--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -12,8 +12,15 @@ from typing_inspection.introspection import is_union_origin
 
 from . import _utils, messages as _messages
 from .exceptions import ModelRetry
-from .result import DEFAULT_OUTPUT_TOOL_NAME, OutputDataT, OutputDataT_inv, OutputValidatorFunc, ToolOutput
-from .tools import AgentDepsT, GenerateToolJsonSchema, RunContext, ToolDefinition
+from .result import (
+    DEFAULT_OUTPUT_TOOL_NAME,
+    OutputDataT,
+    OutputDataT_inv,
+    OutputValidatorFunc,
+    StructuredOutput,
+    ToolOutput,
+)
+from .tools import AgentDepsT, GenerateToolJsonSchema, ObjectJsonSchema, RunContext, ToolDefinition
 
 T = TypeVar('T')
 """An invariant TypeVar."""
@@ -83,13 +90,18 @@ class OutputSchema(Generic[OutputDataT]):
     Similar to `Tool` but for the final output of running an agent.
     """
 
+    # TODO: Since this is currently called "preferred", models that don't have structured output implemented yet ignore it and use tools (except for Mistral).
+    # We should likely raise an error if an unsupported mode is used, _and_ allow the model to pick its own preferred mode if none is forced.
+    preferred_mode: Literal['tool', 'structured'] | None  # TODO: Add mode for manual JSON
+    type_adapter: TypeAdapter[OutputDataT]
     tools: dict[str, OutputSchemaTool[OutputDataT]]
-    allow_text_output: bool
+    allow_text_output: bool  # TODO: Verify structured output works correctly with string as a union member
+    json_schema: ObjectJsonSchema  # TODO: Verify structured output works correctly with a union
 
     @classmethod
     def build(
         cls: type[OutputSchema[T]],
-        output_type: type[T] | ToolOutput[T],
+        output_type: type[T] | ToolOutput[T] | StructuredOutput[T],  # TODO: Support a list of output types/markers
         name: str | None = None,
         description: str | None = None,
         strict: bool | None = None,
@@ -98,15 +110,34 @@ class OutputSchema(Generic[OutputDataT]):
         if output_type is str:
             return None
 
+        preferred_mode = None
         if isinstance(output_type, ToolOutput):
             # do we need to error on conflicts here? (DavidM): If this is internal maybe doesn't matter, if public, use overloads
             name = output_type.name
             description = output_type.description
             output_type_ = output_type.output_type
             strict = output_type.strict
+            preferred_mode = 'tool'
+        elif isinstance(output_type, StructuredOutput):
+            name = output_type.name  # TODO: Get this to the response_format model request arg
+            description = output_type.description  # TODO: Get this to the response_format model request arg
+            output_type_ = output_type.output_type
+            strict = output_type.strict  # TODO: Get this to the response_format model request arg
+            preferred_mode = 'structured'
         else:
             output_type_ = output_type
 
+        type_adapter = cast(TypeAdapter[T], TypeAdapter(output_type_))
+        json_schema = _utils.check_object_json_schema(type_adapter.json_schema(schema_generator=GenerateToolJsonSchema))
+
+        # TODO: Make this description available to the model params
+        if json_schema_description := json_schema.pop('description', None):
+            if description is None:
+                description = json_schema_description
+            else:
+                description = f'{description}. {json_schema_description}'
+
+        # No need to include an output tool for string output
         if output_type_option := extract_str_from_union(output_type):
             output_type_ = output_type_option.value
             allow_text_output = True
@@ -134,7 +165,13 @@ class OutputSchema(Generic[OutputDataT]):
                 ),
             )
 
-        return cls(tools=tools, allow_text_output=allow_text_output)
+        return cls(
+            preferred_mode=preferred_mode,
+            tools=tools,
+            allow_text_output=allow_text_output,
+            type_adapter=type_adapter,
+            json_schema=json_schema,
+        )
 
     def find_named_tool(
         self, parts: Iterable[_messages.ModelResponsePart], tool_name: str
@@ -162,6 +199,35 @@ class OutputSchema(Generic[OutputDataT]):
     def tool_defs(self) -> list[ToolDefinition]:
         """Get tool definitions to register with the model."""
         return [t.tool_def for t in self.tools.values()]
+
+    def validate(
+        self, output_text: str, allow_partial: bool = False, wrap_validation_errors: bool = True
+    ) -> OutputDataT:
+        """Validate a structured output message.
+
+        Args:
+            output_text: The structured output from the LLM to validate.
+            allow_partial: If true, allow partial validation.
+            wrap_validation_errors: If true, wrap the validation errors in a retry message.
+
+        Returns:
+            Either the validated output data (left) or a retry message (right).
+        """
+        try:
+            pyd_allow_partial: Literal['off', 'trailing-strings'] = 'trailing-strings' if allow_partial else 'off'
+            output = self.type_adapter.validate_json(output_text, experimental_allow_partial=pyd_allow_partial)
+        except ValidationError as e:
+            if wrap_validation_errors:
+                m = _messages.RetryPromptPart(
+                    content=e.errors(include_url=False),
+                )
+                raise ToolRetryError(m) from e
+            else:
+                raise
+        else:
+            return output
+
+    # TODO: Build instructions for manual JSON
 
 
 DEFAULT_DESCRIPTION = 'The final response which ends this conversation'

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -23,6 +23,7 @@ from pydantic_ai.messages import (
     ModelResponseStreamEvent,
     PartDeltaEvent,
     PartStartEvent,
+    StructuredOutputPartDelta,
     TextPart,
     TextPartDelta,
     ToolCallPart,
@@ -57,12 +58,12 @@ class ModelResponsePartsManager:
     """Maps a vendor's "part" ID (if provided) to the index in `_parts` where that part resides."""
 
     def get_parts(self) -> list[ModelResponsePart]:
-        """Return only model response parts that are complete (i.e., not ToolCallPartDelta's).
+        """Return only model response parts that are complete (i.e., not ToolCallPartDelta's or StructuredOutputPartDelta's).
 
         Returns:
-            A list of ModelResponsePart objects. ToolCallPartDelta objects are excluded.
+            A list of ModelResponsePart objects. ToolCallPartDelta and StructuredOutputPartDelta objects are excluded.
         """
-        return [p for p in self._parts if not isinstance(p, ToolCallPartDelta)]
+        return [p for p in self._parts if not isinstance(p, (ToolCallPartDelta, StructuredOutputPartDelta))]
 
     def handle_text_delta(
         self,
@@ -90,6 +91,8 @@ class ModelResponsePartsManager:
                 not a TextPart.
         """
         existing_text_part_and_index: tuple[TextPart, int] | None = None
+
+        # TODO: Parse out structured output or manual JSON, with a separate message?
 
         if vendor_part_id is None:
             # If the vendor_part_id is None, check if the latest part is a TextPart to update

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -29,7 +29,7 @@ from . import (
     usage as _usage,
 )
 from .models.instrumented import InstrumentationSettings, InstrumentedModel
-from .result import FinalResult, OutputDataT, StreamedRunResult, ToolOutput
+from .result import FinalResult, OutputDataT, StreamedRunResult, StructuredOutput, ToolOutput
 from .settings import ModelSettings, merge_model_settings
 from .tools import (
     AgentDepsT,
@@ -118,7 +118,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
     be merged with this value, with the runtime argument taking priority.
     """
 
-    output_type: type[OutputDataT] | ToolOutput[OutputDataT]
+    output_type: type[OutputDataT] | ToolOutput[OutputDataT] | StructuredOutput[OutputDataT]
     """
     The type of data output by agent runs, used to validate the data returned by the model, defaults to `str`.
     """
@@ -152,7 +152,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self,
         model: models.Model | models.KnownModelName | str | None = None,
         *,
-        output_type: type[OutputDataT] | ToolOutput[OutputDataT] = str,
+        output_type: type[OutputDataT] | ToolOutput[OutputDataT] | StructuredOutput[OutputDataT] = str,
         instructions: str
         | _system_prompt.SystemPromptFunc[AgentDepsT]
         | Sequence[str | _system_prompt.SystemPromptFunc[AgentDepsT]]
@@ -202,7 +202,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self,
         model: models.Model | models.KnownModelName | str | None = None,
         *,
-        # TODO change this back to `output_type: type[OutputDataT] | ToolOutput[OutputDataT] = str,` when we remove the overloads
+        # TODO change this back to `output_type: type[OutputDataT] | ToolOutput[OutputDataT] | StructuredOutput[OutputDataT] = str,` when we remove the overloads
         output_type: Any = str,
         instructions: str
         | _system_prompt.SystemPromptFunc[AgentDepsT]
@@ -310,6 +310,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self._instructions_functions = []
         if isinstance(instructions, (str, Callable)):
             instructions = [instructions]
+        # TODO: Add OutputSchema to the instructions in JSON mode
         for instruction in instructions or []:
             if isinstance(instruction, str):
                 self._instructions += instruction + '\n'
@@ -357,7 +358,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self,
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
-        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT],
+        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | StructuredOutput[RunOutputDataT],
         message_history: list[_messages.ModelMessage] | None = None,
         model: models.Model | models.KnownModelName | str | None = None,
         deps: AgentDepsT = None,
@@ -387,7 +388,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self,
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
-        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | None = None,
+        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | StructuredOutput[RunOutputDataT] | None = None,
         message_history: list[_messages.ModelMessage] | None = None,
         model: models.Model | models.KnownModelName | str | None = None,
         deps: AgentDepsT = None,
@@ -459,7 +460,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self,
         user_prompt: str | Sequence[_messages.UserContent] | None,
         *,
-        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | None = None,
+        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | StructuredOutput[RunOutputDataT] | None = None,
         message_history: list[_messages.ModelMessage] | None = None,
         model: models.Model | models.KnownModelName | str | None = None,
         deps: AgentDepsT = None,
@@ -491,7 +492,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self,
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
-        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | None = None,
+        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | StructuredOutput[RunOutputDataT] | None = None,
         message_history: list[_messages.ModelMessage] | None = None,
         model: models.Model | models.KnownModelName | str | None = None,
         deps: AgentDepsT = None,
@@ -664,8 +665,6 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         )
         start_node = _agent_graph.UserPromptNode[AgentDepsT](
             user_prompt=user_prompt,
-            instructions=self._instructions,
-            instructions_functions=self._instructions_functions,
             system_prompts=self._system_prompts,
             system_prompt_functions=self._system_prompt_functions,
             system_prompt_dynamic_functions=self._system_prompt_dynamic_functions,
@@ -736,7 +735,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self,
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
-        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | None,
+        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | StructuredOutput[RunOutputDataT] | None = None,
         message_history: list[_messages.ModelMessage] | None = None,
         model: models.Model | models.KnownModelName | str | None = None,
         deps: AgentDepsT = None,
@@ -766,7 +765,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self,
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
-        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | None = None,
+        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | StructuredOutput[RunOutputDataT] | None = None,
         message_history: list[_messages.ModelMessage] | None = None,
         model: models.Model | models.KnownModelName | str | None = None,
         deps: AgentDepsT = None,
@@ -849,7 +848,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self,
         user_prompt: str | Sequence[_messages.UserContent],
         *,
-        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT],
+        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | StructuredOutput[RunOutputDataT],
         message_history: list[_messages.ModelMessage] | None = None,
         model: models.Model | models.KnownModelName | str | None = None,
         deps: AgentDepsT = None,
@@ -880,7 +879,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         self,
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
-        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | None = None,
+        output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | StructuredOutput[RunOutputDataT] | None = None,
         message_history: list[_messages.ModelMessage] | None = None,
         model: models.Model | models.KnownModelName | str | None = None,
         deps: AgentDepsT = None,
@@ -965,6 +964,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
                                     elif isinstance(new_part, _messages.ToolCallPart) and output_schema:
                                         for call, _ in output_schema.find_tool([new_part]):
                                             return FinalResult(s, call.tool_name, call.tool_call_id)
+                                    elif isinstance(new_part, _messages.StructuredOutputPart) and output_schema:
+                                        return FinalResult(s, None, None)
                             return None
 
                         final_result_details = await stream_to_final(streamed_response)
@@ -1598,7 +1599,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         raise AttributeError('The `last_run_messages` attribute has been removed, use `capture_run_messages` instead.')
 
     def _prepare_output_schema(
-        self, output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | None
+        self, output_type: type[RunOutputDataT] | ToolOutput[RunOutputDataT] | StructuredOutput[RunOutputDataT] | None
     ) -> _output.OutputSchema[RunOutputDataT] | None:
         if output_type is not None:
             if self._output_validators:

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -490,6 +490,21 @@ class TextPart:
 
 
 @dataclass
+class StructuredOutputPart:
+    """A structured output response from a model."""
+
+    content: str
+    """The structured content of the response as a JSON-serialized string."""
+
+    part_kind: Literal['structured-output'] = 'structured-output'
+    """Part type identifier, this is available on all parts as a discriminator."""
+
+    def has_content(self) -> bool:
+        """Return `True` if the structured output content is non-empty."""
+        return bool(self.content)
+
+
+@dataclass
 class ToolCallPart:
     """A tool call from a model."""
 
@@ -543,7 +558,7 @@ class ToolCallPart:
             return bool(self.args)
 
 
-ModelResponsePart = Annotated[Union[TextPart, ToolCallPart], pydantic.Discriminator('part_kind')]
+ModelResponsePart = Annotated[Union[TextPart, StructuredOutputPart, ToolCallPart], pydantic.Discriminator('part_kind')]
 """A message part returned by a model."""
 
 
@@ -630,6 +645,33 @@ class TextPartDelta:
         """
         if not isinstance(part, TextPart):
             raise ValueError('Cannot apply TextPartDeltas to non-TextParts')
+        return replace(part, content=part.content + self.content_delta)
+
+
+@dataclass
+class StructuredOutputPartDelta:
+    """A partial update (delta) for a `StructuredOutputPart` to append new structured output content."""
+
+    content_delta: str
+    """The incremental structured output content to add to the existing `StructuredOutputPart` content."""
+
+    part_delta_kind: Literal['structured-output'] = 'structured-output'
+    """Part delta type identifier, used as a discriminator."""
+
+    def apply(self, part: ModelResponsePart) -> StructuredOutputPart:
+        """Apply this structured output delta to an existing `StructuredOutputPart`.
+
+        Args:
+            part: The existing model response part, which must be a `StructuredOutputPart`.
+
+        Returns:
+            A new `StructuredOutputPart` with updated structured output content.
+
+        Raises:
+            ValueError: If `part` is not a `StructuredOutputPart`.
+        """
+        if not isinstance(part, StructuredOutputPart):
+            raise ValueError('Cannot apply StructuredOutputPartDeltas to non-StructuredOutputParts')
         return replace(part, content=part.content + self.content_delta)
 
 
@@ -748,7 +790,9 @@ class ToolCallPartDelta:
         return part
 
 
-ModelResponsePartDelta = Annotated[Union[TextPartDelta, ToolCallPartDelta], pydantic.Discriminator('part_delta_kind')]
+ModelResponsePartDelta = Annotated[
+    Union[TextPartDelta, StructuredOutputPartDelta, ToolCallPartDelta], pydantic.Discriminator('part_delta_kind')
+]
 """A partial update (delta) for any model response part."""
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -21,6 +21,7 @@ from .._parts_manager import ModelResponsePartsManager
 from ..exceptions import UserError
 from ..messages import ModelMessage, ModelRequest, ModelResponse, ModelResponseStreamEvent
 from ..settings import ModelSettings
+from ..tools import ObjectJsonSchema  # TODO: Move to more generic place
 from ..usage import Usage
 
 if TYPE_CHECKING:
@@ -265,8 +266,11 @@ class ModelRequestParameters:
     """Configuration for an agent's request to a model, specifically related to tools and output handling."""
 
     function_tools: list[ToolDefinition]
-    allow_text_output: bool
+
+    preferred_output_mode: Literal['tool', 'structured'] | None
+    allow_text_output: bool  # TODO: How to handle with structured output?
     output_tools: list[ToolDefinition]
+    output_schema: ObjectJsonSchema | None
 
 
 class Model(ABC):

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -22,6 +22,7 @@ from ..messages import (
     ModelResponsePart,
     ModelResponseStreamEvent,
     RetryPromptPart,
+    StructuredOutputPart,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
@@ -320,7 +321,7 @@ class AnthropicModel(Model):
             elif isinstance(m, ModelResponse):
                 assistant_content_params: list[TextBlockParam | ToolUseBlockParam] = []
                 for response_part in m.parts:
-                    if isinstance(response_part, TextPart):
+                    if isinstance(response_part, (TextPart, StructuredOutputPart)):
                         assistant_content_params.append(TextBlockParam(text=response_part.content, type='text'))
                     else:
                         tool_use_block_param = ToolUseBlockParam(

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -14,6 +14,7 @@ from ..messages import (
     ModelResponse,
     ModelResponsePart,
     RetryPromptPart,
+    StructuredOutputPart,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
@@ -203,7 +204,7 @@ class CohereModel(Model):
                 texts: list[str] = []
                 tool_calls: list[ToolCallV2] = []
                 for item in message.parts:
-                    if isinstance(item, TextPart):
+                    if isinstance(item, (TextPart, StructuredOutputPart)):
                         texts.append(item.content)
                     elif isinstance(item, ToolCallPart):
                         tool_calls.append(self._map_tool_call(item))

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -22,6 +22,7 @@ from ..messages import (
     ModelResponse,
     ModelResponseStreamEvent,
     RetryPromptPart,
+    StructuredOutputPart,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
@@ -263,7 +264,7 @@ def _estimate_usage(messages: Iterable[ModelMessage]) -> usage.Usage:
                     assert_never(part)
         elif isinstance(message, ModelResponse):
             for part in message.parts:
-                if isinstance(part, TextPart):
+                if isinstance(part, (TextPart, StructuredOutputPart)):
                     response_tokens += _estimate_string_tokens(part.content)
                 elif isinstance(part, ToolCallPart):
                     call = part

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -28,6 +28,7 @@ from ..messages import (
     ModelResponsePart,
     ModelResponseStreamEvent,
     RetryPromptPart,
+    StructuredOutputPart,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
@@ -163,6 +164,10 @@ class GeminiModel(Model):
             function_tools=[_customize_tool_def(tool) for tool in model_request_parameters.function_tools],
             allow_text_output=model_request_parameters.allow_text_output,
             output_tools=[_customize_tool_def(tool) for tool in model_request_parameters.output_tools],
+            output_schema=_GeminiJsonSchema(model_request_parameters.output_schema).walk()
+            if model_request_parameters.output_schema
+            else None,
+            preferred_output_mode=model_request_parameters.preferred_output_mode,
         )
 
     @property
@@ -523,7 +528,7 @@ def _content_model_response(m: ModelResponse) -> _GeminiContent:
     for item in m.parts:
         if isinstance(item, ToolCallPart):
             parts.append(_function_call_part_from_call(item))
-        elif isinstance(item, TextPart):
+        elif isinstance(item, (TextPart, StructuredOutputPart)):
             if item.content:
                 parts.append(_GeminiTextPart(text=item.content))
         else:

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -21,6 +21,7 @@ from ..messages import (
     ModelResponsePart,
     ModelResponseStreamEvent,
     RetryPromptPart,
+    StructuredOutputPart,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
@@ -266,7 +267,7 @@ class GroqModel(Model):
                 texts: list[str] = []
                 tool_calls: list[chat.ChatCompletionMessageToolCallParam] = []
                 for item in message.parts:
-                    if isinstance(item, TextPart):
+                    if isinstance(item, (TextPart, StructuredOutputPart)):
                         texts.append(item.content)
                     elif isinstance(item, ToolCallPart):
                         tool_calls.append(self._map_tool_call(item))

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -23,6 +23,7 @@ from ..messages import (
     ModelResponsePart,
     ModelResponseStreamEvent,
     RetryPromptPart,
+    StructuredOutputPart,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
@@ -244,6 +245,7 @@ class MistralModel(Model):
             )
 
         elif model_request_parameters.output_tools:
+            # TODO: Port to native "manual JSON" mode
             # Json Mode
             parameters_json_schemas = [tool.parameters_json_schema for tool in model_request_parameters.output_tools]
             user_output_format_message = self._generate_user_output_format(parameters_json_schemas)
@@ -252,7 +254,9 @@ class MistralModel(Model):
             response = await self.client.chat.stream_async(
                 model=str(self._model_name),
                 messages=mistral_messages,
-                response_format={'type': 'json_object'},
+                response_format={
+                    'type': 'json_object'
+                },  # TODO: Should be able to use json_schema now: https://docs.mistral.ai/capabilities/structured-output/custom_structured_output/, https://github.com/mistralai/client-python/blob/bc4adf335968c8a272e1ab7da8461c9943d8e701/src/mistralai/extra/utils/response_format.py#L9
                 stream=True,
                 http_headers={'User-Agent': get_user_agent()},
             )
@@ -472,7 +476,7 @@ class MistralModel(Model):
                 tool_calls: list[MistralToolCall] = []
 
                 for part in message.parts:
-                    if isinstance(part, TextPart):
+                    if isinstance(part, (TextPart, StructuredOutputPart)):
                         content_chunks.append(MistralTextChunk(text=part.content))
                     elif isinstance(part, ToolCallPart):
                         tool_calls.append(self._map_tool_call(part))
@@ -556,6 +560,7 @@ class MistralStreamedResponse(StreamedResponse):
                 # Attempt to produce an output tool call from the received text
                 if self._output_tools:
                     self._delta_content += text
+                    # TODO: Port to native "manual JSON" mode
                     maybe_tool_call_part = self._try_get_output_tool_from_text(self._delta_content, self._output_tools)
                     if maybe_tool_call_part:
                         yield self._parts_manager.handle_tool_call_part(

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -26,6 +26,7 @@ from ..messages import (
     ModelResponsePart,
     ModelResponseStreamEvent,
     RetryPromptPart,
+    StructuredOutputPart,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
@@ -197,7 +198,7 @@ class OpenAIModel(Model):
         response = await self._completions_create(
             messages, False, cast(OpenAIModelSettings, model_settings or {}), model_request_parameters
         )
-        return self._process_response(response), _map_usage(response)
+        return self._process_response(response, model_request_parameters), _map_usage(response)
 
     @asynccontextmanager
     async def request_stream(
@@ -251,15 +252,34 @@ class OpenAIModel(Model):
         model_settings: OpenAIModelSettings,
         model_request_parameters: ModelRequestParameters,
     ) -> chat.ChatCompletion | AsyncStream[ChatCompletionChunk]:
-        tools = self._get_tools(model_request_parameters)
+        tools = [self._map_tool_definition(r) for r in model_request_parameters.function_tools]
+        tool_choice: Literal['none', 'required', 'auto'] | None = None
+        response_format: chat.completion_create_params.ResponseFormat | NotGiven = NOT_GIVEN
 
-        # standalone function to make it easier to override
-        if not tools:
-            tool_choice: Literal['none', 'required', 'auto'] | None = None
-        elif not model_request_parameters.allow_text_output:
-            tool_choice = 'required'
+        if model_request_parameters.preferred_output_mode == 'structured' and (
+            output_schema := model_request_parameters.output_schema
+        ):
+            # TODO: Use ResponseFormatJSONObject on older models
+            response_format = chat.completion_create_params.ResponseFormatJSONSchema(  # pyright: ignore[reportPrivateImportUsage]
+                type='json_schema',
+                json_schema={
+                    'name': 'result',  # TODO: Take from StructuredOutput helper
+                    # 'description': result_tool.description,
+                    'schema': output_schema,
+                    'strict': False,  # TODO: Determine as we do for tools
+                },
+            )
+
+            if tools:
+                tool_choice = 'auto'
         else:
-            tool_choice = 'auto'
+            tools.extend(self._map_tool_definition(r) for r in model_request_parameters.output_tools)
+
+            if tools:
+                if not model_request_parameters.allow_text_output:
+                    tool_choice = 'required'
+                else:
+                    tool_choice = 'auto'
 
         openai_messages = await self._map_messages(messages)
 
@@ -278,6 +298,7 @@ class OpenAIModel(Model):
                 temperature=model_settings.get('temperature', NOT_GIVEN),
                 top_p=model_settings.get('top_p', NOT_GIVEN),
                 timeout=model_settings.get('timeout', NOT_GIVEN),
+                response_format=response_format,
                 seed=model_settings.get('seed', NOT_GIVEN),
                 presence_penalty=model_settings.get('presence_penalty', NOT_GIVEN),
                 frequency_penalty=model_settings.get('frequency_penalty', NOT_GIVEN),
@@ -292,13 +313,18 @@ class OpenAIModel(Model):
                 raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
             raise
 
-    def _process_response(self, response: chat.ChatCompletion) -> ModelResponse:
+    def _process_response(
+        self, response: chat.ChatCompletion, model_request_parameters: ModelRequestParameters
+    ) -> ModelResponse:
         """Process a non-streamed response, and prepare a message to return."""
         timestamp = datetime.fromtimestamp(response.created, tz=timezone.utc)
         choice = response.choices[0]
         items: list[ModelResponsePart] = []
         if choice.message.content is not None:
-            items.append(TextPart(choice.message.content))
+            if model_request_parameters.preferred_output_mode == 'structured':
+                items.append(StructuredOutputPart(choice.message.content))
+            else:
+                items.append(TextPart(choice.message.content))
         if choice.message.tool_calls is not None:
             for c in choice.message.tool_calls:
                 items.append(ToolCallPart(c.function.name, c.function.arguments, tool_call_id=c.id))
@@ -334,7 +360,7 @@ class OpenAIModel(Model):
                 texts: list[str] = []
                 tool_calls: list[chat.ChatCompletionMessageToolCallParam] = []
                 for item in message.parts:
-                    if isinstance(item, TextPart):
+                    if isinstance(item, (TextPart, StructuredOutputPart)):
                         texts.append(item.content)
                     elif isinstance(item, ToolCallPart):
                         tool_calls.append(self._map_tool_call(item))
@@ -525,7 +551,7 @@ class OpenAIResponsesModel(Model):
         response = await self._responses_create(
             messages, False, cast(OpenAIResponsesModelSettings, model_settings or {}), model_request_parameters
         )
-        return self._process_response(response), _map_usage(response)
+        return self._process_response(response, model_request_parameters), _map_usage(response)
 
     @asynccontextmanager
     async def request_stream(
@@ -544,11 +570,17 @@ class OpenAIResponsesModel(Model):
     def customize_request_parameters(self, model_request_parameters: ModelRequestParameters) -> ModelRequestParameters:
         return _customize_request_parameters(model_request_parameters)
 
-    def _process_response(self, response: responses.Response) -> ModelResponse:
+    def _process_response(
+        self, response: responses.Response, model_request_parameters: ModelRequestParameters
+    ) -> ModelResponse:
         """Process a non-streamed response, and prepare a message to return."""
         timestamp = datetime.fromtimestamp(response.created_at, tz=timezone.utc)
         items: list[ModelResponsePart] = []
-        items.append(TextPart(response.output_text))
+        # TODO: Parse out manual JSON, a la split_content_into_text_and_thinking
+        if model_request_parameters.preferred_output_mode == 'structured':
+            items.append(StructuredOutputPart(response.output_text))
+        else:
+            items.append(TextPart(response.output_text))
         for item in response.output:
             if item.type == 'function_call':
                 items.append(ToolCallPart(item.name, item.arguments, tool_call_id=item.call_id))
@@ -610,6 +642,8 @@ class OpenAIResponsesModel(Model):
         reasoning = self._get_reasoning(model_settings)
 
         try:
+            # TODO: Pass text.format = ResponseFormatTextJSONSchemaConfigParam(...): {'type': 'json_schema', 'strict': True, 'name': '...', 'schema': ...}
+            # TODO: Fall back on ResponseFormatJSONObject/json_object on older models?
             return await self.client.responses.create(
                 input=openai_messages,
                 model=self._model_name,
@@ -696,7 +730,7 @@ class OpenAIResponsesModel(Model):
                         assert_never(part)
             elif isinstance(message, ModelResponse):
                 for item in message.parts:
-                    if isinstance(item, TextPart):
+                    if isinstance(item, (TextPart, StructuredOutputPart)):
                         openai_messages.append(responses.EasyInputMessageParam(role='assistant', content=item.content))
                     elif isinstance(item, ToolCallPart):
                         openai_messages.append(self._map_tool_call(item))
@@ -806,6 +840,7 @@ class OpenAIStreamedResponse(StreamedResponse):
             # Handle the text part of the response
             content = choice.delta.content
             if content is not None:
+                # TODO: Handle structured output
                 yield self._parts_manager.handle_text_delta(vendor_part_id='content', content=content)
 
             for dtc in choice.delta.tool_calls or []:
@@ -887,6 +922,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                 pass
 
             elif isinstance(chunk, responses.ResponseTextDeltaEvent):
+                # TODO: Handle structured output
                 yield self._parts_manager.handle_text_delta(vendor_part_id=chunk.content_index, content=chunk.delta)
 
             elif isinstance(chunk, responses.ResponseTextDoneEvent):
@@ -1070,8 +1106,14 @@ def _customize_request_parameters(model_request_parameters: ModelRequestParamete
             t = replace(t, strict=schema_transformer.is_strict_compatible)
         return replace(t, parameters_json_schema=parameters_json_schema)
 
+    # TODO: Customize structured schema, add in strict
+
     return ModelRequestParameters(
         function_tools=[_customize_tool_def(tool) for tool in model_request_parameters.function_tools],
         allow_text_output=model_request_parameters.allow_text_output,
         output_tools=[_customize_tool_def(tool) for tool in model_request_parameters.output_tools],
+        output_schema=_OpenAIJsonSchema(model_request_parameters.output_schema, strict=None).walk()
+        if model_request_parameters.output_schema
+        else None,
+        preferred_output_mode=model_request_parameters.preferred_output_mode,
     )

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -18,6 +18,7 @@ from ..messages import (
     ModelResponsePart,
     ModelResponseStreamEvent,
     RetryPromptPart,
+    StructuredOutputPart,
     TextPart,
     ToolCallPart,
     ToolReturnPart,
@@ -240,7 +241,7 @@ class TestStreamedResponse(StreamedResponse):
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         for i, part in enumerate(self._structured_response.parts):
-            if isinstance(part, TextPart):
+            if isinstance(part, (TextPart, StructuredOutputPart)):
                 text = part.content
                 *words, last_word = text.split(' ')
                 words = [f'{word} ' for word in words]

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -17,7 +17,7 @@ from .usage import Usage, UsageLimits
 if TYPE_CHECKING:
     from . import _output
 
-__all__ = 'OutputDataT', 'OutputDataT_inv', 'ToolOutput', 'OutputValidatorFunc'
+__all__ = 'OutputDataT', 'OutputDataT_inv', 'ToolOutput', 'StructuredOutput', 'OutputValidatorFunc'
 
 
 T = TypeVar('T')
@@ -57,7 +57,7 @@ DEFAULT_OUTPUT_TOOL_NAME = 'final_result'
 
 @dataclass(init=False)
 class ToolOutput(Generic[OutputDataT]):
-    """Marker class to use tools for structured outputs, and customize the tool."""
+    """Marker class to use tools for outputs, and customize the tool."""
 
     output_type: type[OutputDataT]
     # TODO: Add `output_call` support, for calling a function to get the output
@@ -92,6 +92,29 @@ class ToolOutput(Generic[OutputDataT]):
         #         if type_ is None:
         #             raise ValueError('Unable to determine type_ from call signature; please provide it explicitly')
         # self.output_call = call
+
+
+@dataclass(init=False)
+class StructuredOutput(Generic[OutputDataT]):
+    """Marker class to use structured output for outputs."""
+
+    output_type: type[OutputDataT]
+    name: str
+    description: str | None
+    strict: bool | None
+
+    def __init__(
+        self,
+        *,
+        type_: type[OutputDataT],
+        name: str = 'final_result',
+        description: str | None = None,
+        strict: bool | None = None,
+    ):
+        self.output_type = type_
+        self.name = name
+        self.description = description
+        self.strict = strict
 
 
 @dataclass
@@ -157,6 +180,15 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
             for validator in self._output_validators:
                 result_data = await validator.validate(result_data, call, self._run_ctx)
             return result_data
+        elif (
+            self._output_schema is not None
+            and len(message.parts) > 0
+            and isinstance(message.parts[0], _messages.StructuredOutputPart)
+        ):
+            result_data = self._output_schema.validate(message.parts[0].content)
+            for validator in self._output_validators:
+                result_data = await validator.validate(result_data, None, self._run_ctx)
+            return result_data
         else:
             text = '\n\n'.join(x.content for x in message.parts if isinstance(x, _messages.TextPart))
             for validator in self._output_validators:
@@ -192,6 +224,9 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
                                 return _messages.FinalResultEvent(
                                     tool_name=call.tool_name, tool_call_id=call.tool_call_id
                                 )
+                    elif isinstance(new_part, _messages.StructuredOutputPart):
+                        if output_schema:
+                            return _messages.FinalResultEvent(tool_name=None, tool_call_id=None)
                     elif allow_text_output:
                         assert_type(e, _messages.PartStartEvent)
                         return _messages.FinalResultEvent(tool_name=None, tool_call_id=None)
@@ -470,6 +505,15 @@ class StreamedRunResult(Generic[AgentDepsT, OutputDataT]):
 
             for validator in self._output_validators:
                 result_data = await validator.validate(result_data, call, self._run_ctx)
+            return result_data
+        elif (
+            self._output_schema is not None
+            and len(message.parts) > 0
+            and isinstance(message.parts[0], _messages.StructuredOutputPart)
+        ):
+            result_data = self._output_schema.validate(message.parts[0].content)
+            for validator in self._output_validators:
+                result_data = await validator.validate(result_data, None, self._run_ctx)
             return result_data
         else:
             text = '\n\n'.join(x.content for x in message.parts if isinstance(x, _messages.TextPart))

--- a/tests/models/cassettes/test_openai/test_openai_structured_output.yaml
+++ b/tests/models/cassettes/test_openai/test_openai_structured_output.yaml
@@ -1,0 +1,223 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '522'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the largest city in the user country?
+        role: user
+      model: gpt-4o
+      n: 1
+      response_format:
+        json_schema:
+          name: result
+          schema:
+            properties:
+              city:
+                type: string
+              country:
+                type: string
+            required:
+            - city
+            - country
+            type: object
+          strict: false
+        type: json_schema
+      stream: false
+      tool_choice: auto
+      tools:
+      - function:
+          description: ''
+          name: get_user_country
+          parameters:
+            additionalProperties: false
+            properties: {}
+            type: object
+        type: function
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '1066'
+      content-type:
+      - application/json
+      openai-organization:
+      - pydantic-28gund
+      openai-processing-ms:
+      - '341'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: tool_calls
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: null
+          refusal: null
+          role: assistant
+          tool_calls:
+          - function:
+              arguments: '{}'
+              name: get_user_country
+            id: call_PkRGedQNRFUzJp2R7dO7avWR
+            type: function
+      created: 1746142582
+      id: chatcmpl-BSXjyBwGuZrtuuSzNCeaWMpGv2MZ3
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_f5bdcc3276
+      usage:
+        completion_tokens: 12
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 71
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 83
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '753'
+      content-type:
+      - application/json
+      cookie:
+      - __cf_bm=dOa3_E1SoWV.vbgZ8L7tx8o9S.XyNTE.YS0K0I3JHq4-1746142583-1.0.1.1-0TuvhdYsoD.J1522DBXH0yrAP_M9MlzvlcpyfwQQNZy.KO5gri6ejQ.gFuwLV5hGhuY0W2uI1dN7ZF1lirVHKeEnEz5s_89aJjrMWjyBd8M;
+        _cfuvid=xQIJVHkOP28w5fPnAvDHPiCRlU7kkNj6iFV87W4u8Ds-1746142583128-0.0.1.1-604800000
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the largest city in the user country?
+        role: user
+      - role: assistant
+        tool_calls:
+        - function:
+            arguments: '{}'
+            name: get_user_country
+          id: call_PkRGedQNRFUzJp2R7dO7avWR
+          type: function
+      - content: Mexico
+        role: tool
+        tool_call_id: call_PkRGedQNRFUzJp2R7dO7avWR
+      model: gpt-4o
+      n: 1
+      response_format:
+        json_schema:
+          name: result
+          schema:
+            properties:
+              city:
+                type: string
+              country:
+                type: string
+            required:
+            - city
+            - country
+            type: object
+          strict: false
+        type: json_schema
+      stream: false
+      tool_choice: auto
+      tools:
+      - function:
+          description: ''
+          name: get_user_country
+          parameters:
+            additionalProperties: false
+            properties: {}
+            type: object
+        type: function
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '852'
+      content-type:
+      - application/json
+      openai-organization:
+      - pydantic-28gund
+      openai-processing-ms:
+      - '553'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: '{"city":"Mexico City","country":"Mexico"}'
+          refusal: null
+          role: assistant
+      created: 1746142583
+      id: chatcmpl-BSXjzYGu67dhTy5r8KmjJvQ4HhDVO
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_f5bdcc3276
+      usage:
+        completion_tokens: 15
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 92
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 107
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_openai/test_openai_tool_output.yaml
+++ b/tests/models/cassettes/test_openai/test_openai_tool_output.yaml
@@ -1,0 +1,227 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '561'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the largest city in the user country?
+        role: user
+      model: gpt-4o
+      n: 1
+      stream: false
+      tool_choice: required
+      tools:
+      - function:
+          description: ''
+          name: get_user_country
+          parameters:
+            additionalProperties: false
+            properties: {}
+            type: object
+        type: function
+      - function:
+          description: The final response which ends this conversation
+          name: final_result
+          parameters:
+            properties:
+              city:
+                type: string
+              country:
+                type: string
+            required:
+            - city
+            - country
+            type: object
+        type: function
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '1066'
+      content-type:
+      - application/json
+      openai-organization:
+      - pydantic-28gund
+      openai-processing-ms:
+      - '348'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: tool_calls
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: null
+          refusal: null
+          role: assistant
+          tool_calls:
+          - function:
+              arguments: '{}'
+              name: get_user_country
+            id: call_iXFttys57ap0o16JSlC8yhYo
+            type: function
+      created: 1746142584
+      id: chatcmpl-BSXk0dWkG4hfPt0lph4oFO35iT73I
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_f5bdcc3276
+      usage:
+        completion_tokens: 12
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 68
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 80
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '792'
+      content-type:
+      - application/json
+      cookie:
+      - __cf_bm=yM.C6I_kAzJk3Dm7H52actN1zAEW8fj.Gd2yeJ7tKN0-1746142584-1.0.1.1-xk91aElDtLLC8aROrOKHlp5vck_h.R.zQkS6OrsiBOwuFA8rE1kGswpactMEtYxV9WgWDN2B4S2B4zs8heyxmcfiNjmOf075n.OPqYpVla4;
+        _cfuvid=JCllInpf6fg1JdOS7xSj3bZOXYf9PYJ8uoamRTx7ku4-1746142584855-0.0.1.1-604800000
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the largest city in the user country?
+        role: user
+      - role: assistant
+        tool_calls:
+        - function:
+            arguments: '{}'
+            name: get_user_country
+          id: call_iXFttys57ap0o16JSlC8yhYo
+          type: function
+      - content: Mexico
+        role: tool
+        tool_call_id: call_iXFttys57ap0o16JSlC8yhYo
+      model: gpt-4o
+      n: 1
+      stream: false
+      tool_choice: required
+      tools:
+      - function:
+          description: ''
+          name: get_user_country
+          parameters:
+            additionalProperties: false
+            properties: {}
+            type: object
+        type: function
+      - function:
+          description: The final response which ends this conversation
+          name: final_result
+          parameters:
+            properties:
+              city:
+                type: string
+              country:
+                type: string
+            required:
+            - city
+            - country
+            type: object
+        type: function
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '1113'
+      content-type:
+      - application/json
+      openai-organization:
+      - pydantic-28gund
+      openai-processing-ms:
+      - '1919'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: tool_calls
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: null
+          refusal: null
+          role: assistant
+          tool_calls:
+          - function:
+              arguments: '{"city": "Mexico City", "country": "Mexico"}'
+              name: final_result
+            id: call_gmD2oUZUzSoCkmNmp3JPUF7R
+            type: function
+      created: 1746142585
+      id: chatcmpl-BSXk1xGHYzbhXgUkSutK08bdoNv5s
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_f5bdcc3276
+      usage:
+        completion_tokens: 36
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 89
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 125
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -62,7 +62,9 @@ async def test_model_simple(allow_model_requests: None):
     assert m.model_name == 'gemini-1.5-flash'
     assert 'x-goog-api-key' in m.client.headers
 
-    mrp = ModelRequestParameters(function_tools=[], allow_text_output=True, output_tools=[])
+    mrp = ModelRequestParameters(
+        function_tools=[], allow_text_output=True, output_tools=[], preferred_output_mode=None, output_schema=None
+    )
     mrp = m.customize_request_parameters(mrp)
     tools = m._get_tools(mrp)
     tool_config = m._get_tool_config(mrp, tools)
@@ -95,7 +97,13 @@ async def test_model_tools(allow_model_requests: None):
         {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}, 'required': ['spam']},
     )
 
-    mrp = ModelRequestParameters(function_tools=tools, allow_text_output=True, output_tools=[output_tool])
+    mrp = ModelRequestParameters(
+        function_tools=tools,
+        allow_text_output=True,
+        output_tools=[output_tool],
+        preferred_output_mode=None,
+        output_schema=None,
+    )
     mrp = m.customize_request_parameters(mrp)
     tools = m._get_tools(mrp)
     tool_config = m._get_tool_config(mrp, tools)
@@ -137,7 +145,13 @@ async def test_require_response_tool(allow_model_requests: None):
         'This is the tool for the final Result',
         {'type': 'object', 'title': 'Result', 'properties': {'spam': {'type': 'number'}}},
     )
-    mrp = ModelRequestParameters(function_tools=[], allow_text_output=False, output_tools=[output_tool])
+    mrp = ModelRequestParameters(
+        function_tools=[],
+        allow_text_output=False,
+        output_tools=[output_tool],
+        preferred_output_mode=None,
+        output_schema=None,
+    )
     mrp = m.customize_request_parameters(mrp)
     tools = m._get_tools(mrp)
     tool_config = m._get_tool_config(mrp, tools)
@@ -197,7 +211,13 @@ async def test_json_def_replaced(allow_model_requests: None):
         'This is the tool for the final Result',
         json_schema,
     )
-    mrp = ModelRequestParameters(function_tools=[], allow_text_output=True, output_tools=[output_tool])
+    mrp = ModelRequestParameters(
+        function_tools=[],
+        allow_text_output=True,
+        output_tools=[output_tool],
+        preferred_output_mode=None,
+        output_schema=None,
+    )
     mrp = m.customize_request_parameters(mrp)
     assert m._get_tools(mrp) == snapshot(
         _GeminiTools(
@@ -244,7 +264,13 @@ async def test_json_def_replaced_any_of(allow_model_requests: None):
         'This is the tool for the final Result',
         json_schema,
     )
-    mrp = ModelRequestParameters(function_tools=[], allow_text_output=True, output_tools=[output_tool])
+    mrp = ModelRequestParameters(
+        function_tools=[],
+        allow_text_output=True,
+        output_tools=[output_tool],
+        preferred_output_mode=None,
+        output_schema=None,
+    )
     mrp = m.customize_request_parameters(mrp)
     assert m._get_tools(mrp) == snapshot(
         _GeminiTools(
@@ -308,7 +334,13 @@ async def test_json_def_recursive(allow_model_requests: None):
         json_schema,
     )
     with pytest.raises(UserError, match=r'Recursive `\$ref`s in JSON Schema are not supported by Gemini'):
-        mrp = ModelRequestParameters(function_tools=[], allow_text_output=True, output_tools=[output_tool])
+        mrp = ModelRequestParameters(
+            function_tools=[],
+            allow_text_output=True,
+            output_tools=[output_tool],
+            preferred_output_mode=None,
+            output_schema=None,
+        )
         mrp = m.customize_request_parameters(mrp)
         m._get_tools(mrp)
 
@@ -341,7 +373,13 @@ async def test_json_def_date(allow_model_requests: None):
         'This is the tool for the final Result',
         json_schema,
     )
-    mrp = ModelRequestParameters(function_tools=[], allow_text_output=True, output_tools=[output_tool])
+    mrp = ModelRequestParameters(
+        function_tools=[],
+        allow_text_output=True,
+        output_tools=[output_tool],
+        preferred_output_mode=None,
+        output_schema=None,
+    )
     mrp = m.customize_request_parameters(mrp)
     assert m._get_tools(mrp) == snapshot(
         _GeminiTools(

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -140,6 +140,8 @@ async def test_instrumented_model(capfire: CaptureLogfire):
             function_tools=[],
             allow_text_output=True,
             output_tools=[],
+            preferred_output_mode=None,
+            output_schema=None,
         ),
     )
 
@@ -157,7 +159,7 @@ async def test_instrumented_model(capfire: CaptureLogfire):
                     'gen_ai.request.model': 'my_model',
                     'server.address': 'example.com',
                     'server.port': 8000,
-                    'model_request_parameters': '{"function_tools": [], "allow_text_output": true, "output_tools": []}',
+                    'model_request_parameters': '{"function_tools": [], "preferred_output_mode": null, "allow_text_output": true, "output_tools": [], "output_schema": null}',
                     'logfire.json_schema': '{"type": "object", "properties": {"model_request_parameters": {"type": "object"}}}',
                     'gen_ai.request.temperature': 1,
                     'logfire.msg': 'chat my_model',
@@ -336,6 +338,8 @@ async def test_instrumented_model_not_recording():
             function_tools=[],
             allow_text_output=True,
             output_tools=[],
+            preferred_output_mode=None,
+            output_schema=None,
         ),
     )
 
@@ -358,6 +362,8 @@ async def test_instrumented_model_stream(capfire: CaptureLogfire):
             function_tools=[],
             allow_text_output=True,
             output_tools=[],
+            preferred_output_mode=None,
+            output_schema=None,
         ),
     ) as response_stream:
         assert [event async for event in response_stream] == snapshot(
@@ -381,7 +387,7 @@ async def test_instrumented_model_stream(capfire: CaptureLogfire):
                     'gen_ai.request.model': 'my_model',
                     'server.address': 'example.com',
                     'server.port': 8000,
-                    'model_request_parameters': '{"function_tools": [], "allow_text_output": true, "output_tools": []}',
+                    'model_request_parameters': '{"function_tools": [], "preferred_output_mode": null, "allow_text_output": true, "output_tools": [], "output_schema": null}',
                     'logfire.json_schema': '{"type": "object", "properties": {"model_request_parameters": {"type": "object"}}}',
                     'gen_ai.request.temperature': 1,
                     'logfire.msg': 'chat my_model',
@@ -446,6 +452,8 @@ async def test_instrumented_model_stream_break(capfire: CaptureLogfire):
                 function_tools=[],
                 allow_text_output=True,
                 output_tools=[],
+                preferred_output_mode=None,
+                output_schema=None,
             ),
         ) as response_stream:
             async for event in response_stream:
@@ -466,7 +474,7 @@ async def test_instrumented_model_stream_break(capfire: CaptureLogfire):
                     'gen_ai.request.model': 'my_model',
                     'server.address': 'example.com',
                     'server.port': 8000,
-                    'model_request_parameters': '{"function_tools": [], "allow_text_output": true, "output_tools": []}',
+                    'model_request_parameters': '{"function_tools": [], "preferred_output_mode": null, "allow_text_output": true, "output_tools": [], "output_schema": null}',
                     'logfire.json_schema': '{"type": "object", "properties": {"model_request_parameters": {"type": "object"}}}',
                     'gen_ai.request.temperature': 1,
                     'logfire.msg': 'chat my_model',
@@ -553,6 +561,8 @@ async def test_instrumented_model_attributes_mode(capfire: CaptureLogfire):
             function_tools=[],
             allow_text_output=True,
             output_tools=[],
+            preferred_output_mode=None,
+            output_schema=None,
         ),
     )
 
@@ -570,7 +580,7 @@ async def test_instrumented_model_attributes_mode(capfire: CaptureLogfire):
                     'gen_ai.request.model': 'my_model',
                     'server.address': 'example.com',
                     'server.port': 8000,
-                    'model_request_parameters': '{"function_tools": [], "allow_text_output": true, "output_tools": []}',
+                    'model_request_parameters': '{"function_tools": [], "preferred_output_mode": null, "allow_text_output": true, "output_tools": [], "output_schema": null}',
                     'gen_ai.request.temperature': 1,
                     'logfire.msg': 'chat my_model',
                     'logfire.span_type': 'span',

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -23,6 +23,7 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
+    StructuredOutputPart,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
@@ -31,7 +32,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.gemini import GeminiModel
 from pydantic_ai.providers.google_gla import GoogleGLAProvider
-from pydantic_ai.result import Usage
+from pydantic_ai.result import StructuredOutput, ToolOutput, Usage
 from pydantic_ai.settings import ModelSettings
 
 from ..conftest import IsDatetime, IsNow, IsStr, raise_if_exception, try_import
@@ -1430,6 +1431,124 @@ async def test_openai_instructions_with_tool_calls_keep_instructions(allow_model
             ModelResponse(
                 parts=[TextPart(content='The temperature in Tokyo is currently 20.0 degrees Celsius.')],
                 model_name='gpt-4.1-mini-2025-04-14',
+                timestamp=IsDatetime(),
+            ),
+        ]
+    )
+
+
+@pytest.mark.vcr()
+async def test_openai_tool_output(allow_model_requests: None, openai_api_key: str):
+    m = OpenAIModel('gpt-4o', provider=OpenAIProvider(api_key=openai_api_key))
+
+    class CityLocation(BaseModel):
+        city: str
+        country: str
+
+    agent = Agent(m, output_type=ToolOutput(type_=CityLocation))
+
+    @agent.tool_plain
+    async def get_user_country() -> str:
+        return 'Mexico'
+
+    result = await agent.run('What is the largest city in the user country?')
+    assert result.output == snapshot(CityLocation(city='Mexico City', country='Mexico'))
+
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content='What is the largest city in the user country?',
+                        timestamp=IsDatetime(),
+                    )
+                ]
+            ),
+            ModelResponse(
+                parts=[ToolCallPart(tool_name='get_user_country', args='{}', tool_call_id=IsStr())],
+                model_name='gpt-4o-2024-08-06',
+                timestamp=IsDatetime(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='get_user_country',
+                        content='Mexico',
+                        tool_call_id=IsStr(),
+                        timestamp=IsDatetime(),
+                    )
+                ]
+            ),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='final_result',
+                        args='{"city": "Mexico City", "country": "Mexico"}',
+                        tool_call_id=IsStr(),
+                    )
+                ],
+                model_name='gpt-4o-2024-08-06',
+                timestamp=IsDatetime(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='final_result',
+                        content='Final result processed.',
+                        tool_call_id=IsStr(),
+                        timestamp=IsDatetime(),
+                    )
+                ]
+            ),
+        ]
+    )
+
+
+@pytest.mark.vcr()
+async def test_openai_structured_output(allow_model_requests: None, openai_api_key: str):
+    m = OpenAIModel('gpt-4o', provider=OpenAIProvider(api_key=openai_api_key))
+
+    class CityLocation(BaseModel):
+        city: str
+        country: str
+
+    agent = Agent(m, output_type=StructuredOutput(type_=CityLocation))
+
+    @agent.tool_plain
+    async def get_user_country() -> str:
+        return 'Mexico'
+
+    result = await agent.run('What is the largest city in the user country?')
+    assert result.output == snapshot(CityLocation(city='Mexico City', country='Mexico'))
+
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content='What is the largest city in the user country?',
+                        timestamp=IsDatetime(),
+                    )
+                ]
+            ),
+            ModelResponse(
+                parts=[ToolCallPart(tool_name='get_user_country', args='{}', tool_call_id=IsStr())],
+                model_name='gpt-4o-2024-08-06',
+                timestamp=IsDatetime(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='get_user_country',
+                        content='Mexico',
+                        tool_call_id=IsStr(),
+                        timestamp=IsDatetime(),
+                    )
+                ]
+            ),
+            ModelResponse(
+                parts=[StructuredOutputPart(content='{"city":"Mexico City","country":"Mexico"}')],
+                model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
             ),
         ]


### PR DESCRIPTION
- Fixes https://github.com/pydantic/pydantic-ai/issues/582
- Replaces https://github.com/pydantic/pydantic-ai/pull/959

Right now, this only implements `response_format=json_schema` structured output for OpenAI chat completions in non-streaming mode.

- [ ] Address the many, many `TODO`s
- [ ] `response_format=json_object` for older OpenAI models?
- [ ] Manual JSON mode
- [ ] Streaming
- [ ] All models
- [ ] https://github.com/pydantic/pydantic-ai/issues/1615
  - [ ] Callables https://github.com/pydantic/pydantic-ai/pull/1463
  - [ ] `list[ToolOutput]`

This test illustrates the behavior, including the fact that OpenAI supports tool calls alongside structured output (as noted in https://github.com/pydantic/pydantic-ai/issues/582#issuecomment-2748884106):

```py
async def test_openai_structured_output(allow_model_requests: None, openai_api_key: str):
    m = OpenAIModel('gpt-4o', provider=OpenAIProvider(api_key=openai_api_key))

    class CityLocation(BaseModel):
        city: str
        country: str

    agent = Agent(m, output_type=StructuredOutput(type_=CityLocation))

    @agent.tool_plain
    async def get_user_country() -> str:
        return 'Mexico'

    result = await agent.run('What is the largest city in the user country?')
    assert result.output == snapshot(CityLocation(city='Mexico City', country='Mexico'))

    assert result.all_messages() == snapshot(
        [
            ModelRequest(
                parts=[
                    UserPromptPart(
                        content='What is the largest city in the user country?',
                        timestamp=IsDatetime(),
                    )
                ]
            ),
            ModelResponse(
                parts=[ToolCallPart(tool_name='get_user_country', args='{}', tool_call_id=IsStr())],
                model_name='gpt-4o-2024-08-06',
                timestamp=IsDatetime(),
            ),
            ModelRequest(
                parts=[
                    ToolReturnPart(
                        tool_name='get_user_country',
                        content='Mexico',
                        tool_call_id=IsStr(),
                        timestamp=IsDatetime(),
                    )
                ]
            ),
            ModelResponse(
                parts=[StructuredOutputPart(content='{"city":"Mexico City","country":"Mexico"}')],
                model_name='gpt-4o-2024-08-06',
                timestamp=IsDatetime(),
            ),
        ]
    )
```