### PR TITLE
Add GPT-5 OpenAI model strings (prefixed only)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -301,6 +301,13 @@ KnownModelName = TypeAliasType(
         'openai:gpt-4o-mini-search-preview-2025-03-11',
         'openai:gpt-4o-search-preview',
         'openai:gpt-4o-search-preview-2025-03-11',
+        # GPT-5 family
+        'openai:gpt-5',
+        'openai:gpt-5-mini',
+        'openai:gpt-5-nano',
+        'openai:gpt-5-2025-08-07',
+        'openai:gpt-5-mini-2025-08-07',
+        'openai:gpt-5-nano-2025-08-07',
         'openai:o1',
         'openai:o1-2024-12-17',
         'openai:o1-mini',


### PR DESCRIPTION
Adds six GPT-5 model IDs to KnownModelName with openai: prefix only: gpt-5, gpt-5-mini, gpt-5-nano and their 2025-08-07 snapshots.