### PR TITLE
Expose metadata headers for tool calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, Union, cast
 from opentelemetry.trace import Tracer
 from typing_extensions import TypeGuard, TypeVar, assert_never
 
+from mcp.shared.message import MessageMetadata
+from mcp.types import RequestParams
 from pydantic_graph import BaseNode, Graph, GraphRunContext
 from pydantic_graph.nodes import End, NodeRunEndT
 
@@ -100,6 +102,10 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     tracer: Tracer
 
     prepare_tools: ToolsPrepareFunc[DepsT] | None = None
+
+    # Extra metadata headers to pass to MCP tool calls
+    metadata: MessageMetadata = None
+    request_meta: RequestParams.Meta | None = None
 
 
 class AgentNode(BaseNode[GraphAgentState, GraphAgentDeps[DepsT, Any], result.FinalResult[NodeRunEndT]]):
@@ -739,13 +745,19 @@ async def _tool_from_mcp_server(
     Returns:
         The tool with the given name, or `None` if no tool with the given name is found.
     """
+    deps: GraphAgentDeps[DepsT, NodeRunEndT] = ctx.deps
 
     async def run_tool(ctx: RunContext[DepsT], **args: Any) -> Any:
         # There's no normal situation where the server will not be running at this point, we check just in case
         # some weird edge case occurs.
         if not server.is_running:  # pragma: no cover
             raise exceptions.UserError(f'MCP server is not running: {server}')
-        result = await server.call_tool(tool_name, args)
+        result = await server.call_tool(
+            tool_name=tool_name,
+            arguments=args,
+            metadata=deps.metadata,
+            _meta=deps.request_meta,
+        )
         return result
 
     for server in ctx.deps.mcp_servers:

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -14,6 +14,8 @@ from opentelemetry.trace import NoOpTracer, use_span
 from pydantic.json_schema import GenerateJsonSchema
 from typing_extensions import Literal, Never, Self, TypeIs, TypeVar, deprecated
 
+from mcp.shared.message import MessageMetadata
+from mcp.types import RequestParams
 from pydantic_graph import End, Graph, GraphRun, GraphRunContext
 from pydantic_graph._utils import get_event_loop
 
@@ -532,6 +534,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         usage_limits: _usage.UsageLimits | None = None,
         usage: _usage.Usage | None = None,
         infer_name: bool = True,
+        metadata: MessageMetadata | None = None,
+        request_meta: RequestParams.Meta | None = None,
         **_deprecated_kwargs: Never,
     ) -> AsyncIterator[AgentRun[AgentDepsT, Any]]:
         """A contextmanager which can be used to iterate over the agent graph's nodes as they are executed.
@@ -606,6 +610,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             usage_limits: Optional limits on model request count or token usage.
             usage: Optional usage to start with, useful for resuming a conversation or agents used in tools.
             infer_name: Whether to try to infer the agent name from the call frame if it's not set.
+            metadata: Extra metadata headers to pass to MCP tool calls
+            request_meta: Extra request metadata to pass to MCP tool calls
 
         Returns:
             The result of the run.
@@ -695,6 +701,8 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             tracer=tracer,
             prepare_tools=self._prepare_tools,
             get_instructions=get_instructions,
+            metadata=metadata,
+            request_meta=request_meta,
         )
         start_node = _agent_graph.UserPromptNode[AgentDepsT](
             user_prompt=user_prompt,


### PR DESCRIPTION
Goal here is to make it so we can forward request-specific metadata from a pydantic-ai Agent to pass through user ID and push that upstream. For now I've exposed two different metadata paths to try, and we need to pipe through more to our agent.