### PR TITLE
feat(poc) add hook system for tools that require approval (eg. hitl)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/hooks/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/hooks/__init__.py
@@ -1,0 +1,10 @@
+"""Hooks for Pydantic-AI agents and tools."""
+
+from .agent_hooks import AgentHooks, ToolHookManager, HookRegistry
+
+__all__ = [
+    'AgentHooks',
+    'ToolHookManager', 
+    'HookRegistry',
+]
+

--- a/pydantic_ai_slim/pydantic_ai/hooks/agent_hooks.py
+++ b/pydantic_ai_slim/pydantic_ai/hooks/agent_hooks.py
@@ -1,0 +1,82 @@
+"""
+Agent hook management system for Pydantic-AI.
+
+This module provides the hook routing system that connects the public API
+`agent.on.tool(my_tool).before(request_approval_func)` to the actual node instances
+during agent execution.
+"""
+
+
+class HookRegistry:
+    """Connects agent-level hooks to node-level traits during execution.
+    
+    This registry follows the registry pattern to provide a centralized way for nodes
+    to query and access hooks that were set via agent.on.tool(my_tool).before.
+    """
+    
+    def __init__(self, agent_hooks: 'AgentHooks'):
+        self.agent_hooks = agent_hooks
+    
+    def get_tool_hook(self, tool_name: str, hook_type: str):
+        """Get a specific hook for a tool.
+        
+        Args:
+            tool_name: Name of the tool to get hooks for
+            hook_type: Type of hook ('before', 'after', 'error')
+            
+        Returns:
+            The hook function if found, None otherwise
+        """
+        tool_hooks = self.agent_hooks.get_tool_hooks(tool_name)
+        if tool_hooks:
+            return getattr(tool_hooks, hook_type, None)
+        return None
+
+
+class ToolHookManager:
+    """Manages tool-specific hooks for individual tools."""
+    
+    def __init__(self, tool_name: str):
+        self.tool_name = tool_name
+        self.before = None
+        self.after = None
+        self.error = None
+    
+    def set_before(self, hook):
+        """Set the before hook for this tool."""
+        self.before = hook
+    
+    def set_after(self, hook):
+        """Set the after hook for this tool."""
+        self.after = hook
+    
+    def set_error(self, hook):
+        """Set the error hook for this tool."""
+        self.error = hook
+
+
+class AgentHooks:
+    """Tool-specific hooks for agents."""
+    
+    def __init__(self):
+        # Tool-specific hooks storage
+        self._tool_hooks = {}
+    
+    def tool(self, tool_or_name):
+        """Get or create tool-specific hooks.
+        
+        Enables the beautiful API: agent.on.tool(my_tool).before = func
+        """
+        if hasattr(tool_or_name, 'name'):
+            tool_name = tool_or_name.name
+        else:
+            tool_name = str(tool_or_name)
+        
+        if tool_name not in self._tool_hooks:
+            self._tool_hooks[tool_name] = ToolHookManager(tool_name)
+        
+        return self._tool_hooks[tool_name]
+    
+    def get_tool_hooks(self, tool_name: str):
+        """Get hooks for a specific tool. Used by HookRegistry."""
+        return self._tool_hooks.get(tool_name)

--- a/pydantic_ai_slim/test_reactivenodes.ipynb
+++ b/pydantic_ai_slim/test_reactivenodes.ipynb
@@ -1,0 +1,181 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "48622782",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic_ai import Agent, Tool\n",
+    "from pydantic_ai.exceptions import ModelRetry\n",
+    "from pydantic_ai.models.openai import OpenAIModel\n",
+    "from pydantic_ai.providers.openai import OpenAIProvider\n",
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(dotenv_path=\"env/.env\")\n",
+    "\n",
+    "# Create the model with OpenRouter configuration\n",
+    "api_key = os.environ.get(\"OPENROUTER_API_KEY\")\n",
+    "base_url = os.environ.get(\"OPENROUTER_BASE_URL\")\n",
+    "\n",
+    "model = OpenAIModel(\n",
+    "    model_name=\"gpt-3.5-turbo\",\n",
+    "    provider=OpenAIProvider(base_url=base_url, api_key=api_key),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a6f5762",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def plan_holiday(destination: str, duration: str):\n",
+    "    \"\"\"Plan a holiday.\"\"\"\n",
+    "    return f\"Holiday plan completed: {destination} for {duration} days. The plan is ready for booking.\"\n",
+    "\n",
+    "my_tool = Tool(\n",
+    "    name=\"holiday_planner\",\n",
+    "    function=plan_holiday,\n",
+    "    description=\"Plan a complete holiday with destination and duration. Return the final plan ready for booking.\"\n",
+    ")\n",
+    "\n",
+    "# Create agent\n",
+    "agent = Agent(\n",
+    "    model=model,\n",
+    "    tools=[my_tool],\n",
+    "    instructions=\"You are a helpful holiday planning assistant. Use tools when needed.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "414475d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def request_holiday_confirmation(context):\n",
+    "    tool_call = context['tool_call']\n",
+    "    \n",
+    "    # Get the holiday details from the tool call\n",
+    "    args = tool_call.args_as_dict()\n",
+    "    destination = args.get('destination', 'unknown')\n",
+    "    duration = args.get('duration', 'unknown')\n",
+    "    \n",
+    "    print(f\"Please confirm with destionation: {destination} and duration: {duration}\")\n",
+    "    print(\"┌─────────────┬────────────┐\")\n",
+    "    print(\"│    [y]es    │    [n]o    │\")\n",
+    "    print(\"└─────────────┴────────────┘\")\n",
+    "    \n",
+    "    user_input = input(\"Enter y or n: \").lower().strip()\n",
+    "    \n",
+    "    if user_input == 'y':\n",
+    "        print(\"✅ Holiday plan approved - user pressed [y]\")\n",
+    "        return None  # Allow the tool to execute\n",
+    "    elif user_input == 'n':\n",
+    "        print(\"❌ Holiday plan denied - user pressed [n]\")\n",
+    "        return ModelRetry(\"Holiday plan was denied by user. Ask help from the user.\")\n",
+    "    \n",
+    "\n",
+    "async def log_after(context):\n",
+    "    tool_call = context['tool_call']\n",
+    "    print(f\"🔒 {tool_call.tool_name} approved {tool_call.args}\")\n",
+    "\n",
+    "agent.on.tool(my_tool).before = request_holiday_confirmation\n",
+    "agent.on.tool(my_tool).after = log_after"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "052c7d30",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Please confirm with destionation: Switzerland and duration: 7 days\n",
+      "┌─────────────┬────────────┐\n",
+      "│    [y]es    │    [n]o    │\n",
+      "└─────────────┴────────────┘\n",
+      "✅ Holiday plan approved - user pressed [y]\n",
+      "🔒 holiday_planner approved {\"destination\":\"Switzerland\",\"duration\":\"7 days\"}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "AgentRunResult(output='I have planned a holiday to Switzerland for 7 days. The plan is ready for booking.')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Test the holiday planner\n",
+    "await agent.run(\"Plan a holiday to Switzerland for 7 days\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6a6d4a78",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Please confirm with destionation: Switzerland and duration: 7 days\n",
+      "┌─────────────┬────────────┐\n",
+      "│    [y]es    │    [n]o    │\n",
+      "└─────────────┴────────────┘\n",
+      "❌ Holiday plan denied - user pressed [n]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "AgentRunResult(output=\"I'm sorry that the holiday plan was not approved. Let me know how I can assist you better with planning your holiday to Switzerland for 7 days.\")"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Test the holiday planner\n",
+    "await agent.run(\"Plan a holiday to Switzerland for 7 days\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "stable",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a hook system that lets you intercept tool calls for eg human approval before execution. 

It's merely a proof of concept for myself with no intention to use it (yet), but maybe it is of interest here too?

*I think* I'm not keen on manually traversing agent graphs, so I tried to see if we can have a public `agent.on.xx` interface that works directly with observing the nodes. 

The current implementation is a registry-based approach that handles hooks without requiring graph iteration. 

I also explored using traitlets for reactive model/instruction changes (e.g., dynamically switching models or instructions based on user context). I think traitlets integration for dynamic agent configuration/observing still remains interesting for future exploration.

But to start somehwere, first this for before/after tool calling. 

### Example

```python
from pydantic_ai import Agent, Tool, ModelRetry

# Create a tool that needs approval
async def plan_holiday(destination: str, duration: str):
    return f"Holiday plan completed: {destination} for {duration} days!"

my_tool = Tool(name="holiday_planner", function=plan_holiday)
agent = Agent(model=model, tools=[my_tool])

# Set up approval hook
async def request_approval(context):
    tool_call = context['tool_call']
    args = tool_call.args_as_dict()
    
    print(f"Approve holiday to {args['destination']} for {args['duration']} days?")
    user_input = input("y/n: ").lower().strip()
    
    if user_input == 'y':
        return None  # Allow execution
    else:
        return ModelRetry("Holiday denied by user")

# Attach the hook
agent.on.tool(my_tool).before = request_approval

# Run - hook will intercept and ask for approval
await agent.run("Plan a holiday to Switzerland for 7 days")
```

### Current options for the `agent.on` API

- `agent.on.tool(my_tool).before = func` - Run before tool execution
- `agent.on.tool(my_tool).after = func` - Run after tool execution  
- `agent.on.tool(my_tool).error = func` - Run on tool errors
- Return `ModelRetry` to deny execution and suggest alternatives
- Return `None` to allow execution
- Access tool args via `context['tool_call'].args_as_dict()`

### How it works
When you set `agent.on.tool(my_tool).before = func`, the system:
1. Registers your hook in a central registry
2. Nodes query the registry during execution via `ctx.deps.hook_registry`
3. Hooks run automatically during tool execution (no graph iteration needed)
4. No graph modification - existing Pydantic-AI nodes work unchanged

## Testing

See [`test_reactivenodes.ipynb`](https://github.com/mattijn/pydantic-ai/blob/6e0e35b05c78874d3c812e8203c0ac3d4486dea9/pydantic_ai_slim/test_reactivenodes.ipynb) for a working example with simple human-in-the-loop holiday planning approval notebook.