### PR TITLE
Fix VertexAI Empty Model Parts Error

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -492,8 +492,7 @@ def _content_model_response(m: ModelResponse) -> ContentDict:
             function_call = FunctionCallDict(name=item.tool_name, args=item.args_as_dict(), id=item.tool_call_id)
             parts.append({'function_call': function_call})
         elif isinstance(item, TextPart):
-            if item.content:  # pragma: no branch
-                parts.append({'text': item.content})
+            parts.append({'text': item.content})
         elif isinstance(item, ThinkingPart):  # pragma: no cover
             # NOTE: We don't send ThinkingPart to the providers yet. If you are unsatisfied with this,
             # please open an issue. The below code is the code to send thinking to the provider.


### PR DESCRIPTION
Fixes this error that occurs with VertexAI Gemini models fairly often in my experience.

Issue that's open with the same error: [https://github.com/pydantic/pydantic-ai/issues/2032](https://github.com/pydantic/pydantic-ai/issues/2032)

```
ClientError: 400 INVALID_ARGUMENT. {'error': {'code': 400, 'message': 'Unable to submit
request because it must include at least one parts field, which describes the prompt
input. Learn more:
https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini', 'status':
'INVALID_ARGUMENT'}}
```

Due to the last message being something like:

```
    {
        "parts": [{ "content": "", "part_kind": "text" }],
        "usage": {
            "requests": 1,
            "request_tokens": 25308,
            "response_tokens": 0,
            "total_tokens": 25308,
            "details": {
                "cached_content_tokens": 15171,
                "text_cache_tokens": 15171,
                "text_prompt_tokens": 25308
            }
        },
        "model_name": "gemini-2.5-pro",
        "timestamp": "2025-07-14T17:33:52.568858Z",
        "kind": "response",
        "vendor_details": { "finish_reason": "STOP" },
        "vendor_id": "fz91aPDpJYienvgP757VgQ0"
    }
```

Tested the change against a session that was previously hard crashing and it works fine now.