### PR TITLE
Support `us-gov.` and other multi-character Bedrock geo prefixes

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -687,8 +687,8 @@ class BedrockConverseModel(Model):
     def _remove_inference_geo_prefix(model_name: BedrockModelName) -> BedrockModelName:
         """Remove inference geographic prefix from model ID if present."""
         for prefix in BEDROCK_GEO_PREFIXES:
-            if model_name.startswith(prefix):
-                return model_name.removeprefix(prefix)
+            if model_name.startswith(f'{prefix}.'):
+                return model_name.removeprefix(f'{prefix}.')
         return model_name
 
 

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -109,10 +109,19 @@ def test_bedrock_provider_model_profile_all_geo_prefixes(env: TestEnv, prefix: s
     env.set('AWS_DEFAULT_REGION', 'us-east-1')
     provider = BedrockProvider()
 
-    model_name = f'{prefix}anthropic.claude-sonnet-4-5-20250929-v1:0'
+    model_name = f'{prefix}.anthropic.claude-sonnet-4-5-20250929-v1:0'
     profile = provider.model_profile(model_name)
 
     assert profile is not None, f'model_profile returned None for {model_name}'
+
+
+def test_bedrock_provider_model_profile_with_unknown_geo_prefix(env: TestEnv):
+    env.set('AWS_DEFAULT_REGION', 'us-east-1')
+    provider = BedrockProvider()
+
+    model_name = 'narnia.anthropic.claude-sonnet-4-5-20250929-v1:0'
+    profile = provider.model_profile(model_name)
+    assert profile is None, f'model_profile returned {profile} for {model_name}'
 
 
 def test_latest_bedrock_model_names_geo_prefixes_are_supported():
@@ -131,7 +140,7 @@ def test_latest_bedrock_model_names_geo_prefixes_are_supported():
         # - With prefix: "us.anthropic.claude-xxx" (3 parts)
         parts = model_name.split('.')
         if len(parts) >= 3:
-            geo_prefix = parts[0] + '.'
+            geo_prefix = parts[0]
             if geo_prefix not in BEDROCK_GEO_PREFIXES:  # pragma: no cover
                 missing_prefixes.add(geo_prefix)
 


### PR DESCRIPTION
## Summary

The `BedrockProvider.model_profile` method previously only handled 2-character regional prefixes (e.g., `us.`, `eu.`), causing issues with models using longer prefixes like `us-gov.` (AWS GovCloud) and `global.`.

## Problem

When using extended thinking with `us-gov.anthropic.*` models via Bedrock, the `model_profile` method doesn't recognize the `us-gov.` prefix because it only strips 2-character prefixes:

```python
# Previous implementation:
parts = model_name.split('.', 2)
if len(parts) > 2 and len(parts[0]) == 2:
    parts = parts[1:]
```

This causes `bedrock_send_back_thinking_parts` to stay at its default `False` value. As a result, `ThinkingPart` blocks from previous conversation turns are converted to text blocks with thinking tags instead of `reasoningContent`, causing Bedrock to reject the request with:

```
Expected `thinking` or `redacted_thinking`, but found `text`
```

## Solution

1. Added `_strip_geo_prefix()` helper function that properly handles all known geo prefixes including `us-gov.` and `global.`
2. Updated `_AWS_BEDROCK_INFERENCE_GEO_PREFIXES` constant to include `us-gov.` (the comment in the code already suggested this)
3. Added comprehensive parametrized tests for all 8 geo prefixes

## Affected Models

- `us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0`
- `us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0`
- `global.anthropic.claude-opus-4-5-20251101-v1:0`
- And any other cross-region inference profile using multi-character prefixes

## Testing

All existing tests pass, plus new parametrized tests for all geo prefixes