### PR TITLE
Add option to pass expected output to LLMJudge

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -203,32 +203,30 @@ class LLMJudge(Evaluator[object, object, object]):
         self,
         ctx: EvaluatorContext[object, object, object],
     ) -> EvaluatorOutput:
-        match (self.include_input, self.include_expected_output):
-            case (False, False):
-                from .llm_as_a_judge import judge_output
+        if (self.include_input is False) and (self.include_expected_output is False):
+            from .llm_as_a_judge import judge_output
 
-                grading_output = await judge_output(ctx.output, self.rubric, self.model, self.model_settings)
+            grading_output = await judge_output(ctx.output, self.rubric, self.model, self.model_settings)
 
-            case (True, False):
-                from .llm_as_a_judge import judge_input_output
+        elif (self.include_input is True) and (self.include_expected_output is False):
+            from .llm_as_a_judge import judge_input_output
 
-                grading_output = await judge_input_output(
-                    ctx.inputs, ctx.output, self.rubric, self.model, self.model_settings
-                )
+            grading_output = await judge_input_output(
+                ctx.inputs, ctx.output, self.rubric, self.model, self.model_settings
+            )
 
-            case (True, True):
-                from .llm_as_a_judge import judge_input_output_expected
+        elif (self.include_input is True) and (self.include_expected_output is True):
+            from .llm_as_a_judge import judge_input_output_expected
 
-                grading_output = await judge_input_output_expected(
-                    ctx.inputs, ctx.output, ctx.expected_output, self.rubric, self.model, self.model_settings
-                )
+            grading_output = await judge_input_output_expected(
+                ctx.inputs, ctx.output, ctx.expected_output, self.rubric, self.model, self.model_settings
+            )
 
-            case (False, True):
-                raise NotImplementedError('include_expected_output is not supported without include_input')
+        elif (self.include_input is False) and (self.include_expected_output is True):
+            raise NotImplementedError('include_expected_output is not supported without include_input')
 
-            # Include a default case to satisfy the linter
-            case _:
-                raise ValueError(f'Unexpected values for {self.include_input=} and {self.include_expected_output=}')
+        else:
+            raise ValueError(f'Unexpected values for {self.include_input=} and {self.include_expected_output=}')
 
         output: dict[str, EvaluationScalar | EvaluationReason] = {}
         include_both = self.score is not False and self.assertion is not False

--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -223,7 +223,11 @@ class LLMJudge(Evaluator[object, object, object]):
             )
 
         elif (self.include_input is False) and (self.include_expected_output is True):
-            raise NotImplementedError('include_expected_output is not supported without include_input')
+            from .llm_as_a_judge import judge_output_expected
+
+            grading_output = await judge_output_expected(
+                ctx.output, ctx.expected_output, self.rubric, self.model, self.model_settings
+            )
 
         else:  # pragma: no cover - unreachable due to type constraints
             raise ValueError(f'Unexpected values for {self.include_input=} and {self.include_expected_output=}')

--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -225,7 +225,7 @@ class LLMJudge(Evaluator[object, object, object]):
         elif (self.include_input is False) and (self.include_expected_output is True):
             raise NotImplementedError('include_expected_output is not supported without include_input')
 
-        else:
+        else:  # pragma: no cover - unreachable due to type constraints
             raise ValueError(f'Unexpected values for {self.include_input=} and {self.include_expected_output=}')
 
         output: dict[str, EvaluationScalar | EvaluationReason] = {}

--- a/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
+++ b/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
@@ -9,7 +9,13 @@ from pydantic_core import to_json
 from pydantic_ai import Agent, models
 from pydantic_ai.settings import ModelSettings
 
-__all__ = ('GradingOutput', 'judge_input_output', 'judge_output', 'set_default_judge_model')
+__all__ = (
+    'GradingOutput',
+    'judge_input_output',
+    'judge_input_output_expected',
+    'judge_output',
+    'set_default_judge_model',
+)
 
 
 _default_model: models.Model | models.KnownModelName = 'openai:gpt-4o'
@@ -99,6 +105,52 @@ async def judge_input_output(
     user_prompt = f'<Input>\n{_stringify(inputs)}\n</Input>\n<Output>\n{_stringify(output)}\n</Output>\n<Rubric>\n{rubric}\n</Rubric>'
     return (
         await _judge_input_output_agent.run(user_prompt, model=model or _default_model, model_settings=model_settings)
+    ).output
+
+
+_judge_input_output_expected_agent = Agent(
+    name='judge_input_output_expected',
+    system_prompt=dedent(
+        """
+        You are grading output according to a user-specified rubric. If the statement in the rubric is true for the provided input, expected output, and output, then the output passes the test. You respond with a JSON object with this structure: {reason: string, pass: boolean, score: number}
+
+        Examples:
+
+        <Input>What color is the sky?</Input>
+        <ExpectedOutput>Blue</ExpectedOutput>
+        <Output>Cerulean</Output>
+        <Rubric>The output is consistent with the expected output but doesn't have to match exactly</Rubric>
+        {"reason": "'Cerulean' is a shade of blue", "pass": true, "score": 1.0}
+
+        <Input>How many legs does a spider have?</Input>
+        <ExpectedOutput>8</ExpectedOutput>
+        <Output>Six</Output>
+        <Rubric>The output is factually consistent with the expected output</Rubric>
+        {"reason": "Spiders have 8 legs", "pass": false, "score": 0.0}
+        """
+    ),
+    output_type=GradingOutput,
+)
+
+
+async def judge_input_output_expected(
+    inputs: Any,
+    output: Any,
+    expected_output: Any,
+    rubric: str,
+    model: models.Model | models.KnownModelName | None = None,
+    model_settings: ModelSettings | None = None,
+) -> GradingOutput:
+    """Judge the output of a model based on the inputs and a rubric.
+
+    If the model is not specified, a default model is used. The default model starts as 'openai:gpt-4o',
+    but this can be changed using the `set_default_judge_model` function.
+    """
+    user_prompt = f'<Input>\n{_stringify(inputs)}\n</Input>\n<ExpectedOutput>\n{_stringify(expected_output)}\n</ExpectedOutput>\n<Output>\n{_stringify(output)}\n</Output>\n<Rubric>\n{rubric}\n</Rubric>'
+    return (
+        await _judge_input_output_expected_agent.run(
+            user_prompt, model=model or _default_model, model_settings=model_settings
+        )
     ).output
 
 

--- a/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
+++ b/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
@@ -62,7 +62,16 @@ async def judge_output(
     If the model is not specified, a default model is used. The default model starts as 'openai:gpt-4o',
     but this can be changed using the `set_default_judge_model` function.
     """
-    user_prompt = f'<Output>\n{_stringify(output)}\n</Output>\n<Rubric>\n{rubric}\n</Rubric>'
+    user_prompt = dedent(
+        f"""
+        <Output>
+        {_stringify(output)}
+        </Output>
+        <Rubric>
+        {rubric}
+        </Rubric>
+        """
+    )
     return (
         await _judge_output_agent.run(user_prompt, model=model or _default_model, model_settings=model_settings)
     ).output
@@ -103,7 +112,19 @@ async def judge_input_output(
     If the model is not specified, a default model is used. The default model starts as 'openai:gpt-4o',
     but this can be changed using the `set_default_judge_model` function.
     """
-    user_prompt = f'<Input>\n{_stringify(inputs)}\n</Input>\n<Output>\n{_stringify(output)}\n</Output>\n<Rubric>\n{rubric}\n</Rubric>'
+    user_prompt = dedent(
+        f"""
+        <Input>
+        {_stringify(inputs)}
+        </Input>
+        <Output>
+        {_stringify(output)}
+        </Output>
+        <Rubric>
+        {rubric}
+        </Rubric>
+        """
+    )
     return (
         await _judge_input_output_agent.run(user_prompt, model=model or _default_model, model_settings=model_settings)
     ).output
@@ -147,7 +168,23 @@ async def judge_input_output_expected(
     If the model is not specified, a default model is used. The default model starts as 'openai:gpt-4o',
     but this can be changed using the `set_default_judge_model` function.
     """
-    user_prompt = f'<Input>\n{_stringify(inputs)}\n</Input>\n<ExpectedOutput>\n{_stringify(expected_output)}\n</ExpectedOutput>\n<Output>\n{_stringify(output)}\n</Output>\n<Rubric>\n{rubric}\n</Rubric>'
+    user_prompt = dedent(
+        f"""
+        <Input>
+        {_stringify(inputs)}
+        </Input>
+        <ExpectedOutput>
+        {_stringify(expected_output)}
+        </ExpectedOutput>
+        <Output>
+        {_stringify(output)}
+        </Output>
+        <Rubric>
+        {rubric}
+        </Rubric>
+        """
+    )
+
     return (
         await _judge_input_output_expected_agent.run(
             user_prompt, model=model or _default_model, model_settings=model_settings
@@ -190,7 +227,19 @@ async def judge_output_expected(
     If the model is not specified, a default model is used. The default model starts as 'openai:gpt-4o',
     but this can be changed using the `set_default_judge_model` function.
     """
-    user_prompt = f'<ExpectedOutput>\n{_stringify(expected_output)}\n</ExpectedOutput>\n<Output>\n{_stringify(output)}\n</Output>\n<Rubric>\n{rubric}\n</Rubric>'
+    user_prompt = dedent(
+        f"""
+        <ExpectedOutput>
+        {_stringify(expected_output)}
+        </ExpectedOutput>
+        <Output>
+        {_stringify(output)}
+        </Output>
+        <Rubric>
+        {rubric}
+        </Rubric>
+        """
+    )
     return (
         await _judge_output_expected_agent.run(
             user_prompt, model=model or _default_model, model_settings=model_settings

--- a/tests/evals/test_evaluator_common.py
+++ b/tests/evals/test_evaluator_common.py
@@ -208,11 +208,17 @@ async def test_llm_judge_evaluator(mocker: MockerFixture):
     mock_judge_input_output = mocker.patch('pydantic_evals.evaluators.llm_as_a_judge.judge_input_output')
     mock_judge_input_output.return_value = mock_grading_output
 
+    # Mock the judge_input_output_expected function
+    mock_judge_input_output_expected = mocker.patch(
+        'pydantic_evals.evaluators.llm_as_a_judge.judge_input_output_expected'
+    )
+    mock_judge_input_output_expected.return_value = mock_grading_output
+
     ctx = EvaluatorContext(
         name='test',
         inputs={'prompt': 'Hello'},
         metadata=None,
-        expected_output=None,
+        expected_output='Hello',
         output='Hello world',
         duration=0.0,
         _span_tree=SpanTreeRecordingError('spans were not recorded'),
@@ -236,6 +242,18 @@ async def test_llm_judge_evaluator(mocker: MockerFixture):
 
     mock_judge_input_output.assert_called_once_with(
         {'prompt': 'Hello'}, 'Hello world', 'Output contains input', 'openai:gpt-4o', None
+    )
+
+    # Test with input and expected output
+    evaluator = LLMJudge(
+        rubric='Output contains input', include_input=True, include_expected_output=True, model='openai:gpt-4o'
+    )
+    assert to_jsonable_python(await evaluator.evaluate(ctx)) == snapshot(
+        {'LLMJudge': {'value': True, 'reason': 'Test passed'}}
+    )
+
+    mock_judge_input_output_expected.assert_called_once_with(
+        {'prompt': 'Hello'}, 'Hello', 'Hello world', 'Output contains input', 'openai:gpt-4o', None
     )
 
     # Test with failing result
@@ -273,13 +291,18 @@ async def test_llm_judge_evaluator_with_model_settings(mocker: MockerFixture):
     mock_judge_input_output = mocker.patch('pydantic_evals.evaluators.llm_as_a_judge.judge_input_output')
     mock_judge_input_output.return_value = mock_grading_output
 
+    mock_judge_input_output_expected = mocker.patch(
+        'pydantic_evals.evaluators.llm_as_a_judge.judge_input_output_expected'
+    )
+    mock_judge_input_output_expected.return_value = mock_grading_output
+
     custom_model_settings = ModelSettings(temperature=0.77)
 
     ctx = EvaluatorContext(
         name='test_custom_settings',
         inputs={'prompt': 'Hello Custom'},
         metadata=None,
-        expected_output=None,
+        expected_output='Hello',
         output='Hello world custom settings',
         duration=0.0,
         _span_tree=SpanTreeRecordingError('spans were not recorded'),
@@ -308,6 +331,26 @@ async def test_llm_judge_evaluator_with_model_settings(mocker: MockerFixture):
     )
     mock_judge_input_output.assert_called_once_with(
         {'prompt': 'Hello Custom'},
+        'Hello world custom settings',
+        'Output contains input with custom settings',
+        'openai:gpt-3.5-turbo',
+        custom_model_settings,
+    )
+
+    # Test with input and expected output, with custom model_settings
+    evaluator_with_input_expected = LLMJudge(
+        rubric='Output contains input with custom settings',
+        include_input=True,
+        include_expected_output=True,
+        model='openai:gpt-3.5-turbo',
+        model_settings=custom_model_settings,
+    )
+    assert to_jsonable_python(await evaluator_with_input_expected.evaluate(ctx)) == snapshot(
+        {'LLMJudge': {'value': True, 'reason': 'Test passed with settings'}}
+    )
+    mock_judge_input_output_expected.assert_called_once_with(
+        {'prompt': 'Hello Custom'},
+        'Hello',
         'Hello world custom settings',
         'Output contains input with custom settings',
         'openai:gpt-3.5-turbo',

--- a/tests/evals/test_evaluator_common.py
+++ b/tests/evals/test_evaluator_common.py
@@ -253,7 +253,7 @@ async def test_llm_judge_evaluator(mocker: MockerFixture):
     )
 
     mock_judge_input_output_expected.assert_called_once_with(
-        {'prompt': 'Hello'}, 'Hello', 'Hello world', 'Output contains input', 'openai:gpt-4o', None
+        {'prompt': 'Hello'}, 'Hello world', 'Hello', 'Output contains input', 'openai:gpt-4o', None
     )
 
     # Test with failing result
@@ -350,8 +350,8 @@ async def test_llm_judge_evaluator_with_model_settings(mocker: MockerFixture):
     )
     mock_judge_input_output_expected.assert_called_once_with(
         {'prompt': 'Hello Custom'},
-        'Hello',
         'Hello world custom settings',
+        'Hello',
         'Output contains input with custom settings',
         'openai:gpt-3.5-turbo',
         custom_model_settings,

--- a/tests/evals/test_evaluator_common.py
+++ b/tests/evals/test_evaluator_common.py
@@ -357,6 +357,14 @@ async def test_llm_judge_evaluator_with_model_settings(mocker: MockerFixture):
         custom_model_settings,
     )
 
+    # Test with expected output without input
+    with pytest.raises(NotImplementedError):
+        LLMJudge(
+            rubric='Output contains input with custom settings',
+            include_input=False,
+            include_expected_output=True,
+        )
+
 
 async def test_python():
     """Test Python evaluator."""

--- a/tests/evals/test_evaluator_common.py
+++ b/tests/evals/test_evaluator_common.py
@@ -214,6 +214,10 @@ async def test_llm_judge_evaluator(mocker: MockerFixture):
     )
     mock_judge_input_output_expected.return_value = mock_grading_output
 
+    # Mock the judge_output_expected function
+    mock_judge_output_expected = mocker.patch('pydantic_evals.evaluators.llm_as_a_judge.judge_output_expected')
+    mock_judge_output_expected.return_value = mock_grading_output
+
     ctx = EvaluatorContext(
         name='test',
         inputs={'prompt': 'Hello'},
@@ -256,6 +260,17 @@ async def test_llm_judge_evaluator(mocker: MockerFixture):
         {'prompt': 'Hello'}, 'Hello world', 'Hello', 'Output contains input', 'openai:gpt-4o', None
     )
 
+    # Test with output and expected output
+    evaluator = LLMJudge(
+        rubric='Output contains input', include_input=False, include_expected_output=True, model='openai:gpt-4o'
+    )
+    assert to_jsonable_python(await evaluator.evaluate(ctx)) == snapshot(
+        {'LLMJudge': {'value': True, 'reason': 'Test passed'}}
+    )
+
+    mock_judge_output_expected.assert_called_once_with(
+        'Hello world', 'Hello', 'Output contains input', 'openai:gpt-4o', None
+    )
     # Test with failing result
     mock_grading_output.score = 0.0
     mock_grading_output.pass_ = False
@@ -295,6 +310,9 @@ async def test_llm_judge_evaluator_with_model_settings(mocker: MockerFixture):
         'pydantic_evals.evaluators.llm_as_a_judge.judge_input_output_expected'
     )
     mock_judge_input_output_expected.return_value = mock_grading_output
+
+    mock_judge_output_expected = mocker.patch('pydantic_evals.evaluators.llm_as_a_judge.judge_output_expected')
+    mock_judge_output_expected.return_value = mock_grading_output
 
     custom_model_settings = ModelSettings(temperature=0.77)
 
@@ -357,13 +375,24 @@ async def test_llm_judge_evaluator_with_model_settings(mocker: MockerFixture):
         custom_model_settings,
     )
 
-    # Test with expected output without input
-    with pytest.raises(NotImplementedError):
-        LLMJudge(
-            rubric='Output contains input with custom settings',
-            include_input=False,
-            include_expected_output=True,
-        )
+    # Test with output and expected output
+    evaluator_with_output_expected = LLMJudge(
+        rubric='Output contains input with custom settings',
+        include_input=False,
+        include_expected_output=True,
+        model='openai:gpt-3.5-turbo',
+        model_settings=custom_model_settings,
+    )
+    assert to_jsonable_python(await evaluator_with_output_expected.evaluate(ctx)) == snapshot(
+        {'LLMJudge': {'value': True, 'reason': 'Test passed with settings'}}
+    )
+    mock_judge_output_expected.assert_called_once_with(
+        'Hello world custom settings',
+        'Hello',
+        'Output contains input with custom settings',
+        'openai:gpt-3.5-turbo',
+        custom_model_settings,
+    )
 
 
 async def test_python():

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -13,6 +13,7 @@ with try_import() as imports_successful:
         judge_input_output,
         judge_input_output_expected,
         judge_output,
+        judge_output_expected,
     )
 
 pytestmark = [pytest.mark.skipif(not imports_successful(), reason='pydantic-evals not installed'), pytest.mark.anyio]
@@ -218,6 +219,61 @@ async def test_judge_input_output_expected_with_model_settings_mock(mocker: Mock
     mock_run.assert_called_once()
     call_args, call_kwargs = mock_run.call_args
     assert '<Input>\nHello settings\n</Input>' in call_args[0]
+    assert '<ExpectedOutput>\nHello\n</ExpectedOutput>' in call_args[0]
+    assert '<Output>\nHello world with settings\n</Output>' in call_args[0]
+    assert '<Rubric>\nOutput contains input with settings\n</Rubric>' in call_args[0]
+    assert call_kwargs['model_settings'] == test_model_settings
+    # Check if 'model' kwarg is passed, its value will be the default model or None
+    assert 'model' in call_kwargs
+
+
+@pytest.mark.anyio
+async def test_judge_output_expected_mock(mocker: MockerFixture):
+    """Test judge_output_expected function with mocked agent."""
+    # Mock the agent run method
+    mock_result = mocker.MagicMock()
+    mock_result.output = GradingOutput(reason='Test passed', pass_=True, score=1.0)
+    mock_run = mocker.patch('pydantic_ai.Agent.run', return_value=mock_result)
+
+    # Test with string output and expected output
+    result = await judge_output_expected('Hello world', 'Hello', 'Output contains input')
+    assert isinstance(result, GradingOutput)
+    assert result.reason == 'Test passed'
+    assert result.pass_ is True
+    assert result.score == 1.0
+
+    # Verify the agent was called with correct prompt
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args[0]
+    assert '<Input>' not in call_args[0]
+    assert '<ExpectedOutput>\nHello\n</ExpectedOutput>' in call_args[0]
+    assert '<Output>\nHello world\n</Output>' in call_args[0]
+    assert '<Rubric>\nOutput contains input\n</Rubric>' in call_args[0]
+
+
+@pytest.mark.anyio
+async def test_judge_output_expected_with_model_settings_mock(mocker: MockerFixture):
+    """Test judge_output_expected function with model_settings and mocked agent."""
+    mock_result = mocker.MagicMock()
+    mock_result.output = GradingOutput(reason='Test passed with settings', pass_=True, score=1.0)
+    mock_run = mocker.patch('pydantic_ai.Agent.run', return_value=mock_result)
+
+    test_model_settings = ModelSettings(temperature=1)
+
+    result = await judge_output_expected(
+        'Hello world with settings',
+        'Hello',
+        'Output contains input with settings',
+        model_settings=test_model_settings,
+    )
+    assert isinstance(result, GradingOutput)
+    assert result.reason == 'Test passed with settings'
+    assert result.pass_ is True
+    assert result.score == 1.0
+
+    mock_run.assert_called_once()
+    call_args, call_kwargs = mock_run.call_args
+    assert '<Input>' not in call_args[0]
     assert '<ExpectedOutput>\nHello\n</ExpectedOutput>' in call_args[0]
     assert '<Output>\nHello world with settings\n</Output>' in call_args[0]
     assert '<Rubric>\nOutput contains input with settings\n</Rubric>' in call_args[0]

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -11,6 +11,7 @@ with try_import() as imports_successful:
         GradingOutput,
         _stringify,  # pyright: ignore[reportPrivateUsage]
         judge_input_output,
+        judge_input_output_expected,
         judge_output,
     )
 
@@ -162,6 +163,62 @@ async def test_judge_input_output_with_model_settings_mock(mocker: MockerFixture
     mock_run.assert_called_once()
     call_args, call_kwargs = mock_run.call_args
     assert '<Input>\nHello settings\n</Input>' in call_args[0]
+    assert '<Output>\nHello world with settings\n</Output>' in call_args[0]
+    assert '<Rubric>\nOutput contains input with settings\n</Rubric>' in call_args[0]
+    assert call_kwargs['model_settings'] == test_model_settings
+    # Check if 'model' kwarg is passed, its value will be the default model or None
+    assert 'model' in call_kwargs
+
+
+@pytest.mark.anyio
+async def test_judge_input_output_expected_mock(mocker: MockerFixture):
+    """Test judge_input_output_expected function with mocked agent."""
+    # Mock the agent run method
+    mock_result = mocker.MagicMock()
+    mock_result.output = GradingOutput(reason='Test passed', pass_=True, score=1.0)
+    mock_run = mocker.patch('pydantic_ai.Agent.run', return_value=mock_result)
+
+    # Test with string input and output
+    result = await judge_input_output_expected('Hello', 'Hello', 'Hello world', 'Output contains input')
+    assert isinstance(result, GradingOutput)
+    assert result.reason == 'Test passed'
+    assert result.pass_ is True
+    assert result.score == 1.0
+
+    # Verify the agent was called with correct prompt
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args[0]
+    assert '<Input>\nHello\n</Input>' in call_args[0]
+    assert '<ExpectedOutput>\nHello\n</ExpectedOutput>' in call_args[0]
+    assert '<Output>\nHello world\n</Output>' in call_args[0]
+    assert '<Rubric>\nOutput contains input\n</Rubric>' in call_args[0]
+
+
+@pytest.mark.anyio
+async def test_judge_input_output_expected_with_model_settings_mock(mocker: MockerFixture):
+    """Test judge_input_output_expected function with model_settings and mocked agent."""
+    mock_result = mocker.MagicMock()
+    mock_result.output = GradingOutput(reason='Test passed with settings', pass_=True, score=1.0)
+    mock_run = mocker.patch('pydantic_ai.Agent.run', return_value=mock_result)
+
+    test_model_settings = ModelSettings(temperature=1)
+
+    result = await judge_input_output_expected(
+        'Hello settings',
+        'Hello',
+        'Hello world with settings',
+        'Output contains input with settings',
+        model_settings=test_model_settings,
+    )
+    assert isinstance(result, GradingOutput)
+    assert result.reason == 'Test passed with settings'
+    assert result.pass_ is True
+    assert result.score == 1.0
+
+    mock_run.assert_called_once()
+    call_args, call_kwargs = mock_run.call_args
+    assert '<Input>\nHello settings\n</Input>' in call_args[0]
+    assert '<ExpectedOutput>\nHello\n</ExpectedOutput>' in call_args[0]
     assert '<Output>\nHello world with settings\n</Output>' in call_args[0]
     assert '<Rubric>\nOutput contains input with settings\n</Rubric>' in call_args[0]
     assert call_kwargs['model_settings'] == test_model_settings

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -179,7 +179,7 @@ async def test_judge_input_output_expected_mock(mocker: MockerFixture):
     mock_run = mocker.patch('pydantic_ai.Agent.run', return_value=mock_result)
 
     # Test with string input and output
-    result = await judge_input_output_expected('Hello', 'Hello', 'Hello world', 'Output contains input')
+    result = await judge_input_output_expected('Hello', 'Hello world', 'Hello', 'Output contains input')
     assert isinstance(result, GradingOutput)
     assert result.reason == 'Test passed'
     assert result.pass_ is True
@@ -205,8 +205,8 @@ async def test_judge_input_output_expected_with_model_settings_mock(mocker: Mock
 
     result = await judge_input_output_expected(
         'Hello settings',
-        'Hello',
         'Hello world with settings',
+        'Hello',
         'Output contains input with settings',
         model_settings=test_model_settings,
     )


### PR DESCRIPTION
## Change Summary

Add the option to pass a `ReportCase`'s expected output value to `LLMJudge` during evaluation.

## Related issue number

Fixes #1852. (Apologies for creating the issue right before the PR - I missed the part of `contributing.md` that asked for an issue at first.)

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**