### PR TITLE
Capture MCP client exit error

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -306,8 +306,12 @@ class MCPServer(AbstractToolset[Any], ABC):
         async with self._enter_lock:
             self._running_count -= 1
             if self._running_count == 0 and self._exit_stack is not None:
-                await self._exit_stack.aclose()
-                self._exit_stack = None
+                try:
+                    await self._exit_stack.aclose()
+                except RuntimeError:
+                    pass
+                finally:
+                    self._exit_stack = None
 
     @property
     def is_running(self) -> bool:


### PR DESCRIPTION
This PR is meant to prevent `RuntimeError: Attempted to exit cancel scope in a different task than it was entered` from killing runs (closes #2818).

This solution smells a bit to me. I'm not happy about capturing all `RuntimeError`s. I would address that if the overall solution seems viable. I'm _guessing_ the error is actually due to a quirk in the `_transport_client`, maybe it should be fixed there.
