### PR TITLE
Refine reasoning model identification logic

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -62,7 +62,10 @@ class OpenAIModelProfile(ModelProfile):
 
 def openai_model_profile(model_name: str) -> ModelProfile:
     """Get the model profile for an OpenAI model."""
-    is_reasoning_model = model_name.startswith('o') or model_name.startswith('gpt-5')
+    is_reasoning_model = (
+        model_name.startswith('o')
+        or (model_name.startswith('gpt-5') and 'chat' not in model_name)
+    )
     # Check if the model supports web search (only specific search-preview models)
     supports_web_search = '-search-preview' in model_name
 


### PR DESCRIPTION
Current approach will cause an error, saying encrypted content is not allowed. This is due to get-5-chat-latest not being a reasoning model but still being identified as a reasoning model where encrypted content would normally be allowed.

Related to issue #3326 