### PR TITLE
Fix docs build failure by adding MoonshotAIProvider to API docs

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -35,3 +35,5 @@
 ::: pydantic_ai.providers.vercel.VercelProvider
 
 ::: pydantic_ai.providers.huggingface.HuggingFaceProvider
+
+::: pydantic_ai.providers.moonshotai.MoonshotAIProvider


### PR DESCRIPTION
Oversight from https://github.com/pydantic/pydantic-ai/pull/2211