### PR TITLE
Bugfix: record instructions properly on agent run span when using structured output

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -273,11 +273,13 @@ class InstrumentedModel(WrapperModel):
     @staticmethod
     def messages_to_otel_events(messages: list[ModelMessage]) -> list[Event]:
         events: list[Event] = []
-        last_model_request: ModelRequest | None = None
+        instructions = InstrumentedModel._get_instructions(messages)
+        if instructions is not None:
+            events.append(Event('gen_ai.system.message', body={'content': instructions, 'role': 'system'}))
+
         for message_index, message in enumerate(messages):
             message_events: list[Event] = []
             if isinstance(message, ModelRequest):
-                last_model_request = message
                 for part in message.parts:
                     if hasattr(part, 'otel_event'):
                         message_events.append(part.otel_event())
@@ -289,10 +291,7 @@ class InstrumentedModel(WrapperModel):
                     **(event.attributes or {}),
                 }
             events.extend(message_events)
-        if last_model_request and last_model_request.instructions:
-            events.insert(
-                0, Event('gen_ai.system.message', body={'content': last_model_request.instructions, 'role': 'system'})
-            )
+
         for event in events:
             event.body = InstrumentedModel.serialize_any(event.body)
         return events

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -238,6 +238,7 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary], instrument: 
     )
 
 
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
 def test_instructions_with_structured_output(get_logfire_summary: Callable[[], LogfireSummary]) -> None:
     @dataclass
     class MyOutput:

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -238,6 +238,112 @@ def test_logfire(get_logfire_summary: Callable[[], LogfireSummary], instrument: 
     )
 
 
+def test_instructions_with_structured_output(get_logfire_summary: Callable[[], LogfireSummary]) -> None:
+    @dataclass
+    class MyOutput:
+        content: str
+
+    my_agent = Agent(model=TestModel(), instructions='Here are some instructions', instrument=True)
+
+    result = my_agent.run_sync('Hello', output_type=MyOutput)
+    assert result.output == snapshot(MyOutput(content='a'))
+
+    summary = get_logfire_summary()
+    assert summary.attributes[0] == snapshot(
+        {
+            'model_name': 'test',
+            'agent_name': 'my_agent',
+            'logfire.msg': 'my_agent run',
+            'logfire.span_type': 'span',
+            'gen_ai.usage.input_tokens': 51,
+            'gen_ai.usage.output_tokens': 5,
+            'all_messages_events': IsJson(
+                snapshot(
+                    [
+                        {
+                            'content': 'Here are some instructions',
+                            'role': 'system',
+                            'event.name': 'gen_ai.system.message',
+                        },
+                        {
+                            'content': 'Hello',
+                            'role': 'user',
+                            'gen_ai.message.index': 0,
+                            'event.name': 'gen_ai.user.message',
+                        },
+                        {
+                            'role': 'assistant',
+                            'tool_calls': [
+                                {
+                                    'id': IsStr(),
+                                    'type': 'function',
+                                    'function': {'name': 'final_result', 'arguments': {'content': 'a'}},
+                                }
+                            ],
+                            'gen_ai.message.index': 1,
+                            'event.name': 'gen_ai.assistant.message',
+                        },
+                        {
+                            'content': 'Final result processed.',
+                            'role': 'tool',
+                            'id': IsStr(),
+                            'name': 'final_result',
+                            'gen_ai.message.index': 2,
+                            'event.name': 'gen_ai.tool.message',
+                        },
+                    ]
+                )
+            ),
+            'final_result': '{"content": "a"}',
+            'logfire.json_schema': IsJson(
+                snapshot(
+                    {
+                        'type': 'object',
+                        'properties': {'all_messages_events': {'type': 'array'}, 'final_result': {'type': 'object'}},
+                    }
+                )
+            ),
+        }
+    )
+    chat_span_attributes = summary.attributes[1]
+    assert chat_span_attributes['events'] == snapshot(
+        IsJson(
+            snapshot(
+                [
+                    {
+                        'content': 'Here are some instructions',
+                        'role': 'system',
+                        'gen_ai.system': 'test',
+                        'event.name': 'gen_ai.system.message',
+                    },
+                    {
+                        'event.name': 'gen_ai.user.message',
+                        'content': 'Hello',
+                        'role': 'user',
+                        'gen_ai.message.index': 0,
+                        'gen_ai.system': 'test',
+                    },
+                    {
+                        'event.name': 'gen_ai.choice',
+                        'index': 0,
+                        'message': {
+                            'role': 'assistant',
+                            'tool_calls': [
+                                {
+                                    'id': IsStr(),
+                                    'type': 'function',
+                                    'function': {'name': 'final_result', 'arguments': {'content': 'a'}},
+                                }
+                            ],
+                        },
+                        'gen_ai.system': 'test',
+                    },
+                ]
+            )
+        )
+    )
+
+
 def test_instrument_all():
     model = TestModel()
     agent = Agent()


### PR DESCRIPTION
Right now, if your agent uses instructions and ends a run by calling a result tool, the instructions don't end up in the otel output because the most recent "request" won't have instructions. This PR changes the logic to look for instructions on the second-to-most-recent request when the most recent request does not have instructions and only contains tool-return or model-retry parts.

As I noted in a comment in the code — while it's possible that you could have a message history where the most recent request has only tool returns, I believe there is no way to achieve that would _change_ the instructions without manually crafting the most recent message. That might make sense in principle for some usage pattern, but it's enough of an edge case that I think it's not worth worrying about, since you can work around this by inserting another ModelRequest with no parts at all immediately before the request that has the tool calls (that works because we only look at the two most recent ModelRequests).