### PR TITLE
fix: replace logfire-api with logfire dependency in pydantic-evals

### DIFF
--- a/pydantic_evals/pyproject.toml
+++ b/pydantic_evals/pyproject.toml
@@ -49,7 +49,7 @@ requires-python = ">=3.9"
 [tool.hatch.metadata.hooks.uv-dynamic-versioning]
 dependencies = [
     "rich>=13.9.4",
-    "logfire-api>=3.14.1",
+    "logfire>=3.14.1",
     "pydantic>=2.10",
     "pydantic-ai-slim=={{ version }}",
     "anyio>=0",
@@ -58,7 +58,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-logfire = ["logfire>=3.14.1"]
 
 [project.urls]
 Homepage = "https://ai.pydantic.dev/evals"


### PR DESCRIPTION
This fixes the MagicMock issue when logfire is not installed by ensuring logfire is always available. Previously, logfire-api provided only the interface while actual span duration calculations require the full logfire package.

Fixes #2209

Generated with [Claude Code](https://claude.ai/code)