### PR TITLE
Change type of common_tools to work with agent with any deps type

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/duckduckgo.py
@@ -4,7 +4,7 @@ from dataclasses import KW_ONLY, dataclass
 import anyio
 import anyio.to_thread
 from pydantic import TypeAdapter
-from typing_extensions import TypedDict
+from typing_extensions import Any, TypedDict
 
 from pydantic_ai.tools import Tool
 
@@ -69,7 +69,7 @@ def duckduckgo_search_tool(duckduckgo_client: DDGS | None = None, max_results: i
         duckduckgo_client: The DuckDuckGo search client.
         max_results: The maximum number of results. If None, returns results only from the first response.
     """
-    return Tool(
+    return Tool[Any](
         DuckDuckGoSearchTool(client=duckduckgo_client or DDGS(), max_results=max_results).__call__,
         name='duckduckgo_search',
         description='Searches DuckDuckGo for the given query and returns the results.',

--- a/pydantic_ai_slim/pydantic_ai/common_tools/tavily.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/tavily.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from pydantic import TypeAdapter
-from typing_extensions import TypedDict
+from typing_extensions import Any, TypedDict
 
 from pydantic_ai.tools import Tool
 
@@ -74,7 +74,7 @@ def tavily_search_tool(api_key: str):
 
             You can get one by signing up at [https://app.tavily.com/home](https://app.tavily.com/home).
     """
-    return Tool(
+    return Tool[Any](
         TavilySearchTool(client=AsyncTavilyClient(api_key)).__call__,
         name='tavily_search',
         description='Searches Tavily for the given query and returns the results.',


### PR DESCRIPTION
Closes #2977

This PR will prevent linting errors when the `duckduckgo_search_tool` and `tavily_search_tool` are handed to agents with `AgentDepsT` other than `None`.

The problem arises [here](https://github.com/pydantic/pydantic-ai/blob/79ef2bf20b573399a8e358c4c075a7a54a8f839c/pydantic_ai_slim/pydantic_ai/_run_context.py#L17-L18) where the default `AgentDepsT` is set to `None`. Downstream `Tool[AgentDepsT]` also defaults to `Tool[None]` if the tool is defined explicitly (i.e. without an `@agent.tool` decorator).

I suspect `AgentDepsT` should be `Any` by default (for contravariance reasons), but for now hardcoding the type of these common_tools will solve the issue.