### PR TITLE
Fix multi-agent example token limit in documentation

### DIFF
--- a/docs/multi-agent-applications.md
+++ b/docs/multi-agent-applications.md
@@ -48,7 +48,7 @@ async def joke_factory(ctx: RunContext[None], count: int) -> list[str]:
 
 result = joke_selection_agent.run_sync(
     'Tell me a joke.',
-    usage_limits=UsageLimits(request_limit=5, total_tokens_limit=300),
+    usage_limits=UsageLimits(request_limit=5, total_tokens_limit=500),
 )
 print(result.output)
 #> Did you hear about the toothpaste scandal? They called it Colgate.


### PR DESCRIPTION
Increase total_tokens_limit from 300 to 500 to prevent UsageLimitExceeded errors. Users reported actual usage of 353-357 tokens, so the previous limit was too low.

Fixes #1308

Generated with [Claude Code](https://claude.ai/code)