### PR TITLE
Add `priority` `service_tier` to `OpenAIModelSettings` and respect it in `OpenAIResponsesModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -803,6 +803,7 @@ class OpenAIResponsesModel(Model):
                 top_p=sampling_settings.get('top_p', NOT_GIVEN),
                 truncation=model_settings.get('openai_truncation', NOT_GIVEN),
                 timeout=model_settings.get('timeout', NOT_GIVEN),
+                service_tier=model_settings.get('openai_service_tier', NOT_GIVEN),
                 reasoning=reasoning,
                 user=model_settings.get('openai_user', NOT_GIVEN),
                 text=text or NOT_GIVEN,

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -120,10 +120,10 @@ class OpenAIModelSettings(ModelSettings, total=False):
     See [OpenAI's safety best practices](https://platform.openai.com/docs/guides/safety-best-practices#end-user-ids) for more details.
     """
 
-    openai_service_tier: Literal['auto', 'default', 'flex']
+    openai_service_tier: Literal['auto', 'default', 'flex', 'priority']
     """The service tier to use for the model request.
 
-    Currently supported values are `auto`, `default`, and `flex`.
+    Currently supported values are `auto`, `default`, `flex`, and `priority`.
     For more information, see [OpenAI's service tiers documentation](https://platform.openai.com/docs/api-reference/chat/object#chat/object-service_tier).
     """
 


### PR DESCRIPTION
* This PR updates the `service_tier` in the `OpenAIModelSettings` to include `priority` as one of the options per API docs [here](https://platform.openai.com/docs/api-reference/responses/create#responses-create-service_tier).
* It also passes the `service_tier` to the OpenAI Responses API which was missed in the https://github.com/pydantic/pydantic-ai/pull/1923