### PR TITLE
feat: support inferring media types from URLs with query params/fragments

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import KW_ONLY, dataclass, field, replace
 from datetime import datetime
+from functools import cached_property
 from mimetypes import guess_type
 from os import PathLike
 from pathlib import Path
@@ -192,8 +193,7 @@ class FileUrl(ABC):
         """The file format."""
         raise NotImplementedError
 
-    @pydantic.computed_field
-    @property
+    @cached_property
     def base_url(self) -> str:
         """The base URL of the file (removes any query parameters or fragments)."""
         return self.url.split('?', 1)[0].split('#', 1)[0]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -720,7 +720,6 @@ def test_image_url_validation_with_optional_identifier():
             'kind': 'image-url',
             'media_type': 'image/jpeg',
             'identifier': '39cfc4',
-            'base_url': 'https://example.com/image.jpg',
         }
     )
 
@@ -738,7 +737,6 @@ def test_image_url_validation_with_optional_identifier():
             'kind': 'image-url',
             'media_type': 'image/png',
             'identifier': 'foo',
-            'base_url': 'https://example.com/image.jpg',
         }
     )
 


### PR DESCRIPTION
Currently, pydantic-ai cannot infer media type for presigned S3 URLs due to the query parameters added to the URL. This improves the infer method to check just the base URL (query parameters and fragments stripped).