### PR TITLE
docs: Add Braintrust to integrations

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -263,6 +263,7 @@ The following providers have dedicated documentation on Pydantic AI:
 - [Agenta](https://docs.agenta.ai/observability/integrations/pydanticai)
 - [Confident AI](https://documentation.confident-ai.com/docs/llm-tracing/integrations/pydanticai)
 - [LangWatch](https://docs.langwatch.ai/integration/python/integrations/pydantic-ai)
+- [Braintrust](https://www.braintrust.dev/docs/integrations/sdk-integrations/pydantic-ai)
 
 ## Advanced usage
 


### PR DESCRIPTION
Link to the Braintrust docs on tracing with Pydantic AI via OpenTelemetry