### PR TITLE
fix: Handle missing token details in vLLM/OpenAI-compatible APIs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1349,11 +1349,17 @@ def _map_usage(response: chat.ChatCompletion | ChatCompletionChunk | responses.R
             ).items()
             if isinstance(value, int)
         }
-        details['reasoning_tokens'] = response_usage.output_tokens_details.reasoning_tokens
+        # Handle vLLM compatibility - some providers don't include token details
+        if getattr(response_usage, 'output_tokens_details', None) is not None:
+            details['reasoning_tokens'] = response_usage.output_tokens_details.reasoning_tokens
+        else:
+            details['reasoning_tokens'] = 0
         return usage.RequestUsage(
             input_tokens=response_usage.input_tokens,
             output_tokens=response_usage.output_tokens,
-            cache_read_tokens=response_usage.input_tokens_details.cached_tokens,
+            cache_read_tokens=getattr(response_usage.input_tokens_details, 'cached_tokens', 0)
+            if getattr(response_usage, 'input_tokens_details', None) is not None
+            else 0,
             details=details,
         )
     else:


### PR DESCRIPTION
Add defensive null checks for output_tokens_details and input_tokens_details in _map_usage function to prevent AttributeError when using vLLM or other OpenAI-compatible providers that don't always include token detail fields.

Fixes #2598

Generated with [Claude Code](https://claude.ai/code)