### PR TITLE
fix: resolve TypeError in weather agent Gradio app example

### DIFF
--- a/examples/pydantic_ai_examples/weather_agent.py
+++ b/examples/pydantic_ai_examples/weather_agent.py
@@ -13,7 +13,6 @@ from __future__ import annotations as _annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any
 
 import logfire
 from httpx import AsyncClient
@@ -46,6 +45,11 @@ class LatLng(BaseModel):
     lng: float
 
 
+class WeatherResponse(BaseModel):
+    temperature: str
+    description: str
+
+
 @weather_agent.tool
 async def get_lat_lng(ctx: RunContext[Deps], location_description: str) -> LatLng:
     """Get the latitude and longitude of a location.
@@ -64,7 +68,7 @@ async def get_lat_lng(ctx: RunContext[Deps], location_description: str) -> LatLn
 
 
 @weather_agent.tool
-async def get_weather(ctx: RunContext[Deps], lat: float, lng: float) -> dict[str, Any]:
+async def get_weather(ctx: RunContext[Deps], lat: float, lng: float) -> WeatherResponse:
     """Get the weather at a location.
 
     Args:
@@ -85,10 +89,10 @@ async def get_weather(ctx: RunContext[Deps], lat: float, lng: float) -> dict[str
     )
     temp_response.raise_for_status()
     descr_response.raise_for_status()
-    return {
-        'temperature': f'{temp_response.text} °C',
-        'description': descr_response.text,
-    }
+    return WeatherResponse(
+        temperature=f'{temp_response.text} °C',
+        description=descr_response.text,
+    )
 
 
 async def main():


### PR DESCRIPTION
Fix TypeError: argument of type 'bool' is not iterable when launching the Gradio weather agent UI.

Changes:
- Replace dict[str, Any] return type with WeatherResponse Pydantic model in get_weather tool to avoid boolean additionalProperties in JSON schema
- Add monkey patch for Gradio's JSON schema parser to handle boolean additionalProperties gracefully
- Remove explicit type hints from Gradio callback functions to avoid schema introspection issues
- Add api_name=False to submit handler to disable API generation
- Remove unused typing.Any import

The issue was caused by dict[str, Any] generating a JSON schema with additionalProperties: true (boolean), which Gradio's schema parser could not process. Using a proper Pydantic model resolves this.