### PR TITLE
Include report averages

### DIFF
--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -324,6 +324,8 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
                 trace_id=trace_id,
             )
             if (averages := report.averages()) is not None and averages.assertions is not None:
+                experiment_metadata = {'n_cases': len(self.cases), 'averages': averages}
+                eval_span.set_attribute('experiment.metadata', experiment_metadata)
                 eval_span.set_attribute('assertion_pass_rate', averages.assertions)
         return report
 


### PR DESCRIPTION
Allows the evals page in logfire to present some nice stats in the main comparison table:

<img width="1564" height="357" alt="image" src="https://github.com/user-attachments/assets/6aa8ed63-2dff-4f47-b5fd-7d0a44356e4e" />
