### PR TITLE
Add `process_tool_call` hook to MCP servers to modify tool args, metadata, and return value

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 from types import FrameType
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, cast, final, overload
 
-from mcp.types import RequestParams
 from opentelemetry.trace import NoOpTracer, use_span
 from pydantic.json_schema import GenerateJsonSchema
 from typing_extensions import Literal, Never, Self, TypeIs, TypeVar, deprecated
@@ -485,7 +484,6 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         usage_limits: _usage.UsageLimits | None = None,
         usage: _usage.Usage | None = None,
         infer_name: bool = True,
-        request_meta: RequestParams.Meta | None = None,
         **_deprecated_kwargs: Never,
     ) -> AbstractAsyncContextManager[AgentRun[AgentDepsT, OutputDataT]]: ...
 
@@ -502,7 +500,6 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         usage_limits: _usage.UsageLimits | None = None,
         usage: _usage.Usage | None = None,
         infer_name: bool = True,
-        request_meta: RequestParams.Meta | None = None,
         **_deprecated_kwargs: Never,
     ) -> AbstractAsyncContextManager[AgentRun[AgentDepsT, RunOutputDataT]]: ...
 
@@ -520,7 +517,6 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         usage_limits: _usage.UsageLimits | None = None,
         usage: _usage.Usage | None = None,
         infer_name: bool = True,
-        request_meta: RequestParams.Meta | None = None,
     ) -> AbstractAsyncContextManager[AgentRun[AgentDepsT, Any]]: ...
 
     @asynccontextmanager
@@ -536,7 +532,6 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
         usage_limits: _usage.UsageLimits | None = None,
         usage: _usage.Usage | None = None,
         infer_name: bool = True,
-        request_meta: RequestParams.Meta | None = None,
         **_deprecated_kwargs: Never,
     ) -> AsyncIterator[AgentRun[AgentDepsT, Any]]:
         """A contextmanager which can be used to iterate over the agent graph's nodes as they are executed.
@@ -611,7 +606,6 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             usage_limits: Optional limits on model request count or token usage.
             usage: Optional usage to start with, useful for resuming a conversation or agents used in tools.
             infer_name: Whether to try to infer the agent name from the call frame if it's not set.
-            request_meta: Extra request metadata to pass to MCP tool calls
 
         Returns:
             The result of the run.
@@ -701,7 +695,6 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
             tracer=tracer,
             prepare_tools=self._prepare_tools,
             get_instructions=get_instructions,
-            request_meta=request_meta,
         )
         start_node = _agent_graph.UserPromptNode[AgentDepsT](
             user_prompt=user_prompt,

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -4,7 +4,7 @@ import base64
 import functools
 import json
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Awaitable, Sequence
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -35,7 +35,7 @@ from typing_extensions import Self, assert_never, deprecated
 
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import BinaryContent
-from pydantic_ai.tools import ToolDefinition
+from pydantic_ai.tools import RunContext, ToolDefinition
 
 try:
     from mcp.client.session import ClientSession
@@ -64,6 +64,9 @@ class MCPServer(ABC):
 
     e.g. if `tool_prefix='foo'`, then a tool named `bar` will be registered as `foo_bar`
     """
+
+    process_tool_call: ProcessToolCallback | None = None
+    """ Hook to customize tool calling and optionally pass extra metadata."""
 
     _client: ClientSession
     _read_stream: MemoryObjectReceiveStream[SessionMessage | Exception]
@@ -121,14 +124,14 @@ class MCPServer(ABC):
         self,
         tool_name: str,
         arguments: dict[str, Any],
-        _meta: RequestParams.Meta | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> str | BinaryContent | dict[str, Any] | list[Any] | Sequence[str | BinaryContent | dict[str, Any] | list[Any]]:
         """Call a tool on the server.
 
         Args:
             tool_name: The name of the tool to call.
             arguments: The arguments to pass to the tool.
-            _meta: Request-level metadata (optional)
+            metadata: Request-level metadata (optional)
 
         Returns:
             The result of the tool call.
@@ -144,7 +147,7 @@ class MCPServer(ABC):
                 params=CallToolRequestParams(
                     name=unprefixed_tool_name,
                     arguments=arguments,
-                    _meta=_meta,
+                    _meta=RequestParams.Meta(**metadata) if metadata else None,
                 ),
             )
         )
@@ -292,6 +295,9 @@ class MCPServerStdio(MCPServer):
     e.g. if `tool_prefix='foo'`, then a tool named `bar` will be registered as `foo_bar`
     """
 
+    process_tool_call: ProcessToolCallback | None = None
+    """ Hook to customize tool calling and optionally pass extra metadata."""
+
     timeout: float = 5
     """ The timeout in seconds to wait for the client to initialize."""
 
@@ -385,6 +391,9 @@ class _MCPServerHTTP(MCPServer):
 
     For example, if `tool_prefix='foo'`, then a tool named `bar` will be registered as `foo_bar`
     """
+
+    process_tool_call: ProcessToolCallback | None = None
+    """ Hook to customize tool calling and optionally pass extra metadata."""
 
     @property
     @abstractmethod
@@ -544,3 +553,17 @@ class MCPServerStreamableHTTP(_MCPServerHTTP):
     @property
     def _transport_client(self):
         return streamablehttp_client  # pragma: no cover
+
+
+# Callback that accepts a run context, a tool call function, a tool name, and arguments.
+# Allows wrapping an MCP server tool call to customize it, including adding extra request
+# metadata.
+ProcessToolCallback = Callable[
+    [
+        RunContext[Any],
+        Callable[[str, dict[str, Any], dict[str, Any] | None], Awaitable[CallToolResult]],
+        str,
+        dict[str, Any],
+    ],
+    Awaitable[CallToolResult],
+]


### PR DESCRIPTION
The goal here is to allow a persistent Agent to be used within a multi-user app where user-specific metadata/auth should get passed through to the MCP server in a way not visible to an LLM.

To do this, we use the _meta field of the request. See this discussion, method `2. Use the JSON‑RPC _meta field`
https://github.com/orgs/modelcontextprotocol/discussions/309

In our app we directly call `agent.iter` and have verified that this works to then in a FastMCP server tool we can call `ctx.request_context.meta` to access the contents.

Fixes https://github.com/pydantic/pydantic-ai/issues/1872