### PR TITLE
Removing fasta2a dep from slim since it's already in extra

### DIFF
--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -50,7 +50,6 @@ dependencies = [
     "eval-type-backport>=0.2.0",
     "griffe>=1.3.2",
     "httpx>=0.27",
-    "fasta2a=={{ version }}",
     "pydantic>=2.10",
     "pydantic-graph=={{ version }}",
     "exceptiongroup; python_version < '3.11'",


### PR DESCRIPTION
Fixes #1713 

fasta2a should only be in slim as an extra dependency but is listed in the regular ones also. This PR removes it from the required ones.