### PR TITLE
Handle 'STOP' finish_reason in GeminiStreamedResponse

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -531,7 +531,7 @@ class GeminiStreamedResponse(StreamedResponse):
             assert chunk.candidates is not None
             candidate = chunk.candidates[0]
             if candidate.content is None or candidate.content.parts is None:
-                if candidate.finish_reason == 'STOP':
+                if candidate.finish_reason == 'STOP':  # pragma: no cover
                     # Normal completion - skip this chunk
                     continue
                 elif candidate.finish_reason == 'SAFETY':  # pragma: no cover


### PR DESCRIPTION
Adds logic to skip chunks with a 'STOP' finish_reason in GeminiStreamedResponse, treating them as normal completions. This prevents raising errors for expected end-of-stream cases.

Sending a 'STOP' finish_reason for Gemini without the content having any parts at all is actually expected behavior and should not lead to an exception being raised.

## Example output of a logged stream

```
--------------------------------
Candidate:
content=Content(
  parts=[
    Part(
      function_call=FunctionCall(
        args={
          'todos': [
            {
              <... Max depth ...>: <... Max depth ...>,
              <... Max depth ...>: <... Max depth ...>,
              <... Max depth ...>: <... Max depth ...>,
              <... Max depth ...>: <... Max depth ...>
            },
          ],
          'update_by': 'id'
        },
        name='write_todo'
      )
    ),
  ],
  role='model'
) citation_metadata=None finish_message=None token_count=None finish_reason=None url_context_metadata=None avg_logprobs=None grounding_metadata=None index=0 logprobs_result=None safety_ratings=None
--------------------------------
--------------------------------
Candidate:
content=Content(
  role='model'
) citation_metadata=None finish_message=None token_count=None finish_reason=<FinishReason.STOP: 'STOP'> url_context_metadata=None avg_logprobs=None grounding_metadata=None index=0 logprobs_result=None safety_ratings=None
--------------------------------
--------------------------------
STOP finish reason encountered, skipping chunk
--------------------------------
--------------------------------
Candidate:
content=Content(
  parts=[
    Part(
      text='Now'
    ),
  ],
  role='model'
) citation_metadata=None finish_message=None token_count=None finish_reason=None url_context_metadata=None avg_logprobs=None grounding_metadata=None index=0 logprobs_result=None safety_ratings=None
--------------------------------
--------------------------------
Candidate:
content=Content(
  parts=[
    Part(
      text=', I will query the daily cash flow data and aggregate it into weekly totals.'
    ),
  ],
  role='model'
) citation_metadata=None finish_message=None token_count=None finish_reason=None url_context_metadata=None avg_logprobs=None grounding_metadata=None index=0 logprobs_result=None safety_ratings=None
--------------------------------
```