### PR TITLE
feat: store tool_prefix in ctx to process_tool_call

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -40,6 +40,8 @@ class RunContext(Generic[AgentDepsT]):
     """Number of retries for each tool so far."""
     tool_call_id: str | None = None
     """The ID of the tool call."""
+    tool_prefix: str | None = None
+    """Prefix of the tool being called."""
     tool_name: str | None = None
     """Name of the tool being called."""
     retry: int = 0

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -239,7 +239,7 @@ class MCPServer(AbstractToolset[Any], ABC):
     ) -> ToolResult:
         if self.tool_prefix:
             name = name.removeprefix(f'{self.tool_prefix}_')
-            ctx = replace(ctx, tool_name=name)
+            ctx = replace(ctx, tool_name=name, tool_prefix=self.tool_prefix)
 
         if self.process_tool_call is not None:
             return await self.process_tool_call(ctx, self.direct_call_tool, name, tool_args)


### PR DESCRIPTION
PR adds the `tool_prefix` to the context passed to [`process_tool_call`](https://ai.pydantic.dev/mcp/client/#tool-call-customisation) for a MCP if it's set.

My use case was that I was setting the same `process_tool_call` function to multiple MCP servers, and wanted to use the prefix to tweak the behavior, and while I could do `call_tool.__self__.tool_prefix`, I don't get any type help, and also just feels gross reaching into internals like that.