### PR TITLE
Fix token usage for Bedrock when using prompt caching

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -405,11 +405,14 @@ class BedrockConverseModel(Model):
                             tool_call_id=tool_use['toolUseId'],
                         ),
                     )
+        cache_read_tokens = response['usage'].get('cacheReadInputTokens', 0)
+        cache_write_tokens = response['usage'].get('cacheWriteInputTokens', 0)
+        input_tokens = response['usage']['inputTokens'] + cache_read_tokens + cache_write_tokens
         u = usage.RequestUsage(
-            input_tokens=response['usage']['inputTokens'],
+            input_tokens=input_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
             output_tokens=response['usage']['outputTokens'],
-            cache_read_tokens=response['usage'].get('cacheReadInputTokens', 0),
-            cache_write_tokens=response['usage'].get('cacheWriteInputTokens', 0),
         )
         response_id = response.get('ResponseMetadata', {}).get('RequestId', None)
         raw_finish_reason = response['stopReason']

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -1813,7 +1813,7 @@ async def test_bedrock_cache_point_adds_cache_control(
     # Different tokens usage depending on a model - could be written or read depending on the cassette read/write
     usage = result.usage()
     assert usage.cache_write_tokens >= 1000 or usage.cache_read_tokens >= 1000
-    assert usage.input_tokens <= 20
+    assert usage.input_tokens >= 1000
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
Input tokens should include cached tokens as well (misses and hits).

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->
- Closes #3879

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the release changelog.

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
