### PR TITLE
Fix model parameters not being customized in fallback model request stream

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/fallback.py
+++ b/pydantic_ai_slim/pydantic_ai/models/fallback.py
@@ -88,9 +88,10 @@ class FallbackModel(Model):
 
         for model in self.models:
             async with AsyncExitStack() as stack:
+                customized_model_request_parameters = model.customize_request_parameters(model_request_parameters)
                 try:
                     response = await stack.enter_async_context(
-                        model.request_stream(messages, model_settings, model_request_parameters)
+                        model.request_stream(messages, model_settings, customized_model_request_parameters)
                     )
                 except Exception as exc:
                     if self._fallback_on(exc):

--- a/pydantic_ai_slim/pydantic_ai/models/fallback.py
+++ b/pydantic_ai_slim/pydantic_ai/models/fallback.py
@@ -87,8 +87,8 @@ class FallbackModel(Model):
         exceptions: list[Exception] = []
 
         for model in self.models:
+            customized_model_request_parameters = model.customize_request_parameters(model_request_parameters)
             async with AsyncExitStack() as stack:
-                customized_model_request_parameters = model.customize_request_parameters(model_request_parameters)
                 try:
                     response = await stack.enter_async_context(
                         model.request_stream(messages, model_settings, customized_model_request_parameters)


### PR DESCRIPTION
request_stream for fallback model was not customizing request parameters. this led to 400 errors due to improper params. this follows the same behavior of customizing the request parameters for each model as above in the non streaming method.