### PR TITLE
feat: Add Anthropic programmatically_callable (PTC) support

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -8,7 +8,7 @@ from asyncio import Lock
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequence
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager, contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, ClassVar, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
 
 from opentelemetry.trace import NoOpTracer, use_span
 from pydantic.json_schema import GenerateJsonSchema
@@ -1031,6 +1031,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         sequential: bool = False,
         requires_approval: bool = False,
         metadata: dict[str, Any] | None = None,
+        programmatically_callable: bool | Literal['only'] = False,
     ) -> Callable[[ToolFuncContext[AgentDepsT, ToolParams]], ToolFuncContext[AgentDepsT, ToolParams]]: ...
 
     def tool(
@@ -1049,6 +1050,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         sequential: bool = False,
         requires_approval: bool = False,
         metadata: dict[str, Any] | None = None,
+        programmatically_callable: bool | Literal['only'] = False,
     ) -> Any:
         """Decorator to register a tool function which takes [`RunContext`][pydantic_ai.tools.RunContext] as its first argument.
 
@@ -1098,6 +1100,10 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             requires_approval: Whether this tool requires human-in-the-loop approval. Defaults to False.
                 See the [tools documentation](../deferred-tools.md#human-in-the-loop-tool-approval) for more info.
             metadata: Optional metadata for the tool. This is not sent to the model but can be used for filtering and tool behavior customization.
+            programmatically_callable: Whether this tool can be called from code execution.
+                Set to `True` to allow both direct model calls and calls from code execution.
+                Set to `'only'` to only allow calls from code execution.
+                Defaults to `False`. See [`ToolDefinition`][pydantic_ai.tools.ToolDefinition] for more info.
         """
 
         def tool_decorator(
@@ -1118,6 +1124,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 sequential=sequential,
                 requires_approval=requires_approval,
                 metadata=metadata,
+                programmatically_callable=programmatically_callable,
             )
             return func_
 
@@ -1142,6 +1149,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         sequential: bool = False,
         requires_approval: bool = False,
         metadata: dict[str, Any] | None = None,
+        programmatically_callable: bool | Literal['only'] = False,
     ) -> Callable[[ToolFuncPlain[ToolParams]], ToolFuncPlain[ToolParams]]: ...
 
     def tool_plain(
@@ -1160,6 +1168,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         sequential: bool = False,
         requires_approval: bool = False,
         metadata: dict[str, Any] | None = None,
+        programmatically_callable: bool | Literal['only'] = False,
     ) -> Any:
         """Decorator to register a tool function which DOES NOT take `RunContext` as an argument.
 
@@ -1209,6 +1218,10 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             requires_approval: Whether this tool requires human-in-the-loop approval. Defaults to False.
                 See the [tools documentation](../deferred-tools.md#human-in-the-loop-tool-approval) for more info.
             metadata: Optional metadata for the tool. This is not sent to the model but can be used for filtering and tool behavior customization.
+            programmatically_callable: Whether this tool can be called from code execution.
+                Set to `True` to allow both direct model calls and calls from code execution.
+                Set to `'only'` to only allow calls from code execution.
+                Defaults to `False`. See [`ToolDefinition`][pydantic_ai.tools.ToolDefinition] for more info.
         """
 
         def tool_decorator(func_: ToolFuncPlain[ToolParams]) -> ToolFuncPlain[ToolParams]:
@@ -1227,6 +1240,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 sequential=sequential,
                 requires_approval=requires_approval,
                 metadata=metadata,
+                programmatically_callable=programmatically_callable,
             )
             return func_
 

--- a/tests/models/anthropic/test_programmatically_callable.py
+++ b/tests/models/anthropic/test_programmatically_callable.py
@@ -1,0 +1,204 @@
+"""Tests for Anthropic programmatically_callable (Programmatic Tool Calling) feature."""
+
+from __future__ import annotations as _annotations
+
+import pytest
+
+from ...conftest import try_import
+
+with try_import() as imports_successful:
+    from anthropic.types.beta import BetaTextBlock, BetaUsage
+
+    from pydantic_ai import Agent
+    from pydantic_ai.builtin_tools import CodeExecutionTool
+    from pydantic_ai.models.anthropic import AnthropicModel
+    from pydantic_ai.providers.anthropic import AnthropicProvider
+
+    from ..test_anthropic import MockAnthropic, completion_message
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='anthropic not installed'),
+    pytest.mark.anyio,
+]
+
+
+async def test_programmatically_callable_true(allow_model_requests: None):
+    """Test that programmatically_callable=True maps to allowed_callers with both direct and code_execution."""
+    c = completion_message(
+        [BetaTextBlock(text='Done', type='text')],
+        BetaUsage(input_tokens=5, output_tokens=10),
+    )
+    mock_client = MockAnthropic.create_mock(c)
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    agent = Agent(model)
+
+    @agent.tool_plain(programmatically_callable=True)
+    def my_tool(x: int) -> int:
+        """A tool that can be called from code execution."""
+        return x * 2
+
+    await agent.run('test')
+
+    # Check that the tool was configured with allowed_callers
+    assert len(mock_client.chat_completion_kwargs) == 1
+    tools = mock_client.chat_completion_kwargs[0]['tools']
+
+    # Find the my_tool definition
+    my_tool_def = next((t for t in tools if t.get('name') == 'my_tool'), None)
+    assert my_tool_def is not None
+    assert my_tool_def.get('allowed_callers') == ['direct', 'code_execution_20250825']
+
+
+async def test_programmatically_callable_only(allow_model_requests: None):
+    """Test that programmatically_callable='only' maps to allowed_callers with only code_execution."""
+    c = completion_message(
+        [BetaTextBlock(text='Done', type='text')],
+        BetaUsage(input_tokens=5, output_tokens=10),
+    )
+    mock_client = MockAnthropic.create_mock(c)
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    agent = Agent(model)
+
+    @agent.tool_plain(programmatically_callable='only')
+    def my_tool(x: int) -> int:
+        """A tool that can only be called from code execution."""
+        return x * 2
+
+    await agent.run('test')
+
+    # Check that the tool was configured with allowed_callers
+    assert len(mock_client.chat_completion_kwargs) == 1
+    tools = mock_client.chat_completion_kwargs[0]['tools']
+
+    # Find the my_tool definition
+    my_tool_def = next((t for t in tools if t.get('name') == 'my_tool'), None)
+    assert my_tool_def is not None
+    assert my_tool_def.get('allowed_callers') == ['code_execution_20250825']
+
+
+async def test_programmatically_callable_false(allow_model_requests: None):
+    """Test that programmatically_callable=False (default) doesn't add allowed_callers."""
+    c = completion_message(
+        [BetaTextBlock(text='Done', type='text')],
+        BetaUsage(input_tokens=5, output_tokens=10),
+    )
+    mock_client = MockAnthropic.create_mock(c)
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    agent = Agent(model)
+
+    @agent.tool_plain
+    def my_tool(x: int) -> int:
+        """A regular tool."""
+        return x * 2
+
+    await agent.run('test')
+
+    # Check that the tool was NOT configured with allowed_callers
+    assert len(mock_client.chat_completion_kwargs) == 1
+    tools = mock_client.chat_completion_kwargs[0]['tools']
+
+    # Find the my_tool definition
+    my_tool_def = next((t for t in tools if t.get('name') == 'my_tool'), None)
+    assert my_tool_def is not None
+    assert 'allowed_callers' not in my_tool_def
+
+
+async def test_auto_adds_code_execution_tool(allow_model_requests: None):
+    """Test that CodeExecutionTool is auto-added when programmatically_callable is used."""
+    c = completion_message(
+        [BetaTextBlock(text='Done', type='text')],
+        BetaUsage(input_tokens=5, output_tokens=10),
+    )
+    mock_client = MockAnthropic.create_mock(c)
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    # No explicit CodeExecutionTool in builtin_tools
+    agent = Agent(model)
+
+    @agent.tool_plain(programmatically_callable=True)
+    def my_tool(x: int) -> int:
+        """A tool that can be called from code execution."""
+        return x * 2
+
+    await agent.run('test')
+
+    # Check that code_execution tool was auto-added
+    assert len(mock_client.chat_completion_kwargs) == 1
+    tools = mock_client.chat_completion_kwargs[0]['tools']
+
+    # Should have my_tool and code_execution
+    tool_names = [t.get('name') for t in tools]
+    assert 'my_tool' in tool_names
+    assert 'code_execution' in tool_names
+
+    # Check that the newer code execution type is used
+    code_exec_tool = next((t for t in tools if t.get('name') == 'code_execution'), None)
+    assert code_exec_tool is not None
+    assert code_exec_tool.get('type') == 'code_execution_20250825'
+
+
+async def test_uses_newer_code_execution_with_ptc(allow_model_requests: None):
+    """Test that the newer code execution tool is used when PTC is enabled."""
+    c = completion_message(
+        [BetaTextBlock(text='Done', type='text')],
+        BetaUsage(input_tokens=5, output_tokens=10),
+    )
+    mock_client = MockAnthropic.create_mock(c)
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    # Explicitly add CodeExecutionTool
+    agent = Agent(model, builtin_tools=[CodeExecutionTool()])
+
+    @agent.tool_plain(programmatically_callable=True)
+    def my_tool(x: int) -> int:
+        """A tool that can be called from code execution."""
+        return x * 2
+
+    await agent.run('test')
+
+    # Check that the newer code execution type is used
+    assert len(mock_client.chat_completion_kwargs) == 1
+    tools = mock_client.chat_completion_kwargs[0]['tools']
+
+    code_exec_tool = next((t for t in tools if t.get('name') == 'code_execution'), None)
+    assert code_exec_tool is not None
+    assert code_exec_tool.get('type') == 'code_execution_20250825'
+
+    # Also check that the newer beta is used
+    betas = mock_client.chat_completion_kwargs[0].get('betas', [])
+    assert 'code-execution-2025-08-25' in betas
+
+
+async def test_uses_older_code_execution_without_ptc(allow_model_requests: None):
+    """Test that the older code execution tool is used when PTC is not enabled."""
+    c = completion_message(
+        [BetaTextBlock(text='Done', type='text')],
+        BetaUsage(input_tokens=5, output_tokens=10),
+    )
+    mock_client = MockAnthropic.create_mock(c)
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    # Add CodeExecutionTool but no programmatically_callable tools
+    agent = Agent(model, builtin_tools=[CodeExecutionTool()])
+
+    @agent.tool_plain
+    def my_tool(x: int) -> int:
+        """A regular tool."""
+        return x * 2
+
+    await agent.run('test')
+
+    # Check that the older code execution type is used
+    assert len(mock_client.chat_completion_kwargs) == 1
+    tools = mock_client.chat_completion_kwargs[0]['tools']
+
+    code_exec_tool = next((t for t in tools if t.get('name') == 'code_execution'), None)
+    assert code_exec_tool is not None
+    assert code_exec_tool.get('type') == 'code_execution_20250522'
+
+    # Also check that the older beta is used
+    betas = mock_client.chat_completion_kwargs[0].get('betas', [])
+    assert 'code-execution-2025-05-22' in betas

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -150,6 +150,7 @@ def test_docstring_google(docstring_format: Literal['google', 'auto']):
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -184,6 +185,7 @@ def test_docstring_sphinx(docstring_format: Literal['sphinx', 'auto']):
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -226,6 +228,7 @@ def test_docstring_numpy(docstring_format: Literal['numpy', 'auto']):
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -268,6 +271,7 @@ def test_google_style_with_returns():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -308,6 +312,7 @@ def test_sphinx_style_with_returns():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -354,6 +359,7 @@ def test_numpy_style_with_returns():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -388,6 +394,7 @@ def test_only_returns_type():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -413,6 +420,7 @@ def test_docstring_unknown():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -456,6 +464,7 @@ def test_docstring_google_no_body(docstring_format: Literal['google', 'auto']):
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -492,6 +501,7 @@ def test_takes_just_model():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -537,6 +547,7 @@ def test_takes_model_and_int():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -902,6 +913,7 @@ def test_suppress_griffe_logging(caplog: LogCaptureFixture):
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 
@@ -974,6 +986,7 @@ def test_json_schema_required_parameters():
                 'kind': 'function',
                 'sequential': False,
                 'metadata': None,
+                'programmatically_callable': False,
             },
             {
                 'description': None,
@@ -989,6 +1002,7 @@ def test_json_schema_required_parameters():
                 'kind': 'function',
                 'sequential': False,
                 'metadata': None,
+                'programmatically_callable': False,
             },
         ]
     )
@@ -1077,6 +1091,7 @@ def test_schema_generator():
                 'kind': 'function',
                 'sequential': False,
                 'metadata': None,
+                'programmatically_callable': False,
             },
             {
                 'description': None,
@@ -1090,6 +1105,7 @@ def test_schema_generator():
                 'kind': 'function',
                 'sequential': False,
                 'metadata': None,
+                'programmatically_callable': False,
             },
         ]
     )
@@ -1127,6 +1143,7 @@ def test_tool_parameters_with_attribute_docstrings():
             'kind': 'function',
             'sequential': False,
             'metadata': None,
+            'programmatically_callable': False,
         }
     )
 


### PR DESCRIPTION
## Summary

This adds support for Anthropic's programmatic tool calling feature, allowing tools to be called from within code execution blocks.

**Part 3 of 3** - Following the review recommendations on #3550, splitting into:
1. PR #3619: `input_examples` feature
2. PR #3620: Tool Search + `defer_loading` feature  
3. **This PR**: Programmatic Tool Calling (`programmatically_callable`)

### Changes

- Add `programmatically_callable` field to `ToolDefinition` dataclass
  - `False` (default): Tool can only be called directly by the model
  - `True`: Tool callable both directly and from code execution
  - `'only'`: Tool only callable from code execution

- Add `programmatically_callable` parameter to:
  - `Tool` class constructor
  - `FunctionToolset.add_function()` and `@tool` decorator
  - `Agent.tool()` and `Agent.tool_plain()` decorators

- Update Anthropic model:
  - Map `programmatically_callable` to Anthropic's `allowed_callers` API
  - Auto-add `CodeExecutionTool` when `programmatically_callable` is used
  - Use newer code execution tool (20250825) when PTC is enabled
  - Store `caller` and `container_id` in `ToolCallPart.provider_details` for tools called from code execution

### Example Usage

```python
from pydantic_ai import Agent
from pydantic_ai.builtin_tools import CodeExecutionTool

agent = Agent('anthropic:claude-sonnet-4-5', builtin_tools=[CodeExecutionTool()])

# Tool callable both directly by model and from code execution
@agent.tool_plain(programmatically_callable=True)
def add_numbers(x: int, y: int) -> int:
    """Add two numbers."""
    return x + y

# Tool only callable from code execution (not directly by model)
@agent.tool_plain(programmatically_callable='only')
def calculate_pi(precision: int) -> float:
    """Calculate pi to given precision."""
    # Only code execution can call this
    return 3.14159265358979
```

## Test plan

- [x] Added unit tests for `programmatically_callable` values (True, 'only', False)
- [x] Added test for auto-adding CodeExecutionTool when PTC is used
- [x] Added tests verifying correct code execution tool version is used
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)