### PR TITLE
Timeout for initializing MCP client

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any
 
+import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp.types import (
     BlobResourceContents,
@@ -78,6 +79,9 @@ class MCPServer(ABC):
         """Get the log level for the MCP server."""
         raise NotImplementedError('MCP Server subclasses must implement this method.')
 
+    def _get_client_initialize_timeout(self) -> float:
+        return 5
+
     def get_prefixed_tool_name(self, tool_name: str) -> str:
         """Get the tool name with prefix if `tool_prefix` is set."""
         return f'{self.tool_prefix}_{tool_name}' if self.tool_prefix else tool_name
@@ -137,7 +141,9 @@ class MCPServer(ABC):
         client = ClientSession(read_stream=self._read_stream, write_stream=self._write_stream)
         self._client = await self._exit_stack.enter_async_context(client)
 
-        await self._client.initialize()
+        with anyio.fail_after(self._get_client_initialize_timeout()):
+            await self._client.initialize()
+
         if log_level := self._get_log_level():
             await self._client.set_logging_level(log_level)
         self.is_running = True
@@ -252,6 +258,9 @@ class MCPServerStdio(MCPServer):
     e.g. if `tool_prefix='foo'`, then a tool named `bar` will be registered as `foo_bar`
     """
 
+    timeout: float = 5
+    """ The timeout in seconds to wait for the client to initialize."""
+
     @asynccontextmanager
     async def client_streams(
         self,
@@ -270,6 +279,9 @@ class MCPServerStdio(MCPServer):
 
     def __repr__(self) -> str:
         return f'MCPServerStdio(command={self.command!r}, args={self.args!r}, tool_prefix={self.tool_prefix!r})'
+
+    def _get_client_initialize_timeout(self) -> float:
+        return self.timeout
 
 
 @dataclass
@@ -368,3 +380,6 @@ class MCPServerHTTP(MCPServer):
 
     def __repr__(self) -> str:  # pragma: no cover
         return f'MCPServerHTTP(url={self.url!r}, tool_prefix={self.tool_prefix!r})'
+
+    def _get_client_initialize_timeout(self) -> float:
+        return self.timeout

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -80,7 +80,7 @@ class MCPServer(ABC):
         raise NotImplementedError('MCP Server subclasses must implement this method.')
 
     def _get_client_initialize_timeout(self) -> float:
-        return 5
+        return 5  # pragma: no cover
 
     def get_prefixed_tool_name(self, tool_name: str) -> str:
         """Get the tool name with prefix if `tool_prefix` is set."""
@@ -381,5 +381,5 @@ class MCPServerHTTP(MCPServer):
     def __repr__(self) -> str:  # pragma: no cover
         return f'MCPServerHTTP(url={self.url!r}, tool_prefix={self.tool_prefix!r})'
 
-    def _get_client_initialize_timeout(self) -> float:
+    def _get_client_initialize_timeout(self) -> float:  # pragma: no cover
         return self.timeout

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -81,30 +81,29 @@ def test_http_server_with_header_and_timeout():
     http_server = MCPServerHTTP(
         url='http://localhost:8000/sse',
         headers={'my-custom-header': 'my-header-value'},
-        timeout=timedelta(seconds=10),
-        sse_read_timeout=timedelta(seconds=100),
+        timeout=10,
+        sse_read_timeout=100,
         log_level='info',
     )
     assert http_server.url == 'http://localhost:8000/sse'
     assert http_server.headers is not None and http_server.headers['my-custom-header'] == 'my-header-value'
-    assert http_server.timeout == timedelta(seconds=10)
-    assert http_server.sse_read_timeout == timedelta(seconds=100)
+    assert http_server.timeout == 10
+    assert http_server.sse_read_timeout == 100
     assert http_server._get_log_level() == 'info'  # pyright: ignore[reportPrivateUsage]
 
 
-def test_http_server_with_deprecated_arguments():
-    with pytest.warns(DeprecationWarning):
-        http_server = MCPServerHTTP(
-            url='http://localhost:8000/sse',
-            headers={'my-custom-header': 'my-header-value'},
-            timeout=10,
-            sse_read_timeout=100,
-            log_level='info',
-        )
+def test_http_server_with_timedelta_arguments():
+    http_server = MCPServerHTTP(
+        url='http://localhost:8000/sse',
+        headers={'my-custom-header': 'my-header-value'},
+        timeout=timedelta(seconds=10),  # type: ignore[arg-type]
+        sse_read_timeout=timedelta(seconds=100),  # type: ignore[arg-type]
+        log_level='info',
+    )
     assert http_server.url == 'http://localhost:8000/sse'
     assert http_server.headers is not None and http_server.headers['my-custom-header'] == 'my-header-value'
-    assert http_server.timeout == timedelta(seconds=10)
-    assert http_server.sse_read_timeout == timedelta(seconds=100)
+    assert http_server.timeout == 10
+    assert http_server.sse_read_timeout == 100
     assert http_server._get_log_level() == 'info'  # pyright: ignore[reportPrivateUsage]
 
 


### PR DESCRIPTION
Demo script:

```python
import asyncio

from pydantic_ai import Agent
from pydantic_ai.mcp import MCPServerStdio

server = MCPServerStdio('python', args=[], timeout=100)  # will wait this many seconds
agent = Agent('openai:gpt-4o', mcp_servers=[server])


async def main():
    async with agent.run_mcp_servers():
        ...


asyncio.run(main())
```