### PR TITLE
Ensure tool call parts with custom argument model validation errors are serializable

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -407,7 +407,7 @@ class OutputTool(Generic[OutputDataT]):
             if wrap_validation_errors:
                 m = _messages.RetryPromptPart(
                     tool_name=tool_call.tool_name,
-                    content=e.errors(include_url=False),
+                    content=e.errors(include_url=False, include_context=False),
                     tool_call_id=tool_call.tool_call_id,
                 )
                 raise ToolRetryError(m) from e

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -392,7 +392,7 @@ class Tool(Generic[AgentDepsT]):
             raise UnexpectedModelBehavior(f'Tool exceeded max retries count of {self.max_retries}') from exc
         else:
             if isinstance(exc, ValidationError):
-                content = exc.errors(include_url=False)
+                content = exc.errors(include_url=False, include_context=False)
             else:
                 content = exc.message
             return _messages.RetryPromptPart(


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic-ai/issues/1859

`pydantic_core.ErrorDetails.ctx["error"]` would have held the `ValueError`, so we exclude context. The error message is already copied onto `ErrorDetails.msg` anyway, as shown in the snapshot.