### PR TITLE
feat: add support for custom prompt history path via CLI and environment variable

### DIFF
--- a/clai/README.md
+++ b/clai/README.md
@@ -53,7 +53,7 @@ Either way, running `clai` will start an interactive session where you can chat 
 ## Help
 
 ```
-usage: clai [-h] [-m [MODEL]] [-a AGENT] [-l] [-t [CODE_THEME]] [--no-stream] [--version] [prompt]
+usage: clai [-h] [-m [MODEL]] [-a AGENT] [-l] [-t [CODE_THEME]] [--no-stream] [-o PATH] [--version] [prompt]
 
 PydanticAI CLI v...
 
@@ -75,5 +75,7 @@ options:
   -t [CODE_THEME], --code-theme [CODE_THEME]
                         Which colors to use for code, can be "dark", "light" or any theme from pygments.org/styles/. Defaults to "dark" which works well on dark terminals.
   --no-stream           Disable streaming from the model
+  -o PATH, --prompt-history PATH
+                        Custom path for storing prompt history. Overrides PYDANTIC_AI_HISTORY_PATH environment variable.
   --version             Show version and exit
 ```


### PR DESCRIPTION
**Allow custom prompt history path via CLI flags or env var**

This PR introduces the ability to specify a custom path for storing the prompt history file via an environment variable (`PYDANTIC_AI_HISTORY_PATH`) or CLI flags (`-o` or `--prompt-history`). CLI arguments take precedence over the environment variable, which in turn overrides the default location.

**What Changed:**

* Added CLI arguments `-o` and `--prompt-history`.
* Added environment variable support (`PYDANTIC_AI_HISTORY_PATH`).
* Implemented priority order: CLI > Environment Variable > Default.
* Added user-friendly notices indicating when the default path is overridden.
* Expanded tests to verify correct behavior for all scenarios.

**Testing Done:**

* Manually verified:

  * Default behavior (no CLI arg, no env var).
  * CLI arg provided (no env var).
  * Environment variable set (no CLI arg).
  * Both CLI arg and env var set (CLI arg takes precedence).
* Confirmed that history files and directories are created correctly.
* Verified existing history resumes correctly.
* Ran complete test suite (`make`): **1111 passed, 34 skipped, coverage at 98.15%**.
