### PR TITLE
Allow `RunContext` to not be documented when `require_parameter_descriptions=True` as it's not passed to the model anyway

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_pydantic.py
+++ b/pydantic_ai_slim/pydantic_ai/_pydantic.py
@@ -76,13 +76,13 @@ def function_schema(  # noqa: C901
     description, field_descriptions = doc_descriptions(function, sig, docstring_format=docstring_format)
 
     if require_parameter_descriptions:
-        missing_params = set(sig.parameters) - set(field_descriptions)
-
         if takes_ctx:
-            for name in missing_params:
-                if _is_call_ctx(sig.parameters[name].annotation):
-                    missing_params.remove(name)
-                    break
+            parameters_without_ctx = set(
+                name for name in sig.parameters if not _is_call_ctx(sig.parameters[name].annotation)
+            )
+            missing_params = parameters_without_ctx - set(field_descriptions)
+        else:
+            missing_params = set(sig.parameters) - set(field_descriptions)
 
         if missing_params:
             errors.append(f'Missing parameter descriptions for {", ".join(missing_params)}')

--- a/pydantic_ai_slim/pydantic_ai/_pydantic.py
+++ b/pydantic_ai_slim/pydantic_ai/_pydantic.py
@@ -76,8 +76,15 @@ def function_schema(  # noqa: C901
     description, field_descriptions = doc_descriptions(function, sig, docstring_format=docstring_format)
 
     if require_parameter_descriptions:
-        if len(field_descriptions) != len(sig.parameters):
-            missing_params = set(sig.parameters) - set(field_descriptions)
+        missing_params = set(sig.parameters) - set(field_descriptions)
+
+        if takes_ctx:
+            for name in missing_params:
+                if _is_call_ctx(sig.parameters[name].annotation):
+                    missing_params.remove(name)
+                    break
+
+        if missing_params:
             errors.append(f'Missing parameter descriptions for {", ".join(missing_params)}')
 
     for index, (name, p) in enumerate(sig.parameters.items()):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -785,16 +785,15 @@ def test_enforce_parameter_descriptions() -> None:
     assert all(err_part in error_reason for err_part in error_parts)
 
 
-async def complete_parameter_descriptions_docstring(ctx: RunContext, foo: int) -> str:  # pragma: no cover
-    """Describes function ops, but missing ctx description and contains non-existent parameter description.
-
-    :param foo: The foo thing.
-    :param bar: The bar thing.
-    """
-    return f'{foo}'
-
-
 def test_enforce_parameter_descriptions_noraise() -> None:
+    async def complete_parameter_descriptions_docstring(ctx: RunContext, foo: int) -> str:
+        """Describes function ops, but missing ctx description and contains non-existent parameter description.
+
+        :param foo: The foo thing.
+        :param bar: The bar thing.
+        """
+        return f'{foo}'
+
     agent = Agent(FunctionModel(get_json_schema))
 
     agent.tool(require_parameter_descriptions=True)(complete_parameter_descriptions_docstring)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -785,6 +785,21 @@ def test_enforce_parameter_descriptions() -> None:
     assert all(err_part in error_reason for err_part in error_parts)
 
 
+async def complete_parameter_descriptions_docstring(ctx: RunContext, foo: int) -> str:  # pragma: no cover
+    """Describes function ops, but missing ctx description and contains non-existent parameter description.
+
+    :param foo: The foo thing.
+    :param bar: The bar thing.
+    """
+    return f'{foo}'
+
+
+def test_enforce_parameter_descriptions_noraise() -> None:
+    agent = Agent(FunctionModel(get_json_schema))
+
+    agent.tool(require_parameter_descriptions=True)(complete_parameter_descriptions_docstring)
+
+
 def test_json_schema_required_parameters(set_event_loop: None):
     agent = Agent(FunctionModel(get_json_schema))
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -786,7 +786,7 @@ def test_enforce_parameter_descriptions() -> None:
 
 
 def test_enforce_parameter_descriptions_noraise() -> None:
-    async def complete_parameter_descriptions_docstring(ctx: RunContext, foo: int) -> str:
+    async def complete_parameter_descriptions_docstring(ctx: RunContext, foo: int) -> str:  # pragma: no cover
         """Describes function ops, but missing ctx description and contains non-existent parameter description.
 
         :param foo: The foo thing.


### PR DESCRIPTION
This PR refines the behavior of the `require_parameter_descriptions=True` argument in the `@agent.tool` and `@agent.tool_plain` decorators to be more permissive and robust. Previously, this setting exhibited incorrect behavior by raising errors in scenarios where docstrings either omitted descriptions for the `RunContext` parameter or included descriptions for parameters not present in the function signature. The latter case was particularly problematic as the error message incorrectly indicated missing descriptions when the issue was the presence of descriptions for non-existent parameters.

With this change, the following is now allowed when `require_parameter_descriptions=True`:

* Ignoring `RunContext` Descriptions: The docstring of a tool function can now omit a description for the `RunContext` parameter. Since `RunContext` is not typically a parameter directly consumed by the agent's logic, requiring its description was often unnecessary and could clutter docstrings.
* Silently Ignoring Descriptions for Non-Existent Parameters: Docstrings can now contain descriptions for parameters that do not exist in the function definition. Previously, this scenario would trigger a misleading error message ("Missing parameter descriptions for"). Now, these descriptions are silently ignored during validation, preventing unnecessary errors and providing more flexibility when maintaining docstrings during code refactoring.

Examples:
```python
@agent.tool(require_parameter_descriptions=True)
def add_task(ctx: RunContext[TaskList], description: str) -> Task:
    """Adds a task to the list and returns it.

    :param description: The short description of the task.
    :return: The task that was added.
    """
    return ctx.deps.add_task(description)
```
Before this PR, with `require_parameter_descriptions=True`, an error would be raised because the docstring lacked a description for the `ctx` parameter. This is now allowed, streamlining docstrings for tools utilizing `RunContext`.

Next, consider a function with a parameter description that doesn't match a function parameter:
```python
@agent.tool_plain(require_parameter_descriptions=True)
def get_time() -> datetime.time:
    """Returns the current time

    :param tz: Timezone
    :return: The current time of the day
    """
    return datetime.datetime.now().time()
```
Before this fix, the presence of the `:param tz:` in the docstring would incorrectly trigger the error message:

> Missing parameter descriptions for

This was misleading because the issue wasn't a missing description, but rather the presence of a description for a non-existent parameter. Now, the description for the non-existent `tz` parameter is correctly and silently ignored, and no error is raised.

P.S. Yes, Gemini helped me rewrite and refine this description. However, I encountered the issues described above and made necessary changes in the code myself. Hope you'll find them helpful.