### PR TITLE
Immediately raise error when response is empty because of token limit

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -584,7 +584,7 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                         model_settings = ctx.deps.model_settings
                         max_tokens = model_settings.get('max_tokens') if model_settings else None
                         raise exceptions.UnexpectedModelBehavior(
-                            f'Model token limit ({max_tokens or "provider default"}) exceeded, resulting in an empty response. Increase the `max_tokens` model setting, or simplify the prompt to result in a shorter response that will fit within the limit.'
+                            f'Model token limit ({max_tokens or "provider default"}) exceeded before any response was generated. Increase the `max_tokens` model setting, or simplify the prompt to result in a shorter response that will fit within the limit.'
                         )
 
                     # we got an empty response.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2807,13 +2807,13 @@ def test_empty_response_with_finish_reason_length():
 
     with pytest.raises(
         UnexpectedModelBehavior,
-        match=r'Model token limit \(10\) exceeded, resulting in an empty response.',
+        match=r'Model token limit \(10\) exceeded before any response was generated.',
     ):
         agent.run_sync('Hello', model_settings=ModelSettings(max_tokens=10))
 
     with pytest.raises(
         UnexpectedModelBehavior,
-        match=r'Model token limit \(provider default\) exceeded, resulting in an empty response.',
+        match=r'Model token limit \(provider default\) exceeded before any response was generated.',
     ):
         agent.run_sync('Hello')
 


### PR DESCRIPTION
Related to https://github.com/pydantic/pydantic-ai/issues/3504