### PR TITLE
V1: Remove span_id and trace_id from EvaluationReport and ReportCase

### DIFF
--- a/pydantic_evals/pydantic_evals/reporting/__init__.py
+++ b/pydantic_evals/pydantic_evals/reporting/__init__.py
@@ -67,10 +67,6 @@ class ReportCase(Generic[InputsT, OutputT, MetadataT]):
     task_duration: float
     total_duration: float  # includes evaluator execution time
 
-    # TODO(DavidM): Drop these once we can reference child spans in details panel:
-    trace_id: str | None
-    span_id: str | None
-
 
 ReportCaseAdapter = TypeAdapter(ReportCase[Any, Any, Any])
 
@@ -161,12 +157,6 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
 
     cases: list[ReportCase[InputsT, OutputT, MetadataT]]
     """The cases in the report."""
-
-    span_id: str | None = None
-    """The span ID of the evaluation."""
-
-    trace_id: str | None = None
-    """The trace ID of the evaluation."""
 
     def averages(self) -> ReportCaseAggregate:
         return ReportCaseAggregate.average(self.cases)

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -221,10 +221,8 @@ async def test_evaluate_async(
                     'value': 1.0,
                 }
             },
-            'span_id': '0000000000000003',
             'task_duration': 1.0,
             'total_duration': 6.0,
-            'trace_id': '00000000000000000000000000000001',
         }
     )
 
@@ -273,10 +271,8 @@ async def test_evaluate_sync(
                     'value': 1.0,
                 }
             },
-            'span_id': '0000000000000003',
             'task_duration': IsNumber(),  # the runtime behavior is not deterministic due to threading
             'total_duration': IsNumber(),  # the runtime behavior is not deterministic due to threading
-            'trace_id': '00000000000000000000000000000001',
         }
     )
 
@@ -325,10 +321,8 @@ async def test_evaluate_with_concurrency(
                     'value': 1.0,
                 }
             },
-            'span_id': '0000000000000003',
             'task_duration': 1.0,
             'total_duration': 3.0,
-            'trace_id': '00000000000000000000000000000001',
         }
     )
 
@@ -1202,8 +1196,6 @@ async def test_evaluate_async_logfire(
                             },
                             'task_duration': 1.0,
                             'total_duration': 6.0,
-                            'trace_id': '00000000000000000000000000000001',
-                            'span_id': '0000000000000003',
                         },
                         {
                             'name': 'case2',
@@ -1232,8 +1224,6 @@ async def test_evaluate_async_logfire(
                             },
                             'task_duration': 1.0,
                             'total_duration': 4.0,
-                            'trace_id': '00000000000000000000000000000001',
-                            'span_id': '0000000000000007',
                         },
                     ],
                     'averages': {

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -409,8 +409,6 @@ async def test_increment_eval_metric(example_dataset: Dataset[TaskInput, TaskOut
                 assertions={},
                 task_duration=1.0,
                 total_duration=3.0,
-                trace_id='00000000000000000000000000000001',
-                span_id='0000000000000003',
             ),
             ReportCase(
                 name='case2',
@@ -425,8 +423,6 @@ async def test_increment_eval_metric(example_dataset: Dataset[TaskInput, TaskOut
                 assertions={},
                 task_duration=1.0,
                 total_duration=3.0,
-                trace_id='00000000000000000000000000000001',
-                span_id='0000000000000007',
             ),
         ]
     )
@@ -468,8 +464,6 @@ async def test_repeated_name_outputs(example_dataset: Dataset[TaskInput, TaskOut
                 assertions={},
                 task_duration=1.0,
                 total_duration=6.0,
-                trace_id='00000000000000000000000000000001',
-                span_id='0000000000000003',
             ),
             ReportCase(
                 name='case2',
@@ -494,8 +488,6 @@ async def test_repeated_name_outputs(example_dataset: Dataset[TaskInput, TaskOut
                 assertions={},
                 task_duration=1.0,
                 total_duration=4.0,
-                trace_id='00000000000000000000000000000001',
-                span_id='0000000000000007',
             ),
         ]
     )
@@ -534,8 +526,6 @@ async def test_report_round_trip_serialization(example_dataset: Dataset[TaskInpu
                     assertions={},
                     task_duration=1.0,
                     total_duration=6.0,
-                    trace_id='00000000000000000000000000000001',
-                    span_id='0000000000000003',
                 ),
                 ReportCase(
                     name='case2',
@@ -557,12 +547,8 @@ async def test_report_round_trip_serialization(example_dataset: Dataset[TaskInpu
                     assertions={},
                     task_duration=1.0,
                     total_duration=4.0,
-                    trace_id='00000000000000000000000000000001',
-                    span_id='0000000000000007',
                 ),
             ],
-            span_id='0000000000000001',
-            trace_id='00000000000000000000000000000001',
         )
     )
 
@@ -601,8 +587,6 @@ async def test_genai_attribute_collection(example_dataset: Dataset[TaskInput, Ta
                 assertions={},
                 task_duration=5.0,
                 total_duration=7.0,
-                trace_id='00000000000000000000000000000001',
-                span_id='0000000000000003',
             ),
             ReportCase(
                 name='case2',
@@ -617,8 +601,6 @@ async def test_genai_attribute_collection(example_dataset: Dataset[TaskInput, Ta
                 assertions={},
                 task_duration=5.0,
                 total_duration=7.0,
-                trace_id='00000000000000000000000000000001',
-                span_id='000000000000000b',
             ),
         ]
     )

--- a/tests/evals/test_reporting.py
+++ b/tests/evals/test_reporting.py
@@ -89,8 +89,6 @@ def sample_report_case(
         assertions={sample_assertion.name: sample_assertion},
         task_duration=0.1,
         total_duration=0.2,
-        trace_id='test-trace-id',
-        span_id='test-span-id',
     )
 
 
@@ -206,8 +204,6 @@ async def test_evaluation_renderer_with_baseline(sample_report: EvaluationReport
                 assertions={},
                 task_duration=0.15,
                 total_duration=0.25,
-                trace_id='test-trace-id',
-                span_id='test-span-id',
             )
         ],
         name='baseline_report',
@@ -264,8 +260,6 @@ async def test_evaluation_renderer_with_removed_cases(sample_report: EvaluationR
                 assertions={},
                 task_duration=0.1,
                 total_duration=0.15,
-                trace_id='test-trace-id-2',
-                span_id='test-span-id-2',
             )
         ],
         name='baseline_report',
@@ -412,8 +406,6 @@ async def test_report_case_aggregate_average():
             },
             task_duration=0.1,
             total_duration=0.2,
-            trace_id='test-trace-id-1',
-            span_id='test-span-id-1',
         ),
         ReportCase(
             name='case2',
@@ -449,8 +441,6 @@ async def test_report_case_aggregate_average():
             },
             task_duration=0.15,
             total_duration=0.25,
-            trace_id='test-trace-id-2',
-            span_id='test-span-id-2',
         ),
     ]
 

--- a/tests/evals/test_reports.py
+++ b/tests/evals/test_reports.py
@@ -217,10 +217,8 @@ async def test_report_with_error(mock_evaluator: Evaluator[TaskInput, TaskOutput
             'name': 'error_case',
             'output': None,
             'scores': {},
-            'span_id': 'test-error-span-id',
             'task_duration': 0.05,
             'total_duration': 0.1,
-            'trace_id': 'test-error-trace-id',
         }
     )
 

--- a/tests/evals/test_reports.py
+++ b/tests/evals/test_reports.py
@@ -76,8 +76,6 @@ def sample_report_case(sample_evaluation_result: EvaluationResult[bool]) -> Repo
         assertions={sample_evaluation_result.name: sample_evaluation_result},
         task_duration=0.1,
         total_duration=0.2,
-        trace_id='test-trace-id',
-        span_id='test-span-id',
     )
 
 
@@ -122,8 +120,6 @@ async def test_report_add_case(
         assertions={},
         task_duration=0.1,
         total_duration=0.15,
-        trace_id='test-trace-id-2',
-        span_id='test-span-id-2',
     )
 
     # Add the case
@@ -194,8 +190,6 @@ async def test_report_with_error(mock_evaluator: Evaluator[TaskInput, TaskOutput
         assertions={error_output.name: error_output},
         task_duration=0.05,
         total_duration=0.1,
-        trace_id='test-error-trace-id',
-        span_id='test-error-span-id',
     )
 
     # Create a report with the error case


### PR DESCRIPTION
This will break deserialization => allow extras