### PR TITLE
feat(mcp): add `client` property into `MCPServer`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -287,7 +287,7 @@ class MCPServer(AbstractToolset[Any], ABC):
             if self._running_count == 0:
                 async with AsyncExitStack() as exit_stack:
                     self._read_stream, self._write_stream = await exit_stack.enter_async_context(self.client_streams())
-                    client = ClientSession(
+                    self._client = ClientSession(
                         read_stream=self._read_stream,
                         write_stream=self._write_stream,
                         sampling_callback=self._sampling_callback if self.allow_sampling else None,
@@ -295,7 +295,7 @@ class MCPServer(AbstractToolset[Any], ABC):
                         logging_callback=self.log_handler,
                         read_timeout_seconds=timedelta(seconds=self.read_timeout),
                     )
-                    self._client = await exit_stack.enter_async_context(client)
+                    self._client = await exit_stack.enter_async_context(self._client)
 
                     with anyio.fail_after(self.timeout):
                         await self._client.initialize()
@@ -306,6 +306,15 @@ class MCPServer(AbstractToolset[Any], ABC):
                     self._exit_stack = exit_stack.pop_all()
             self._running_count += 1
         return self
+
+    @property
+    def client(self) -> ClientSession:
+        """Access the underlying `ClientSession`."""
+        if getattr(self, '_client', None) is None:
+            raise AttributeError(
+                f'The `{self.__class__.__name__}.client` is only instantiated when entering the async context manager.'
+            )
+        return self._client
 
     async def __aexit__(self, *args: Any) -> bool | None:
         if self._running_count == 0:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -11,6 +11,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from inline_snapshot import snapshot
+from inline_snapshot.extra import raises
+from pydantic import AnyUrl
 
 from pydantic_ai.agent import Agent
 from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior, UserError
@@ -1408,3 +1410,68 @@ def test_load_mcp_servers(tmp_path: Path):
 
     with pytest.raises(FileNotFoundError):
         load_mcp_servers(tmp_path / 'does_not_exist.json')
+
+
+async def test_mcp_server_access_client(mcp_server: MCPServerStdio):
+    with raises(
+        snapshot(
+            'AttributeError: The `MCPServerStdio.client` is only instantiated when entering the async context manager.'
+        )
+    ):
+        mcp_server.client
+
+    async with mcp_server:
+        resources = await mcp_server.client.list_resources()
+        assert resources.model_dump() == snapshot(
+            {
+                'meta': None,
+                'nextCursor': None,
+                'resources': [
+                    {
+                        'name': 'kiwi_resource',
+                        'title': None,
+                        'uri': AnyUrl('resource://kiwi.png'),
+                        'description': '',
+                        'mimeType': 'image/png',
+                        'size': None,
+                        'annotations': None,
+                        'meta': None,
+                    },
+                    {
+                        'name': 'marcelo_resource',
+                        'title': None,
+                        'uri': AnyUrl('resource://marcelo.mp3'),
+                        'description': '',
+                        'mimeType': 'audio/mpeg',
+                        'size': None,
+                        'annotations': None,
+                        'meta': None,
+                    },
+                    {
+                        'name': 'product_name_resource',
+                        'title': None,
+                        'uri': AnyUrl('resource://product_name.txt'),
+                        'description': '',
+                        'mimeType': 'text/plain',
+                        'size': None,
+                        'annotations': None,
+                        'meta': None,
+                    },
+                ],
+            }
+        )
+
+        resource = await mcp_server.client.read_resource(AnyUrl('resource://product_name.txt'))
+        assert resource.model_dump() == snapshot(
+            {
+                'meta': None,
+                'contents': [
+                    {
+                        'uri': AnyUrl('resource://product_name.txt'),
+                        'mimeType': 'text/plain',
+                        'meta': None,
+                        'text': 'Pydantic AI\n',
+                    }
+                ],
+            }
+        )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `MCPServer.client` property to access the underlying `ClientSession` when running, with docs and tests verifying safe access.
> 
> - **MCP Core (`pydantic_ai/mcp.py`)**:
>   - **New API**: `MCPServer.client` property exposes the underlying `ClientSession`; raises `AttributeError` if accessed outside the async context.
>   - **Init refactor**: Store `ClientSession` on `self._client` immediately and enter it via the exit stack in `__aenter__`.
> - **Docs (`docs/mcp/client.md`)**:
>   - **New section**: How to access the underlying client with examples for listing/reading prompts/resources and context-manager caveats.
> - **Tests (`tests/test_mcp.py`)**:
>   - **New test**: Validates `MCPServerStdio.client` access behavior (error before context; usable inside), and reading resources.
>   - Minor imports added for snapshots and URL types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd77803e4f5f05a2da9f2950687c75bdb70d2dda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->