### PR TITLE
Function output have normal tool name without `final_result_` prefix

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -211,9 +211,13 @@ class OutputSchema(Generic[OutputDataT]):
                 tool_output_type = output_type
 
             if tool_name is None:
-                tool_name = default_tool_name
-                if multiple:
-                    tool_name += f'_{tool_output_type.__name__}'
+                tool_name = (
+                    tool_output_type.__name__
+                    if inspect.isfunction(tool_output_type)
+                    else f'{default_tool_name}_{tool_output_type.__name__}'
+                    if multiple
+                    else default_tool_name
+                )
 
             i = 1
             original_tool_name = tool_name


### PR DESCRIPTION
Following #1785 , I want the function output behave with the same name as normal tools, i.e. `hand_off_to_maths_agent` instead of `final_result_hand_off_to_maths_agent`.