### PR TITLE
Scrubbing sensitive content

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -305,3 +305,15 @@ agent = Agent('gpt-4o', instrument=instrumentation_settings)
 # or to instrument all agents:
 Agent.instrument_all(instrumentation_settings)
 ```
+
+### Excluding sensitive content
+
+```python {title="exluding_sensitive_content.py"}
+from pydantic_ai.agent import Agent, InstrumentationSettings
+
+instrumentation_settings = InstrumentationSettings(include_sensitive_content=False)
+
+agent = Agent('gpt-4o', instrument=instrumentation_settings)
+# or to instrument all agents:
+Agent.instrument_all(instrumentation_settings)
+```

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -356,7 +356,7 @@ class UserPromptPart:
 
     def otel_event(self, settings: InstrumentationSettings) -> Event:
         if not settings.include_sensitive_content:
-            return Event('gen_ai.user.message', body={'content': 'SCRUBBED', 'role': 'user'})  # Redacting the content
+            return Event('gen_ai.user.message', body={'content': 'SCRUBBED', 'role': 'user'})
         content: str | list[dict[str, Any] | str]
         if isinstance(self.content, str):
             content = self.content

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -92,6 +92,7 @@ class InstrumentationSettings:
         meter_provider: MeterProvider | None = None,
         event_logger_provider: EventLoggerProvider | None = None,
         include_binary_content: bool = True,
+        include_sensitive_content: bool = True,
     ):
         """Create instrumentation options.
 
@@ -109,6 +110,7 @@ class InstrumentationSettings:
                 Calling `logfire.configure()` sets the global event logger provider, so most users don't need this.
                 This is only used if `event_mode='logs'`.
             include_binary_content: Whether to include binary content in the instrumentation events.
+            include_sensitive_content: Whether to include prompt and completion messages in the instrumentation events.
         """
         from pydantic_ai import __version__
 
@@ -121,6 +123,7 @@ class InstrumentationSettings:
         self.event_logger = event_logger_provider.get_event_logger(scope_name, __version__)
         self.event_mode = event_mode
         self.include_binary_content = include_binary_content
+        self.include_sensitive_content = include_sensitive_content
 
         # As specified in the OpenTelemetry GenAI metrics spec:
         # https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage
@@ -161,7 +164,7 @@ class InstrumentationSettings:
                     if hasattr(part, 'otel_event'):
                         message_events.append(part.otel_event(self))
             elif isinstance(message, ModelResponse):  # pragma: no branch
-                message_events = message.otel_events()
+                message_events = message.otel_events(self)
             for event in message_events:
                 event.attributes = {
                     'gen_ai.message.index': message_index,

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -835,6 +835,8 @@ def test_messages_to_otel_events_without_prompts_and_completions():
         ModelResponse(parts=[TextPart('text1')]),
         ModelRequest(parts=[UserPromptPart('user_prompt')]),
         ModelResponse(parts=[TextPart('text2')]),
+        ModelRequest(parts=[ToolReturnPart('tool', 'tool_return_content', 'tool_call_1')]),
+        ModelRequest(parts=[RetryPromptPart('retry_prompt', tool_name='tool', tool_call_id='tool_call_2')]),
     ]
     settings = InstrumentationSettings(include_sensitive_content=False)
     assert [InstrumentedModel.event_to_dict(e) for e in settings.messages_to_otel_events(messages)] == snapshot(
@@ -862,6 +864,22 @@ def test_messages_to_otel_events_without_prompts_and_completions():
                 'role': 'assistant',
                 'gen_ai.message.index': 3,
                 'event.name': 'gen_ai.assistant.message',
+            },
+            {
+                'content': 'SCRUBBED',
+                'role': 'tool',
+                'id': 'tool_call_1',
+                'name': 'tool',
+                'gen_ai.message.index': 4,
+                'event.name': 'gen_ai.tool.message',
+            },
+            {
+                'content': 'SCRUBBED',
+                'role': 'tool',
+                'id': 'tool_call_2',
+                'name': 'tool',
+                'gen_ai.message.index': 5,
+                'event.name': 'gen_ai.tool.message',
             },
         ]
     )

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -827,3 +827,41 @@ def test_messages_to_otel_events_without_binary_content(document_content: Binary
             }
         ]
     )
+
+
+def test_messages_to_otel_events_without_prompts_and_completions():
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[SystemPromptPart('system_prompt')]),
+        ModelResponse(parts=[TextPart('text1')]),
+        ModelRequest(parts=[UserPromptPart('user_prompt')]),
+        ModelResponse(parts=[TextPart('text2')]),
+    ]
+    settings = InstrumentationSettings(include_sensitive_content=False)
+    assert [InstrumentedModel.event_to_dict(e) for e in settings.messages_to_otel_events(messages)] == snapshot(
+        [
+            {
+                'content': 'SCRUBBED',
+                'role': 'system',
+                'gen_ai.message.index': 0,
+                'event.name': 'gen_ai.system.message',
+            },
+            {
+                'content': 'SCRUBBED',
+                'role': 'assistant',
+                'gen_ai.message.index': 1,
+                'event.name': 'gen_ai.assistant.message',
+            },
+            {
+                'content': 'SCRUBBED',
+                'role': 'user',
+                'gen_ai.message.index': 2,
+                'event.name': 'gen_ai.user.message',
+            },
+            {
+                'content': 'SCRUBBED',
+                'role': 'assistant',
+                'gen_ai.message.index': 3,
+                'event.name': 'gen_ai.assistant.message',
+            },
+        ]
+    )


### PR DESCRIPTION
Fixes #1571

## Adds include_sensitive_content flag in InstrumentationSettings, default set to True

### Adds guard clauses to SCRUB out the content but keeps the event
### Adds example in logfire docs

