### PR TITLE
Fix: AG-UI assistant text and tool call order

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ag_ui.py
+++ b/pydantic_ai_slim/pydantic_ai/ag_ui.py
@@ -477,7 +477,6 @@ class _Adapter(Generic[AgentDepsT, OutputDataT]):
                 if isinstance(item, BaseEvent):  # pragma: no branch
                     yield item
 
-
 def _messages_from_ag_ui(messages: list[Message]) -> list[ModelMessage]:
     """Convert a AG-UI history to a Pydantic AI one."""
     result: list[ModelMessage] = []
@@ -486,6 +485,9 @@ def _messages_from_ag_ui(messages: list[Message]) -> list[ModelMessage]:
         if isinstance(msg, UserMessage):
             result.append(ModelRequest(parts=[UserPromptPart(content=msg.content)]))
         elif isinstance(msg, AssistantMessage):
+            if msg.content:
+                result.append(ModelResponse(parts=[TextPart(content=msg.content)]))
+
             if msg.tool_calls:
                 for tool_call in msg.tool_calls:
                     tool_calls[tool_call.id] = tool_call.function.name
@@ -502,9 +504,6 @@ def _messages_from_ag_ui(messages: list[Message]) -> list[ModelMessage]:
                         ]
                     )
                 )
-
-            if msg.content:
-                result.append(ModelResponse(parts=[TextPart(content=msg.content)]))
         elif isinstance(msg, SystemMessage):
             result.append(ModelRequest(parts=[SystemPromptPart(content=msg.content)]))
         elif isinstance(msg, ToolMessage):
@@ -527,7 +526,6 @@ def _messages_from_ag_ui(messages: list[Message]) -> list[ModelMessage]:
             result.append(ModelRequest(parts=[SystemPromptPart(content=msg.content)]))
 
     return result
-
 
 @runtime_checkable
 class StateHandler(Protocol):

--- a/pydantic_ai_slim/pydantic_ai/ag_ui.py
+++ b/pydantic_ai_slim/pydantic_ai/ag_ui.py
@@ -477,6 +477,7 @@ class _Adapter(Generic[AgentDepsT, OutputDataT]):
                 if isinstance(item, BaseEvent):  # pragma: no branch
                     yield item
 
+
 def _messages_from_ag_ui(messages: list[Message]) -> list[ModelMessage]:
     """Convert a AG-UI history to a Pydantic AI one."""
     result: list[ModelMessage] = []
@@ -526,6 +527,7 @@ def _messages_from_ag_ui(messages: list[Message]) -> list[ModelMessage]:
             result.append(ModelRequest(parts=[SystemPromptPart(content=msg.content)]))
 
     return result
+
 
 @runtime_checkable
 class StateHandler(Protocol):


### PR DESCRIPTION
Anthropic is picky about the order of `tool_calls`.  From [their docs](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/implement-tool-use).

> Tool result blocks must immediately follow their corresponding tool use blocks in the message history. You cannot include any messages between the assistant’s tool use message and the user’s tool result message.

There's probably a more elegant fix, and IDK if this might conflict with other model providers.

Fixes #2327