### PR TITLE
use `yaml.safe_load` in tests

### DIFF
--- a/tests/json_body_serializer.py
+++ b/tests/json_body_serializer.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 else:
     try:
         from yaml import CDumper as Dumper
-    except ImportError:
+    except ImportError:  # pragma: no cover
         from yaml import Dumper
 
 FILTERED_HEADER_PREFIXES = ['anthropic-', 'cf-', 'x-']
@@ -45,7 +45,7 @@ def deserialize(cassette_string: str):
     return cassette_dict
 
 
-def serialize(cassette_dict: Any):
+def serialize(cassette_dict: Any):  # pragma: lax no cover
     for interaction in cassette_dict['interactions']:
         for _kind, data in interaction.items():
             headers: dict[str, list[str]] = data.get('headers', {})

--- a/tests/json_body_serializer.py
+++ b/tests/json_body_serializer.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 if TYPE_CHECKING:
-    from yaml import Dumper, Loader
+    from yaml import Dumper
 else:
     try:
-        from yaml import CDumper as Dumper, CLoader as Loader
+        from yaml import CDumper as Dumper
     except ImportError:
-        from yaml import Dumper, Loader
+        from yaml import Dumper
 
 FILTERED_HEADER_PREFIXES = ['anthropic-', 'cf-', 'x-']
 FILTERED_HEADERS = {'authorization', 'date', 'request-id', 'server', 'user-agent', 'via', 'set-cookie', 'api-key'}
@@ -35,7 +35,7 @@ LiteralDumper.add_representer(str, str_presenter)
 
 
 def deserialize(cassette_string: str):
-    cassette_dict = yaml.load(cassette_string, Loader=Loader)
+    cassette_dict = yaml.safe_load(cassette_string)
     for interaction in cassette_dict['interactions']:
         for kind, data in interaction.items():
             parsed_body = data.pop('parsed_body', None)


### PR DESCRIPTION
Mini security audit pointed this out, is there any reason not to use this?

If there's a good reason to use `yaml.load(cassette_string, Loader=Loader)`, that's fine, let's just add a comment.

cc @Kludex @dmontagu (not sure who originally wrote this)