### PR TITLE
Fix "test_download_item_no_content_type test fails on macOS"

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -312,6 +312,19 @@ class DocumentUrl(FileUrl):
 
     def _infer_media_type(self) -> str:
         """Return the media type of the document, based on the url."""
+        # Common document types are hardcoded here as mime-type support for these
+        # extensions varies across operating systems.
+        if self.url.endswith(('.md', '.mdx', '.markdown')):
+            return 'text/markdown'
+        elif self.url.endswith('.asciidoc'):
+            return 'text/x-asciidoc'
+        elif self.url.endswith('.txt'):
+            return 'text/plain'
+        elif self.url.endswith('.pdf'):
+            return 'application/pdf'
+        elif self.url.endswith('.rtf'):
+            return 'application/rtf'
+
         type_, _ = guess_type(self.url)
         if type_ is None:
             raise ValueError(f'Unknown document file extension: {self.url}')

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -41,6 +41,24 @@ def test_youtube_video_url(url: str, is_youtube: bool):
     assert video_url.format == 'mp4'
 
 
+@pytest.mark.parametrize(
+    'url, expected_data_type',
+    [
+        ('https://raw.githubusercontent.com/pydantic/pydantic-ai/refs/heads/main/docs/help.md', 'text/markdown'),
+        ('https://raw.githubusercontent.com/pydantic/pydantic-ai/refs/heads/main/docs/help.txt', 'text/plain'),
+        ('https://raw.githubusercontent.com/pydantic/pydantic-ai/refs/heads/main/docs/help.pdf', 'application/pdf'),
+        ('https://raw.githubusercontent.com/pydantic/pydantic-ai/refs/heads/main/docs/help.rtf', 'application/rtf'),
+        (
+            'https://raw.githubusercontent.com/pydantic/pydantic-ai/refs/heads/main/docs/help.asciidoc',
+            'text/x-asciidoc',
+        ),
+    ],
+)
+def test_document_url_other_types(url: str, expected_data_type: str) -> None:
+    document_url = DocumentUrl(url=url)
+    assert document_url.media_type == expected_data_type
+
+
 def test_document_url():
     document_url = DocumentUrl(url='https://example.com/document.pdf')
     assert document_url.media_type == 'application/pdf'


### PR DESCRIPTION
Fixes: https://github.com/pydantic/pydantic-ai/issues/2403

Adds hard-coded mimetypes for the most common document formats to avoid OS-specific mimetype categorization issues for the most common formats.