### PR TITLE
Handle include_pending=false for bank_support example

### DIFF
--- a/examples/pydantic_ai_examples/bank_support.py
+++ b/examples/pydantic_ai_examples/bank_support.py
@@ -26,10 +26,14 @@ class DatabaseConn:
 
     @classmethod
     async def customer_balance(cls, *, id: int, include_pending: bool) -> float:
-        if id == 123 and include_pending:
-            return 123.45
+        if id == 123:
+            if include_pending:
+                return 123.45
+            else:
+                return 100.00
         else:
             raise ValueError('Customer not found')
+
 
 
 @dataclass


### PR DESCRIPTION
The bank_support example was breaking whenever the LLM passed include_pending=False. Now customer_balance returns a cleared balance (100.00) for ID 123 instead of raising an error.