### PR TITLE
Add ability to specify the evaluation name for all provided Evaluators

### DIFF
--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -1036,14 +1036,14 @@ def _get_registry(
             raise ValueError(
                 f'All custom evaluator classes must be decorated with `@dataclass`, but {evaluator_class} is not'
             )
-        name = evaluator_class.name()
+        name = evaluator_class.get_serialization_name()
         if name in registry:
             raise ValueError(f'Duplicate evaluator class name: {name!r}')
         registry[name] = evaluator_class
 
     for evaluator_class in DEFAULT_EVALUATORS:
         # Allow overriding the default evaluators with custom evaluators raising an error
-        registry.setdefault(evaluator_class.name(), evaluator_class)
+        registry.setdefault(evaluator_class.get_serialization_name(), evaluator_class)
 
     return registry
 

--- a/pydantic_evals/pydantic_evals/evaluators/__init__.py
+++ b/pydantic_evals/pydantic_evals/evaluators/__init__.py
@@ -1,4 +1,14 @@
-from .common import Contains, Equals, EqualsExpected, HasMatchingSpan, IsInstance, LLMJudge, MaxDuration, Python
+from .common import (
+    Contains,
+    Equals,
+    EqualsExpected,
+    HasMatchingSpan,
+    IsInstance,
+    LLMJudge,
+    MaxDuration,
+    OutputConfig,
+    Python,
+)
 from .context import EvaluatorContext
 from .evaluator import EvaluationReason, EvaluationResult, Evaluator, EvaluatorOutput
 
@@ -11,6 +21,7 @@ __all__ = (
     'MaxDuration',
     'LLMJudge',
     'HasMatchingSpan',
+    'OutputConfig',
     'Python',
     # context
     'EvaluatorContext',

--- a/pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py
@@ -42,7 +42,7 @@ async def run_evaluator(
     except ValidationError as e:
         raise ValueError(f'{evaluator!r}.evaluate returned a value of an invalid type: {raw_results!r}.') from e
 
-    results = _convert_to_mapping(results, scalar_name=evaluator.name())
+    results = _convert_to_mapping(results, scalar_name=evaluator.get_default_evaluation_name())
 
     details: list[EvaluationResult] = []
     for name, result in results.items():

--- a/pydantic_evals/pydantic_evals/evaluators/_spec.py
+++ b/pydantic_evals/pydantic_evals/evaluators/_spec.py
@@ -32,18 +32,19 @@ class EvaluatorSpec(BaseModel):
     * `{'MyEvaluator': {k1: v1, k2: v2}}` - Multiple kwargs are passed to `MyEvaluator.__init__`
 
     Args:
-        name: The name of the evaluator to use. Unless overridden, this is the snake_case version of the class name.
+        name: The serialization name of the evaluator class returned by `EvaluatorClass.get_serialization_name()`;
+            this is usually just the class name itself.
         arguments: The arguments to pass to the evaluator's constructor. Can be None (for no arguments),
             a tuple (for a single positional argument), or a dict (for multiple keyword arguments).
     """
 
     name: str
-    """The name of the evaluator class; should be the value returned by EvaluatorClass.name()"""
+    """The name of the evaluator class; should be the value returned by `EvaluatorClass.get_serialization_name()`"""
 
     arguments: None | tuple[Any] | dict[str, Any]
     """The arguments to pass to the evaluator's constructor.
 
-    Can be None (no arguments), a tuple (positional arguments), or a dict (keyword arguments).
+    Can be None (no arguments), a tuple (a single positional argument), or a dict (keyword arguments).
     """
 
     @property

--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -22,6 +22,7 @@ __all__ = (
     'LLMJudge',
     'HasMatchingSpan',
     'Python',
+    'OutputConfig',
 )
 
 
@@ -162,6 +163,8 @@ class MaxDuration(Evaluator[object, object, object]):
 
 
 class OutputConfig(TypedDict, total=False):
+    """Configuration for the score and assertion outputs of the LLMJudge evaluator."""
+
     evaluation_name: str
     include_reason: bool
 

--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -30,7 +30,7 @@ class Equals(Evaluator[object, object, object]):
     """Check if the output exactly equals the provided value."""
 
     value: Any
-    evaluation_name: str | None = None
+    evaluation_name: str | None = field(default=None, repr=False)
 
     def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> bool:
         return ctx.output == self.value
@@ -40,7 +40,7 @@ class Equals(Evaluator[object, object, object]):
 class EqualsExpected(Evaluator[object, object, object]):
     """Check if the output exactly equals the expected output."""
 
-    evaluation_name: str | None = None
+    evaluation_name: str | None = field(default=None, repr=False)
 
     def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> bool | dict[str, bool]:
         if ctx.expected_output is None:
@@ -73,7 +73,7 @@ class Contains(Evaluator[object, object, object]):
     value: Any
     case_sensitive: bool = True
     as_strings: bool = False
-    evaluation_name: str | None = None
+    evaluation_name: str | None = field(default=None, repr=False)
 
     def evaluate(
         self,
@@ -133,7 +133,7 @@ class IsInstance(Evaluator[object, object, object]):
     """Check if the output is an instance of a type with the given name."""
 
     type_name: str
-    evaluation_name: str | None = None
+    evaluation_name: str | None = field(default=None, repr=False)
 
     def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> EvaluationReason:
         output = ctx.output
@@ -241,7 +241,7 @@ class HasMatchingSpan(Evaluator[object, object, object]):
     """Check if the span tree contains a span that matches the specified query."""
 
     query: SpanQuery
-    evaluation_name: str | None = None
+    evaluation_name: str | None = field(default=None, repr=False)
 
     def evaluate(
         self,
@@ -259,7 +259,7 @@ class Python(Evaluator[object, object, object]):
     """
 
     expression: str
-    evaluation_name: str | None = None
+    evaluation_name: str | None = field(default=None, repr=False)
 
     def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> EvaluatorOutput:
         # Evaluate the condition, exposing access to the evaluator context as `ctx`.

--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -1,15 +1,17 @@
 from __future__ import annotations as _annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Any, cast
+from typing import Any, Literal, cast
+
+from typing_extensions import TypedDict
 
 from pydantic_ai import models
 from pydantic_ai.settings import ModelSettings
 
 from ..otel.span_tree import SpanQuery
 from .context import EvaluatorContext
-from .evaluator import EvaluationReason, Evaluator, EvaluatorOutput
+from .evaluator import EvaluationReason, EvaluationScalar, Evaluator, EvaluatorOutput
 
 __all__ = (
     'Equals',
@@ -28,6 +30,7 @@ class Equals(Evaluator[object, object, object]):
     """Check if the output exactly equals the provided value."""
 
     value: Any
+    evaluation_name: str | None = None
 
     def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> bool:
         return ctx.output == self.value
@@ -36,6 +39,8 @@ class Equals(Evaluator[object, object, object]):
 @dataclass
 class EqualsExpected(Evaluator[object, object, object]):
     """Check if the output exactly equals the expected output."""
+
+    evaluation_name: str | None = None
 
     def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> bool | dict[str, bool]:
         if ctx.expected_output is None:
@@ -68,6 +73,7 @@ class Contains(Evaluator[object, object, object]):
     value: Any
     case_sensitive: bool = True
     as_strings: bool = False
+    evaluation_name: str | None = None
 
     def evaluate(
         self,
@@ -127,6 +133,7 @@ class IsInstance(Evaluator[object, object, object]):
     """Check if the output is an instance of a type with the given name."""
 
     type_name: str
+    evaluation_name: str | None = None
 
     def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> EvaluationReason:
         output = ctx.output
@@ -154,6 +161,25 @@ class MaxDuration(Evaluator[object, object, object]):
         return duration <= seconds
 
 
+class OutputConfig(TypedDict, total=False):
+    evaluation_name: str
+    include_reason: bool
+
+
+def _update_combined_output(
+    combined_output: dict[str, EvaluationScalar | EvaluationReason],
+    value: EvaluationScalar,
+    reason: str | None,
+    config: OutputConfig,
+    default_name: str,
+) -> None:
+    name = config.get('evaluation_name') or default_name
+    if config.get('include_reason') and reason is not None:
+        combined_output[name] = EvaluationReason(value=value, reason=reason)
+    else:
+        combined_output[name] = value
+
+
 @dataclass
 class LLMJudge(Evaluator[object, object, object]):
     """Judge whether the output of a language model meets the criteria of a provided rubric.
@@ -166,11 +192,13 @@ class LLMJudge(Evaluator[object, object, object]):
     model: models.Model | models.KnownModelName | None = None
     include_input: bool = False
     model_settings: ModelSettings | None = None
+    score: OutputConfig | Literal[False] = False
+    assertion: OutputConfig | Literal[False] = field(default_factory=lambda: OutputConfig(include_reason=True))
 
     async def evaluate(
         self,
         ctx: EvaluatorContext[object, object, object],
-    ) -> EvaluationReason:
+    ) -> EvaluatorOutput:
         if self.include_input:
             from .llm_as_a_judge import judge_input_output
 
@@ -181,7 +209,20 @@ class LLMJudge(Evaluator[object, object, object]):
             from .llm_as_a_judge import judge_output
 
             grading_output = await judge_output(ctx.output, self.rubric, self.model, self.model_settings)
-        return EvaluationReason(value=grading_output.pass_, reason=grading_output.reason)
+
+        output: dict[str, EvaluationScalar | EvaluationReason] = {}
+        include_both = self.score is not False and self.assertion is not False
+        evaluation_name = self.get_default_evaluation_name()
+
+        if self.score is not False:
+            default_name = f'{evaluation_name}_score' if include_both else evaluation_name
+            _update_combined_output(output, grading_output.score, grading_output.reason, self.score, default_name)
+
+        if self.assertion is not False:
+            default_name = f'{evaluation_name}_pass' if include_both else evaluation_name
+            _update_combined_output(output, grading_output.pass_, grading_output.reason, self.assertion, default_name)
+
+        return output
 
     def build_serialization_arguments(self):
         result = super().build_serialization_arguments()
@@ -200,6 +241,7 @@ class HasMatchingSpan(Evaluator[object, object, object]):
     """Check if the span tree contains a span that matches the specified query."""
 
     query: SpanQuery
+    evaluation_name: str | None = None
 
     def evaluate(
         self,
@@ -217,6 +259,7 @@ class Python(Evaluator[object, object, object]):
     """
 
     expression: str
+    evaluation_name: str | None = None
 
     def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> EvaluatorOutput:
         # Evaluate the condition, exposing access to the evaluator context as `ctx`.

--- a/tests/evals/test_evaluator_base.py
+++ b/tests/evals/test_evaluator_base.py
@@ -172,10 +172,11 @@ async def test_evaluator_async():
     assert result is True
 
 
-async def test_evaluator_name():
+async def test_evaluation_name():
     """Test evaluator name method."""
     evaluator = SimpleEvaluator()
-    assert evaluator.name() == 'SimpleEvaluator'
+    assert evaluator.get_serialization_name() == 'SimpleEvaluator'
+    assert evaluator.get_default_evaluation_name() == 'SimpleEvaluator'
 
 
 async def test_evaluator_serialization():

--- a/tests/evals/test_evaluator_common.py
+++ b/tests/evals/test_evaluator_common.py
@@ -219,7 +219,7 @@ async def test_llm_judge_evaluator(mocker: MockerFixture):
 
     # Test without input
     evaluator = LLMJudge(rubric='Content contains a greeting')
-    result = await evaluator.evaluate(ctx)
+    result = cast(Any, await evaluator.evaluate(ctx))['LLMJudge']
     assert isinstance(result, EvaluationReason)
     assert result.value is True
     assert result.reason == 'Test passed'
@@ -228,7 +228,7 @@ async def test_llm_judge_evaluator(mocker: MockerFixture):
 
     # Test with input
     evaluator = LLMJudge(rubric='Output contains input', include_input=True, model='openai:gpt-4o')
-    result = await evaluator.evaluate(ctx)
+    result = cast(Any, await evaluator.evaluate(ctx))['LLMJudge']
     assert isinstance(result, EvaluationReason)
     assert result.value is True
     assert result.reason == 'Test passed'
@@ -240,7 +240,7 @@ async def test_llm_judge_evaluator(mocker: MockerFixture):
     # Test with failing result
     mock_grading_output.pass_ = False
     mock_grading_output.reason = 'Test failed'
-    result = await evaluator.evaluate(ctx)
+    result = cast(Any, await evaluator.evaluate(ctx))['LLMJudge']
     assert isinstance(result, EvaluationReason)
     assert result.value is False
     assert result.reason == 'Test failed'

--- a/tests/evals/test_evaluator_common.py
+++ b/tests/evals/test_evaluator_common.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from inline_snapshot import snapshot
@@ -275,7 +275,8 @@ async def test_llm_judge_evaluator_with_model_settings(mocker: MockerFixture):
 
     # Test without input, with custom model_settings
     evaluator_no_input = LLMJudge(rubric='Greeting with custom settings', model_settings=custom_model_settings)
-    result_no_input = await evaluator_no_input.evaluate(ctx)
+    result_no_input = cast(Any, await evaluator_no_input.evaluate(ctx))['LLMJudge']
+    assert isinstance(result_no_input, EvaluationReason)
     assert result_no_input.value is True
     assert result_no_input.reason == 'Test passed with settings'
     mock_judge_output.assert_called_once_with(
@@ -289,7 +290,8 @@ async def test_llm_judge_evaluator_with_model_settings(mocker: MockerFixture):
         model='openai:gpt-3.5-turbo',
         model_settings=custom_model_settings,
     )
-    result_with_input = await evaluator_with_input.evaluate(ctx)
+    result_with_input = cast(Any, await evaluator_with_input.evaluate(ctx))['LLMJudge']
+    assert isinstance(result_with_input, EvaluationReason)
     assert result_with_input.value is True
     assert result_with_input.reason == 'Test passed with settings'
     mock_judge_input_output.assert_called_once_with(

--- a/tests/evals/test_evaluators.py
+++ b/tests/evals/test_evaluators.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel, TypeAdapter
+from pydantic_core import to_jsonable_python
 
 from pydantic_ai.messages import ModelMessage, ModelResponse
 from pydantic_ai.models import Model, ModelRequestParameters
@@ -207,12 +208,6 @@ async def test_is_instance_evaluator():
     assert result.value is False
 
 
-async def test_llm_judge_evaluator():
-    """Test the LLMJudge evaluator."""
-    # We can't easily test this without mocking the LLM, so we'll just check that it's importable
-    assert LLMJudge
-
-
 async def test_custom_evaluator(test_context: EvaluatorContext[TaskInput, TaskOutput, TaskMetadata]):
     """Test a custom evaluator."""
 
@@ -232,9 +227,25 @@ async def test_custom_evaluator(test_context: EvaluatorContext[TaskInput, TaskOu
 
     evaluator = CustomEvaluator()
     result = evaluator.evaluate(test_context)
-    assert isinstance(result, dict)
-    assert result['is_correct'] is True
-    assert result['difficulty'] == 'easy'
+    assert result == snapshot({'difficulty': 'easy', 'is_correct': True})
+
+
+async def test_custom_evaluator_name(test_context: EvaluatorContext[TaskInput, TaskOutput, TaskMetadata]):
+    """Test error handling in evaluators."""
+
+    @dataclass
+    class CustomNameEvaluator(Evaluator[TaskInput, TaskOutput, TaskMetadata]):
+        result: int
+        evaluation_name: str
+
+        def evaluate(self, ctx: EvaluatorContext[TaskInput, TaskOutput, TaskMetadata]) -> EvaluatorOutput:
+            return self.result
+
+    evaluator = CustomNameEvaluator(result=123, evaluation_name='abc')
+
+    assert to_jsonable_python(await run_evaluator(evaluator, test_context)) == snapshot(
+        [{'name': 'abc', 'reason': None, 'source': {'evaluation_name': 'abc', 'result': 123}, 'value': 123}]
+    )
 
 
 async def test_evaluator_error_handling(test_context: EvaluatorContext[TaskInput, TaskOutput, TaskMetadata]):


### PR DESCRIPTION
This adds the ability to specify the name of all built-in evaluators via (serializable) config.

It also gives a convenient way to have a state-dependent name for user-defined evaluators — just add a field or property called `evaluation_name` (of type `str`) and it will be used as the name of the evaluation if the returned value is not a mapping (which would then include the name). (Of course, you could just do this manually in a custom evaluator, but this removes a lot of the associated boilerplate.)

This also goes a bit farther in the case of LLMJudge and makes it possible to expose the LLMJudge score as an evaluation output, and lets you specify whether to include the assertion or score or both, and what the name of each should be.

(These improvements has been requested by several users.)