### PR TITLE
Remove unused non-user-code-prefixes stuff

### DIFF
--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -50,16 +50,6 @@ if sys.version_info < (3, 11):
 else:
     ExceptionGroup = ExceptionGroup  # pragma: lax no cover
 
-# while waiting for https://github.com/pydantic/logfire/issues/745
-try:
-    import logfire._internal.stack_info
-except ImportError:
-    pass
-else:
-    from pathlib import Path
-
-    logfire._internal.stack_info.NON_USER_CODE_PREFIXES += (str(Path(__file__).parent.absolute()),)  # pyright: ignore[reportPrivateImportUsage]
-
 __all__ = (
     'Case',
     'Dataset',

--- a/pydantic_graph/pydantic_graph/graph.py
+++ b/pydantic_graph/pydantic_graph/graph.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator, Sequence
 from contextlib import AbstractContextManager, ExitStack, asynccontextmanager
 from dataclasses import dataclass, field
 from functools import cached_property
+from pathlib import Path
 from typing import Any, Generic, cast, overload
 
 import logfire_api
@@ -17,17 +18,6 @@ from ._utils import AbstractSpan, get_traceparent
 from .nodes import BaseNode, DepsT, End, GraphRunContext, NodeDef, RunEndT, StateT
 from .persistence import BaseStatePersistence
 from .persistence.in_mem import SimpleStatePersistence
-
-# while waiting for https://github.com/pydantic/logfire/issues/745
-try:
-    import logfire._internal.stack_info
-except ImportError:
-    pass
-else:
-    from pathlib import Path
-
-    logfire._internal.stack_info.NON_USER_CODE_PREFIXES += (str(Path(__file__).parent.absolute()),)  # pyright: ignore[reportPrivateImportUsage]
-
 
 __all__ = 'Graph', 'GraphRun', 'GraphRunResult'
 


### PR DESCRIPTION
Talking with Alex, sounds like this stuff was mostly just added for tests and obviously isn't doing anything if the tests still pass without this code.

If we wanted to keep this around to get clearer logfire code references when running scripts under the dev environment for pydantic-ai, the solution would be to add:
```python
logfire_api.add_non_user_code_prefix(Path(__file__).parent.absolute())
```
to the `pydantic_evals/__init__.py`  and `pydantic_graph/__init__.py`.