### PR TITLE
Fix StructuredDict with nested JSON schemas using $ref

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -99,9 +99,15 @@ def _contains_ref(obj: Any) -> bool:
     if isinstance(obj, dict):
         if '$ref' in obj:
             return True
-        return any(_contains_ref(v) for v in obj.values() if isinstance(v, (dict, list)))
+        for v in obj.values():
+            if isinstance(v, (dict, list)) and _contains_ref(v):
+                return True
+        return False
     elif isinstance(obj, list):
-        return any(_contains_ref(item) for item in obj if isinstance(item, (dict, list)))
+        for item in obj:
+            if isinstance(item, (dict, list)) and _contains_ref(item):
+                return True
+        return False
     return False
 
 

--- a/pydantic_ai_slim/pydantic_ai/output.py
+++ b/pydantic_ai_slim/pydantic_ai/output.py
@@ -341,9 +341,15 @@ def _contains_refs(schema: JsonSchemaValue) -> bool:
     if isinstance(schema, dict):
         if '$ref' in schema:
             return True
-        return any(_contains_refs(v) for v in schema.values() if isinstance(v, (dict, list)))
+        for v in schema.values():
+            if isinstance(v, (dict, list)) and _contains_refs(v):
+                return True
+        return False
     elif isinstance(schema, list):
-        return any(_contains_refs(item) for item in schema if isinstance(item, (dict, list)))
+        for item in schema:
+            if isinstance(item, (dict, list)) and _contains_refs(item):
+                return True
+        return False
     return False
 
 
@@ -363,7 +369,7 @@ def _resolve_refs(schema: JsonSchemaValue, defs: dict[str, JsonSchemaValue] | No
             return schema
         else:
             # Recursively resolve refs in nested structures
-            result = {}
+            result: dict[str, Any] = {}
             for key, value in schema.items():
                 if key == '$defs':
                     # Skip $defs at root level since we're inlining them


### PR DESCRIPTION
## Summary

Fixes #2466 - StructuredDict now properly handles nested JSON schemas with `$ref` references.

## Problem

`StructuredDict` was failing when given JSON schemas containing nested `$ref` references because pydantic's JSON schema generator couldn't resolve them, resulting in a `KeyError`.

Example schema that was failing:
```python
{
    "$defs": {
        "Tire": {
            "type": "object",
            "properties": {
                "brand": {"type": "string"},
                "size": {"type": "integer"}
            }
        }
    },
    "type": "object",
    "properties": {
        "tires": {
            "type": "array",
            "items": {"$ref": "#/$defs/Tire"}
        }
    }
}
```

## Solution

1. **Added helper functions** to detect and resolve nested references:
   - `_contains_ref()`: Recursively checks if a schema contains any `$ref` references
   - `_resolve_refs()`: Recursively resolves all `$ref` references inline

2. **Updated `StructuredDict`** to:
   - Detect when a schema contains `$defs` with nested references
   - Resolve all references inline before passing to pydantic
   - Remove `$defs` after inlining to avoid confusion

3. **Improved `check_object_json_schema`**:
   - Replaced hacky string matching with proper recursive checking
   - Handles unresolvable refs gracefully (external URLs, missing refs, non-standard formats)

## Test plan

- [x] Added `test_output_type_structured_dict_nested` to test the main fix with nested car/tire schema
- [x] Added `test_output_type_structured_dict_unresolvable_ref` to test edge cases
- [x] Added comprehensive coverage tests in `test_utils.py`
- [x] All existing tests pass
- [x] Linting and formatting checks pass
- [x] Type checking with pyright passes

## Example Usage

```python
from pydantic_ai import Agent, StructuredDict

car_schema = {
    "$defs": {
        "Tire": {
            "type": "object",
            "properties": {
                "brand": {"type": "string"},
                "size": {"type": "integer"}
            }
        }
    },
    "type": "object",
    "properties": {
        "make": {"type": "string"},
        "model": {"type": "string"},
        "tires": {
            "type": "array",
            "items": {"$ref": "#/$defs/Tire"}
        }
    }
}

CarDict = StructuredDict(car_schema, name="Car")
agent = Agent('openai:gpt-4o', output_type=CarDict)
result = agent.run_sync('Create a car')
# Now works without KeyError\!
```