### PR TITLE
BREAKING CHANGE: Remove Python evaluator for security reasons

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,12 @@ Once we release V2, in April 2026 at the earliest, we'll continue to provide sec
 
 Here's a filtered list of the breaking changes for each version to help you upgrade Pydantic AI.
 
+### v1.0.1 (2025-09-05)
+
+The following breaking change was accidentally left out of v1.0.0:
+
+- See [#2808](https://github.com/pydantic/pydantic-ai/pull/2808) - Remove `Python` evaluator from `pydantic_evals` for security reasons
+
 ### v1.0.0 (2025-09-04)
 
 - See [#2725](https://github.com/pydantic/pydantic-ai/pull/2725) - Drop support for Python 3.9

--- a/pydantic_evals/pydantic_evals/evaluators/__init__.py
+++ b/pydantic_evals/pydantic_evals/evaluators/__init__.py
@@ -36,7 +36,7 @@ __all__ = (
 
 def __getattr__(name: str):
     if name == 'Python':
-        raise ImportError(  # pragma: no cover
+        raise ImportError(
             'The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.'
         )
     raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/pydantic_evals/pydantic_evals/evaluators/__init__.py
+++ b/pydantic_evals/pydantic_evals/evaluators/__init__.py
@@ -7,7 +7,6 @@ from .common import (
     LLMJudge,
     MaxDuration,
     OutputConfig,
-    Python,
 )
 from .context import EvaluatorContext
 from .evaluator import EvaluationReason, EvaluationResult, Evaluator, EvaluatorFailure, EvaluatorOutput, EvaluatorSpec
@@ -22,7 +21,6 @@ __all__ = (
     'LLMJudge',
     'HasMatchingSpan',
     'OutputConfig',
-    'Python',
     # context
     'EvaluatorContext',
     # evaluator
@@ -34,3 +32,11 @@ __all__ = (
     'EvaluationReason',
     'EvaluationResult',
 )
+
+
+def __getattr__(name: str):
+    if name == 'Python':
+        raise ImportError(  # pragma: no cover
+            'The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.'
+        )
+    raise AttributeError(f'module {__name__} has no attribute {name}')

--- a/pydantic_evals/pydantic_evals/evaluators/__init__.py
+++ b/pydantic_evals/pydantic_evals/evaluators/__init__.py
@@ -39,4 +39,4 @@ def __getattr__(name: str):
         raise ImportError(  # pragma: no cover
             'The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.'
         )
-    raise AttributeError(f'module {__name__} has no attribute {name}')
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -283,4 +283,4 @@ def __getattr__(name: str):
         raise ImportError(
             'The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.'
         )
-    raise AttributeError(f'module {__name__} has no attribute {name}')
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -21,7 +21,6 @@ __all__ = (
     'MaxDuration',
     'LLMJudge',
     'HasMatchingSpan',
-    'Python',
     'OutputConfig',
 )
 
@@ -268,22 +267,6 @@ class HasMatchingSpan(Evaluator[object, object, object]):
         return ctx.span_tree.any(self.query)
 
 
-# TODO: Consider moving this to docs rather than providing it with the library, given the security implications
-@dataclass(repr=False)
-class Python(Evaluator[object, object, object]):
-    """The output of this evaluator is the result of evaluating the provided Python expression.
-
-    ***WARNING***: this evaluator runs arbitrary Python code, so you should ***NEVER*** use it with untrusted inputs.
-    """
-
-    expression: str
-    evaluation_name: str | None = field(default=None)
-
-    def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> EvaluatorOutput:
-        # Evaluate the condition, exposing access to the evaluator context as `ctx`.
-        return eval(self.expression, {'ctx': ctx})
-
-
 DEFAULT_EVALUATORS: tuple[type[Evaluator[object, object, object]], ...] = (
     Equals,
     EqualsExpected,
@@ -292,5 +275,12 @@ DEFAULT_EVALUATORS: tuple[type[Evaluator[object, object, object]], ...] = (
     MaxDuration,
     LLMJudge,
     HasMatchingSpan,
-    # Python,  # not included by default for security reasons
 )
+
+
+def __getattr__(name: str):
+    if name == 'Python':
+        raise ImportError(
+            'The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.'
+        )
+    raise AttributeError(f'module {__name__} has no attribute {name}')

--- a/tests/evals/test_evaluators.py
+++ b/tests/evals/test_evaluators.py
@@ -27,7 +27,6 @@ with try_import() as imports_successful:
         IsInstance,
         LLMJudge,
         MaxDuration,
-        Python,
     )
     from pydantic_evals.evaluators.context import EvaluatorContext
     from pydantic_evals.evaluators.evaluator import (
@@ -577,36 +576,3 @@ async def test_span_query_evaluator(
     evaluator = HasMatchingSpan(query=query)
     result = evaluator.evaluate(context)
     assert result is False
-
-
-async def test_python_evaluator(test_context: EvaluatorContext[TaskInput, TaskOutput, TaskMetadata]):
-    """Test the python evaluator."""
-    # Test with a simple condition
-    evaluator = Python(expression="ctx.output.answer == '4'")
-    assert evaluator.evaluate(test_context) == snapshot(True)
-
-    # Test type sensitivity
-    evaluator = Python(expression='ctx.output.answer == 4')
-    assert evaluator.evaluate(test_context) == snapshot(False)
-
-    # Test with a named condition
-    evaluator = Python(expression="{'correct_answer': ctx.output.answer == '4'}")
-    assert evaluator.evaluate(test_context) == snapshot({'correct_answer': True})
-
-    # Test with a condition that returns false
-    evaluator = Python(expression="ctx.output.answer == '5'")
-    assert evaluator.evaluate(test_context) == snapshot(False)
-
-    # Test with a condition that accesses context properties
-    evaluator = Python(expression="ctx.output.answer == '4' and ctx.metadata.difficulty == 'easy'")
-    assert evaluator.evaluate(test_context) == snapshot(True)
-
-    # Test reason rendering for strings
-    evaluator = Python(expression='ctx.output.answer')
-    assert evaluator.evaluate(test_context) == snapshot('4')
-
-    # Test with a condition that returns a dict
-    evaluator = Python(
-        expression="{'is_correct': ctx.output.answer == '4', 'is_easy': ctx.metadata.difficulty == 'easy'}"
-    )
-    assert evaluator.evaluate(test_context) == snapshot({'is_correct': True, 'is_easy': True})

--- a/tests/evals/test_evaluators.py
+++ b/tests/evals/test_evaluators.py
@@ -576,3 +576,45 @@ async def test_span_query_evaluator(
     evaluator = HasMatchingSpan(query=query)
     result = evaluator.evaluate(context)
     assert result is False
+
+
+async def test_import_errors():
+    with pytest.raises(
+        ImportError,
+        match='The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.',
+    ):
+        from pydantic_evals.evaluators import Python  # pyright: ignore[reportUnusedImport]
+
+    with pytest.raises(
+        ImportError,
+        match='The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.',
+    ):
+        from pydantic_evals.evaluators.common import Python  # pyright: ignore[reportUnusedImport] # noqa: F401
+
+    with pytest.raises(
+        ImportError,
+        match="cannot import name 'Foo' from 'pydantic_evals.evaluators'",
+    ):
+        from pydantic_evals.evaluators import Foo  # pyright: ignore[reportUnusedImport]
+
+    with pytest.raises(
+        ImportError,
+        match="cannot import name 'Foo' from 'pydantic_evals.evaluators.common'",
+    ):
+        from pydantic_evals.evaluators.common import Foo  # pyright: ignore[reportUnusedImport] # noqa: F401
+
+    with pytest.raises(
+        AttributeError,
+        match="module 'pydantic_evals.evaluators' has no attribute 'Foo'",
+    ):
+        import pydantic_evals.evaluators as _evaluators
+
+        _evaluators.Foo
+
+    with pytest.raises(
+        AttributeError,
+        match="module 'pydantic_evals.evaluators.common' has no attribute 'Foo'",
+    ):
+        import pydantic_evals.evaluators.common as _common
+
+        _common.Foo


### PR DESCRIPTION
We used to provide an evaluator that could be used to run arbitrary (trusted) Python code:

```python
from dataclasses import field, dataclass

from pydantic_evals.evaluators import EvaluatorOutput, EvaluatorContext, Evaluator


@dataclass(repr=False)
class Python(Evaluator[object, object, object]):
    expression: str
    evaluation_name: str | None = field(default=None)

    def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> EvaluatorOutput:
        # Evaluate the condition, exposing access to the evaluator context as `ctx`.
        return eval(self.expression, {'ctx': ctx})
```

However, because of the dramatic potential security implications of running deserialized code (even if you _should_ only be running it on known and trusted inputs), we've made the decision to remove the `Python` evaluator from the library for the time being.

**Workaround:** If you want to keep making use of this evaluator, I would suggest that you vendor the above code into your own application — noting that the bar for using `eval` directly in any production-grade codebase should be very high.

----

We have some ideas about how to make use of https://github.com/pydantic/mcp-run-python to provide a more secure way to run arbitrary code (in an Evaluator or otherwise), but we felt more comfortable removing the `Python` evaluator prior to releasing Pydantic AI V1. We'll consider eventually re-adding a version that makes use of `mcp-run-python` to run such code more securely once we have an implementation we trust to be secure enough to recommend to the community.