### PR TITLE
Rename `StreamedRunResult` methods to be consistent with `AgentStream`

### DIFF
--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -18,9 +18,9 @@ and [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult] (returned by [`A
 
     E.g. you've awaited one of the following coroutines:
 
-    * [`StreamedRunResult.stream()`][pydantic_ai.result.StreamedRunResult.stream]
+    * [`StreamedRunResult.stream_output()`][pydantic_ai.result.StreamedRunResult.stream_output]
     * [`StreamedRunResult.stream_text()`][pydantic_ai.result.StreamedRunResult.stream_text]
-    * [`StreamedRunResult.stream_structured()`][pydantic_ai.result.StreamedRunResult.stream_structured]
+    * [`StreamedRunResult.stream_responses()`][pydantic_ai.result.StreamedRunResult.stream_responses]
     * [`StreamedRunResult.get_output()`][pydantic_ai.result.StreamedRunResult.get_output]
 
     **Note:** The final result message will NOT be added to result messages if you use [`.stream_text(delta=True)`][pydantic_ai.result.StreamedRunResult.stream_text] since in this case the result content is never built as one string.

--- a/docs/output.md
+++ b/docs/output.md
@@ -573,7 +573,7 @@ agent = Agent(
 async def main():
     user_input = 'My name is Ben, I was born on January 28th 1990, I like the chain the dog and the pyramid.'
     async with agent.run_stream(user_input) as result:
-        async for profile in result.stream():
+        async for profile in result.stream_output():
             print(profile)
             #> {'name': 'Ben'}
             #> {'name': 'Ben'}
@@ -609,9 +609,9 @@ agent = Agent('openai:gpt-4o', output_type=UserProfile)
 async def main():
     user_input = 'My name is Ben, I was born on January 28th 1990, I like the chain the dog and the pyramid.'
     async with agent.run_stream(user_input) as result:
-        async for message, last in result.stream_structured(debounce_by=0.01):  # (1)!
+        async for message, last in result.stream_responses(debounce_by=0.01):  # (1)!
             try:
-                profile = await result.validate_structured_output(  # (2)!
+                profile = await result.validate_response_output(  # (2)!
                     message,
                     allow_partial=not last,
                 )
@@ -627,8 +627,8 @@ async def main():
             #> {'name': 'Ben', 'dob': date(1990, 1, 28), 'bio': 'Likes the chain the dog and the pyramid'}
 ```
 
-1. [`stream_structured`][pydantic_ai.result.StreamedRunResult.stream_structured] streams the data as [`ModelResponse`][pydantic_ai.messages.ModelResponse] objects, thus iteration can't fail with a `ValidationError`.
-2. [`validate_structured_output`][pydantic_ai.result.StreamedRunResult.validate_structured_output] validates the data, `allow_partial=True` enables pydantic's [`experimental_allow_partial` flag on `TypeAdapter`][pydantic.type_adapter.TypeAdapter.validate_json].
+1. [`stream_responses`][pydantic_ai.result.StreamedRunResult.stream_responses] streams the data as [`ModelResponse`][pydantic_ai.messages.ModelResponse] objects, thus iteration can't fail with a `ValidationError`.
+2. [`validate_response_output`][pydantic_ai.result.StreamedRunResult.validate_response_output] validates the data, `allow_partial=True` enables pydantic's [`experimental_allow_partial` flag on `TypeAdapter`][pydantic.type_adapter.TypeAdapter.validate_json].
 
 _(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
 

--- a/examples/pydantic_ai_examples/chat_app.py
+++ b/examples/pydantic_ai_examples/chat_app.py
@@ -127,7 +127,7 @@ async def post_chat(
         messages = await database.get_messages()
         # run the agent with the user prompt and the chat history
         async with agent.run_stream(prompt, message_history=messages) as result:
-            async for text in result.stream(debounce_by=0.01):
+            async for text in result.stream_output(debounce_by=0.01):
                 # text here is a `str` and the frontend wants
                 # JSON encoded ModelResponse, so we create one
                 m = ModelResponse(parts=[TextPart(text)], timestamp=result.timestamp())

--- a/examples/pydantic_ai_examples/stream_markdown.py
+++ b/examples/pydantic_ai_examples/stream_markdown.py
@@ -42,7 +42,7 @@ async def main():
             console.log(f'Using model: {model}')
             with Live('', console=console, vertical_overflow='visible') as live:
                 async with agent.run_stream(prompt, model=model) as result:
-                    async for message in result.stream():
+                    async for message in result.stream_output():
                         live.update(Markdown(message))
             console.log(result.usage())
         else:

--- a/examples/pydantic_ai_examples/stream_whales.py
+++ b/examples/pydantic_ai_examples/stream_whales.py
@@ -51,7 +51,7 @@ async def main():
         ) as result:
             console.print('Response:', style='green')
 
-            async for whales in result.stream(debounce_by=0.01):
+            async for whales in result.stream_output(debounce_by=0.01):
                 table = Table(
                     title='Species of Whale',
                     caption='Streaming Structured responses from GPT-4',

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -652,7 +652,7 @@ async def test_stream_structured(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        chunks = [c async for c in result.stream(debounce_by=None)]
+        chunks = [c async for c in result.stream_output(debounce_by=None)]
 
         # The tool output doesn't echo any content to the stream, so we only get the final payload once when
         # the block starts and once when it ends.

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -171,7 +171,7 @@ async def test_first_failed_instrumented_stream(capfire: CaptureLogfire) -> None
     fallback_model = FallbackModel(failure_model_stream, success_model_stream)
     agent = Agent(model=fallback_model, instrument=True)
     async with agent.run_stream('input') as result:
-        assert [c async for c, _is_last in result.stream_structured(debounce_by=None)] == snapshot(
+        assert [c async for c, _is_last in result.stream_responses(debounce_by=None)] == snapshot(
             [
                 ModelResponse(
                     parts=[TextPart(content='hello ')],
@@ -356,7 +356,7 @@ async def test_first_success_streaming() -> None:
     fallback_model = FallbackModel(success_model_stream, failure_model_stream)
     agent = Agent(model=fallback_model)
     async with agent.run_stream('input') as result:
-        assert [c async for c, _is_last in result.stream_structured(debounce_by=None)] == snapshot(
+        assert [c async for c, _is_last in result.stream_responses(debounce_by=None)] == snapshot(
             [
                 ModelResponse(
                     parts=[TextPart(content='hello ')],
@@ -385,7 +385,7 @@ async def test_first_failed_streaming() -> None:
     fallback_model = FallbackModel(failure_model_stream, success_model_stream)
     agent = Agent(model=fallback_model)
     async with agent.run_stream('input') as result:
-        assert [c async for c, _is_last in result.stream_structured(debounce_by=None)] == snapshot(
+        assert [c async for c, _is_last in result.stream_responses(debounce_by=None)] == snapshot(
             [
                 ModelResponse(
                     parts=[TextPart(content='hello ')],
@@ -415,7 +415,7 @@ async def test_all_failed_streaming() -> None:
     agent = Agent(model=fallback_model)
     with pytest.raises(ExceptionGroup) as exc_info:
         async with agent.run_stream('hello') as result:
-            [c async for c, _is_last in result.stream_structured(debounce_by=None)]  # pragma: lax no cover
+            [c async for c, _is_last in result.stream_responses(debounce_by=None)]  # pragma: lax no cover
     assert 'All models from FallbackModel failed' in exc_info.value.args[0]
     exceptions = exc_info.value.exceptions
     assert len(exceptions) == 2

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -814,7 +814,7 @@ async def test_stream_text(get_gemini_client: GetGeminiClient):
     agent = Agent(m)
 
     async with agent.run_stream('Hello') as result:
-        chunks = [chunk async for chunk in result.stream(debounce_by=None)]
+        chunks = [chunk async for chunk in result.stream_output(debounce_by=None)]
         assert chunks == snapshot(
             [
                 'Hello ',
@@ -859,7 +859,7 @@ async def test_stream_invalid_unicode_text(get_gemini_client: GetGeminiClient):
     agent = Agent(m)
 
     async with agent.run_stream('Hello') as result:
-        chunks = [chunk async for chunk in result.stream(debounce_by=None)]
+        chunks = [chunk async for chunk in result.stream_output(debounce_by=None)]
         assert chunks == snapshot(['abc', 'abc€def', 'abc€def'])
     assert result.usage() == snapshot(RunUsage(requests=1, input_tokens=1, output_tokens=2))
 
@@ -889,7 +889,7 @@ async def test_stream_structured(get_gemini_client: GetGeminiClient):
     agent = Agent(model, output_type=tuple[int, int])
 
     async with agent.run_stream('Hello') as result:
-        chunks = [chunk async for chunk in result.stream(debounce_by=None)]
+        chunks = [chunk async for chunk in result.stream_output(debounce_by=None)]
         assert chunks == snapshot([(1, 2), (1, 2)])
     assert result.usage() == snapshot(RunUsage(requests=1, input_tokens=1, output_tokens=2))
 

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -384,7 +384,9 @@ async def test_stream_text(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [c async for c in result.stream(debounce_by=None)] == snapshot(['hello ', 'hello world', 'hello world'])
+        assert [c async for c in result.stream_output(debounce_by=None)] == snapshot(
+            ['hello ', 'hello world', 'hello world']
+        )
         assert result.is_complete
 
 
@@ -396,7 +398,7 @@ async def test_stream_text_finish_reason(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [c async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [c async for c in result.stream_output(debounce_by=None)] == snapshot(
             ['hello ', 'hello world', 'hello world.', 'hello world.']
         )
         assert result.is_complete
@@ -443,7 +445,7 @@ async def test_stream_structured(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [dict(c) async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 {},
                 {'first': 'One'},
@@ -498,7 +500,7 @@ async def test_stream_structured_finish_reason(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [dict(c) async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 {'first': 'One'},
                 {'first': 'One', 'second': 'Two'},
@@ -529,7 +531,9 @@ async def test_no_delta(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [c async for c in result.stream(debounce_by=None)] == snapshot(['hello ', 'hello world', 'hello world'])
+        assert [c async for c in result.stream_output(debounce_by=None)] == snapshot(
+            ['hello ', 'hello world', 'hello world']
+        )
         assert result.is_complete
 
 

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -555,7 +555,7 @@ async def test_stream_structured(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [dict(c) async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 {},
                 {'first': 'One'},
@@ -584,7 +584,7 @@ async def test_stream_structured_finish_reason(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [dict(c) async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 {'first': 'One'},
                 {'first': 'One', 'second': 'Two'},

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -592,7 +592,7 @@ async def test_stream_structured_with_all_type(allow_model_requests: None):
 
     async with agent.run_stream('User prompt value') as result:
         assert not result.is_complete
-        v = [dict(c) async for c in result.stream(debounce_by=None)]
+        v = [dict(c) async for c in result.stream_output(debounce_by=None)]
         assert v == snapshot(
             [
                 {'first': 'One'},
@@ -701,7 +701,7 @@ async def test_stream_result_type_primitif_dict(allow_model_requests: None):
 
     async with agent.run_stream('User prompt value') as result:
         assert not result.is_complete
-        v = [c async for c in result.stream(debounce_by=None)]
+        v = [c async for c in result.stream_output(debounce_by=None)]
         assert v == snapshot(
             [
                 {'first': 'O'},
@@ -756,7 +756,7 @@ async def test_stream_result_type_primitif_int(allow_model_requests: None):
 
     async with agent.run_stream('User prompt value') as result:
         assert not result.is_complete
-        v = [c async for c in result.stream(debounce_by=None)]
+        v = [c async for c in result.stream_output(debounce_by=None)]
         assert v == snapshot([1, 1, 1])
         assert result.is_complete
         assert result.usage().input_tokens == 6
@@ -814,7 +814,7 @@ async def test_stream_result_type_primitif_array(allow_model_requests: None):
 
     async with agent.run_stream('User prompt value') as result:
         assert not result.is_complete
-        v = [c async for c in result.stream(debounce_by=None)]
+        v = [c async for c in result.stream_output(debounce_by=None)]
         assert v == snapshot(
             [
                 [''],
@@ -906,7 +906,7 @@ async def test_stream_result_type_basemodel_with_default_params(allow_model_requ
 
     async with agent.run_stream('User prompt value') as result:
         assert not result.is_complete
-        v = [c async for c in result.stream(debounce_by=None)]
+        v = [c async for c in result.stream_output(debounce_by=None)]
         assert v == snapshot(
             [
                 MyTypedBaseModel(first='O', second=''),
@@ -990,7 +990,7 @@ async def test_stream_result_type_basemodel_with_required_params(allow_model_req
 
     async with agent.run_stream('User prompt value') as result:
         assert not result.is_complete
-        v = [c async for c in result.stream(debounce_by=None)]
+        v = [c async for c in result.stream_output(debounce_by=None)]
         assert v == snapshot(
             [
                 MyTypedBaseModel(first='One', second=''),
@@ -1355,7 +1355,7 @@ async def test_stream_tool_call_with_return_type(allow_model_requests: None):
 
     async with agent.run_stream('User prompt value') as result:
         assert not result.is_complete
-        v = [c async for c in result.stream(debounce_by=None)]
+        v = [c async for c in result.stream_output(debounce_by=None)]
         assert v == snapshot([{'won': True}, {'won': True}])
         assert result.is_complete
         assert result.timestamp() == datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
@@ -1458,7 +1458,7 @@ async def test_stream_tool_call(allow_model_requests: None):
 
     async with agent.run_stream('User prompt value') as result:
         assert not result.is_complete
-        v = [c async for c in result.stream(debounce_by=None)]
+        v = [c async for c in result.stream_output(debounce_by=None)]
         assert v == snapshot(['final ', 'final response', 'final response'])
         assert result.is_complete
         assert result.timestamp() == datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -518,7 +518,7 @@ async def test_stream_structured(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [dict(c) async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 {},
                 {'first': 'One'},
@@ -547,7 +547,7 @@ async def test_stream_structured_finish_reason(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [dict(c) async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 {'first': 'One'},
                 {'first': 'One', 'second': 'Two'},
@@ -573,7 +573,7 @@ async def test_stream_native_output(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [dict(c) async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [dict(c) async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 {'first': 'One'},
                 {'first': 'One', 'second': 'Two'},
@@ -609,7 +609,7 @@ async def test_stream_tool_call_with_empty_text(allow_model_requests: None):
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [c async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [c async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 {'first': 'One'},
                 {'first': 'One', 'second': 'Two'},
@@ -640,7 +640,7 @@ async def test_stream_text_empty_think_tag_and_text_before_tool_call(allow_model
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [c async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [c async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 {},
                 {'first': 'One'},

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -150,8 +150,8 @@ async def test_structured_response_iter():
 
     chunks: list[list[int]] = []
     async with agent.run_stream('') as result:
-        async for structured_response, last in result.stream_structured(debounce_by=None):
-            response_data = await result.validate_structured_output(structured_response, allow_partial=not last)
+        async for structured_response, last in result.stream_responses(debounce_by=None):
+            response_data = await result.validate_response_output(structured_response, allow_partial=not last)
             chunks.append(response_data)
 
     assert chunks == snapshot([[1], [1, 2, 3, 4], [1, 2, 3, 4]])
@@ -176,7 +176,7 @@ async def test_streamed_text_stream():
 
     async with agent.run_stream('Hello') as result:
         # typehint to test (via static typing) that the stream type is correctly inferred
-        chunks: list[str] = [c async for c in result.stream()]
+        chunks: list[str] = [c async for c in result.stream_output()]
         # two chunks with `stream()` due to not-final vs. final
         assert chunks == snapshot(['The cat sat on the mat.', 'The cat sat on the mat.'])
         assert result.is_complete
@@ -208,7 +208,7 @@ async def test_streamed_text_stream():
         return text.upper()
 
     async with agent.run_stream('Hello', output_type=TextOutput(upcase)) as result:
-        assert [c async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [c async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 'THE ',
                 'THE CAT ',
@@ -221,7 +221,7 @@ async def test_streamed_text_stream():
         )
 
     async with agent.run_stream('Hello') as result:
-        assert [c async for c, _is_last in result.stream_structured(debounce_by=None)] == snapshot(
+        assert [c async for c, _is_last in result.stream_responses(debounce_by=None)] == snapshot(
             [
                 ModelResponse(
                     parts=[TextPart(content='The ')],
@@ -1081,7 +1081,7 @@ async def test_stream_structured_output():
 
     async with agent.run_stream('') as result:
         assert not result.is_complete
-        assert [c async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [c async for c in result.stream_output(debounce_by=None)] == snapshot(
             [
                 CityLocation(city='Mexico '),
                 CityLocation(city='Mexico City'),
@@ -1359,7 +1359,7 @@ async def test_run_stream_event_stream_handler():
             events.append(event)
 
     async with test_agent.run_stream('Hello', event_stream_handler=event_stream_handler) as result:
-        assert [c async for c in result.stream(debounce_by=None)] == snapshot(
+        assert [c async for c in result.stream_output(debounce_by=None)] == snapshot(
             ['{"ret_a":', '{"ret_a":"a-apple"}', '{"ret_a":"a-apple"}']
         )
 

--- a/tests/typed_agent.py
+++ b/tests/typed_agent.py
@@ -134,7 +134,7 @@ def run_sync() -> None:
 
 async def run_stream() -> None:
     async with typed_agent.run_stream('testing', deps=MyDeps(foo=1, bar=2)) as streamed_result:
-        result_items = [chunk async for chunk in streamed_result.stream()]
+        result_items = [chunk async for chunk in streamed_result.stream_output()]
         assert_type(result_items, list[str])
 
 


### PR DESCRIPTION
- `StreamedRunResult.stream` -> `StreamedRunResult.stream_output`
- `StreamedRunResult.stream_structured` -> `StreamedRunResult.stream_responses`
- `StreamedRunResult.validate_structured_output` -> `StreamedRunResult.validate_response_output` (The old name implies it took output and validated it, but it takes a model response and returns validated output)

The original methods were deprecated, so this is not a breaking change.

The inconsistency with `AgentStream` bothered me, as did the "stream structured" name for something that really returns (a stream of) model responses.