### PR TITLE
Fix weather agent example with UI

### DIFF
--- a/examples/pydantic_ai_examples/weather_agent_gradio.py
+++ b/examples/pydantic_ai_examples/weather_agent_gradio.py
@@ -36,7 +36,7 @@ async def stream_from_agent(prompt: str, chatbot: list[dict], past_messages: lis
                     call_args = (
                         call.args.args_json
                         if hasattr(call.args, 'args_json')
-                        else json.dumps(call.args)
+                        else call.args_as_json_str()
                     )
                     metadata = {
                         'title': f'🛠️ Using {TOOL_TO_DISPLAY_NAME[call.tool_name]}',

--- a/examples/pydantic_ai_examples/weather_agent_gradio.py
+++ b/examples/pydantic_ai_examples/weather_agent_gradio.py
@@ -33,11 +33,7 @@ async def stream_from_agent(prompt: str, chatbot: list[dict], past_messages: lis
         for message in result.new_messages():
             for call in message.parts:
                 if isinstance(call, ToolCallPart):
-                    call_args = (
-                        call.args.args_json
-                        if hasattr(call.args, 'args_json')
-                        else call.args_as_json_str()
-                    )
+                    call_args = call.args_as_json_str()
                     metadata = {
                         'title': f'🛠️ Using {TOOL_TO_DISPLAY_NAME[call.tool_name]}',
                     }

--- a/examples/pydantic_ai_examples/weather_agent_gradio.py
+++ b/examples/pydantic_ai_examples/weather_agent_gradio.py
@@ -36,13 +36,13 @@ async def stream_from_agent(prompt: str, chatbot: list[dict], past_messages: lis
                     call_args = (
                         call.args.args_json
                         if hasattr(call.args, 'args_json')
-                        else json.dumps(call.args.args_dict)
+                        else json.dumps(call.args)
                     )
                     metadata = {
                         'title': f'🛠️ Using {TOOL_TO_DISPLAY_NAME[call.tool_name]}',
                     }
                     if call.tool_call_id is not None:
-                        metadata['id'] = {call.tool_call_id}
+                        metadata['id'] = call.tool_call_id
 
                     gr_message = {
                         'role': 'assistant',


### PR DESCRIPTION
There are two bugs, the first was introduced in the last commit. It set the tool call id to a dictionary instead of a string. He didnt notice since he used gemini which doesnt make use of that field.

The 2nd bug was older, it still remained undetected since LLMs (i guess until recently) set the args_json in the call args. Now at least openai doesnt set that field which causes the code to execute the code path with the bug that attempts to use that field

Tested with gpt4o on 28/05/2025