### PR TITLE
[Draft] Use explicit context managers for Agent and Toolset

### DIFF
--- a/mcp-run-python/README.md
+++ b/mcp-run-python/README.md
@@ -30,7 +30,7 @@ where:
 - `warmup` will run a minimal Python script to download and cache the Python standard library. This is also useful to
   check the server is running correctly.
 
-Here's an example of using `@pydantic/mcp-run-python` with Pydantic AI:
+Here’s an example of using `@pydantic/mcp-run-python` with Pydantic AI:
 
 ```python
 from pydantic_ai import Agent
@@ -56,7 +56,7 @@ agent = Agent('claude-3-5-haiku-latest', toolsets=[server])
 
 
 async def main():
-    async with agent:
+    async with agent.setup():
         result = await agent.run('How many days between 2000-01-01 and 2025-03-18?')
     print(result.output)
     #> There are 9,208 days between January 1, 2000, and March 18, 2025.w

--- a/pydantic_ai_slim/pydantic_ai/_a2a.py
+++ b/pydantic_ai_slim/pydantic_ai/_a2a.py
@@ -64,7 +64,7 @@ async def worker_lifespan(app: FastA2A, worker: Worker, agent: Agent[AgentDepsT,
 
     This ensures the worker is started and ready to process tasks as soon as the application starts.
     """
-    async with app.task_manager, agent:
+    async with app.task_manager, agent.setup():
         async with worker.run():
             yield
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, Protocol
 
@@ -79,19 +81,13 @@ class AbstractToolset(ABC, Generic[AgentDepsT]):
         """A hint for how to avoid name conflicts with other toolsets for use in error messages."""
         return 'Rename the tool or wrap the toolset in a `PrefixedToolset` to avoid name conflicts.'
 
-    async def __aenter__(self) -> Self:
-        """Enter the toolset context.
+    @asynccontextmanager
+    async def setup(self) -> AsyncGenerator[Self, Any]:
+        """Set up the toolset.
 
         This is where you can set up network connections in a concrete implementation.
         """
-        return self
-
-    async def __aexit__(self, *args: Any) -> bool | None:
-        """Exit the toolset context.
-
-        This is where you can tear down network connections in a concrete implementation.
-        """
-        return None
+        yield self
 
     @abstractmethod
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
@@ -153,3 +149,5 @@ class AbstractToolset(ABC, Generic[AgentDepsT]):
         from .renamed import RenamedToolset
 
         return RenamedToolset(self, name_map)
+
+

--- a/pydantic_ai_slim/pydantic_ai/toolsets/dynamic.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/dynamic.py
@@ -5,33 +5,31 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from typing_extensions import Self
-
 from .._run_context import AgentDepsT, RunContext
 from .abstract import AbstractToolset, ToolsetTool
 
 
 @dataclass
-class WrapperToolset(AbstractToolset[AgentDepsT]):
+class DynamicToolset(AbstractToolset[AgentDepsT]):
     """A toolset that wraps another toolset and delegates to it.
 
     See [toolset docs](../toolsets.md#wrapping-a-toolset) for more information.
     """
 
-    wrapped: AbstractToolset[AgentDepsT]
+    dynamic_toolset_func: Callable[[], AbstractToolset[AgentDepsT]]
 
     @asynccontextmanager
-    async def setup(self) -> AsyncGenerator[Self, Any]:
-        async with self.wrapped.setup():
-            yield self
+    async def setup(self) -> AsyncGenerator[AbstractToolset[AgentDepsT], Any]:
+        async with self.dynamic_toolset_func().setup() as dynamic_toolset:
+            yield dynamic_toolset
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
-        return await self.wrapped.get_tools(ctx)
+        raise NotImplementedError('Dynamic toolsets cannot be used to get tools')
 
     async def call_tool(
         self, name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT], tool: ToolsetTool[AgentDepsT]
     ) -> Any:
-        return await self.wrapped.call_tool(name, tool_args, ctx, tool)
+        raise NotImplementedError('Dynamic toolsets cannot be used to call tools')
 
     def apply(self, visitor: Callable[[AbstractToolset[AgentDepsT]], None]) -> None:
-        self.wrapped.apply(visitor)
+        raise NotImplementedError('Dynamic toolsets cannot be used to apply visitors')

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3866,7 +3866,7 @@ def test_prepare_output_tools():
     )
 
 
-async def test_explicit_context_manager():
+async def test_legacy_context_manager():
     try:
         from pydantic_ai.mcp import MCPServerStdio
     except ImportError:  # pragma: lax no cover
@@ -3882,6 +3882,26 @@ async def test_explicit_context_manager():
         assert server2.is_running
 
         async with agent:
+            assert server1.is_running
+            assert server2.is_running
+
+
+async def test_explicit_context_manager():
+    try:
+        from pydantic_ai.mcp import MCPServerStdio
+    except ImportError:  # pragma: lax no cover
+        pytest.skip('mcp is not installed')
+
+    server1 = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
+    server2 = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
+    toolset = CombinedToolset([server1, PrefixedToolset(server2, 'prefix')])
+    agent = Agent('test', toolsets=[toolset])
+
+    async with agent.setup():
+        assert server1.is_running
+        assert server2.is_running
+
+        async with agent.setup():
             assert server1.is_running
             assert server2.is_running
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -72,7 +72,7 @@ def run_context(model: Model) -> RunContext[int]:
 
 async def test_stdio_server(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
-    async with server:
+    async with server.setup():
         tools = [tool.tool_def for tool in (await server.get_tools(run_context)).values()]
         assert len(tools) == snapshot(16)
         assert tools[0].name == 'celsius_to_fahrenheit'
@@ -86,8 +86,8 @@ async def test_stdio_server(run_context: RunContext[int]):
 
 async def test_reentrant_context_manager():
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
-    async with server:
-        async with server:
+    async with server.setup():
+        async with server.setup():
             pass
 
 
@@ -98,16 +98,17 @@ async def test_context_manager_initialization_error() -> None:
 
     with patch.object(ClientSession, 'initialize', side_effect=Exception):
         with pytest.raises(Exception):
-            async with server:
+            async with server.setup():
                 pass
 
-    assert server._read_stream._closed  # pyright: ignore[reportPrivateUsage]
-    assert server._write_stream._closed  # pyright: ignore[reportPrivateUsage]
+    assert server._client is not None  # pyright: ignore[reportPrivateUsage]
+    assert server._client._read_stream._closed  # pyright: ignore[reportPrivateUsage]
+    assert server._client._write_stream._closed  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_stdio_server_with_tool_prefix(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'], tool_prefix='foo')
-    async with server:
+    async with server.setup():
         tools = await server.get_tools(run_context)
         assert all(name.startswith('foo_') for name in tools.keys())
 
@@ -120,7 +121,7 @@ async def test_stdio_server_with_tool_prefix(run_context: RunContext[int]):
 async def test_stdio_server_with_cwd(run_context: RunContext[int]):
     test_dir = Path(__file__).parent
     server = MCPServerStdio('python', ['mcp_server.py'], cwd=test_dir)
-    async with server:
+    async with server.setup():
         tools = await server.get_tools(run_context)
         assert len(tools) == snapshot(16)
 
@@ -140,7 +141,7 @@ async def test_process_tool_call(run_context: RunContext[int]) -> int:
         return await call_tool(name, tool_args, {'deps': ctx.deps})
 
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'], process_tool_call=process_tool_call)
-    async with server:
+    async with server.setup():
         agent = Agent(deps_type=int, model=TestModel(call_tools=['echo_deps']), toolsets=[server])
         result = await agent.run('Echo with deps set to 42', deps=42)
         assert result.output == snapshot('{"echo_deps":{"echo":"This is an echo message","deps":42}}')
@@ -180,7 +181,7 @@ def test_sse_server_conflicting_timeout_params():
 
 @pytest.mark.vcr()
 async def test_agent_with_stdio_server(allow_model_requests: None, agent: Agent):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('What is 0 degrees Celsius in Fahrenheit?')
         assert result.output == snapshot('0 degrees Celsius is equal to 32 degrees Fahrenheit.')
         assert result.all_messages() == snapshot(
@@ -257,7 +258,7 @@ async def test_agent_with_conflict_tool_name(agent: Agent):
         """Return nothing"""
         return None
 
-    async with agent:
+    async with agent.setup():
         with pytest.raises(
             UserError,
             match=re.escape(
@@ -280,7 +281,7 @@ async def test_agent_with_prefix_tool_name(openai_api_key: str):
         """Return nothing"""
         return None
 
-    async with agent:
+    async with agent.setup():
         # This means that we passed the _prepare_request_parameters check and there is no conflict in the tool name
         with pytest.raises(RuntimeError, match='Model requests are not allowed, since ALLOW_MODEL_REQUESTS is False'):
             await agent.run('No conflict')
@@ -295,7 +296,7 @@ async def test_agent_with_server_not_running(agent: Agent, allow_model_requests:
 async def test_log_level_unset(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
     assert server.log_level is None
-    async with server:
+    async with server.setup():
         tools = [tool.tool_def for tool in (await server.get_tools(run_context)).values()]
         assert len(tools) == snapshot(16)
         assert tools[13].name == 'get_log_level'
@@ -307,14 +308,14 @@ async def test_log_level_unset(run_context: RunContext[int]):
 async def test_log_level_set(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'], log_level='info')
     assert server.log_level == 'info'
-    async with server:
+    async with server.setup():
         result = await server.direct_call_tool('get_log_level', {})
         assert result == snapshot('info')
 
 
 @pytest.mark.vcr()
 async def test_tool_returning_str(allow_model_requests: None, agent: Agent):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('What is the weather in Mexico City?')
         assert result.output == snapshot(
             'The weather in Mexico City is currently sunny with a temperature of 26 degrees Celsius.'
@@ -393,7 +394,7 @@ async def test_tool_returning_str(allow_model_requests: None, agent: Agent):
 
 @pytest.mark.vcr()
 async def test_tool_returning_text_resource(allow_model_requests: None, agent: Agent):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('Get me the product name')
         assert result.output == snapshot('The product name is "Pydantic AI".')
         assert result.all_messages() == snapshot(
@@ -466,7 +467,7 @@ async def test_tool_returning_text_resource(allow_model_requests: None, agent: A
 
 @pytest.mark.vcr()
 async def test_tool_returning_text_resource_link(allow_model_requests: None, agent: Agent):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('Get me the product name via get_product_name_link')
         assert result.output == snapshot('The product name is "Pydantic AI".')
         assert result.all_messages() == snapshot(
@@ -539,7 +540,7 @@ async def test_tool_returning_text_resource_link(allow_model_requests: None, age
 
 @pytest.mark.vcr()
 async def test_tool_returning_image_resource(allow_model_requests: None, agent: Agent, image_content: BinaryContent):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('Get me the image resource')
         assert result.output == snapshot(
             'This is an image of a sliced kiwi with a vibrant green interior and black seeds.'
@@ -621,7 +622,7 @@ async def test_tool_returning_image_resource(allow_model_requests: None, agent: 
 async def test_tool_returning_image_resource_link(
     allow_model_requests: None, agent: Agent, image_content: BinaryContent
 ):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('Get me the image resource via get_image_resource_link')
         assert result.output == snapshot(
             'This is an image of a sliced kiwi fruit. It shows the green, seed-speckled interior with fuzzy brown skin around the edges.'
@@ -704,7 +705,7 @@ async def test_tool_returning_audio_resource(
     allow_model_requests: None, agent: Agent, audio_content: BinaryContent, gemini_api_key: str
 ):
     model = GoogleModel('gemini-2.5-pro-preview-03-25', provider=GoogleProvider(api_key=gemini_api_key))
-    async with agent:
+    async with agent.setup():
         result = await agent.run("What's the content of the audio resource?", model=model)
         assert result.output == snapshot('The audio resource contains a voice saying "Hello, my name is Marcelo."')
         assert result.all_messages() == snapshot(
@@ -758,7 +759,7 @@ async def test_tool_returning_audio_resource_link(
     allow_model_requests: None, agent: Agent, audio_content: BinaryContent, gemini_api_key: str
 ):
     model = GoogleModel('gemini-2.5-pro-preview-03-25', provider=GoogleProvider(api_key=gemini_api_key))
-    async with agent:
+    async with agent.setup():
         result = await agent.run("What's the content of the audio resource via get_audio_resource_link?", model=model)
         assert result.output == snapshot('00:05')
         assert result.all_messages() == snapshot(
@@ -819,7 +820,7 @@ async def test_tool_returning_audio_resource_link(
 
 @pytest.mark.vcr()
 async def test_tool_returning_image(allow_model_requests: None, agent: Agent, image_content: BinaryContent):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('Get me an image')
         assert result.output == snapshot('Here is an image of a sliced kiwi on a white background.')
         assert result.all_messages() == snapshot(
@@ -899,7 +900,7 @@ async def test_tool_returning_image(allow_model_requests: None, agent: Agent, im
 
 @pytest.mark.vcr()
 async def test_tool_returning_dict(allow_model_requests: None, agent: Agent):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('Get me a dict, respond on one line')
         assert result.output == snapshot('{"foo":"bar","baz":123}')
         assert result.all_messages() == snapshot(
@@ -966,7 +967,7 @@ async def test_tool_returning_dict(allow_model_requests: None, agent: Agent):
 
 @pytest.mark.vcr()
 async def test_tool_returning_error(allow_model_requests: None, agent: Agent):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('Get me an error, pass False as a value, unless the tool tells you otherwise')
         assert result.output == snapshot(
             'I called the tool with the correct parameter, and it returned: "This is not an error."'
@@ -1080,7 +1081,7 @@ async def test_tool_returning_error(allow_model_requests: None, agent: Agent):
 
 @pytest.mark.vcr()
 async def test_tool_returning_none(allow_model_requests: None, agent: Agent):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('Call the none tool and say Hello')
         assert result.output == snapshot('Hello! How can I assist you today?')
         assert result.all_messages() == snapshot(
@@ -1147,7 +1148,7 @@ async def test_tool_returning_none(allow_model_requests: None, agent: Agent):
 
 @pytest.mark.vcr()
 async def test_tool_returning_multiple_items(allow_model_requests: None, agent: Agent, image_content: BinaryContent):
-    async with agent:
+    async with agent.setup():
         result = await agent.run('Get me multiple items and summarize in one sentence')
         assert result.output == snapshot(
             'The data includes two strings, a dictionary with a key-value pair, and an image of a sliced kiwi.'
@@ -1239,7 +1240,7 @@ async def test_tool_returning_multiple_items(allow_model_requests: None, agent: 
 async def test_client_sampling(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
     server.sampling_model = TestModel(custom_output_text='sampling model response')
-    async with server:
+    async with server.setup():
         result = await server.direct_call_tool('use_sampling', {'foo': 'bar'})
         assert result == snapshot(
             {
@@ -1255,7 +1256,7 @@ async def test_client_sampling(run_context: RunContext[int]):
 async def test_client_sampling_disabled(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'], allow_sampling=False)
     server.sampling_model = TestModel(custom_output_text='sampling model response')
-    async with server:
+    async with server.setup():
         with pytest.raises(ModelRetry, match='Error executing tool use_sampling: Sampling not supported'):
             await server.direct_call_tool('use_sampling', {'foo': 'bar'})
 
@@ -1265,7 +1266,7 @@ async def test_mcp_server_raises_mcp_error(
 ) -> None:
     mcp_error = McpError(error=ErrorData(code=400, message='Test MCP error conversion'))
 
-    async with agent:
+    async with agent.setup():
         with patch.object(
             mcp_server._client,  # pyright: ignore[reportPrivateUsage]
             'send_request',


### PR DESCRIPTION
For discussion

Use explicit yielding async context managers for Agent and Toolsets.

This allows toolsets and Agents to be entered and exited more granularly as exitstacks only allow exiting all accumulated context managers at once.

I dont expect this to be merged but just wanted to noodle on it