### PR TITLE
Prevent Anthropic API errors from empty message content

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -283,7 +283,7 @@ class AnthropicModel(Model):
             tools += [self._map_tool_definition(r) for r in model_request_parameters.output_tools]
         return tools
 
-    async def _map_message(self, messages: list[ModelMessage]) -> tuple[str, list[BetaMessageParam]]:
+    async def _map_message(self, messages: list[ModelMessage]) -> tuple[str, list[BetaMessageParam]]:  # noqa: C901
         """Just maps a `pydantic_ai.Message` to a `anthropic.types.MessageParam`."""
         system_prompt_parts: list[str] = []
         anthropic_messages: list[BetaMessageParam] = []

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -322,7 +322,8 @@ class AnthropicModel(Model):
                 assistant_content_params: list[BetaTextBlockParam | BetaToolUseBlockParam] = []
                 for response_part in m.parts:
                     if isinstance(response_part, TextPart):
-                        assistant_content_params.append(BetaTextBlockParam(text=response_part.content, type='text'))
+                        if response_part.content:  # Only add non-empty text
+                            assistant_content_params.append(BetaTextBlockParam(text=response_part.content, type='text'))
                     else:
                         tool_use_block_param = BetaToolUseBlockParam(
                             id=_guard_tool_call_id(t=response_part),
@@ -331,7 +332,8 @@ class AnthropicModel(Model):
                             input=response_part.args_as_dict(),
                         )
                         assistant_content_params.append(tool_use_block_param)
-                anthropic_messages.append(BetaMessageParam(role='assistant', content=assistant_content_params))
+                if len(assistant_content_params) > 0:
+                    anthropic_messages.append(BetaMessageParam(role='assistant', content=assistant_content_params))
             else:
                 assert_never(m)
         system_prompt = '\n\n'.join(system_prompt_parts)
@@ -344,11 +346,13 @@ class AnthropicModel(Model):
         part: UserPromptPart,
     ) -> AsyncGenerator[BetaContentBlockParam]:
         if isinstance(part.content, str):
-            yield BetaTextBlockParam(text=part.content, type='text')
+            if part.content:  # Only yield non-empty text
+                yield BetaTextBlockParam(text=part.content, type='text')
         else:
             for item in part.content:
                 if isinstance(item, str):
-                    yield BetaTextBlockParam(text=item, type='text')
+                    if item:  # Only yield non-empty text
+                        yield BetaTextBlockParam(text=item, type='text')
                 elif isinstance(item, BinaryContent):
                     if item.is_image:
                         yield BetaImageBlockParam(

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -1105,8 +1105,7 @@ async def test_anthropic_empty_content_filtering(env: TestEnv):
     ]
     _, anthropic_messages = await model._map_message(messages)  # type: ignore[attr-defined]
     # The empty assistant message should be filtered out
-    assert len(anthropic_messages) == 1
-    assert anthropic_messages[0]['role'] == 'user'
+    assert anthropic_messages == snapshot([{'role': 'user', 'content': [{'text': 'Hello', 'type': 'text'}]}])
 
     # Test with only empty assistant parts
     messages_resp: list[ModelMessage] = [


### PR DESCRIPTION
- Check for empty text content before adding to assistant messages
- Only append messages with non-empty content to avoid API errors
- Filter empty strings in user prompts before yielding text blocks

This fixes the invalid_request_error: "all messages must have non-empty content except for the optional final assistant message"

🤖 Generated with [Claude Code](https://claude.ai/code)