### PR TITLE
Document performance implications of async vs sync tools

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -724,6 +724,8 @@ def my_flaky_tool(query: str) -> str:
 
 Raising `ModelRetry` also generates a `RetryPromptPart` containing the exception message, which is sent back to the LLM to guide its next attempt. Both `ValidationError` and `ModelRetry` respect the `retries` setting configured on the `Tool` or `Agent`.
 
+When the LLM requests multiple tool executions, they are run concurrently via `asyncio.create_task`. For this concurrency to be effective, the tools must be defined as async functions and use non-blocking clients (e.g., `httpx.AsyncClient` instead of `httpx.Client`).
+
 ## Third-Party Tools
 
 ### MCP Tools {#mcp-tools}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -730,8 +730,8 @@ When a model returns multiple tool calls in one response, PydanticAI schedules t
 
 - Prefer `async def` tools that use non-blocking I/O (e.g., `httpx.AsyncClient`).
 - If you must use blocking libraries (e.g., `requests`, filesystem), declare the tool as `def` so it runs off the event loop in a thread.
-- Don’t do blocking I/O inside an `async def` tool; either switch to an async client or offload with `anyio.to_thread.run_sync`.
-- CPU-bound work (like `numpy` o `scikit-learn` operations) doesn’t benefit from async; keep it in `def` tools (thread offload) or move to a separate process for heavy workloads.
+- Don't do blocking I/O inside an `async def` tool; either switch to an async client or offload with `anyio.to_thread.run_sync`.
+- CPU-bound work (like `numpy` o `scikit-learn` operations) doesn't benefit from async; keep it in `def` tools (thread offload) or move to a separate process for heavy workloads.
 
 ## Third-Party Tools
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -726,12 +726,9 @@ Raising `ModelRetry` also generates a `RetryPromptPart` containing the exception
 
 ### Parallel tool calls & concurrency
 
-When a model returns multiple tool calls in one response, PydanticAI schedules them concurrently (with `asyncio.create_task`). To achieve real speed-ups:
+When a model returns multiple tool calls in one response, Pydantic AI schedules them concurrently using `asyncio.create_task`.
 
-- Prefer `async def` tools that use non-blocking I/O (e.g., `httpx.AsyncClient`).
-- If you must use blocking libraries (e.g., `requests`, filesystem), declare the tool as `def` so it runs off the event loop in a thread.
-- Don't do blocking I/O inside an `async def` tool; either switch to an async client or offload with `anyio.to_thread.run_sync`.
-- CPU-bound work (like `numpy` o `scikit-learn` operations) doesn't benefit from async; keep it in `def` tools (thread offload) or move to a separate process for heavy workloads.
+Async functions are run on the event loop, while sync functions are offloaded to threads. To get the best performance, _always_ use an async function _unless_ you're doing blocking I/O (and there's no way to use a non-blocking library instead) or CPU-bound work (like `numpy` or `scikit-learn` operations), so that simple functions are not offloaded to threads unnecessarily.
 
 ## Third-Party Tools
 


### PR DESCRIPTION
Added minor change to documentation so specify the requirements for tools to be concurrently executed.

Slack conversation reference: https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1753301883710229