### PR TITLE
V1: Rename `ModelResponse.provider_request_id` to `provider_response_id`

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -118,7 +118,7 @@ print(response.all_messages())
         model_name='claude-3-5-sonnet-latest',
         timestamp=datetime.datetime(...),
         kind='response',
-        provider_request_id=None,
+        provider_response_id=None,
     ),
 ]
 """

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -938,7 +938,7 @@ class ModelResponse:
     For OpenAI models, this may include 'logprobs', 'finish_reason', etc.
     """
 
-    provider_request_id: str | None = None
+    provider_response_id: str | None = None
     """request ID as specified by the model provider. This can be used to track the specific request to the model."""
 
     def price(self) -> genai_types.PriceCalculation:
@@ -1026,9 +1026,14 @@ class ModelResponse:
         return self.provider_details
 
     @property
-    @deprecated('`vendor_id` is deprecated, use `provider_request_id` instead')
+    @deprecated('`vendor_id` is deprecated, use `provider_response_id` instead')
     def vendor_id(self) -> str | None:
-        return self.provider_request_id
+        return self.provider_response_id
+
+    @property
+    @deprecated('`provider_request_id` is deprecated, use `provider_response_id` instead')
+    def provider_request_id(self) -> str | None:
+        return self.provider_response_id
 
     __repr__ = _utils.dataclasses_no_defaults_repr
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -330,7 +330,7 @@ class AnthropicModel(Model):
             items,
             usage=_map_usage(response),
             model_name=response.model,
-            provider_request_id=response.id,
+            provider_response_id=response.id,
             provider_name=self._provider.name,
         )
 

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -301,9 +301,13 @@ class BedrockConverseModel(Model):
             input_tokens=response['usage']['inputTokens'],
             output_tokens=response['usage']['outputTokens'],
         )
-        vendor_id = response.get('ResponseMetadata', {}).get('RequestId', None)
+        response_id = response.get('ResponseMetadata', {}).get('RequestId', None)
         return ModelResponse(
-            items, usage=u, model_name=self.model_name, provider_request_id=vendor_id, provider_name=self._provider.name
+            items,
+            usage=u,
+            model_name=self.model_name,
+            provider_response_id=response_id,
+            provider_name=self._provider.name,
         )
 
     @overload

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -690,7 +690,7 @@ def _process_response_from_parts(
                 f'Unsupported response from Gemini, expected all parts to be function calls or text, got: {part!r}'
             )
     return ModelResponse(
-        parts=items, usage=usage, model_name=model_name, provider_request_id=vendor_id, provider_details=vendor_details
+        parts=items, usage=usage, model_name=model_name, provider_response_id=vendor_id, provider_details=vendor_details
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -648,7 +648,7 @@ def _process_response_from_parts(
         parts=items,
         model_name=model_name,
         usage=usage,
-        provider_request_id=vendor_id,
+        provider_response_id=vendor_id,
         provider_details=vendor_details,
         provider_name=provider_name,
     )

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -289,7 +289,7 @@ class GroqModel(Model):
             usage=_map_usage(response),
             model_name=response.model,
             timestamp=timestamp,
-            provider_request_id=response.id,
+            provider_response_id=response.id,
             provider_name=self._provider.name,
         )
 

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -271,7 +271,7 @@ class HuggingFaceModel(Model):
             usage=_map_usage(response),
             model_name=response.model,
             timestamp=timestamp,
-            provider_request_id=response.id,
+            provider_response_id=response.id,
             provider_name=self._provider.name,
         )
 

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -352,7 +352,7 @@ class MistralModel(Model):
             usage=_map_usage(response),
             model_name=response.model,
             timestamp=timestamp,
-            provider_request_id=response.id,
+            provider_response_id=response.id,
             provider_name=self._provider.name,
         )
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -517,7 +517,7 @@ class OpenAIChatModel(Model):
             model_name=response.model,
             timestamp=timestamp,
             provider_details=vendor_details,
-            provider_request_id=response.id,
+            provider_response_id=response.id,
             provider_name=self._provider.name,
         )
 
@@ -831,7 +831,7 @@ class OpenAIResponsesModel(Model):
             items,
             usage=_map_usage(response),
             model_name=response.model,
-            provider_request_id=response.id,
+            provider_response_id=response.id,
             timestamp=timestamp,
             provider_name=self._provider.name,
         )

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -205,7 +205,7 @@ async def test_sync_request_text_response(allow_model_requests: None):
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -214,7 +214,7 @@ async def test_sync_request_text_response(allow_model_requests: None):
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -303,7 +303,7 @@ async def test_request_structured_response(allow_model_requests: None):
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -368,7 +368,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -392,7 +392,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -410,7 +410,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -757,7 +757,7 @@ async def test_image_as_binary_content_tool_response(
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_01Kwjzggomz7bv9og51qGFuH',
+                provider_response_id='msg_01Kwjzggomz7bv9og51qGFuH',
             ),
             ModelRequest(
                 parts=[
@@ -795,7 +795,7 @@ async def test_image_as_binary_content_tool_response(
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_015btMBYLTuDnMP7zAeuHQGi',
+                provider_response_id='msg_015btMBYLTuDnMP7zAeuHQGi',
             ),
         ]
     )
@@ -917,7 +917,7 @@ async def test_anthropic_model_instructions(allow_model_requests: None, anthropi
                 model_name='claude-3-opus-20240229',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_01Fg1JVgvCYUHWsxrj9GkpEv',
+                provider_response_id='msg_01Fg1JVgvCYUHWsxrj9GkpEv',
             ),
         ]
     )
@@ -965,7 +965,7 @@ I'll provide this information in a clear, helpful way, emphasizing safety withou
                 model_name='claude-3-7-sonnet-20250219',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_01BnZvs3naGorn93wjjCDwbd',
+                provider_response_id='msg_01BnZvs3naGorn93wjjCDwbd',
             ),
         ]
     )
@@ -992,7 +992,7 @@ I'll provide this information in a clear, helpful way, emphasizing safety withou
                 model_name='claude-3-7-sonnet-20250219',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1035,7 +1035,7 @@ I'll keep the format similar to my street-crossing response for consistency.\
                 model_name='claude-3-7-sonnet-20250219',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -1465,7 +1465,7 @@ Several major events are happening today, including:
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_01W2YfD2EF8BbAqLRr8ftH4W',
+                provider_response_id='msg_01W2YfD2EF8BbAqLRr8ftH4W',
             ),
         ]
     )
@@ -1521,7 +1521,7 @@ print(f"3 * 12390 = {result}")\
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_01RJnbK7VMxvS2SyvtyJAQVU',
+                provider_response_id='msg_01RJnbK7VMxvS2SyvtyJAQVU',
             ),
         ]
     )
@@ -1571,7 +1571,7 @@ It's being celebrated as:
                 model_name='gpt-4.1-2025-04-14',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_689dc4abe31c81968ed493d15d8810fe0afe80ec3d42722e',
+                provider_response_id='resp_689dc4abe31c81968ed493d15d8810fe0afe80ec3d42722e',
             ),
         ]
     )
@@ -1687,7 +1687,7 @@ async def test_anthropic_tool_output(allow_model_requests: None, anthropic_api_k
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_012TXW181edhmR5JCsQRsBKx',
+                provider_response_id='msg_012TXW181edhmR5JCsQRsBKx',
             ),
             ModelRequest(
                 parts=[
@@ -1720,7 +1720,7 @@ async def test_anthropic_tool_output(allow_model_requests: None, anthropic_api_k
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_01K4Fzcf1bhiyLzHpwLdrefj',
+                provider_response_id='msg_01K4Fzcf1bhiyLzHpwLdrefj',
             ),
             ModelRequest(
                 parts=[
@@ -1785,7 +1785,7 @@ async def test_anthropic_text_output_function(allow_model_requests: None, anthro
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_01MsqUB7ZyhjGkvepS1tCXp3',
+                provider_response_id='msg_01MsqUB7ZyhjGkvepS1tCXp3',
             ),
             ModelRequest(
                 parts=[
@@ -1816,7 +1816,7 @@ async def test_anthropic_text_output_function(allow_model_requests: None, anthro
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_0142umg4diSckrDtV9vAmmPL',
+                provider_response_id='msg_0142umg4diSckrDtV9vAmmPL',
             ),
         ]
     )
@@ -1874,7 +1874,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_018YiNXULHGpoKoHkTt6GivG',
+                provider_response_id='msg_018YiNXULHGpoKoHkTt6GivG',
             ),
             ModelRequest(
                 parts=[
@@ -1908,7 +1908,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_01WiRVmLhCrJbJZRqmAWKv3X',
+                provider_response_id='msg_01WiRVmLhCrJbJZRqmAWKv3X',
             ),
         ]
     )
@@ -1966,7 +1966,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='claude-3-5-sonnet-20241022',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
-                provider_request_id='msg_01N2PwwVQo2aBtt6UFhMDtEX',
+                provider_response_id='msg_01N2PwwVQo2aBtt6UFhMDtEX',
             ),
         ]
     )

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -443,7 +443,7 @@ async def test_cohere_model_thinking_part(allow_model_requests: None, co_api_key
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_680739f4ad748191bd11096967c37c8b048efc3f8b2a068e',
+                provider_response_id='resp_680739f4ad748191bd11096967c37c8b048efc3f8b2a068e',
             ),
         ]
     )
@@ -468,7 +468,7 @@ async def test_cohere_model_thinking_part(allow_model_requests: None, co_api_key
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_680739f4ad748191bd11096967c37c8b048efc3f8b2a068e',
+                provider_response_id='resp_680739f4ad748191bd11096967c37c8b048efc3f8b2a068e',
             ),
             ModelRequest(
                 parts=[

--- a/tests/models/test_deepseek.py
+++ b/tests/models/test_deepseek.py
@@ -56,7 +56,7 @@ async def test_deepseek_model_thinking_part(allow_model_requests: None, deepseek
                 model_name='deepseek-reasoner',
                 timestamp=IsDatetime(),
                 provider_name='deepseek',
-                provider_request_id='181d9669-2b3a-445e-bd13-2ebff2c378f6',
+                provider_response_id='181d9669-2b3a-445e-bd13-2ebff2c378f6',
             ),
         ]
     )

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -1491,7 +1491,7 @@ Always be cautious—even if you have the right-of-way—and understand that it'
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_680393ff82488191a7d0850bf0dd99a004f0817ea037a07b',
+                provider_response_id='resp_680393ff82488191a7d0850bf0dd99a004f0817ea037a07b',
             ),
         ]
     )
@@ -1518,7 +1518,7 @@ Always be cautious—even if you have the right-of-way—and understand that it'
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_680393ff82488191a7d0850bf0dd99a004f0817ea037a07b',
+                provider_response_id='resp_680393ff82488191a7d0850bf0dd99a004f0817ea037a07b',
             ),
             ModelRequest(
                 parts=[
@@ -1688,7 +1688,7 @@ async def test_gemini_tool_config_any_with_tool_without_args(allow_model_request
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1714,7 +1714,7 @@ async def test_gemini_tool_config_any_with_tool_without_args(allow_model_request
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1765,7 +1765,7 @@ async def test_gemini_tool_output(allow_model_requests: None, gemini_api_key: st
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1791,7 +1791,7 @@ async def test_gemini_tool_output(allow_model_requests: None, gemini_api_key: st
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1849,7 +1849,7 @@ It's the capital of Mexico and one of the largest metropolitan areas in the worl
                 model_name='models/gemini-2.5-pro-preview-05-06',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id='TT9IaNfGN_DmqtsPzKnE4AE',
+                provider_response_id='TT9IaNfGN_DmqtsPzKnE4AE',
             ),
         ]
     )
@@ -1915,7 +1915,7 @@ async def test_gemini_native_output(allow_model_requests: None, gemini_api_key: 
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -1970,7 +1970,7 @@ async def test_gemini_native_output_multiple(allow_model_requests: None, gemini_
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -2018,7 +2018,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -2068,7 +2068,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='models/gemini-2.5-pro-preview-05-06',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -2095,7 +2095,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='models/gemini-2.5-pro-preview-05-06',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -2149,7 +2149,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )

--- a/tests/models/test_gemini_vertex.py
+++ b/tests/models/test_gemini_vertex.py
@@ -149,7 +149,7 @@ async def test_url_input(
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -186,7 +186,7 @@ async def test_url_input_force_download(allow_model_requests: None) -> None:  # 
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -113,7 +113,7 @@ async def test_google_model(allow_model_requests: None, google_provider: GoogleP
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -180,7 +180,7 @@ async def test_google_model_structured_output(allow_model_requests: None, google
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -206,7 +206,7 @@ async def test_google_model_structured_output(allow_model_requests: None, google
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -263,7 +263,7 @@ async def test_google_model_retry(allow_model_requests: None, google_provider: G
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -288,7 +288,7 @@ async def test_google_model_retry(allow_model_requests: None, google_provider: G
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -563,7 +563,7 @@ async def test_google_model_instructions(allow_model_requests: None, google_prov
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -684,7 +684,7 @@ print(f'{day_of_week=}')
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -744,7 +744,7 @@ print(f'{day_of_week=}')
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(parts=[UserPromptPart(content='What day is tomorrow?', timestamp=IsDatetime())]),
             ModelResponse(
@@ -794,7 +794,7 @@ print(f'{day_of_week=}')
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -949,7 +949,7 @@ async def test_google_model_thinking_part(allow_model_requests: None, google_pro
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -1103,7 +1103,7 @@ async def test_google_url_input(
                 timestamp=IsDatetime(),
                 provider_name='google-vertex',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -1141,7 +1141,7 @@ async def test_google_url_input_force_download(
                 model_name='gemini-2.0-flash',
                 timestamp=IsDatetime(),
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
                 provider_name='google-vertex',
             ),
         ]
@@ -1191,7 +1191,7 @@ async def test_google_tool_config_any_with_tool_without_args(
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1218,7 +1218,7 @@ async def test_google_tool_config_any_with_tool_without_args(
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1280,7 +1280,7 @@ async def test_google_tool_output(allow_model_requests: None, google_provider: G
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1307,7 +1307,7 @@ async def test_google_tool_output(allow_model_requests: None, google_provider: G
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1359,7 +1359,7 @@ async def test_google_text_output_function(allow_model_requests: None, google_pr
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1380,7 +1380,7 @@ async def test_google_text_output_function(allow_model_requests: None, google_pr
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -1445,7 +1445,7 @@ async def test_google_native_output(allow_model_requests: None, google_provider:
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -1500,7 +1500,7 @@ async def test_google_native_output_multiple(allow_model_requests: None, google_
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -1544,7 +1544,7 @@ Don't include any text or Markdown fencing before or after.\
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -1594,7 +1594,7 @@ Don't include any text or Markdown fencing before or after.\
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
@@ -1622,7 +1622,7 @@ Don't include any text or Markdown fencing before or after.\
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -1676,7 +1676,7 @@ Don't include any text or Markdown fencing before or after.\
                 timestamp=IsDatetime(),
                 provider_name='google-gla',
                 provider_details={'finish_reason': 'STOP'},
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -158,7 +158,7 @@ async def test_request_simple_success(allow_model_requests: None):
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='groq',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -166,7 +166,7 @@ async def test_request_simple_success(allow_model_requests: None):
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='groq',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -219,7 +219,7 @@ async def test_request_structured_response(allow_model_requests: None):
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
                 provider_name='groq',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -308,7 +308,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='groq',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -332,7 +332,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='groq',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -349,7 +349,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='llama-3.3-70b-versatile-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='groq',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -590,7 +590,7 @@ async def test_image_as_binary_content_tool_response(
                 model_name='meta-llama/llama-4-scout-17b-16e-instruct',
                 timestamp=IsDatetime(),
                 provider_name='groq',
-                provider_request_id='chatcmpl-3c327c89-e9f5-4aac-a5d5-190e6f6f25c9',
+                provider_response_id='chatcmpl-3c327c89-e9f5-4aac-a5d5-190e6f6f25c9',
             ),
             ModelRequest(
                 parts=[
@@ -615,7 +615,7 @@ async def test_image_as_binary_content_tool_response(
                 model_name='meta-llama/llama-4-scout-17b-16e-instruct',
                 timestamp=IsDatetime(),
                 provider_name='groq',
-                provider_request_id='chatcmpl-82dfad42-6a28-4089-82c3-c8633f626c0d',
+                provider_response_id='chatcmpl-82dfad42-6a28-4089-82c3-c8633f626c0d',
             ),
         ]
     )
@@ -694,7 +694,7 @@ async def test_groq_model_instructions(allow_model_requests: None, groq_api_key:
                 model_name='llama-3.3-70b-versatile',
                 timestamp=IsDatetime(),
                 provider_name='groq',
-                provider_request_id='chatcmpl-7586b6a9-fb4b-4ec7-86a0-59f0a77844cf',
+                provider_response_id='chatcmpl-7586b6a9-fb4b-4ec7-86a0-59f0a77844cf',
             ),
         ]
     )
@@ -897,7 +897,7 @@ The current day is Tuesday.\
                 model_name='compound-beta',
                 timestamp=IsDatetime(),
                 provider_name='groq',
-                provider_request_id='stub',
+                provider_response_id='stub',
             ),
         ]
     )
@@ -921,7 +921,7 @@ async def test_groq_model_thinking_part(allow_model_requests: None, groq_api_key
                 model_name='deepseek-r1-distill-llama-70b',
                 timestamp=IsDatetime(),
                 provider_name='groq',
-                provider_request_id=IsStr(),
+                provider_response_id=IsStr(),
             ),
         ]
     )
@@ -943,7 +943,7 @@ async def test_groq_model_thinking_part(allow_model_requests: None, groq_api_key
                 model_name='deepseek-r1-distill-llama-70b',
                 timestamp=IsDatetime(),
                 provider_name='groq',
-                provider_request_id='chatcmpl-9748c1af-1065-410a-969a-d7fb48039fbb',
+                provider_response_id='chatcmpl-9748c1af-1065-410a-969a-d7fb48039fbb',
             ),
             ModelRequest(
                 parts=[
@@ -960,7 +960,7 @@ async def test_groq_model_thinking_part(allow_model_requests: None, groq_api_key
                 model_name='deepseek-r1-distill-llama-70b',
                 timestamp=IsDatetime(),
                 provider_name='groq',
-                provider_request_id='chatcmpl-994aa228-883a-498c-8b20-9655d770b697',
+                provider_response_id='chatcmpl-994aa228-883a-498c-8b20-9655d770b697',
             ),
         ]
     )

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -172,7 +172,7 @@ async def test_simple_completion(allow_model_requests: None, huggingface_api_key
             model_name='Qwen/Qwen2.5-72B-Instruct-fast',
             timestamp=datetime(2025, 7, 8, 13, 42, 33, tzinfo=timezone.utc),
             provider_name='huggingface',
-            provider_request_id='chatcmpl-d445c0d473a84791af2acf356cc00df7',
+            provider_response_id='chatcmpl-d445c0d473a84791af2acf356cc00df7',
         )
     )
 
@@ -240,7 +240,7 @@ async def test_request_structured_response(
             model_name='hf-model',
             timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
             provider_name='huggingface',
-            provider_request_id='123',
+            provider_response_id='123',
         )
     )
 
@@ -373,7 +373,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='hf-model',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='huggingface',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -397,7 +397,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='hf-model',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='huggingface',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -414,7 +414,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='hf-model',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='huggingface',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -662,7 +662,7 @@ async def test_image_url_input(allow_model_requests: None, huggingface_api_key: 
                 model_name='Qwen/Qwen2.5-VL-72B-Instruct',
                 timestamp=datetime(2025, 7, 8, 14, 4, 39, tzinfo=timezone.utc),
                 provider_name='huggingface',
-                provider_request_id='chatcmpl-49aa100effab4ca28514d5ccc00d7944',
+                provider_response_id='chatcmpl-49aa100effab4ca28514d5ccc00d7944',
             ),
         ]
     )
@@ -729,7 +729,7 @@ async def test_hf_model_instructions(allow_model_requests: None, huggingface_api
                 model_name='Qwen/Qwen2.5-72B-Instruct-fast',
                 timestamp=IsDatetime(),
                 provider_name='huggingface',
-                provider_request_id='chatcmpl-b3936940372c481b8d886e596dc75524',
+                provider_response_id='chatcmpl-b3936940372c481b8d886e596dc75524',
             ),
         ]
     )
@@ -821,7 +821,7 @@ async def test_retry_prompt_without_tool_name(allow_model_requests: None):
                 model_name='hf-model',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='huggingface',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -838,7 +838,7 @@ async def test_retry_prompt_without_tool_name(allow_model_requests: None):
                 model_name='hf-model',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='huggingface',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -969,7 +969,7 @@ async def test_hf_model_thinking_part(allow_model_requests: None, huggingface_ap
                 model_name='Qwen/Qwen3-235B-A22B',
                 timestamp=IsDatetime(),
                 provider_name='huggingface',
-                provider_request_id='chatcmpl-957db61fe60d4440bcfe1f11f2c5b4b9',
+                provider_response_id='chatcmpl-957db61fe60d4440bcfe1f11f2c5b4b9',
             ),
         ]
     )
@@ -993,7 +993,7 @@ async def test_hf_model_thinking_part(allow_model_requests: None, huggingface_ap
                 model_name='Qwen/Qwen3-235B-A22B',
                 timestamp=IsDatetime(),
                 provider_name='huggingface',
-                provider_request_id='chatcmpl-957db61fe60d4440bcfe1f11f2c5b4b9',
+                provider_response_id='chatcmpl-957db61fe60d4440bcfe1f11f2c5b4b9',
             ),
             ModelRequest(
                 parts=[
@@ -1012,7 +1012,7 @@ async def test_hf_model_thinking_part(allow_model_requests: None, huggingface_ap
                 model_name='Qwen/Qwen3-235B-A22B',
                 timestamp=IsDatetime(),
                 provider_name='huggingface',
-                provider_request_id='chatcmpl-35fdec1307634f94a39f7e26f52e12a7',
+                provider_response_id='chatcmpl-35fdec1307634f94a39f7e26f52e12a7',
             ),
         ]
     )

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -221,7 +221,7 @@ async def test_multiple_completions(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='hello again', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -230,7 +230,7 @@ async def test_multiple_completions(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -273,7 +273,7 @@ async def test_three_completions(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='hello again', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -282,7 +282,7 @@ async def test_three_completions(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='final message', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -291,7 +291,7 @@ async def test_three_completions(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -408,7 +408,7 @@ async def test_request_native_with_arguments_dict_response(allow_model_requests:
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -469,7 +469,7 @@ async def test_request_native_with_arguments_str_response(allow_model_requests: 
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -529,7 +529,7 @@ async def test_request_output_type_with_arguments_str_response(allow_model_reque
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1092,7 +1092,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1116,7 +1116,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1134,7 +1134,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -1237,7 +1237,7 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1261,7 +1261,7 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1285,7 +1285,7 @@ async def test_request_tool_call_with_result_type(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -1809,7 +1809,7 @@ async def test_image_as_binary_content_tool_response(
                 model_name='pixtral-12b-latest',
                 timestamp=IsDatetime(),
                 provider_name='mistral',
-                provider_request_id='fce6d16a4e5940edb24ae16dd0369947',
+                provider_response_id='fce6d16a4e5940edb24ae16dd0369947',
             ),
             ModelRequest(
                 parts=[
@@ -1838,7 +1838,7 @@ async def test_image_as_binary_content_tool_response(
                 model_name='pixtral-12b-latest',
                 timestamp=IsDatetime(),
                 provider_name='mistral',
-                provider_request_id='26e7de193646460e8904f8e604a60dc1',
+                provider_response_id='26e7de193646460e8904f8e604a60dc1',
             ),
         ]
     )
@@ -1877,7 +1877,7 @@ async def test_image_url_input(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=IsDatetime(),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -1911,7 +1911,7 @@ async def test_image_as_binary_content_input(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=IsDatetime(),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -1948,7 +1948,7 @@ async def test_pdf_url_input(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=IsDatetime(),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -1979,7 +1979,7 @@ async def test_pdf_as_binary_content_input(allow_model_requests: None):
                 model_name='mistral-large-123',
                 timestamp=IsDatetime(),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -2056,7 +2056,7 @@ async def test_mistral_model_instructions(allow_model_requests: None, mistral_ap
                 model_name='mistral-large-123',
                 timestamp=IsDatetime(),
                 provider_name='mistral',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -2084,7 +2084,7 @@ async def test_mistral_model_thinking_part(allow_model_requests: None, openai_ap
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68079acebbfc819189ec20e1e5bf525d0493b22e4095129c',
+                provider_response_id='resp_68079acebbfc819189ec20e1e5bf525d0493b22e4095129c',
             ),
         ]
     )
@@ -2143,7 +2143,7 @@ These suggestions are meant to help you think through pedestrian safety. Differe
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68079acebbfc819189ec20e1e5bf525d0493b22e4095129c',
+                provider_response_id='resp_68079acebbfc819189ec20e1e5bf525d0493b22e4095129c',
             ),
             ModelRequest(
                 parts=[
@@ -2159,7 +2159,7 @@ These suggestions are meant to help you think through pedestrian safety. Differe
                 model_name='mistral-large-latest',
                 timestamp=IsDatetime(),
                 provider_name='mistral',
-                provider_request_id='a088e80a476e44edaaa959a1ff08f358',
+                provider_response_id='a088e80a476e44edaaa959a1ff08f358',
             ),
         ]
     )

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -122,7 +122,7 @@ async def test_request_simple_success(allow_model_requests: None):
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='openai',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(parts=[UserPromptPart(content='hello', timestamp=IsNow(tz=timezone.utc))]),
             ModelResponse(
@@ -130,7 +130,7 @@ async def test_request_simple_success(allow_model_requests: None):
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
                 provider_name='openai',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -208,7 +208,7 @@ async def test_request_structured_response(allow_model_requests: None):
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
                 provider_name='openai',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -303,7 +303,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
                 provider_name='openai',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -331,7 +331,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
                 provider_name='openai',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
             ModelRequest(
                 parts=[
@@ -348,7 +348,7 @@ async def test_request_tool_call(allow_model_requests: None):
                 model_name='gpt-4o-123',
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
                 provider_name='openai',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )
@@ -804,7 +804,7 @@ async def test_image_url_tool_response(allow_model_requests: None, openai_api_ke
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BRmTHlrARTzAHK1na9s80xDlQGYPX',
+                provider_response_id='chatcmpl-BRmTHlrARTzAHK1na9s80xDlQGYPX',
             ),
             ModelRequest(
                 parts=[
@@ -840,7 +840,7 @@ async def test_image_url_tool_response(allow_model_requests: None, openai_api_ke
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BRmTI0Y2zmkGw27kLarhsmiFQTGxR',
+                provider_response_id='chatcmpl-BRmTI0Y2zmkGw27kLarhsmiFQTGxR',
             ),
         ]
     )
@@ -882,7 +882,7 @@ async def test_image_as_binary_content_tool_response(
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BRlkLhPc87BdohVobEJJCGq3rUAG2',
+                provider_response_id='chatcmpl-BRlkLhPc87BdohVobEJJCGq3rUAG2',
             ),
             ModelRequest(
                 parts=[
@@ -916,7 +916,7 @@ async def test_image_as_binary_content_tool_response(
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BRlkORPA5rXMV3uzcOcgK4eQFKCVW',
+                provider_response_id='chatcmpl-BRlkORPA5rXMV3uzcOcgK4eQFKCVW',
             ),
         ]
     )
@@ -1835,7 +1835,7 @@ async def test_openai_instructions(allow_model_requests: None, openai_api_key: s
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BJjf61mLb9z5H45ClJzbx0UWKwjo1',
+                provider_response_id='chatcmpl-BJjf61mLb9z5H45ClJzbx0UWKwjo1',
             ),
         ]
     )
@@ -1880,7 +1880,7 @@ async def test_openai_instructions_with_tool_calls_keep_instructions(allow_model
                 model_name='gpt-4.1-mini-2025-04-14',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BMxEwRA0p0gJ52oKS7806KAlfMhqq',
+                provider_response_id='chatcmpl-BMxEwRA0p0gJ52oKS7806KAlfMhqq',
             ),
             ModelRequest(
                 parts=[
@@ -1905,7 +1905,7 @@ async def test_openai_instructions_with_tool_calls_keep_instructions(allow_model
                 model_name='gpt-4.1-mini-2025-04-14',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BMxEx6B8JEj6oDC45MOWKp0phg8UP',
+                provider_response_id='chatcmpl-BMxEx6B8JEj6oDC45MOWKp0phg8UP',
             ),
         ]
     )
@@ -1932,7 +1932,7 @@ async def test_openai_responses_model_thinking_part(allow_model_requests: None, 
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68034835d12481919c80a7fd8dbe6f7e08c845d2be9bcdd8',
+                provider_response_id='resp_68034835d12481919c80a7fd8dbe6f7e08c845d2be9bcdd8',
             ),
         ]
     )
@@ -1956,7 +1956,7 @@ async def test_openai_responses_model_thinking_part(allow_model_requests: None, 
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68034835d12481919c80a7fd8dbe6f7e08c845d2be9bcdd8',
+                provider_response_id='resp_68034835d12481919c80a7fd8dbe6f7e08c845d2be9bcdd8',
             ),
             ModelRequest(
                 parts=[
@@ -1977,7 +1977,7 @@ async def test_openai_responses_model_thinking_part(allow_model_requests: None, 
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_6803484f19a88191b9ea975d7cfbbe8408c845d2be9bcdd8',
+                provider_response_id='resp_6803484f19a88191b9ea975d7cfbbe8408c845d2be9bcdd8',
             ),
         ]
     )
@@ -2005,7 +2005,7 @@ async def test_openai_model_thinking_part(allow_model_requests: None, openai_api
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_680797310bbc8191971fff5a405113940ed3ec3064b5efac',
+                provider_response_id='resp_680797310bbc8191971fff5a405113940ed3ec3064b5efac',
             ),
         ]
     )
@@ -2030,7 +2030,7 @@ async def test_openai_model_thinking_part(allow_model_requests: None, openai_api
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_680797310bbc8191971fff5a405113940ed3ec3064b5efac',
+                provider_response_id='resp_680797310bbc8191971fff5a405113940ed3ec3064b5efac',
             ),
             ModelRequest(
                 parts=[
@@ -2055,7 +2055,7 @@ async def test_openai_model_thinking_part(allow_model_requests: None, openai_api
                 model_name='o3-mini-2025-01-31',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BP7ocN6qxho4C1UzUJWnU5tPJno55',
+                provider_response_id='chatcmpl-BP7ocN6qxho4C1UzUJWnU5tPJno55',
             ),
         ]
     )
@@ -2355,7 +2355,7 @@ async def test_openai_tool_output(allow_model_requests: None, openai_api_key: st
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BSXk0dWkG4hfPt0lph4oFO35iT73I',
+                provider_response_id='chatcmpl-BSXk0dWkG4hfPt0lph4oFO35iT73I',
             ),
             ModelRequest(
                 parts=[
@@ -2388,7 +2388,7 @@ async def test_openai_tool_output(allow_model_requests: None, openai_api_key: st
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BSXk1xGHYzbhXgUkSutK08bdoNv5s',
+                provider_response_id='chatcmpl-BSXk1xGHYzbhXgUkSutK08bdoNv5s',
             ),
             ModelRequest(
                 parts=[
@@ -2446,7 +2446,7 @@ async def test_openai_text_output_function(allow_model_requests: None, openai_ap
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BgeDFS85bfHosRFEEAvq8reaCPCZ8',
+                provider_response_id='chatcmpl-BgeDFS85bfHosRFEEAvq8reaCPCZ8',
             ),
             ModelRequest(
                 parts=[
@@ -2473,7 +2473,7 @@ async def test_openai_text_output_function(allow_model_requests: None, openai_ap
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BgeDGX9eDyVrEI56aP2vtIHahBzFH',
+                provider_response_id='chatcmpl-BgeDGX9eDyVrEI56aP2vtIHahBzFH',
             ),
         ]
     )
@@ -2524,7 +2524,7 @@ async def test_openai_native_output(allow_model_requests: None, openai_api_key: 
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BSXjyBwGuZrtuuSzNCeaWMpGv2MZ3',
+                provider_response_id='chatcmpl-BSXjyBwGuZrtuuSzNCeaWMpGv2MZ3',
             ),
             ModelRequest(
                 parts=[
@@ -2551,7 +2551,7 @@ async def test_openai_native_output(allow_model_requests: None, openai_api_key: 
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-BSXjzYGu67dhTy5r8KmjJvQ4HhDVO',
+                provider_response_id='chatcmpl-BSXjzYGu67dhTy5r8KmjJvQ4HhDVO',
             ),
         ]
     )
@@ -2604,7 +2604,7 @@ async def test_openai_native_output_multiple(allow_model_requests: None, openai_
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-Bgg5utuCSXMQ38j0n2qgfdQKcR9VD',
+                provider_response_id='chatcmpl-Bgg5utuCSXMQ38j0n2qgfdQKcR9VD',
             ),
             ModelRequest(
                 parts=[
@@ -2635,7 +2635,7 @@ async def test_openai_native_output_multiple(allow_model_requests: None, openai_
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-Bgg5vrxUtCDlvgMreoxYxPaKxANmd',
+                provider_response_id='chatcmpl-Bgg5vrxUtCDlvgMreoxYxPaKxANmd',
             ),
         ]
     )
@@ -2691,7 +2691,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-Bgh27PeOaFW6qmF04qC5uI2H9mviw',
+                provider_response_id='chatcmpl-Bgh27PeOaFW6qmF04qC5uI2H9mviw',
             ),
             ModelRequest(
                 parts=[
@@ -2725,7 +2725,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-Bgh28advCSFhGHPnzUevVS6g6Uwg0',
+                provider_response_id='chatcmpl-Bgh28advCSFhGHPnzUevVS6g6Uwg0',
             ),
         ]
     )
@@ -2785,7 +2785,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-Bgh2AW2NXGgMc7iS639MJXNRgtatR',
+                provider_response_id='chatcmpl-Bgh2AW2NXGgMc7iS639MJXNRgtatR',
             ),
             ModelRequest(
                 parts=[
@@ -2823,7 +2823,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='chatcmpl-Bgh2BthuopRnSqCuUgMbBnOqgkDHC',
+                provider_response_id='chatcmpl-Bgh2BthuopRnSqCuUgMbBnOqgkDHC',
             ),
         ]
     )

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -205,7 +205,7 @@ async def test_openai_responses_model_retry(allow_model_requests: None, openai_a
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_67e547c48c9481918c5c4394464ce0c60ae6111e84dd5c08',
+                provider_response_id='resp_67e547c48c9481918c5c4394464ce0c60ae6111e84dd5c08',
             ),
             ModelRequest(
                 parts=[
@@ -237,7 +237,7 @@ For **London**, it's located at approximately latitude 51° N and longitude 0° 
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_67e547c5a2f08191802a1f43620f348503a2086afed73b47',
+                provider_response_id='resp_67e547c5a2f08191802a1f43620f348503a2086afed73b47',
             ),
         ]
     )
@@ -271,7 +271,7 @@ async def test_image_as_binary_content_tool_response(
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_681134d3aa3481919ca581a267db1e510fe7a5a4e2123dc3',
+                provider_response_id='resp_681134d3aa3481919ca581a267db1e510fe7a5a4e2123dc3',
             ),
             ModelRequest(
                 parts=[
@@ -296,7 +296,7 @@ async def test_image_as_binary_content_tool_response(
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_681134d53c48819198ce7b89db78dffd02cbfeaababb040c',
+                provider_response_id='resp_681134d53c48819198ce7b89db78dffd02cbfeaababb040c',
             ),
         ]
     )
@@ -428,7 +428,7 @@ OpenAI's recent launch of GPT-5 has faced mixed reactions. Despite strong benchm
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_689b7c90010c8196ac0efd68b021490f07450cfc2d48b975',
+                provider_response_id='resp_689b7c90010c8196ac0efd68b021490f07450cfc2d48b975',
             ),
         ]
     )
@@ -452,7 +452,7 @@ async def test_openai_responses_model_instructions(allow_model_requests: None, o
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_67f3fdfd9fa08191a3d5825db81b8df6003bc73febb56d77',
+                provider_response_id='resp_67f3fdfd9fa08191a3d5825db81b8df6003bc73febb56d77',
             ),
         ]
     )
@@ -696,7 +696,7 @@ async def test_tool_output(allow_model_requests: None, openai_api_key: str):
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68477f0b40a8819cb8d55594bc2c232a001fd29e2d5573f7',
+                provider_response_id='resp_68477f0b40a8819cb8d55594bc2c232a001fd29e2d5573f7',
             ),
             ModelRequest(
                 parts=[
@@ -720,7 +720,7 @@ async def test_tool_output(allow_model_requests: None, openai_api_key: str):
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68477f0bfda8819ea65458cd7cc389b801dc81d4bc91f560',
+                provider_response_id='resp_68477f0bfda8819ea65458cd7cc389b801dc81d4bc91f560',
             ),
             ModelRequest(
                 parts=[
@@ -770,7 +770,7 @@ async def test_text_output_function(allow_model_requests: None, openai_api_key: 
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68477f0d9494819ea4f123bba707c9ee0356a60c98816d6a',
+                provider_response_id='resp_68477f0d9494819ea4f123bba707c9ee0356a60c98816d6a',
             ),
             ModelRequest(
                 parts=[
@@ -788,7 +788,7 @@ async def test_text_output_function(allow_model_requests: None, openai_api_key: 
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68477f0e2b28819d9c828ef4ee526d6a03434b607c02582d',
+                provider_response_id='resp_68477f0e2b28819d9c828ef4ee526d6a03434b607c02582d',
             ),
         ]
     )
@@ -829,7 +829,7 @@ async def test_native_output(allow_model_requests: None, openai_api_key: str):
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68477f0f220081a1a621d6bcdc7f31a50b8591d9001d2329',
+                provider_response_id='resp_68477f0f220081a1a621d6bcdc7f31a50b8591d9001d2329',
             ),
             ModelRequest(
                 parts=[
@@ -847,7 +847,7 @@ async def test_native_output(allow_model_requests: None, openai_api_key: str):
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68477f0fde708192989000a62809c6e5020197534e39cc1f',
+                provider_response_id='resp_68477f0fde708192989000a62809c6e5020197534e39cc1f',
             ),
         ]
     )
@@ -890,7 +890,7 @@ async def test_native_output_multiple(allow_model_requests: None, openai_api_key
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68477f10f2d081a39b3438f413b3bafc0dd57d732903c563',
+                provider_response_id='resp_68477f10f2d081a39b3438f413b3bafc0dd57d732903c563',
             ),
             ModelRequest(
                 parts=[
@@ -912,7 +912,7 @@ async def test_native_output_multiple(allow_model_requests: None, openai_api_key
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68477f119830819da162aa6e10552035061ad97e2eef7871',
+                provider_response_id='resp_68477f119830819da162aa6e10552035061ad97e2eef7871',
             ),
         ]
     )
@@ -958,7 +958,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68482f12d63881a1830201ed101ecfbf02f8ef7f2fb42b50',
+                provider_response_id='resp_68482f12d63881a1830201ed101ecfbf02f8ef7f2fb42b50',
             ),
             ModelRequest(
                 parts=[
@@ -983,7 +983,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68482f1b556081918d64c9088a470bf0044fdb7d019d4115',
+                provider_response_id='resp_68482f1b556081918d64c9088a470bf0044fdb7d019d4115',
             ),
         ]
     )
@@ -1033,7 +1033,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68482f1d38e081a1ac828acda978aa6b08e79646fe74d5ee',
+                provider_response_id='resp_68482f1d38e081a1ac828acda978aa6b08e79646fe74d5ee',
             ),
             ModelRequest(
                 parts=[
@@ -1062,7 +1062,7 @@ Don't include any text or Markdown fencing before or after.\
                 model_name='gpt-4o-2024-08-06',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='resp_68482f28c1b081a1ae73cbbee012ee4906b4ab2d00d03024',
+                provider_response_id='resp_68482f28c1b081a1ae73cbbee012ee4906b4ab2d00d03024',
             ),
         ]
     )
@@ -1117,7 +1117,7 @@ async def test_openai_responses_usage_without_tokens_details(allow_model_request
                 model_name='gpt-4o-123',
                 timestamp=IsDatetime(),
                 provider_name='openai',
-                provider_request_id='123',
+                provider_response_id='123',
             ),
         ]
     )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3063,7 +3063,7 @@ def test_binary_content_serializable():
                 'model_name': 'test',
                 'provider_name': None,
                 'provider_details': None,
-                'provider_request_id': None,
+                'provider_response_id': None,
                 'timestamp': IsStr(),
                 'kind': 'response',
             },
@@ -3118,7 +3118,7 @@ def test_image_url_serializable_missing_media_type():
                 'timestamp': IsStr(),
                 'provider_name': None,
                 'provider_details': None,
-                'provider_request_id': None,
+                'provider_response_id': None,
                 'kind': 'response',
             },
         ]
@@ -3179,7 +3179,7 @@ def test_image_url_serializable():
                 'timestamp': IsStr(),
                 'provider_name': None,
                 'provider_details': None,
-                'provider_request_id': None,
+                'provider_response_id': None,
                 'kind': 'response',
             },
         ]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -215,7 +215,7 @@ async def test_agent_with_stdio_server(allow_model_requests: None, agent: Agent)
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRlnvvqIPFofAtKqtQKMWZkgXhzlT',
+                    provider_response_id='chatcmpl-BRlnvvqIPFofAtKqtQKMWZkgXhzlT',
                 ),
                 ModelRequest(
                     parts=[
@@ -242,7 +242,7 @@ async def test_agent_with_stdio_server(allow_model_requests: None, agent: Agent)
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRlnyjUo5wlyqvdNdM5I8vIWjo1qF',
+                    provider_response_id='chatcmpl-BRlnyjUo5wlyqvdNdM5I8vIWjo1qF',
                 ),
             ]
         )
@@ -345,7 +345,7 @@ async def test_tool_returning_str(allow_model_requests: None, agent: Agent):
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRlo3e1Ud2lnvkddMilmwC7LAemiy',
+                    provider_response_id='chatcmpl-BRlo3e1Ud2lnvkddMilmwC7LAemiy',
                 ),
                 ModelRequest(
                     parts=[
@@ -376,7 +376,7 @@ async def test_tool_returning_str(allow_model_requests: None, agent: Agent):
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRlo41LxqBYgGKWgGrQn67fQacOLp',
+                    provider_response_id='chatcmpl-BRlo41LxqBYgGKWgGrQn67fQacOLp',
                 ),
             ]
         )
@@ -417,7 +417,7 @@ async def test_tool_returning_text_resource(allow_model_requests: None, agent: A
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRmhyweJVYonarb7s9ckIMSHf2vHo',
+                    provider_response_id='chatcmpl-BRmhyweJVYonarb7s9ckIMSHf2vHo',
                 ),
                 ModelRequest(
                     parts=[
@@ -444,7 +444,7 @@ async def test_tool_returning_text_resource(allow_model_requests: None, agent: A
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRmhzqXFObpYwSzREMpJvX9kbDikR',
+                    provider_response_id='chatcmpl-BRmhzqXFObpYwSzREMpJvX9kbDikR',
                 ),
             ]
         )
@@ -485,7 +485,7 @@ async def test_tool_returning_text_resource_link(allow_model_requests: None, age
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BwdHSFe0EykAOpf0LWZzsWAodIQzb',
+                    provider_response_id='chatcmpl-BwdHSFe0EykAOpf0LWZzsWAodIQzb',
                 ),
                 ModelRequest(
                     parts=[
@@ -512,7 +512,7 @@ async def test_tool_returning_text_resource_link(allow_model_requests: None, age
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BwdHTIlBZWzXJPBR8VTOdC4O57ZQA',
+                    provider_response_id='chatcmpl-BwdHTIlBZWzXJPBR8VTOdC4O57ZQA',
                 ),
             ]
         )
@@ -555,7 +555,7 @@ async def test_tool_returning_image_resource(allow_model_requests: None, agent: 
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRlo7KYJVXuNZ5lLLdYcKZDsX2CHb',
+                    provider_response_id='chatcmpl-BRlo7KYJVXuNZ5lLLdYcKZDsX2CHb',
                 ),
                 ModelRequest(
                     parts=[
@@ -587,7 +587,7 @@ async def test_tool_returning_image_resource(allow_model_requests: None, agent: 
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloBGHh27w3fQKwxq4fX2cPuZJa9',
+                    provider_response_id='chatcmpl-BRloBGHh27w3fQKwxq4fX2cPuZJa9',
                 ),
             ]
         )
@@ -632,7 +632,7 @@ async def test_tool_returning_image_resource_link(
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BwdHygYePH1mZgHo2Xxzib0Y7sId7',
+                    provider_response_id='chatcmpl-BwdHygYePH1mZgHo2Xxzib0Y7sId7',
                 ),
                 ModelRequest(
                     parts=[
@@ -664,7 +664,7 @@ async def test_tool_returning_image_resource_link(
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BwdI2D2r9dvqq3pbsA0qgwKDEdTtD',
+                    provider_response_id='chatcmpl-BwdI2D2r9dvqq3pbsA0qgwKDEdTtD',
                 ),
             ]
         )
@@ -691,7 +691,7 @@ async def test_tool_returning_audio_resource(
                     timestamp=IsDatetime(),
                     provider_name='google-gla',
                     provider_details={'finish_reason': 'STOP'},
-                    provider_request_id=IsStr(),
+                    provider_response_id=IsStr(),
                 ),
                 ModelRequest(
                     parts=[
@@ -716,7 +716,7 @@ async def test_tool_returning_audio_resource(
                     timestamp=IsDatetime(),
                     provider_name='google-gla',
                     provider_details={'finish_reason': 'STOP'},
-                    provider_request_id=IsStr(),
+                    provider_response_id=IsStr(),
                 ),
             ]
         )
@@ -753,7 +753,7 @@ async def test_tool_returning_audio_resource_link(
                     timestamp=IsDatetime(),
                     provider_name='google-gla',
                     provider_details={'finish_reason': 'STOP'},
-                    provider_request_id=IsStr(),
+                    provider_response_id=IsStr(),
                 ),
                 ModelRequest(
                     parts=[
@@ -778,7 +778,7 @@ async def test_tool_returning_audio_resource_link(
                     timestamp=IsDatetime(),
                     provider_name='google-gla',
                     provider_details={'finish_reason': 'STOP'},
-                    provider_request_id=IsStr(),
+                    provider_response_id=IsStr(),
                 ),
             ]
         )
@@ -819,7 +819,7 @@ async def test_tool_returning_image(allow_model_requests: None, agent: Agent, im
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloGQJWIX0Qk7gtNzF4s2Fez0O29',
+                    provider_response_id='chatcmpl-BRloGQJWIX0Qk7gtNzF4s2Fez0O29',
                 ),
                 ModelRequest(
                     parts=[
@@ -853,7 +853,7 @@ async def test_tool_returning_image(allow_model_requests: None, agent: Agent, im
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloJHR654fSD0fcvLWZxtKtn0pag',
+                    provider_response_id='chatcmpl-BRloJHR654fSD0fcvLWZxtKtn0pag',
                 ),
             ]
         )
@@ -888,7 +888,7 @@ async def test_tool_returning_dict(allow_model_requests: None, agent: Agent):
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloOs7Bb2tq8wJyy9Rv7SQ7L65a7',
+                    provider_response_id='chatcmpl-BRloOs7Bb2tq8wJyy9Rv7SQ7L65a7',
                 ),
                 ModelRequest(
                     parts=[
@@ -915,7 +915,7 @@ async def test_tool_returning_dict(allow_model_requests: None, agent: Agent):
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloPczU1HSCWnreyo21DdNtdOM7L',
+                    provider_response_id='chatcmpl-BRloPczU1HSCWnreyo21DdNtdOM7L',
                 ),
             ]
         )
@@ -958,7 +958,7 @@ async def test_tool_returning_error(allow_model_requests: None, agent: Agent):
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloSNg7aGSp1rXDkhInjMIUHKd7A',
+                    provider_response_id='chatcmpl-BRloSNg7aGSp1rXDkhInjMIUHKd7A',
                 ),
                 ModelRequest(
                     parts=[
@@ -991,7 +991,7 @@ async def test_tool_returning_error(allow_model_requests: None, agent: Agent):
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloTvSkFeX4DZKQLqfH9KbQkWlpt',
+                    provider_response_id='chatcmpl-BRloTvSkFeX4DZKQLqfH9KbQkWlpt',
                 ),
                 ModelRequest(
                     parts=[
@@ -1022,7 +1022,7 @@ async def test_tool_returning_error(allow_model_requests: None, agent: Agent):
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloU3MhnqNEqujs28a3ofRbs7VPF',
+                    provider_response_id='chatcmpl-BRloU3MhnqNEqujs28a3ofRbs7VPF',
                 ),
             ]
         )
@@ -1057,7 +1057,7 @@ async def test_tool_returning_none(allow_model_requests: None, agent: Agent):
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloX2RokWc9j9PAXAuNXGR73WNqY',
+                    provider_response_id='chatcmpl-BRloX2RokWc9j9PAXAuNXGR73WNqY',
                 ),
                 ModelRequest(
                     parts=[
@@ -1084,7 +1084,7 @@ async def test_tool_returning_none(allow_model_requests: None, agent: Agent):
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloYWGujk8yE94gfVSsM1T1Ol2Ej',
+                    provider_response_id='chatcmpl-BRloYWGujk8yE94gfVSsM1T1Ol2Ej',
                 ),
             ]
         )
@@ -1127,7 +1127,7 @@ async def test_tool_returning_multiple_items(allow_model_requests: None, agent: 
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRlobKLgm6vf79c9O8sloZaYx3coC',
+                    provider_response_id='chatcmpl-BRlobKLgm6vf79c9O8sloZaYx3coC',
                 ),
                 ModelRequest(
                     parts=[
@@ -1170,7 +1170,7 @@ async def test_tool_returning_multiple_items(allow_model_requests: None, agent: 
                     model_name='gpt-4o-2024-08-06',
                     timestamp=IsDatetime(),
                     provider_name='openai',
-                    provider_request_id='chatcmpl-BRloepWR5NJpTgSqFBGTSPeM1SWm8',
+                    provider_response_id='chatcmpl-BRloepWR5NJpTgSqFBGTSPeM1SWm8',
                 ),
             ]
         )


### PR DESCRIPTION
Originally renamed from `vendor_id` to `provider_request_id` in https://github.com/pydantic/pydantic-ai/pull/2378, but it's really the response ID rather than the request ID. For example, it's what should be used as `previous_response_id` (https://github.com/pydantic/pydantic-ai/issues/2663) on the OpenAI Responses API.