### PR TITLE
feat: add '/cp' command to copy last response to clipboard 

### DIFF
--- a/clai/README.md
+++ b/clai/README.md
@@ -49,6 +49,7 @@ Either way, running `clai` will start an interactive session where you can chat 
 - `/exit`: Exit the session
 - `/markdown`: Show the last response in markdown format
 - `/multiline`: Toggle multiline input mode (use Ctrl+D to submit)
+- `/cp`: Copy the last response to clipboard
 
 ## Help
 
@@ -61,6 +62,7 @@ Special prompts:
 * `/exit` - exit the interactive mode (ctrl-c and ctrl-d also work)
 * `/markdown` - show the last markdown output of the last question
 * `/multiline` - toggle multiline mode
+* `/cp` - copy the last response to clipboard
 
 positional arguments:
   prompt                AI Prompt, if omitted fall into interactive mode

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,6 +46,7 @@ Either way, running `clai` will start an interactive session where you can chat 
 - `/exit`: Exit the session
 - `/markdown`: Show the last response in markdown format
 - `/multiline`: Toggle multiline input mode (use Ctrl+D to submit)
+- `/cp`: Copy the last response to clipboard
 
 ### Help
 

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -73,7 +73,7 @@ bedrock = ["boto3>=1.37.24"]
 duckduckgo = ["duckduckgo-search>=7.0.0"]
 tavily = ["tavily-python>=0.5.0"]
 # CLI
-cli = ["rich>=13", "prompt-toolkit>=3", "argcomplete>=3.5.0"]
+cli = ["rich>=13", "prompt-toolkit>=3", "argcomplete>=3.5.0", "pyperclip>=1.9.0"]
 # MCP
 mcp = ["mcp>=1.9.4; python_version >= '3.10'"]
 # Evals

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,10 +162,17 @@ def test_cli_prompt(capfd: CaptureFixture[str], env: TestEnv):
 
 def test_chat(capfd: CaptureFixture[str], mocker: MockerFixture, env: TestEnv):
     env.set('OPENAI_API_KEY', 'test')
+
+    # mocking is needed because of ci does not have xclip or xselect installed
+    def mock_copy(text: str) -> None:
+        pass
+
+    mocker.patch('pyperclip.copy', mock_copy)
     with create_pipe_input() as inp:
         inp.send_text('\n')
         inp.send_text('hello\n')
         inp.send_text('/markdown\n')
+        inp.send_text('/cp\n')
         inp.send_text('/exit\n')
         session = PromptSession[Any](input=inp, output=DummyOutput())
         m = mocker.patch('pydantic_ai._cli.PromptSession', return_value=session)
@@ -179,6 +186,7 @@ def test_chat(capfd: CaptureFixture[str], mocker: MockerFixture, env: TestEnv):
                 IsStr(regex='goodbye *Markdown output of last question:'),
                 '',
                 'goodbye',
+                'Copied last output to clipboard.',
                 'Exiting…',
             ]
         )
@@ -207,6 +215,33 @@ def test_handle_slash_command_multiline():
     io = StringIO()
     assert handle_slash_command('/multiline', [], True, Console(file=io), 'default') == (None, False)
     assert io.getvalue() == snapshot('Disabling multiline mode.\n')
+
+
+def test_handle_slash_command_copy(mocker: MockerFixture):
+    io = StringIO()
+    # mocking is needed because of ci does not have xclip or xselect installed
+    mock_clipboard: list[str] = []
+
+    def append_to_clipboard(text: str) -> None:
+        mock_clipboard.append(text)
+
+    mocker.patch('pyperclip.copy', append_to_clipboard)
+    assert handle_slash_command('/cp', [], False, Console(file=io), 'default') == (None, False)
+    assert io.getvalue() == snapshot('No output available to copy.\n')
+    assert len(mock_clipboard) == 0
+
+    messages: list[ModelMessage] = [ModelResponse(parts=[TextPart(''), ToolCallPart('foo', '{}')])]
+    io = StringIO()
+    assert handle_slash_command('/cp', messages, True, Console(file=io), 'default') == (None, True)
+    assert io.getvalue() == snapshot('No text content to copy.\n')
+    assert len(mock_clipboard) == 0
+
+    messages: list[ModelMessage] = [ModelResponse(parts=[TextPart('hello'), ToolCallPart('foo', '{}')])]
+    io = StringIO()
+    assert handle_slash_command('/cp', messages, True, Console(file=io), 'default') == (None, True)
+    assert io.getvalue() == snapshot('Copied last output to clipboard.\n')
+    assert len(mock_clipboard) == 1
+    assert mock_clipboard[0] == snapshot('hello')
 
 
 def test_handle_slash_command_exit():

--- a/uv.lock
+++ b/uv.lock
@@ -3012,6 +3012,7 @@ bedrock = [
 cli = [
     { name = "argcomplete" },
     { name = "prompt-toolkit" },
+    { name = "pyperclip" },
     { name = "rich" },
 ]
 cohere = [
@@ -3093,6 +3094,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-evals", marker = "extra == 'evals'", editable = "pydantic_evals" },
     { name = "pydantic-graph", editable = "pydantic_graph" },
+    { name = "pyperclip", marker = "extra == 'cli'", specifier = ">=1.9.0" },
     { name = "requests", marker = "extra == 'vertexai'", specifier = ">=2.32.2" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13" },
     { name = "tavily-python", marker = "extra == 'tavily'", specifier = ">=0.5.0" },
@@ -3308,6 +3310,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/7c/44/e6de2fdc880ad0ec7
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/f5/b9e2a42aa8f9e34d52d66de87941ecd236570c7ed2e87775ed23bbe4e224/pymdown_extensions-10.14.3-py3-none-any.whl", hash = "sha256:05e0bee73d64b9c71a4ae17c72abc2f700e8bc8403755a00580b49a4e9f189e9", size = 264467, upload-time = "2025-02-01T15:43:13.995Z" },
 ]
+
+[[package]]
+name = "pyperclip"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/23/2f0a3efc4d6a32f3b63cdff36cd398d9701d26cda58e3ab97ac79fb5e60d/pyperclip-1.9.0.tar.gz", hash = "sha256:b7de0142ddc81bfc5c7507eea19da920b92252b548b96186caf94a5e2527d310", size = 20961, upload-time = "2024-06-18T20:38:48.401Z" }
 
 [[package]]
 name = "pyright"


### PR DESCRIPTION
This feature is for `clai` package.

It adds  `/cp` command  (analogus to linux cp command)  to clai that coppies model output to clipboard as is.

TL DR what was done:
- added new `clai` dependency: `pyperclip`
- added handler in `clai` for comand  `/cp`  to store  data to clipboard
- added documentation
- added unit tests
- tested manualy