### PR TITLE
fix handling of non textual responses in Agent.to_cli cli tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_cli.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli.py
@@ -284,7 +284,7 @@ async def ask_agent(
                         stack.enter_context(live)  # entering multiple times is idempotent
 
                         async for content in handle_stream.stream_output(debounce_by=None):
-                            live.update(Markdown(content, code_theme=code_theme))
+                            live.update(Markdown(str(content), code_theme=code_theme))
 
         assert agent_run.result is not None
         return agent_run.result.all_messages()


### PR DESCRIPTION
currently when trying to create a cli tool for an agent using Agent.to_cli(), if the agent returns non string responses the tool will crash.