### PR TITLE
Fix missing `content` in OpenAI assistant message

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -467,7 +467,7 @@ class OpenAIModel(Model):
                         assert_never(item)
                 # Note: model responses from this model should only have one text item, so the following
                 # shouldn't merge multiple texts into one unless you switch models between runs:
-                message_param = chat.ChatCompletionAssistantMessageParam(role='assistant', content= '\n\n'.join(texts))
+                message_param = chat.ChatCompletionAssistantMessageParam(role='assistant', content='\n\n'.join(texts))
                 if tool_calls:
                     message_param['tool_calls'] = tool_calls
                 openai_messages.append(message_param)

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -465,11 +465,9 @@ class OpenAIModel(Model):
                         tool_calls.append(self._map_tool_call(item))
                     else:
                         assert_never(item)
-                message_param = chat.ChatCompletionAssistantMessageParam(role='assistant')
-                if texts:
-                    # Note: model responses from this model should only have one text item, so the following
-                    # shouldn't merge multiple texts into one unless you switch models between runs:
-                    message_param['content'] = '\n\n'.join(texts)
+                # Note: model responses from this model should only have one text item, so the following
+                # shouldn't merge multiple texts into one unless you switch models between runs:
+                message_param = chat.ChatCompletionAssistantMessageParam(role='assistant', content= '\n\n'.join(texts))
                 if tool_calls:
                     message_param['tool_calls'] = tool_calls
                 openai_messages.append(message_param)


### PR DESCRIPTION
When LLM responds with `ToolCall` directly without any `TextPart` it's missing `content` key in Assistant Message. It usually doesn't cause any error but if you try to pass PDF afterwards OpenAI API responds with 500

```jsonc
[
  {
    "content": "...",
    "role": "system"
  },
  { "role": "user", "content": "yash resume search" },
// --------- Assistant message without content key ----------
  {
    "role": "assistant",
    "tool_calls": [
      {
        "id": "call_EPt7QObN5htQwx6WBQaWS8GX",
        "type": "function",
        "function": {
          "name": "search_tool",
          "arguments": "{\"query_text\":\"I am searching for resumes or CVs related to a person named Yash. The document should be a resume or curriculum vitae. yash, resume, CV, curriculum vitae\",\"max_num_documents\":8}"
        }
      }
    ]
  },
  {
    "role": "tool",
    "tool_call_id": "call_EPt7QObN5htQwx6WBQaWS8GX",
    "content": "{\"documents\":[{\"file_path\":\"Yash_resume.pdf\",\"id\":\"e1d7eb5a-e151-450a-b23b-ac446cde4179\",\"score\":0.01639344262295082,\"file_name\":\"Yash_resume.pdf\",\"content\":\"\"}]}"
  },
  {
    "role": "assistant",
    "content": "I found a document titled \"Yash_resume.pdf\" that matches your search for a resume related to a person named Yash. \n\nWould you like me to extract the content, summarize, or perform any specific action with this resume? Please let me know how you'd like to proceed."
  },
// --------- Now this message returns 500 error ------------
  {
    "role": "user",
    "content": [
      { "text": "who is yash?", "type": "text" },
      {
        "file": {
          "file_data": "data:application/pdf;base64,...",
          "filename": "filename.pdf"
        },
        "type": "file"
      }
    ]
  }
]
```

OpenAI Error:
```
pydantic_ai.exceptions.ModelHTTPError: status_code: 500, model_name: gpt-4.1, body: {'message': 'The server had an error processing your request. Sorry about that! You can retry your request, or contact us through our help center at help.openai.com if you keep seeing this error. (Please include the request ID df449f7f-6810-4aa8-b06a-c08eef9f09b2 in your email.)', 'type': 'server_error', 'param': None, 'code': None}
```