### PR TITLE
Add custom Vertex AI Model Garden example

### DIFF
--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -110,7 +110,7 @@ agent = Agent(model)
 
 #### Customizing Model
 
-You can access models from the [Model Garden](https://cloud.google.com/model-garden?hl=en) that support the generateContent API and are available under your GCP project, including but not limited to Gemini, using one of the following `model_name` patterns: `{model_id}`, `publishers/{publisher}/models/{model_id}`, or `projects/{project}/locations/{location}/publishers/{publisher}/models/{model_id}`.
+You can access models from the [Model Garden](https://cloud.google.com/model-garden?hl=en) that support the generateContent API and are available under your GCP project, including but not limited to Gemini, using one of the following `model_name` patterns: `{model_id}` for Gemini models, `{publisher}/{model_id}`, `publishers/{publisher}/models/{model_id}`, or `projects/{project}/locations/{location}/publishers/{publisher}/models/{model_id}`.
 
 ```python
 from google.oauth2 import service_account
@@ -128,7 +128,7 @@ provider = GoogleProvider(
     project='your-gcp-project-id',
     location='us-central1',  # the region where the model is available
 )
-model = GoogleModel('llama-3.3-70b-instruct-maas', provider=provider)
+model = GoogleModel('meta/llama-3.3-70b-instruct-maas', provider=provider)
 agent = Agent(model)
 ...
 ```

--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -110,7 +110,7 @@ agent = Agent(model)
 
 #### Customizing Model
 
-You can access models from the [Model Garden](https://cloud.google.com/model-garden?hl=en) that support the generateContent API and are available under your GCP project, including but not limited to Gemini, using one of the following `model_name` patterns: 
+You can access models from the [Model Garden](https://cloud.google.com/model-garden?hl=en) that support the generateContent API and are available under your GCP project, including but not limited to Gemini, using one of the following `model_name` patterns:
 
 - `{model_id}` for Gemini models
 - `{publisher}/{model_id}`

--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -119,21 +119,16 @@ from pydantic_ai import Agent
 from pydantic_ai.models.google import GoogleModel
 from pydantic_ai.providers.google import GoogleProvider
 
-location = 'your-region'
-project = 'your-project-id'
 credentials = service_account.Credentials.from_service_account_file(
     'path/to/service-account.json',
     scopes=['https://www.googleapis.com/auth/cloud-platform'],
 )
 provider = GoogleProvider(
     credentials=credentials,
-    project=project,
-    location=location
+    project='your-gcp-project-id',
+    location='us-central1',  # the region where the model is available
 )
-model = GoogleModel(
-    f'projects/{project}/locations/{location}/publishers/meta/models/llama-3.3-70b-instruct-maas',
-    provider=provider
-)
+model = GoogleModel('llama-3.3-70b-instruct-maas', provider=provider)
 agent = Agent(model)
 ...
 ```

--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -110,9 +110,14 @@ agent = Agent(model)
 
 #### Customizing Model
 
-You can access models from the [Model Garden](https://cloud.google.com/model-garden?hl=en) that support the generateContent API and are available under your GCP project, including but not limited to Gemini, using one of the following `model_name` patterns: `{model_id}` for Gemini models, `{publisher}/{model_id}`, `publishers/{publisher}/models/{model_id}`, or `projects/{project}/locations/{location}/publishers/{publisher}/models/{model_id}`.
+You can access models from the [Model Garden](https://cloud.google.com/model-garden?hl=en) that support the generateContent API and are available under your GCP project, including but not limited to Gemini, using one of the following `model_name` patterns: 
 
-```python
+- `{model_id}` for Gemini models
+- `{publisher}/{model_id}`
+- `publishers/{publisher}/models/{model_id}`
+- `projects/{project}/locations/{location}/publishers/{publisher}/models/{model_id}`
+
+```python {test="skip"}
 from google.oauth2 import service_account
 
 from pydantic_ai import Agent

--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -110,7 +110,7 @@ agent = Agent(model)
 
 #### Customizing Model
 
-You can access models from the [Model Garden](https://cloud.google.com/model-garden?hl=en) that are available under your GCP project, including but not limited to Gemini, using one of the following `model_name` patterns: `{model_id}`, `publishers/{publisher}/models/{model_id}`, or `projects/{project}/locations/{location}/publishers/{publisher}/models/{model_id}`.
+You can access models from the [Model Garden](https://cloud.google.com/model-garden?hl=en) that support the generateContent API and are available under your GCP project, including but not limited to Gemini, using one of the following `model_name` patterns: `{model_id}`, `publishers/{publisher}/models/{model_id}`, or `projects/{project}/locations/{location}/publishers/{publisher}/models/{model_id}`.
 
 ```python
 from google.oauth2 import service_account

--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -108,6 +108,39 @@ agent = Agent(model)
 ...
 ```
 
+#### Customizing Model
+
+You can access models from the Model Garden, including but not limited to Gemini, available under your GCP project using one of the following `model_name` patterns: `{model_id}`, `publishers/{publisher}/models/{model_id}`, or `projects/{project}/locations/{location}/publishers/{publisher}/models/{model_id}`.
+
+```python
+from google.oauth2 import service_account
+from google.genai import Client
+
+from pydantic_ai import Agent
+from pydantic_ai.models.google import GoogleModel
+from pydantic_ai.providers.google import GoogleProvider
+
+location = 'your-region'
+project = 'your-project-id'
+credentials = service_account.Credentials.from_service_account_file(
+    'path/to/service-account.json',
+    scopes=['https://www.googleapis.com/auth/cloud-platform'],
+)
+client = Client(
+    vertexai=True,
+    location=location,
+    project=project,
+    credentials=credentials
+)
+provider = GoogleProvider(client=client)
+model = GoogleModel(
+    f'projects/{project}/locations/{location}/publishers/meta/models/llama-3.3-70b-instruct-maas',
+    provider=provider
+)
+agent = Agent(model)
+...
+```
+
 ## Provider Argument
 
 You can supply a custom `GoogleProvider` instance using the `provider` argument to configure advanced client options, such as setting a custom `base_url`.

--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -114,7 +114,6 @@ You can access models from the [Model Garden](https://cloud.google.com/model-gar
 
 ```python
 from google.oauth2 import service_account
-from google.genai import Client
 
 from pydantic_ai import Agent
 from pydantic_ai.models.google import GoogleModel
@@ -126,13 +125,11 @@ credentials = service_account.Credentials.from_service_account_file(
     'path/to/service-account.json',
     scopes=['https://www.googleapis.com/auth/cloud-platform'],
 )
-client = Client(
-    vertexai=True,
-    location=location,
+provider = GoogleProvider(
+    credentials=credentials,
     project=project,
-    credentials=credentials
+    location=location
 )
-provider = GoogleProvider(client=client)
 model = GoogleModel(
     f'projects/{project}/locations/{location}/publishers/meta/models/llama-3.3-70b-instruct-maas',
     provider=provider

--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -110,7 +110,7 @@ agent = Agent(model)
 
 #### Customizing Model
 
-You can access models from the Model Garden, including but not limited to Gemini, available under your GCP project using one of the following `model_name` patterns: `{model_id}`, `publishers/{publisher}/models/{model_id}`, or `projects/{project}/locations/{location}/publishers/{publisher}/models/{model_id}`.
+You can access models from the [Model Garden](https://cloud.google.com/model-garden?hl=en) that are available under your GCP project, including but not limited to Gemini, using one of the following `model_name` patterns: `{model_id}`, `publishers/{publisher}/models/{model_id}`, or `projects/{project}/locations/{location}/publishers/{publisher}/models/{model_id}`.
 
 ```python
 from google.oauth2 import service_account


### PR DESCRIPTION
This PR adds an example of how to use models besides Gemini from the Vertex AI Model Garden. 

- Fixes #960.