### PR TITLE
Clarify usage limits priority in docs

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -619,7 +619,8 @@ except UsageLimitExceeded as e:
 2. This run will error after 3 requests, preventing the infinite tool calling.
 
 !!! note
-    This is especially relevant if you've registered many tools. The `request_limit` can be used to prevent the model from calling them in a loop too many times.
+    - Usage limits are especially relevant if you've registered many tools. The `request_limit` can be used to prevent the model from calling them in a loop too many times.
+    - These limits are enforced at the final stage before the LLM is called. If your limits are stricter than your retry settings, the usage limit will be reached before all retries are attempted.
 
 #### Model (Run) Settings
 


### PR DESCRIPTION
This commit clarifies that usage limits take priority over retries in the documentation.

See https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1755212536027129?thread_ts=1755206443.507839&cid=C083V7PMHHA