### PR TITLE
docs: Fix import for BaseModel in graph example code

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -653,7 +653,7 @@ Instead of running the entire graph in a single process invocation, we run the g
 
     from dataclasses import dataclass, field
 
-    from groq import BaseModel
+    from pydantic import BaseModel
     from pydantic_graph import (
         BaseNode,
         End,


### PR DESCRIPTION
Noticed that we were importing `BaseModel` from `groq` in this example - I figured this is an accidental auto-import and we probably want to import `from pydantic` here.