### PR TITLE
Fix: Bug with streaming deltas when content parses as number

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1207,6 +1207,15 @@ class ToolCallPartDelta:
                 )
             updated_args_delta = {**(delta.args_delta or {}), **self.args_delta}
             delta = replace(delta, args_delta=updated_args_delta)
+        elif self.args_delta is not None:
+            # Handle non-string, non-dict args_delta (e.g., numbers, booleans)
+            if isinstance(delta.args_delta, dict):
+                raise UnexpectedModelBehavior(
+                    f'Cannot apply non-JSON deltas to dict tool arguments ({delta=}, {self=})'
+                )
+            # Convert the non-string args_delta to string and concatenate
+            updated_args_delta = (delta.args_delta or '') + str(self.args_delta)
+            delta = replace(delta, args_delta=updated_args_delta)
 
         if self.tool_call_id:
             delta = replace(delta, tool_call_id=self.tool_call_id)
@@ -1234,6 +1243,13 @@ class ToolCallPartDelta:
                 raise UnexpectedModelBehavior(f'Cannot apply dict deltas to non-dict tool arguments ({part=}, {self=})')
             updated_dict = {**(part.args or {}), **self.args_delta}
             part = replace(part, args=updated_dict)
+        elif self.args_delta is not None:
+            # Handle non-string, non-dict args_delta (e.g., numbers, booleans)
+            if isinstance(part.args, dict):
+                raise UnexpectedModelBehavior(f'Cannot apply non-JSON deltas to dict tool arguments ({part=}, {self=})')
+            # Convert the non-string args_delta to string and concatenate
+            updated_json = (part.args or '') + str(self.args_delta)
+            part = replace(part, args=updated_json)
 
         if self.tool_call_id:
             part = replace(part, tool_call_id=self.tool_call_id)


### PR DESCRIPTION
Might be related to #2660 ([problem described in comment](https://github.com/pydantic/pydantic-ai/issues/2660#issuecomment-3231964104))

It would probably make more sense to fix this upstream when the stream itself is parsed into `{'input': 23}` instead of `{'input': '23'}`.  

I also think there maybe still a bug where if there is whitespace at the end of a number, it results in the getting `trimmed`.

EG Response should be: `hello 123`, but it comes through like this:

`{'input': 'hello'}`
`{'input': 123}` _instead of `{'input': ' 123'}`_

Results in `hello123`