### PR TITLE
docs: replace "customisation" by "customization"

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -216,10 +216,10 @@ async def main():
 
 _(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
 
-## Tool call customisation
+## Tool call customization
 
 The MCP servers provide the ability to set a `process_tool_call` which allows
-the customisation of tool call requests and their responses.
+the customization of tool call requests and their responses.
 
 A common use case for this is to inject metadata to the requests which the server
 call needs:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes spelling by changing “customisation” to “customization” in `docs/mcp/client.md` section heading and description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fa4e0a94ac3683ae32b309b5c0af999cb127b28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->