### PR TITLE
Fix serializability of ModelRequestParameters

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -12,7 +12,6 @@ from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from functools import cache
-from typing import TYPE_CHECKING
 
 import httpx
 from typing_extensions import Literal, TypeAliasType
@@ -21,11 +20,8 @@ from .._parts_manager import ModelResponsePartsManager
 from ..exceptions import UserError
 from ..messages import ModelMessage, ModelRequest, ModelResponse, ModelResponseStreamEvent
 from ..settings import ModelSettings
+from ..tools import ToolDefinition
 from ..usage import Usage
-
-if TYPE_CHECKING:
-    from ..tools import ToolDefinition
-
 
 KnownModelName = TypeAliasType(
     'KnownModelName',

--- a/tests/models/test_model_request_parameters.py
+++ b/tests/models/test_model_request_parameters.py
@@ -1,0 +1,12 @@
+from pydantic import TypeAdapter
+
+from pydantic_ai.models import ModelRequestParameters
+
+
+def test_model_request_parameters_are_serializable():
+    params = ModelRequestParameters(function_tools=[], allow_text_output=False, output_tools=[])
+    assert TypeAdapter(ModelRequestParameters).dump_python(params) == {
+        'function_tools': [],
+        'allow_text_output': False,
+        'output_tools': [],
+    }


### PR DESCRIPTION
This makes it possible to serialize types with `ModelRequestParameters` as a field (at any level of nesting).