### PR TITLE
Fix `BedrockConverseModel` error when `ModelResponse.parts` is empty

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -584,7 +584,8 @@ class BedrockConverseModel(Model):
                     else:
                         assert isinstance(item, ToolCallPart)
                         content.append(self._map_tool_call(item))
-                bedrock_messages.append({'role': 'assistant', 'content': content})
+                if content:
+                    bedrock_messages.append({'role': 'assistant', 'content': content})
             else:
                 assert_never(message)
 

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -1624,3 +1624,33 @@ async def test_cache_point_filtering():
     # CachePoint should be filtered out, message should still be valid
     assert len(messages) == 1
     assert messages[0]['role'] == 'user'
+
+
+async def test_bedrock_empty_model_response_skipped(bedrock_provider: BedrockProvider):
+    """Test that ModelResponse with empty parts (e.g. content_filtered) is skipped in message mapping."""
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+
+    # Create a message history that includes a ModelResponse with empty parts
+    req = [
+        ModelRequest(parts=[UserPromptPart(content='Hello')]),
+        ModelResponse(
+            parts=[],
+            usage=RequestUsage(input_tokens=100, output_tokens=1),
+            model_name='us.amazon.nova-micro-v1:0',
+            provider_name='bedrock',
+            provider_details={'finish_reason': 'content_filtered'},
+            finish_reason='content_filter',
+        ),
+        ModelRequest(parts=[UserPromptPart(content='Follow up question')]),
+    ]
+
+    # Call the mapping function directly
+    _, bedrock_messages = await model._map_messages(req, ModelRequestParameters())  # type: ignore[reportPrivateUsage]
+
+    # The empty ModelResponse should be skipped, so we should only have 2 user messages
+    # that get merged into one since they're consecutive after the empty response is skipped
+    assert bedrock_messages == snapshot(
+        [
+            {'role': 'user', 'content': [{'text': 'Hello'}, {'text': 'Follow up question'}]},
+        ]
+    )


### PR DESCRIPTION
## Fix: avoid adding empty `ModelResponse` to content for BedrockConverseModel

### Problem
When a Bedrock model returns a content-filtered response, the ModelResponse has `parts=[]`. Previously, `_map_messages` would still append an empty assistant message to the Bedrock request:

```
bedrock_messages.append({'role': 'assistant', 'content': []})
```

This causes ModelHTTPErrors when sending follow-up requests to Bedrock with an empty assistant message in the conversation history: e.g. `The content field in the Message object at messages.2 is empty...`

### Solution
Added a conditional check to only append assistant messages when there is actual content:
if content: 

```
bedrock_messages.append({'role': 'assistant', 'content': content})
```

This ensures that `ModelResponse` messages with empty `parts` (e.g., from content-filtered responses) are gracefully skipped during message mapping.

Adds tests. Thanks @DouweM for suggesting the fix.