### PR TITLE
docs: Fix cross references

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,7 +191,7 @@ clai web --agent my_module:my_agent -i 'Always respond in Spanish'
 
 When using `--agent`, the agent's configured model becomes the default. CLI models (`-m`) are additional options. Without `--agent`, the first `-m` model is the default.
 
-The web chat UI can also be launched programmatically using [`Agent.to_web()`][pydantic_ai.Agent.to_web], see the [Web UI documentation](web.md).
+The web chat UI can also be launched programmatically using [`Agent.to_web()`][pydantic_ai.agent.Agent.to_web], see the [Web UI documentation](web.md).
 
 Run the `web` command with `--help` to see all available options:
 

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -159,7 +159,7 @@ To ensure that Temporal knows what code to run when an activity fails or is inte
 
 When `TemporalAgent` dynamically creates activities for the wrapped agent's model requests and toolsets (specifically those that implement their own tool listing and calling, i.e. [`FunctionToolset`][pydantic_ai.toolsets.FunctionToolset] and [`MCPServer`][pydantic_ai.mcp.MCPServer]), their names are derived from the agent's [`name`][pydantic_ai.agent.AbstractAgent.name] and the toolsets' [`id`s][pydantic_ai.toolsets.AbstractToolset.id]. These fields are normally optional, but are required to be set when using Temporal. They should not be changed once the durable agent has been deployed to production as this would break active workflows.
 
-For dynamic toolsets created with the [`@agent.toolset`][pydantic_ai.Agent.toolset] decorator, the `id` parameter must be set explicitly. Note that with Temporal, `per_run_step=False` is not respected, as the toolset always needs to be created on-the-fly in the activity.
+For dynamic toolsets created with the [`@agent.toolset`][pydantic_ai.agent.Agent.toolset] decorator, the `id` parameter must be set explicitly. Note that with Temporal, `per_run_step=False` is not respected, as the toolset always needs to be created on-the-fly in the activity.
 
 Other than that, any agent and toolset will just work!
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -16,7 +16,7 @@ pip/uv-add 'pydantic-ai-slim[web]'
 
 ## Basic Usage
 
-Create a web app from an agent instance using [`Agent.to_web()`][pydantic_ai.Agent.to_web]:
+Create a web app from an agent instance using [`Agent.to_web()`][pydantic_ai.agent.Agent.to_web]:
 
 ```python
 from pydantic_ai import Agent


### PR DESCRIPTION
After cloning the repository, `make docs` prints:

```
WARNING -  mkdocs_autorefs: cli.md: Could not find cross-reference target
           'pydantic_ai.Agent.to_web'
WARNING -  mkdocs_autorefs: web.md: Could not find cross-reference target
           'pydantic_ai.Agent.to_web'
WARNING -  mkdocs_autorefs: durable_execution/temporal.md: Could not find
           cross-reference target 'pydantic_ai.Agent.toolset'
```