### PR TITLE
Fix bug related to Azure OpenAI model streaming response

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1173,7 +1173,7 @@ class OpenAIStreamedResponse(StreamedResponse):
 
             # Handle the text part of the response
             content = choice.delta.content
-            if content is not None:
+            if (delta := choice.delta) is not None and (content := delta.content) is not None:
                 maybe_event = self._parts_manager.handle_text_delta(
                     vendor_part_id='content',
                     content=content,


### PR DESCRIPTION
Solves: https://github.com/pydantic/pydantic-ai/issues/797

This PR is an identical fix as the PR https://github.com/pydantic/pydantic-ai/pull/932 and fixes an issue happening with Azure OpenAI streaming Response causing the raise of an AttributeError.

As stated on the https://github.com/pydantic/pydantic-ai/issues/797, the error occurs in pydantic-ai's OpenAI model implementation where it assumes every delta in the streaming response contains a content field. However, with Azure OpenAI's API, some deltas (like role initialization) may not include content when an async content filter is enabled, resulting in choice.delta.content being None.
More info on async content filters: https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/content-filter?tabs=warning%2Cuser-prompt%2Cpython-new#asynchronous-filter