### PR TITLE
Added support for google specific arguments for video analysis

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -11,7 +11,7 @@ from .exceptions import (
     UserError,
 )
 from .format_prompt import format_as_xml
-from .messages import AudioUrl, BinaryContent, DocumentUrl, ImageUrl, VideoUrl
+from .messages import AudioUrl, BinaryContent, DocumentUrl, ImageUrl, VendorMetadata, VideoUrl
 from .output import NativeOutput, PromptedOutput, TextOutput, ToolOutput
 from .tools import RunContext, Tool
 
@@ -36,6 +36,7 @@ __all__ = (
     'ImageUrl',
     'AudioUrl',
     'VideoUrl',
+    'VendorMetadata',
     'DocumentUrl',
     'BinaryContent',
     # tools

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -86,6 +86,20 @@ class SystemPromptPart:
 
 
 @dataclass(repr=False)
+class VendorMetadata:
+    """The video metadata for video processing."""
+
+    google_start_offset: str | None = None
+    """Usable only by Google Models. The start offset for video processing."""
+
+    google_end_offset: str | None = None
+    """Usable only by Google Models. The end offset for video processing."""
+
+    google_fps: float | None = None
+    """Usable only by Google Models. The frames rate sampling for video."""
+
+
+@dataclass(repr=False)
 class FileUrl(ABC):
     """Abstract base class for any URL-based file."""
 
@@ -98,6 +112,9 @@ class FileUrl(ABC):
     * If True, the file is downloaded and the data is sent to the model as bytes.
     * If False, the URL is sent directly to the model and no download is performed.
     """
+
+    vendor_metadata: VendorMetadata | None = None
+    """The vendor specific metadata for the file."""
 
     @property
     @abstractmethod
@@ -262,6 +279,9 @@ class BinaryContent:
 
     media_type: AudioMediaType | ImageMediaType | DocumentMediaType | str
     """The media type of the binary data."""
+
+    vendor_metadata: VendorMetadata | None = None
+    """The vendor specific metadata for the file."""
 
     kind: Literal['binary'] = 'binary'
     """Type identifier, this is available on all parts as a discriminator."""

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -125,7 +125,7 @@ class GoogleModelSettings(ModelSettings, total=False):
 
     google_video_resolution: MediaResolution
     """The video resolution to use for the model.
-    
+
     See <https://ai.google.dev/api/generate-content#MediaResolution> for more information.
     """
 
@@ -410,21 +410,31 @@ class GoogleModel(Model):
                     base64_encoded = base64.b64encode(item.data).decode('utf-8')
                     if item.vendor_metadata:
                         video_metadata = VideoMetadata(
-                            fps = item.vendor_metadata.google_fps, 
-                            start_offset = item.vendor_metadata.google_start_offset, 
-                            end_offset = item.vendor_metadata.google_end_offset,
+                            fps=item.vendor_metadata.google_fps,
+                            start_offset=item.vendor_metadata.google_start_offset,
+                            end_offset=item.vendor_metadata.google_end_offset,
                         )
-                        content.append({'inline_data': {'data': base64_encoded, 'mime_type': item.media_type}, 'video_metadata': video_metadata})  # type: ignore
+                        content.append(
+                            {
+                                'inline_data': {'data': base64_encoded, 'mime_type': item.media_type},
+                                'video_metadata': video_metadata,  # type: ignore
+                            }
+                        )
                     else:
                         content.append({'inline_data': {'data': base64_encoded, 'mime_type': item.media_type}})  # type: ignore
                 elif isinstance(item, VideoUrl) and item.is_youtube:
                     if item.vendor_metadata:
                         video_metadata = VideoMetadata(
-                            fps = item.vendor_metadata.google_fps, 
-                            start_offset = item.vendor_metadata.google_start_offset, 
-                            end_offset = item.vendor_metadata.google_end_offset,
+                            fps=item.vendor_metadata.google_fps,
+                            start_offset=item.vendor_metadata.google_start_offset,
+                            end_offset=item.vendor_metadata.google_end_offset,
                         )
-                        content.append({'file_data': {'file_uri': item.url, 'mime_type': item.media_type}, 'video_metadata': video_metadata})
+                        content.append(
+                            {
+                                'file_data': {'file_uri': item.url, 'mime_type': item.media_type},
+                                'video_metadata': video_metadata,  # type: ignore
+                            }
+                        )
                     else:
                         content.append({'file_data': {'file_uri': item.url, 'mime_type': item.media_type}})
                 elif isinstance(item, FileUrl):

--- a/uv.lock
+++ b/uv.lock
@@ -1191,7 +1191,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.15.0"
+version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1199,12 +1199,13 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "requests" },
+    { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/19/da5a085ce419c33b9e6ae308005efad9bfa1b10f59f449d075bba1f16a64/google_genai-1.15.0.tar.gz", hash = "sha256:118bb26960d6343cd64f1aeb5c2b02144a36ad06716d0d1eb1fa3e0904db51f1", size = 173452, upload-time = "2025-05-13T13:55:17.73Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/8a/ac6f0efa0a874072b87ea13a827d549116c7c78ade93042abf0a3492039f/google_genai-1.23.0.tar.gz", hash = "sha256:a3ce7803ac3b038d4c4e166070451b560278c9f20cd819650debd17cd69cb1b3", size = 223825, upload-time = "2025-06-27T23:45:56.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/e2/acc99d36fd439fb2e558c7aebd049329dbfc08a094faf17d847d393e2810/google_genai-1.15.0-py3-none-any.whl", hash = "sha256:6d7f149cc735038b680722bed495004720514c234e2a445ab2f27967955071dd", size = 171278, upload-time = "2025-05-13T13:55:16.314Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b1/9bc286d0880173ac81b72b12363eea54db552265933bec5f5b3c8385cc44/google_genai-1.23.0-py3-none-any.whl", hash = "sha256:59d603e35440fb1e61482264ee214d17f8c4ed9d29ec08cd4a6de8d090aaabb9", size = 223845, upload-time = "2025-06-27T23:45:55.442Z" },
 ]
 
 [[package]]
@@ -3872,6 +3873,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/db/ff/ba1a3769c34d022aeba544ff7b18cbcd0d23a6358fc3566b2101c6bf2817/tavily_python-0.5.1.tar.gz", hash = "sha256:44b0eefe79a057cd11d3cd03780b63b4913400122350e38285acfb502c2fffc1", size = 107503, upload-time = "2025-02-07T00:22:06.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/cd/71088461d7720128c78802289b3b36298f42745e5f8c334b0ffc157b881e/tavily_python-0.5.1-py3-none-any.whl", hash = "sha256:169601f703c55cf338758dcacfa7102473b479a9271d65a3af6fc3668990f757", size = 43767, upload-time = "2025-02-07T00:22:04.99Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4d/6a19536c50b849338fcbe9290d562b52cbdcf30d8963d3588a68a4107df1/tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78", size = 47309, upload-time = "2024-07-05T07:25:31.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/3f/8ba87d9e287b9d385a02a7114ddcef61b26f86411e121c9003eb509a1773/tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687", size = 28165, upload-time = "2024-07-05T07:25:29.591Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Added support for Google models specific arguments when processing video, those arguments are:
- media_resolution, which is model setting, settings this to LOW instead of default HIGH results in ~3x lower amount of input tokens consumed for video input.
- fps, which is video specific settings, set by setting vendor_metadata in FileUrl/BinaryContent, controls frame sampling. Default is 1.0 for Google models, setting this to lower value decrease amount of input video tokens, setting it to higher value increase analysis quality in highly dynamic videos.
- start_offset, which is video specific settings, set by setting vendor_metadata in FileUrl/BinaryContent, controls start offset of video. Useful for capping token consumption per video. According to docs it needs to contain s at the end, ex. 300s
- end_offset, which is video specific settings, set by setting vendor_metadata in FileUrl/BinaryContent, controls end offset of video. Useful for capping token consumption per video.

Official Google docs for those new arguments:
https://ai.google.dev/gemini-api/docs/video-understanding