### PR TITLE
Use asyncio lock instead of anyio lock

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -4,12 +4,12 @@ import dataclasses
 import inspect
 import json
 import warnings
+from asyncio import Lock
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequence
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar, cast, overload
 
-import anyio
 from opentelemetry.trace import NoOpTracer, use_span
 from pydantic.json_schema import GenerateJsonSchema
 from typing_extensions import Self, TypeVar, deprecated
@@ -157,7 +157,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
     _event_stream_handler: EventStreamHandler[AgentDepsT] | None = dataclasses.field(repr=False)
 
-    _enter_lock: anyio.Lock = dataclasses.field(repr=False)
+    _enter_lock: Lock = dataclasses.field(repr=False)
     _entered_count: int = dataclasses.field(repr=False)
     _exit_stack: AsyncExitStack | None = dataclasses.field(repr=False)
 
@@ -374,7 +374,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             _utils.Option[Sequence[Tool[AgentDepsT] | ToolFuncEither[AgentDepsT, ...]]]
         ] = ContextVar('_override_tools', default=None)
 
-        self._enter_lock = anyio.Lock()
+        self._enter_lock = Lock()
         self._entered_count = 0
         self._exit_stack = None
 

--- a/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import functools
+from asyncio import Lock
 from collections.abc import AsyncGenerator, Mapping
 from pathlib import Path
 from typing import Literal, overload
@@ -118,7 +119,7 @@ class GoogleVertexProvider(Provider[httpx.AsyncClient]):
 class _VertexAIAuth(httpx.Auth):
     """Auth class for Vertex AI API."""
 
-    _refresh_lock: anyio.Lock = anyio.Lock()
+    _refresh_lock: Lock = Lock()
 
     credentials: BaseCredentials | ServiceAccountCredentials | None
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from asyncio import Lock
 from collections.abc import Callable, Sequence
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field, replace
 from typing import Any
 
-import anyio
 from typing_extensions import Self
 
 from .._run_context import AgentDepsT, RunContext
@@ -31,7 +31,7 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
 
     toolsets: Sequence[AbstractToolset[AgentDepsT]]
 
-    _enter_lock: anyio.Lock = field(compare=False, init=False, default_factory=anyio.Lock)
+    _enter_lock: Lock = field(compare=False, init=False, default_factory=Lock)
     _entered_count: int = field(init=False, default=0)
     _exit_stack: AsyncExitStack | None = field(init=False, default=None)
 


### PR DESCRIPTION
The following script works with this PR, but not with anyio.Lock (which was introduced in the PR that dropped support for 3.9).

```python
from __future__ import annotations

import asyncio
from typing import Literal

from temporalio import workflow
from temporalio.client import Client
from temporalio.testing import WorkflowEnvironment
from temporalio.worker import Worker

from pydantic_ai import Agent, RunContext
from pydantic_ai.durable_exec.temporal import AgentPlugin, TemporalAgent, PydanticAIPlugin
from pydantic_ai.exceptions import ApprovalRequired, CallDeferred
from pydantic_ai.messages import (
    ModelMessage,
    ModelRequest,
)
from pydantic_ai.run import AgentRunResult
from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults

TEMPORAL_PORT = 7233
TASK_QUEUE = 'pydantic-ai-agent-task-queue'

hitl_agent = Agent(
    'openai:gpt-5-mini',
    name='hitl_agent',
    output_type=[str, DeferredToolRequests],
    instructions='Just call tools without asking for confirmation.',
)


@hitl_agent.tool
def create_file(ctx: RunContext[None], path: str) -> None:
    raise CallDeferred


@hitl_agent.tool
def delete_file(ctx: RunContext[None], path: str) -> bool:
    if not ctx.tool_call_approved:
        raise ApprovalRequired
    return True


hitl_temporal_agent = TemporalAgent(hitl_agent)


@workflow.defn
class HitlAgentWorkflow:
    def __init__(self):
        self._status: Literal['running', 'waiting_for_results', 'done'] = 'running'
        self._deferred_tool_requests: DeferredToolRequests | None = None
        self._deferred_tool_results: DeferredToolResults | None = None

    @workflow.run
    async def run(self, prompt: str) -> AgentRunResult[str | DeferredToolRequests]:
        messages: list[ModelMessage] = [ModelRequest.user_text_prompt(prompt)]
        while True:
            result = await hitl_temporal_agent.run(
                message_history=messages, deferred_tool_results=self._deferred_tool_results
            )
            messages = result.all_messages()

            if isinstance(result.output, DeferredToolRequests):
                self._deferred_tool_requests = result.output
                self._deferred_tool_results = None
                self._status = 'waiting_for_results'

                await workflow.wait_condition(lambda: self._deferred_tool_results is not None)
                self._status = 'running'
            else:
                self._status = 'done'
                return result

    @workflow.query
    def get_status(self) -> Literal['running', 'waiting_for_results', 'done']:
        return self._status

    @workflow.query
    def get_deferred_tool_requests(self) -> DeferredToolRequests | None:
        return self._deferred_tool_requests

    @workflow.signal
    def set_deferred_tool_results(self, results: DeferredToolResults) -> None:
        self._status = 'running'
        self._deferred_tool_requests = None
        self._deferred_tool_results = results


async def test_temporal_agent_with_hitl_tool():
    async with await WorkflowEnvironment.start_local(port=TEMPORAL_PORT, ui=True) as env:  # pyright: ignore[reportUnknownMemberType]
        client = await Client.connect(
            f'localhost:{TEMPORAL_PORT}',
            plugins=[PydanticAIPlugin()],
        )

        async with Worker(
            client,
            task_queue=TASK_QUEUE,
            workflows=[HitlAgentWorkflow],
            plugins=[AgentPlugin(hitl_temporal_agent)],
        ):
            workflow = await client.start_workflow(  # pyright: ignore[reportUnknownMemberType]
                HitlAgentWorkflow.run,
                args=['Delete the file `.env` and create `test.txt`'],
                id=HitlAgentWorkflow.__name__,
                task_queue=TASK_QUEUE,
            )
            while True:
                import asyncio
                await asyncio.sleep(1)
                status = await workflow.query(HitlAgentWorkflow.get_status)  # pyright: ignore[reportUnknownMemberType]
                if status == 'done':
                    break
                elif status == 'waiting_for_results':  # pragma: no branch
                    deferred_tool_requests = await workflow.query(HitlAgentWorkflow.get_deferred_tool_requests)  # pyright: ignore[reportUnknownMemberType]
                    assert deferred_tool_requests is not None

                    results = DeferredToolResults()
                    # Approve all calls
                    for tool_call in deferred_tool_requests.approvals:
                        results.approvals[tool_call.tool_call_id] = True

                    for tool_call in deferred_tool_requests.calls:
                        results.calls[tool_call.tool_call_id] = 'Success'

                    await workflow.signal(HitlAgentWorkflow.set_deferred_tool_results, results)

            result = await workflow.result()
            print(result.output)
            print(result.all_messages())


if __name__ == '__main__':
    asyncio.run(test_temporal_agent_with_hitl_tool())
```

This might be a temporal bug, and weirdly our test `test_temporal_agent_with_hitl_tool` which basically does exactly above passes, and I can't figure out what's different. But as far as I'm aware the downside of using `asyncio.Lock` is smaller than the downside of the obvious way of using `temporal` just not working.

Annoyingly I don't know how to test this because this is basically literally a test, but I think we make this change now because I'm currently trying to put together some related examples and can't make them work without this change.