### PR TITLE
feat: add message_history parameter to agent.to_cli()

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_cli.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli.py
@@ -228,6 +228,7 @@ async def run_chat(
     prog_name: str,
     config_dir: Path | None = None,
     deps: AgentDepsT = None,
+    message_history: list[ModelMessage] | None = None,
 ) -> int:
     prompt_history_path = (config_dir or PYDANTIC_AI_HOME) / PROMPT_HISTORY_FILENAME
     prompt_history_path.parent.mkdir(parents=True, exist_ok=True)
@@ -235,7 +236,7 @@ async def run_chat(
     session: PromptSession[Any] = PromptSession(history=FileHistory(str(prompt_history_path)))
 
     multiline = False
-    messages: list[ModelMessage] = []
+    messages: list[ModelMessage] = message_history[:] if message_history else []
 
     while True:
         try:

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -899,12 +899,18 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             lifespan=lifespan,
         )
 
-    async def to_cli(self: Self, deps: AgentDepsT = None, prog_name: str = 'pydantic-ai') -> None:
+    async def to_cli(
+        self: Self,
+        deps: AgentDepsT = None,
+        prog_name: str = 'pydantic-ai',
+        message_history: list[_messages.ModelMessage] | None = None,
+    ) -> None:
         """Run the agent in a CLI chat interface.
 
         Args:
             deps: The dependencies to pass to the agent.
             prog_name: The name of the program to use for the CLI. Defaults to 'pydantic-ai'.
+            message_history: History of the conversation so far.
 
         Example:
         ```python {title="agent_to_cli.py" test="skip"}
@@ -920,14 +926,28 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
 
         from pydantic_ai._cli import run_chat
 
-        await run_chat(stream=True, agent=self, deps=deps, console=Console(), code_theme='monokai', prog_name=prog_name)
+        await run_chat(
+            stream=True,
+            agent=self,
+            deps=deps,
+            console=Console(),
+            code_theme='monokai',
+            prog_name=prog_name,
+            message_history=message_history,
+        )
 
-    def to_cli_sync(self: Self, deps: AgentDepsT = None, prog_name: str = 'pydantic-ai') -> None:
+    def to_cli_sync(
+        self: Self,
+        deps: AgentDepsT = None,
+        prog_name: str = 'pydantic-ai',
+        message_history: list[_messages.ModelMessage] | None = None,
+    ) -> None:
         """Run the agent in a CLI chat interface with the non-async interface.
 
         Args:
             deps: The dependencies to pass to the agent.
             prog_name: The name of the program to use for the CLI. Defaults to 'pydantic-ai'.
+            message_history: History of the conversation so far.
 
         ```python {title="agent_to_cli_sync.py" test="skip"}
         from pydantic_ai import Agent
@@ -937,4 +957,6 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         agent.to_cli_sync(prog_name='assistant')
         ```
         """
-        return get_event_loop().run_until_complete(self.to_cli(deps=deps, prog_name=prog_name))
+        return get_event_loop().run_until_complete(
+            self.to_cli(deps=deps, prog_name=prog_name, message_history=message_history)
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -291,6 +291,7 @@ def test_agent_to_cli_sync(mocker: MockerFixture, env: TestEnv):
         code_theme='monokai',
         prog_name='pydantic-ai',
         deps=None,
+        message_history=None,
     )
 
 
@@ -306,4 +307,44 @@ async def test_agent_to_cli_async(mocker: MockerFixture, env: TestEnv):
         code_theme='monokai',
         prog_name='pydantic-ai',
         deps=None,
+        message_history=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_agent_to_cli_with_message_history(mocker: MockerFixture, env: TestEnv):
+    env.set('OPENAI_API_KEY', 'test')
+    mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
+
+    # Create some test message history - cast to the proper base type
+    test_messages: list[ModelMessage] = [ModelResponse(parts=[TextPart('Hello!')])]
+
+    await cli_agent.to_cli(message_history=test_messages)
+    mock_run_chat.assert_awaited_once_with(
+        stream=True,
+        agent=IsInstance(Agent),
+        console=IsInstance(Console),
+        code_theme='monokai',
+        prog_name='pydantic-ai',
+        deps=None,
+        message_history=test_messages,
+    )
+
+
+def test_agent_to_cli_sync_with_message_history(mocker: MockerFixture, env: TestEnv):
+    env.set('OPENAI_API_KEY', 'test')
+    mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
+
+    # Create some test message history - cast to the proper base type
+    test_messages: list[ModelMessage] = [ModelResponse(parts=[TextPart('Hello!')])]
+
+    cli_agent.to_cli_sync(message_history=test_messages)
+    mock_run_chat.assert_awaited_once_with(
+        stream=True,
+        agent=IsInstance(Agent),
+        console=IsInstance(Console),
+        code_theme='monokai',
+        prog_name='pydantic-ai',
+        deps=None,
+        message_history=test_messages,
     )


### PR DESCRIPTION
## Summary
- Add `message_history` parameter to `Agent.to_cli()` and `Agent.to_cli_sync()` methods
- Update `run_chat` function in `_cli.py` to accept and use message_history
- Add comprehensive tests for the new functionality
- Enables CLI sessions to start with existing conversation history

## Test plan
- [x] Add unit tests to verify `message_history` parameter is properly passed through
- [x] Test both sync and async versions of `to_cli()` method
- [x] Ensure backward compatibility - existing calls work without changes
- [x] Verify that message history is properly initialized in CLI chat loop

Fixes #2650

🤖 Generated with [Claude Code](https://claude.ai/code)