### PR TITLE
Don't run deploy-docs-preview after a PR is merged to main

### DIFF
--- a/.github/workflows/after-ci.yml
+++ b/.github/workflows/after-ci.yml
@@ -41,7 +41,7 @@ jobs:
 
   deploy-docs-preview:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_branch != 'main'
     environment:
       name: deploy-docs-preview
 


### PR DESCRIPTION
Should fix failures like https://github.com/pydantic/pydantic-ai/actions/runs/18136562767