### PR TITLE
⚡️ Speed up method `Usage.opentelemetry_attributes` by 85%

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -57,13 +57,19 @@ class Usage:
 
     def opentelemetry_attributes(self) -> dict[str, int]:
         """Get the token limits as OpenTelemetry attributes."""
-        result = {
-            'gen_ai.usage.input_tokens': self.request_tokens,
-            'gen_ai.usage.output_tokens': self.response_tokens,
-        }
-        for key, value in (self.details or {}).items():
-            result[f'gen_ai.usage.details.{key}'] = value  # pragma: no cover
-        return {k: v for k, v in result.items() if v}
+        result = {}
+        if self.request_tokens:
+            result['gen_ai.usage.input_tokens'] = self.request_tokens
+        if self.response_tokens:
+            result['gen_ai.usage.output_tokens'] = self.response_tokens
+        details = self.details
+        if details:
+            prefix = 'gen_ai.usage.details.'
+            for key, value in details.items():
+                # Skipping check for value since spec implies all detail values are relevant
+                if value:
+                    result[prefix + key] = value  # pragma: no cover
+        return result
 
     def has_values(self) -> bool:
         """Whether any values are set and non-zero."""

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -57,7 +57,7 @@ class Usage:
 
     def opentelemetry_attributes(self) -> dict[str, int]:
         """Get the token limits as OpenTelemetry attributes."""
-        result = {}
+        result: dict[str, int] = {}
         if self.request_tokens:
             result['gen_ai.usage.input_tokens'] = self.request_tokens
         if self.response_tokens:
@@ -68,7 +68,7 @@ class Usage:
             for key, value in details.items():
                 # Skipping check for value since spec implies all detail values are relevant
                 if value:
-                    result[prefix + key] = value  # pragma: no cover
+                    result[prefix + key] = value
         return result
 
     def has_values(self) -> bool:

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -176,6 +176,15 @@ async def test_multi_agent_usage_no_incr():
     # confirm the usage from result2 is the sum of the usage from result1
     assert result2.usage() == functools.reduce(operator.add, run_1_usages)
 
+    result1_usage = result1.usage()
+    result1_usage.details = {'custom1': 10, 'custom2': 20}
+    assert result1_usage.opentelemetry_attributes() == {
+        'gen_ai.usage.input_tokens': 103,
+        'gen_ai.usage.output_tokens': 13,
+        'gen_ai.usage.details.custom1': 10,
+        'gen_ai.usage.details.custom2': 20,
+    }
+
 
 async def test_multi_agent_usage_sync():
     """As in `test_multi_agent_usage_async`, with a sync tool."""

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -177,7 +177,7 @@ async def test_multi_agent_usage_no_incr():
     assert result2.usage() == functools.reduce(operator.add, run_1_usages)
 
     result1_usage = result1.usage()
-    result1_usage.details = {'custom1': 10, 'custom2': 20}
+    result1_usage.details = {'custom1': 10, 'custom2': 20, 'custom3': 0}
     assert result1_usage.opentelemetry_attributes() == {
         'gen_ai.usage.input_tokens': 103,
         'gen_ai.usage.output_tokens': 13,


### PR DESCRIPTION
### 📄 85% (0.85x) speedup for ***`Usage.opentelemetry_attributes` in `pydantic_ai_slim/pydantic_ai/usage.py`***

⏱️ Runtime :   **`2.09 milliseconds`**  **→** **`1.13 milliseconds`** (best of `77` runs)
### 📝 Explanation and details

Here is the optimized version of your program for maximal runtime efficiency and reduced memory allocations, especially for the bottleneck section.



**Performance improvements:**
- Avoided unconditional allocation and population of dictionary keys with possibly falsy values, which were later filtered out at return. This eliminates the need to create then filter unnecessary key-value pairs, and the dict comprehension at the end.
- Reuses the string prefix instead of f-strings in the tight loop for minor efficiency improvement.
- Now we only touch details if it's not None (no allocation of empty dict).
- No post-process dict comprehension; only desired keys added directly.

The function returns exactly the same result as the original, but avoids unnecessary work and memory churn.


✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **2004 Passed** |
| ⏪ Replay Tests | ✅ **243 Passed** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
from collections import namedtuple
# function to test
from copy import copy
from dataclasses import dataclass
from typing import Optional

# imports
import pytest  # used for our unit tests
from pydantic_ai.usage import Usage


# Dummy _utils for repr to avoid import error
class _utils:
    @staticmethod
    def dataclasses_no_defaults_repr(self):
        return f"Usage(requests={self.requests}, request_tokens={self.request_tokens}, response_tokens={self.response_tokens}, total_tokens={self.total_tokens}, details={self.details})"
from pydantic_ai.usage import Usage

# unit tests

# Basic Test Cases





def test_empty_usage():
    # All fields are None or 0, should return empty dict
    usage = Usage()
    codeflash_output = usage.opentelemetry_attributes(); attrs = codeflash_output # 1.76μs -> 668ns (163% faster)

# Edge Test Cases

















from copy import copy
from dataclasses import dataclass

# imports
import pytest  # used for our unit tests
from pydantic_ai.usage import Usage


# Dummy _utils for repr to avoid dependency on pydantic_ai._utils
class _utils:
    @staticmethod
    def dataclasses_no_defaults_repr(self):
        return f"Usage({self.requests}, {self.request_tokens}, {self.response_tokens}, {self.total_tokens}, {self.details})"
from pydantic_ai.usage import Usage

# unit tests

# 1. Basic Test Cases











def test_edge_all_none():
    # All fields None or default
    usage = Usage()
    codeflash_output = usage.opentelemetry_attributes(); attrs = codeflash_output # 1.73μs -> 614ns (181% faster)









def test_large_scale_tokens_and_details_none():
    # All fields None, large number of Usage objects
    usages = [Usage() for _ in range(1000)]
    for usage in usages:
        codeflash_output = usage.opentelemetry_attributes() # 417μs -> 178μs (134% faster)



from pydantic_ai.usage import Usage

def test_Usage_opentelemetry_attributes():
    Usage.opentelemetry_attributes(Usage(requests=0, request_tokens=None, response_tokens=None, total_tokens=None, details={'': -1}))

def test_Usage_opentelemetry_attributes_2():
    Usage.opentelemetry_attributes(Usage(requests=0, request_tokens=None, response_tokens=0, total_tokens=None, details=None))
```

</details>

<details>
<summary>⏪ Replay Tests and Runtime</summary>

| Test File::Test Function                                                                                                                                                             | Original ⏱️   | Optimized ⏱️   | Speedup   |
|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------------|:----------|
| `codeflash_concolic_t7q2nx26/tmpwofuw3vl/test_concolic_coverage.py::test_Usage_opentelemetry_attributes`                                                                             | 2.32μs        | 1.41μs         | ✅65.2%   |
| `codeflash_concolic_t7q2nx26/tmpwofuw3vl/test_concolic_coverage.py::test_Usage_opentelemetry_attributes_2`                                                                           | 1.81μs        | 691ns          | ✅163%    |
| `test_pytest_inlinesnapshotdisable_testsproviderstest_bedrock_py_testsproviderstest_google_gla_py_teststes__replay_test_0.py::test_pydantic_ai_usage_Usage_opentelemetry_attributes` | 138μs         | 82.8μs         | ✅67.6%   |
| `test_pytest_inlinesnapshotdisable_teststest_messages_py_teststest_mcp_py_teststest_deps_py__replay_test_0.py::test_pydantic_ai_usage_Usage_opentelemetry_attributes`                | 9.00μs        | 4.72μs         | ✅90.4%   |

</details>


To edit these changes `git checkout codeflash/optimize-Usage.opentelemetry_attributes-md0bn5hj` and push.

[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)