### PR TITLE
Add Streaming Support to A2A

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent.py
+++ b/pydantic_ai_slim/pydantic_ai/agent.py
@@ -1950,6 +1950,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
     def to_a2a(
         self,
         *,
+        enable_streaming: bool = False,
         storage: Storage | None = None,
         broker: Broker | None = None,
         # Agent card
@@ -1988,6 +1989,7 @@ class Agent(Generic[AgentDepsT, OutputDataT]):
 
         return agent_to_a2a(
             self,
+            enable_streaming=enable_streaming,
             storage=storage,
             broker=broker,
             name=name,


### PR DESCRIPTION
This PR implements streaming capabilities for pydantic-ai's A2A integration, enabling real-time updates during agent execution.

 - Streaming Agent Execution: Switched from blocking agent.run() to streaming agent.iter() to emit real-time updates
  - Real-time Status Updates: Agents now emit TaskStatusUpdateEvent messages for working/completed states
  - Incremental Message Streaming: Agent responses are streamed as they're generated when enable_streaming=True
  - Artifact Updates: Final results are emitted as TaskArtifactUpdateEvent for structured outputs

[ ] Blocked by https://github.com/pydantic/fasta2a/pull/26 -- This PR relies on functionality introduced in my previous fasta2a PR

