### PR TITLE
Re-disable live tests for groq

### DIFF
--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -99,9 +99,9 @@ def cohere(http_client: httpx.AsyncClient, _tmp_path: Path) -> Model:
 
 params = [
     pytest.param(openai, id='openai'),
-    pytest.param(gemini, marks=pytest.mark.skip(reason='API seems very flaky'), id='gemini'),
+    pytest.param(gemini, id='gemini', marks=pytest.mark.skip(reason='API seems very flaky')),
     pytest.param(vertexai, id='vertexai'),
-    pytest.param(groq, id='groq'),
+    pytest.param(groq, id='groq', marks=pytest.mark.skip(reason='test_structured has started failing')),
     pytest.param(anthropic, id='anthropic'),
     pytest.param(ollama, id='ollama'),
     pytest.param(mistral, id='mistral'),


### PR DESCRIPTION
It's still failing: https://github.com/pydantic/pydantic-ai/actions/runs/17650242542/job/50159081161?pr=2869

Reverts pydantic/pydantic-ai#2847