### PR TITLE
Adds native structured output support for `claude-haiku-4-5`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/anthropic.py
@@ -8,7 +8,12 @@ from . import ModelProfile
 
 def anthropic_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for an Anthropic model."""
-    models_that_support_json_schema_output = ('claude-sonnet-4-5', 'claude-opus-4-1', 'claude-opus-4-5')
+    models_that_support_json_schema_output = (
+        'claude-haiku-4-5',
+        'claude-sonnet-4-5',
+        'claude-opus-4-1',
+        'claude-opus-4-5',
+    )
     """These models support both structured outputs and strict tool calling."""
     # TODO update when new models are released that support structured outputs
     # https://docs.claude.com/en/docs/build-with-claude/structured-outputs#example-usage


### PR DESCRIPTION
Anthropic has added native structured output support for Haiku 4.5 as of December 04 https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-outputs