### PR TITLE
Fix OTel for built-in tools returning a list (e.g. Anthropic web search)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1161,11 +1161,7 @@ class ModelResponse:
                 if settings.include_content and part.content is not None:  # pragma: no branch
                     from .models.instrumented import InstrumentedModel
 
-                    return_part['result'] = (
-                        part.content
-                        if isinstance(part.content, str)
-                        else {k: InstrumentedModel.serialize_any(v) for k, v in part.content.items()}
-                    )
+                    return_part['result'] = InstrumentedModel.serialize_any(part.content)
 
                 parts.append(return_part)
         return parts

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -1359,6 +1359,22 @@ def test_message_with_builtin_tool_calls():
                 BuiltinToolCallPart('code_execution', {'code': '2 * 2'}, tool_call_id='tool_call_1'),
                 BuiltinToolReturnPart('code_execution', {'output': '4'}, tool_call_id='tool_call_1'),
                 TextPart('text2'),
+                BuiltinToolCallPart(
+                    'web_search',
+                    '{"query": "weather: San Francisco, CA", "type": "search"}',
+                    tool_call_id='tool_call_2',
+                ),
+                BuiltinToolReturnPart(
+                    'web_search',
+                    [
+                        {
+                            'url': 'https://www.weather.com/weather/today/l/USCA0987:1:US',
+                            'title': 'Weather in San Francisco',
+                        }
+                    ],
+                    tool_call_id='tool_call_2',
+                ),
+                TextPart('text3'),
             ]
         ),
     ]
@@ -1387,6 +1403,26 @@ def test_message_with_builtin_tool_calls():
                         'result': {'output': '4'},
                     },
                     {'type': 'text', 'content': 'text2'},
+                    {
+                        'type': 'tool_call',
+                        'id': 'tool_call_2',
+                        'name': 'web_search',
+                        'builtin': True,
+                        'arguments': '{"query": "weather: San Francisco, CA", "type": "search"}',
+                    },
+                    {
+                        'type': 'tool_call_response',
+                        'id': 'tool_call_2',
+                        'name': 'web_search',
+                        'builtin': True,
+                        'result': [
+                            {
+                                'url': 'https://www.weather.com/weather/today/l/USCA0987:1:US',
+                                'title': 'Weather in San Francisco',
+                            }
+                        ],
+                    },
+                    {'type': 'text', 'content': 'text3'},
                 ],
             }
         ]


### PR DESCRIPTION
Follow-up to https://github.com/pydantic/pydantic-ai/pull/2954

Fixes this example reported on Slack:

```py
from typing import TypedDict

import logfire
from pydantic_ai import Agent, WebSearchTool

logfire.configure()
logfire.instrument_pydantic_ai()


class Person(TypedDict):
    name: str
    age: int


agent = Agent(
    'anthropic:claude-sonnet-4-0',
    output_type=str | Person,
    builtin_tools=[WebSearchTool()],
    instructions="""
You are a helpful assistant that can find people online, and return their age, if you don't find it, explain me how I can find it.
""",
)

agent.run_sync("Search for Marcelo Trylesinski and return their age.")
```