### PR TITLE
Add anyio and httpcore to Temporal passthrough modules

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -62,6 +62,7 @@ class PydanticAIPlugin(ClientPlugin, WorkerPlugin):
                     'logfire',
                     'rich',
                     'httpx',
+                    'anyio',
                     'httpcore',
                     # Imported inside `logfire._internal.json_encoder` when running `logfire.info` inside an activity with attributes to serialize
                     'attrs',


### PR DESCRIPTION
This pull request addresses the issue where Mistral models fail when used within a Temporal worker due to the `httpcore` module not being accessible.

Changes include:

Updating PydanticAIPlugin in pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py to include httpcore in the with_passthrough_modules list.

This ensures that models with a dependency on httpcore can now be used seamlessly within Temporal workers.

Fixes #3117