### PR TITLE
Don't send strict to HuggingFace API as it's not supported by their types and at least some models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -377,8 +377,6 @@ class HuggingFaceModel(Model):
                 },
             }
         )
-        if f.strict is not None:
-            tool_param['function']['strict'] = f.strict
         return tool_param
 
     async def _map_user_message(


### PR DESCRIPTION
Reported on [Slack](https://pydanticlogfire.slack.com/archives/C083V7PMHHA/p1759285519752389):

```
I'm trying to use Qwen/Qwen3-Coder-480B-A35B-Instruct through Hugging Face.
I get the following error on every call:
E           pydantic_ai.exceptions.ModelHTTPError: status_code: 500, model_name: Qwen/Qwen3-Coder-480B-A35B-Instruct, body: {'message': 'Encountered a server error, please try again. strict=True is not supported for Qwen Coder model.', 'type': 'server_error'}
```