### PR TITLE
Fix GitHub Models docs links

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -28,4 +28,6 @@
 
 ::: pydantic_ai.providers.heroku.HerokuProvider
 
+::: pydantic_ai.providers.github.GitHubProvider
+
 ::: pydantic_ai.providers.openrouter.OpenRouterProvider

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -23,6 +23,7 @@ In addition, many providers are compatible with the OpenAI API, and can be used 
 * [Together AI](openai.md#together-ai)
 * [Azure AI Foundry](openai.md#azure-ai-foundry)
 * [Heroku](openai.md#heroku-ai)
+* [GitHub Models](openai.md#github-models)
 
 PydanticAI also comes with [`TestModel`](../api/models/test.md) and [`FunctionModel`](../api/models/function.md)
 for testing and development.


### PR DESCRIPTION
https://github.com/pydantic/pydantic-ai/pull/2114 was green but `docs` failed on `main`: https://github.com/pydantic/pydantic-ai/actions/runs/16081790577/job/45387524408