### PR TITLE
Set StreamedResponse.model_name from later streamed chunk for Azure OpenAI with content filter

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -586,7 +586,8 @@ class OpenAIChatModel(Model):
                 'Streamed response ended without content or tool calls'
             )
 
-        # ChatCompletionChunk.model is required to be set, but Azure OpenAI omits it so we fall back to the model name set by the user.
+        # When using Azure OpenAI and a content filter is enabled, the first chunk will contain a `''` model name,
+        # so we set it from a later chunk in `OpenAIChatStreamedResponse`.
         model_name = first_chunk.model or self._model_name
 
         return OpenAIStreamedResponse(
@@ -1352,8 +1353,11 @@ class OpenAIStreamedResponse(StreamedResponse):
         async for chunk in self._response:
             self._usage += _map_usage(chunk)
 
-            if chunk.id and self.provider_response_id is None:
+            if chunk.id:
                 self.provider_response_id = chunk.id
+
+            if chunk.model:
+                self._model_name = chunk.model
 
             try:
                 choice = chunk.choices[0]

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -398,7 +398,7 @@ async def test_stream_text(allow_model_requests: None):
 
 async def test_stream_text_finish_reason(allow_model_requests: None):
     first_chunk = text_chunk('hello ')
-    # Test that we fall back to the model name set by the user if the model name is not set in the first chunk, like on Azure OpenAI.
+    # Test that we get the model name from a later chunk if it is not set on the first one, like on Azure OpenAI with content filter enabled.
     first_chunk.model = ''
     stream = [
         first_chunk,
@@ -421,7 +421,7 @@ async def test_stream_text_finish_reason(allow_model_requests: None):
                     ModelResponse(
                         parts=[TextPart(content='hello world.')],
                         usage=RequestUsage(input_tokens=6, output_tokens=3),
-                        model_name='gpt-4o',
+                        model_name='gpt-4o-123',
                         timestamp=IsDatetime(),
                         provider_name='openai',
                         provider_details={'finish_reason': 'stop'},


### PR DESCRIPTION
- Fixes https://github.com/pydantic/pydantic-ai/issues/2943
- Replaces https://github.com/pydantic/pydantic-ai/pull/2945