### PR TITLE
Handle None input_tokens from Anthropic SDK

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -418,7 +418,7 @@ def _map_usage(message: AnthropicMessage | RawMessageStreamEvent) -> usage.Usage
     # Tokens are only counted once between input_tokens, cache_creation_input_tokens, and cache_read_input_tokens
     # This approach maintains request_tokens as the count of all input tokens, with cached counts as details
     request_tokens = (
-        getattr(response_usage, 'input_tokens', 0)
+        (getattr(response_usage, 'input_tokens', 0) or 0)
         + (getattr(response_usage, 'cache_creation_input_tokens', 0) or 0)  # These can be missing, None, or int
         + (getattr(response_usage, 'cache_read_input_tokens', 0) or 0)
     )


### PR DESCRIPTION
With version 0.51.0 of the Anthropic Python SDK, Anthropic models in Pydantic AI no longer work with streaming due to how we unpack the input_tokens field. Previously we assumed that `getattr(response_usage, 'input_tokens', 0)` would always be an `int`, which is no longer true

I have not added a test case for this, since the current tests already capture the bug and fail when the current version of Anthropic SDK is installed (a win for the awesome test coverage!!)