### PR TITLE
Correct code snippet for native output

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -325,7 +325,7 @@ agent = Agent(
     'openai:gpt-4o',
     output_type=NativeOutput(
         [Fruit, Vehicle], # (1)!
-        name='Fruit or vehicle',
+        name='Fruit_or_vehicle',
         description='Return a fruit or vehicle.'
     ),
 )


### PR DESCRIPTION
Remove spaces from the name of the JSON schema to comply with [OpenAI API docs on structured output](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format).

Otherwise, the snippet would return this error:
```
pydantic_ai.exceptions.ModelHTTPError: status_code: 400, model_name: gpt-4o, body: {'message': "Invalid 'response_format.json_schema.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.", 'type': 'invalid_request_error', 'param': 'response_format.json_schema.name', 'code': 'invalid_value'}
```