### PR TITLE
Fix type annotations for `Agent.iter()`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -500,7 +500,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
     @overload
     def iter(
         self,
-        user_prompt: str | Sequence[_messages.UserContent] | None,
+        user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: None = None,
         message_history: list[_messages.ModelMessage] | None = None,
@@ -516,7 +516,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
     @overload
     def iter(
         self,
-        user_prompt: str | Sequence[_messages.UserContent] | None,
+        user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: OutputSpec[RunOutputDataT],
         message_history: list[_messages.ModelMessage] | None = None,
@@ -533,7 +533,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
     @deprecated('`result_type` is deprecated, use `output_type` instead.')
     def iter(
         self,
-        user_prompt: str | Sequence[_messages.UserContent] | None,
+        user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         result_type: type[RunOutputDataT],
         message_history: list[_messages.ModelMessage] | None = None,


### PR DESCRIPTION
The current type annotations for `Agent.iter()` do not allow calling it without a `user_prompt` argument, although it is not strictly required:

```python
# example.py
from pydantic_ai import Agent
from pydantic_ai.messages import ModelMessage

agent = Agent()
history: list[ModelMessage] = []
agent.iter(message_history=history)
```

```shell
$ mypy example.py
example.py:6: error: No overload variant of "iter" of "Agent" matches argument type "list[ModelRequest | ModelResponse]"  [call-overload]
```

This PR updates type annotations of the overloaded `Agent.iter()` variants to match the main method definition, where `user_prompt` defaults to `None`. 