### PR TITLE
chore: disable python 3.9 coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
           enable-cache: true
 
       - run: uv sync --package pydantic-ai-slim --only-dev
+      - run: rm coverage/.coverage.*-py3.9-* # Exclude 3.9 coverage as it gets the wrong line numbers, causing invalid failures.
       - run: uv run coverage combine coverage
 
       - run: uv run coverage html --show-contexts --title "PydanticAI coverage for ${{ github.sha }}"

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -143,7 +143,7 @@ def test_model_request_stream_sync_without_context_manager():
 
     with pytest.raises(RuntimeError, match=expected_error_msg):
         for _ in stream_cm:
-            break
+            break  # pragma: no cover
 
 
 def test_model_request_stream_sync_exception_in_stream():


### PR DESCRIPTION
Disable python 3.9 coverage in CI as it can get the wrong line numbers resulting in unsolvable coverage errors, as it conflicts with 3.10+.

[pep-0626](https://peps.python.org/pep-0626/) (3.10) introduced accurate line number tracking.

There's an example of 3.9 getting the wrong line number in `tests/test_direct.py` which is now covered with a `# pragma: no cover`

This was discovered when developing the AG-UI feature, where multiple `if` `elif` blocks were flagged covered by 3.9 but not by other versions, which resulted in failure cycle of not covered and incorrectly marked as not covered.