### PR TITLE
Allowing skipping initialization for HTTP MCP connections

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -83,6 +83,29 @@ Will display as follows:
 
 ![Logfire run python code](../img/logfire-run-python-code.png)
 
+#### Initialization
+
+If you're connecting to an HTTP server that is stateless (one that doesn't require a persistent connection or session), you
+may want to skip sending the initialization request and only send requests as needed. To do this, you can set the
+`skip_initialization` parameter to `True` when instantiating the server.
+
+This allows you to de-couple instantiating your agents with connecting to MCP servers for situations like multi-agent systems or health checks.
+
+```python {title="mcp_http_client_skip_initialization.py" py="3.10"}
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerHTTP
+
+server = MCPServerHTTP(url='http://localhost:3001/mcp', skip_initialization=True)
+agent = Agent('openai:gpt-4o', mcp_servers=[server])
+
+
+async def main():
+    async with agent.run_mcp_servers():  # No call to the MCP server is made here
+        result = await agent.run('What tools do you have access to?') # the first call is made here
+```
+
+
+
 ### MCP "stdio" Server
 
 The other transport offered by MCP is the [stdio transport](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#stdio) where the server is run as a subprocess and communicates with the client over `stdin` and `stdout`. In this case, you'd use the [`MCPServerStdio`][pydantic_ai.mcp.MCPServerStdio] class.

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -91,7 +91,7 @@ may want to skip sending the initialization request and only send requests as ne
 
 This allows you to de-couple instantiating your agents with connecting to MCP servers for situations like multi-agent systems or health checks.
 
-```python {title="mcp_http_client_skip_initialization.py" py="3.10"}
+```python {title="mcp_http_client_skip_initialization.py" test="skip"}
 from pydantic_ai import Agent
 from pydantic_ai.mcp import MCPServerHTTP
 

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -101,7 +101,7 @@ agent = Agent('openai:gpt-4o', mcp_servers=[server])
 
 async def main():
     async with agent.run_mcp_servers():  # No call to the MCP server is made here
-        result = await agent.run('What tools do you have access to?') # the first call is made here
+        await agent.run('What tools do you have access to?') # the first call is made here
 ```
 
 

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -376,7 +376,7 @@ class MCPServerHTTP(MCPServer):
         self,
     ) -> AsyncIterator[
         tuple[MemoryObjectReceiveStream[SessionMessage | Exception], MemoryObjectSendStream[SessionMessage]]
-    ]:  # pragma: no cover
+    ]:
         async with streamablehttp_client(
             url=self.url,
             headers=self.headers,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -215,6 +215,12 @@ async def test_agent_with_prefix_tool_name(openai_api_key: str):
             await agent.run('No conflict')
 
 
+async def test_with_skipped_initialization():
+    server = MCPServerHTTP('no-url', skip_initialization=True)
+    async with server:
+        assert server.is_running  # no error occurs because we haven't made a call yet
+
+
 async def test_agent_with_server_not_running(openai_api_key: str):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
     model = OpenAIModel('gpt-4o', provider=OpenAIProvider(api_key=openai_api_key))


### PR DESCRIPTION
It's useful to be able to skip the initialization request for an MCP server if you're using stateless http and don't need the initial handshake for anything.

We've had this come up in two places:

- Not wanting to require our MCP servers to be running for our Agents API to be running for initial bootup and health checks
- Not wanting the extra requests each time we instantiate an agent in a multi-agent system.

I went with `skip_initialization` instead of `stateless` because I thought it was more intention revealing and helps avoid a coupling between the MCP client and server, but I'm always open to discussion!

resolves #1844 
