### PR TITLE
feat: Add markdown format option for tool descriptions

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_function_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_function_schema.py
@@ -24,7 +24,7 @@ from ._run_context import RunContext
 from ._utils import check_object_json_schema, is_async_callable, is_model_like, run_in_executor
 
 if TYPE_CHECKING:
-    from .tools import DocstringFormat, ObjectJsonSchema
+    from .tools import DescriptionFormat, DocstringFormat, ObjectJsonSchema
 
 
 __all__ = ('function_schema',)
@@ -76,16 +76,18 @@ def function_schema(  # noqa: C901
     schema_generator: type[GenerateJsonSchema],
     takes_ctx: bool | None = None,
     docstring_format: DocstringFormat = 'auto',
+    description_format: DescriptionFormat = 'xml',
     require_parameter_descriptions: bool = False,
 ) -> FunctionSchema:
     """Build a Pydantic validator and JSON schema from a tool function.
 
     Args:
         function: The function to build a validator and JSON schema for.
+        schema_generator: The JSON schema generator class to use.
         takes_ctx: Whether the function takes a `RunContext` first argument.
         docstring_format: The docstring format to use.
+        description_format: The output format for the description ('xml' or 'markdown').
         require_parameter_descriptions: Whether to require descriptions for all tool function parameters.
-        schema_generator: The JSON schema generator class to use.
 
     Returns:
         A `FunctionSchema` instance.
@@ -112,7 +114,9 @@ def function_schema(  # noqa: C901
     var_positional_field: str | None = None
     decorators = _decorators.DecoratorInfos()
 
-    description, field_descriptions = doc_descriptions(function, sig, docstring_format=docstring_format)
+    description, field_descriptions = doc_descriptions(
+        function, sig, docstring_format=docstring_format, description_format=description_format
+    )
 
     if require_parameter_descriptions:
         if takes_ctx:

--- a/pydantic_ai_slim/pydantic_ai/_griffe.py
+++ b/pydantic_ai_slim/pydantic_ai/_griffe.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from griffe import Docstring, DocstringSectionKind, Object as GriffeObject
 
 if TYPE_CHECKING:
-    from .tools import DocstringFormat
+    from .tools import DescriptionFormat, DocstringFormat
 
 DocstringStyle = Literal['google', 'numpy', 'sphinx']
 
@@ -20,18 +20,27 @@ def doc_descriptions(
     sig: Signature,
     *,
     docstring_format: DocstringFormat,
+    description_format: DescriptionFormat = 'xml',
 ) -> tuple[str | None, dict[str, str]]:
     """Extract the function description and parameter descriptions from a function's docstring.
 
     The function parses the docstring using the specified format (or infers it if 'auto')
     and extracts both the main description and parameter descriptions. If a returns section
-    is present in the docstring, the main description will be formatted as XML.
+    is present in the docstring, the main description will be formatted based on the
+    description_format parameter.
+
+    Args:
+        func: The function to extract descriptions from.
+        sig: The function signature.
+        docstring_format: The docstring parsing format to use.
+        description_format: The output format for the description ('xml' or 'markdown').
 
     Returns:
         A tuple containing:
         - str: Main description string, which may be either:
             * Plain text if no returns section is present
-            * XML-formatted if returns section exists, including <summary> and <returns> tags
+            * XML-formatted if description_format is 'xml' and returns section exists
+            * Markdown-formatted if description_format is 'markdown' and returns section exists
         - dict[str, str]: Dictionary mapping parameter names to their descriptions
     """
     doc = func.__doc__
@@ -65,13 +74,25 @@ def doc_descriptions(
         return_statement = return_.value[0]
         return_desc = return_statement.description
         return_type = return_statement.annotation
-        type_tag = f'<type>{return_type}</type>\n' if return_type else ''
-        return_xml = f'<returns>\n{type_tag}<description>{return_desc}</description>\n</returns>'
 
-        if main_desc:
-            main_desc = f'<summary>{main_desc}</summary>\n{return_xml}'
+        if description_format == 'markdown':
+            # Format as markdown
+            type_line = f'**Type:** `{return_type}`\n\n' if return_type else ''
+            return_formatted = f'### Returns\n\n{type_line}{return_desc}'
+
+            if main_desc:
+                main_desc = f'## Summary\n\n{main_desc}\n\n{return_formatted}'
+            else:
+                main_desc = return_formatted
         else:
-            main_desc = return_xml
+            # Format as XML (default)
+            type_tag = f'<type>{return_type}</type>\n' if return_type else ''
+            return_xml = f'<returns>\n{type_tag}<description>{return_desc}</description>\n</returns>'
+
+            if main_desc:
+                main_desc = f'<summary>{main_desc}</summary>\n{return_xml}'
+            else:
+                main_desc = return_xml
 
     return main_desc, params
 

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -17,6 +17,7 @@ from .messages import RetryPromptPart, ToolCallPart, ToolReturn
 __all__ = (
     'AgentDepsT',
     'DocstringFormat',
+    'DescriptionFormat',
     'RunContext',
     'SystemPromptFunc',
     'ToolFuncContext',
@@ -129,6 +130,13 @@ DocstringFormat: TypeAlias = Literal['google', 'numpy', 'sphinx', 'auto']
 * `'numpy'` — [Numpy-style](https://numpydoc.readthedocs.io/en/latest/format.html) docstrings.
 * `'sphinx'` — [Sphinx-style](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html#the-sphinx-docstring-format) docstrings.
 * `'auto'` — Automatically infer the format based on the structure of the docstring.
+"""
+
+DescriptionFormat: TypeAlias = Literal['xml', 'markdown']
+"""Supported description output formats.
+
+* `'xml'` — Format tool descriptions with XML tags (default).
+* `'markdown'` — Format tool descriptions with markdown formatting.
 """
 
 
@@ -251,6 +259,7 @@ class Tool(Generic[AgentDepsT]):
     description: str | None
     prepare: ToolPrepareFunc[AgentDepsT] | None
     docstring_format: DocstringFormat
+    description_format: DescriptionFormat
     require_parameter_descriptions: bool
     strict: bool | None
     sequential: bool
@@ -273,6 +282,7 @@ class Tool(Generic[AgentDepsT]):
         description: str | None = None,
         prepare: ToolPrepareFunc[AgentDepsT] | None = None,
         docstring_format: DocstringFormat = 'auto',
+        description_format: DescriptionFormat = 'xml',
         require_parameter_descriptions: bool = False,
         schema_generator: type[GenerateJsonSchema] = GenerateToolJsonSchema,
         strict: bool | None = None,
@@ -327,6 +337,8 @@ class Tool(Generic[AgentDepsT]):
                 or omit it completely from a step. See [`ToolPrepareFunc`][pydantic_ai.tools.ToolPrepareFunc].
             docstring_format: The format of the docstring, see [`DocstringFormat`][pydantic_ai.tools.DocstringFormat].
                 Defaults to `'auto'`, such that the format is inferred from the structure of the docstring.
+            description_format: The format for the tool description output, see [`DescriptionFormat`][pydantic_ai.tools.DescriptionFormat].
+                Defaults to `'xml'`. Use `'markdown'` for markdown-formatted tool descriptions.
             require_parameter_descriptions: If True, raise an error if a parameter description is missing. Defaults to False.
             schema_generator: The JSON schema generator class to use. Defaults to `GenerateToolJsonSchema`.
             strict: Whether to enforce JSON schema compliance (only affects OpenAI).
@@ -343,6 +355,7 @@ class Tool(Generic[AgentDepsT]):
             schema_generator,
             takes_ctx=takes_ctx,
             docstring_format=docstring_format,
+            description_format=description_format,
             require_parameter_descriptions=require_parameter_descriptions,
         )
         self.takes_ctx = self.function_schema.takes_ctx
@@ -351,6 +364,7 @@ class Tool(Generic[AgentDepsT]):
         self.description = description or self.function_schema.description
         self.prepare = prepare
         self.docstring_format = docstring_format
+        self.description_format = description_format
         self.require_parameter_descriptions = require_parameter_descriptions
         self.strict = strict
         self.sequential = sequential


### PR DESCRIPTION
## Summary

Adds a new `description_format` parameter to tool definitions that allows tool descriptions to be formatted as markdown instead of XML.

This PR closes #3130 by allowing users to specify whether they want tool descriptions formatted with markdown or XML tags.

## Changes

- Added `DescriptionFormat` type alias with `'xml'` and `'markdown'` options
- Added `description_format` parameter to `Tool` class (defaults to `'xml'` for backward compatibility)
- Updated `doc_descriptions()` function in `_griffe.py` to format the returns section based on the format
- Markdown format uses headers (`##`, `###`) and bold text instead of XML tags (`<summary>`, `<returns>`)

## Example Usage

```python
from pydantic_ai import Agent, Tool

def my_tool(x: int, y: int) -> int:
    """Add two numbers.
    
    Args:
        x: First number
        y: Second number
        
    Returns:
        The sum of x and y
    """
    return x + y

# Use markdown format
tool = Tool(my_tool, description_format='markdown')
agent = Agent('openai:gpt-4o', tools=[tool])
```

With `description_format='markdown'`, the tool description will be formatted as:

```markdown
## Summary

Add two numbers.

### Returns

**Type:** `int`

The sum of x and y
```

Instead of the default XML format:

```xml
<summary>Add two numbers.</summary>
<returns>
<type>int</type>
<description>The sum of x and y</description>
</returns>
```

## Test Plan

- [x] Code compiles without syntax errors
- [x] Added parameter documentation to all modified functions
- [x] Backward compatible (defaults to 'xml' format)

Closes #3130

🤖 Generated with [Claude Code](https://claude.com/claude-code)