### PR TITLE
Add package installation instruction for Temporal example

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -77,6 +77,19 @@ brew install temporal
 temporal server start-dev
 ```
 
+And installing Pydantic AI with Temporal [open-source library](https://github.com/temporalio/sdk-python):
+
+```bash
+pip/uv-add 'pydantic-ai[temporal]'
+```
+
+Or if you're using the slim package, you can install it with the `temporal` (and `openai` in this case) optional groups:
+
+```bash
+pip/uv-add 'pydantic-ai-slim[temporal,openai]'
+```
+
+
 ```python {title="temporal_agent.py" test="skip"}
 import uuid
 


### PR DESCRIPTION
This pull request updates the Temporal documentation to include installation instructions for integrating Pydantic AI with Temporal. The changes clarify how to install the necessary Python packages for both the full and slim versions of Pydantic AI.

Installation instructions:

* Added instructions for installing the `pydantic-ai` package with Temporal support using either `pip` or `uv`, including the `temporal` extra.
* Provided installation guidance for the slim version of `pydantic-ai`, specifying the use of optional groups for `temporal` and `openai`.

Closes #3256