### PR TITLE
Docs: update `MCPServerStreamableHTTP` usage example to use `url` argument

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -54,7 +54,7 @@ Then we can create the client:
 from pydantic_ai import Agent
 from pydantic_ai.mcp import MCPServerStreamableHTTP
 
-server = MCPServerStreamableHTTP('http://localhost:8000/mcp')  # (1)!
+server = MCPServerStreamableHTTP(url='http://localhost:8000/mcp')  # (1)!
 agent = Agent('openai:gpt-4o', toolsets=[server])  # (2)!
 
 async def main():


### PR DESCRIPTION
This PR updates the documentation example for initializing MCPServerStreamableHTTP.

Previously, the example used a positional argument:

```
server = MCPServerStreamableHTTP('http://localhost:8000/mcp')  # (1)!
```

Updated to explicitly use the url keyword argument:

```
server = MCPServerStreamableHTTP(url='http://localhost:8000/mcp')  # (1)!
```

This change improves clarity, aligns with the current API, and avoids confusion for users referencing the docs.