### PR TITLE
When starting run with message history ending in `ModelRequest`, make its content available in `RunContext.prompt`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -167,7 +167,7 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
     system_prompt_functions: list[_system_prompt.SystemPromptRunner[DepsT]]
     system_prompt_dynamic_functions: dict[str, _system_prompt.SystemPromptRunner[DepsT]]
 
-    async def run(
+    async def run(  # noqa: C901
         self, ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]]
     ) -> ModelRequestNode[DepsT, NodeRunEndT] | CallToolsNode[DepsT, NodeRunEndT]:
         try:
@@ -186,8 +186,6 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
         # Use the `capture_run_messages` list as the message history so that new messages are added to it
         ctx.state.message_history = messages
 
-        parts: list[_messages.ModelRequestPart] = []
-
         if (tool_call_results := ctx.deps.tool_call_results) is not None:
             if messages and (last_message := messages[-1]) and isinstance(last_message, _messages.ModelRequest):
                 # If tool call results were provided, that means the previous run ended on deferred tool calls.
@@ -202,19 +200,20 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
             if not messages:
                 raise exceptions.UserError('Tool call results were provided, but the message history is empty.')
 
+        next_message: _messages.ModelRequest | None = None
+
         if messages and (last_message := messages[-1]):
             if isinstance(last_message, _messages.ModelRequest) and self.user_prompt is None:
                 # Drop last message from history and reuse its parts
                 messages.pop()
-                parts.extend(last_message.parts)
-                # Extract UserPromptPart content from the popped message and add to ctx.deps.prompt
+                next_message = _messages.ModelRequest(parts=last_message.parts)
+
+                # Extract `UserPromptPart` content from the popped message and add to `ctx.deps.prompt`
                 user_prompt_parts = [part for part in last_message.parts if isinstance(part, _messages.UserPromptPart)]
                 if user_prompt_parts:
-                    # For single part, use content directly; for multiple parts, combine them
                     if len(user_prompt_parts) == 1:
                         ctx.deps.prompt = user_prompt_parts[0].content
                     else:
-                        # Combine multiple UserPromptPart contents
                         combined_content: list[_messages.UserContent] = []
                         for part in user_prompt_parts:
                             if isinstance(part.content, str):
@@ -227,19 +226,26 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
                 if call_tools_node is not None:
                     return call_tools_node
 
+        # Build the run context after `ctx.deps.prompt` has been updated
         run_context = build_run_context(ctx)
 
+        parts: list[_messages.ModelRequestPart] = []
         if messages:
-            # Reevaluate any dynamic system prompt parts
             await self._reevaluate_dynamic_prompts(messages, run_context)
+
+        if next_message:
+            await self._reevaluate_dynamic_prompts([next_message], run_context)
         else:
-            parts.extend(await self._sys_parts(run_context))
+            parts: list[_messages.ModelRequestPart] = []
+            if not messages:
+                parts.extend(await self._sys_parts(run_context))
 
-        if self.user_prompt is not None:
-            parts.append(_messages.UserPromptPart(self.user_prompt))
+            if self.user_prompt is not None:
+                parts.append(_messages.UserPromptPart(self.user_prompt))
 
-        instructions = await ctx.deps.get_instructions(run_context)
-        next_message = _messages.ModelRequest(parts, instructions=instructions)
+            next_message = _messages.ModelRequest(parts=parts)
+
+        next_message.instructions = await ctx.deps.get_instructions(run_context)
 
         return ModelRequestNode[DepsT, NodeRunEndT](request=next_message)
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2008,7 +2008,12 @@ def test_run_with_history_ending_on_model_request_and_no_user_prompt():
     ]
 
     m = TestModel()
-    agent = Agent(m, instructions='New instructions')
+    agent = Agent(m)
+
+    @agent.instructions
+    async def instructions(ctx: RunContext) -> str:
+        assert ctx.prompt == 'Hello'
+        return 'New instructions'
 
     result = agent.run_sync(message_history=messages)
     assert result.all_messages() == snapshot(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2004,7 +2004,10 @@ def test_run_with_history_new_structured():
 
 def test_run_with_history_ending_on_model_request_and_no_user_prompt():
     messages: list[ModelMessage] = [
-        ModelRequest(parts=[UserPromptPart(content='Hello')], instructions='Original instructions'),
+        ModelRequest(
+            parts=[UserPromptPart(content=['Hello', ImageUrl('https://example.com/image.jpg')])],
+            instructions='Original instructions',
+        ),
     ]
 
     m = TestModel()
@@ -2012,7 +2015,7 @@ def test_run_with_history_ending_on_model_request_and_no_user_prompt():
 
     @agent.instructions
     async def instructions(ctx: RunContext) -> str:
-        assert ctx.prompt == 'Hello'
+        assert ctx.prompt == ['Hello', ImageUrl('https://example.com/image.jpg')]
         return 'New instructions'
 
     result = agent.run_sync(message_history=messages)
@@ -2021,7 +2024,7 @@ def test_run_with_history_ending_on_model_request_and_no_user_prompt():
             ModelRequest(
                 parts=[
                     UserPromptPart(
-                        content='Hello',
+                        content=['Hello', ImageUrl('https://example.com/image.jpg')],
                         timestamp=IsDatetime(),
                     )
                 ],


### PR DESCRIPTION
When invoking an agent with only message_history, the latest ModelRequest gets popped off the history but wasn't made available in RunContext.prompt. This fix extracts UserPromptPart content from the popped message and sets it to ctx.deps.prompt.

Also moves the build_run_context call to after message processing to ensure the context includes the extracted prompt content.

Fixes #2876

🤖 Generated with [Claude Code](https://claude.ai/code)