### PR TITLE
fix: Copy `extra_headers` to allow `model_settings` reuse 

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -424,7 +424,7 @@ class AnthropicModel(Model):
         Handles merging custom `anthropic-beta` header from `extra_headers` into betas set
         and ensuring `User-Agent` is set.
         """
-        extra_headers = model_settings.get('extra_headers', {})
+        extra_headers = dict(model_settings.get('extra_headers', {}))
         extra_headers.setdefault('User-Agent', get_user_agent())
 
         betas: set[str] = set()
@@ -434,7 +434,7 @@ class AnthropicModel(Model):
         if has_strict_tools or model_request_parameters.output_mode == 'native':
             betas.add('structured-outputs-2025-11-13')
 
-        if beta_header := extra_headers.get('anthropic-beta', None):
+        if beta_header := extra_headers.pop('anthropic-beta', None):
             betas.update({stripped_beta for beta in beta_header.split(',') if (stripped_beta := beta.strip())})
 
         return betas, extra_headers


### PR DESCRIPTION
we can't reuse `model_settings` as pop the beta headers

```python
from pydantic_ai import Agent

from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
from pydantic_ai.providers.anthropic import AnthropicProvider

API_KEY = ''
provider = AnthropicProvider(
    api_key=API_KEY,
)

model_settings = AnthropicModelSettings(
    extra_headers={"anthropic-beta": "context-1m-2025-08-07"}
)
async def main():

    agent = Agent(
        model=AnthropicModel(
            "claude-sonnet-4-5", provider=provider, settings=model_settings
        ),
        system_prompt="You are a helpful assistant.",
    )
    result = await agent.run("Check budget:token_budget tag I tould you")
    print(result.output)
    async with agent.run_stream('Check budget:token_budget tag I tould you') as response:
        print(await response.get_output())
```