### PR TITLE
Fix: TypeError in MCPServerSSE due to improper initialization

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -543,6 +543,7 @@ class _MCPServerHTTP(MCPServer):
         self.max_retries = max_retries
         self.sampling_model = sampling_model
         self.read_timeout = read_timeout
+        self.__post_init__()
 
     @property
     @abstractmethod


### PR DESCRIPTION
This PR resolves a `TypeError` that occurs when using `MCPServerSSE` and other HTTP-based MCP servers. The issue stemmed from the `_MCPServerHTTP` class constructor, which was not calling the `__post_init__` method from the `MCPServer` base class. This led to `_enter_lock` not being correctly initialized as an `asyncio.Lock`.

The fix ensures `__post_init__` is called within the `_MCPServerHTTP` constructor, correcting the initialization sequence.

Fixes #2318