### PR TITLE
feat: Add ToolSearchTool and defer_loading for dynamic tool discovery

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1142,6 +1142,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         sequential: bool = False,
         requires_approval: bool = False,
         metadata: dict[str, Any] | None = None,
+        defer_loading: bool = False,
     ) -> Callable[[ToolFuncPlain[ToolParams]], ToolFuncPlain[ToolParams]]: ...
 
     def tool_plain(
@@ -1160,6 +1161,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         sequential: bool = False,
         requires_approval: bool = False,
         metadata: dict[str, Any] | None = None,
+        defer_loading: bool = False,
     ) -> Any:
         """Decorator to register a tool function which DOES NOT take `RunContext` as an argument.
 
@@ -1209,6 +1211,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             requires_approval: Whether this tool requires human-in-the-loop approval. Defaults to False.
                 See the [tools documentation](../deferred-tools.md#human-in-the-loop-tool-approval) for more info.
             metadata: Optional metadata for the tool. This is not sent to the model but can be used for filtering and tool behavior customization.
+            defer_loading: Whether to defer loading this tool until discovered via tool search. Defaults to False.
+                See [`ToolDefinition.defer_loading`][pydantic_ai.tools.ToolDefinition.defer_loading] for more info.
         """
 
         def tool_decorator(func_: ToolFuncPlain[ToolParams]) -> ToolFuncPlain[ToolParams]:
@@ -1227,6 +1231,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 sequential=sequential,
                 requires_approval=requires_approval,
                 metadata=metadata,
+                defer_loading=defer_loading,
             )
             return func_
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -119,6 +119,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         sequential: bool | None = None,
         requires_approval: bool | None = None,
         metadata: dict[str, Any] | None = None,
+        defer_loading: bool | None = None,
     ) -> Callable[[ToolFuncEither[AgentDepsT, ToolParams]], ToolFuncEither[AgentDepsT, ToolParams]]: ...
 
     def tool(
@@ -137,6 +138,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         sequential: bool | None = None,
         requires_approval: bool | None = None,
         metadata: dict[str, Any] | None = None,
+        defer_loading: bool | None = None,
     ) -> Any:
         """Decorator to register a tool function which takes [`RunContext`][pydantic_ai.tools.RunContext] as its first argument.
 
@@ -193,6 +195,8 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 If `None`, the default value is determined by the toolset.
             metadata: Optional metadata for the tool. This is not sent to the model but can be used for filtering and tool behavior customization.
                 If `None`, the default value is determined by the toolset. If provided, it will be merged with the toolset's metadata.
+            defer_loading: Whether to defer loading this tool until discovered via tool search. Defaults to False.
+                See [`ToolDefinition.defer_loading`][pydantic_ai.tools.ToolDefinition.defer_loading] for more info.
         """
 
         def tool_decorator(
@@ -213,6 +217,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 sequential=sequential,
                 requires_approval=requires_approval,
                 metadata=metadata,
+                defer_loading=defer_loading,
             )
             return func_
 
@@ -233,6 +238,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         sequential: bool | None = None,
         requires_approval: bool | None = None,
         metadata: dict[str, Any] | None = None,
+        defer_loading: bool | None = None,
     ) -> None:
         """Add a function as a tool to the toolset.
 
@@ -267,6 +273,8 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 If `None`, the default value is determined by the toolset.
             metadata: Optional metadata for the tool. This is not sent to the model but can be used for filtering and tool behavior customization.
                 If `None`, the default value is determined by the toolset. If provided, it will be merged with the toolset's metadata.
+            defer_loading: Whether to defer loading this tool until discovered via tool search. Defaults to False.
+                See [`ToolDefinition.defer_loading`][pydantic_ai.tools.ToolDefinition.defer_loading] for more info.
         """
         if docstring_format is None:
             docstring_format = self.docstring_format
@@ -295,6 +303,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             sequential=sequential,
             requires_approval=requires_approval,
             metadata=metadata,
+            defer_loading=defer_loading or False,
         )
         self.add_tool(tool)
 

--- a/tests/models/anthropic/test_tool_search.py
+++ b/tests/models/anthropic/test_tool_search.py
@@ -1,0 +1,180 @@
+"""Tests for Anthropic ToolSearchTool and defer_loading features.
+
+These features enable dynamic tool discovery without loading all definitions upfront.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from pydantic_ai import Agent, Tool
+from pydantic_ai.tools import ToolDefinition
+
+from ...conftest import try_import
+from ..test_anthropic import MockAnthropic, completion_message
+
+with try_import() as imports_successful:
+    from anthropic.types.beta import BetaTextBlock, BetaUsage
+
+    from pydantic_ai.builtin_tools import ToolSearchTool
+    from pydantic_ai.models.anthropic import AnthropicModel
+    from pydantic_ai.providers.anthropic import AnthropicProvider
+
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='anthropic not installed'),
+]
+
+
+class TestToolDefinitionDeferLoading:
+    """Tests for ToolDefinition.defer_loading field."""
+
+    def test_defer_loading_defaults_to_false(self):
+        """Test that defer_loading defaults to False."""
+        tool_def = ToolDefinition(name='test_tool')
+        assert tool_def.defer_loading is False
+
+    def test_defer_loading_can_be_set(self):
+        """Test setting defer_loading."""
+        tool_def = ToolDefinition(name='test_tool', defer_loading=True)
+        assert tool_def.defer_loading is True
+
+
+class TestToolDeferLoading:
+    """Tests for Tool class with defer_loading."""
+
+    def test_tool_defer_loading_default(self):
+        """Test that Tool.defer_loading defaults to False."""
+
+        def my_tool(x: int) -> str:
+            return str(x)
+
+        tool = Tool(my_tool)
+        assert tool.defer_loading is False
+        assert tool.tool_def.defer_loading is False
+
+    def test_tool_defer_loading_set(self):
+        """Test setting Tool.defer_loading."""
+
+        def my_tool(x: int) -> str:
+            return str(x)
+
+        tool = Tool(my_tool, defer_loading=True)
+        assert tool.defer_loading is True
+        assert tool.tool_def.defer_loading is True
+
+
+class TestToolSearchTool:
+    """Tests for ToolSearchTool builtin tool."""
+
+    def test_tool_search_tool_defaults(self):
+        """Test ToolSearchTool defaults."""
+        tool = ToolSearchTool()
+        assert tool.kind == 'tool_search'
+        assert tool.search_type is None
+
+    def test_tool_search_tool_with_regex(self):
+        """Test ToolSearchTool with regex search type."""
+        tool = ToolSearchTool(search_type='regex')
+        assert tool.search_type == 'regex'
+
+    def test_tool_search_tool_with_bm25(self):
+        """Test ToolSearchTool with bm25 search type."""
+        tool = ToolSearchTool(search_type='bm25')
+        assert tool.search_type == 'bm25'
+
+
+class TestAnthropicMapToolDefinitionDeferLoading:
+    """Tests for AnthropicModel._map_tool_definition with defer_loading."""
+
+    def test_map_tool_definition_without_defer_loading(self):
+        """Test tool definition mapping without defer_loading."""
+        tool_def = ToolDefinition(
+            name='test_tool',
+            description='A test tool',
+        )
+        c = completion_message(
+            [BetaTextBlock(text='Hello', type='text')],
+            BetaUsage(input_tokens=5, output_tokens=10),
+        )
+        mock_client = MockAnthropic.create_mock(c)
+        model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+        result = model._map_tool_definition(tool_def)  # pyright: ignore[reportPrivateUsage]
+        result_dict = cast(dict[str, Any], result)
+        assert 'defer_loading' not in result_dict
+
+    def test_map_tool_definition_with_defer_loading(self):
+        """Test tool definition mapping with defer_loading."""
+        tool_def = ToolDefinition(
+            name='test_tool',
+            description='A test tool',
+            defer_loading=True,
+        )
+        c = completion_message(
+            [BetaTextBlock(text='Hello', type='text')],
+            BetaUsage(input_tokens=5, output_tokens=10),
+        )
+        mock_client = MockAnthropic.create_mock(c)
+        model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+        result = model._map_tool_definition(tool_def)  # pyright: ignore[reportPrivateUsage]
+        result_dict = cast(dict[str, Any], result)
+        assert result_dict['defer_loading'] is True
+
+
+class TestAgentWithDeferLoading:
+    """Tests for Agent with defer_loading on tools."""
+
+    def test_agent_with_defer_loading_tool(self):
+        """Test creating an agent with a tool that has defer_loading."""
+
+        def my_tool(x: int) -> str:
+            """A test tool."""
+            return str(x)
+
+        agent = Agent(
+            'test',
+            tools=[Tool(my_tool, defer_loading=True)],
+        )
+
+        # Verify the tool was registered with defer_loading
+        tool = agent._function_toolset.tools.get('my_tool')  # pyright: ignore[reportPrivateUsage]
+        assert tool is not None
+        assert tool.defer_loading is True
+
+    def test_agent_tool_plain_decorator_with_defer_loading(self):
+        """Test the @agent.tool_plain decorator with defer_loading."""
+        agent: Agent[None, str] = Agent('test')
+
+        @agent.tool_plain(defer_loading=True)
+        def my_deferred_tool(x: int) -> str:
+            """A tool with defer_loading."""
+            return str(x)
+
+        tool = agent._function_toolset.tools.get('my_deferred_tool')  # pyright: ignore[reportPrivateUsage]
+        assert tool is not None
+        assert tool.defer_loading is True
+
+
+class TestAgentWithToolSearchTool:
+    """Tests for Agent with ToolSearchTool."""
+
+    def test_agent_with_tool_search_tool(self):
+        """Test creating an agent with ToolSearchTool."""
+        agent = Agent(
+            'test',
+            builtin_tools=[ToolSearchTool()],
+        )
+
+        assert any(isinstance(t, ToolSearchTool) for t in agent._builtin_tools)  # pyright: ignore[reportPrivateUsage]
+
+    def test_agent_with_tool_search_tool_bm25(self):
+        """Test creating an agent with ToolSearchTool using bm25."""
+        agent = Agent(
+            'test',
+            builtin_tools=[ToolSearchTool(search_type='bm25')],
+        )
+
+        tool_search = next(t for t in agent._builtin_tools if isinstance(t, ToolSearchTool))  # pyright: ignore[reportPrivateUsage]
+        assert tool_search.search_type == 'bm25'

--- a/tests/models/test_model_request_parameters.py
+++ b/tests/models/test_model_request_parameters.py
@@ -68,6 +68,7 @@ def test_model_request_parameters_are_serializable():
                     'sequential': False,
                     'kind': 'function',
                     'metadata': None,
+                    'defer_loading': False,
                 }
             ],
             'builtin_tools': [
@@ -131,6 +132,7 @@ def test_model_request_parameters_are_serializable():
                     'sequential': False,
                     'kind': 'function',
                     'metadata': None,
+                    'defer_loading': False,
                 }
             ],
             'prompted_output_template': None,

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -547,6 +547,7 @@ def test_logfire(
                                 'sequential': False,
                                 'kind': 'function',
                                 'metadata': None,
+                                'defer_loading': False,
                             }
                         ],
                         'builtin_tools': [],
@@ -994,6 +995,7 @@ def test_instructions_with_structured_output_exclude_content_v2_v3(
                                 'sequential': False,
                                 'kind': 'output',
                                 'metadata': None,
+                                'defer_loading': False,
                             }
                         ],
                         'prompted_output_template': None,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -150,6 +150,7 @@ def test_docstring_google(docstring_format: Literal['google', 'auto']):
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -184,6 +185,7 @@ def test_docstring_sphinx(docstring_format: Literal['sphinx', 'auto']):
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -226,6 +228,7 @@ def test_docstring_numpy(docstring_format: Literal['numpy', 'auto']):
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -268,6 +271,7 @@ def test_google_style_with_returns():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -308,6 +312,7 @@ def test_sphinx_style_with_returns():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -354,6 +359,7 @@ def test_numpy_style_with_returns():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -388,6 +394,7 @@ def test_only_returns_type():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -413,6 +420,7 @@ def test_docstring_unknown():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -456,6 +464,7 @@ def test_docstring_google_no_body(docstring_format: Literal['google', 'auto']):
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -492,6 +501,7 @@ def test_takes_just_model():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -537,6 +547,7 @@ def test_takes_model_and_int():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -902,6 +913,7 @@ def test_suppress_griffe_logging(caplog: LogCaptureFixture):
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 
@@ -974,6 +986,7 @@ def test_json_schema_required_parameters():
                 'kind': 'function',
                 'sequential': False,
                 'metadata': None,
+                'defer_loading': False,
             },
             {
                 'description': None,
@@ -989,6 +1002,7 @@ def test_json_schema_required_parameters():
                 'kind': 'function',
                 'sequential': False,
                 'metadata': None,
+                'defer_loading': False,
             },
         ]
     )
@@ -1077,6 +1091,7 @@ def test_schema_generator():
                 'kind': 'function',
                 'sequential': False,
                 'metadata': None,
+                'defer_loading': False,
             },
             {
                 'description': None,
@@ -1090,6 +1105,7 @@ def test_schema_generator():
                 'kind': 'function',
                 'sequential': False,
                 'metadata': None,
+                'defer_loading': False,
             },
         ]
     )
@@ -1127,6 +1143,7 @@ def test_tool_parameters_with_attribute_docstrings():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'defer_loading': False,
         }
     )
 


### PR DESCRIPTION
## Summary

Adds support for dynamic tool discovery without loading all tool definitions upfront, reducing token usage for agents with many tools.

- Add `ToolSearchTool` builtin tool for on-demand tool discovery
  - Supports `search_type` of 'regex' or 'bm25' (defaults to `None` = provider's default)
- Add `defer_loading` field to `ToolDefinition` and `Tool` class
- Automatically add `ToolSearchTool` when any tool has `defer_loading=True`
- Update Anthropic model to map `defer_loading` to API
- Enable `advanced-tool-use-2025-11-20` beta automatically when features are used

Supported by Anthropic models.
See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/tool-search-tool

## Test plan

- [x] Added unit tests in `tests/models/anthropic/test_tool_search.py`
- [x] All tests pass
- [x] No new pyright errors introduced

## Related

Split from #3550 per @DouweM's recommendation to separate the features into individual PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)