### PR TITLE
Add `service_tier` to `OpenAIModelSettings`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -116,6 +116,13 @@ class OpenAIModelSettings(ModelSettings, total=False):
     See [OpenAI's safety best practices](https://platform.openai.com/docs/guides/safety-best-practices#end-user-ids) for more details.
     """
 
+    openai_service_tier: Literal['auto', 'default', 'flex']
+    """The service tier to use for the model request.
+
+    Currently supported values are `auto`, `default`, and `flex`.
+    For more information, see [OpenAI's service tiers documentation](https://platform.openai.com/docs/api-reference/chat/object#chat/object-service_tier).
+    """
+
 
 class OpenAIResponsesModelSettings(OpenAIModelSettings, total=False):
     """Settings used for an OpenAI Responses model request.
@@ -298,6 +305,7 @@ class OpenAIModel(Model):
                 logprobs=model_settings.get('openai_logprobs', NOT_GIVEN),
                 top_logprobs=model_settings.get('openai_top_logprobs', NOT_GIVEN),
                 user=model_settings.get('openai_user', NOT_GIVEN),
+                service_tier=model_settings.get('openai_service_tier', NOT_GIVEN),
                 extra_headers=extra_headers,
                 extra_body=model_settings.get('extra_body'),
             )


### PR DESCRIPTION
This pull request introduces support for specifying the OpenAI service tier in model requests. The changes include adding a new field to the `OpenAIModelSettings` class and updating the `_completions_create` method to utilize this field.

Enhancements to OpenAI model settings:

* [`pydantic_ai_slim/pydantic_ai/models/openai.py`](diffhunk://#diff-b1c6daf2aed6a2c661aefda51026b68403994823f2d401706e2ebe99b48b75fbR119-R125): Added the `openai_service_tier` field to the `OpenAIModelSettings` class to allow specifying the service tier for model requests. Supported values are `auto`, `default`, and `flex`.

Integration of service tier in request handling:

* [`pydantic_ai_slim/pydantic_ai/models/openai.py`](diffhunk://#diff-b1c6daf2aed6a2c661aefda51026b68403994823f2d401706e2ebe99b48b75fbR308): Updated the `_completions_create` method to include the `service_tier` parameter, enabling the use of the newly added `openai_service_tier` field in model settings.