### PR TITLE
Suppress broken resource errors if cancelling

### DIFF
--- a/pydantic_graph/pydantic_graph/beta/graph.py
+++ b/pydantic_graph/pydantic_graph/beta/graph.py
@@ -756,7 +756,7 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                 else:
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, result))
             except BrokenResourceError:
-                pass  # This can happen in difficult-to-reproduce circumstances when cancelling an asyncio task
+                pass  # pragma: no cover # This can happen in difficult-to-reproduce circumstances when cancelling an asyncio task
 
     async def _run_task(
         self,


### PR DESCRIPTION
Closes #3655.

I am not sure if this fully addresses that issue, and it does have some downsides (namely, it will suppress errors in cases of real misbehavior, but I'm not sure whether it's possible to hit that misbehavior without modifying internals; even if it's not it's not ideal but I think this may be a reasonable compromise in at least some cases).

I think what's going on is that `iter_stream_sender` is getting closed in another task during clean-up caused by asyncio cancellation errors, but anyio is running other tasks that expect that `iter_stream_sender` to be working. Using `anyio` for task groups prevents this problem, and I shared a snippet in https://github.com/pydantic/pydantic-ai/issues/3655#issuecomment-3629071685 that provides a way to get asyncio semantics for task cancellation while still using anyio task groups, etc.

But I also think it's reasonable to make the change in this PR to just make asyncio tasks behave better. If this doesn't resolve the issue or somehow leads to new misbehaviors I wouldn't hesitate to revert this PR and try to find a different solution, but I suspect it is unlikely to cause new issues or we would have seen more reports.