### PR TITLE
Add more audio type in AudioUrl

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from .models.instrumented import InstrumentationSettings
 
 
-AudioMediaType: TypeAlias = Literal['audio/wav', 'audio/mpeg']
+AudioMediaType: TypeAlias = Literal['audio/wav', 'audio/mpeg', "audio/ogg", "audio/flac", "audio/aiff", "audio/aac"]
 ImageMediaType: TypeAlias = Literal['image/jpeg', 'image/png', 'image/gif', 'image/webp']
 DocumentMediaType: TypeAlias = Literal[
     'application/pdf',
@@ -175,13 +175,23 @@ class AudioUrl(FileUrl):
 
     @property
     def media_type(self) -> AudioMediaType:
-        """Return the media type of the audio file, based on the url."""
-        if self.url.endswith('.mp3'):
-            return 'audio/mpeg'
-        elif self.url.endswith('.wav'):
-            return 'audio/wav'
-        else:
-            raise ValueError(f'Unknown audio file extension: {self.url}')
+        """Return the media type of the audio file, based on the url.
+
+        References:
+        - Gemini: https://ai.google.dev/gemini-api/docs/audio#supported-formats
+        """
+        for suffix, mime_type in {
+            ('.mp3', 'audio/mpeg'),
+            ('.wav', 'audio/wav'),
+            ('.flac', 'audio/flac'),
+            ('.oga', 'audio/ogg'),
+            ('.aiff', 'audio/aiff'),
+            ('.aac', 'audio/aac'),
+        }:
+            if self.url.endswith(suffix):
+                return mime_type
+
+        raise ValueError(f'Unknown audio file extension: {self.url}')
 
     @property
     def format(self) -> AudioFormat:


### PR DESCRIPTION
This should address #2143 

Tested with the following code:

```python
from pydantic_ai.models.gemini import GeminiModel
from pydantic_ai.agent import Agent
from pydantic_ai.messages import AudioUrl
# from pydantic_ai.models.openai import OpenAIModel
from dotenv import load_dotenv



load_dotenv()

async def main():
    # model = OpenAIModel("gpt-4.1-mini") AssertionError: Unsupported audio format: ...
    model = GeminiModel('gemini-2.0-flash')
    agent = Agent(model, instructions="You are a helpful assistant who can transcribe audio into text.")
    for suffix in [
        "mp3", "oga", "aiff", "aac", "flac", "wav"
    ]:
        response = await agent.run([
            "What can you tell me about this audio?",
            AudioUrl(f"https://storage.googleapis.com/pydantic-pr-audio-url-testing-gemini/sample-0.{suffix}", force_download=True)
        ])
        print(response.output)

if __name__ == "__main__":
    import asyncio
    asyncio.run(main())
```

The url should be public and available until this is merged.