### PR TITLE
Remove hardcoded `n` parameter from OpenAIModel requests

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -277,7 +277,6 @@ class OpenAIModel(Model):
             return await self.client.chat.completions.create(
                 model=self._model_name,
                 messages=openai_messages,
-                n=1,
                 parallel_tool_calls=model_settings.get('parallel_tool_calls', NOT_GIVEN),
                 tools=tools or NOT_GIVEN,
                 tool_choice=tool_choice or NOT_GIVEN,

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -188,7 +188,6 @@ async def test_request_simple_success(allow_model_requests: None):
         {
             'messages': [{'content': 'hello', 'role': 'user'}],
             'model': 'gpt-4o',
-            'n': 1,
             'extra_headers': {'User-Agent': IsStr(regex=r'pydantic-ai\/.*')},
             'extra_body': None,
         },
@@ -199,7 +198,6 @@ async def test_request_simple_success(allow_model_requests: None):
                 {'content': 'hello', 'role': 'user'},
             ],
             'model': 'gpt-4o',
-            'n': 1,
             'extra_headers': {'User-Agent': IsStr(regex=r'pydantic-ai\/.*')},
             'extra_body': None,
         },
@@ -586,7 +584,6 @@ async def test_system_prompt_role(
                 {'content': 'hello', 'role': 'user'},
             ],
             'model': 'gpt-4o',
-            'n': 1,
             'extra_headers': {'User-Agent': IsStr(regex=r'pydantic-ai\/.*')},
             'extra_body': None,
         }
@@ -663,7 +660,6 @@ async def test_image_url_input(allow_model_requests: None):
                         ],
                     }
                 ],
-                'n': 1,
                 'extra_headers': {'User-Agent': IsStr(regex=r'pydantic-ai\/.*')},
                 'extra_body': None,
             }


### PR DESCRIPTION
I'm removing the hardcoded `n` parameter from `OpenAIModel` as it already default to `1` (https://platform.openai.com/docs/api-reference/chat/create#chat-create-n) so it will be `1` for models that supports it and will be `null` (or not_given) for models that doesnt

I was wondering if I should add it to OpenAI Model Settings but I think not as we always take the first choice to work on....

It should fix #1418 