### PR TITLE
Make `OpenRouterProvider` and `DeepSeekProvider` `__init__` overloads less restrictive

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -58,16 +58,16 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
         ).update(profile)
 
     @overload
-    def __init__(self) -> None: ...
+    def __init__(self, *, openai_client: AsyncOpenAI) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str) -> None: ...
-
-    @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
-
-    @overload
-    def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        openai_client: None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None: ...
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -137,25 +137,18 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
         ).update(profile)
 
     @overload
-    def __init__(self) -> None: ...
+    def __init__(self, *, openai_client: AsyncOpenAI) -> None: ...
 
     @overload
-    def __init__(self, *, api_key: str) -> None: ...
-
-    @overload
-    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
-
-    @overload
-    def __init__(self, *, api_key: str, app_url: str, app_title: str) -> None: ...
-
-    @overload
-    def __init__(self, *, api_key: str, app_url: str, app_title: str, http_client: httpx.AsyncClient) -> None: ...
-
-    @overload
-    def __init__(self, *, http_client: httpx.AsyncClient) -> None: ...
-
-    @overload
-    def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        app_url: str | None = None,
+        app_title: str | None = None,
+        openai_client: None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None: ...
 
     def __init__(
         self,


### PR DESCRIPTION
closes #3730 