### PR TITLE
Let almost all types used in docs examples be imported directly from `pydantic_ai`

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -116,7 +116,7 @@ import asyncio
 from collections.abc import AsyncIterable
 from datetime import date
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import (
     AgentStreamEvent,
     FinalResultEvent,
@@ -128,7 +128,6 @@ from pydantic_ai.messages import (
     ThinkingPartDelta,
     ToolCallPartDelta,
 )
-from pydantic_ai.tools import RunContext
 
 weather_agent = Agent(
     'openai:gpt-4o',
@@ -395,7 +394,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import date
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import (
     FinalResultEvent,
     FunctionToolCallEvent,
@@ -406,7 +405,6 @@ from pydantic_ai.messages import (
     ThinkingPartDelta,
     ToolCallPartDelta,
 )
-from pydantic_ai.tools import RunContext
 
 
 @dataclass
@@ -548,9 +546,7 @@ You can apply these settings by passing the `usage_limits` argument to the `run{
 Consider the following example, where we limit the number of response tokens:
 
 ```py
-from pydantic_ai import Agent
-from pydantic_ai.exceptions import UsageLimitExceeded
-from pydantic_ai.usage import UsageLimits
+from pydantic_ai import Agent, UsageLimitExceeded, UsageLimits
 
 agent = Agent('anthropic:claude-3-5-sonnet-latest')
 
@@ -578,9 +574,7 @@ Restricting the number of requests can be useful in preventing infinite loops or
 ```py
 from typing_extensions import TypedDict
 
-from pydantic_ai import Agent, ModelRetry
-from pydantic_ai.exceptions import UsageLimitExceeded
-from pydantic_ai.usage import UsageLimits
+from pydantic_ai import Agent, ModelRetry, UsageLimitExceeded, UsageLimits
 
 
 class NeverOutputType(TypedDict):
@@ -636,9 +630,8 @@ For example, if you'd like to set the `temperature` setting to `0.0` to ensure l
 you can do the following:
 
 ```py
-from pydantic_ai import Agent
+from pydantic_ai import Agent, ModelSettings
 from pydantic_ai.models.openai import OpenAIChatModel
-from pydantic_ai.settings import ModelSettings
 
 # 1. Model-level defaults
 model = OpenAIChatModel(

--- a/docs/common-tools.md
+++ b/docs/common-tools.md
@@ -106,7 +106,7 @@ Here's an example of how you can use the Tavily search tool with an agent:
 ```py {title="tavily_search.py" test="skip"}
 import os
 
-from pydantic_ai.agent import Agent
+from pydantic_ai import Agent
 from pydantic_ai.common_tools.tavily import tavily_search_tool
 
 api_key = os.getenv('TAVILY_API_KEY')

--- a/docs/direct.md
+++ b/docs/direct.md
@@ -43,10 +43,10 @@ Even here we can use Pydantic to generate the JSON schema for the tool:
 from pydantic import BaseModel
 from typing_extensions import Literal
 
+from pydantic_ai import ToolDefinition
 from pydantic_ai.direct import model_request
 from pydantic_ai.messages import ModelRequest
 from pydantic_ai.models import ModelRequestParameters
-from pydantic_ai.tools import ToolDefinition
 
 
 class Divide(BaseModel):

--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -226,7 +226,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import set_tracer_provider
 
-from pydantic_ai.agent import Agent
+from pydantic_ai import Agent
 
 os.environ['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://localhost:4318'
 exporter = OTLPSpanExporter()
@@ -296,7 +296,7 @@ By default, the global `TracerProvider` and `EventLoggerProvider` are used. Thes
 from opentelemetry.sdk._events import EventLoggerProvider
 from opentelemetry.sdk.trace import TracerProvider
 
-from pydantic_ai.agent import Agent, InstrumentationSettings
+from pydantic_ai import Agent, InstrumentationSettings
 
 instrumentation_settings = InstrumentationSettings(
     tracer_provider=TracerProvider(),
@@ -322,7 +322,7 @@ agent = Agent(model)
 ### Excluding binary content
 
 ```python {title="excluding_binary_content.py"}
-from pydantic_ai.agent import Agent, InstrumentationSettings
+from pydantic_ai import Agent, InstrumentationSettings
 
 instrumentation_settings = InstrumentationSettings(include_binary_content=False)
 
@@ -338,7 +338,7 @@ For privacy and security reasons, you may want to monitor your agent's behavior 
 When `include_content=False` is set, Pydantic AI will exclude sensitive content from OpenTelemetry events, including user prompts and model completions, tool call arguments and responses, and any other message content.
 
 ```python {title="excluding_sensitive_content.py"}
-from pydantic_ai.agent import Agent
+from pydantic_ai import Agent
 from pydantic_ai.models.instrumented import InstrumentationSettings
 
 instrumentation_settings = InstrumentationSettings(include_content=False)

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -174,10 +174,9 @@ call needs.
 ```python {title="mcp_process_tool_call.py"}
 from typing import Any
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, RunContext
 from pydantic_ai.mcp import CallToolFunc, MCPServerStdio, ToolResult
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.tools import RunContext
 
 
 async def process_tool_call(

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -402,9 +402,8 @@ History processors can optionally accept a [`RunContext`][pydantic_ai.tools.RunC
 additional information about the current run, such as dependencies, model information, and usage statistics:
 
 ```python {title="context_aware_processor.py"}
-from pydantic_ai import Agent
+from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import ModelMessage
-from pydantic_ai.tools import RunContext
 
 
 def context_aware_processor(

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -134,11 +134,10 @@ The `ModelResponse` message above indicates in the `model_name` field that the o
 You can configure different [`ModelSettings`][pydantic_ai.settings.ModelSettings] for each model in a fallback chain by passing the `settings` parameter when creating each model. This is particularly useful when different providers have different optimal configurations:
 
 ```python {title="fallback_model_per_settings.py"}
-from pydantic_ai import Agent
+from pydantic_ai import Agent, ModelSettings
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.openai import OpenAIChatModel
-from pydantic_ai.settings import ModelSettings
 
 # Configure each model with provider-specific optimal settings
 openai_model = OpenAIChatModel(
@@ -170,7 +169,7 @@ contains all the exceptions encountered during the `run` execution.
 
     ```python {title="fallback_model_failure.py" py="3.11"}
     from pydantic_ai import Agent
-    from pydantic_ai.exceptions import ModelHTTPError
+    from pydantic_ai import ModelHTTPError
     from pydantic_ai.models.anthropic import AnthropicModel
     from pydantic_ai.models.fallback import FallbackModel
     from pydantic_ai.models.openai import OpenAIChatModel
@@ -197,7 +196,7 @@ contains all the exceptions encountered during the `run` execution.
     from exceptiongroup import catch
 
     from pydantic_ai import Agent
-    from pydantic_ai.exceptions import ModelHTTPError
+    from pydantic_ai import ModelHTTPError
     from pydantic_ai.models.anthropic import AnthropicModel
     from pydantic_ai.models.fallback import FallbackModel
     from pydantic_ai.models.openai import OpenAIChatModel

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -168,8 +168,7 @@ contains all the exceptions encountered during the `run` execution.
 === "Python >=3.11"
 
     ```python {title="fallback_model_failure.py" py="3.11"}
-    from pydantic_ai import Agent
-    from pydantic_ai import ModelHTTPError
+    from pydantic_ai import Agent, ModelHTTPError
     from pydantic_ai.models.anthropic import AnthropicModel
     from pydantic_ai.models.fallback import FallbackModel
     from pydantic_ai.models.openai import OpenAIChatModel
@@ -195,8 +194,7 @@ contains all the exceptions encountered during the `run` execution.
     ```python {title="fallback_model_failure.py" noqa="F821" test="skip"}
     from exceptiongroup import catch
 
-    from pydantic_ai import Agent
-    from pydantic_ai import ModelHTTPError
+    from pydantic_ai import Agent, ModelHTTPError
     from pydantic_ai.models.anthropic import AnthropicModel
     from pydantic_ai.models.fallback import FallbackModel
     from pydantic_ai.models.openai import OpenAIChatModel

--- a/docs/multi-agent-applications.md
+++ b/docs/multi-agent-applications.md
@@ -22,8 +22,7 @@ You'll generally want to pass [`ctx.usage`][pydantic_ai.RunContext.usage] to the
     Agent delegation doesn't need to use the same model for each agent. If you choose to use different models within a run, calculating the monetary cost from the final [`result.usage()`][pydantic_ai.agent.AgentRunResult.usage] of the run will not be possible, but you can still use [`UsageLimits`][pydantic_ai.usage.UsageLimits] to avoid unexpected costs.
 
 ```python {title="agent_delegation_simple.py"}
-from pydantic_ai import Agent, RunContext
-from pydantic_ai.usage import UsageLimits
+from pydantic_ai import Agent, RunContext,  UsageLimits
 
 joke_selection_agent = Agent(  # (1)!
     'openai:gpt-4o',
@@ -186,9 +185,8 @@ from typing import Literal, Union
 from pydantic import BaseModel, Field
 from rich.prompt import Prompt
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, RunContext, RunUsage, UsageLimits
 from pydantic_ai.messages import ModelMessage
-from pydantic_ai.usage import RunUsage, UsageLimits
 
 
 class FlightDetails(BaseModel):

--- a/docs/output.md
+++ b/docs/output.md
@@ -133,8 +133,7 @@ import re
 
 from pydantic import BaseModel
 
-from pydantic_ai import Agent, ModelRetry, RunContext
-from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai import Agent, ModelRetry, RunContext, UnexpectedModelBehavior
 
 
 class Row(BaseModel):

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -86,7 +86,7 @@ import pytest
 
 from dirty_equals import IsNow, IsStr
 
-from pydantic_ai import models, capture_run_messages
+from pydantic_ai import models, capture_run_messages, RequestUsage
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.messages import (
     ModelResponse,
@@ -97,7 +97,6 @@ from pydantic_ai.messages import (
     UserPromptPart,
     ModelRequest,
 )
-from pydantic_ai.usage import RequestUsage
 
 from fake_database import DatabaseConn
 from weather_app import run_weather_forecast, weather_agent

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -526,8 +526,7 @@ As with the previous example, we use [`TestModel`][pydantic_ai.models.test.TestM
 
 ```python {title="tool_only_if_42.py"}
 
-from pydantic_ai import Agent, RunContext
-from pydantic_ai.tools import ToolDefinition
+from pydantic_ai import Agent, RunContext,  ToolDefinition
 
 agent = Agent('test')
 
@@ -563,9 +562,8 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, RunContext, Tool, ToolDefinition
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.tools import Tool, ToolDefinition
 
 
 def greet(name: str) -> str:
@@ -622,8 +620,7 @@ Here's an example that makes all tools strict if the model is an OpenAI model:
 ```python {title="agent_prepare_tools_customize.py" noqa="I001"}
 from dataclasses import replace
 
-from pydantic_ai import Agent, RunContext
-from pydantic_ai.tools import ToolDefinition
+from pydantic_ai import Agent, RunContext, ToolDefinition
 from pydantic_ai.models.test import TestModel
 
 
@@ -660,8 +657,7 @@ Here's another example that conditionally filters out the tools by name if the d
 
 ```python {title="agent_prepare_tools_filter_out.py" noqa="I001"}
 
-from pydantic_ai import Agent, RunContext
-from pydantic_ai.tools import Tool, ToolDefinition
+from pydantic_ai import Agent, RunContext, Tool, ToolDefinition
 
 
 def launch_potato(target: str) -> str:
@@ -732,10 +728,7 @@ Once you've gathered the user's approvals or denials, you can build a [`Deferred
 Here's an example that shows how to require approval for all file deletions, and for updates of specific protected files:
 
 ```python {title="tool_requires_approval.py"}
-from pydantic_ai import Agent
-from pydantic_ai.exceptions import ApprovalRequired
-from pydantic_ai.output import DeferredToolRequests
-from pydantic_ai.tools import DeferredToolResults, RunContext, ToolDenied
+from pydantic_ai import Agent, RunContext, ApprovalRequired, DeferredToolRequests, DeferredToolResults, ToolDenied
 
 agent = Agent('openai:gpt-5', output_type=[str, DeferredToolRequests])
 
@@ -886,10 +879,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic_ai import Agent
-from pydantic_ai.exceptions import CallDeferred, ModelRetry
-from pydantic_ai.output import DeferredToolRequests
-from pydantic_ai.tools import DeferredToolResults, RunContext
+from pydantic_ai import Agent, ModelRetry, RunContext, CallDeferred, DeferredToolRequests, DeferredToolResults
 
 
 @dataclass

--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -257,9 +257,8 @@ from dataclasses import replace
 
 from renamed_toolset import renamed_toolset
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, RunContext, ToolDefinition
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.tools import ToolDefinition
 
 descriptions = {
     'temperature_celsius': 'Get the temperature in degrees Celsius',
@@ -341,10 +340,8 @@ See the [Human-in-the-Loop Tool Approval](tools.md#human-in-the-loop-tool-approv
 ```python {title="approval_required_toolset.py" requires="function_toolset.py,combined_toolset.py,renamed_toolset.py,prepared_toolset.py"}
 from prepared_toolset import prepared_toolset
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, DeferredToolRequests, DeferredToolResults
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.output import DeferredToolRequests
-from pydantic_ai.tools import DeferredToolResults
 
 approval_required_toolset = prepared_toolset.approval_required(lambda ctx, tool_def, tool_args: tool_def.name.startswith('temperature'))
 
@@ -404,9 +401,8 @@ from typing_extensions import Any
 
 from prepared_toolset import prepared_toolset
 
-from pydantic_ai.agent import Agent
+from pydantic_ai import Agent, RunContext
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.tools import RunContext
 from pydantic_ai.toolsets import WrapperToolset, ToolsetTool
 
 LOG = []
@@ -498,8 +494,7 @@ Next, let's define a function that represents a hypothetical "run agent" API end
 ```python {title="deferred_toolset_api.py" requires="deferred_toolset_agent.py"}
 from deferred_toolset_agent import agent, PersonalizedGreeting
 
-from pydantic_ai.output import DeferredToolRequests
-from pydantic_ai.tools import DeferredToolResults, ToolDefinition
+from pydantic_ai import ToolDefinition, DeferredToolRequests, DeferredToolResults
 from pydantic_ai.toolsets import ExternalToolset
 from pydantic_ai.messages import ModelMessage
 
@@ -527,10 +522,8 @@ Now, imagine that the code below is implemented on the frontend, and `run_agent`
 ```python {title="deferred_tools.py" requires="deferred_toolset_agent.py,deferred_toolset_api.py"}
 from deferred_toolset_api import run_agent
 
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai import ModelRetry, ToolDefinition, DeferredToolRequests, DeferredToolResults
 from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
-from pydantic_ai.output import DeferredToolRequests
-from pydantic_ai.tools import DeferredToolResults, ToolDefinition
 
 frontend_tool_definitions = [
     ToolDefinition(

--- a/examples/pydantic_ai_examples/chat_app.py
+++ b/examples/pydantic_ai_examples/chat_app.py
@@ -25,8 +25,7 @@ from fastapi import Depends, Request
 from fastapi.responses import FileResponse, Response, StreamingResponse
 from typing_extensions import LiteralString, ParamSpec, TypedDict
 
-from pydantic_ai import Agent
-from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai import Agent, UnexpectedModelBehavior
 from pydantic_ai.messages import (
     ModelMessage,
     ModelMessagesTypeAdapter,

--- a/examples/pydantic_ai_examples/flight_booking.py
+++ b/examples/pydantic_ai_examples/flight_booking.py
@@ -11,9 +11,8 @@ import logfire
 from pydantic import BaseModel, Field
 from rich.prompt import Prompt
 
-from pydantic_ai import Agent, ModelRetry, RunContext
+from pydantic_ai import Agent, ModelRetry, RunContext, RunUsage, UsageLimits
 from pydantic_ai.messages import ModelMessage
-from pydantic_ai.usage import RunUsage, UsageLimits
 
 # 'if-token-present' means nothing will be sent (and the example will work) if you don't have logfire configured
 logfire.configure(send_to_logfire='if-token-present')

--- a/examples/pydantic_ai_examples/rag.py
+++ b/examples/pydantic_ai_examples/rag.py
@@ -34,8 +34,7 @@ from openai import AsyncOpenAI
 from pydantic import TypeAdapter
 from typing_extensions import AsyncGenerator
 
-from pydantic_ai import RunContext
-from pydantic_ai.agent import Agent
+from pydantic_ai import Agent, RunContext
 
 # 'if-token-present' means nothing will be sent (and the example will work) if you don't have logfire configured
 logfire.configure(send_to_logfire='if-token-present')

--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -1,9 +1,19 @@
 from importlib.metadata import version as _metadata_version
 
-from .agent import Agent, CallToolsNode, EndStrategy, ModelRequestNode, UserPromptNode, capture_run_messages
+from .agent import (
+    Agent,
+    CallToolsNode,
+    EndStrategy,
+    InstrumentationSettings,
+    ModelRequestNode,
+    UserPromptNode,
+    capture_run_messages,
+)
 from .builtin_tools import CodeExecutionTool, UrlContextTool, WebSearchTool, WebSearchUserLocation
 from .exceptions import (
     AgentRunError,
+    ApprovalRequired,
+    CallDeferred,
     FallbackExceptionGroup,
     ModelHTTPError,
     ModelRetry,
@@ -14,7 +24,9 @@ from .exceptions import (
 from .format_prompt import format_as_xml
 from .messages import AudioUrl, BinaryContent, DocumentUrl, ImageUrl, VideoUrl
 from .output import NativeOutput, PromptedOutput, StructuredDict, TextOutput, ToolOutput
-from .tools import RunContext, Tool
+from .settings import ModelSettings
+from .tools import DeferredToolRequests, DeferredToolResults, RunContext, Tool, ToolApproved, ToolDefinition, ToolDenied
+from .usage import RequestUsage, RunUsage, UsageLimits
 
 __all__ = (
     '__version__',
@@ -25,8 +37,11 @@ __all__ = (
     'ModelRequestNode',
     'UserPromptNode',
     'capture_run_messages',
+    'InstrumentationSettings',
     # exceptions
     'AgentRunError',
+    'CallDeferred',
+    'ApprovalRequired',
     'ModelRetry',
     'ModelHTTPError',
     'FallbackExceptionGroup',
@@ -41,7 +56,12 @@ __all__ = (
     'BinaryContent',
     # tools
     'Tool',
+    'ToolDefinition',
     'RunContext',
+    'DeferredToolRequests',
+    'DeferredToolResults',
+    'ToolApproved',
+    'ToolDenied',
     # builtin_tools
     'WebSearchTool',
     'WebSearchUserLocation',
@@ -55,5 +75,11 @@ __all__ = (
     'StructuredDict',
     # format_prompt
     'format_as_xml',
+    # settings
+    'ModelSettings',
+    # usage
+    'RunUsage',
+    'RequestUsage',
+    'UsageLimits',
 )
 __version__ = _metadata_version('pydantic_ai_slim')

--- a/pydantic_ai_slim/pydantic_ai/ag_ui.py
+++ b/pydantic_ai_slim/pydantic_ai/ag_ui.py
@@ -45,9 +45,9 @@ from .messages import (
     UserPromptPart,
 )
 from .models import KnownModelName, Model
-from .output import DeferredToolRequests, OutputDataT, OutputSpec
+from .output import OutputDataT, OutputSpec
 from .settings import ModelSettings
-from .tools import AgentDepsT, ToolDefinition
+from .tools import AgentDepsT, DeferredToolRequests, ToolDefinition
 from .toolsets import AbstractToolset
 from .toolsets.external import ExternalToolset
 from .usage import RunUsage, UsageLimits

--- a/pydantic_ai_slim/pydantic_ai/output.py
+++ b/pydantic_ai_slim/pydantic_ai/output.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Generic, Literal
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
@@ -11,7 +11,7 @@ from typing_extensions import TypeAliasType, TypeVar, deprecated
 
 from . import _utils
 from .messages import ToolCallPart
-from .tools import RunContext, ToolDefinition
+from .tools import DeferredToolRequests, RunContext, ToolDefinition
 
 __all__ = (
     # classes
@@ -351,23 +351,6 @@ You should not need to import or use this type directly.
 
 See [output docs](../output.md) for more information.
 """
-
-
-@dataclass
-class DeferredToolRequests:
-    """Tool calls that require approval or external execution.
-
-    This can be used as an agent's `output_type` and will be used as the output of the agent run if the model called any deferred tools.
-
-    Results can be passed to the next agent run using a [`DeferredToolResults`][pydantic_ai.tools.DeferredToolResults] object with the same tool call IDs.
-
-    See [deferred tools docs](../tools.md#deferred-tools) for more information.
-    """
-
-    calls: list[ToolCallPart] = field(default_factory=list)
-    """Tool calls that require external execution."""
-    approvals: list[ToolCallPart] = field(default_factory=list)
-    """Tool calls that require human-in-the-loop approval."""
 
 
 @deprecated('`DeferredToolCalls` is deprecated, use `DeferredToolRequests` instead')

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -12,7 +12,7 @@ from typing_extensions import ParamSpec, Self, TypeVar
 from . import _function_schema, _utils
 from ._run_context import AgentDepsT, RunContext
 from .exceptions import ModelRetry
-from .messages import RetryPromptPart, ToolReturn
+from .messages import RetryPromptPart, ToolCallPart, ToolReturn
 
 __all__ = (
     'AgentDepsT',
@@ -28,6 +28,7 @@ __all__ = (
     'Tool',
     'ObjectJsonSchema',
     'ToolDefinition',
+    'DeferredToolRequests',
     'DeferredToolResults',
     'ToolApproved',
     'ToolDenied',
@@ -129,6 +130,23 @@ DocstringFormat: TypeAlias = Literal['google', 'numpy', 'sphinx', 'auto']
 * `'sphinx'` — [Sphinx-style](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html#the-sphinx-docstring-format) docstrings.
 * `'auto'` — Automatically infer the format based on the structure of the docstring.
 """
+
+
+@dataclass
+class DeferredToolRequests:
+    """Tool calls that require approval or external execution.
+
+    This can be used as an agent's `output_type` and will be used as the output of the agent run if the model called any deferred tools.
+
+    Results can be passed to the next agent run using a [`DeferredToolResults`][pydantic_ai.tools.DeferredToolResults] object with the same tool call IDs.
+
+    See [deferred tools docs](../tools.md#deferred-tools) for more information.
+    """
+
+    calls: list[ToolCallPart] = field(default_factory=list)
+    """Tool calls that require external execution."""
+    approvals: list[ToolCallPart] = field(default_factory=list)
+    """Tool calls that require human-in-the-loop approval."""
 
 
 @dataclass

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -45,10 +45,10 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.output import DeferredToolRequests, StructuredDict, ToolOutput
+from pydantic_ai.output import StructuredDict, ToolOutput
 from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.result import RunUsage
-from pydantic_ai.tools import DeferredToolResults, ToolDefinition, ToolDenied
+from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDefinition, ToolDenied
 from pydantic_ai.toolsets.abstract import AbstractToolset
 from pydantic_ai.toolsets.combined import CombinedToolset
 from pydantic_ai.toolsets.function import FunctionToolset

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -35,9 +35,9 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.output import DeferredToolRequests, PromptedOutput, TextOutput
+from pydantic_ai.output import PromptedOutput, TextOutput
 from pydantic_ai.result import AgentStream, FinalResult, RunUsage
-from pydantic_ai.tools import DeferredToolResults, ToolApproved, ToolDefinition
+from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolApproved, ToolDefinition
 from pydantic_ai.usage import RequestUsage
 from pydantic_graph import End
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -33,9 +33,8 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models import Model, cached_async_http_client
-from pydantic_ai.output import DeferredToolRequests
 from pydantic_ai.run import AgentRunResult
-from pydantic_ai.tools import DeferredToolResults, ToolDefinition
+from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDefinition
 from pydantic_ai.toolsets import ExternalToolset, FunctionToolset
 from pydantic_ai.usage import RequestUsage
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -28,8 +28,8 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.output import DeferredToolRequests, ToolOutput
-from pydantic_ai.tools import DeferredToolResults, ToolApproved, ToolDefinition, ToolDenied
+from pydantic_ai.output import ToolOutput
+from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolApproved, ToolDefinition, ToolDenied
 from pydantic_ai.toolsets.external import ExternalToolset
 from pydantic_ai.toolsets.function import FunctionToolset
 from pydantic_ai.toolsets.prefixed import PrefixedToolset

--- a/tests/typed_agent.py
+++ b/tests/typed_agent.py
@@ -11,8 +11,8 @@ from typing_extensions import assert_type
 
 from pydantic_ai import Agent, ModelRetry, RunContext, Tool
 from pydantic_ai.agent import AgentRunResult
-from pydantic_ai.output import DeferredToolRequests, StructuredDict, TextOutput, ToolOutput
-from pydantic_ai.tools import ToolDefinition
+from pydantic_ai.output import StructuredDict, TextOutput, ToolOutput
+from pydantic_ai.tools import DeferredToolRequests, ToolDefinition
 
 # Define here so we can check `if MYPY` below. This will not be executed, MYPY will always set it to True
 MYPY = False


### PR DESCRIPTION
Found using `from pydantic_ai\.(?!models|mcp|providers|ag_ui|messages|toolsets|profiles|direct|ext|retries|durable_exec|common_tools)` limited to `docs` dir. Those are the more specialized modules whose types don't make sense at the top level.