### PR TITLE
Make BinaryImage work with inline-snapshot

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -595,9 +595,13 @@ class BinaryImage(BinaryContent):
         media_type: str,
         identifier: str | None = None,
         vendor_metadata: dict[str, Any] | None = None,
+        # Required for inline-snapshot which expects all dataclass `__init__` methods to take all field names as kwargs.
         kind: Literal['binary'] = 'binary',
+        _identifier: str | None = None,
     ):
-        super().__init__(data=data, media_type=media_type, identifier=identifier, vendor_metadata=vendor_metadata)
+        super().__init__(
+            data=data, media_type=media_type, identifier=identifier or _identifier, vendor_metadata=vendor_metadata
+        )
 
         if not self.is_image:
             raise ValueError('`BinaryImage` must be have a media type that starts with "image/"')  # pragma: no cover


### PR DESCRIPTION
Tiny fix to make tests not error when inline-snapshot is enabled, same as with the parent BinaryContent