### PR TITLE
fix(bedrock): skip SystemPromptPart with empty content

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -423,7 +423,7 @@ class BedrockConverseModel(Model):
         for message in messages:
             if isinstance(message, ModelRequest):
                 for part in message.parts:
-                    if isinstance(part, SystemPromptPart):
+                    if isinstance(part, SystemPromptPart) and part.content:
                         system_prompt.append({'text': part.content})
                     elif isinstance(part, UserPromptPart):
                         bedrock_messages.extend(await self._map_user_prompt(part, document_count))


### PR DESCRIPTION
## Fix: Filter out empty SystemPromptPart content in Bedrock model

Partially addresses https://github.com/pydantic/pydantic-ai/issues/2519

### Problem
The Bedrock model was processing `SystemPromptPart` instances even when they had empty or falsy content, causing issues with the Bedrock API calls
```
botocore.exceptions.ParamValidationError: Parameter validation failed: Invalid length for parameter system[1].text, value: 0, valid min length: 1
```

A general solution for other model providers will be addressed in separate PRs.

### Solution
Added a content check (`and part.content`) to the SystemPromptPart filtering logic in `_map_messages()` method. Now only SystemPromptPart instances with actual content are added to the system_prompt list sent to the Bedrock converse API.

### Changes
- **pydantic_ai_slim/pydantic_ai/models/bedrock.py**: Added `and part.content` condition to filter out empty SystemPromptPart content

This is a simple one-line fix that prevents empty system prompt parts from being processed.

