### PR TITLE
Revert "Pin tokenizers <= 0.21.2 as later 0.21.4 doesn't have required wheels"

### DIFF
--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -63,12 +63,7 @@ dependencies = [
 logfire = ["logfire>=3.11.0"]
 # Models
 openai = ["openai>=1.92.0"]
-cohere = [
-    "cohere>=5.16.0; platform_system != 'Emscripten'",
-    # Remove once all wheels for 0.21.4+ are built successfully
-    # https://github.com/huggingface/tokenizers/actions/runs/16570140346/job/46860152621
-    "tokenizers<=0.21.2",
-]
+cohere = ["cohere>=5.16.0; platform_system != 'Emscripten'"]
 vertexai = ["google-auth>=2.36.0", "requests>=2.32.2"]
 google = ["google-genai>=1.24.0"]
 anthropic = ["anthropic>=0.52.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -3153,7 +3153,6 @@ cli = [
 ]
 cohere = [
     { name = "cohere", marker = "sys_platform != 'emscripten'" },
-    { name = "tokenizers" },
 ]
 duckduckgo = [
     { name = "ddgs" },
@@ -3245,7 +3244,6 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'ag-ui'", specifier = ">=0.45.3" },
     { name = "tavily-python", marker = "extra == 'tavily'", specifier = ">=0.5.0" },
     { name = "tenacity", marker = "extra == 'retries'", specifier = ">=8.2.3" },
-    { name = "tokenizers", marker = "extra == 'cohere'", specifier = "<=0.21.2" },
     { name = "typing-inspection", specifier = ">=0.4.0" },
 ]
 provides-extras = ["a2a", "ag-ui", "anthropic", "bedrock", "cli", "cohere", "duckduckgo", "evals", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "tavily", "vertexai"]


### PR DESCRIPTION
Reverts pydantic/pydantic-ai#2335 as it's not needed anymore now that the new wheels are available.