### PR TITLE
Support strict mode in NativeOutput

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -182,6 +182,7 @@ class OutputSchema(BaseOutputSchema[OutputDataT], ABC):
                     _flatten_output_spec(output_spec.outputs),
                     name=output_spec.name,
                     description=output_spec.description,
+                    strict=output_spec.strict,
                 )
             )
         elif isinstance(output_spec, PromptedOutput):

--- a/pydantic_ai_slim/pydantic_ai/output.py
+++ b/pydantic_ai_slim/pydantic_ai/output.py
@@ -155,7 +155,7 @@ class NativeOutput(Generic[OutputDataT]):
     description: str | None
     """The description of the structured output that will be passed to the model. If not specified and only one output is provided, the docstring of the output type or function will be used."""
     strict: bool | None
-    """Whether to use strict mode for the output."""
+    """Whether to use strict mode for the output, if the model supports it."""
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/output.py
+++ b/pydantic_ai_slim/pydantic_ai/output.py
@@ -154,6 +154,8 @@ class NativeOutput(Generic[OutputDataT]):
     """The name of the structured output that will be passed to the model. If not specified and only one output is provided, the name of the output type or function will be used."""
     description: str | None
     """The description of the structured output that will be passed to the model. If not specified and only one output is provided, the docstring of the output type or function will be used."""
+    strict: bool | None
+    """Whether to use strict mode for the output."""
 
     def __init__(
         self,
@@ -161,10 +163,12 @@ class NativeOutput(Generic[OutputDataT]):
         *,
         name: str | None = None,
         description: str | None = None,
+        strict: bool | None = None,
     ):
         self.outputs = outputs
         self.name = name
         self.description = description
+        self.strict = strict
 
 
 @dataclass(init=False)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -15,6 +15,7 @@ from typing_extensions import Self
 from pydantic_ai import Agent, ModelRetry, RunContext, UnexpectedModelBehavior, UserError, capture_run_messages
 from pydantic_ai._output import (
     NativeOutput,
+    NativeOutputSchema,
     OutputSpec,
     PromptedOutput,
     TextOutput,
@@ -1511,6 +1512,17 @@ def test_native_output():
             ),
         ]
     )
+
+
+def test_native_output_strict_mode():
+    class CityLocation(BaseModel):
+        city: str
+        country: str
+
+    agent = Agent(output_type=NativeOutput(CityLocation, strict=True))
+    output_schema = agent._output_schema  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(output_schema, NativeOutputSchema)
+    assert output_schema.object_def.strict
 
 
 def test_prompted_output_function_with_retry():


### PR DESCRIPTION
This PR adds the boolean parameter `strict` to the newly introduced `NativeOutput`, analogous to the parameter that already existed on `ToolOutput`. This enables strict mode in supported models. For OpenAI, this turns on constrained grammar sampling, which guarantees at the LLM-level that the output conforms to the JSON schema (at least the subset of supported features).

closes https://github.com/pydantic/pydantic-ai/issues/2080)