### PR TITLE
Add 'global' region to Google provider options

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -165,6 +165,7 @@ VertexAILocation = Literal[
     'europe-west6',
     'europe-west8',
     'europe-west9',
+    'global',
     'me-central1',
     'me-central2',
     'me-west1',


### PR DESCRIPTION
Currently, the list of supported providers is missing the "global" option for the google vertex ai provider.