### PR TITLE
Add prompt caching options to OpenAIChatModelSettings

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -201,6 +201,18 @@ class OpenAIChatModelSettings(ModelSettings, total=False):
     This feature is currently only supported for some OpenAI models.
     """
 
+    openai_prompt_cache_key: str
+    """Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
+
+    See the [OpenAI Prompt Caching documentation](https://platform.openai.com/docs/guides/prompt-caching#how-it-works) for more information.
+    """
+
+    openai_prompt_cache_retention: Literal['in-memory', '24h']
+    """The retention policy for the prompt cache. Set to 24h to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours.
+
+    See the [OpenAI Prompt Caching documentation](https://platform.openai.com/docs/guides/prompt-caching#how-it-works) for more information.
+    """
+
 
 @deprecated('Use `OpenAIChatModelSettings` instead.')
 class OpenAIModelSettings(OpenAIChatModelSettings, total=False):
@@ -550,6 +562,8 @@ class OpenAIChatModel(Model):
                 logit_bias=model_settings.get('logit_bias', OMIT),
                 logprobs=model_settings.get('openai_logprobs', OMIT),
                 top_logprobs=model_settings.get('openai_top_logprobs', OMIT),
+                prompt_cache_key=model_settings.get('openai_prompt_cache_key', OMIT),
+                prompt_cache_retention=model_settings.get('openai_prompt_cache_retention', OMIT),
                 extra_headers=extra_headers,
                 extra_body=model_settings.get('extra_body'),
             )
@@ -1393,6 +1407,8 @@ class OpenAIResponsesModel(Model):
                 user=model_settings.get('openai_user', OMIT),
                 text=text or OMIT,
                 include=include or OMIT,
+                prompt_cache_key=model_settings.get('openai_prompt_cache_key', OMIT),
+                prompt_cache_retention=model_settings.get('openai_prompt_cache_retention', OMIT),
                 extra_headers=extra_headers,
                 extra_body=model_settings.get('extra_body'),
             )


### PR DESCRIPTION
Adding support for OpenAI's prompt caching configuration parameters (`prompt_cache_key` and `prompt_cache_retention`) to the `OpenAIResponsesModelSettings`, enabling users to optimize cache hit rates and control cache retention behavior.

###  Why This Is Needed

While OpenAI's automatic prompt caching works out-of-the-box, the API provides additional parameters that allow developers to control and significantly improve caching effectiveness:

Cache control is incredibly important for controlling cost and latency at scale, in applications with significant input token reuse.

#### Cache Routing Optimization (prompt_cache_key)
OpenAI routes requests to servers based on a hash of the prompt prefix. When multiple requests share long common prefixes, providing a consistent prompt_cache_key helps route them to the same machine, improving cache hit rates. This is particularly beneficial for applications with shared system prompts or instructions across many user requests.

####  Cache Retention Control (prompt_cache_retention)
Default in-memory caching retains prefixes for 5-10 minutes (up to 1 hour max). Extended retention (24h) keeps cached prefixes active for up to 24 hours on supported models (gpt-5.1, gpt-5.1-codex, gpt-5, gpt-4.1), enabling applications to benefit from caching across longer time periods

### Changes

- Added `openai_prompt_cache_key: str` field to `OpenAIResponsesModelSettings`
- Added `openai_prompt_cache_retention field: Literal["in-memory", "24h"]` to `OpenAIResponsesModelSettings`
- Both parameters are passed through to the OpenAI Responses API as optional parameters
- Includes docstrings with links to OpenAI's official prompt caching guide