### PR TITLE
Disable use of `tool_choice=required` for deepseek-reasoner

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -53,6 +53,8 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
             openai_chat_thinking_field='reasoning_content',
             # Starting from DeepSeek v3.2, DeepSeek requires sending thinking parts for optimal agentic performance.
             openai_chat_send_back_thinking_parts='field',
+            # DeepSeek v3.2 reasoning mode does not support tool_choice=required yet
+            openai_supports_tool_choice_required=(model_name != 'deepseek-reasoner'),
         ).update(profile)
 
     @overload


### PR DESCRIPTION
I've been experimenting with DeepSeek v3.2 recently, and find the reasoner model from the official endpoint yields 400 Bad Request when `openai_supports_tool_choice_required` is not set to False. That is, deepseek-reasoner does not support `tool_choice=required`, at least for now.

I'm not sure if it's a provider-specific issue or a model characteristic, so I'm changing the provider side.