### PR TITLE
Add context dependencies to Tool.from_schema()

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -271,7 +271,7 @@ class Tool(Generic[AgentDepsT]):
         name: str,
         description: str,
         json_schema: JsonSchemaValue,
-        takes_ctx: bool = False
+        takes_ctx: bool = False,
     ) -> Self:
         """Creates a Pydantic tool from a function and a JSON schema.
 


### PR DESCRIPTION
This PR adds a "takes_ctx" optional boolean argument indicating whether the function accepts the context object as an argument. Solving #2122