### PR TITLE
Make `AgentStream.stream_output` (available inside `agent.iter`) stream validated output data instead of raising validation errors

### DIFF
--- a/examples/pydantic_ai_examples/stream_whales.py
+++ b/examples/pydantic_ai_examples/stream_whales.py
@@ -11,7 +11,7 @@ Run with:
 from typing import Annotated
 
 import logfire
-from pydantic import Field, ValidationError
+from pydantic import Field
 from rich.console import Console
 from rich.live import Live
 from rich.table import Table
@@ -51,20 +51,7 @@ async def main():
         ) as result:
             console.print('Response:', style='green')
 
-            async for message, last in result.stream_structured(debounce_by=0.01):
-                try:
-                    whales = await result.validate_structured_output(
-                        message, allow_partial=not last
-                    )
-                except ValidationError as exc:
-                    if all(
-                        e['type'] == 'missing' and e['loc'] == ('response',)
-                        for e in exc.errors()
-                    ):
-                        continue
-                    else:
-                        raise
-
+            async for whales in result.stream(debounce_by=0.01):
                 table = Table(
                     title='Species of Whale',
                     caption='Streaming Structured responses from GPT-4',

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -59,7 +59,12 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
         """Asynchronously stream the (validated) agent outputs."""
         async for response in self.stream_responses(debounce_by=debounce_by):
             if self._final_result_event is not None:
-                yield await self._validate_response(response, self._final_result_event.tool_name, allow_partial=True)
+                try:
+                    yield await self._validate_response(
+                        response, self._final_result_event.tool_name, allow_partial=True
+                    )
+                except ValidationError:
+                    pass
         if self._final_result_event is not None:  # pragma: no branch
             yield await self._validate_response(
                 self._raw_stream_response.get(), self._final_result_event.tool_name, allow_partial=False


### PR DESCRIPTION
`StreamedRunResult.stream` (available inside `agent.run_stream`) already worked this way.

Brought up in Slack: https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1751559059148199