### PR TITLE
Raise error if MCP server __aexit__ is called when _running_count is already 0

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -301,7 +301,7 @@ class MCPServer(AbstractToolset[Any], ABC):
 
     async def __aexit__(self, *args: Any) -> bool | None:
         if self._running_count == 0:
-            raise exceptions.UserError('MCPServer.__aexit__ called more times than __aenter__')
+            raise ValueError('MCPServer.__aexit__ called more times than __aenter__')
         async with self._enter_lock:
             self._running_count -= 1
             if self._running_count == 0 and self._exit_stack is not None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -110,13 +110,13 @@ async def test_context_manager_initialization_error() -> None:
 async def test_aexit_called_more_times_than_aenter():
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
 
-    with pytest.raises(UserError, match='MCPServer.__aexit__ called more times than __aenter__'):
+    with pytest.raises(ValueError, match='MCPServer.__aexit__ called more times than __aenter__'):
         await server.__aexit__(None, None, None)
 
     async with server:
         pass  # This will call __aenter__ and __aexit__ once each
 
-    with pytest.raises(UserError, match='MCPServer.__aexit__ called more times than __aenter__'):
+    with pytest.raises(ValueError, match='MCPServer.__aexit__ called more times than __aenter__'):
         await server.__aexit__(None, None, None)
 
 


### PR DESCRIPTION
We recently had a situation in our agentic CLI tool where we a block of code that had called `__aexit__` on an already stopped server and the running count dropped below 0 to -1.

However, when trying to debug and compare active/running vs. stopped servers, we were relying on the `is_running` property and we were incorrectly seeing stopped servers being classified as running servers. I believe this is because `bool(-1)` evaluates to True, so this PR simplifies the property condition to only consider a server as running if the `_running_count` is greater than 0.