### PR TITLE
Fix parallel tool call limit enforcement

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -637,6 +637,8 @@ except UsageLimitExceeded as e:
     - Usage limits are especially relevant if you've registered many tools. Use `request_limit` to bound the number of model turns, and `tool_calls_limit` to cap the number of successful tool executions within a run.
     - The `tool_calls_limit` is checked before executing tool calls. If the model returns parallel tool calls that would exceed the limit, no tools will be executed.
 
+#### Model (Run) Settings
+
 Pydantic AI offers a [`settings.ModelSettings`][pydantic_ai.settings.ModelSettings] structure to help you fine tune your requests.
 This structure allows you to configure common parameters that influence the model's behavior, such as `temperature`, `max_tokens`,
 `timeout`, and more.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -630,16 +630,12 @@ try:
     agent.run_sync('Please call the tool twice', usage_limits=UsageLimits(tool_calls_limit=1))
 except UsageLimitExceeded as e:
     print(e)
-    """
-    With the next tool call(s), the projected amount of tool calls (2) would exceed the limit of 1.
-    """
+    #> The next tool call(s) would exceed the tool_calls_limit of 1 (tool_calls=2).
 ```
 
 !!! note
     - Usage limits are especially relevant if you've registered many tools. Use `request_limit` to bound the number of model turns, and `tool_calls_limit` to cap the number of successful tool executions within a run.
-    - The `tool_calls_limit` is checked before executing tool calls. If the projected total would exceed the limit, no tools from that batch are executed.
-
-#### Model (Run) Settings
+    - The `tool_calls_limit` is checked before executing tool calls. If the model returns parallel tool calls that would exceed the limit, no tools will be executed.
 
 Pydantic AI offers a [`settings.ModelSettings`][pydantic_ai.settings.ModelSettings] structure to help you fine tune your requests.
 This structure allows you to configure common parameters that influence the model's behavior, such as `temperature`, `max_tokens`,

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -630,12 +630,14 @@ try:
     agent.run_sync('Please call the tool twice', usage_limits=UsageLimits(tool_calls_limit=1))
 except UsageLimitExceeded as e:
     print(e)
-    #> The next tool call would exceed the tool_calls_limit of 1 (tool_calls=1)
+    """
+    With the next tool call(s), the projected amount of tool calls (2) would exceed the limit of 1.
+    """
 ```
 
 !!! note
     - Usage limits are especially relevant if you've registered many tools. Use `request_limit` to bound the number of model turns, and `tool_calls_limit` to cap the number of successful tool executions within a run.
-    - These limits are enforced at the final stage before the LLM is called. If your limits are stricter than your retry settings, the usage limit will be reached before all retries are attempted.
+    - The `tool_calls_limit` is checked before executing tool calls. If the projected total would exceed the limit, no tools from that batch are executed.
 
 #### Model (Run) Settings
 

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -230,7 +230,6 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
         # Build the run context after `ctx.deps.prompt` has been updated
         run_context = build_run_context(ctx)
 
-        parts: list[_messages.ModelRequestPart] = []
         if messages:
             await self._reevaluate_dynamic_prompts(messages, run_context)
 

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -862,6 +862,29 @@ async def process_tool_calls(  # noqa: C901
         output_final_result.append(final_result)
 
 
+def _enforce_tool_call_limits(
+    tool_manager: ToolManager[DepsT],
+    tool_calls: list[_messages.ToolCallPart],
+    usage_limits: _usage.UsageLimits | None,
+) -> tuple[list[_messages.ToolCallPart], int]:
+    """Enforce tool call limits and return limited calls and extra count."""
+    if usage_limits is None or usage_limits.tool_calls_limit is None:
+        return tool_calls, 0
+
+    current_tool_calls = tool_manager.ctx.usage.tool_calls if tool_manager.ctx is not None else 0
+    remaining_allowed = usage_limits.tool_calls_limit - current_tool_calls
+
+    if remaining_allowed <= 0:
+        usage_limits.check_before_tool_call(tool_manager.ctx.usage if tool_manager.ctx else _usage.RunUsage())
+
+    if remaining_allowed < len(tool_calls):
+        limited_tool_calls = tool_calls[: max(0, remaining_allowed)]
+        extra_calls_count = len(tool_calls) - len(limited_tool_calls)
+        return limited_tool_calls, extra_calls_count
+
+    return tool_calls, 0
+
+
 async def _call_tools(
     tool_manager: ToolManager[DepsT],
     tool_calls: list[_messages.ToolCallPart],
@@ -908,6 +931,8 @@ async def _call_tools(
 
                 return _messages.FunctionToolResultEvent(tool_part)
 
+        executed_calls: list[_messages.ToolCallPart] = tool_calls
+
         if tool_manager.should_call_sequentially(tool_calls):
             for index, call in enumerate(tool_calls):
                 if event := await handle_call_or_result(
@@ -917,12 +942,14 @@ async def _call_tools(
                     yield event
 
         else:
+            executed_calls, extra_calls_count = _enforce_tool_call_limits(tool_manager, tool_calls, usage_limits)
+
             tasks = [
                 asyncio.create_task(
                     _call_tool(tool_manager, call, tool_call_results.get(call.tool_call_id), usage_limits),
                     name=call.tool_name,
                 )
-                for call in tool_calls
+                for call in executed_calls
             ]
 
             pending = tasks
@@ -933,13 +960,17 @@ async def _call_tools(
                     if event := await handle_call_or_result(coro_or_task=task, index=index):
                         yield event
 
+            # If there were extra calls beyond the allowed limit, raise now
+            if extra_calls_count and usage_limits is not None:
+                usage_limits.check_before_tool_call(tool_manager.ctx.usage if tool_manager.ctx else _usage.RunUsage())
+
     # We append the results at the end, rather than as they are received, to retain a consistent ordering
     # This is mostly just to simplify testing
     output_parts.extend([tool_parts_by_index[k] for k in sorted(tool_parts_by_index)])
     output_parts.extend([user_parts_by_index[k] for k in sorted(user_parts_by_index)])
 
     for k in sorted(deferred_calls_by_index):
-        output_deferred_calls[deferred_calls_by_index[k]].append(tool_calls[k])
+        output_deferred_calls[deferred_calls_by_index[k]].append(executed_calls[k])
 
 
 async def _call_tool(

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -159,9 +159,6 @@ class ToolManager(Generic[AgentDepsT]):
             else:
                 args_dict = validator.validate_python(call.args or {}, allow_partial=pyd_allow_partial)
 
-            if usage_limits is not None and count_tool_usage:
-                usage_limits.check_before_tool_call(self.ctx.usage)
-
             result = await self.toolset.call_tool(name, args_dict, ctx, tool)
 
             if count_tool_usage:

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -125,7 +125,6 @@ class ToolManager(Generic[AgentDepsT]):
         call: ToolCallPart,
         allow_partial: bool,
         wrap_validation_errors: bool,
-        usage_limits: UsageLimits | None = None,
         count_tool_usage: bool = True,
     ) -> Any:
         if self.tools is None or self.ctx is None:
@@ -239,7 +238,7 @@ class ToolManager(Generic[AgentDepsT]):
             attributes=span_attributes,
         ) as span:
             try:
-                tool_result = await self._call_tool(call, allow_partial, wrap_validation_errors, usage_limits)
+                tool_result = await self._call_tool(call, allow_partial, wrap_validation_errors)
             except ToolRetryError as e:
                 part = e.tool_retry
                 if include_content and span.is_recording():

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -343,9 +343,10 @@ class UsageLimits:
     def check_before_tool_call(self, projected_usage: RunUsage) -> None:
         """Raises a `UsageLimitExceeded` exception if the next tool call(s) would exceed the tool call limit."""
         tool_calls_limit = self.tool_calls_limit
-        if tool_calls_limit is not None and projected_usage.tool_calls > tool_calls_limit:
+        tool_calls = projected_usage.tool_calls
+        if tool_calls_limit is not None and tool_calls > tool_calls_limit:
             raise UsageLimitExceeded(
-                f'With the next tool call(s), the projected amount of tool calls ({projected_usage.tool_calls}) would exceed the limit of {tool_calls_limit}.'
+                f'The next tool call(s) would exceed the tool_calls_limit of {tool_calls_limit} ({tool_calls=}).'
             )
 
     __repr__ = _utils.dataclasses_no_defaults_repr

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -340,12 +340,12 @@ class UsageLimits:
         if self.total_tokens_limit is not None and total_tokens > self.total_tokens_limit:
             raise UsageLimitExceeded(f'Exceeded the total_tokens_limit of {self.total_tokens_limit} ({total_tokens=})')
 
-    def check_before_tool_call(self, usage: RunUsage) -> None:
-        """Raises a `UsageLimitExceeded` exception if the next tool call would exceed the tool call limit."""
+    def check_before_tool_call(self, projected_usage: RunUsage) -> None:
+        """Raises a `UsageLimitExceeded` exception if the next tool call(s) would exceed the tool call limit."""
         tool_calls_limit = self.tool_calls_limit
-        if tool_calls_limit is not None and usage.tool_calls >= tool_calls_limit:
+        if tool_calls_limit is not None and projected_usage.tool_calls > tool_calls_limit:
             raise UsageLimitExceeded(
-                f'The next tool call would exceed the tool_calls_limit of {tool_calls_limit} (tool_calls={usage.tool_calls})'
+                f'With the next tool call(s), the projected amount of tool calls ({projected_usage.tool_calls}) would exceed the limit of {tool_calls_limit}.'
             )
 
     __repr__ = _utils.dataclasses_no_defaults_repr

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -387,7 +387,10 @@ text_responses: dict[str, str | ToolCallPart | Sequence[ToolCallPart]] = {
         'The capital of Italy is Rome (Roma, in Italian), which has been a cultural and political center for centuries.'
         'Rome is known for its rich history, stunning architecture, and delicious cuisine.'
     ),
-    'Please call the tool twice': ToolCallPart(tool_name='do_work', args={}, tool_call_id='pyd_ai_tool_call_id'),
+    'Please call the tool twice': [
+        ToolCallPart(tool_name='do_work', args={}, tool_call_id='pyd_ai_tool_call_id_1'),
+        ToolCallPart(tool_name='do_work', args={}, tool_call_id='pyd_ai_tool_call_id_2'),
+    ],
     'Begin infinite retry loop!': ToolCallPart(
         tool_name='infinite_retry_tool', args={}, tool_call_id='pyd_ai_tool_call_id'
     ),

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -325,7 +325,7 @@ async def test_output_tool_allowed_at_limit() -> None:
 
 
 async def test_failed_tool_calls_not_counted() -> None:
-    """Test that failed tool calls (raising ModelRetry) are not counted."""
+    """Test that failed tool calls (raising ModelRetry) are not counted in usage or against limits."""
     test_agent = Agent(TestModel())
 
     call_count = 0
@@ -338,8 +338,7 @@ async def test_failed_tool_calls_not_counted() -> None:
             raise ModelRetry('Temporary failure, please retry')
         return f'{x}-success'
 
-    result = await test_agent.run('test')
-    # The tool was called twice (1 failure + 1 success), but only the successful call should be counted
+    result = await test_agent.run('test', usage_limits=UsageLimits(tool_calls_limit=1))
     assert call_count == 2
     assert result.usage() == snapshot(RunUsage(requests=3, input_tokens=176, output_tokens=29, tool_calls=1))
 

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -257,9 +257,7 @@ async def test_tool_call_limit() -> None:
 
     with pytest.raises(
         UsageLimitExceeded,
-        match=re.escape(
-            'With the next tool call(s), the projected amount of tool calls (1) would exceed the limit of 0.'
-        ),
+        match=re.escape('The next tool call(s) would exceed the tool_calls_limit of 0 (tool_calls=1).'),
     ):
         await test_agent.run('Hello', usage_limits=UsageLimits(tool_calls_limit=0))
 
@@ -380,9 +378,7 @@ async def test_parallel_tool_calls_limit_enforced():
     # Run with tool call limit of 6; expecting an error when trying to execute 3 more tools
     with pytest.raises(
         UsageLimitExceeded,
-        match=re.escape(
-            'With the next tool call(s), the projected amount of tool calls (8) would exceed the limit of 6.'
-        ),
+        match=re.escape('The next tool call(s) would exceed the tool_calls_limit of 6 (tool_calls=8).'),
     ):
         await agent.run('Use tools', usage_limits=UsageLimits(tool_calls_limit=6))
 


### PR DESCRIPTION
## Fix parallel tool call limit enforcement

### Problem
The `tool_calls_limit` in `UsageLimits` was not properly enforced for parallel tool execution. When multiple tools were called in parallel, all tools would start executing before the limit was checked, allowing the limit to be exceeded before raising `UsageLimitExceeded`.

For example, if `tool_calls_limit=6` and the model returned 8 parallel tool calls, all 8 tools would start executing before the error was raised.

### Solution
This PR modifies the parallel tool execution logic in `_agent_graph.py` to enforce the limit before starting tool tasks:

1. **Pre-execution limit check**: Before creating async tasks for parallel tools, we now check how many tool calls are remaining within the limit
3. **Immediate error**: Raise `UsageLimitExceeded` if the requested tool amount would violate the usage limit