### PR TITLE
Fix mp3 handling

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -759,6 +759,8 @@ async def download_item(
     data_type = media_type
     if type_format == 'extension':
         data_type = data_type.split('/')[1]
+        if data_type == 'mpeg':
+            data_type = 'mp3'
 
     data = response.content
     if data_format in ('base64', 'base64_uri'):


### PR DESCRIPTION
Right now, if you retrieve a file with mime type `audio/mpeg`, it will hit an assertion error because it needs to be of type `mp3` when building the request to openai.

@Kludex Please take a look and fix this "properly" before the next release.