### PR TITLE
Allow setting temperature to 0 on bedrock.

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -355,7 +355,7 @@ class BedrockConverseModel(Model):
 
         if max_tokens := model_settings.get('max_tokens'):
             inference_config['maxTokens'] = max_tokens
-        if temperature := model_settings.get('temperature'):
+        if (temperature := model_settings.get('temperature')) is not None:
             inference_config['temperature'] = temperature
         if top_p := model_settings.get('top_p'):
             inference_config['topP'] = top_p


### PR DESCRIPTION
The original code would not allow setting the temperature to 0 on Bedrock. This would leave the temperature at the models' defaults which is often 1 not 0.

The change allows setting the temperature to any value, including zero, if the model_setting temperature property is set.