### PR TITLE
Proposal: AdaptiveModel

### DIFF
--- a/adaptive_proposal.md
+++ b/adaptive_proposal.md
@@ -1,0 +1,962 @@
+# AdaptiveModel Design Proposal
+
+## Overview
+
+`AdaptiveModel` is a new model type that provides full control over model selection at runtime. Unlike `FallbackModel` which tries models sequentially, `AdaptiveModel` allows custom logic to select the next model based on rich context including attempts, exceptions, and agent dependencies.
+
+## Core API
+
+```python
+class AdaptiveModel[StateT](Model):
+    def __init__(
+        self,
+        selector: Callable[[AdaptiveContext[StateT]], Model]
+                  | Callable[[AdaptiveContext[StateT]], Awaitable[Model]],
+        *,
+        state: StateT | None = None,
+        on_attempt_failed: (
+            Callable[[StateT, Model, Exception, datetime, timedelta], bool]
+            | Callable[[StateT, Model, Exception, datetime, timedelta], Awaitable[bool]]
+            | None
+        ) = None,
+        on_attempt_succeeded: (
+            Callable[[StateT, Model, ModelResponse, datetime, timedelta], None]
+            | Callable[[StateT, Model, ModelResponse, datetime, timedelta], Awaitable[None]]
+            | None
+        ) = None,
+    ):
+        """
+        Args:
+            selector: Sync or async function that selects the next model to try.
+                     Must return a Model or raise an exception to stop.
+                     The selector manages its own pool of models (via closure, state, etc.).
+            state: State object passed to selector. If None, an empty dict is used.
+                   Reuse the same AdaptiveModel instance to share state across runs.
+                   Create new instances for isolated state.
+            on_attempt_failed: Optional sync or async hook called after each failed attempt.
+                              Receives (state, model, exception, timestamp, duration).
+                              Must return bool: True to continue, False to stop and re-raise.
+            on_attempt_succeeded: Optional sync or async hook called after successful attempt.
+                                 Receives (state, model, response, timestamp, duration).
+        """
+
+# Usage - state is managed at the model level, NOT passed through Agent
+# Models are managed by the selector (via closure, state, etc.)
+models = [Model('openai:gpt-4o'), Model('anthropic:claude-3-5-sonnet')]
+
+def my_selector(ctx: AdaptiveContext[MyState]) -> Model:
+    # Selector has full control over model selection
+    return models[0]  # Can use models from closure, state, or anywhere
+
+adaptive = AdaptiveModel(
+    selector=my_selector,
+    state=MyState(),  # State lives in the model
+    on_attempt_failed=my_failure_handler,  # Optional lifecycle hooks
+    on_attempt_succeeded=my_success_handler,
+)
+agent = Agent(adaptive)
+
+# Just run normally - no changes to Agent API
+result = await agent.run('query')
+```
+
+## Lifecycle Hooks
+
+AdaptiveModel provides two optional lifecycle hooks for clean separation of concerns:
+
+### `on_attempt_failed`
+
+Called after each failed model attempt. Can be sync or async. **Must return bool**:
+- `True`: Continue trying (call selector for next model)
+- `False`: Stop immediately (re-raise the exception)
+
+Use for:
+- Conditional retry logic (e.g., only retry on specific exceptions)
+- Throttling detection and tracking
+- Error rate monitoring
+- Circuit breaker patterns
+- Failure analytics
+
+```python
+# Sync hook
+def on_failure(state: MyState, model: Model, exception: Exception, timestamp: datetime, duration: timedelta) -> bool:
+    """Called when a model attempt fails. Returns True to continue, False to stop."""
+    if 'throttl' in str(exception).lower():
+        state.throttled_models[id(model)] = timestamp
+        return True  # Continue trying with other models
+
+    # For non-retryable errors, stop immediately
+    if isinstance(exception, ValueError):
+        return False
+
+    return True  # Default: continue
+
+# Async hook
+async def on_failure_async(state: MyState, model: Model, exception: Exception, timestamp: datetime, duration: timedelta) -> bool:
+    """Called when a model attempt fails - can do async operations."""
+    if 'throttl' in str(exception).lower():
+        state.throttled_models[id(model)] = timestamp
+        # Log to external service
+        await log_service.record_throttle(model.model_name, timestamp)
+        return True  # Continue trying
+
+    return False  # Stop on other errors
+```
+
+### `on_attempt_succeeded`
+
+Called after a successful model attempt. Can be sync or async. Use for:
+- Quality tracking and metrics
+- Quota deduction
+- Cost tracking
+- Response caching
+- Performance monitoring
+
+```python
+# Sync hook
+def on_success(state: MyState, model: Model, response: ModelResponse, timestamp: datetime, duration: timedelta):
+    """Called when a model attempt succeeds."""
+    # Track quality
+    quality_score = evaluate_response(response)
+    state.quality_history[model.model_name].append(quality_score)
+
+    # Deduct quota
+    tokens_used = response.usage.total_tokens if response.usage else 0
+    state.quota_remaining -= tokens_used
+
+# Async hook
+async def on_success_async(state: MyState, model: Model, response: ModelResponse, timestamp: datetime, duration: timedelta):
+    """Called when a model attempt succeeds - can do async operations."""
+    # Store metrics in database
+    await metrics_db.insert({
+        'model': model.model_name,
+        'duration': duration.total_seconds(),
+        'tokens': response.usage.total_tokens if response.usage else 0,
+        'timestamp': timestamp
+    })
+```
+
+**Note:** For streaming requests, `on_attempt_succeeded` is called when the stream starts, not when it completes.
+
+## Execution Flow
+
+The `AdaptiveModel` automatically handles fallback and retry by:
+
+1. Calling `selector(context)` to get the next model to try
+2. Attempting the request with that model
+3. If the request **succeeds**:
+   - Call `on_attempt_succeeded` hook (if provided)
+   - Return the result
+4. If the request **fails**:
+   - Recording the attempt (model + exception) in `context.attempts`
+   - Call `on_attempt_failed` hook (if provided)
+     - If hook returns `False`, re-raise the exception immediately
+     - If hook returns `True` (or hook not provided), continue to step 5
+5. Calling `selector(context)` again with updated context
+   - If selector returns a `Model`, goto step 2 (retry/fallback)
+   - If selector raises an exception, stop and raise `FallbackExceptionGroup`
+
+The selector has **full control** over retry/fallback logic:
+- Return the **same model** that failed → retry with same model
+- Return a **different model** → fallback to another model
+- Raise an exception → stop trying
+- Use `await asyncio.sleep()` for backoff/waiting (selector can be async)
+
+Lifecycle hooks provide **clean separation of concerns**:
+- `on_attempt_failed`: Decides **whether to continue** (True/False) + side effects
+- `selector`: Decides **which model to use next**
+- `on_attempt_succeeded`: Handles **success side effects** (metrics, tracking, etc.)
+
+## Context
+
+```python
+@dataclass
+class AdaptiveContext[StateT]:
+    """Context provided to the selector function."""
+
+    state: StateT  # User-defined state object
+    attempts: list[Attempt]  # History of attempts in this request
+    messages: list[ModelMessage]  # The original request
+    model_settings: ModelSettings | None
+    model_request_parameters: ModelRequestParameters
+
+@dataclass
+class Attempt:
+    """Record of a single attempt."""
+    model: Model
+    exception: Exception | None
+    timestamp: datetime
+    duration: timedelta
+```
+
+## State Management
+
+State is managed at the `AdaptiveModel` level - it's part of the model instance, not passed through the Agent. This keeps the Agent API unchanged and makes state management explicit and simple.
+
+### Defining State
+
+State can be any Python type - typically a dataclass for complex state or a simple dict for basic cases:
+
+```python
+@dataclass
+class AdaptiveState:
+    """State for adaptive model selection."""
+    throttled_models: dict[int, float] = field(default_factory=dict)
+    model_call_counts: dict[int, int] = field(default_factory=dict)
+
+# State is part of the model instance
+adaptive = AdaptiveModel(
+    models=[gpt35, gpt4, claude],
+    selector=my_selector,
+    state=AdaptiveState()  # Pass state here
+)
+```
+
+### Concurrency Considerations
+
+⚠️ **Important:** State objects are **not automatically thread-safe or async-safe**.
+
+For **concurrent async requests** (e.g., FastAPI, multiple simultaneous requests):
+
+**✅ Safe: Per-Request State (Recommended)**
+```python
+@app.post("/query")
+async def handle_query(query: str):
+    # Create fresh model instance per request - completely safe
+    adaptive = AdaptiveModel(
+        models=[...],
+        selector=my_selector,
+        state=MyState()  # Fresh state per request
+    )
+    agent = Agent(adaptive)
+    result = await agent.run(query)
+    return result.output
+```
+
+**⚠️ Requires Synchronization: Shared State**
+
+If you need shared state across concurrent requests, use locks:
+
+```python
+import asyncio
+
+# Global shared state
+global_state = LoadBalanceState()
+state_lock = asyncio.Lock()
+
+async def locked_selector(ctx: AdaptiveContext[LoadBalanceState]) -> Model | None:
+    async with state_lock:
+        # Only one request can access state at a time
+        model = min(ctx.models, key=lambda m: ctx.state.call_counts.get(id(m), 0))
+        ctx.state.call_counts[id(model)] = ctx.state.call_counts.get(id(model), 0) + 1
+        return model
+
+# Reused across all requests
+adaptive = AdaptiveModel(
+    models=[...],
+    selector=locked_selector,
+    state=global_state
+)
+
+@app.post("/query")
+async def handle_query(query: str):
+    agent = Agent(adaptive)  # Reuses same adaptive instance
+    result = await agent.run(query)
+    return result.output
+```
+
+**Alternative: Lock in Hooks**
+```python
+state_lock = asyncio.Lock()
+
+async def on_failure_locked(state: MyState, model: Model, exception: Exception, timestamp: datetime, duration: timedelta) -> bool:
+    async with state_lock:
+        # Thread-safe state update
+        if 'throttl' in str(exception).lower():
+            state.throttled_models[id(model)] = timestamp
+            return True  # Continue trying
+    return False  # Stop on other errors
+
+adaptive = AdaptiveModel(
+    selector=my_selector,
+    state=global_state,
+    on_attempt_failed=on_failure_locked  # Hook handles locking
+)
+```
+
+**When to Use Locks:**
+- ✅ Load balancing across requests (shared call counts)
+- ✅ Global throttling (shared throttle timers)
+- ✅ System-wide quotas (shared quota tracking)
+- ❌ Per-request retry logic (use per-request state instead)
+
+### Per-Run State (Isolated)
+
+For state that should be **isolated per run**, create a new `AdaptiveModel` instance for each run:
+
+```python
+def selector(ctx: AdaptiveContext[AdaptiveState]) -> Model | None:
+    # Access state - unique to this model instance
+    if not ctx.attempts:
+        return ctx.models[0]
+    return None
+
+# Create new model instance for each run
+def run_with_fresh_state(query: str):
+    adaptive = AdaptiveModel(
+        models=[...],
+        selector=selector,
+        state=AdaptiveState()  # Fresh state
+    )
+    agent = Agent(adaptive)
+    return agent.run_sync(query)
+
+result1 = run_with_fresh_state('query 1')  # Fresh state
+result2 = run_with_fresh_state('query 2')  # Fresh state
+```
+
+### Global State (Shared)
+
+For state that should be **shared across runs**, reuse the same `AdaptiveModel` instance:
+
+```python
+# Global model with shared state
+adaptive = AdaptiveModel(
+    models=[...],
+    selector=selector,
+    state=AdaptiveState()  # Shared state
+)
+agent = Agent(adaptive)
+
+# All runs share the same model instance and state
+result1 = await agent.run('query 1')  # Uses shared state
+result2 = await agent.run('query 2')  # Same state persists
+
+# State persists: throttling, call counts, etc. are maintained
+```
+
+### Per-User State (API Sessions)
+
+For multi-user applications, create a model instance per user:
+
+```python
+# Model instance per user
+user_models: dict[str, AdaptiveModel] = {}
+
+async def api_endpoint(user_id: str, query: str):
+    # Get or create model for this user
+    if user_id not in user_models:
+        user_models[user_id] = AdaptiveModel(
+            models=[...],
+            selector=selector,
+            state=AdaptiveState(user_tier='premium')
+        )
+
+    agent = Agent(user_models[user_id])
+    result = await agent.run(query)
+    return result.output
+```
+
+**Key Differences:**
+
+| Pattern | Model Lifetime | Use Case |
+|---------|---------------|----------|
+| **Per-Run** | New instance per run | Retry logic within one request |
+| **Global** | Single instance | Throttling, load balancing, system-wide quotas |
+| **Per-User** | Instance per user | User-specific quotas, preferences, history |
+
+## Use Cases
+
+### 1. Throttling with Timeout (Global State)
+
+Handle rate limiting by timing out models for 30 seconds after throttling errors.
+
+⚠️ **Concurrency:** This example uses shared state across concurrent requests with proper locking.
+
+```python
+import asyncio
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+# Models managed by selector (via closure)
+models = [primary, secondary, tertiary]
+
+@dataclass
+class ThrottleState:
+    throttled_models: dict[int, datetime] = field(default_factory=dict)  # model_id -> timestamp
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+async def on_throttle_error(
+    state: ThrottleState,
+    model: Model,
+    exception: Exception,
+    timestamp: datetime,
+    duration: timedelta
+) -> bool:
+    """Hook: Record throttled models and decide whether to continue."""
+    if 'throttl' in str(exception).lower():
+        async with state.lock:
+            state.throttled_models[id(model)] = timestamp
+        return True  # Continue trying other models
+    return False  # Stop on non-throttle errors
+
+async def throttle_aware_selector(ctx: AdaptiveContext[ThrottleState]) -> Model:
+    """Selector: Choose first available non-throttled model."""
+    async with ctx.state.lock:
+        now = datetime.now()
+        # Find first available model
+        for model in models:
+            model_id = id(model)
+            if model_id in ctx.state.throttled_models:
+                if (now - ctx.state.throttled_models[model_id]).total_seconds() < 30:
+                    continue
+                del ctx.state.throttled_models[model_id]
+            return model
+
+        # All throttled - wait for soonest available
+        if ctx.state.throttled_models and len(ctx.attempts) < 10:
+            soonest = min(ctx.state.throttled_models.items(), key=lambda x: x[1])
+            wait_time = 30 - (now - soonest[1]).total_seconds()
+            if wait_time > 0:
+                # Release lock during sleep
+                pass
+        else:
+            raise RuntimeError("All models throttled")
+
+    # Sleep outside lock
+    if wait_time > 0:
+        await asyncio.sleep(wait_time)
+        async with ctx.state.lock:
+            del ctx.state.throttled_models[soonest[0]]
+            return next(m for m in models if id(m) == soonest[0])
+
+    raise RuntimeError("All models throttled")
+
+adaptive = AdaptiveModel(
+    selector=throttle_aware_selector,
+    state=ThrottleState(),
+    on_attempt_failed=on_throttle_error,
+)
+
+# Reuse same model instance - state persists across runs
+agent = Agent(adaptive)
+
+result1 = await agent.run('query 1')  # Uses shared throttle state
+result2 = await agent.run('query 2')  # Same state persists
+```
+
+**Benefits of using hook:**
+- ✅ Hook decides whether to continue based on exception type
+- ✅ Selector focuses on selection logic only
+- ✅ Cleaner separation of concerns
+- ✅ Lock ensures thread-safe state updates
+
+### 2. Load Balancing (Global State)
+
+Distribute requests evenly across multiple accounts/instances.
+
+⚠️ **Concurrency:** This example uses shared state across concurrent requests with proper locking.
+
+```python
+# Models managed by selector (via closure)
+models = [
+    OpenAIChatModel('gpt-4o', api_key=key1),
+    OpenAIChatModel('gpt-4o', api_key=key2),
+]
+
+@dataclass
+class LoadBalanceState:
+    call_counts: dict[int, int] = field(default_factory=dict)  # model_id -> count
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+async def round_robin_selector(ctx: AdaptiveContext[LoadBalanceState]) -> Model:
+    async with ctx.state.lock:
+        if not ctx.attempts:
+            # Use least-used model
+            model = min(models, key=lambda m: ctx.state.call_counts.get(id(m), 0))
+            ctx.state.call_counts[id(model)] = ctx.state.call_counts.get(id(model), 0) + 1
+            return model
+
+        # On retry, try next least-used
+        failed = {id(a.model) for a in ctx.attempts}
+        available = [m for m in models if id(m) not in failed]
+        if available:
+            return min(available, key=lambda m: ctx.state.call_counts.get(id(m), 0))
+        raise RuntimeError("All models failed")
+
+# Load balance across accounts
+adaptive = AdaptiveModel(
+    selector=round_robin_selector,
+    state=LoadBalanceState()  # Shared state in model
+)
+
+# Reuse same model instance - state persists across runs
+agent = Agent(adaptive)
+
+result1 = await agent.run('query 1')  # Uses account 1
+result2 = await agent.run('query 2')  # Uses account 2
+result3 = await agent.run('query 3')  # Uses account 1
+```
+
+### 3. User Tier-Based Selection (Per-User State)
+
+Route to different models based on user subscription level.
+
+⚠️ **Concurrency:** If the same user makes concurrent requests, add locking. Otherwise, per-user state is isolated.
+
+```python
+# Models managed by selector (via closure)
+models = [gpt35, gpt4mini, gpt4]
+
+@dataclass
+class UserState:
+    tier: str  # 'free', 'pro', 'enterprise'
+    monthly_tokens_used: int
+    monthly_token_limit: int
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)  # For concurrent requests from same user
+
+async def tier_based_selector(ctx: AdaptiveContext[UserState]) -> Model:
+    async with ctx.state.lock:
+        user = ctx.state
+
+        if not ctx.attempts:
+            if user.tier == 'enterprise':
+                return next((m for m in models if 'gpt-4o' in m.model_name), models[0])
+            elif user.tier == 'pro':
+                # Check usage limits
+                if user.monthly_tokens_used < user.monthly_token_limit * 0.9:
+                    return next((m for m in models if 'gpt-4o-mini' in m.model_name), models[0])
+                return next((m for m in models if 'gpt-3.5' in m.model_name), models[0])
+            else:
+                return next((m for m in models if 'gpt-3.5' in m.model_name), models[0])
+
+        # Retry with next model
+        tried = {id(a.model) for a in ctx.attempts}
+        available = [m for m in models if id(m) not in tried]
+        if available:
+            return available[0]
+        raise RuntimeError("All models failed")
+
+# Per-user model instances in API endpoint
+user_models: dict[str, AdaptiveModel] = {}
+
+async def api_endpoint(user_id: str, query: str):
+    if user_id not in user_models:
+        user_models[user_id] = AdaptiveModel(
+            selector=tier_based_selector,
+            state=UserState(tier='pro', monthly_tokens_used=80000, monthly_token_limit=100000)
+        )
+
+    agent = Agent(user_models[user_id])
+    result = await agent.run(query)
+    return result.output
+```
+
+### 4. Cost-Optimized with Quality Fallback (Global State)
+
+Start with cheap models, upgrade if quality is insufficient.
+
+⚠️ **Concurrency:** This example uses shared state across concurrent requests with proper locking.
+
+```python
+# Models managed by selector (via closure), sorted by cost
+models = [gpt35, gpt4mini, gpt4]
+
+@dataclass
+class QualityState:
+    quality_threshold: float = 0.8
+    model_history: dict[str, list[float]] = field(default_factory=dict)  # model -> quality scores
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+async def cost_quality_selector(ctx: AdaptiveContext[QualityState]) -> Model:
+    async with ctx.state.lock:
+        if not ctx.attempts:
+            # Check if cheap model historically meets quality threshold
+            cheap_model = models[0]
+            avg_quality = (
+                sum(ctx.state.model_history.get(cheap_model.model_name, [1.0])) /
+                len(ctx.state.model_history.get(cheap_model.model_name, [1.0]))
+            )
+
+            if avg_quality >= ctx.state.quality_threshold:
+                return cheap_model
+            # Quality too low, start with better model
+            return models[1] if len(models) > 1 else cheap_model
+
+        # Upgrade on failure
+        tried = {id(a.model) for a in ctx.attempts}
+        available = [m for m in models if id(m) not in tried]
+        if available:
+            return available[0]
+        raise RuntimeError("All models failed")
+
+async def on_success_track_quality(
+    state: QualityState,
+    model: Model,
+    response: ModelResponse,
+    timestamp: datetime,
+    duration: timedelta
+):
+    """Hook: Track quality metrics."""
+    quality_score = await evaluate_response_quality(response)
+    async with state.lock:
+        if model.model_name not in state.model_history:
+            state.model_history[model.model_name] = []
+        state.model_history[model.model_name].append(quality_score)
+        # Keep only last 100 scores
+        state.model_history[model.model_name] = state.model_history[model.model_name][-100:]
+
+adaptive = AdaptiveModel(
+    selector=cost_quality_selector,
+    state=QualityState(),
+    on_attempt_succeeded=on_success_track_quality  # Automatic quality tracking
+)
+
+# Reuse same model instance - quality history persists
+agent = Agent(adaptive)
+
+result = await agent.run('query')
+```
+
+### 5. Smart Retry with Exponential Backoff (Per-Run State)
+
+Retry same model with backoff for transient errors, fallback for permanent errors.
+
+```python
+import asyncio
+from typing import Any
+
+# Models managed by selector (via closure)
+models = [primary, backup]
+
+def on_failure_check(state: Any, model: Model, exception: Exception, timestamp: datetime, duration: timedelta) -> bool:
+    """Decide whether to retry based on exception type."""
+    # Only retry on transient errors (5xx)
+    is_transient = (
+        hasattr(exception, 'status_code') and
+        500 <= exception.status_code < 600
+    )
+    return is_transient  # True = continue, False = stop
+
+async def exponential_backoff_selector(ctx: AdaptiveContext[Any]) -> Model:
+    # No state needed - retry logic is per-run only
+    if not ctx.attempts:
+        return models[0]
+
+    last = ctx.attempts[-1]
+    is_transient = (
+        last.exception and
+        hasattr(last.exception, 'status_code') and
+        500 <= last.exception.status_code < 600
+    )
+
+    if is_transient and len(ctx.attempts) <= 5:
+        # Exponential backoff: 1s, 2s, 4s, 8s, 16s
+        await asyncio.sleep(2 ** (len(ctx.attempts) - 1))
+        return last.model  # Retry same model
+
+    # Try different model
+    tried = {id(a.model) for a in ctx.attempts}
+    available = [m for m in models if id(m) not in tried]
+    if available:
+        return available[0]
+    raise RuntimeError("All models failed")
+
+adaptive = AdaptiveModel(
+    selector=exponential_backoff_selector,
+    on_attempt_failed=on_failure_check  # Stop on non-transient errors
+    # No state parameter - defaults to empty dict
+)
+
+agent = Agent(adaptive)
+# Each run has independent retry logic based on ctx.attempts
+result = await agent.run('query')
+```
+
+### 6. Context Length-Based Model Upgrade (Per-Run State)
+
+Automatically upgrade to a long-context model when conversation exceeds a threshold.
+
+```python
+from typing import Any
+
+# Models sorted by context length capability
+models = [
+    OpenAIChatModel('gpt-4o-mini'),           # 128K context
+    OpenAIChatModel('gpt-4o'),                # 128K context
+    AnthropicModel('claude-3-7-sonnet-latest'),  # 1M context
+]
+
+def context_aware_selector(ctx: AdaptiveContext[Any]) -> Model:
+    """Upgrade to long-context model when conversation gets large."""
+    # No state needed - decision based on current message count only
+
+    message_count = len(ctx.messages)
+
+    if not ctx.attempts:
+        # First attempt - choose based on context size
+        if message_count > 50:
+            # Use long-context model for large conversations
+            return next((m for m in models if 'claude-3-7-sonnet' in m.model_name), models[0])
+        else:
+            # Use standard model for normal conversations
+            return next((m for m in models if 'gpt-4o-mini' in m.model_name), models[0])
+
+    # On retry, try next available model
+    tried = {id(a.model) for a in ctx.attempts}
+    available = [m for m in models if id(m) not in tried]
+    if available:
+        return available[0]
+    raise RuntimeError("All models failed")
+
+adaptive = AdaptiveModel(
+    selector=context_aware_selector
+    # No state parameter - decision based on message count only
+)
+
+agent = Agent(adaptive)
+
+# Short conversation uses cheap model
+result1 = agent.run_sync('Hello')  # Uses gpt-4o-mini
+
+# Long conversation automatically upgrades
+messages = result1.new_messages()
+for i in range(60):
+    result = agent.run_sync(f'Message {i}', message_history=messages)
+    messages = result.new_messages()
+# Automatically switched to claude-3-7-sonnet due to message count
+```
+
+### 7. Self-Directed Model Selection via Tool (Per-Run State)
+
+Agent dynamically selects its own model for the next cycle based on task complexity.
+
+```python
+from pydantic import BaseModel
+from typing import Any, Literal
+
+# Models managed by selector (via closure)
+models = [
+    OpenAIChatModel('gpt-4o'),           # Default balanced
+    OpenAIChatModel('gpt-5-mini'),       # Fast, simple tasks
+    OpenAIChatModel('gpt-5', model_settings=ModelSettings(reasoning_level='medium')),  # Complex tasks
+]
+
+class NextModelHint(BaseModel):
+    """Tool for agent to request specific model characteristics for next cycle."""
+    reasoning_level: Literal['minimal', 'medium', 'high']
+    complexity: Literal['simple', 'complex']
+
+def self_directed_selector(ctx: AdaptiveContext[Any]) -> Model:
+    """Select model based on agent's own hint from previous cycle."""
+    # No state needed - decision based on message history only
+
+    # Look for hint in last response
+    if ctx.messages and isinstance(last_msg := ctx.messages[-1], ModelResponse):
+        for part in last_msg.parts:
+            if isinstance(part, ToolCallPart) and part.tool_name == 'next_model_hint':
+                args = part.args_as_dict()
+
+                # Agent requested high reasoning for complex task
+                if args.get('reasoning_level') == 'high' and args.get('complexity') == 'complex':
+                    return next((m for m in models if 'gpt-5' in m.model_name), models[0])
+
+                # Agent requested minimal reasoning for simple task
+                if args.get('reasoning_level') == 'minimal':
+                    return next((m for m in models if 'gpt-5-mini' in m.model_name), models[1])
+
+    # Default to balanced model
+    return models[0]
+
+adaptive = AdaptiveModel(
+    selector=self_directed_selector
+    # No state parameter - decision based on message history only
+)
+
+agent = Agent(adaptive)
+
+@agent.tool
+def next_model_hint(ctx: RunContext, reasoning_level: str, complexity: str) -> str:
+    """Request specific model for next cycle. Always call with other tools."""
+    return f"Will use {reasoning_level} reasoning, {complexity} model next cycle"
+
+# Agent decides its own model per cycle:
+# Cycle 1: "I need to generate complex SQL" → calls next_model_hint(reasoning_level='high', complexity='complex')
+# Cycle 2: Uses gpt-5 with medium reasoning for SQL generation
+# Cycle 3: "Just checking if embeddings exist" → calls next_model_hint(reasoning_level='minimal', complexity='simple')
+# Cycle 4: Uses gpt-5-mini for fast simple check
+```
+
+**Key Benefits:**
+- Agent self-optimizes based on task complexity it discovers
+- No external orchestration needed
+- Works within standard ReAct flow
+- Hint tool runs in parallel with other tools (no extra cycle)
+
+### 8. Account Quota Management (Global State)
+
+Rotate across accounts based on remaining quota.
+
+⚠️ **Concurrency:** This example uses shared state across concurrent requests with proper locking.
+
+```python
+from datetime import datetime
+
+# Models managed by selector (via closure)
+models = [
+    OpenAIChatModel('gpt-4o', api_key=key1),
+    OpenAIChatModel('gpt-4o', api_key=key2),
+    OpenAIChatModel('gpt-4o', api_key=key3),
+]
+
+@dataclass
+class AccountPool:
+    accounts: dict[str, dict]  # account_id -> {api_key, quota_remaining, quota_limit, reset_time}
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def get_available_account(self) -> str | None:
+        async with self.lock:
+            now = datetime.now()
+            for account_id, info in self.accounts.items():
+                if now >= info['reset_time']:
+                    info['quota_remaining'] = info['quota_limit']
+                if info['quota_remaining'] > 0:
+                    return account_id
+            return None
+
+async def quota_rotation_selector(ctx: AdaptiveContext[AccountPool]) -> Model:
+    tried = {id(a.model) for a in ctx.attempts}
+
+    account_id = await ctx.state.get_available_account()
+    if not account_id:
+        raise RuntimeError("No accounts with available quota")
+
+    # Find model for this account that hasn't been tried
+    async with ctx.state.lock:
+        model = next(
+            (m for m in models
+             if hasattr(m, 'api_key') and m.api_key == ctx.state.accounts[account_id]['api_key']
+             and id(m) not in tried),
+            None
+        )
+        if model:
+            return model
+        raise RuntimeError("All accounts exhausted")
+
+async def on_success_deduct_quota(
+    state: AccountPool,
+    model: Model,
+    response: ModelResponse,
+    timestamp: datetime,
+    duration: timedelta
+):
+    """Hook: Deduct tokens from quota."""
+    tokens_used = response.usage.total_tokens if response.usage else 0
+    async with state.lock:
+        for account_id, info in state.accounts.items():
+            if hasattr(model, 'api_key') and model.api_key == info['api_key']:
+                info['quota_remaining'] -= tokens_used
+                break
+
+adaptive = AdaptiveModel(
+    selector=quota_rotation_selector,
+    state=AccountPool(accounts={
+        'account1': {'api_key': key1, 'quota_remaining': 100000, 'quota_limit': 100000, 'reset_time': datetime(2025, 12, 1)},
+        'account2': {'api_key': key2, 'quota_remaining': 50000, 'quota_limit': 100000, 'reset_time': datetime(2025, 12, 1)},
+    }),
+    on_attempt_succeeded=on_success_deduct_quota  # Automatic quota deduction
+)
+
+# Reuse same model instance - quotas tracked across all requests
+agent = Agent(adaptive)
+
+result = await agent.run('query')
+# State persists: quotas are tracked and deducted automatically
+```
+
+## Key Benefits
+
+1. **Full Control**: Custom logic for model selection based on any criteria
+2. **Stateful Logic**: Maintain state across calls (throttle timers, usage counts, quality metrics)
+3. **Smart Waiting**: Wait for throttled models instead of giving up
+4. **Load Distribution**: Balance across identical models on different accounts
+5. **User-Aware**: Access agent dependencies for user-specific routing
+6. **Cost Optimization**: Dynamic model selection based on cost, quality, and usage
+7. **Complex Retry**: Implement exponential backoff, circuit breakers, etc.
+
+## State Pattern Summary
+
+State is managed at the `AdaptiveModel` level, not passed through the Agent. This provides three distinct usage patterns based on model instance lifetime:
+
+### When to Use Each Pattern
+
+**Per-Run State (Isolated):**
+- ✅ Retry logic within a single request
+- ✅ Context-based decisions (message count, complexity)
+- ✅ No cross-request coordination needed
+- Example: Exponential backoff, context length upgrades
+
+**Global State (Shared):**
+- ✅ System-wide throttling and rate limiting
+- ✅ Load balancing across accounts
+- ✅ Cross-request metrics and quality tracking
+- Example: Throttle timers, call counts, quotas
+
+**Per-User State (Session):**
+- ✅ User-specific quotas and limits
+- ✅ User tier-based routing
+- ✅ Per-user preferences and history
+- Example: API endpoints with user sessions
+
+### Implementation Pattern
+
+```python
+# 1. Define state type
+@dataclass
+class MyState:
+    field1: str
+    field2: int
+
+# 2. Create adaptive model with state
+adaptive = AdaptiveModel(
+    models=[...],
+    selector=my_selector,
+    state=MyState()  # State lives in model
+)
+
+# 3. Use the model - no changes to Agent API
+agent = Agent(adaptive)
+
+# Per-run: create new model instance each time
+def run_isolated(query: str):
+    adaptive = AdaptiveModel(models=[...], selector=my_selector, state=MyState())
+    agent = Agent(adaptive)
+    return agent.run_sync(query)
+
+# Global: reuse same model instance
+global_adaptive = AdaptiveModel(models=[...], selector=my_selector, state=MyState())
+global_agent = Agent(global_adaptive)
+result1 = await global_agent.run('query1')  # Shared state
+result2 = await global_agent.run('query2')  # Same state persists
+
+# Per-user: model instance per user
+user_models: dict[str, AdaptiveModel] = {}
+if user_id not in user_models:
+    user_models[user_id] = AdaptiveModel(models=[...], selector=my_selector, state=MyState())
+agent = Agent(user_models[user_id])
+result = await agent.run('query')
+```
+
+## Comparison with FallbackModel
+
+| Feature | FallbackModel | AdaptiveModel |
+|---------|--------------|---------------|
+| Model Selection | Sequential | Custom logic |
+| State Management | None | Per-run, global, or per-user |
+| Wait/Retry Logic | Not supported | Full control (async sleep) |
+| Load Balancing | Not supported | Supported |
+| Context Access | None | Messages, attempts, state |
+| Complexity | Simple | Flexible |
+
+`AdaptiveModel` complements `FallbackModel` by supporting sophisticated routing scenarios while `FallbackModel` remains the simpler choice for basic sequential fallback.

--- a/fallback_via_adaptive.py
+++ b/fallback_via_adaptive.py
@@ -1,0 +1,109 @@
+"""Reimplementation of FallbackModel using AdaptiveModel to test flexibility.
+
+This demonstrates that AdaptiveModel can fully replicate FallbackModel's behavior
+while being more composable and flexible.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+from pydantic_ai_slim.pydantic_ai.models import Model, infer_model
+from pydantic_ai_slim.pydantic_ai.models.adaptive import AdaptiveContext, AdaptiveModel
+
+if TYPE_CHECKING:
+    from pydantic_ai_slim.pydantic_ai.exceptions import ModelHTTPError
+
+
+@dataclass
+class FallbackState:
+    """State for fallback model selection."""
+
+    models: list[Model]
+    fallback_on: Callable[[Exception], bool] | None = None
+    current_index: int = 0
+
+
+def fallback_selector(ctx: AdaptiveContext[FallbackState]) -> Model:
+    """Select the next model in the fallback sequence."""
+    state = ctx.state
+
+    # If this is the first attempt, start with the first model
+    if len(ctx.attempts) == 0:
+        state.current_index = 0
+        return state.models[0]
+
+    # Move to next model
+    state.current_index += 1
+    if state.current_index < len(state.models):
+        return state.models[state.current_index]
+    else:
+        # No more models to try
+        raise RuntimeError(f"All {len(state.models)} models failed")
+
+
+def on_attempt_failed(
+    state: FallbackState,
+    model: Model,
+    exception: Exception,
+    timestamp: datetime,
+    duration: timedelta,
+) -> bool:
+    """Decide whether to continue trying after a failure.
+
+    Returns True if the exception should trigger a fallback, False to stop immediately.
+    """
+    return state.fallback_on(exception)
+
+
+def create_fallback_model(
+    default_model: Model | str,
+    *fallback_models: Model | str,
+    fallback_on: Callable[[Exception], bool] | tuple[type[Exception], ...] = None,
+) -> AdaptiveModel[FallbackState]:
+    """Create a FallbackModel using AdaptiveModel.
+
+    Args:
+        default_model: The name or instance of the default model to use.
+        fallback_models: The names or instances of the fallback models to use upon failure.
+        fallback_on: A callable or tuple of exceptions that should trigger a fallback.
+            Defaults to ModelHTTPError.
+
+    Returns:
+        An AdaptiveModel configured to behave like FallbackModel.
+    """
+    # Convert all models
+    models = [infer_model(default_model), *[infer_model(m) for m in fallback_models]]
+
+    # Handle fallback_on parameter
+    if fallback_on is None:
+        # Default to ModelHTTPError
+        from pydantic_ai_slim.pydantic_ai.exceptions import ModelHTTPError
+
+        fallback_on_callable = lambda exc: isinstance(exc, ModelHTTPError)
+    elif isinstance(fallback_on, tuple):
+        # Convert tuple of exceptions to callable
+        fallback_on_callable = lambda exc: isinstance(exc, fallback_on)
+    else:
+        fallback_on_callable = fallback_on
+
+    # Create state
+    state = FallbackState(models=models, fallback_on=fallback_on_callable)
+
+    # Create adaptive model with failure hook
+    return AdaptiveModel(
+        selector=fallback_selector,
+        state=state,
+        on_attempt_failed=on_attempt_failed,
+    )
+
+
+# Example usage comparison:
+if __name__ == "__main__":
+    print("Fallback via Adaptive implementation loaded successfully!")
+    print("\nUsage:")
+    print("  model = create_fallback_model('openai:gpt-4o', 'anthropic:claude-3-5-sonnet')")
+    print("\nThis demonstrates AdaptiveModel can fully replicate FallbackModel behavior.")

--- a/pydantic_ai_slim/pydantic_ai/models/adaptive.py
+++ b/pydantic_ai_slim/pydantic_ai/models/adaptive.py
@@ -1,30 +1,32 @@
 from __future__ import annotations as _annotations
 
 import inspect
-import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass
+from datetime import datetime, timedelta
+from functools import cached_property
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from opentelemetry.trace import get_current_span
 
-from pydantic_ai._run_context import RunContext
 from pydantic_ai.models.instrumented import InstrumentedModel
 
 from ..exceptions import FallbackExceptionGroup
-from ..settings import merge_model_settings
+from ..profiles import ModelProfile
 from . import Model, ModelRequestParameters, StreamedResponse
 
 if TYPE_CHECKING:
+    from pydantic_ai._run_context import RunContext
+
     from ..messages import ModelMessage, ModelResponse
     from ..settings import ModelSettings
 
-AgentDepsT = TypeVar('AgentDepsT')
+StateT = TypeVar('StateT')
 
 
 @dataclass
-class AttemptResult:
+class Attempt:
     """Record of a single attempt to use a model."""
 
     model: Model
@@ -33,28 +35,22 @@ class AttemptResult:
     exception: Exception | None
     """The exception raised by the model, if any."""
 
-    timestamp: float
-    """Unix timestamp when the attempt was made."""
+    timestamp: datetime
+    """When the attempt was made."""
 
-    duration: float
-    """Duration of the attempt in seconds."""
+    duration: timedelta
+    """Duration of the attempt."""
 
 
 @dataclass
-class AdaptiveContext(Generic[AgentDepsT]):
+class AdaptiveContext(Generic[StateT]):
     """Context provided to the selector function."""
 
-    run_context: RunContext[AgentDepsT] | None
-    """Access to agent dependencies. May be None for non-streaming requests."""
+    state: StateT
+    """User-defined state object for the selector."""
 
-    models: Sequence[Model]
-    """Available models to choose from."""
-
-    attempts: list[AttemptResult]
+    attempts: list[Attempt]
     """History of attempts in this request."""
-
-    attempt_number: int
-    """Current attempt number (1-indexed)."""
 
     messages: list[ModelMessage]
     """The original request messages."""
@@ -67,65 +63,102 @@ class AdaptiveContext(Generic[AgentDepsT]):
 
 
 @dataclass(init=False)
-class AdaptiveModel(Model, Generic[AgentDepsT]):
+class AdaptiveModel(Model, Generic[StateT]):
     """A model that uses custom logic to select which model to try next.
 
     Unlike FallbackModel which tries models sequentially, AdaptiveModel gives
     full control over model selection based on rich context including attempts,
-    exceptions, and agent dependencies.
+    exceptions, and custom state.
 
     The selector function is called before each attempt and can:
     - Return a Model to try next (can be the same model for retry)
-    - Return None to stop trying
+    - Raise an exception to stop trying
     - Use async/await for delays (exponential backoff, etc.)
-    - Access agent dependencies via ctx.run_context.deps
+    - Access custom state via ctx.state
     - Inspect previous attempts via ctx.attempts
+
+    Lifecycle hooks provide clean separation of concerns:
+    - on_attempt_failed: Called after each failed attempt. Returns bool to continue (True) or stop (False).
+    - on_attempt_succeeded: Called after successful attempt (for metrics, quota tracking)
     """
 
-    models: Sequence[Model]
-    _selector: (
-        Callable[[AdaptiveContext[AgentDepsT]], Model | None]
-        | Callable[[AdaptiveContext[AgentDepsT]], Awaitable[Model | None]]
+    _selector: Callable[[AdaptiveContext[StateT]], Model] | Callable[[AdaptiveContext[StateT]], Awaitable[Model]]
+    _state: StateT
+    _on_attempt_failed: (
+        Callable[[StateT, Model, Exception, datetime, timedelta], bool]
+        | Callable[[StateT, Model, Exception, datetime, timedelta], Awaitable[bool]]
+        | None
     )
-    _max_attempts: int | None
+    _on_attempt_succeeded: (
+        Callable[[StateT, Model, ModelResponse, datetime, timedelta], None]
+        | Callable[[StateT, Model, ModelResponse, datetime, timedelta], Awaitable[None]]
+        | None
+    )
 
     def __init__(
         self,
-        models: Sequence[Model],
-        selector: Callable[[AdaptiveContext[AgentDepsT]], Model | None]
-        | Callable[[AdaptiveContext[AgentDepsT]], Awaitable[Model | None]],
+        selector: Callable[[AdaptiveContext[StateT]], Model] | Callable[[AdaptiveContext[StateT]], Awaitable[Model]],
         *,
-        max_attempts: int | None = None,
+        state: StateT | None = None,
+        on_attempt_failed: (
+            Callable[[StateT, Model, Exception, datetime, timedelta], bool]
+            | Callable[[StateT, Model, Exception, datetime, timedelta], Awaitable[bool]]
+            | None
+        ) = None,
+        on_attempt_succeeded: (
+            Callable[[StateT, Model, ModelResponse, datetime, timedelta], None]
+            | Callable[[StateT, Model, ModelResponse, datetime, timedelta], Awaitable[None]]
+            | None
+        ) = None,
     ):
         """Initialize an adaptive model instance.
 
         Args:
-            models: Pool of models to choose from.
             selector: Sync or async function that selects the next model to try.
                 Called before each attempt with context including previous attempts.
-                Return a Model to try, or None to stop.
-            max_attempts: Maximum total attempts across all models (None = unlimited).
+                Must return a Model. Raise an exception to stop trying.
+                The selector manages its own pool of models (via closure, state, etc.).
+            state: State object passed to selector. If None, an empty dict is used.
+                Reuse the same AdaptiveModel instance to share state across runs.
+                Create new instances for isolated state.
+            on_attempt_failed: Optional sync or async hook called after each failed attempt.
+                Receives (state, model, exception, timestamp, duration).
+                Must return bool: True to continue trying, False to stop and re-raise the exception.
+                Use for conditional retry logic, throttling detection, error tracking.
+            on_attempt_succeeded: Optional sync or async hook called after successful attempt.
+                Receives (state, model, response, timestamp, duration).
+                Use for quality tracking, quota deduction, metrics collection.
         """
         super().__init__()
-        if not models:
-            raise ValueError('At least one model must be provided')
-
-        self.models = list(models)
         self._selector = selector
-        self._max_attempts = max_attempts
+        self._state = state if state is not None else {}  # type: ignore
+        self._on_attempt_failed = on_attempt_failed
+        self._on_attempt_succeeded = on_attempt_succeeded
 
     @property
     def model_name(self) -> str:
         """The model name."""
-        return f'adaptive:{",".join(model.model_name for model in self.models)}'
+        return 'adaptive'
 
     @property
     def system(self) -> str:
-        return f'adaptive:{",".join(model.system for model in self.models)}'
+        return 'adaptive'
 
     @property
     def base_url(self) -> str | None:
-        return self.models[0].base_url if self.models else None
+        return None
+
+    @cached_property
+    def profile(self) -> ModelProfile:
+        raise NotImplementedError('AdaptiveModel does not have its own model profile.')
+
+    def customize_request_parameters(self, model_request_parameters: ModelRequestParameters) -> ModelRequestParameters:
+        return model_request_parameters
+
+    def prepare_request(
+        self, model_settings: ModelSettings | None, model_request_parameters: ModelRequestParameters
+    ) -> tuple[ModelSettings | None, ModelRequestParameters]:
+        return model_settings, model_request_parameters
 
     async def request(
         self,
@@ -133,71 +166,66 @@ class AdaptiveModel(Model, Generic[AgentDepsT]):
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
     ) -> ModelResponse:
-        """Try models based on selector logic until one succeeds or selector returns None."""
-        attempts: list[AttemptResult] = []
-        attempt_number = 0
+        """Try models based on selector logic until one succeeds."""
+        attempts: list[Attempt] = []
 
         while True:
-            attempt_number += 1
-
-            # Check max attempts
-            if self._max_attempts is not None and attempt_number > self._max_attempts:
-                exceptions = [a.exception for a in attempts if a.exception is not None]
-                if exceptions:
-                    raise FallbackExceptionGroup(
-                        f'AdaptiveModel exceeded max_attempts of {self._max_attempts}', exceptions
-                    )
-                else:
-                    raise FallbackExceptionGroup(
-                        f'AdaptiveModel exceeded max_attempts of {self._max_attempts}',
-                        [RuntimeError('No models were attempted')],
-                    )
-
-            # Create context for selector
-            context = AdaptiveContext(
-                run_context=None,  # run_context not available in non-streaming request
-                models=self.models,
-                attempts=attempts,
-                attempt_number=attempt_number,
-                messages=messages,
-                model_settings=model_settings,
-                model_request_parameters=model_request_parameters,
-            )
-
             # Call selector to get next model
-            model = await self._call_selector(context)
-
-            if model is None:
-                # Selector says stop trying
-                exceptions = [a.exception for a in attempts if a.exception is not None]
-                if exceptions:
-                    raise FallbackExceptionGroup('AdaptiveModel selector returned None', exceptions)
-                else:
-                    raise FallbackExceptionGroup(
-                        'AdaptiveModel selector returned None', [RuntimeError('No models were attempted')]
+            try:
+                model = await self._call_selector(
+                    AdaptiveContext(
+                        state=self._state,
+                        attempts=attempts,
+                        messages=messages,
+                        model_settings=model_settings,
+                        model_request_parameters=model_request_parameters,
                     )
+                )
+            except Exception as exc:
+                # Selector raised an exception - stop trying
+                exceptions = [a.exception for a in attempts if a.exception is not None]
+                raise FallbackExceptionGroup(
+                    'AdaptiveModel selector raised an exception',
+                    exceptions + [exc],
+                ) from exc
 
             # Try the selected model
-            start_time = time.time()
-            customized_params = model.customize_request_parameters(model_request_parameters)
-            merged_settings = merge_model_settings(model.settings, model_settings)
+            start_time = datetime.now()
+            _, prepared_params = model.prepare_request(model_settings, model_request_parameters)
 
             try:
-                response = await model.request(messages, merged_settings, customized_params)
-                # Success! Set span attributes and return
-                self._set_span_attributes(model)
+                response = await model.request(messages, model_settings, model_request_parameters)
+                # Success! Set span attributes and call success hook
+                duration = datetime.now() - start_time
+                self._set_span_attributes(model, prepared_params)
+
+                if self._on_attempt_succeeded is not None:
+                    await self._call_hook(
+                        self._on_attempt_succeeded, self._state, model, response, start_time, duration
+                    )
+
                 return response
             except Exception as exc:
                 # Record the attempt
-                duration = time.time() - start_time
+                duration = datetime.now() - start_time
                 attempts.append(
-                    AttemptResult(
+                    Attempt(
                         model=model,
                         exception=exc,
                         timestamp=start_time,
                         duration=duration,
                     )
                 )
+
+                # Call failure hook to decide whether to continue
+                if self._on_attempt_failed is not None:
+                    should_continue = await self._call_hook(
+                        self._on_attempt_failed, self._state, model, exc, start_time, duration
+                    )
+                    if not should_continue:
+                        # Hook says stop - re-raise the exception
+                        raise exc
+
                 # Continue loop to try again
 
     @asynccontextmanager
@@ -206,92 +234,104 @@ class AdaptiveModel(Model, Generic[AgentDepsT]):
         messages: list[ModelMessage],
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
-        run_context: RunContext[AgentDepsT] | None = None,
+        run_context: RunContext | None = None,
     ) -> AsyncIterator[StreamedResponse]:
-        """Try models based on selector logic until one succeeds or selector returns None."""
-        attempts: list[AttemptResult] = []
-        attempt_number = 0
+        """Try models based on selector logic until one succeeds."""
+        attempts: list[Attempt] = []
 
         while True:
-            attempt_number += 1
-
-            # Check max attempts
-            if self._max_attempts is not None and attempt_number > self._max_attempts:
-                exceptions = [a.exception for a in attempts if a.exception is not None]
-                if exceptions:
-                    raise FallbackExceptionGroup(
-                        f'AdaptiveModel exceeded max_attempts of {self._max_attempts}', exceptions
-                    )
-                else:
-                    raise FallbackExceptionGroup(
-                        f'AdaptiveModel exceeded max_attempts of {self._max_attempts}',
-                        [RuntimeError('No models were attempted')],
-                    )
-
-            # Create context for selector
-            context = AdaptiveContext(
-                run_context=run_context,
-                models=self.models,
-                attempts=attempts,
-                attempt_number=attempt_number,
-                messages=messages,
-                model_settings=model_settings,
-                model_request_parameters=model_request_parameters,
-            )
-
             # Call selector to get next model
-            model = await self._call_selector(context)
-
-            if model is None:
-                # Selector says stop trying
-                exceptions = [a.exception for a in attempts if a.exception is not None]
-                if exceptions:
-                    raise FallbackExceptionGroup('AdaptiveModel selector returned None', exceptions)
-                else:
-                    raise FallbackExceptionGroup(
-                        'AdaptiveModel selector returned None', [RuntimeError('No models were attempted')]
+            try:
+                model = await self._call_selector(
+                    AdaptiveContext(
+                        state=self._state,
+                        attempts=attempts,
+                        messages=messages,
+                        model_settings=model_settings,
+                        model_request_parameters=model_request_parameters,
                     )
+                )
+            except Exception as exc:
+                # Selector raised an exception - stop trying
+                exceptions = [a.exception for a in attempts if a.exception is not None]
+                raise FallbackExceptionGroup(
+                    'AdaptiveModel selector raised an exception',
+                    exceptions + [exc],
+                ) from exc
 
             # Try the selected model
-            start_time = time.time()
-            customized_params = model.customize_request_parameters(model_request_parameters)
-            merged_settings = merge_model_settings(model.settings, model_settings)
+            start_time = datetime.now()
+            _, prepared_params = model.prepare_request(model_settings, model_request_parameters)
 
             async with AsyncExitStack() as stack:
                 try:
                     response = await stack.enter_async_context(
-                        model.request_stream(messages, merged_settings, customized_params, run_context)
+                        model.request_stream(messages, model_settings, model_request_parameters, run_context)
                     )
                 except Exception as exc:
-                    # Record the attempt and continue
-                    duration = time.time() - start_time
+                    # Record the attempt
+                    duration = datetime.now() - start_time
                     attempts.append(
-                        AttemptResult(
+                        Attempt(
                             model=model,
                             exception=exc,
                             timestamp=start_time,
                             duration=duration,
                         )
                     )
+
+                    # Call failure hook to decide whether to continue
+                    if self._on_attempt_failed is not None:
+                        should_continue = await self._call_hook(
+                            self._on_attempt_failed, self._state, model, exc, start_time, duration
+                        )
+                        if not should_continue:
+                            # Hook says stop - re-raise the exception
+                            raise exc
+
                     continue
 
                 # Success! Set span attributes and yield
-                self._set_span_attributes(model)
+                duration = datetime.now() - start_time
+                self._set_span_attributes(model, prepared_params)
+
+                # Note: We call the success hook here, but the response hasn't been fully consumed yet.
+                # For streaming, we don't have access to the final ModelResponse until the stream completes.
+                # This is a limitation of the streaming API - the hook is called when streaming starts.
+                if self._on_attempt_succeeded is not None:
+                    # For streaming, we pass the StreamedResponse wrapper
+                    # Users should be aware this is called before the stream is consumed
+                    await self._call_hook(
+                        self._on_attempt_succeeded, self._state, model, response, start_time, duration
+                    )  # type: ignore
+
                 yield response
                 return
 
-    async def _call_selector(self, context: AdaptiveContext[AgentDepsT]) -> Model | None:
+    async def _call_selector(self, context: AdaptiveContext[StateT]) -> Model:
         """Call the selector function, handling both sync and async."""
         if inspect.iscoroutinefunction(self._selector):
             return await self._selector(context)
         else:
             return self._selector(context)  # type: ignore
 
-    def _set_span_attributes(self, model: Model):
+    async def _call_hook(self, hook: Callable, *args) -> None:  # type: ignore
+        """Call a hook function, handling both sync and async."""
+        if inspect.iscoroutinefunction(hook):
+            await hook(*args)
+        else:
+            hook(*args)
+
+    def _set_span_attributes(self, model: Model, model_request_parameters: ModelRequestParameters):
         """Set OpenTelemetry span attributes for the successful model."""
         with suppress(Exception):
             span = get_current_span()
             if span.is_recording():
                 attributes = getattr(span, 'attributes', {})
                 if attributes.get('gen_ai.request.model') == self.model_name:  # pragma: no branch
-                    span.set_attributes(InstrumentedModel.model_attributes(model))
+                    span.set_attributes(
+                        {
+                            **InstrumentedModel.model_attributes(model),
+                            **InstrumentedModel.model_request_parameters_attributes(model_request_parameters),
+                        }
+                    )

--- a/tests/models/test_adaptive.py
+++ b/tests/models/test_adaptive.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from pydantic_ai import Agent, ModelHTTPError, ModelResponse, TextPart
+from pydantic_ai.models.adaptive import AdaptiveContext, AdaptiveModel
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+pytestmark = pytest.mark.anyio
+
+
+def success_response(messages, agent_info: AgentInfo) -> ModelResponse:
+    return ModelResponse(parts=[TextPart('success')])
+
+
+def failure_response(messages, agent_info: AgentInfo) -> ModelResponse:
+    raise ModelHTTPError(status_code=500, model_name='test-function-model', body={'error': 'test error'})
+
+
+success_model = FunctionModel(success_response)
+failure_model = FunctionModel(failure_response)
+
+
+async def test_basic_success():
+    """Test that adaptive model works with first model succeeding."""
+    models = [success_model]
+
+    def selector(ctx: AdaptiveContext) -> FunctionModel:
+        # First attempt - use first model
+        if not ctx.attempts:
+            return models[0]
+        raise RuntimeError('Should not retry on success')
+
+    adaptive = AdaptiveModel(selector=selector)
+    agent = Agent(model=adaptive)
+    result = await agent.run('hello')
+    assert result.output == 'success'
+
+
+async def test_fallback_to_second_model():
+    """Test fallback from failing model to success model."""
+    models = [failure_model, success_model]
+
+    def selector(ctx: AdaptiveContext) -> FunctionModel:
+        if not ctx.attempts:
+            # Try first model
+            return models[0]
+        elif len(ctx.attempts) == 1:
+            # First failed, try second
+            return models[1]
+        raise RuntimeError('All models exhausted')
+
+    adaptive = AdaptiveModel(selector=selector)
+    agent = Agent(model=adaptive)
+    result = await agent.run('hello')
+    assert result.output == 'success'
+
+
+async def test_retry_same_model():
+    """Test retrying the same model."""
+    call_count = 0
+
+    def counting_response(messages, agent_info: AgentInfo) -> ModelResponse:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ModelHTTPError(status_code=500, model_name='test', body={'error': 'first attempt'})
+        return ModelResponse(parts=[TextPart('success on retry')])
+
+    retry_model = FunctionModel(counting_response)
+    models = [retry_model]
+
+    def selector(ctx: AdaptiveContext) -> FunctionModel:
+        if len(ctx.attempts) < 2:
+            # Retry same model up to 2 times
+            return models[0]
+        raise RuntimeError('Max retries exceeded')
+
+    adaptive = AdaptiveModel(selector=selector)
+    agent = Agent(model=adaptive)
+    result = await agent.run('hello')
+    assert result.output == 'success on retry'
+    assert call_count == 2
+
+
+# test_max_attempts removed - max_attempts feature was removed from API
+# Users should implement their own limits in the selector
+
+
+async def test_selector_raises_exception():
+    """Test that selector raising exception stops the loop."""
+
+    def selector(ctx: AdaptiveContext) -> FunctionModel:
+        raise RuntimeError('No suitable model')  # Immediately give up
+
+    adaptive = AdaptiveModel(selector=selector)
+    agent = Agent(model=adaptive)
+
+    with pytest.raises(Exception) as exc_info:
+        await agent.run('hello')
+
+    assert 'selector raised an exception' in str(exc_info.value)
+
+
+async def test_attempts_history():
+    """Test that attempts history is correctly tracked."""
+    attempts_log = []
+    models = [failure_model, success_model]
+
+    def selector(ctx: AdaptiveContext) -> FunctionModel:
+        attempts_log.append(len(ctx.attempts))
+
+        if not ctx.attempts:
+            return models[0]  # Try failure model
+        elif len(ctx.attempts) == 1:
+            # Check first attempt was recorded
+            assert ctx.attempts[0].model == models[0]
+            assert ctx.attempts[0].exception is not None
+            assert isinstance(ctx.attempts[0].exception, ModelHTTPError)
+            assert ctx.attempts[0].duration.total_seconds() > 0
+            return models[1]  # Try success model
+        raise RuntimeError('All models exhausted')
+
+    adaptive = AdaptiveModel(selector=selector)
+    agent = Agent(model=adaptive)
+    result = await agent.run('hello')
+
+    assert result.output == 'success'
+    assert attempts_log == [0, 1]  # Called with 0 attempts, then 1 attempt
+
+
+async def test_async_selector():
+    """Test that async selectors work."""
+    models = [success_model]
+
+    async def async_selector(ctx: AdaptiveContext) -> FunctionModel:
+        await asyncio.sleep(0.01)  # Small async delay
+        if not ctx.attempts:
+            return models[0]
+        raise RuntimeError('Should not retry')
+
+    adaptive = AdaptiveModel(selector=async_selector)
+    agent = Agent(model=adaptive)
+    result = await agent.run('hello')
+    assert result.output == 'success'
+
+
+async def test_async_selector_with_backoff():
+    """Test exponential backoff with async selector."""
+    call_times = []
+
+    def time_tracking_response(messages, agent_info: AgentInfo) -> ModelResponse:
+        call_times.append(time.time())
+        if len(call_times) < 3:
+            raise ModelHTTPError(status_code=500, model_name='test', body={'error': 'retry'})
+        return ModelResponse(parts=[TextPart('success')])
+
+    retry_model = FunctionModel(time_tracking_response)
+    models = [retry_model]
+
+    async def backoff_selector(ctx: AdaptiveContext) -> FunctionModel:
+        if ctx.attempts:
+            # Exponential backoff: 0.01s, 0.02s
+            delay = 0.01 * (2 ** (len(ctx.attempts) - 1))
+            await asyncio.sleep(delay)
+
+        if len(ctx.attempts) < 3:
+            return models[0]
+        raise RuntimeError('Max retries exceeded')
+
+    adaptive = AdaptiveModel(selector=backoff_selector)
+    agent = Agent(model=adaptive)
+    result = await agent.run('hello')
+
+    assert result.output == 'success'
+    assert len(call_times) == 3
+
+    # Verify backoff delays
+    if len(call_times) >= 2:
+        delay1 = call_times[1] - call_times[0]
+        assert delay1 >= 0.01  # At least 10ms
+
+    if len(call_times) >= 3:
+        delay2 = call_times[2] - call_times[1]
+        assert delay2 >= 0.02  # At least 20ms
+
+
+async def test_context_has_correct_fields():
+    """Test that AdaptiveContext has all expected fields."""
+    models = [success_model]
+
+    def selector(ctx: AdaptiveContext) -> FunctionModel:
+        assert hasattr(ctx, 'state')
+        assert hasattr(ctx, 'attempts')
+        assert hasattr(ctx, 'messages')
+        assert hasattr(ctx, 'model_settings')
+        assert hasattr(ctx, 'model_request_parameters')
+
+        # Fields that were removed
+        assert not hasattr(ctx, 'models')  # Models are in closure now
+        assert not hasattr(ctx, 'attempt_number')  # Use len(attempts) instead
+        assert not hasattr(ctx, 'run_context')  # Replaced by state
+
+        assert len(ctx.attempts) == 0  # First attempt
+        assert len(ctx.messages) > 0
+
+        return models[0]
+
+    adaptive = AdaptiveModel(selector=selector)
+    agent = Agent(model=adaptive)
+    result = await agent.run('hello')
+    assert result.output == 'success'
+
+
+async def test_with_state():
+    """Test that state works correctly with selector."""
+
+    @dataclass
+    class MyState:
+        counter: int = 0
+
+    models_list = []
+
+    async def stream_response(messages, agent_info: AgentInfo) -> AsyncIterator[str]:
+        yield 'success'
+
+    stream_model = FunctionModel(stream_function=stream_response)
+    models_list.append(stream_model)
+
+    def selector(ctx: AdaptiveContext[MyState]) -> FunctionModel:
+        # Access state
+        assert isinstance(ctx.state, MyState)
+        ctx.state.counter += 1
+
+        if not ctx.attempts:
+            return models_list[0]
+        raise RuntimeError('Should not retry')
+
+    from collections.abc import AsyncIterator
+
+    my_state = MyState()
+    adaptive = AdaptiveModel(selector=selector, state=my_state)
+    agent = Agent(model=adaptive)
+
+    async with agent.run_stream('hello') as result:
+        text = await result.get_output()
+
+    assert text == 'success'
+    assert my_state.counter == 1  # Selector was called once
+
+
+async def test_streaming():
+    """Test that streaming works with adaptive model."""
+    from collections.abc import AsyncIterator
+
+    async def stream_response(messages, agent_info: AgentInfo) -> AsyncIterator[str]:
+        yield 'hello '
+        yield 'world'
+
+    stream_model = FunctionModel(stream_function=stream_response)
+    models = [stream_model]
+
+    def selector(ctx: AdaptiveContext) -> FunctionModel:
+        return models[0]
+
+    adaptive = AdaptiveModel(selector=selector)
+    agent = Agent(model=adaptive)
+
+    async with agent.run_stream('test') as result:
+        text = await result.get_output()
+        assert text == 'hello world'
+
+
+# test_empty_models_list removed - models parameter was removed from API
+
+
+async def test_model_name():
+    """Test that model_name is correctly formatted."""
+    adaptive = AdaptiveModel(selector=lambda ctx: success_model)
+    assert adaptive.model_name == 'adaptive'


### PR DESCRIPTION
_WIP: submitted code in POC stage_
_Based on discussions from https://github.com/pydantic/pydantic-ai/issues/3023_

`AdaptiveModel` is a new model type that provides full control over model selection at runtime. Unlike `FallbackModel` which tries models sequentially, `AdaptiveModel` allows custom logic to select the next model based on rich context including attempts, exceptions, and agent dependencies.


## Core API

```python
class AdaptiveModel[AgentDepsT](Model):
    def __init__(
        self,
        models: Sequence[Model],
        selector: Callable[[AdaptiveContext[AgentDepsT]], Model | None] 
                  | Callable[[AdaptiveContext[AgentDepsT]], Awaitable[Model | None]],
        *,
        max_attempts: int | None = None,
    ):
        """
        Args:
            models: Pool of models to choose from
            selector: Sync or async function that selects the next model to try
            max_attempts: Maximum total attempts across all models (None = unlimited)
        """
```

## Execution Flow

The `AdaptiveModel` automatically handles fallback and retry by:

1. Calling `selector(context)` to get the next model to try
2. Attempting the request with that model
3. If the request succeeds, returning the result
4. If the request fails:
   - Recording the attempt (model + exception) in `context.attempts`
   - Calling `selector(context)` again with updated context
   - If selector returns a `Model`, goto step 2 (retry/fallback)
   - If selector returns `None`, raise exception group with all failures
5. If `max_attempts` is reached, stop and raise exception group

The selector has **full control** over retry/fallback logic:
- Return the **same model** that failed → retry with same model
- Return a **different model** → fallback to another model  
- Return `None` → stop trying
- Inspect `ctx.attempts[-1].exception` to make decisions
- Use `time.sleep()` or `await asyncio.sleep()` for backoff/waiting (selector can be sync or async)

## Context

```python
@dataclass
class AdaptiveContext[AgentDepsT]:
    """Context provided to the selector function."""
    
    run_context: RunContext[AgentDepsT] | None  # Access to agent dependencies (None for non-streaming)
    models: Sequence[Model]  # Available models
    attempts: list[AttemptResult]  # History of attempts in this request
    attempt_number: int  # Current attempt number (1-indexed)
    messages: list[ModelMessage]  # The original request
    model_settings: ModelSettings | None
    model_request_parameters: ModelRequestParameters

@dataclass
class AttemptResult:
    """Record of a single attempt."""
    model: Model
    exception: Exception | None
    timestamp: float
    duration: float  # seconds
```

### Important Implementation Notes

**Agent Dependencies Availability:**
- `run_context` (and thus `ctx.run_context.deps`) is **only available in streaming mode** (`run_stream`)
  - For non-streaming requests (`run`, `run_sync`), `ctx.run_context` will be `None`
  - This is due to the base `Model.request()` API not accepting a `run_context` parameter
  
## Use Cases

### 1. Throttling with Timeout

Handle rate limiting by timing out models for 30 seconds after throttling errors.

```python
import asyncio
import time

throttled_models = {}  # model_id -> timestamp

async def throttle_aware_selector(ctx: AdaptiveContext) -> Model | None:
    # Record throttling from last attempt
    if ctx.attempts:
        last = ctx.attempts[-1]
        if last.exception and 'throttl' in str(last.exception).lower():
            throttled_models[id(last.model)] = time.time()
    
    # Find first available model
    for model in ctx.models:
        model_id = id(model)
        if model_id in throttled_models:
            if time.time() - throttled_models[model_id] < 30:
                continue
            del throttled_models[model_id]
        return model
    
    # All throttled - wait for soonest available
    if throttled_models and ctx.attempt_number < 10:
        soonest = min(throttled_models.items(), key=lambda x: x[1])
        wait_time = 30 - (time.time() - soonest[1])
        if wait_time > 0:
            await asyncio.sleep(wait_time)
            del throttled_models[soonest[0]]
            return next(m for m in ctx.models if id(m) == soonest[0])
    
    return None

adaptive = AdaptiveModel(
    models=[primary, secondary, tertiary],
    selector=throttle_aware_selector,
    max_attempts=15
)
```

### 2. Load Balancing

Distribute requests evenly across multiple accounts/instances.

```python
call_counts = {}  # model_id -> count

def round_robin_selector(ctx: AdaptiveContext) -> Model | None:
    if not ctx.attempts:
        # Use least-used model
        model = min(ctx.models, key=lambda m: call_counts.get(id(m), 0))
        call_counts[id(model)] = call_counts.get(id(model), 0) + 1
        return model
    
    # On retry, try next least-used
    failed = {id(a.model) for a in ctx.attempts}
    available = [m for m in ctx.models if id(m) not in failed]
    return min(available, key=lambda m: call_counts.get(id(m), 0)) if available else None

# Load balance across accounts
adaptive = AdaptiveModel(
    models=[
        OpenAIChatModel('gpt-4o', api_key=key1),
        OpenAIChatModel('gpt-4o', api_key=key2),
    ],
    selector=round_robin_selector
)
```

### 3. User Tier-Based Selection

Route to different models based on user subscription level.

```python
@dataclass
class UserContext:
    tier: str  # 'free', 'pro', 'enterprise'
    monthly_tokens_used: int
    monthly_token_limit: int

def tier_based_selector(ctx: AdaptiveContext[UserContext]) -> Model | None:
    user = ctx.run_context.deps
    
    if not ctx.attempts:
        if user.tier == 'enterprise':
            return next((m for m in ctx.models if 'gpt-4o' in m.model_name), ctx.models[0])
        elif user.tier == 'pro':
            # Check usage limits
            if user.monthly_tokens_used < user.monthly_token_limit * 0.9:
                return next((m for m in ctx.models if 'gpt-4o-mini' in m.model_name), ctx.models[0])
            return next((m for m in ctx.models if 'gpt-3.5' in m.model_name), ctx.models[0])
        else:
            return next((m for m in ctx.models if 'gpt-3.5' in m.model_name), ctx.models[0])
    
    # Retry with next model
    tried = {id(a.model) for a in ctx.attempts}
    available = [m for m in ctx.models if id(m) not in tried]
    return available[0] if available else None

adaptive = AdaptiveModel(
    models=[gpt35, gpt4mini, gpt4],
    selector=tier_based_selector
)

agent = Agent(adaptive, deps_type=UserContext)
result = agent.run_sync(
    'Explain quantum computing',
    deps=UserContext(tier='pro', monthly_tokens_used=80000, monthly_token_limit=100000)
)
```

### 4. Extended Context Model Upgrade

Automatically upgrade to a long-context model when conversation exceeds a threshold.

```python
def context_aware_selector(ctx: AdaptiveContext) -> Model | None:
    """Upgrade to long-context model when conversation gets large."""
    
    # Count messages in conversation
    message_count = len(ctx.messages)
    
    if not ctx.attempts:
        # First attempt - choose based on context size
        if message_count > 50:
            # Use long-context model for large conversations
            return next((m for m in ctx.models if 'claude-3-7-sonnet' in m.model_name), ctx.models[0])
        else:
            # Use standard model for normal conversations
            return next((m for m in ctx.models if 'gpt-4o-mini' in m.model_name), ctx.models[0])
    
    # On retry, try next available model
    tried = {id(a.model) for a in ctx.attempts}
    available = [m for m in ctx.models if id(m) not in tried]
    return available[0] if available else None

# Models sorted by context length capability
adaptive = AdaptiveModel(
    models=[
        OpenAIChatModel('gpt-4o-mini'),           # 128K context
        OpenAIChatModel('gpt-4o'),                # 128K context  
        AnthropicModel('claude-3-7-sonnet-latest'),  # 1M context
    ],
    selector=context_aware_selector
)

agent = Agent(adaptive)

# Short conversation uses cheap model
result1 = agent.run_sync('Hello')  # Uses gpt-4o-mini

# Long conversation automatically upgrades
messages = result1.new_messages()
for i in range(60):
    result = agent.run_sync(f'Message {i}', message_history=messages)
    messages = result.new_messages()
# Automatically switched to claude-3-7-sonnet due to message count
```

### 5. Cost-Optimized with Quality Fallback

Start with cheap models, upgrade if quality is insufficient.

```python
@dataclass
class QualityTracker:
    quality_threshold: float = 0.8
    model_history: dict[str, list[float]] = field(default_factory=dict)  # model -> quality scores

def cost_quality_selector(ctx: AdaptiveContext[QualityTracker]) -> Model | None:
    tracker = ctx.run_context.deps
    
    if not ctx.attempts:
        # Check if cheap model historically meets quality threshold
        cheap_model = ctx.models[0]
        avg_quality = (
            sum(tracker.model_history.get(cheap_model.model_name, [1.0])) / 
            len(tracker.model_history.get(cheap_model.model_name, [1.0]))
        )
        
        if avg_quality >= tracker.quality_threshold:
            return cheap_model
        # Quality too low, start with better model
        return ctx.models[1] if len(ctx.models) > 1 else cheap_model
    
    # Upgrade on failure
    tried = {id(a.model) for a in ctx.attempts}
    available = [m for m in ctx.models if id(m) not in tried]
    return available[0] if available else None

adaptive = AdaptiveModel(
    models=[gpt35, gpt4mini, gpt4],  # Sorted by cost
    selector=cost_quality_selector
)

agent = Agent(adaptive, deps_type=QualityTracker)
```

### 6. Smart Retry with Exponential Backoff

Retry same model with backoff for transient errors, fallback for permanent errors.

```python
import asyncio

async def exponential_backoff_selector(ctx: AdaptiveContext) -> Model | None:
    if not ctx.attempts:
        return ctx.models[0]
    
    last = ctx.attempts[-1]
    is_transient = (
        last.exception and 
        hasattr(last.exception, 'status_code') and 
        500 <= last.exception.status_code < 600
    )
    
    if is_transient and ctx.attempt_number <= 5:
        # Exponential backoff: 1s, 2s, 4s, 8s, 16s
        await asyncio.sleep(2 ** (ctx.attempt_number - 2))
        return last.model  # Retry same model
    
    # Try different model
    tried = {id(a.model) for a in ctx.attempts}
    available = [m for m in ctx.models if id(m) not in tried]
    return available[0] if available else None

adaptive = AdaptiveModel(
    models=[primary, backup],
    selector=exponential_backoff_selector
)
```

### 7. Account Quota Management

Rotate across accounts based on remaining quota.

```python
@dataclass
class AccountPool:
    accounts: dict[str, dict]  # account_id -> {api_key, quota_remaining, reset_time}
    
    def get_available_account(self) -> str | None:
        now = datetime.now()
        for account_id, info in self.accounts.items():
            if now >= info['reset_time']:
                info['quota_remaining'] = info['quota_limit']
            if info['quota_remaining'] > 0:
                return account_id
        return None

def quota_rotation_selector(ctx: AdaptiveContext[AccountPool]) -> Model | None:
    pool = ctx.run_context.deps
    tried = {id(a.model) for a in ctx.attempts}
    
    account_id = pool.get_available_account()
    if not account_id:
        return None
    
    # Find model for this account that hasn't been tried
    return next(
        (m for m in ctx.models 
         if m.api_key == pool.accounts[account_id]['api_key'] and id(m) not in tried),
        None
    )

adaptive = AdaptiveModel(
    models=[
        OpenAIChatModel('gpt-4o', api_key=key1),
        OpenAIChatModel('gpt-4o', api_key=key2),
        OpenAIChatModel('gpt-4o', api_key=key3),
    ],
    selector=quota_rotation_selector
)
```

## Key Benefits

1. **Full Control**: Custom logic for model selection based on any criteria
2. **Stateful Logic**: Maintain state across calls (throttle timers, usage counts, quality metrics)
3. **Smart Waiting**: Wait for throttled models instead of giving up
4. **Load Distribution**: Balance across identical models on different accounts
5. **User-Aware**: Access agent dependencies for user-specific routing
6. **Cost Optimization**: Dynamic model selection based on cost, quality, and usage
7. **Complex Retry**: Implement exponential backoff, circuit breakers, etc.

## Comparison with FallbackModel

| Feature | FallbackModel | AdaptiveModel |
|---------|--------------|---------------|
| Model Selection | Sequential | Custom logic |
| State Management | External only | External + internal |
| Wait/Retry Logic | Not supported | Full control |
| Load Balancing | Not supported | Supported |
| User Context | Via callbacks | Direct access via RunContext |
| Complexity | Simple | Flexible |

`AdaptiveModel` complements `FallbackModel` by supporting sophisticated routing scenarios while `FallbackModel` remains the simpler choice for basic sequential fallback.

