### PR TITLE
Make Edge hashable

### DIFF
--- a/pydantic_graph/pydantic_graph/nodes.py
+++ b/pydantic_graph/pydantic_graph/nodes.py
@@ -174,7 +174,7 @@ def generate_snapshot_id(node_id: str) -> str:
     return f'{node_id}:{uuid4().hex}'
 
 
-@dataclass
+@dataclass(frozen=True)
 class Edge:
     """Annotation to apply a label to an edge in a graph."""
 

--- a/tests/graph/test_mermaid.py
+++ b/tests/graph/test_mermaid.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import timezone
 from pathlib import Path
-from typing import Annotated, Callable
+from typing import Annotated, Callable, Union
 
 import httpx
 import pytest
@@ -426,3 +426,16 @@ def test_wrong_return_type():
 
     with pytest.raises(GraphSetupError, match="Invalid return type: <class 'int'>"):
         NoReturnType.get_node_def({})
+
+
+def test_edge_union():
+    """Test that a union of things annotated with an Edge doesn't raise a TypeError.
+
+    This is important because such unions may occur as a return type for a graph, and needs to be evaluated when
+    generating a mermaid diagram.
+    """
+    # This would raise an error on 3.10 if Edge was not hashable:
+    edges_union = Union[
+        Annotated[End[None], Edge(label='first label')], Annotated[End[None], Edge(label='second label')]
+    ]
+    assert edges_union


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic-ai/issues/2046

Note this was only causing an error in python<=3.10, but I don't see any reason not to make Edge hashable, which does resolve the issue in 3.10.