### PR TITLE
Handle `McpError` from MCP tool calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -15,6 +15,7 @@ import anyio
 import httpx
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp.client.streamable_http import GetSessionIdCallback, streamablehttp_client
+from mcp.shared.exceptions import McpError
 from mcp.shared.message import SessionMessage
 from mcp.types import (
     AudioContent,
@@ -127,7 +128,10 @@ class MCPServer(ABC):
         Raises:
             ModelRetry: If the tool call fails.
         """
-        result = await self._client.call_tool(self.get_unprefixed_tool_name(tool_name), arguments)
+        try:
+            result = await self._client.call_tool(self.get_unprefixed_tool_name(tool_name), arguments)
+        except McpError as e:
+            raise ModelRetry(e.error.message)
 
         content = [self._map_tool_result_part(part) for part in result.content]
 


### PR DESCRIPTION
### ✨  Summary
Fixes [#1989](https://github.com/pydantic/pydantic-ai/issues/1989) – runtime errors raised by the MCP backend now surface as ModelRetry, allowing the caller’s retry logic to work correctly.

Additional improvements bundled into the same patch:
	1.	Export hygiene – replace the accidental string‐literal __all__ with a tuple so IDEs and static analysers discover the five public server classes.
	2.	Type-annotation & formatting clean-ups – wrap long generics/context-manager signatures to the Black default line length for readability.