### PR TITLE
Add id and finish_reason to OpenTelemetry instrumentation (closes #886)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -243,6 +243,10 @@ class InstrumentedModel(WrapperModel):
                         )
                     )
                 new_attributes: dict[str, AttributeValue] = response.usage.opentelemetry_attributes()  # pyright: ignore[reportAssignmentType]
+                if response.vendor_id is not None:
+                    new_attributes['gen_ai.response.id'] = response.vendor_id
+                if response.vendor_details is not None:
+                    new_attributes['gen_ai.response.finish_reasons'] = json.dumps(response.vendor_details)
                 attributes.update(getattr(span, 'attributes', {}))
                 request_model = attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]
                 new_attributes['gen_ai.response.model'] = response.model_name or request_model

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -81,6 +81,8 @@ class MyModel(Model):
             ],
             usage=Usage(request_tokens=100, response_tokens=200),
             model_name='my_model_123',
+            vendor_id='chatcmpl-123',
+            vendor_details={'stop': True},
         )
 
     @asynccontextmanager
@@ -158,6 +160,8 @@ async def test_instrumented_model(capfire: CaptureLogfire):
                     'logfire.span_type': 'span',
                     'gen_ai.response.model': 'my_model_123',
                     'gen_ai.usage.input_tokens': 100,
+                    'gen_ai.response.id': 'chatcmpl-123',
+                    'gen_ai.response.finish_reasons': '{"stop": true}',
                     'gen_ai.usage.output_tokens': 200,
                 },
             },
@@ -566,6 +570,8 @@ async def test_instrumented_model_attributes_mode(capfire: CaptureLogfire):
                     'logfire.span_type': 'span',
                     'gen_ai.response.model': 'my_model_123',
                     'gen_ai.usage.input_tokens': 100,
+                    'gen_ai.response.id': 'chatcmpl-123',
+                    'gen_ai.response.finish_reasons': '{"stop": true}',
                     'gen_ai.usage.output_tokens': 200,
                     'events': IsJson(
                         snapshot(


### PR DESCRIPTION
This PR addresses [issue #886](https://github.com/pydantic/pydantic-ai/issues/886) by adding support for gen_ai.response.id and gen_ai.response.finish_reasons attributes to the OpenTelemetry instrumented.py implementation, in accordance with the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#genai-attributes).