### PR TITLE
Fix broken documentation rendering for OpenAI model page

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -130,7 +130,7 @@ Image generation is not currently supported. If you need this feature, please co
 
 File search and Computer use can be enabled by passing an [`openai.types.responses.FileSearchToolParam`](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/file_search_tool_param.py) or [`openai.types.responses.ComputerToolParam`](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/computer_tool_param.py) in the `openai_builtin_tools` setting on [`OpenAIResponsesModelSettings`][pydantic_ai.models.openai.OpenAIResponsesModelSettings]. They don't currently generate [`BuiltinToolCallPart`][pydantic_ai.messages.BuiltinToolCallPart] or [`BuiltinToolReturnPart`][pydantic_ai.messages.BuiltinToolReturnPart] parts in the message history, or streamed events; please submit an issue if you need native support for these built-in tools.
 
-```python{title="file_search_tool.py"}
+```python {title="file_search_tool.py"}
 from openai.types.responses import FileSearchToolParam
 
 from pydantic_ai import Agent


### PR DESCRIPTION
Before:
<img width="750" height="854" alt="image" src="https://github.com/user-attachments/assets/5871796b-54da-42d2-a2c8-44d2623f9fd4" />
 
After:
<img width="770" height="624" alt="image" src="https://github.com/user-attachments/assets/e67611a3-c388-4af3-89b0-598a249055b6" />
