### PR TITLE
Change type of 'source' field on EvaluationResult

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py
@@ -48,7 +48,9 @@ async def run_evaluator(
     for name, result in results.items():
         if not isinstance(result, EvaluationReason):
             result = EvaluationReason(value=result)
-        details.append(EvaluationResult(name=name, value=result.value, reason=result.reason, source=evaluator))
+        details.append(
+            EvaluationResult(name=name, value=result.value, reason=result.reason, source=evaluator.as_spec())
+        )
 
     return details
 

--- a/pydantic_evals/pydantic_evals/evaluators/evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/evaluator.py
@@ -71,13 +71,13 @@ class EvaluationResult(Generic[EvaluationScalarT]):
         name: The name of the evaluation.
         value: The scalar result of the evaluation.
         reason: An optional explanation of the evaluation result.
-        source: The evaluator that produced this result.
+        source: The spec of the evaluator that produced this result.
     """
 
     name: str
     value: EvaluationScalarT
     reason: str | None
-    source: Evaluator
+    source: EvaluatorSpec
 
     def downcast(self, *value_types: type[T]) -> EvaluationResult[T] | None:
         """Attempt to downcast this result to a more specific type.
@@ -246,6 +246,13 @@ class Evaluator(Generic[InputsT, OutputT, MetadataT], metaclass=_StrictABCMeta):
         Returns:
             A JSON-serializable representation of this evaluator as an EvaluatorSpec.
         """
+        return to_jsonable_python(
+            self.as_spec(),
+            context=info.context,
+            serialize_unknown=True,
+        )
+
+    def as_spec(self) -> EvaluatorSpec:
         raw_arguments = self.build_serialization_arguments()
 
         arguments: None | tuple[Any,] | dict[str, Any]
@@ -255,11 +262,8 @@ class Evaluator(Generic[InputsT, OutputT, MetadataT], metaclass=_StrictABCMeta):
             arguments = (next(iter(raw_arguments.values())),)
         else:
             arguments = raw_arguments
-        return to_jsonable_python(
-            EvaluatorSpec(name=self.get_serialization_name(), arguments=arguments),
-            context=info.context,
-            serialize_unknown=True,
-        )
+
+        return EvaluatorSpec(name=self.get_serialization_name(), arguments=arguments)
 
     def build_serialization_arguments(self) -> dict[str, Any]:
         """Build the arguments for serialization.

--- a/pydantic_evals/pydantic_evals/reporting/__init__.py
+++ b/pydantic_evals/pydantic_evals/reporting/__init__.py
@@ -669,7 +669,11 @@ class ReportCaseRenderer:
             row.append(scores_diff)
 
         if self.include_labels:  # pragma: no branch
-            labels_diff = self._render_dicts_diff(baseline.labels, new_case.labels, self.label_renderers)
+            labels_diff = self._render_dicts_diff(
+                {k: v.value for k, v in baseline.labels.items()},
+                {k: v.value for k, v in new_case.labels.items()},
+                self.label_renderers,
+            )
             row.append(labels_diff)
 
         if self.include_metrics:  # pragma: no branch

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -456,13 +456,13 @@ async def test_repeated_name_outputs(example_dataset: Dataset[TaskInput, TaskOut
                 scores={},
                 labels={
                     'output': EvaluationResult(
-                        name='output', value='a', reason=None, source=MockEvaluator(output={'output': 'a'})
+                        name='output', value='a', reason=None, source=MockEvaluator(output={'output': 'a'}).as_spec()
                     ),
                     'output_2': EvaluationResult(
-                        name='output', value='b', reason=None, source=MockEvaluator(output={'output': 'b'})
+                        name='output', value='b', reason=None, source=MockEvaluator(output={'output': 'b'}).as_spec()
                     ),
                     'output_3': EvaluationResult(
-                        name='output', value='c', reason=None, source=MockEvaluator(output={'output': 'c'})
+                        name='output', value='c', reason=None, source=MockEvaluator(output={'output': 'c'}).as_spec()
                     ),
                 },
                 assertions={},
@@ -482,13 +482,13 @@ async def test_repeated_name_outputs(example_dataset: Dataset[TaskInput, TaskOut
                 scores={},
                 labels={
                     'output': EvaluationResult(
-                        name='output', value='a', reason=None, source=MockEvaluator(output={'output': 'a'})
+                        name='output', value='a', reason=None, source=MockEvaluator(output={'output': 'a'}).as_spec()
                     ),
                     'output_2': EvaluationResult(
-                        name='output', value='b', reason=None, source=MockEvaluator(output={'output': 'b'})
+                        name='output', value='b', reason=None, source=MockEvaluator(output={'output': 'b'}).as_spec()
                     ),
                     'output_3': EvaluationResult(
-                        name='output', value='c', reason=None, source=MockEvaluator(output={'output': 'c'})
+                        name='output', value='c', reason=None, source=MockEvaluator(output={'output': 'c'}).as_spec()
                     ),
                 },
                 assertions={},

--- a/tests/evals/test_evaluator_base.py
+++ b/tests/evals/test_evaluator_base.py
@@ -52,11 +52,11 @@ def test_evaluation_result():
     evaluator = DummyEvaluator()
 
     # Test basic result
-    result = EvaluationResult(name='test', value=True, reason='Success', source=evaluator)
+    result = EvaluationResult(name='test', value=True, reason='Success', source=evaluator.as_spec())
     assert result.name == 'test'
     assert result.value is True
     assert result.reason == 'Success'
-    assert result.source == evaluator
+    assert result.source == evaluator.as_spec()
 
     # Test downcast with matching type
     downcast = result.downcast(bool)

--- a/tests/evals/test_evaluators.py
+++ b/tests/evals/test_evaluators.py
@@ -162,7 +162,7 @@ async def test_evaluator_call(test_context: EvaluatorContext[TaskInput, TaskOutp
     assert results[0].name == 'result'
     assert results[0].value == 'passed'
     assert results[0].reason is None
-    assert results[0].source is evaluator
+    assert results[0].source == EvaluatorSpec(name='ExampleEvaluator', arguments=None)
 
 
 async def test_is_instance_evaluator():
@@ -242,7 +242,14 @@ async def test_custom_evaluator_name(test_context: EvaluatorContext[TaskInput, T
     evaluator = CustomNameFieldEvaluator(result=123, evaluation_name='abc')
 
     assert to_jsonable_python(await run_evaluator(evaluator, test_context)) == snapshot(
-        [{'name': 'abc', 'reason': None, 'source': {'evaluation_name': 'abc', 'result': 123}, 'value': 123}]
+        [
+            {
+                'name': 'abc',
+                'reason': None,
+                'source': {'arguments': {'evaluation_name': 'abc', 'result': 123}, 'name': 'CustomNameFieldEvaluator'},
+                'value': 123,
+            }
+        ]
     )
 
     @dataclass
@@ -260,7 +267,14 @@ async def test_custom_evaluator_name(test_context: EvaluatorContext[TaskInput, T
     evaluator = CustomNamePropertyEvaluator(result=123, my_name='marcelo')
 
     assert to_jsonable_python(await run_evaluator(evaluator, test_context)) == snapshot(
-        [{'name': 'hello marcelo', 'reason': None, 'source': {'my_name': 'marcelo', 'result': 123}, 'value': 123}]
+        [
+            {
+                'name': 'hello marcelo',
+                'reason': None,
+                'source': {'arguments': {'my_name': 'marcelo', 'result': 123}, 'name': 'CustomNamePropertyEvaluator'},
+                'value': 123,
+            }
+        ]
     )
 
 

--- a/tests/evals/test_reporting.py
+++ b/tests/evals/test_reporting.py
@@ -48,7 +48,7 @@ def sample_assertion(mock_evaluator: Evaluator[TaskInput, TaskOutput, TaskMetada
         name='MockEvaluator',
         value=True,
         reason=None,
-        source=mock_evaluator,
+        source=mock_evaluator.as_spec(),
     )
 
 
@@ -58,7 +58,7 @@ def sample_score(mock_evaluator: Evaluator[TaskInput, TaskOutput, TaskMetadata])
         name='MockEvaluator',
         value=2.5,
         reason=None,
-        source=mock_evaluator,
+        source=mock_evaluator.as_spec(),
     )
 
 
@@ -68,7 +68,7 @@ def sample_label(mock_evaluator: Evaluator[TaskInput, TaskOutput, TaskMetadata])
         name='MockEvaluator',
         value='hello',
         reason=None,
-        source=mock_evaluator,
+        source=mock_evaluator.as_spec(),
     )
 
 
@@ -195,16 +195,16 @@ async def test_evaluation_renderer_with_baseline(sample_report: EvaluationReport
 
     table = renderer.build_diff_table(sample_report, baseline_report)
     assert render_table(table) == snapshot("""\
-                                                                                                                               Evaluation Diff: baseline_report → test_report
-┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Case ID   ┃ Inputs                    ┃ Metadata               ┃ Expected Output ┃ Outputs         ┃ Scores       ┃ Labels                                                                              ┃ Metrics                                 ┃ Assertions   ┃                             Durations ┃
-┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ test_case │ {'query': 'What is 2+2?'} │ {'difficulty': 'easy'} │ {'answer': '4'} │ {'answer': '4'} │ score1: 2.50 │ label1: EvaluationResult(name='MockEvaluator', value='hello', reason=None,          │ accuracy: 0.900 → 0.950 (+0.05 / +5.6%) │  → ✔         │  task: 0.150 → 0.100 (-0.05 / -33.3%) │
-│           │                           │                        │                 │                 │              │ source=mock_evaluator.<locals>.MockEvaluator())                                     │                                         │              │ total: 0.250 → 0.200 (-0.05 / -20.0%) │
-├───────────┼───────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────┼─────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┼──────────────┼───────────────────────────────────────┤
-│ Averages  │                           │                        │                 │                 │ score1: 2.50 │ label1: {'hello': 1.0}                                                              │ accuracy: 0.900 → 0.950 (+0.05 / +5.6%) │ - → 100.0% ✔ │  task: 0.150 → 0.100 (-0.05 / -33.3%) │
-│           │                           │                        │                 │                 │              │                                                                                     │                                         │              │ total: 0.250 → 0.200 (-0.05 / -20.0%) │
-└───────────┴───────────────────────────┴────────────────────────┴─────────────────┴─────────────────┴──────────────┴─────────────────────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────┴──────────────┴───────────────────────────────────────┘
+                                                                                                Evaluation Diff: baseline_report → test_report
+┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Case ID   ┃ Inputs                    ┃ Metadata               ┃ Expected Output ┃ Outputs         ┃ Scores       ┃ Labels                 ┃ Metrics                                 ┃ Assertions   ┃                             Durations ┃
+┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ test_case │ {'query': 'What is 2+2?'} │ {'difficulty': 'easy'} │ {'answer': '4'} │ {'answer': '4'} │ score1: 2.50 │ label1: hello          │ accuracy: 0.900 → 0.950 (+0.05 / +5.6%) │  → ✔         │  task: 0.150 → 0.100 (-0.05 / -33.3%) │
+│           │                           │                        │                 │                 │              │                        │                                         │              │ total: 0.250 → 0.200 (-0.05 / -20.0%) │
+├───────────┼───────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────┼────────────────────────┼─────────────────────────────────────────┼──────────────┼───────────────────────────────────────┤
+│ Averages  │                           │                        │                 │                 │ score1: 2.50 │ label1: {'hello': 1.0} │ accuracy: 0.900 → 0.950 (+0.05 / +5.6%) │ - → 100.0% ✔ │  task: 0.150 → 0.100 (-0.05 / -33.3%) │
+│           │                           │                        │                 │                 │              │                        │                                         │              │ total: 0.250 → 0.200 (-0.05 / -20.0%) │
+└───────────┴───────────────────────────┴────────────────────────┴─────────────────┴─────────────────┴──────────────┴────────────────────────┴─────────────────────────────────────────┴──────────────┴───────────────────────────────────────┘
 """)
 
 
@@ -350,7 +350,7 @@ async def test_report_case_aggregate_average():
                     name='MockEvaluator',
                     value=0.8,
                     reason=None,
-                    source=MockEvaluator(),
+                    source=MockEvaluator().as_spec(),
                 )
             },
             labels={
@@ -358,7 +358,7 @@ async def test_report_case_aggregate_average():
                     name='MockEvaluator',
                     value='good',
                     reason=None,
-                    source=MockEvaluator(),
+                    source=MockEvaluator().as_spec(),
                 )
             },
             assertions={
@@ -366,7 +366,7 @@ async def test_report_case_aggregate_average():
                     name='MockEvaluator',
                     value=True,
                     reason=None,
-                    source=MockEvaluator(),
+                    source=MockEvaluator().as_spec(),
                 )
             },
             task_duration=0.1,
@@ -387,7 +387,7 @@ async def test_report_case_aggregate_average():
                     name='MockEvaluator',
                     value=0.7,
                     reason=None,
-                    source=MockEvaluator(),
+                    source=MockEvaluator().as_spec(),
                 )
             },
             labels={
@@ -395,7 +395,7 @@ async def test_report_case_aggregate_average():
                     name='MockEvaluator',
                     value='good',
                     reason=None,
-                    source=MockEvaluator(),
+                    source=MockEvaluator().as_spec(),
                 )
             },
             assertions={
@@ -403,7 +403,7 @@ async def test_report_case_aggregate_average():
                     name='MockEvaluator',
                     value=False,
                     reason=None,
-                    source=MockEvaluator(),
+                    source=MockEvaluator().as_spec(),
                 )
             },
             task_duration=0.15,

--- a/tests/evals/test_reports.py
+++ b/tests/evals/test_reports.py
@@ -57,7 +57,7 @@ def sample_evaluation_result(
         name='MockEvaluator',
         value=True,
         reason=None,
-        source=mock_evaluator,
+        source=mock_evaluator.as_spec(),
     )
 
 
@@ -177,7 +177,7 @@ async def test_report_with_error(mock_evaluator: Evaluator[TaskInput, TaskOutput
         name='error_evaluator',
         value=False,  # No result
         reason='Test error message',
-        source=mock_evaluator,
+        source=mock_evaluator.as_spec(),
     )
 
     # Create a case


### PR DESCRIPTION
Closes #1953.

Basically, this moves from storing the raw evaluator to its spec on the `source` field of the EvaluationResult, which I feel is a reasonable change, as it better-represents the original intent of the design and fixes a user-reported issue.

Note, @DouweM **this is a breaking change** (though admittedly unlikely to affect many people).