### PR TITLE
Stop sharing tool retry count across all runs of the same agent

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -151,10 +151,6 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
         ctx.state.message_history = history
         run_context.messages = history
 
-        # TODO: We need to make it so that function_tools are not shared between runs
-        #   See comment on the current_retry field of `Tool` for more details.
-        for tool in ctx.deps.function_tools.values():
-            tool.current_retry = 0
         return next_message
 
     async def _prepare_messages(

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -215,8 +215,10 @@ class Tool(Generic[AgentDepsT]):
     This schema may be modified by the `prepare` function or by the Model class prior to including it in an API request.
     """
 
-    # TODO: Move this state off the Tool class, which is otherwise stateless.
-    #   This should be tracked inside a specific agent run, not the tool.
+    # TODO: Consider moving this current_retry state to live on something other than the tool.
+    #   We've worked around this for now by copying instances of the tool when creating new runs,
+    #   but this is a bit fragile. Moving the tool retry counts to live on the agent run state would likely clean things
+    #   up, though is also likely a larger effort to refactor.
     current_retry: int = field(default=0, init=False)
 
     def __init__(

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations as _annotations
 
+import asyncio
+import dataclasses
 from datetime import timezone
 from typing import Annotated, Any, Literal
 
 import pytest
 from annotated_types import Ge, Gt, Le, Lt, MaxLen, MinLen
+from anyio import Event
 from inline_snapshot import snapshot
 from pydantic import BaseModel, Field
 
@@ -158,6 +161,36 @@ def test_output_tool_retry_error_handled():
         agent.run_sync('Hello', model=TestModel())
 
     assert call_count == 3
+
+
+@dataclasses.dataclass
+class AgentRunDeps:
+    run_id: int
+
+
+@pytest.mark.anyio
+async def test_multiple_concurrent_tool_retries():
+    class OutputModel(BaseModel):
+        x: int
+        y: str
+
+    agent = Agent('test', deps_type=AgentRunDeps, output_type=OutputModel, retries=2)
+    retried_run_ids = set[int]()
+    event = Event()
+
+    run_ids = list(range(5))  # fire off 5 run ids that will all retry the tool before they finish
+
+    @agent.tool
+    async def tool_that_must_be_retried(ctx: RunContext[AgentRunDeps]) -> None:
+        if ctx.deps.run_id not in retried_run_ids:
+            retried_run_ids.add(ctx.deps.run_id)
+            raise ModelRetry('Fail')
+        if len(retried_run_ids) == len(run_ids):  # pragma: no branch  # won't branch if all runs happen very quickly
+            event.set()
+        await event.wait()  # ensure a retry is done by all runs before any of them finish their flow
+        return None
+
+    await asyncio.gather(*[agent.run('Hello', model=TestModel(), deps=AgentRunDeps(run_id)) for run_id in run_ids])
 
 
 def test_output_tool_retry_error_handled_with_custom_args(set_event_loop: None):

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -93,7 +93,7 @@ params = [
     pytest.param(anthropic, id='anthropic'),
     pytest.param(ollama, id='ollama'),
     pytest.param(mistral, id='mistral'),
-    pytest.param(cohere, id='cohere'),
+    pytest.param(cohere, id='cohere', marks=pytest.mark.skip(reason='Might be causing hangs in CI')),
 ]
 GetModel = Callable[[httpx.AsyncClient, Path], Model]
 


### PR DESCRIPTION
Right now, any concurrent agent runs will have shared current_retry count for a given tool, even if they are completely unrelated runs. This was a known bug for a while and probably should have been fixed sooner, but anyway, here it is.

I'll note that a better fix might be to move the `Tool.retry_count` value to live in a dict on `pydantic_ai._agent_graph.GraphAgentDeps`, so tools would be stateless. I don't have time to do that now, and I'm a bit worried it will make some of the code harder to read/follow, but I think ultimately the end result will be a bit more future-bug-proof.

But I think this should work for now and be functionally equivalent. Still need to add a test though.

If this _doesn't_ actually work, or otherwise it doesn't feel too hard to just refactor to move `self.current_retry` off the tool, maybe we just do that instead, though that change could always be made after merging this... 