### PR TITLE
Capture thought signatures from Google models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -682,7 +682,7 @@ class ThinkingPart:
     signature: str | None = None
     """The signature of the thinking.
 
-    The signature is only available on the Anthropic models.
+    The signature is only available on the Anthropic and Google models.
     """
 
     part_kind: Literal['thinking'] = 'thinking'


### PR DESCRIPTION
## Overview

Capture the thought signature for Google Models. 

Note: This requires casting the bytes Google provides to a base64-encoded string for compatibility with `ThoughtPart()`'s `signature` field, and then back to bytes when returning the response to Google.

Closes #2293