### PR TITLE
Add FileSystemToolset for file system access

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -11,6 +11,7 @@ from .agent import (
 )
 from .builtin_tools import (
     CodeExecutionTool,
+    FileSystemTool,
     ImageGenerationTool,
     MCPServerTool,
     MemoryTool,
@@ -102,6 +103,7 @@ from .toolsets import (
     ApprovalRequiredToolset,
     CombinedToolset,
     ExternalToolset,
+    FileSystemToolset,
     FilteredToolset,
     FunctionToolset,
     PrefixedToolset,
@@ -206,6 +208,7 @@ __all__ = (
     'ApprovalRequiredToolset',
     'CombinedToolset',
     'ExternalToolset',
+    'FileSystemToolset',
     'FilteredToolset',
     'FunctionToolset',
     'PrefixedToolset',
@@ -220,6 +223,7 @@ __all__ = (
     'WebFetchTool',
     'UrlContextTool',
     'CodeExecutionTool',
+    'FileSystemTool',
     'ImageGenerationTool',
     'MemoryTool',
     'MCPServerTool',

--- a/pydantic_ai_slim/pydantic_ai/builtin_tools.py
+++ b/pydantic_ai_slim/pydantic_ai/builtin_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 from abc import ABC
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Union
 
 import pydantic
@@ -436,9 +437,7 @@ class FileSystemTool(AbstractBuiltinTool):
         ```
     """
 
-    from pathlib import Path as _Path
-
-    allowed_paths: list[str | _Path] | None = None
+    allowed_paths: list[str | Path] | None = None
     """List of paths the agent is allowed to access.
     If None or empty, allows access to current working directory only."""
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/__init__.py
@@ -3,6 +3,7 @@ from .abstract import AbstractToolset, ToolsetTool
 from .approval_required import ApprovalRequiredToolset
 from .combined import CombinedToolset
 from .external import DeferredToolset, ExternalToolset  # pyright: ignore[reportDeprecated]
+from .filesystem import FileSystemToolset
 from .filtered import FilteredToolset
 from .function import FunctionToolset
 from .prefixed import PrefixedToolset
@@ -17,6 +18,7 @@ __all__ = (
     'CombinedToolset',
     'ExternalToolset',
     'DeferredToolset',
+    'FileSystemToolset',
     'FilteredToolset',
     'FunctionToolset',
     'PrefixedToolset',

--- a/pydantic_ai_slim/pydantic_ai/toolsets/filesystem.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/filesystem.py
@@ -1,0 +1,457 @@
+"""FileSystemToolset for providing file system access to agents."""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic import TypeAdapter
+
+from .._run_context import AgentDepsT, RunContext
+from ..tools import ToolDefinition
+from .abstract import AbstractToolset, SchemaValidatorProt, ToolsetTool
+
+__all__ = ('FileSystemToolset',)
+
+
+@dataclass(kw_only=True)
+class FileSystemToolset(AbstractToolset[AgentDepsT]):
+    """A toolset that provides file system operations to agents.
+
+    This toolset allows agents to read, write, list, search, and delete files
+    within configured allowed directories.
+
+    Example usage:
+        ```python
+        from pydantic_ai import Agent
+        from pydantic_ai.toolsets import FileSystemToolset
+
+        agent = Agent(
+            'openai:gpt-4',
+            toolsets=[
+                FileSystemToolset(
+                    allowed_paths=['/home/user/data'],
+                    allow_write=False,
+                ),
+            ],
+        )
+        ```
+    """
+
+    allowed_paths: list[str | Path] = field(default_factory=list)
+    """List of paths the agent is allowed to access.
+    If empty, allows access to current working directory only."""
+
+    allow_write: bool = False
+    """Whether to allow write operations (create, modify)."""
+
+    allow_delete: bool = False
+    """Whether to allow delete operations. Only applies if allow_write is True."""
+
+    max_file_size: int = 10 * 1024 * 1024  # 10 MB
+    """Maximum file size to read in bytes."""
+
+    allowed_extensions: list[str] | None = None
+    """If provided, only files with these extensions can be accessed.
+    Example: ['.txt', '.json', '.py']"""
+
+    _id: str | None = None
+    """Optional unique ID for the toolset."""
+
+    @property
+    def id(self) -> str | None:
+        """Return the toolset ID."""
+        return self._id
+
+    def _validate_path(self, path: str | Path) -> Path:
+        """Validate that path is within allowed directories.
+
+        Args:
+            path: The path to validate.
+
+        Returns:
+            The resolved path.
+
+        Raises:
+            PermissionError: If the path is outside allowed directories or has a disallowed extension.
+        """
+        resolved = Path(path).resolve()
+
+        # Check allowed paths
+        if self.allowed_paths:
+            allowed = False
+            for allowed_path in self.allowed_paths:
+                allowed_resolved = Path(allowed_path).resolve()
+                try:
+                    resolved.relative_to(allowed_resolved)
+                    allowed = True
+                    break
+                except ValueError:
+                    continue
+            if not allowed:
+                raise PermissionError(f'Path {path} is outside allowed directories: {self.allowed_paths}')
+        else:
+            # Default: only allow current directory
+            cwd = Path.cwd().resolve()
+            try:
+                resolved.relative_to(cwd)
+            except ValueError:
+                raise PermissionError(
+                    f'Path {path} is outside current directory. Configure allowed_paths to access other directories.'
+                )
+
+        # Check extension for files (only if path exists and is a file, or if it's a new file being written)
+        if self.allowed_extensions:
+            suffix = resolved.suffix.lower()
+            allowed_lower = [ext.lower() for ext in self.allowed_extensions]
+            if suffix and suffix not in allowed_lower:
+                raise PermissionError(
+                    f'File extension {resolved.suffix} not in allowed extensions: {self.allowed_extensions}'
+                )
+
+        return resolved
+
+    def _validate_operation(self, operation: str) -> None:
+        """Validate that the operation is allowed.
+
+        Args:
+            operation: The operation to validate (read, write, list, info, search, delete).
+
+        Raises:
+            PermissionError: If the operation is not allowed.
+        """
+        if operation == 'write' and not self.allow_write:
+            raise PermissionError('Write operations are not allowed')
+        if operation == 'delete':
+            if not self.allow_write:
+                raise PermissionError('Delete operations require allow_write=True')
+            if not self.allow_delete:
+                raise PermissionError('Delete operations are not allowed')
+
+    async def _read_file(self, path: str) -> str:
+        """Read contents of a file.
+
+        Args:
+            path: Path to the file to read.
+
+        Returns:
+            The contents of the file.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            PermissionError: If the path is not allowed or file is too large.
+            IsADirectoryError: If the path is a directory.
+        """
+        resolved = self._validate_path(path)
+
+        if not resolved.exists():
+            raise FileNotFoundError(f'File not found: {path}')
+
+        if resolved.is_dir():
+            raise IsADirectoryError(f'Path is a directory, not a file: {path}')
+
+        # Check file size
+        file_size = resolved.stat().st_size
+        if file_size > self.max_file_size:
+            raise PermissionError(
+                f'File size ({file_size} bytes) exceeds maximum allowed size ({self.max_file_size} bytes)'
+            )
+
+        return resolved.read_text(encoding='utf-8')
+
+    async def _write_file(self, path: str, content: str) -> str:
+        """Write content to a file.
+
+        Args:
+            path: Path to the file to write.
+            content: Content to write to the file.
+
+        Returns:
+            A success message.
+
+        Raises:
+            PermissionError: If the path is not allowed or write is disabled.
+            IsADirectoryError: If the path is a directory.
+        """
+        self._validate_operation('write')
+        resolved = self._validate_path(path)
+
+        if resolved.exists() and resolved.is_dir():
+            raise IsADirectoryError(f'Path is a directory, not a file: {path}')
+
+        # Create parent directories if they don't exist
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+
+        resolved.write_text(content, encoding='utf-8')
+        return f'Successfully wrote {len(content)} characters to {path}'
+
+    async def _list_directory(self, path: str) -> list[dict[str, Any]]:
+        """List contents of a directory.
+
+        Args:
+            path: Path to the directory to list.
+
+        Returns:
+            List of file/directory information dictionaries.
+
+        Raises:
+            FileNotFoundError: If the directory does not exist.
+            NotADirectoryError: If the path is not a directory.
+            PermissionError: If the path is not allowed.
+        """
+        resolved = self._validate_path(path)
+
+        if not resolved.exists():
+            raise FileNotFoundError(f'Directory not found: {path}')
+
+        if not resolved.is_dir():
+            raise NotADirectoryError(f'Path is not a directory: {path}')
+
+        entries: list[dict[str, Any]] = []
+        for entry in resolved.iterdir():
+            try:
+                stat = entry.stat()
+                entries.append(
+                    {
+                        'name': entry.name,
+                        'type': 'directory' if entry.is_dir() else 'file',
+                        'size': stat.st_size if entry.is_file() else None,
+                        'modified': stat.st_mtime,
+                    }
+                )
+            except (PermissionError, OSError):  # pragma: lax no cover
+                # Skip entries we can't access
+                entries.append(
+                    {
+                        'name': entry.name,
+                        'type': 'unknown',
+                        'size': None,
+                        'modified': None,
+                    }
+                )
+
+        return entries
+
+    async def _file_info(self, path: str) -> dict[str, Any]:
+        """Get information about a file or directory.
+
+        Args:
+            path: Path to the file or directory.
+
+        Returns:
+            Dictionary with file/directory information.
+
+        Raises:
+            FileNotFoundError: If the path does not exist.
+            PermissionError: If the path is not allowed.
+        """
+        resolved = self._validate_path(path)
+
+        if not resolved.exists():
+            raise FileNotFoundError(f'Path not found: {path}')
+
+        stat = resolved.stat()
+        return {
+            'name': resolved.name,
+            'path': str(resolved),
+            'type': 'directory' if resolved.is_dir() else 'file',
+            'size': stat.st_size if resolved.is_file() else None,
+            'modified': stat.st_mtime,
+            'created': stat.st_ctime,
+            'is_symlink': resolved.is_symlink(),
+        }
+
+    async def _search_files(self, directory: str, pattern: str) -> list[str]:
+        """Search for files matching a pattern.
+
+        Args:
+            directory: Directory to search in.
+            pattern: Glob pattern to match files against (e.g., '*.txt', '**/*.py').
+
+        Returns:
+            List of matching file paths.
+
+        Raises:
+            FileNotFoundError: If the directory does not exist.
+            NotADirectoryError: If the path is not a directory.
+            PermissionError: If the path is not allowed.
+        """
+        resolved = self._validate_path(directory)
+
+        if not resolved.exists():
+            raise FileNotFoundError(f'Directory not found: {directory}')
+
+        if not resolved.is_dir():
+            raise NotADirectoryError(f'Path is not a directory: {directory}')
+
+        matches: list[str] = []
+        for entry in resolved.rglob('*'):
+            if fnmatch.fnmatch(entry.name, pattern):
+                # Validate each matched path is within allowed directories
+                try:
+                    self._validate_path(entry)
+                    matches.append(str(entry))
+                except PermissionError:  # pragma: lax no cover
+                    # Skip files outside allowed paths
+                    pass
+
+        return matches
+
+    async def _delete_file(self, path: str) -> str:
+        """Delete a file.
+
+        Args:
+            path: Path to the file to delete.
+
+        Returns:
+            A success message.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            IsADirectoryError: If the path is a directory (use rmdir for directories).
+            PermissionError: If the path is not allowed or delete is disabled.
+        """
+        self._validate_operation('delete')
+        resolved = self._validate_path(path)
+
+        if not resolved.exists():
+            raise FileNotFoundError(f'File not found: {path}')
+
+        if resolved.is_dir():
+            raise IsADirectoryError(f'Path is a directory, not a file: {path}. Use rmdir for directories.')
+
+        resolved.unlink()
+        return f'Successfully deleted {path}'
+
+    async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
+        """Get the file system tool definition.
+
+        Args:
+            ctx: The run context.
+
+        Returns:
+            Dictionary mapping tool name to tool definition.
+        """
+        # Build allowed operations list based on configuration
+        allowed_ops: list[str] = ['read', 'list', 'info', 'search']
+        if self.allow_write:
+            allowed_ops.append('write')
+            if self.allow_delete:
+                allowed_ops.append('delete')
+
+        description = (
+            f'Access the local file system to read and manage files. Allowed operations: {", ".join(allowed_ops)}.'
+        )
+        if self.allowed_paths:
+            paths_str = ', '.join(str(p) for p in self.allowed_paths)
+            description += f' Allowed paths: {paths_str}.'
+        if self.allowed_extensions:
+            description += f' Allowed extensions: {", ".join(self.allowed_extensions)}.'
+
+        # Build the parameters schema
+        operation_enum = allowed_ops
+        properties: dict[str, Any] = {
+            'operation': {
+                'type': 'string',
+                'enum': operation_enum,
+                'description': 'The operation to perform',
+            },
+            'path': {
+                'type': 'string',
+                'description': 'Path to the file or directory',
+            },
+        }
+
+        if self.allow_write:
+            properties['content'] = {
+                'type': 'string',
+                'description': 'Content to write (required for write operation)',
+            }
+
+        properties['pattern'] = {
+            'type': 'string',
+            'description': 'Search pattern for glob matching (required for search operation)',
+        }
+
+        parameters_schema = {
+            'type': 'object',
+            'properties': properties,
+            'required': ['operation', 'path'],
+            'additionalProperties': False,
+        }
+
+        tool_def = ToolDefinition(
+            name='file_system',
+            description=description,
+            parameters_json_schema=parameters_schema,
+        )
+
+        # Create a TypeAdapter for validation that returns a dict
+        from typing_extensions import TypedDict
+
+        class FileSystemArgsRequired(TypedDict):
+            operation: str
+            path: str
+
+        class FileSystemArgs(FileSystemArgsRequired, total=False):
+            content: str
+            pattern: str
+
+        validator = cast(SchemaValidatorProt, TypeAdapter(FileSystemArgs).validator)
+
+        return {
+            'file_system': ToolsetTool(
+                toolset=self,
+                tool_def=tool_def,
+                max_retries=1,
+                args_validator=validator,
+            )
+        }
+
+    async def call_tool(
+        self, name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT], tool: ToolsetTool[AgentDepsT]
+    ) -> Any:
+        """Call the file system tool with the given arguments.
+
+        Args:
+            name: The name of the tool (should be 'file_system').
+            tool_args: The arguments for the tool call.
+            ctx: The run context.
+            tool: The tool definition.
+
+        Returns:
+            The result of the file system operation.
+
+        Raises:
+            ValueError: If the operation is unknown or required arguments are missing.
+        """
+        operation = tool_args.get('operation')
+        path = tool_args.get('path')
+
+        if not operation:
+            raise ValueError('Missing required argument: operation')
+        if not path:
+            raise ValueError('Missing required argument: path')
+
+        if operation == 'read':
+            return await self._read_file(path)
+        elif operation == 'write':
+            content = tool_args.get('content')
+            if content is None:
+                raise ValueError('Missing required argument for write operation: content')
+            return await self._write_file(path, content)
+        elif operation == 'list':
+            return await self._list_directory(path)
+        elif operation == 'info':
+            return await self._file_info(path)
+        elif operation == 'search':
+            pattern = tool_args.get('pattern')
+            if not pattern:
+                raise ValueError('Missing required argument for search operation: pattern')
+            return await self._search_files(path, pattern)
+        elif operation == 'delete':
+            return await self._delete_file(path)
+        else:
+            raise ValueError(f'Unknown operation: {operation}')

--- a/tests/test_filesystem_tool.py
+++ b/tests/test_filesystem_tool.py
@@ -1,0 +1,939 @@
+"""Tests for FileSystemToolset and FileSystemTool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pydantic_ai import FileSystemTool, FileSystemToolset, ToolCallPart
+from pydantic_ai._run_context import RunContext
+from pydantic_ai._tool_manager import ToolManager
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+
+pytestmark = pytest.mark.anyio
+
+
+def build_run_context(deps: Any = None, run_step: int = 0) -> RunContext[Any]:
+    return RunContext(
+        deps=deps,
+        model=TestModel(),
+        usage=RunUsage(),
+        prompt=None,
+        messages=[],
+        run_step=run_step,
+    )
+
+
+class TestFileSystemToolsetPathValidation:
+    """Tests for path validation in FileSystemToolset."""
+
+    async def test_access_within_allowed_paths_succeeds(self, tmp_path: Path):
+        """Test that accessing files within allowed paths succeeds."""
+        file = tmp_path / 'test.txt'
+        file.write_text('Hello, World!')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+        assert 'file_system' in tools
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'read', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+        assert result == 'Hello, World!'
+
+    async def test_access_outside_allowed_paths_raises_permission_error(self, tmp_path: Path):
+        """Test that accessing files outside allowed paths raises PermissionError."""
+        # Create a file outside allowed paths
+        other_dir = tmp_path / 'other'
+        other_dir.mkdir()
+        file = other_dir / 'test.txt'
+        file.write_text('Secret content')
+
+        # Only allow access to a different directory
+        allowed_dir = tmp_path / 'allowed'
+        allowed_dir.mkdir()
+
+        toolset = FileSystemToolset(allowed_paths=[str(allowed_dir)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(PermissionError, match='outside allowed directories'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'read', 'path': str(file)},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_path_traversal_blocked(self, tmp_path: Path):
+        """Test that path traversal attempts are blocked."""
+        allowed_dir = tmp_path / 'allowed'
+        allowed_dir.mkdir()
+
+        # Try to escape using ..
+        toolset = FileSystemToolset(allowed_paths=[str(allowed_dir)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(PermissionError, match='outside allowed directories'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'read', 'path': str(allowed_dir / '..' / 'secret.txt')},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_default_cwd_restriction(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Test that default restriction to current directory works."""
+        # Change to tmp_path
+        monkeypatch.chdir(tmp_path)
+
+        file = tmp_path / 'test.txt'
+        file.write_text('Hello')
+
+        # No allowed_paths means only cwd is allowed
+        toolset = FileSystemToolset()
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        # Access within cwd should work
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'read', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+        assert result == 'Hello'
+
+    async def test_access_outside_cwd_when_no_allowed_paths(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Test that accessing outside cwd raises error when no allowed_paths configured."""
+        cwd = tmp_path / 'cwd'
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+
+        outside_file = tmp_path / 'outside.txt'
+        outside_file.write_text('Outside content')
+
+        toolset = FileSystemToolset()
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(PermissionError, match='outside current directory'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'read', 'path': str(outside_file)},
+                ctx,
+                tools['file_system'],
+            )
+
+
+class TestFileSystemToolsetExtensionFiltering:
+    """Tests for extension filtering in FileSystemToolset."""
+
+    async def test_allowed_extensions_can_be_accessed(self, tmp_path: Path):
+        """Test that files with allowed extensions can be accessed."""
+        file = tmp_path / 'test.txt'
+        file.write_text('Text content')
+
+        toolset = FileSystemToolset(
+            allowed_paths=[str(tmp_path)],
+            allowed_extensions=['.txt', '.json'],
+        )
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'read', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+        assert result == 'Text content'
+
+    async def test_disallowed_extensions_raise_error(self, tmp_path: Path):
+        """Test that files with disallowed extensions raise PermissionError."""
+        file = tmp_path / 'script.py'
+        file.write_text('print("hello")')
+
+        toolset = FileSystemToolset(
+            allowed_paths=[str(tmp_path)],
+            allowed_extensions=['.txt', '.json'],
+        )
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(PermissionError, match='not in allowed extensions'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'read', 'path': str(file)},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_extension_checking_case_insensitive(self, tmp_path: Path):
+        """Test that extension checking is case insensitive."""
+        file = tmp_path / 'test.TXT'
+        file.write_text('Content')
+
+        toolset = FileSystemToolset(
+            allowed_paths=[str(tmp_path)],
+            allowed_extensions=['.txt'],
+        )
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'read', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+        assert result == 'Content'
+
+
+class TestFileSystemToolsetOperationPermissions:
+    """Tests for operation permission validation."""
+
+    async def test_read_operations_work_when_allowed(self, tmp_path: Path):
+        """Test that read operations work by default."""
+        file = tmp_path / 'test.txt'
+        file.write_text('Content')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'read', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+        assert result == 'Content'
+
+    async def test_write_operations_blocked_by_default(self, tmp_path: Path):
+        """Test that write operations are blocked when allow_write=False."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(PermissionError, match='Write operations are not allowed'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'write', 'path': str(tmp_path / 'new.txt'), 'content': 'test'},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_write_operations_allowed_when_enabled(self, tmp_path: Path):
+        """Test that write operations work when allow_write=True."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], allow_write=True)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        file = tmp_path / 'new.txt'
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'write', 'path': str(file), 'content': 'New content'},
+            ctx,
+            tools['file_system'],
+        )
+        assert 'Successfully wrote' in result
+        assert file.read_text() == 'New content'
+
+    async def test_delete_operations_blocked_by_default(self, tmp_path: Path):
+        """Test that delete operations are blocked when allow_delete=False."""
+        file = tmp_path / 'test.txt'
+        file.write_text('Content')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], allow_write=True)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(PermissionError, match='Delete operations are not allowed'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'delete', 'path': str(file)},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_delete_requires_allow_write(self, tmp_path: Path):
+        """Test that delete requires allow_write=True."""
+        file = tmp_path / 'test.txt'
+        file.write_text('Content')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], allow_delete=True)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(PermissionError, match='Delete operations require allow_write=True'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'delete', 'path': str(file)},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_delete_operations_allowed_when_enabled(self, tmp_path: Path):
+        """Test that delete operations work when both allow_write and allow_delete are True."""
+        file = tmp_path / 'test.txt'
+        file.write_text('Content')
+
+        toolset = FileSystemToolset(
+            allowed_paths=[str(tmp_path)],
+            allow_write=True,
+            allow_delete=True,
+        )
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'delete', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+        assert 'Successfully deleted' in result
+        assert not file.exists()
+
+
+class TestFileSystemToolsetFileSizeLimit:
+    """Tests for file size limit validation."""
+
+    async def test_files_under_limit_can_be_read(self, tmp_path: Path):
+        """Test that files under the size limit can be read."""
+        file = tmp_path / 'small.txt'
+        file.write_text('Small content')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], max_file_size=1000)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'read', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+        assert result == 'Small content'
+
+    async def test_files_over_limit_raise_error(self, tmp_path: Path):
+        """Test that files over the size limit raise PermissionError."""
+        file = tmp_path / 'large.txt'
+        file.write_text('x' * 1000)  # 1000 bytes
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], max_file_size=100)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(PermissionError, match='exceeds maximum allowed size'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'read', 'path': str(file)},
+                ctx,
+                tools['file_system'],
+            )
+
+
+class TestFileSystemToolsetOperations:
+    """Tests for individual file system operations."""
+
+    async def test_read_file(self, tmp_path: Path):
+        """Test read operation."""
+        file = tmp_path / 'test.txt'
+        file.write_text('File content')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'read', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+        assert result == 'File content'
+
+    async def test_read_nonexistent_file(self, tmp_path: Path):
+        """Test reading a nonexistent file."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(FileNotFoundError, match='File not found'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'read', 'path': str(tmp_path / 'nonexistent.txt')},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_read_directory_as_file(self, tmp_path: Path):
+        """Test reading a directory as a file raises error."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(IsADirectoryError, match='is a directory'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'read', 'path': str(tmp_path)},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_write_new_file(self, tmp_path: Path):
+        """Test writing a new file."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], allow_write=True)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        file = tmp_path / 'new.txt'
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'write', 'path': str(file), 'content': 'New content'},
+            ctx,
+            tools['file_system'],
+        )
+        assert 'Successfully wrote' in result
+        assert file.read_text() == 'New content'
+
+    async def test_write_creates_parent_directories(self, tmp_path: Path):
+        """Test that write creates parent directories if needed."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], allow_write=True)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        file = tmp_path / 'subdir' / 'nested' / 'file.txt'
+        await toolset.call_tool(
+            'file_system',
+            {'operation': 'write', 'path': str(file), 'content': 'Nested content'},
+            ctx,
+            tools['file_system'],
+        )
+        assert file.exists()
+        assert file.read_text() == 'Nested content'
+
+    async def test_write_overwrites_existing(self, tmp_path: Path):
+        """Test that write overwrites existing files."""
+        file = tmp_path / 'existing.txt'
+        file.write_text('Old content')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], allow_write=True)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        await toolset.call_tool(
+            'file_system',
+            {'operation': 'write', 'path': str(file), 'content': 'New content'},
+            ctx,
+            tools['file_system'],
+        )
+        assert file.read_text() == 'New content'
+
+    async def test_write_to_directory_raises_error(self, tmp_path: Path):
+        """Test writing to a directory path raises error."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], allow_write=True)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(IsADirectoryError, match='is a directory'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'write', 'path': str(tmp_path), 'content': 'test'},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_list_directory(self, tmp_path: Path):
+        """Test listing directory contents."""
+        (tmp_path / 'file1.txt').write_text('content1')
+        (tmp_path / 'file2.txt').write_text('content2')
+        (tmp_path / 'subdir').mkdir()
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'list', 'path': str(tmp_path)},
+            ctx,
+            tools['file_system'],
+        )
+
+        names = {entry['name'] for entry in result}
+        assert names == {'file1.txt', 'file2.txt', 'subdir'}
+
+        for entry in result:
+            if entry['name'] == 'subdir':
+                assert entry['type'] == 'directory'
+            else:
+                assert entry['type'] == 'file'
+
+    async def test_list_nonexistent_directory(self, tmp_path: Path):
+        """Test listing a nonexistent directory."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(FileNotFoundError, match='Directory not found'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'list', 'path': str(tmp_path / 'nonexistent')},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_list_file_as_directory(self, tmp_path: Path):
+        """Test listing a file as a directory raises error."""
+        file = tmp_path / 'file.txt'
+        file.write_text('content')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(NotADirectoryError, match='not a directory'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'list', 'path': str(file)},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_file_info(self, tmp_path: Path):
+        """Test getting file info."""
+        file = tmp_path / 'test.txt'
+        file.write_text('content')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'info', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+
+        assert result['name'] == 'test.txt'
+        assert result['type'] == 'file'
+        assert result['size'] == 7  # len('content')
+        assert 'modified' in result
+        assert 'created' in result
+        assert result['is_symlink'] is False
+
+    async def test_directory_info(self, tmp_path: Path):
+        """Test getting directory info."""
+        subdir = tmp_path / 'subdir'
+        subdir.mkdir()
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'info', 'path': str(subdir)},
+            ctx,
+            tools['file_system'],
+        )
+
+        assert result['name'] == 'subdir'
+        assert result['type'] == 'directory'
+        assert result['size'] is None
+
+    async def test_info_nonexistent_path(self, tmp_path: Path):
+        """Test info on nonexistent path."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(FileNotFoundError, match='Path not found'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'info', 'path': str(tmp_path / 'nonexistent')},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_search_files(self, tmp_path: Path):
+        """Test searching for files."""
+        (tmp_path / 'file1.txt').write_text('content1')
+        (tmp_path / 'file2.txt').write_text('content2')
+        (tmp_path / 'file3.py').write_text('code')
+        subdir = tmp_path / 'subdir'
+        subdir.mkdir()
+        (subdir / 'nested.txt').write_text('nested')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'search', 'path': str(tmp_path), 'pattern': '*.txt'},
+            ctx,
+            tools['file_system'],
+        )
+
+        assert len(result) == 3  # file1.txt, file2.txt, nested.txt
+
+    async def test_search_nonexistent_directory(self, tmp_path: Path):
+        """Test searching in nonexistent directory."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(FileNotFoundError, match='Directory not found'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'search', 'path': str(tmp_path / 'nonexistent'), 'pattern': '*.txt'},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_search_file_as_directory(self, tmp_path: Path):
+        """Test searching with file path."""
+        file = tmp_path / 'file.txt'
+        file.write_text('content')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(NotADirectoryError, match='not a directory'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'search', 'path': str(file), 'pattern': '*.txt'},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_delete_file(self, tmp_path: Path):
+        """Test deleting a file."""
+        file = tmp_path / 'test.txt'
+        file.write_text('content')
+
+        toolset = FileSystemToolset(
+            allowed_paths=[str(tmp_path)],
+            allow_write=True,
+            allow_delete=True,
+        )
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'delete', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+        assert 'Successfully deleted' in result
+        assert not file.exists()
+
+    async def test_delete_nonexistent_file(self, tmp_path: Path):
+        """Test deleting a nonexistent file."""
+        toolset = FileSystemToolset(
+            allowed_paths=[str(tmp_path)],
+            allow_write=True,
+            allow_delete=True,
+        )
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(FileNotFoundError, match='File not found'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'delete', 'path': str(tmp_path / 'nonexistent.txt')},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_delete_directory_raises_error(self, tmp_path: Path):
+        """Test deleting a directory raises error."""
+        subdir = tmp_path / 'subdir'
+        subdir.mkdir()
+
+        toolset = FileSystemToolset(
+            allowed_paths=[str(tmp_path)],
+            allow_write=True,
+            allow_delete=True,
+        )
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(IsADirectoryError, match='is a directory'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'delete', 'path': str(subdir)},
+                ctx,
+                tools['file_system'],
+            )
+
+
+class TestFileSystemToolsetToolDefinition:
+    """Tests for the tool definition generation."""
+
+    async def test_tool_definition_read_only(self, tmp_path: Path):
+        """Test tool definition for read-only access."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        tool_def = tools['file_system'].tool_def
+        assert tool_def.name == 'file_system'
+        assert tool_def.description is not None
+        assert 'read' in tool_def.description
+        assert 'write' not in tool_def.description or 'allow_write' in tool_def.description
+
+        schema = tool_def.parameters_json_schema
+        assert schema is not None
+        assert 'operation' in schema['properties']
+        assert 'write' not in schema['properties']['operation']['enum']
+        assert 'delete' not in schema['properties']['operation']['enum']
+
+    async def test_tool_definition_with_write(self, tmp_path: Path):
+        """Test tool definition with write enabled."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], allow_write=True)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        tool_def = tools['file_system'].tool_def
+        schema = tool_def.parameters_json_schema
+        assert 'write' in schema['properties']['operation']['enum']
+        assert 'delete' not in schema['properties']['operation']['enum']
+
+    async def test_tool_definition_with_delete(self, tmp_path: Path):
+        """Test tool definition with delete enabled."""
+        toolset = FileSystemToolset(
+            allowed_paths=[str(tmp_path)],
+            allow_write=True,
+            allow_delete=True,
+        )
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        tool_def = tools['file_system'].tool_def
+        schema = tool_def.parameters_json_schema
+        assert 'write' in schema['properties']['operation']['enum']
+        assert 'delete' in schema['properties']['operation']['enum']
+
+    async def test_tool_definition_includes_allowed_paths(self, tmp_path: Path):
+        """Test that tool definition includes allowed paths in description."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        tool_def = tools['file_system'].tool_def
+        assert tool_def.description is not None
+        assert str(tmp_path) in tool_def.description
+
+    async def test_tool_definition_includes_allowed_extensions(self, tmp_path: Path):
+        """Test that tool definition includes allowed extensions in description."""
+        toolset = FileSystemToolset(
+            allowed_paths=[str(tmp_path)],
+            allowed_extensions=['.txt', '.json'],
+        )
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        tool_def = tools['file_system'].tool_def
+        assert tool_def.description is not None
+        assert '.txt' in tool_def.description
+        assert '.json' in tool_def.description
+
+
+class TestFileSystemToolsetEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    async def test_unknown_operation(self, tmp_path: Path):
+        """Test unknown operation raises error."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(ValueError, match='Unknown operation'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'unknown', 'path': str(tmp_path)},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_missing_operation(self, tmp_path: Path):
+        """Test missing operation raises error."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(ValueError, match='Missing required argument: operation'):
+            await toolset.call_tool(
+                'file_system',
+                {'path': str(tmp_path)},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_missing_path(self, tmp_path: Path):
+        """Test missing path raises error."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(ValueError, match='Missing required argument: path'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'read'},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_write_missing_content(self, tmp_path: Path):
+        """Test write without content raises error."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)], allow_write=True)
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(ValueError, match='Missing required argument for write operation: content'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'write', 'path': str(tmp_path / 'test.txt')},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_search_missing_pattern(self, tmp_path: Path):
+        """Test search without pattern raises error."""
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        with pytest.raises(ValueError, match='Missing required argument for search operation: pattern'):
+            await toolset.call_tool(
+                'file_system',
+                {'operation': 'search', 'path': str(tmp_path)},
+                ctx,
+                tools['file_system'],
+            )
+
+    async def test_empty_file(self, tmp_path: Path):
+        """Test reading an empty file."""
+        file = tmp_path / 'empty.txt'
+        file.write_text('')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+        tools = await toolset.get_tools(ctx)
+
+        result = await toolset.call_tool(
+            'file_system',
+            {'operation': 'read', 'path': str(file)},
+            ctx,
+            tools['file_system'],
+        )
+        assert result == ''
+
+    async def test_toolset_id(self):
+        """Test toolset ID property."""
+        toolset_no_id = FileSystemToolset()
+        assert toolset_no_id.id is None
+
+        toolset_with_id = FileSystemToolset(_id='my-fs-toolset')
+        assert toolset_with_id.id == 'my-fs-toolset'
+
+
+class TestFileSystemToolBuiltinTool:
+    """Tests for the FileSystemTool builtin tool configuration."""
+
+    def test_file_system_tool_kind(self):
+        """Test that FileSystemTool has correct kind."""
+        tool = FileSystemTool()
+        assert tool.kind == 'file_system'
+
+    def test_file_system_tool_default_values(self):
+        """Test default values for FileSystemTool."""
+        tool = FileSystemTool()
+        assert tool.allowed_paths is None
+        assert tool.allow_write is False
+        assert tool.allow_delete is False
+        assert tool.max_file_size == 10 * 1024 * 1024
+        assert tool.allowed_extensions is None
+
+    def test_file_system_tool_custom_values(self, tmp_path: Path):
+        """Test custom values for FileSystemTool."""
+        tool = FileSystemTool(
+            allowed_paths=[str(tmp_path)],
+            allow_write=True,
+            allow_delete=True,
+            max_file_size=1000,
+            allowed_extensions=['.txt'],
+        )
+        assert tool.allowed_paths == [str(tmp_path)]
+        assert tool.allow_write is True
+        assert tool.allow_delete is True
+        assert tool.max_file_size == 1000
+        assert tool.allowed_extensions == ['.txt']
+
+    def test_to_toolset(self, tmp_path: Path):
+        """Test converting FileSystemTool to FileSystemToolset."""
+        tool = FileSystemTool(
+            allowed_paths=[str(tmp_path)],
+            allow_write=True,
+            allow_delete=True,
+            max_file_size=1000,
+            allowed_extensions=['.txt'],
+        )
+        toolset = tool.to_toolset()
+
+        assert isinstance(toolset, FileSystemToolset)
+        assert toolset.allowed_paths == [str(tmp_path)]
+        assert toolset.allow_write is True
+        assert toolset.allow_delete is True
+        assert toolset.max_file_size == 1000
+        assert toolset.allowed_extensions == ['.txt']
+
+    def test_to_toolset_empty_allowed_paths(self):
+        """Test converting FileSystemTool with no allowed paths."""
+        tool = FileSystemTool()
+        toolset = tool.to_toolset()
+
+        assert isinstance(toolset, FileSystemToolset)
+        assert toolset.allowed_paths == []
+
+
+class TestFileSystemToolsetWithToolManager:
+    """Tests for FileSystemToolset integration with ToolManager."""
+
+    async def test_tool_manager_integration(self, tmp_path: Path):
+        """Test that FileSystemToolset works with ToolManager."""
+        file = tmp_path / 'test.txt'
+        file.write_text('Content')
+
+        toolset = FileSystemToolset(allowed_paths=[str(tmp_path)])
+        ctx = build_run_context()
+
+        tool_manager = await ToolManager(toolset).for_run_step(ctx)
+
+        tool_defs = tool_manager.tool_defs
+        assert len(tool_defs) == 1
+        assert tool_defs[0].name == 'file_system'
+
+        result = await tool_manager.handle_call(
+            ToolCallPart(
+                tool_name='file_system',
+                args={'operation': 'read', 'path': str(file)},
+            )
+        )
+        assert result == 'Content'


### PR DESCRIPTION
## Summary

Add new `FileSystemToolset` that allows agents to access the local file system with security controls.

### Features
- **Operations**: `read`, `write`, `list`, `info`, `search`, `delete`
- **Security controls**:
  - `allowed_paths` - restrict access to specific directories
  - `allow_write` / `allow_delete` - control write/delete permissions
  - `max_file_size` - limit readable file size
  - `allowed_extensions` - filter by file extensions
- Path traversal protection (prevents `../` attacks)

### Usage

```python
from pydantic_ai import Agent
from pydantic_ai.toolsets import FileSystemToolset

agent = Agent(
    'openai:gpt-4.1',
    toolsets=[
        FileSystemToolset(
            allowed_paths=['/home/user/data'],
            allow_write=True,
            allowed_extensions=['.txt', '.json'],
        ),
    ],
)
```

Also available as `FileSystemTool` builtin tool configuration:

```python
from pydantic_ai import Agent
from pydantic_ai.builtin_tools import FileSystemTool

agent = Agent(
    'openai:gpt-4.1',
    builtin_tools=[
        FileSystemTool(
            allowed_paths=['/home/user/data'],
        ),
    ],
)
```

## Test plan

- [x] Path validation tests (allowed paths, traversal attacks, cwd restriction)
- [x] Extension filtering tests
- [x] Operation permission tests (read, write, delete)
- [x] File size limit tests
- [x] All file operations (read, write, list, info, search, delete)
- [x] Tool definition generation tests
- [x] Edge cases and error handling
- [x] ToolManager integration test
- [x] 100% coverage for `filesystem.py`

---

Context: Found during production work at [Vstorm](https://vstorm.co) · [github.com/vstorm-co](https://github.com/vstorm-co).