### PR TITLE
Record instructions on the agent run span even when they are dynamic

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -687,7 +687,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 if instrumentation_settings and run_span.is_recording():
                     run_span.set_attributes(
                         self._run_span_end_attributes(
-                            state, usage, instrumentation_settings, graph_deps.new_message_index
+                            instrumentation_settings, usage, state.message_history, graph_deps.new_message_index
                         )
                     )
             finally:
@@ -695,38 +695,42 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
     def _run_span_end_attributes(
         self,
-        state: _agent_graph.GraphAgentState,
-        usage: _usage.RunUsage,
         settings: InstrumentationSettings,
+        usage: _usage.RunUsage,
+        message_history: list[_messages.ModelMessage],
         new_message_index: int,
     ):
         if settings.version == 1:
             attrs = {
                 'all_messages_events': json.dumps(
-                    [
-                        InstrumentedModel.event_to_dict(e)
-                        for e in settings.messages_to_otel_events(state.message_history)
-                    ]
+                    [InstrumentedModel.event_to_dict(e) for e in settings.messages_to_otel_events(message_history)]
                 )
             }
         else:
             # Store the last instructions here for convenience
-            last_instructions = InstrumentedModel._get_instructions(state.message_history)  # pyright: ignore[reportPrivateUsage]
+            last_instructions = InstrumentedModel._get_instructions(message_history)  # pyright: ignore[reportPrivateUsage]
             attrs: dict[str, Any] = {
-                'pydantic_ai.all_messages': json.dumps(settings.messages_to_otel_messages(list(state.message_history))),
+                'pydantic_ai.all_messages': json.dumps(settings.messages_to_otel_messages(list(message_history))),
                 **settings.system_instructions_attributes(last_instructions),
             }
 
-            # Store an attribute that indicates that the instructions from this agent run were not always the same
-            # This can signal to an observability UI that different steps in the agent run had different instructions
+            # If this agent run was provided with existing history, store an attribute indicating the point at which the
+            # new messages begin.
+            if new_message_index > 0:
+                attrs['pydantic_ai.new_message_index'] = new_message_index
+
+            # If the instructions for this agent run were not always the same, store an attribute that indicates that.
+            # This can signal to an observability UI that different steps in the agent run had different instructions.
             # Note: We purposely only look at "new" messages because they are the only ones produced by this agent run.
-            for m in state.message_history[new_message_index:]:
-                if (
+            if any(
+                (
                     isinstance(m, _messages.ModelRequest)
                     and m.instructions is not None
                     and m.instructions != last_instructions
-                ):
-                    attrs['pydantic_ai.variable_instructions'] = True
+                )
+                for m in message_history[new_message_index:]
+            ):
+                attrs['pydantic_ai.variable_instructions'] = True
 
         return {
             **usage.opentelemetry_attributes(),

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -2846,6 +2846,7 @@ def test_function_instructions_with_history_in_agent_run_span(
                         ]
                     )
                 ),
+                'pydantic_ai.new_message_index': 2,
                 'gen_ai.system_instructions': '[{"type": "text", "content": "Instructions for the current agent run"}]',
                 'logfire.json_schema': IsJson(
                     snapshot(
@@ -2853,6 +2854,7 @@ def test_function_instructions_with_history_in_agent_run_span(
                             'type': 'object',
                             'properties': {
                                 'pydantic_ai.all_messages': {'type': 'array'},
+                                'pydantic_ai.new_message_index': {},
                                 'gen_ai.system_instructions': {'type': 'array'},
                                 'final_result': {'type': 'object'},
                             },


### PR DESCRIPTION
This does the following:
* Always records (potentially-)dynamic instructions on the agent run span, using the value from the last message
* In the event that there is another "new" message (i.e., one from the current run of the agent) with _different_ instructions, we set a new attribute on the agent run span `pydantic_ai.variable_instructions` to `True` as a way to have a signal in a UI like Logfire that the agent run made use of different instructions in different steps.

Closes #2884 