### PR TITLE
docs: indicate Google model support for WebSearchTool

### DIFF
--- a/docs/builtin-tools.md
+++ b/docs/builtin-tools.md
@@ -27,7 +27,7 @@ making it ideal for queries that require up-to-date data.
 | OpenAI | ✅ | Full feature support |
 | Anthropic | ✅ | Full feature support |
 | Groq | ✅ | Limited parameter support |
-| Google | ❌ | Not supported |
+| Google | ✅ | No parameter support |
 | Bedrock | ❌ | Not supported |
 | Mistral | ❌ | Not supported |
 | Cohere | ❌ | Not supported |

--- a/pydantic_ai_slim/pydantic_ai/builtin_tools.py
+++ b/pydantic_ai_slim/pydantic_ai/builtin_tools.py
@@ -29,6 +29,7 @@ class WebSearchTool(AbstractBuiltinTool):
     * Anthropic
     * OpenAI
     * Groq
+    * Google
     """
 
     search_context_size: Literal['low', 'medium', 'high'] = 'medium'


### PR DESCRIPTION
As seen here: https://github.com/pydantic/pydantic-ai/blob/main/pydantic_ai_slim/pydantic_ai/models/google.py#L271-L273 `WebSearchTool` can be passed to Google models. Currently the docs would imply that doing so would raise a `UserError`