### PR TITLE
feat: include missing fields in usage details

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1062,7 +1062,13 @@ def _map_usage(response: chat.ChatCompletion | ChatCompletionChunk | responses.R
     if response_usage is None:
         return usage.Usage()
     elif isinstance(response_usage, responses.ResponseUsage):
-        details: dict[str, int] = {}
+        details: dict[str, int] = {
+            key: value
+            for key, value in response_usage.model_dump(
+                exclude={'input_tokens', 'output_tokens', 'total_tokens'}
+            ).items()
+            if isinstance(value, int)
+        }
         return usage.Usage(
             request_tokens=response_usage.input_tokens,
             response_tokens=response_usage.output_tokens,
@@ -1073,7 +1079,13 @@ def _map_usage(response: chat.ChatCompletion | ChatCompletionChunk | responses.R
             },
         )
     else:
-        details = {}
+        details = {
+            key: value
+            for key, value in response_usage.model_dump(
+                exclude={'prompt_tokens', 'completion_tokens', 'total_tokens'}
+            ).items()
+            if isinstance(value, int)
+        }
         if response_usage.completion_tokens_details is not None:
             details.update(response_usage.completion_tokens_details.model_dump(exclude_none=True))
         if response_usage.prompt_tokens_details is not None:

--- a/tests/models/test_deepseek.py
+++ b/tests/models/test_deepseek.py
@@ -35,7 +35,12 @@ async def test_deepseek_model_thinking_part(allow_model_requests: None, deepseek
                     request_tokens=12,
                     response_tokens=789,
                     total_tokens=801,
-                    details={'reasoning_tokens': 415, 'cached_tokens': 0},
+                    details={
+                        'prompt_cache_hit_tokens': 0,
+                        'prompt_cache_miss_tokens': 12,
+                        'reasoning_tokens': 415,
+                        'cached_tokens': 0,
+                    },
                 ),
                 model_name='deepseek-reasoner',
                 timestamp=IsDatetime(),


### PR DESCRIPTION
When I was using the litellm proxy api, I found that the usgae for the openai model did not contain all the fields.

As you can also see from the testcase modification, I would like us to be able to get other fields that are not in the standard fields (such as vendor-defined cache reads and writes) via usage.detials