### PR TITLE
Add support for `"openai-responses"` model inference string

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -679,6 +679,10 @@ def infer_model(model: Model | KnownModelName | str) -> Model:  # noqa: C901
         from .openai import OpenAIModel
 
         return OpenAIModel(model_name, provider=provider)
+    elif provider == 'openai-responses':
+        from .openai import OpenAIResponsesModel
+
+        return OpenAIResponsesModel(model_name, provider='openai')
     elif provider in ('google-gla', 'google-vertex'):
         from .google import GoogleModel
 

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -96,6 +96,14 @@ TEST_CASES = [
         'grok',
         'OpenAIModel',
     ),
+    (
+        'OPENAI_API_KEY',
+        'openai-responses:gpt-4o',
+        'gpt-4o',
+        'openai',
+        'openai',
+        'OpenAIResponsesModel',
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
This PR adds support for using the `openai-responses:` prefix in model strings to explicitly create an `OpenAIResponsesModel` through the `infer_model` function.

## Changes
- Modified `infer_model()` function in `pydantic_ai_slim/pydantic_ai/models/__init__.py` to recognize the `openai-responses` provider
- Added test case in `tests/models/test_model.py` to verify the new functionality

## Usage
Users can now use the `openai-responses:` prefix to get an OpenAI Responses model:

```python
from pydantic_ai.models import infer_model
from pydantic_ai.agent import Agent

# These are now equivalent:
model1 = OpenAIResponsesModel('gpt-4o')
model2 = infer_model('openai-responses:gpt-4o')

# Works with Agent class:
agent = Agent(model='openai-responses:gpt-4o')
```

## Testing
- All existing tests pass
- New test case verifies that `openai-responses:gpt-4o` correctly returns an `OpenAIResponsesModel`
- Manually tested integration with Agent class
- Verified backward compatibility with existing model inference patterns

## Backward Compatibility
✅ This change is fully backward compatible - all existing functionality remains unchanged.

The implementation follows the existing pattern used by other providers (e.g., 'openai:', 'anthropic:', etc.) and integrates seamlessly with the current model inference system.

🤖 Generated with [Claude Code](https://claude.ai/code)