### PR TITLE
Including a url parameter when using MCPServerStreamableHTTP (Change Docs)

### DIFF
--- a/docs/.hooks/snippets.py
+++ b/docs/.hooks/snippets.py
@@ -149,7 +149,8 @@ def parse_snippet_directive(line: str) -> SnippetDirective | None:
 
 def parse_file_sections(file_path: Path) -> ParsedFile:
     """Parse a file and extract sections marked with ### [section] or /// [section]"""
-    input_lines = file_path.read_text().splitlines()
+    # input_lines = file_path.read_text().splitlines()
+    input_lines = file_path.read_text(encoding="utf-8").splitlines()
     output_lines: list[str] = []
     lines_mapping: dict[int, int] = {}
 

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -54,7 +54,7 @@ Then we can create the client:
 from pydantic_ai import Agent
 from pydantic_ai.mcp import MCPServerStreamableHTTP
 
-server = MCPServerStreamableHTTP('http://localhost:8000/mcp')  # (1)!
+server = MCPServerStreamableHTTP(url='http://localhost:8000/mcp')  # (1)!
 agent = Agent('openai:gpt-4o', toolsets=[server])  # (2)!
 
 async def main():


### PR DESCRIPTION
I have noticed that when you run;
`server = MCPServerStreamableHTTP('http://localhost:8000/mcp')` as mentioned in the current docs, you will get an error because of the positional arguments.

This PR is intended to update the docs so that it reflects the correct format which is;
`server = MCPServerStreamableHTTP(url='http://localhost:8000/mcp')`

I have modified locally to prove it's working and should be like below on the pydantic-ai website
<img width="1352" height="611" alt="image" src="https://github.com/user-attachments/assets/6c50d312-7cd8-478e-86ea-14571450a1be" />
