### PR TITLE
Feat: Add `id` and `finish_reason` to `ModelResponse`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ examples/pydantic_ai_examples/.chat_app_messages.sqlite
 /docs-site/.wrangler/
 /CLAUDE.md
 node_modules/
+**.idea/
+.coverage*

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -155,6 +155,7 @@ async def main():
                 model_name='gpt-4o',
                 timestamp=datetime.datetime(...),
                 kind='response',
+                vendor_id=None,
             )
         ),
         End(data=FinalResult(output='Paris', tool_name=None, tool_call_id=None)),
@@ -226,6 +227,7 @@ async def main():
                     model_name='gpt-4o',
                     timestamp=datetime.datetime(...),
                     kind='response',
+                    vendor_id=None,
                 )
             ),
             End(data=FinalResult(output='Paris', tool_name=None, tool_call_id=None)),
@@ -829,6 +831,7 @@ with capture_run_messages() as messages:  # (2)!
                 model_name='gpt-4o',
                 timestamp=datetime.datetime(...),
                 kind='response',
+                vendor_id=None,
             ),
             ModelRequest(
                 parts=[
@@ -862,6 +865,7 @@ with capture_run_messages() as messages:  # (2)!
                 model_name='gpt-4o',
                 timestamp=datetime.datetime(...),
                 kind='response',
+                vendor_id=None,
             ),
         ]
         """

--- a/docs/direct.md
+++ b/docs/direct.md
@@ -95,6 +95,7 @@ async def main():
         model_name='gpt-4.1-nano',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     )
     """
 ```

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -74,6 +74,7 @@ print(result.all_messages())
         model_name='gpt-4o',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     ),
 ]
 """
@@ -159,6 +160,7 @@ async def main():
                 model_name='gpt-4o',
                 timestamp=datetime.datetime(...),
                 kind='response',
+                vendor_id=None,
             ),
         ]
         """
@@ -225,6 +227,7 @@ print(result2.all_messages())
         model_name='gpt-4o',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     ),
     ModelRequest(
         parts=[
@@ -254,6 +257,7 @@ print(result2.all_messages())
         model_name='gpt-4o',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     ),
 ]
 """
@@ -367,6 +371,7 @@ print(result2.all_messages())
         model_name='gpt-4o',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     ),
     ModelRequest(
         parts=[
@@ -396,6 +401,7 @@ print(result2.all_messages())
         model_name='gemini-1.5-pro',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     ),
 ]
 """

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -105,6 +105,7 @@ print(response.all_messages())
         model_name='claude-3-5-sonnet-latest',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     ),
 ]
 """

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -106,6 +106,7 @@ print(dice_result.all_messages())
         model_name='gemini-1.5-flash',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     ),
     ModelRequest(
         parts=[
@@ -139,6 +140,7 @@ print(dice_result.all_messages())
         model_name='gemini-1.5-flash',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     ),
     ModelRequest(
         parts=[
@@ -170,6 +172,7 @@ print(dice_result.all_messages())
         model_name='gemini-1.5-flash',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     ),
 ]
 """

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,25 +105,24 @@ theme:
   custom_dir: docs/.overrides
   palette:
     - media: "(prefers-color-scheme)"
-      scheme: default
       primary: pink
       accent: pink
       toggle:
-        icon: material/lightbulb
+        icon: material/brightness-auto
         name: "Switch to light mode"
     - media: "(prefers-color-scheme: light)"
       scheme: default
       primary: pink
       accent: pink
       toggle:
-        icon: material/lightbulb-outline
+        icon: material/brightness-7
         name: "Switch to dark mode"
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       primary: pink
       accent: pink
       toggle:
-        icon: material/lightbulb-auto-outline
+        icon: material/brightness-4
         name: "Switch to system preference"
   features:
     - search.suggest

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -585,6 +585,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
                         model_name='gpt-4o',
                         timestamp=datetime.datetime(...),
                         kind='response',
+                        vendor_id=None,
                     )
                 ),
                 End(data=FinalResult(output='Paris', tool_name=None, tool_call_id=None)),
@@ -1854,6 +1855,7 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
                     model_name='gpt-4o',
                     timestamp=datetime.datetime(...),
                     kind='response',
+                    vendor_id=None,
                 )
             ),
             End(data=FinalResult(output='Paris', tool_name=None, tool_call_id=None)),
@@ -1999,6 +2001,7 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
                             model_name='gpt-4o',
                             timestamp=datetime.datetime(...),
                             kind='response',
+                            vendor_id=None,
                         )
                     ),
                     End(data=FinalResult(output='Paris', tool_name=None, tool_call_id=None)),

--- a/pydantic_ai_slim/pydantic_ai/direct.py
+++ b/pydantic_ai_slim/pydantic_ai/direct.py
@@ -52,6 +52,7 @@ async def model_request(
             model_name='claude-3-5-haiku-latest',
             timestamp=datetime.datetime(...),
             kind='response',
+            vendor_id=None,
         )
         '''
     ```
@@ -108,6 +109,7 @@ def model_request_sync(
         model_name='claude-3-5-haiku-latest',
         timestamp=datetime.datetime(...),
         kind='response',
+        vendor_id=None,
     )
     '''
     ```

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -562,6 +562,13 @@ class ModelResponse:
     kind: Literal['response'] = 'response'
     """Message type identifier, this is available on all parts as a discriminator."""
 
+    vendor_details: dict[str, Any] | None = field(default=None, repr=False)
+    """Additional vendor-specific details in a serializable format.
+
+    This allows storing selected vendor-specific data that isn't mapped to standard ModelResponse fields.
+    For OpenAI models, this may include 'logprobs', 'finish_reason', etc.
+    """
+
     def otel_events(self) -> list[Event]:
         """Return OpenTelemetry events for the response."""
         result: list[Event] = []

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -569,6 +569,9 @@ class ModelResponse:
     For OpenAI models, this may include 'logprobs', 'finish_reason', etc.
     """
 
+    vendor_id: str | None = None
+    """Vendor ID as specified by the model provider. This can be used to track the specific request to the model."""
+
     def otel_events(self) -> list[Event]:
         """Return OpenTelemetry events for the response."""
         result: list[Event] = []

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from mimetypes import guess_type
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, List, cast, overload
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, cast, overload
 
 import pydantic
 import pydantic_core
@@ -559,7 +559,7 @@ class ModelResponse:
     If the model provides an ID in the response that will be used, otherwise a random UUID will be generated.
     """
 
-    finish_reasons: List[str] | None = None
+    finish_reasons: list[str] | None = None
     """The reasons why the model finished generating the response, one for each part of the response."""
 
     timestamp: datetime = field(default_factory=_now_utc)

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -553,12 +553,6 @@ class ModelResponse:
     model_name: str | None = None
     """The name of the model that generated the response."""
 
-    id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    """The ID of the response.
-
-    If the model provides an ID in the response that will be used, otherwise a random UUID will be generated.
-    """
-
     finish_reasons: list[str] = field(default_factory=list)
     """The reasons why the model finished generating the response, one for each part of the response."""
 

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -555,7 +555,7 @@ class ModelResponse:
 
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     """The ID of the response.
-    
+
     If the model provides an ID in the response that will be used, otherwise a random UUID will be generated.
     """
 

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -559,7 +559,7 @@ class ModelResponse:
     If the model provides an ID in the response that will be used, otherwise a random UUID will be generated.
     """
 
-    finish_reasons: list[str] | None = None
+    finish_reasons: list[str] = field(default_factory=list)
     """The reasons why the model finished generating the response, one for each part of the response."""
 
     timestamp: datetime = field(default_factory=_now_utc)

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from mimetypes import guess_type
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, cast, overload
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, List, cast, overload
 
 import pydantic
 import pydantic_core
@@ -552,6 +552,15 @@ class ModelResponse:
 
     model_name: str | None = None
     """The name of the model that generated the response."""
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    """The ID of the response.
+    
+    If the model provides an ID in the response that will be used, otherwise a random UUID will be generated.
+    """
+
+    finish_reasons: List[str] | None = None
+    """The reasons why the model finished generating the response, one for each part of the response."""
 
     timestamp: datetime = field(default_factory=_now_utc)
     """The timestamp of the response.

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -262,7 +262,7 @@ class AnthropicModel(Model):
                     )
                 )
 
-        return ModelResponse(items, usage=_map_usage(response), model_name=response.model)
+        return ModelResponse(items, usage=_map_usage(response), model_name=response.model, vendor_id=response.id)
 
     async def _process_streamed_response(self, response: AsyncStream[RawMessageStreamEvent]) -> StreamedResponse:
         peekable_response = _utils.PeekableAsyncStream(response)

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -271,7 +271,8 @@ class BedrockConverseModel(Model):
             response_tokens=response['usage']['outputTokens'],
             total_tokens=response['usage']['totalTokens'],
         )
-        return ModelResponse(items, usage=u, model_name=self.model_name)
+        vendor_id = response.get('ResponseMetadata', {}).get('RequestId', None)
+        return ModelResponse(items, usage=u, model_name=self.model_name, vendor_id=vendor_id)
 
     @overload
     async def _messages_create(

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -608,7 +608,7 @@ def _process_response_from_parts(
     parts: Sequence[_GeminiPartUnion],
     model_name: GeminiModelName,
     usage: usage.Usage,
-    id: str | None,
+    id: str,
     finish_reasons: list[str],
 ) -> ModelResponse:
     items: list[ModelResponsePart] = []

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -273,7 +273,11 @@ class GeminiModel(Model):
                     'Content field missing from Gemini response', str(response)
                 )
         parts = response['candidates'][0]['content']['parts']
-        finish_reasons = response['candidates'][0].get('finish_reason')
+        finish_reasons = [
+            finish_reason
+            for finish_reason in [response['candidates'][0].get('finish_reason')]
+            if finish_reason is not None
+        ]
         id = response.get('id')
         usage = _metadata_as_usage(response)
         usage.requests = 1

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -277,7 +277,9 @@ class GeminiModel(Model):
         id = response.get('id')
         usage = _metadata_as_usage(response)
         usage.requests = 1
-        return _process_response_from_parts(parts, response.get('model_version', self._model_name), usage, id=id, finish_reasons=finish_reasons)
+        return _process_response_from_parts(
+            parts, response.get('model_version', self._model_name), usage, id=id, finish_reasons=finish_reasons
+        )
 
     async def _process_streamed_response(self, http_response: HTTPResponse) -> StreamedResponse:
         """Process a streamed response, and prepare a streaming response to return."""
@@ -599,7 +601,11 @@ def _function_call_part_from_call(tool: ToolCallPart) -> _GeminiFunctionCallPart
 
 
 def _process_response_from_parts(
-    parts: Sequence[_GeminiPartUnion], model_name: GeminiModelName, usage: usage.Usage, id: str, finish_reasons: list[str]
+    parts: Sequence[_GeminiPartUnion],
+    model_name: GeminiModelName,
+    usage: usage.Usage,
+    id: str,
+    finish_reasons: list[str],
 ) -> ModelResponse:
     items: list[ModelResponsePart] = []
     for part in parts:
@@ -724,7 +730,6 @@ class _GeminiResponse(TypedDict):
     prompt_feedback: NotRequired[Annotated[_GeminiPromptFeedback, pydantic.Field(alias='promptFeedback')]]
     model_version: NotRequired[Annotated[str, pydantic.Field(alias='modelVersion')]]
     id: NotRequired[Annotated[str, pydantic.Field(alias='responseId')]]
-
 
 
 class _GeminiCandidates(TypedDict):

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -278,7 +278,7 @@ class GeminiModel(Model):
             for finish_reason in [response['candidates'][0].get('finish_reason')]
             if finish_reason is not None
         ]
-        id = response.get('id')
+        id = response.get('id', str(uuid4()))
         usage = _metadata_as_usage(response)
         usage.requests = 1
         return _process_response_from_parts(
@@ -608,7 +608,7 @@ def _process_response_from_parts(
     parts: Sequence[_GeminiPartUnion],
     model_name: GeminiModelName,
     usage: usage.Usage,
-    id: str,
+    id: str | None,
     finish_reasons: list[str],
 ) -> ModelResponse:
     items: list[ModelResponsePart] = []

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -239,7 +239,9 @@ class GroqModel(Model):
         if choice.message.tool_calls is not None:
             for c in choice.message.tool_calls:
                 items.append(ToolCallPart(tool_name=c.function.name, args=c.function.arguments, tool_call_id=c.id))
-        return ModelResponse(items, usage=_map_usage(response), model_name=response.model, timestamp=timestamp)
+        return ModelResponse(
+            items, usage=_map_usage(response), model_name=response.model, timestamp=timestamp, vendor_id=response.id
+        )
 
     async def _process_streamed_response(self, response: AsyncStream[chat.ChatCompletionChunk]) -> GroqStreamedResponse:
         """Process a streamed response, and prepare a streaming response to return."""

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -325,7 +325,9 @@ class MistralModel(Model):
                 tool = self._map_mistral_to_pydantic_tool_call(tool_call=tool_call)
                 parts.append(tool)
 
-        return ModelResponse(parts, usage=_map_usage(response), model_name=response.model, timestamp=timestamp)
+        return ModelResponse(
+            parts, usage=_map_usage(response), model_name=response.model, timestamp=timestamp, vendor_id=response.id
+        )
 
     async def _process_streamed_response(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -339,6 +339,7 @@ class OpenAIModel(Model):
             model_name=response.model,
             timestamp=timestamp,
             vendor_details=vendor_details,
+            vendor_id=response.id,
         )
 
     async def _process_streamed_response(self, response: AsyncStream[ChatCompletionChunk]) -> OpenAIStreamedResponse:

--- a/pydantic_graph/pydantic_graph/graph.py
+++ b/pydantic_graph/pydantic_graph/graph.py
@@ -10,7 +10,6 @@ from typing import Any, Generic, cast, overload
 
 import logfire_api
 import typing_extensions
-from opentelemetry.trace import Span
 from typing_extensions import deprecated
 from typing_inspection import typing_objects
 
@@ -212,7 +211,7 @@ class Graph(Generic[StateT, DepsT, RunEndT]):
         state: StateT = None,
         deps: DepsT = None,
         persistence: BaseStatePersistence[StateT, RunEndT] | None = None,
-        span: AbstractContextManager[Span] | None = None,
+        span: AbstractContextManager[AbstractSpan] | None = None,
         infer_name: bool = True,
     ) -> AsyncIterator[GraphRun[StateT, DepsT, RunEndT]]:
         """A contextmanager which can be used to iterate over the graph's nodes as they are executed.

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -184,6 +184,7 @@ async def test_sync_request_text_response(allow_model_requests: None):
                 ),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -197,6 +198,7 @@ async def test_sync_request_text_response(allow_model_requests: None):
                 ),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
+                vendor_id='123',
             ),
         ]
     )
@@ -287,6 +289,7 @@ async def test_request_structured_response(allow_model_requests: None):
                 ),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -356,6 +359,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 ),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -384,6 +388,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 ),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -406,6 +411,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 ),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
+                vendor_id='123',
             ),
         ]
     )
@@ -754,6 +760,7 @@ async def test_image_as_binary_content_tool_response(
                 ),
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
+                vendor_id='msg_01BPu4UTHXhqtR1TvsRhBLYY',
             ),
             ModelRequest(
                 parts=[
@@ -792,6 +799,7 @@ async def test_image_as_binary_content_tool_response(
                 ),
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
+                vendor_id='msg_01Ua6uyZUF15YV3G1PusaqSq',
             ),
         ]
     )
@@ -924,6 +932,7 @@ async def test_anthropic_model_instructions(allow_model_requests: None, anthropi
                 ),
                 model_name='claude-3-opus-20240229',
                 timestamp=IsDatetime(),
+                vendor_id='msg_01U58nruzfn9BrXrrF2hhb4m',
             ),
         ]
     )

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -147,6 +147,7 @@ async def test_request_simple_success(allow_model_requests: None):
                 usage=Usage(requests=1),
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -154,6 +155,7 @@ async def test_request_simple_success(allow_model_requests: None):
                 usage=Usage(requests=1),
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
         ]
     )
@@ -206,6 +208,7 @@ async def test_request_structured_response(allow_model_requests: None):
                 usage=Usage(requests=1),
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -293,6 +296,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=2, response_tokens=1, total_tokens=3),
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -315,6 +319,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=3, response_tokens=2, total_tokens=6),
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -331,6 +336,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 usage=Usage(requests=1),
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
         ]
     )
@@ -567,6 +573,7 @@ async def test_image_as_binary_content_tool_response(
                 usage=Usage(requests=1, request_tokens=192, response_tokens=8, total_tokens=200),
                 model_name='meta-llama/llama-4-scout-17b-16e-instruct',
                 timestamp=IsDatetime(),
+                vendor_id='chatcmpl-3c327c89-e9f5-4aac-a5d5-190e6f6f25c9',
             ),
             ModelRequest(
                 parts=[
@@ -590,6 +597,7 @@ async def test_image_as_binary_content_tool_response(
                 usage=Usage(requests=1, request_tokens=2552, response_tokens=11, total_tokens=2563),
                 model_name='meta-llama/llama-4-scout-17b-16e-instruct',
                 timestamp=IsDatetime(),
+                vendor_id='chatcmpl-82dfad42-6a28-4089-82c3-c8633f626c0d',
             ),
         ]
     )
@@ -669,6 +677,7 @@ async def test_groq_model_instructions(allow_model_requests: None, groq_api_key:
                 usage=Usage(requests=1, request_tokens=48, response_tokens=8, total_tokens=56),
                 model_name='llama-3.3-70b-versatile',
                 timestamp=IsDatetime(),
+                vendor_id='chatcmpl-7586b6a9-fb4b-4ec7-86a0-59f0a77844cf',
             ),
         ]
     )

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -216,6 +216,7 @@ async def test_multiple_completions(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=IsNow(tz=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='hello again', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -223,6 +224,7 @@ async def test_multiple_completions(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
         ]
     )
@@ -267,6 +269,7 @@ async def test_three_completions(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='hello again', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -274,6 +277,7 @@ async def test_three_completions(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='final message', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -281,6 +285,7 @@ async def test_three_completions(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
         ]
     )
@@ -399,6 +404,7 @@ async def test_request_model_structured_with_arguments_dict_response(allow_model
                 usage=Usage(requests=1, request_tokens=1, response_tokens=2, total_tokens=3),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -459,6 +465,7 @@ async def test_request_model_structured_with_arguments_str_response(allow_model_
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -518,6 +525,7 @@ async def test_request_output_type_with_arguments_str_response(allow_model_reque
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1085,6 +1093,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=2, response_tokens=1, total_tokens=3),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1107,6 +1116,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=3, response_tokens=2, total_tokens=6),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1123,6 +1133,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
         ]
     )
@@ -1225,6 +1236,7 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=2, response_tokens=1, total_tokens=3),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1247,6 +1259,7 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=3, response_tokens=2, total_tokens=6),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1269,6 +1282,7 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=2, response_tokens=1, total_tokens=3),
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1787,6 +1801,7 @@ async def test_image_as_binary_content_tool_response(
                 usage=Usage(requests=1, request_tokens=65, response_tokens=16, total_tokens=81),
                 model_name='pixtral-12b-latest',
                 timestamp=IsDatetime(),
+                vendor_id='fce6d16a4e5940edb24ae16dd0369947',
             ),
             ModelRequest(
                 parts=[
@@ -1814,6 +1829,7 @@ async def test_image_as_binary_content_tool_response(
                 usage=Usage(requests=1, request_tokens=2931, response_tokens=70, total_tokens=3001),
                 model_name='pixtral-12b-latest',
                 timestamp=IsDatetime(),
+                vendor_id='26e7de193646460e8904f8e604a60dc1',
             ),
         ]
     )
@@ -1851,6 +1867,7 @@ async def test_image_url_input(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=IsDatetime(),
+                vendor_id='123',
             ),
         ]
     )
@@ -1883,6 +1900,7 @@ async def test_image_as_binary_content_input(allow_model_requests: None):
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=IsDatetime(),
+                vendor_id='123',
             ),
         ]
     )
@@ -1943,6 +1961,7 @@ async def test_mistral_model_instructions(allow_model_requests: None, mistral_ap
                 usage=Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=1),
                 model_name='mistral-large-123',
                 timestamp=IsDatetime(),
+                vendor_id='123',
             ),
         ]
     )

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -172,6 +172,7 @@ async def test_request_simple_success(allow_model_requests: None):
                 usage=Usage(requests=1),
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -179,6 +180,7 @@ async def test_request_simple_success(allow_model_requests: None):
                 usage=Usage(requests=1),
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
         ]
     )
@@ -252,6 +254,7 @@ async def test_request_structured_response(allow_model_requests: None):
                 usage=Usage(requests=1),
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -343,6 +346,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 ),
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -367,6 +371,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 ),
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -383,6 +388,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 usage=Usage(requests=1),
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                vendor_id='123',
             ),
         ]
     )
@@ -723,6 +729,7 @@ async def test_image_url_tool_response(allow_model_requests: None, openai_api_ke
                 ),
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
+                vendor_id='chatcmpl-BRmTHlrARTzAHK1na9s80xDlQGYPX',
             ),
             ModelRequest(
                 parts=[
@@ -760,6 +767,7 @@ async def test_image_url_tool_response(allow_model_requests: None, openai_api_ke
                 ),
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
+                vendor_id='chatcmpl-BRmTI0Y2zmkGw27kLarhsmiFQTGxR',
             ),
         ]
     )
@@ -804,6 +812,7 @@ async def test_image_as_binary_content_tool_response(
                 ),
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
+                vendor_id='chatcmpl-BRlkLhPc87BdohVobEJJCGq3rUAG2',
             ),
             ModelRequest(
                 parts=[
@@ -839,6 +848,7 @@ async def test_image_as_binary_content_tool_response(
                 ),
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
+                vendor_id='chatcmpl-BRlkORPA5rXMV3uzcOcgK4eQFKCVW',
             ),
         ]
     )
@@ -1474,6 +1484,7 @@ async def test_openai_instructions(allow_model_requests: None, openai_api_key: s
                 ),
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
+                vendor_id='chatcmpl-BJjf61mLb9z5H45ClJzbx0UWKwjo1',
             ),
         ]
     )
@@ -1522,6 +1533,7 @@ async def test_openai_instructions_with_tool_calls_keep_instructions(allow_model
                 ),
                 model_name='gpt-4.1-mini-2025-04-14',
                 timestamp=IsDatetime(),
+                vendor_id='chatcmpl-BMxEwRA0p0gJ52oKS7806KAlfMhqq',
             ),
             ModelRequest(
                 parts=[
@@ -1548,6 +1560,7 @@ async def test_openai_instructions_with_tool_calls_keep_instructions(allow_model
                 ),
                 model_name='gpt-4.1-mini-2025-04-14',
                 timestamp=IsDatetime(),
+                vendor_id='chatcmpl-BMxEx6B8JEj6oDC45MOWKp0phg8UP',
             ),
         ]
     )

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -40,7 +40,7 @@ from .mock_async_stream import MockAsyncStream
 with try_import() as imports_successful:
     from openai import NOT_GIVEN, APIStatusError, AsyncOpenAI
     from openai.types import chat
-    from openai.types.chat.chat_completion import Choice
+    from openai.types.chat.chat_completion import Choice, ChoiceLogprobs
     from openai.types.chat.chat_completion_chunk import (
         Choice as ChunkChoice,
         ChoiceDelta,
@@ -49,6 +49,7 @@ with try_import() as imports_successful:
     )
     from openai.types.chat.chat_completion_message import ChatCompletionMessage
     from openai.types.chat.chat_completion_message_tool_call import Function
+    from openai.types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob
     from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
 
     from pydantic_ai.models.openai import (
@@ -129,10 +130,15 @@ def get_mock_chat_completion_kwargs(async_open_ai: AsyncOpenAI) -> list[dict[str
         raise RuntimeError('Not a MockOpenAI instance')
 
 
-def completion_message(message: ChatCompletionMessage, *, usage: CompletionUsage | None = None) -> chat.ChatCompletion:
+def completion_message(
+    message: ChatCompletionMessage, *, usage: CompletionUsage | None = None, logprobs: ChoiceLogprobs | None = None
+) -> chat.ChatCompletion:
+    choices = [Choice(finish_reason='stop', index=0, message=message)]
+    if logprobs:
+        choices = [Choice(finish_reason='stop', index=0, message=message, logprobs=logprobs)]
     return chat.ChatCompletion(
         id='123',
-        choices=[Choice(finish_reason='stop', index=0, message=message)],
+        choices=choices,
         created=1704067200,  # 2024-01-01
         model='gpt-4o-123',
         object='chat.completion',
@@ -141,7 +147,9 @@ def completion_message(message: ChatCompletionMessage, *, usage: CompletionUsage
 
 
 async def test_request_simple_success(allow_model_requests: None):
-    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    c = completion_message(
+        ChatCompletionMessage(content='world', role='assistant'),
+    )
     mock_client = MockOpenAI.create_mock(c)
     m = OpenAIModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
     agent = Agent(m)
@@ -1543,3 +1551,43 @@ async def test_openai_instructions_with_tool_calls_keep_instructions(allow_model
             ),
         ]
     )
+
+
+@pytest.mark.vcr()
+async def test_openai_instructions_with_logprobs(allow_model_requests: None):
+    # Create a mock response with logprobs
+    c = completion_message(
+        ChatCompletionMessage(content='world', role='assistant'),
+        logprobs=ChoiceLogprobs(
+            content=[
+                ChatCompletionTokenLogprob(
+                    token='world', logprob=-0.6931, top_logprobs=[], bytes=[119, 111, 114, 108, 100]
+                )
+            ],
+        ),
+    )
+
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIModel(
+        'gpt-4o',
+        provider=OpenAIProvider(openai_client=mock_client),
+    )
+    agent = Agent(
+        m,
+        instructions='You are a helpful assistant.',
+    )
+    result = await agent.run(
+        'What is the capital of Minas Gerais?',
+        model_settings=OpenAIModelSettings(openai_logprobs=True),
+    )
+    messages = result.all_messages()
+    response = cast(Any, messages[1])
+    assert response.vendor_details is not None
+    assert response.vendor_details['logprobs'] == [
+        {
+            'token': 'world',
+            'logprob': -0.6931,
+            'bytes': [119, 111, 114, 108, 100],
+            'top_logprobs': [],
+        }
+    ]

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1757,6 +1757,7 @@ def test_binary_content_all_messages_json():
                 'model_name': 'test',
                 'timestamp': IsStr(),
                 'kind': 'response',
+                'vendor_details': None,
             },
         ]
     )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1755,6 +1755,7 @@ def test_binary_content_all_messages_json():
                     'details': None,
                 },
                 'model_name': 'test',
+                'vendor_id': None,
                 'timestamp': IsStr(),
                 'kind': 'response',
                 'vendor_details': None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,7 @@ def test_agent_flag(
     create_test_module: Callable[..., None],
 ):
     env.remove('OPENAI_API_KEY')
+    env.set('COLUMNS', '150')
 
     test_agent = Agent(TestModel(custom_output_text='Hello from custom agent'))
     create_test_module(custom_agent=test_agent)
@@ -98,6 +99,7 @@ def test_agent_flag_set_model(
     create_test_module: Callable[..., None],
 ):
     env.set('OPENAI_API_KEY', 'xxx')
+    env.set('COLUMNS', '150')
 
     custom_agent = Agent(TestModel(custom_output_text='Hello from custom agent'))
     create_test_module(custom_agent=custom_agent)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -121,6 +121,7 @@ async def test_agent_with_stdio_server(allow_model_requests: None, agent: Agent)
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRlnvvqIPFofAtKqtQKMWZkgXhzlT',
                 ),
                 ModelRequest(
                     parts=[
@@ -149,6 +150,7 @@ async def test_agent_with_stdio_server(allow_model_requests: None, agent: Agent)
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRlnyjUo5wlyqvdNdM5I8vIWjo1qF',
                 ),
             ]
         )
@@ -222,6 +224,7 @@ async def test_tool_returning_str(allow_model_requests: None, agent: Agent):
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRlo3e1Ud2lnvkddMilmwC7LAemiy',
                 ),
                 ModelRequest(
                     parts=[
@@ -254,6 +257,7 @@ async def test_tool_returning_str(allow_model_requests: None, agent: Agent):
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRlo41LxqBYgGKWgGrQn67fQacOLp',
                 ),
             ]
         )
@@ -295,6 +299,7 @@ async def test_tool_returning_text_resource(allow_model_requests: None, agent: A
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRmhyweJVYonarb7s9ckIMSHf2vHo',
                 ),
                 ModelRequest(
                     parts=[
@@ -323,6 +328,7 @@ async def test_tool_returning_text_resource(allow_model_requests: None, agent: A
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRmhzqXFObpYwSzREMpJvX9kbDikR',
                 ),
             ]
         )
@@ -366,6 +372,7 @@ async def test_tool_returning_image_resource(allow_model_requests: None, agent: 
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRlo7KYJVXuNZ5lLLdYcKZDsX2CHb',
                 ),
                 ModelRequest(
                     parts=[
@@ -405,6 +412,7 @@ async def test_tool_returning_image_resource(allow_model_requests: None, agent: 
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloBGHh27w3fQKwxq4fX2cPuZJa9',
                 ),
             ]
         )
@@ -444,6 +452,7 @@ async def test_tool_returning_image(allow_model_requests: None, agent: Agent, im
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloGQJWIX0Qk7gtNzF4s2Fez0O29',
                 ),
                 ModelRequest(
                     parts=[
@@ -479,6 +488,7 @@ async def test_tool_returning_image(allow_model_requests: None, agent: Agent, im
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloJHR654fSD0fcvLWZxtKtn0pag',
                 ),
             ]
         )
@@ -516,6 +526,7 @@ async def test_tool_returning_dict(allow_model_requests: None, agent: Agent):
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloOs7Bb2tq8wJyy9Rv7SQ7L65a7',
                 ),
                 ModelRequest(
                     parts=[
@@ -544,6 +555,7 @@ async def test_tool_returning_dict(allow_model_requests: None, agent: Agent):
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloPczU1HSCWnreyo21DdNtdOM7L',
                 ),
             ]
         )
@@ -587,6 +599,7 @@ async def test_tool_returning_error(allow_model_requests: None, agent: Agent):
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloSNg7aGSp1rXDkhInjMIUHKd7A',
                 ),
                 ModelRequest(
                     parts=[
@@ -619,6 +632,7 @@ async def test_tool_returning_error(allow_model_requests: None, agent: Agent):
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloTvSkFeX4DZKQLqfH9KbQkWlpt',
                 ),
                 ModelRequest(
                     parts=[
@@ -651,6 +665,7 @@ async def test_tool_returning_error(allow_model_requests: None, agent: Agent):
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloU3MhnqNEqujs28a3ofRbs7VPF',
                 ),
             ]
         )
@@ -688,6 +703,7 @@ async def test_tool_returning_none(allow_model_requests: None, agent: Agent):
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloX2RokWc9j9PAXAuNXGR73WNqY',
                 ),
                 ModelRequest(
                     parts=[
@@ -716,6 +732,7 @@ async def test_tool_returning_none(allow_model_requests: None, agent: Agent):
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloYWGujk8yE94gfVSsM1T1Ol2Ej',
                 ),
             ]
         )
@@ -759,6 +776,7 @@ async def test_tool_returning_multiple_items(allow_model_requests: None, agent: 
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRlobKLgm6vf79c9O8sloZaYx3coC',
                 ),
                 ModelRequest(
                     parts=[
@@ -803,6 +821,7 @@ async def test_tool_returning_multiple_items(allow_model_requests: None, agent: 
                     ),
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
+                    vendor_id='chatcmpl-BRloepWR5NJpTgSqFBGTSPeM1SWm8',
                 ),
             ]
         )


### PR DESCRIPTION
# Add `id` and `finish_reason` to `ModelResponse`

## Description
Following issue #886, this update adds `id` and `finish_reasons` to `ModelResponse`.

Below the details:

- `id`: id of the request, defaults to a random UUID
- `finish_reasons`: list of reasons why the generation ended, defaults to an empty list

### Gemini implementation

Included in the PR there is an implementation of the fields for Gemini.

- `id`: maps to [`responseId`](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/GenerateContentResponse)
- `finish_reasons`: list containing [`finishReason`](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/GenerateContentResponse#Candidate) for the first candidate of the output

The handling of finish_reasons aligns with the current approach for other response parts, where only the first candidate's reason is considered. Note that only those finish reasons defined in the Literal type will be included.

Implementations for other model providers are currently missing due to lack of testing access.

## Testing
The changes were validated using my API key, and the behavior matches expectations.

## Impact
This update potentially affects all providers. However, with sensible default values in place, the change should have no immediate impact. Provider-specific implementations can be added independently later.
