### PR TITLE
Ignore dynamic instructions returning an empty string

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -701,7 +701,7 @@ _(This example is complete, it can be run "as is")_
 
 You can also dynamically change the instructions for an agent by using the `@agent.instructions` decorator.
 
-Returning an empty string will result in no instruction message added.
+Note that returning an empty string will result in no instruction message added.
 
 ```python {title="dynamic_instructions.py"}
 from datetime import date

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -701,6 +701,8 @@ _(This example is complete, it can be run "as is")_
 
 You can also dynamically change the instructions for an agent by using the `@agent.instructions` decorator.
 
+Returning an empty string will result in no instruction message added.
+
 ```python {title="dynamic_instructions.py"}
 from datetime import date
 

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -677,7 +677,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             instructions = [self._instructions] if self._instructions else []
             for instructions_runner in self._instructions_functions:
                 instructions.append(await instructions_runner.run(run_context))
-            concatenated_instructions = '/n'.join(instruction for instruction in instructions if instruction)
+            concatenated_instructions = '\n'.join(instruction for instruction in instructions if instruction)
             return concatenated_instructions.strip() if concatenated_instructions else None
 
         graph_deps = _agent_graph.GraphAgentDeps[AgentDepsT, RunOutputDataT](

--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -674,10 +674,11 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             if self._instructions is None and not self._instructions_functions:
                 return None
 
-            instructions = self._instructions or ''
+            instructions = [self._instructions] if self._instructions else []
             for instructions_runner in self._instructions_functions:
-                instructions += '\n' + await instructions_runner.run(run_context)
-            return instructions.strip()
+                instructions.append(await instructions_runner.run(run_context))
+            concatenated_instructions = '/n'.join(instruction for instruction in instructions if instruction)
+            return concatenated_instructions.strip() if concatenated_instructions else None
 
         graph_deps = _agent_graph.GraphAgentDeps[AgentDepsT, RunOutputDataT](
             user_deps=deps,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2392,6 +2392,10 @@ def test_instructions_raise_error_when_instructions_is_set():
     def instructions() -> str:
         return 'An instructions!'
 
+    @agent.instructions
+    def empty_instructions() -> str:
+        return ''
+
     result = agent.run_sync('Hello')
     assert result.all_messages()[0] == snapshot(
         ModelRequest(
@@ -2479,7 +2483,10 @@ def test_instructions_parameter_with_sequence():
     def instructions() -> str:
         return 'You are a potato.'
 
-    agent = Agent('test', instructions=('You are a helpful assistant.', instructions))
+    def empty_instructions() -> str:
+        return ''
+
+    agent = Agent('test', instructions=('You are a helpful assistant.', empty_instructions, instructions))
     result = agent.run_sync('Hello')
     assert result.all_messages()[0] == snapshot(
         ModelRequest(


### PR DESCRIPTION
This PR is follow up of https://github.com/pydantic/pydantic-ai/pull/864

For dynamic system prompts we have a minor problem: when they return an empty value an empty useless message is added.

Now with the instructions https://ai.pydantic.dev/agents/#instructions we can build dynamic system prompts where:

- All different instructions are merged in a single system message
- If the result of dynamic instructions is empty, no message is added (any model has this logic in its messages building methods)

Given system prompts will be deprecated and instructions practically solve the problem discussed in https://github.com/pydantic/pydantic-ai/pull/864, with this PR I am only slightly improving the code and adding an explicit indications in the docs about what empty instructions do.

In my opinion we do not need an explicit typing with None as a possible return value at the moment. Dynamic instructions share the same typing abstractions with dynamic system prompts, changing them would bring the issues discussed in the previous PR.