### PR TITLE
Google: Continue on MALFORMED_FUNCTION_CALL

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -640,6 +640,8 @@ class GeminiStreamedResponse(StreamedResponse):
                 if candidate.finish_reason == 'STOP':  # pragma: no cover
                     # Normal completion - skip this chunk
                     continue
+                elif candidate.finish_reason == 'MALFORMED_FUNCTION_CALL':  # pragma: no cover
+                    continue
                 elif candidate.finish_reason == 'SAFETY':  # pragma: no cover
                     raise UnexpectedModelBehavior('Safety settings triggered', str(chunk))
                 else:  # pragma: no cover


### PR DESCRIPTION
Using Gemini, we are frequently running into the MALFORMED_FUNCTION_CALL as the finish reason.
Google seemingly does not provide any context in the response for the reason of the MALFORMED_FUNCTION_CALL.

In these cases, the agent can continue retrying which I why I suggest to simply `continue` in the case of a MALFORMED_FUNCTION_CALL.

Related to #631 

The issue is most prevalent when using Gemini 2.5 Flash (compared to Gemini 2.5 Pro where it also happens but less frequently).

Example `chunk`:
```
sdk_http_response=HttpResponse(
  headers=<dict len=11>
) candidates=[Candidate(
  finish_reason=<FinishReason.MALFORMED_FUNCTION_CALL: 'MALFORMED_FUNCTION_CALL'>,
  index=0
)] create_time=None model_version=None prompt_feedback=None response_id=None usage_metadata=GenerateContentResponseUsageMetadata(
  prompt_token_count=2595,
  prompt_tokens_details=[
    ModalityTokenCount(
      modality=<MediaModality.TEXT: 'TEXT'>,
      token_count=2595
    ),
  ],
  total_token_count=2595
) automatic_function_calling_history=None parsed=None
```