### PR TITLE
Fix KeyError when parsing video metadata without audio track in Google models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -878,7 +878,7 @@ def _metadata_as_usage(response: _GeminiResponse) -> usage.Usage:
             metadata_details = cast(list[_GeminiModalityTokenCount], metadata_details)
             suffix = key.removesuffix('_details')
             for detail in metadata_details:
-                details[f'{detail["modality"].lower()}_{suffix}'] = detail['token_count']
+                details[f'{detail["modality"].lower()}_{suffix}'] = detail.get('token_count', 0)
 
     return usage.Usage(
         request_tokens=metadata.get('prompt_token_count', 0),

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -603,7 +603,7 @@ def _metadata_as_usage(response: GenerateContentResponse) -> usage.Usage:
         if key.endswith('_details') and metadata_details:
             suffix = key.removesuffix('_details')
             for detail in metadata_details:
-                details[f'{detail["modality"].lower()}_{suffix}'] = detail['token_count']
+                details[f'{detail["modality"].lower()}_{suffix}'] = detail.get('token_count', 0)
 
     return usage.Usage(
         request_tokens=metadata.get('prompt_token_count', 0),


### PR DESCRIPTION
This PR fixes #2489.

## Problem
When processing video content that lacks an audio track through Google's Gemini models, the metadata parsing fails with a `KeyError`. The API response includes an AUDIO modality entry in the metadata details, but without the `token_count` field, causing the code to crash when trying to access it.

This can be reproduced by adding the following line in [pydantic_ai_slim/pydantic_ai/models/google.py#L606](pydantic_ai_slim/pydantic_ai/models/google.py#L606):
```python
for key, metadata_details in metadata.items():
    if key.endswith('_details') and metadata_details:
        suffix = key.removesuffix('_details')
        for detail in metadata_details:
            details[f'{detail["modality"].lower()}_{suffix}'] = detail.get('token_count', 0)
            print("DEBUG: detail: ", detail)  # <-- Add this debug line
```
processing a video file without an audio track. Debug output shows:
```
DEBUG: detail:  {'modality': <MediaModality.TEXT: 'TEXT'>, 'token_count': 1201}
DEBUG: detail:  {'modality': <MediaModality.VIDEO: 'VIDEO'>, 'token_count': 2064}
DEBUG: detail:  {'modality': <MediaModality.TEXT: 'TEXT'>, 'token_count': 1717}
DEBUG: detail:  {'modality': <MediaModality.AUDIO: 'AUDIO'>}
```

## Solution
Use `.get('token_count', 0)` instead of direct key access to safely handle missing `token_count` fields:

```python
# Before (causes KeyError):
details[f'{detail["modality"].lower()}_{suffix}'] = detail['token_count']

# After (safe with default):
details[f'{detail["modality"].lower()}_{suffix}'] = detail.get('token_count', 0)
```

This ensures that modalities without token counts (like audio tracks in silent videos) default to 0 tokens rather than crashing the application.

### Testing
- Verified the fix resolves the issue with video files lacking audio tracks
- All existing Google model tests pass without regression