### PR TITLE
Make it possible to stream structured while using `.iter`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -95,7 +95,7 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
             match = self._output_schema.find_named_tool(message.parts, output_tool_name)
             if match is None:
                 raise exceptions.UnexpectedModelBehavior(  # pragma: no cover
-                    f'Invalid response, unable to find tool: {self._output_schema.tool_names()}'
+                    f'Invalid response, unable to find tool {output_tool_name!r}; expected one of {self._output_schema.tool_names()}'
                 )
 
             call, output_tool = match
@@ -413,7 +413,7 @@ class StreamedRunResult(Generic[AgentDepsT, OutputDataT]):
             match = self._output_schema.find_named_tool(message.parts, self._output_tool_name)
             if match is None:
                 raise exceptions.UnexpectedModelBehavior(  # pragma: no cover
-                    f'Invalid response, unable to find tool: {self._output_schema.tool_names()}'
+                    f'Invalid response, unable to find tool {self._output_tool_name!r}; expected one of {self._output_schema.tool_names()}'
                 )
 
             call, output_tool = match


### PR DESCRIPTION
Addresses the request [here](https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1750876349862449) to support structured streaming while using `.iter`.

In particular, the analogous example to the whales streaming stuff would look like:

```python
async with agent.iter(my_prompt) as run:
  async for node in run:
     ...
     # probably only want to do it one these nodes?
     elif Agent.is_model_request_node(node):
        async with node.stream(run.ctx) as request_stream:
          async for message, last in request_stream.stream_responses():
          maybe_whales = await run.validate_structured_output(message, allow_partial=not last)
          if maybe_whales is not None:
              whales = maybe_whales.output
    ...
```

I have some concerns about the type names etc. but I think overall this seems like a reasonable thing to add.