### PR TITLE
Added support to load mcp servers from string.

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2125,6 +2125,18 @@ def test_load_mcp_servers_with_mixed_syntax(tmp_path: Path, monkeypatch: pytest.
     assert server.args == ['default_arg']
 
 
+def test_load_mcp_servers_from_json_string_config_broken_config():
+    config = '{"foo": }'
+    with pytest.raises(ValueError):
+        load_mcp_servers(config)
+
+
+def test_load_mcp_servers_from_json_string_config_valid_config():
+    config = '{"mcpServers": {"mcp0": {"url": "https://example.com/mcp"}}}'
+    server = load_mcp_servers(config)[0]
+    assert server == MCPServerStreamableHTTP(url='https://example.com/mcp', id='mcp0', tool_prefix='mcp0')
+
+
 async def test_server_info(mcp_server: MCPServerStdio) -> None:
     with pytest.raises(
         AttributeError, match='The `MCPServerStdio.server_info` is only instantiated after initialization.'


### PR DESCRIPTION
Added unit test for testing of new feature.

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->
- Closes #<issue>

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the release changelog.

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
