### PR TITLE
Add test to ensure we allow message history starting with assistant message (model response)

### DIFF
--- a/tests/models/cassettes/test_openai/test_message_history_can_start_with_model_response.yaml
+++ b/tests/models/cassettes/test_openai/test_message_history_can_start_with_model_response.yaml
@@ -32,13 +32,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '839'
+      - '841'
       content-type:
       - application/json
       openai-organization:
       - deeplytalented
       openai-processing-ms:
-      - '400'
+      - '423'
       openai-project:
       - proj_1aziXuKoVAC897wPxnvH0q7Z
       openai-version:
@@ -54,17 +54,17 @@ interactions:
         logprobs: null
         message:
           annotations: []
-          content: Tux is Linux’s penguin mascot.
+          content: Linux mascot, a penguin character.
           refusal: null
           role: assistant
-      created: 1763803487
-      id: chatcmpl-Cee9HJclmrDapXpXuyDHw5BWDGJfK
+      created: 1763805700
+      id: chatcmpl-Ceeiy4ivEE0hcL1EX5ZfLuW5xNUXB
       model: gpt-4.1-mini-2025-04-14
       object: chat.completion
       service_tier: default
       system_fingerprint: fp_9766e549b2
       usage:
-        completion_tokens: 9
+        completion_tokens: 8
         completion_tokens_details:
           accepted_prediction_tokens: 0
           audio_tokens: 0
@@ -74,7 +74,7 @@ interactions:
         prompt_tokens_details:
           audio_tokens: 0
           cached_tokens: 0
-        total_tokens: 40
+        total_tokens: 39
     status:
       code: 200
       message: OK

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -1226,7 +1226,7 @@ async def test_message_history_can_start_with_model_response(allow_model_request
 
     result = await agent.run('Answer in 5 words only. Who is Tux?', message_history=message_history)
 
-    assert result.output == snapshot("Tux is Linux's penguin mascot.")
+    assert result.output == snapshot('Linux mascot, a penguin character.')
     assert result.all_messages() == snapshot(
         [
             ModelResponse(
@@ -1243,10 +1243,10 @@ async def test_message_history_can_start_with_model_response(allow_model_request
                 run_id=IsStr(),
             ),
             ModelResponse(
-                parts=[TextPart(content="Tux is Linux's penguin mascot.")],
+                parts=[TextPart(content='Linux mascot, a penguin character.')],
                 usage=RequestUsage(
                     input_tokens=31,
-                    output_tokens=9,
+                    output_tokens=8,
                     details={
                         'accepted_prediction_tokens': 0,
                         'audio_tokens': 0,
@@ -1258,7 +1258,7 @@ async def test_message_history_can_start_with_model_response(allow_model_request
                 timestamp=IsDatetime(),
                 provider_name='openai',
                 provider_details={'finish_reason': 'stop'},
-                provider_response_id='chatcmpl-Cee9HJclmrDapXpXuyDHw5BWDGJfK',
+                provider_response_id='chatcmpl-Ceeiy4ivEE0hcL1EX5ZfLuW5xNUXB',
                 finish_reason='stop',
                 run_id=IsStr(),
             ),


### PR DESCRIPTION
Fixes #3503 