### PR TITLE
chore: simplify output function call with model retry

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -127,7 +127,7 @@ async def execute_traced_output_function(
                     m.tool_call_id = run_context.tool_call_id  # pragma: no cover
                 raise ToolRetryError(m) from r
             else:
-                raise  # pragma: no cover
+                raise
 
         # Record response if content inclusion is enabled
         if run_context.trace_include_content and span.is_recording():


### PR DESCRIPTION
Follow up from #2191 

## Improvements:

- Include tool name (and optionally tool id) in RetryPrompt for output functions
- Dedupe try-catch block for function schema call.