### PR TITLE
hotfix: Register audio/aac mimetype

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -52,6 +52,7 @@ _mime_types.add_type('video/x-matroska', '.mkv')
 _mime_types.add_type('video/x-ms-wmv', '.wmv')
 
 # Audio types
+# NOTE: aac is platform specific (linux: audio/x-aac, macos: audio/aac) but x-aac is deprecated https://mimetype.io/audio/aac
 _mime_types.add_type('audio/aac', '.aac')
 _mime_types.add_type('audio/aiff', '.aiff')
 _mime_types.add_type('audio/flac', '.flac')


### PR DESCRIPTION
We're guessing mime types in a new way since #3501 and locally on macos `uv run pytest 'tests/test_messages.py::test_audio_url[aac]' -vv` fails because the test expects `audio/x-aac`, but `audio/x-aac` is deprecated acc to https://mimetype.io/audio/aac so this PR registers `audio/aac` as the preferred mime type in our inference function