### PR TITLE
Stop calling MCP server `get_tools` ahead of `agent run` span

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -251,6 +251,8 @@ async def _prepare_request_parameters(
 ) -> models.ModelRequestParameters:
     """Build tools and create an agent model."""
     run_context = build_run_context(ctx)
+
+    # This will raise errors for any tool name conflicts
     ctx.deps.tool_manager = await ctx.deps.tool_manager.for_run_step(run_context)
 
     output_schema = ctx.deps.output_schema

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -46,7 +46,7 @@ class ToolManager(Generic[AgentDepsT]):
         return self.__class__(
             toolset=self.toolset,
             ctx=ctx,
-            tools=await self.toolset.get_tools(ctx) if ctx else None,
+            tools=await self.toolset.get_tools(ctx),
         )
 
     @property

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -53,14 +53,14 @@ class ToolManager(Generic[AgentDepsT]):
     def tool_defs(self) -> list[ToolDefinition]:
         """The tool definitions for the tools in this tool manager."""
         if self.tools is None:
-            raise ValueError('ToolManager has not been prepared for a run step yet')
+            raise ValueError('ToolManager has not been prepared for a run step yet')  # pragma: no cover
 
         return [tool.tool_def for tool in self.tools.values()]
 
     def get_tool_def(self, name: str) -> ToolDefinition | None:
         """Get the tool definition for a given tool name, or `None` if the tool is unknown."""
         if self.tools is None:
-            raise ValueError('ToolManager has not been prepared for a run step yet')
+            raise ValueError('ToolManager has not been prepared for a run step yet')  # pragma: no cover
 
         try:
             return self.tools[name].tool_def
@@ -78,7 +78,7 @@ class ToolManager(Generic[AgentDepsT]):
             wrap_validation_errors: Whether to wrap validation errors in a retry prompt part.
         """
         if self.tools is None or self.ctx is None:
-            raise ValueError('ToolManager has not been prepared for a run step yet')
+            raise ValueError('ToolManager has not been prepared for a run step yet')  # pragma: no cover
 
         if (tool := self.tools.get(call.tool_name)) and tool.tool_def.kind == 'output':
             # Output tool calls are not traced
@@ -94,7 +94,7 @@ class ToolManager(Generic[AgentDepsT]):
 
     async def _call_tool(self, call: ToolCallPart, allow_partial: bool, wrap_validation_errors: bool) -> Any:
         if self.tools is None or self.ctx is None:
-            raise ValueError('ToolManager has not been prepared for a run step yet')
+            raise ValueError('ToolManager has not been prepared for a run step yet')  # pragma: no cover
 
         name = call.tool_name
         tool = self.tools.get(name)

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
 from typing import Any, Generic
 
+from opentelemetry.trace import Tracer
 from pydantic import ValidationError
 from typing_extensions import assert_never
 
@@ -21,41 +22,46 @@ from .toolsets.abstract import AbstractToolset, ToolsetTool
 class ToolManager(Generic[AgentDepsT]):
     """Manages tools for an agent run step. It caches the agent run's toolset's tool definitions and handles calling tools and retries."""
 
-    ctx: RunContext[AgentDepsT]
-    """The agent run context for a specific run step."""
     toolset: AbstractToolset[AgentDepsT]
     """The toolset that provides the tools for this run step."""
-    tools: dict[str, ToolsetTool[AgentDepsT]]
+    ctx: RunContext[AgentDepsT] | None = None
+    """The agent run context for a specific run step."""
+    tools: dict[str, ToolsetTool[AgentDepsT]] | None = None
     """The cached tools for this run step."""
     failed_tools: set[str] = field(default_factory=set)
     """Names of tools that failed in this run step."""
 
-    @classmethod
-    async def build(cls, toolset: AbstractToolset[AgentDepsT], ctx: RunContext[AgentDepsT]) -> ToolManager[AgentDepsT]:
-        """Build a new tool manager for a specific run step."""
-        return cls(
-            ctx=ctx,
-            toolset=toolset,
-            tools=await toolset.get_tools(ctx),
-        )
-
     async def for_run_step(self, ctx: RunContext[AgentDepsT]) -> ToolManager[AgentDepsT]:
         """Build a new tool manager for the next run step, carrying over the retries from the current run step."""
-        if ctx.run_step == self.ctx.run_step:
-            return self
+        if self.ctx is not None:
+            if ctx.run_step == self.ctx.run_step:
+                return self
 
-        retries = {
-            failed_tool_name: self.ctx.retries.get(failed_tool_name, 0) + 1 for failed_tool_name in self.failed_tools
-        }
-        return await self.__class__.build(self.toolset, replace(ctx, retries=retries))
+            retries = {
+                failed_tool_name: self.ctx.retries.get(failed_tool_name, 0) + 1
+                for failed_tool_name in self.failed_tools
+            }
+            ctx = replace(ctx, retries=retries)
+
+        return self.__class__(
+            toolset=self.toolset,
+            ctx=ctx,
+            tools=await self.toolset.get_tools(ctx) if ctx else None,
+        )
 
     @property
     def tool_defs(self) -> list[ToolDefinition]:
         """The tool definitions for the tools in this tool manager."""
+        if self.tools is None:
+            raise ValueError('ToolManager has not been prepared for a run step yet')
+
         return [tool.tool_def for tool in self.tools.values()]
 
     def get_tool_def(self, name: str) -> ToolDefinition | None:
         """Get the tool definition for a given tool name, or `None` if the tool is unknown."""
+        if self.tools is None:
+            raise ValueError('ToolManager has not been prepared for a run step yet')
+
         try:
             return self.tools[name].tool_def
         except KeyError:
@@ -71,15 +77,25 @@ class ToolManager(Generic[AgentDepsT]):
             allow_partial: Whether to allow partial validation of the tool arguments.
             wrap_validation_errors: Whether to wrap validation errors in a retry prompt part.
         """
+        if self.tools is None or self.ctx is None:
+            raise ValueError('ToolManager has not been prepared for a run step yet')
+
         if (tool := self.tools.get(call.tool_name)) and tool.tool_def.kind == 'output':
             # Output tool calls are not traced
             return await self._call_tool(call, allow_partial, wrap_validation_errors)
         else:
-            return await self._call_tool_traced(call, allow_partial, wrap_validation_errors)
+            return await self._call_tool_traced(
+                call,
+                allow_partial,
+                wrap_validation_errors,
+                self.ctx.tracer,
+                self.ctx.trace_include_content,
+            )
 
-    async def _call_tool(
-        self, call: ToolCallPart, allow_partial: bool = False, wrap_validation_errors: bool = True
-    ) -> Any:
+    async def _call_tool(self, call: ToolCallPart, allow_partial: bool, wrap_validation_errors: bool) -> Any:
+        if self.tools is None or self.ctx is None:
+            raise ValueError('ToolManager has not been prepared for a run step yet')
+
         name = call.tool_name
         tool = self.tools.get(name)
         try:
@@ -137,14 +153,19 @@ class ToolManager(Generic[AgentDepsT]):
                 raise e
 
     async def _call_tool_traced(
-        self, call: ToolCallPart, allow_partial: bool = False, wrap_validation_errors: bool = True
+        self,
+        call: ToolCallPart,
+        allow_partial: bool,
+        wrap_validation_errors: bool,
+        tracer: Tracer,
+        include_content: bool = False,
     ) -> Any:
         """See <https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span>."""
         span_attributes = {
             'gen_ai.tool.name': call.tool_name,
             # NOTE: this means `gen_ai.tool.call.id` will be included even if it was generated by pydantic-ai
             'gen_ai.tool.call.id': call.tool_call_id,
-            **({'tool_arguments': call.args_as_json_str()} if self.ctx.trace_include_content else {}),
+            **({'tool_arguments': call.args_as_json_str()} if include_content else {}),
             'logfire.msg': f'running tool: {call.tool_name}',
             # add the JSON schema so these attributes are formatted nicely in Logfire
             'logfire.json_schema': json.dumps(
@@ -156,7 +177,7 @@ class ToolManager(Generic[AgentDepsT]):
                                 'tool_arguments': {'type': 'object'},
                                 'tool_response': {'type': 'object'},
                             }
-                            if self.ctx.trace_include_content
+                            if include_content
                             else {}
                         ),
                         'gen_ai.tool.name': {},
@@ -165,16 +186,16 @@ class ToolManager(Generic[AgentDepsT]):
                 }
             ),
         }
-        with self.ctx.tracer.start_as_current_span('running tool', attributes=span_attributes) as span:
+        with tracer.start_as_current_span('running tool', attributes=span_attributes) as span:
             try:
                 tool_result = await self._call_tool(call, allow_partial, wrap_validation_errors)
             except ToolRetryError as e:
                 part = e.tool_retry
-                if self.ctx.trace_include_content and span.is_recording():
+                if include_content and span.is_recording():
                     span.set_attribute('tool_response', part.model_response())
                 raise e
 
-            if self.ctx.trace_include_content and span.is_recording():
+            if include_content and span.is_recording():
                 span.set_attribute(
                     'tool_response',
                     tool_result

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1104,18 +1104,7 @@ async def test_request_with_state() -> None:
             events.append(json.loads(event.removeprefix('data: ')))
 
         assert events == simple_result()
-    assert seen_states == snapshot(
-        [
-            41,  # run msg_1, prepare_tools call 1
-            42,  # run msg_1, prepare_tools call 2
-            0,  # run msg_2, prepare_tools call 1
-            1,  # run msg_2, prepare_tools call 2
-            0,  # run msg_3, prepare_tools call 1
-            1,  # run msg_3, prepare_tools call 2
-            42,  # run msg_4, prepare_tools call 1
-            43,  # run msg_4, prepare_tools call 2
-        ]
-    )
+    assert seen_states == snapshot([41, 0, 0, 42])
 
 
 async def test_request_with_state_without_handler() -> None:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3768,11 +3768,7 @@ def test_toolset_factory():
     assert run_result._state.run_step == 3  # pyright: ignore[reportPrivateUsage]
     assert len(available_tools) == 3
     assert toolset_creation_counts == snapshot(
-        {
-            'via_toolsets_arg': 4,
-            'via_toolset_decorator': 4,
-            'via_toolset_decorator_for_entire_run': 1,
-        }
+        defaultdict(int, {'via_toolsets_arg': 3, 'via_toolset_decorator': 3, 'via_toolset_decorator_for_entire_run': 1})
     )
 
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -322,8 +322,6 @@ async def test_complex_agent_run_in_workflow(
             'RunWorkflow:ComplexAgentWorkflow',
             'StartActivity:agent__complex_agent__mcp_server__mcp__get_tools',
             'RunActivity:agent__complex_agent__mcp_server__mcp__get_tools',
-            'StartActivity:agent__complex_agent__mcp_server__mcp__get_tools',
-            'RunActivity:agent__complex_agent__mcp_server__mcp__get_tools',
             'StartActivity:agent__complex_agent__model_request_stream',
             'ctx.run_step=1',
             '{"index":0,"part":{"tool_name":"get_country","args":"","tool_call_id":"call_3rqTYrA6H21AYUaRGP4F66oq","part_kind":"tool-call"},"event_kind":"part_start"}',

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1226,10 +1226,9 @@ def test_tool_retries():
     with pytest.raises(UnexpectedModelBehavior, match="Tool 'infinite_retry_tool' exceeded max retries count of 5"):
         agent.run_sync('Begin infinite retry loop!')
 
-    # There are extra 0s here because the toolset is prepared once ahead of the graph run, before the user prompt part is added in.
-    assert prepare_tools_retries == [0, 0, 1, 2, 3, 4, 5]
-    assert prepare_retries == [0, 0, 1, 2, 3, 4, 5]
-    assert call_retries == [0, 1, 2, 3, 4, 5]
+    assert prepare_tools_retries == snapshot([0, 1, 2, 3, 4, 5])
+    assert prepare_retries == snapshot([0, 1, 2, 3, 4, 5])
+    assert call_retries == snapshot([0, 1, 2, 3, 4, 5])
 
 
 def test_deferred_tool():

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -61,7 +61,7 @@ async def test_function_toolset():
         return a + b
 
     no_prefix_context = build_run_context(PrefixDeps())
-    no_prefix_toolset = await ToolManager[PrefixDeps].build(toolset, no_prefix_context)
+    no_prefix_toolset = await ToolManager[PrefixDeps](toolset).for_run_step(no_prefix_context)
     assert no_prefix_toolset.tool_defs == snapshot(
         [
             ToolDefinition(
@@ -79,7 +79,7 @@ async def test_function_toolset():
     assert await no_prefix_toolset.handle_call(ToolCallPart(tool_name='add', args={'a': 1, 'b': 2})) == 3
 
     foo_context = build_run_context(PrefixDeps(prefix='foo'))
-    foo_toolset = await ToolManager[PrefixDeps].build(toolset, foo_context)
+    foo_toolset = await ToolManager[PrefixDeps](toolset).for_run_step(foo_context)
     assert foo_toolset.tool_defs == snapshot(
         [
             ToolDefinition(
@@ -102,7 +102,7 @@ async def test_function_toolset():
         return a - b  # pragma: lax no cover
 
     bar_context = build_run_context(PrefixDeps(prefix='bar'))
-    bar_toolset = await ToolManager[PrefixDeps].build(toolset, bar_context)
+    bar_toolset = await ToolManager[PrefixDeps](toolset).for_run_step(bar_context)
     assert bar_toolset.tool_defs == snapshot(
         [
             ToolDefinition(
@@ -162,7 +162,7 @@ async def test_prepared_toolset_user_error_add_new_tools():
             'Prepare function cannot add or rename tools. Use `FunctionToolset.add_function()` or `RenamedToolset` instead.'
         ),
     ):
-        await ToolManager[None].build(prepared_toolset, context)
+        await ToolManager[None](prepared_toolset).for_run_step(context)
 
 
 async def test_prepared_toolset_user_error_change_tool_names():
@@ -198,7 +198,7 @@ async def test_prepared_toolset_user_error_change_tool_names():
             'Prepare function cannot add or rename tools. Use `FunctionToolset.add_function()` or `RenamedToolset` instead.'
         ),
     ):
-        await ToolManager[None].build(prepared_toolset, context)
+        await ToolManager[None](prepared_toolset).for_run_step(context)
 
 
 async def test_comprehensive_toolset_composition():
@@ -285,7 +285,7 @@ async def test_comprehensive_toolset_composition():
     # Test with regular user context
     regular_deps = TestDeps(user_role='user', enable_advanced=True)
     regular_context = build_run_context(regular_deps)
-    final_toolset = await ToolManager[TestDeps].build(prepared_toolset, regular_context)
+    final_toolset = await ToolManager[TestDeps](prepared_toolset).for_run_step(regular_context)
     # Tool definitions should have role annotation
     assert final_toolset.tool_defs == snapshot(
         [
@@ -338,7 +338,7 @@ async def test_comprehensive_toolset_composition():
     # Test with admin user context (should have string tools)
     admin_deps = TestDeps(user_role='admin', enable_advanced=True)
     admin_context = build_run_context(admin_deps)
-    admin_final_toolset = await ToolManager[TestDeps].build(prepared_toolset, admin_context)
+    admin_final_toolset = await ToolManager[TestDeps](prepared_toolset).for_run_step(admin_context)
     assert admin_final_toolset.tool_defs == snapshot(
         [
             ToolDefinition(
@@ -421,7 +421,7 @@ async def test_comprehensive_toolset_composition():
     # Test with advanced features disabled
     basic_deps = TestDeps(user_role='user', enable_advanced=False)
     basic_context = build_run_context(basic_deps)
-    basic_final_toolset = await ToolManager[TestDeps].build(prepared_toolset, basic_context)
+    basic_final_toolset = await ToolManager[TestDeps](prepared_toolset).for_run_step(basic_context)
     assert basic_final_toolset.tool_defs == snapshot(
         [
             ToolDefinition(
@@ -506,7 +506,7 @@ async def test_tool_manager_reuse_self():
 
     run_context = build_run_context(None, run_step=1)
 
-    tool_manager = ToolManager[None](run_context, FunctionToolset[None](), tools={})
+    tool_manager = await ToolManager[None](FunctionToolset()).for_run_step(run_context)
 
     same_tool_manager = await tool_manager.for_run_step(ctx=run_context)
 
@@ -544,7 +544,7 @@ async def test_tool_manager_retry_logic():
 
     # Create initial context and tool manager
     initial_context = build_run_context(TestDeps())
-    tool_manager = await ToolManager[TestDeps].build(toolset, initial_context)
+    tool_manager = await ToolManager[TestDeps](toolset).for_run_step(initial_context)
 
     # Initially no failed tools
     assert tool_manager.failed_tools == set()
@@ -625,7 +625,7 @@ async def test_tool_manager_multiple_failed_tools():
 
     # Create tool manager
     context = build_run_context(TestDeps())
-    tool_manager = await ToolManager[TestDeps].build(toolset, context)
+    tool_manager = await ToolManager[TestDeps](toolset).for_run_step(context)
 
     # Call tool_a - should fail and be added to failed_tools
     with pytest.raises(ToolRetryError):

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -568,6 +568,7 @@ async def test_tool_manager_retry_logic():
     new_tool_manager = await tool_manager.for_run_step(new_context)
 
     # The new tool manager should have retry count for the failed tool
+    assert new_tool_manager.ctx is not None
     assert new_tool_manager.ctx.retries == {'failing_tool': 1}
     assert new_tool_manager.failed_tools == set()  # reset for new run step
 
@@ -591,6 +592,7 @@ async def test_tool_manager_retry_logic():
     another_tool_manager = await new_tool_manager.for_run_step(another_context)
 
     # Should now have retry count of 2 for failing_tool
+    assert another_tool_manager.ctx is not None
     assert another_tool_manager.ctx.retries == {'failing_tool': 2}
     assert another_tool_manager.failed_tools == set()
 
@@ -646,6 +648,7 @@ async def test_tool_manager_multiple_failed_tools():
     new_context = build_run_context(TestDeps(), run_step=1)
     new_tool_manager = await tool_manager.for_run_step(new_context)
 
+    assert new_tool_manager.ctx is not None
     assert new_tool_manager.ctx.retries == {'tool_a': 1, 'tool_b': 1}
     assert new_tool_manager.failed_tools == set()  # reset for new run step
 


### PR DESCRIPTION
This also fixes an issue with duplicate calls to prepare functions.