### PR TITLE
docs: Add message_history parameter documentation for CLI methods

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -108,3 +108,25 @@ async def main():
 ```
 
 _(You'll need to add `asyncio.run(main())` to run `main`)_
+
+### Message History
+
+Both `Agent.to_cli()` and `Agent.to_cli_sync()` support a `message_history` parameter, allowing you to continue an existing conversation or provide conversation context:
+
+```python {title="agent_with_history.py" test="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, UserPromptPart, TextPart
+
+agent = Agent('openai:gpt-4.1')
+
+# Create some conversation history
+message_history: list[ModelMessage] = [
+    ModelRequest([UserPromptPart(content='What is 2+2?')]),
+    ModelResponse([TextPart(content='2+2 equals 4.')])
+]
+
+# Start CLI with existing conversation context
+agent.to_cli_sync(message_history=message_history)
+```
+
+The CLI will start with the provided conversation history, allowing the agent to refer back to previous exchanges and maintain context throughout the session.


### PR DESCRIPTION
## Summary
- Document the `message_history` parameter for `Agent.to_cli()` and `Agent.to_cli_sync()` methods
- Add example showing how to provide conversation context when starting a CLI session
- Improve CLI documentation completeness by covering this existing but undocumented feature

## Test plan
- [x] Review documentation changes for clarity and accuracy
- [x] Verify example code follows existing patterns in the codebase
- [x] Check that documentation links and formatting are correct

The `message_history` parameter already exists in the code but was not documented in the CLI documentation page. This change adds proper documentation with a practical example.

🤖 Generated with [Claude Code](https://claude.ai/code)