### PR TITLE
add response id for streaming response

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -609,6 +609,7 @@ class StreamedResponse(ABC):
             timestamp=self.timestamp,
             usage=self.usage(),
             provider_name=self.provider_name,
+            provider_response_id=self.provider_response_id,
         )
 
     def usage(self) -> RequestUsage:
@@ -626,6 +627,11 @@ class StreamedResponse(ABC):
     def provider_name(self) -> str | None:
         """Get the provider name."""
         raise NotImplementedError()
+
+    @property
+    def provider_response_id(self) -> str | None:
+        """Get the provider response id."""
+        return None
 
     @property
     @abstractmethod

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -532,6 +532,7 @@ class OpenAIChatModel(Model):
             _response=peekable_response,
             _timestamp=number_to_datetime(first_chunk.created),
             _provider_name=self._provider.name,
+            _provider_response_id=first_chunk.id,
         )
 
     def _get_tools(self, model_request_parameters: ModelRequestParameters) -> list[chat.ChatCompletionToolParam]:
@@ -847,6 +848,7 @@ class OpenAIResponsesModel(Model):
             _response=peekable_response,
             _timestamp=number_to_datetime(first_chunk.response.created_at),
             _provider_name=self._provider.name,
+            _provider_response_id=first_chunk.response.id,
         )
 
     @overload
@@ -1161,6 +1163,7 @@ class OpenAIStreamedResponse(StreamedResponse):
     _response: AsyncIterable[ChatCompletionChunk]
     _timestamp: datetime
     _provider_name: str
+    _provider_response_id: str
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         async for chunk in self._response:
@@ -1210,6 +1213,11 @@ class OpenAIStreamedResponse(StreamedResponse):
         return self._provider_name
 
     @property
+    def provider_response_id(self) -> str:
+        """Get the provider response id."""
+        return self._provider_response_id
+
+    @property
     def timestamp(self) -> datetime:
         """Get the timestamp of the response."""
         return self._timestamp
@@ -1223,6 +1231,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
     _response: AsyncIterable[responses.ResponseStreamEvent]
     _timestamp: datetime
     _provider_name: str
+    _provider_response_id: str
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
         async for chunk in self._response:
@@ -1344,6 +1353,11 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
     def provider_name(self) -> str:
         """Get the provider name."""
         return self._provider_name
+
+    @property
+    def provider_response_id(self) -> str:
+        """Get the provider response id."""
+        return self._provider_response_id
 
     @property
     def timestamp(self) -> datetime:

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -83,6 +83,7 @@ class TestModel(Model):
     """
     _model_name: str = field(default='test', repr=False)
     _system: str = field(default='test', repr=False)
+    __provider_response_id: str = field(default='resp_test', repr=False)
 
     def __init__(
         self,
@@ -132,6 +133,7 @@ class TestModel(Model):
             _structured_response=model_response,
             _messages=messages,
             _provider_name=self._system,
+            _provider_response_id=self.__provider_response_id,
         )
 
     @property
@@ -285,6 +287,7 @@ class TestStreamedResponse(StreamedResponse):
     _structured_response: ModelResponse
     _messages: InitVar[Iterable[ModelMessage]]
     _provider_name: str
+    _provider_response_id: str
     _timestamp: datetime = field(default_factory=_utils.now_utc, init=False)
 
     def __post_init__(self, _messages: Iterable[ModelMessage]):
@@ -326,6 +329,11 @@ class TestStreamedResponse(StreamedResponse):
     def model_name(self) -> str:
         """Get the model name of the response."""
         return self._model_name
+
+    @property
+    def provider_response_id(self) -> str:
+        """Get the provider name."""
+        return self._provider_response_id
 
     @property
     def provider_name(self) -> str:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -68,6 +68,7 @@ async def test_streamed_text_response():
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 ),
                 ModelRequest(
                     parts=[
@@ -98,6 +99,7 @@ async def test_streamed_text_response():
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 ),
                 ModelRequest(
                     parts=[
@@ -112,6 +114,7 @@ async def test_streamed_text_response():
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 ),
             ]
         )
@@ -230,6 +233,7 @@ async def test_streamed_text_stream():
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 ),
                 ModelResponse(
                     parts=[TextPart(content='The cat ')],
@@ -237,6 +241,7 @@ async def test_streamed_text_stream():
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 ),
                 ModelResponse(
                     parts=[TextPart(content='The cat sat ')],
@@ -244,6 +249,7 @@ async def test_streamed_text_stream():
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 ),
                 ModelResponse(
                     parts=[TextPart(content='The cat sat on ')],
@@ -251,6 +257,7 @@ async def test_streamed_text_stream():
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 ),
                 ModelResponse(
                     parts=[TextPart(content='The cat sat on the ')],
@@ -258,6 +265,7 @@ async def test_streamed_text_stream():
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 ),
                 ModelResponse(
                     parts=[TextPart(content='The cat sat on the mat.')],
@@ -265,6 +273,7 @@ async def test_streamed_text_stream():
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 ),
                 ModelResponse(
                     parts=[TextPart(content='The cat sat on the mat.')],
@@ -272,6 +281,7 @@ async def test_streamed_text_stream():
                     model_name='test',
                     timestamp=IsNow(tz=timezone.utc),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 ),
             ]
         )
@@ -796,6 +806,7 @@ async def test_early_strategy_does_not_apply_to_tool_calls_without_final_tool():
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='test',
+                provider_response_id='resp_test',
             ),
             ModelRequest(
                 parts=[
@@ -810,6 +821,7 @@ async def test_early_strategy_does_not_apply_to_tool_calls_without_final_tool():
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='test',
+                provider_response_id='resp_test',
             ),
             ModelRequest(
                 parts=[
@@ -914,6 +926,7 @@ async def test_iter_stream_responses():
             timestamp=IsNow(tz=timezone.utc),
             kind='response',
             provider_name='test',
+            provider_response_id='resp_test',
         )
         for text in [
             '',
@@ -1197,6 +1210,7 @@ async def test_tool_raises_call_deferred():
                     model_name='test',
                     timestamp=IsDatetime(),
                     provider_name='test',
+                    provider_response_id='resp_test',
                 )
             ]
         )

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -97,6 +97,7 @@ async def test_streamed_text_limits() -> None:
                         model_name='test',
                         timestamp=IsNow(tz=timezone.utc),
                         provider_name='test',
+                        provider_response_id='resp_test',
                     ),
                     ModelRequest(
                         parts=[


### PR DESCRIPTION
Further changes for https://github.com/pydantic/pydantic-ai/issues/2663

- Add `provider_response_id` as an additional property to streamed responses.
- Added this as part of ModelResponse for `OpenAIResponsesStreamedResponse` and `OpenAIStreamedResponse`