### PR TITLE
Ensure CLI prompt history directory and file exist before usage

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_cli.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli.py
@@ -203,6 +203,10 @@ Special prompts:
             pass
         return 0
 
+    # Ensure the history directory and file exist
+    PROMPT_HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    PROMPT_HISTORY_PATH.touch(exist_ok=True)
+
     # doing this instead of `PromptSession[Any](history=` allows mocking of PromptSession in tests
     session: PromptSession[Any] = PromptSession(history=FileHistory(str(PROMPT_HISTORY_PATH)))
     try:


### PR DESCRIPTION
Fixes an issue where the PydanticAI CLI crashes with a `FileNotFoundError` if the `~/.pydantic-ai/` directory doesn’t exist when creating or accessing `prompt-history.txt`.

What Changed:
	•	Added logic to create the parent directory and touch the history file before initializing `FileHistory`.

Testing Done:
	•	Ran the complete test suite using make. Results: **1066 passed, 34 skipped, 98% test coverage**.
	•	Manually verified: deleted `~/.pydantic-ai/` and confirmed the CLI initializes properly, creates the history file, and updates it across multiple sessions.