### PR TITLE
Support streaming tool calls from models that pass args as None when there are no function parameters

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -370,7 +370,8 @@ if __name__ == '__main__':
     [
         '=== UserPromptNode: What will the weather be like in Paris on Tuesday? ===',
         '=== ModelRequestNode: streaming partial request tokens ===',
-        '[Request] Starting part 0: ToolCallPart(tool_name=\'weather_forecast\', args=\'{"location":"Pa\', tool_call_id=\'0001\', part_kind=\'tool-call\')',
+        "[Request] Starting part 0: ToolCallPart(tool_name='weather_forecast', args=None, tool_call_id='0001', part_kind='tool-call')",
+        '[Request] Part 0 args_delta={"location":"Pa',
         '[Request] Part 0 args_delta=ris","forecast_',
         '[Request] Part 0 args_delta=date":"2030-01-',
         '[Request] Part 0 args_delta=01"}',

--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -231,9 +231,13 @@ class OutputSchemaTool(Generic[OutputDataT]):
         try:
             pyd_allow_partial: Literal['off', 'trailing-strings'] = 'trailing-strings' if allow_partial else 'off'
             if isinstance(tool_call.args, str):
-                output = self.type_adapter.validate_json(tool_call.args, experimental_allow_partial=pyd_allow_partial)
+                output = self.type_adapter.validate_json(
+                    tool_call.args or '{}', experimental_allow_partial=pyd_allow_partial
+                )
             else:
-                output = self.type_adapter.validate_python(tool_call.args, experimental_allow_partial=pyd_allow_partial)
+                output = self.type_adapter.validate_python(
+                    tool_call.args or {}, experimental_allow_partial=pyd_allow_partial
+                )
         except ValidationError as e:
             if wrap_validation_errors:
                 m = _messages.RetryPromptPart(

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -132,7 +132,7 @@ class ModelResponsePartsManager:
     ) -> ModelResponseStreamEvent | None:
         """Handle or update a tool call, creating or updating a `ToolCallPart` or `ToolCallPartDelta`.
 
-        Managed items remain as `ToolCallPartDelta`s until they have both a tool_name and arguments, at which
+        Managed items remain as `ToolCallPartDelta`s until they have at least a tool_name, at which
         point they are upgraded to `ToolCallPart`s.
 
         If `vendor_part_id` is None, updates the latest matching ToolCallPart (or ToolCallPartDelta)
@@ -143,11 +143,11 @@ class ModelResponsePartsManager:
                 If None, the latest matching tool call may be updated.
             tool_name: The name of the tool. If None, the manager does not enforce
                 a name match when `vendor_part_id` is None.
-            args: Arguments for the tool call, either as a string or a dictionary of key-value pairs.
+            args: Arguments for the tool call, either as a string, a dictionary of key-value pairs, or None.
             tool_call_id: An optional string representing an identifier for this tool call.
 
         Returns:
-            - A `PartStartEvent` if a new (fully realized) ToolCallPart is created.
+            - A `PartStartEvent` if a new ToolCallPart is created.
             - A `PartDeltaEvent` if an existing part is updated.
             - `None` if no new event is emitted (e.g., the part is still incomplete).
 
@@ -207,7 +207,7 @@ class ModelResponsePartsManager:
         *,
         vendor_part_id: Hashable | None,
         tool_name: str,
-        args: str | dict[str, Any],
+        args: str | dict[str, Any] | None,
         tool_call_id: str | None = None,
     ) -> ModelResponseStreamEvent:
         """Immediately create or fully-overwrite a ToolCallPart with the given information.
@@ -218,7 +218,7 @@ class ModelResponsePartsManager:
             vendor_part_id: The vendor's ID for this tool call part. If not
                 None and an existing part is found, that part is overwritten.
             tool_name: The name of the tool being invoked.
-            args: The arguments for the tool call, either as a string or a dictionary.
+            args: The arguments for the tool call, either as a string, a dictionary, or None.
             tool_call_id: An optional string identifier for this tool call.
 
         Returns:

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -552,8 +552,8 @@ class BedrockStreamedResponse(StreamedResponse):
                         args=None,
                         tool_call_id=tool_id,
                     )
-                    if maybe_event:
-                        yield maybe_event  # pragma: no cover
+                    if maybe_event:  # pragma: no branch
+                        yield maybe_event
             if 'contentBlockDelta' in chunk:
                 index = chunk['contentBlockDelta']['contentBlockIndex']
                 delta = chunk['contentBlockDelta']['delta']

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -442,7 +442,7 @@ def _process_response_from_parts(parts: list[Part], model_name: GoogleModelName,
             items.append(TextPart(content=part.text))
         elif part.function_call:
             assert part.function_call.name is not None
-            tool_call_part = ToolCallPart(tool_name=part.function_call.name, args=part.function_call.args or {})
+            tool_call_part = ToolCallPart(tool_name=part.function_call.name, args=part.function_call.args)
             if part.function_call.id is not None:
                 tool_call_part.tool_call_id = part.function_call.id  # pragma: no cover
             items.append(tool_call_part)

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -368,7 +368,7 @@ class MistralModel(Model):
         return MistralToolCall(
             id=_utils.guard_tool_call_id(t=t),
             type='function',
-            function=MistralFunctionCall(name=t.tool_name, arguments=t.args),
+            function=MistralFunctionCall(name=t.tool_name, arguments=t.args or {}),
         )
 
     def _generate_user_output_format(self, schemas: list[dict[str, Any]]) -> MistralUserMessage:

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -367,7 +367,7 @@ class Tool(Generic[AgentDepsT]):
             if isinstance(message.args, str):
                 args_dict = self._validator.validate_json(message.args or '{}')
             else:
-                args_dict = self._validator.validate_python(message.args)
+                args_dict = self._validator.validate_python(message.args or {})
         except ValidationError as e:
             return self._on_error(e, message)
 

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -26,6 +26,7 @@ from pydantic_ai.messages import (
     TextPart,
     TextPartDelta,
     ToolCallPart,
+    ToolCallPartDelta,
     ToolReturnPart,
     UserPromptPart,
     VideoUrl,
@@ -396,10 +397,11 @@ async def test_bedrock_model_iter_stream(allow_model_requests: None, bedrock_pro
             PartDeltaEvent(index=0, delta=TextPartDelta(content_delta='thinking')),
             PartDeltaEvent(index=0, delta=TextPartDelta(content_delta='>\n')),
             PartStartEvent(
+                index=1, part=ToolCallPart(tool_name='get_temperature', tool_call_id='tooluse_lAG_zP8QRHmSYOwZzzaCqA')
+            ),
+            PartDeltaEvent(
                 index=1,
-                part=ToolCallPart(
-                    tool_name='get_temperature', args='{"city":"Paris"}', tool_call_id='tooluse_lAG_zP8QRHmSYOwZzzaCqA'
-                ),
+                delta=ToolCallPartDelta(args_delta='{"city":"Paris"}', tool_call_id='tooluse_lAG_zP8QRHmSYOwZzzaCqA'),
             ),
             IsInstance(FunctionToolCallEvent),
             FunctionToolResultEvent(

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -432,6 +432,7 @@ async def test_stream_structured(allow_model_requests: None):
         assert not result.is_complete
         assert [dict(c) async for c in result.stream(debounce_by=None)] == snapshot(
             [
+                {},
                 {'first': 'One'},
                 {'first': 'One', 'second': 'Two'},
                 {'first': 'One', 'second': 'Two'},

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -470,8 +470,9 @@ async def test_stream_structure():
         assert agent_info.output_tools is not None
         assert len(agent_info.output_tools) == 1
         name = agent_info.output_tools[0].name
-        yield {0: DeltaToolCall(name=name)}
+        # Args don't typically come before the tool name, but it's technically possible and this ensures test coverage
         yield {0: DeltaToolCall(json_args='{"x": ')}
+        yield {0: DeltaToolCall(name=name)}
         yield {0: DeltaToolCall(json_args='1}')}
 
     agent = Agent(FunctionModel(stream_function=stream_structured_function), output_type=Foo)

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -497,6 +497,7 @@ async def test_stream_structured(allow_model_requests: None):
         assert not result.is_complete
         assert [dict(c) async for c in result.stream(debounce_by=None)] == snapshot(
             [
+                {},
                 {'first': 'One'},
                 {'first': 'One', 'second': 'Two'},
                 {'first': 'One', 'second': 'Two'},


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic-ai/issues/1654

We now allow `ToolCallPartDelta`s to be converted into a `ToolCallPart` even if there are no arguments (yet), as any way of not passing any arguments (as `None`, `''` or `{}`) should be valid when the tool doesn't take parameters.