### PR TITLE
Pin deno to v2.5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.5.x
 
       - run: mkdir .coverage
 
@@ -222,7 +222,7 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.5.x
 
       - run: mkdir .coverage
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.5.x
 
       - run: uv tool install pre-commit
 


### PR DESCRIPTION
- Pinning required by https://github.com/denoland/deno/issues/31557
- Related to https://github.com/pydantic/mcp-run-python/pull/33