### PR TITLE
Bump min version of griffe to `1.14.0`

### DIFF
--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -53,7 +53,7 @@ Changelog = "https://github.com/pydantic/pydantic-ai/releases"
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning]
 dependencies = [
-    "griffe>=1.3.2",
+    "griffe>=1.14.0",
     "httpx>=0.27",
     "pydantic>=2.10",
     "pydantic-graph=={{ version }}",

--- a/uv.lock
+++ b/uv.lock
@@ -5685,7 +5685,7 @@ requires-dist = [
     { name = "genai-prices", specifier = ">=0.0.40" },
     { name = "google-auth", marker = "extra == 'vertexai'", specifier = ">=2.36.0" },
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.55.0" },
-    { name = "griffe", specifier = ">=1.3.2" },
+    { name = "griffe", specifier = ">=1.14.0" },
     { name = "groq", marker = "extra == 'groq'", specifier = ">=0.25.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'web'", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Problem

Currently, the min version of `griffe` is `1.3.2` but if a dependent has locked a version `< 1.14.0` it will fail with:
```
ImportError: cannot import name 'GoogleOptions' from 'griffe'
```

New dependency on `GoogleOptions` was recently added in PR #3706 .

`GoogleOptions` was added in version `1.14.0` as confirmed here: https://github.com/mkdocstrings/griffe/compare/1.13.0...1.14.0#diff-2409ce288ced6b5e0fad6d48271cd7e9d79a7818065c6fdd047fd928652a370aR503

## MRE

1. Pin the version of `griffe==1.13.0` in `pydantic-ai-slim`
2. Run `make test`
    ```
    $ make test
    COLUMNS=150  uv run  coverage run -m pytest -n auto --dist=loadgroup --durations=20
    ImportError while loading conftest '.../Projects/pydantic-ai/tests/conftest.py'.
    tests/conftest.py:25: in <module>
        import pydantic_ai.models
    pydantic_ai_slim/pydantic_ai/__init__.py:3: in <module>
        from .agent import (
    pydantic_ai_slim/pydantic_ai/agent/__init__.py:19: in <module>
        from .. import (
    pydantic_ai_slim/pydantic_ai/_agent_graph.py:19: in <module>
        from pydantic_ai._function_schema import _takes_ctx as is_takes_ctx  # type: ignore
    pydantic_ai_slim/pydantic_ai/_function_schema.py:22: in <module>
        from ._griffe import doc_descriptions
    pydantic_ai_slim/pydantic_ai/_griffe.py:10: in <module>
        from griffe import Docstring, DocstringSectionKind, GoogleOptions, Object as GriffeObject
    E   ImportError: cannot import name 'GoogleOptions' from 'griffe' (/Users/jerrylin/Projects/pydantic-ai/.venv/lib/python3.12/site-packages/griffe/__init__.py)
    ```

Issue goes away if I pin `griffe==1.14.0`. 