### PR TITLE
docs: use the correct URL for the `google-genai` package

### DIFF
--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -1,6 +1,6 @@
 # Google
 
-The `GoogleModel` is a model that uses the [`google-genai`](https://pypi.org/project/google-generativeai/) package under the hood to
+The `GoogleModel` is a model that uses the [`google-genai`](https://pypi.org/project/google-genai/) package under the hood to
 access Google's Gemini models via both the Generative Language API and Vertex AI.
 
 ## Install


### PR DESCRIPTION
The [previous URL](https://pypi.org/project/google-generativeai/) links to the **deprecated** package:

<img width="917" alt="Screenshot 2025-05-20 at 23 23 01" src="https://github.com/user-attachments/assets/2e886517-5b41-499d-a746-1b27e0c6fedd" />


The [updated URL](https://pypi.org/project/google-genai/):

<img width="906" alt="Screenshot 2025-05-20 at 23 30 16" src="https://github.com/user-attachments/assets/274bb533-d2d4-4ab2-8668-655587138663" />
