### PR TITLE
docs: add Bedrock application inference profiles documentation

### DIFF
--- a/docs/models/bedrock.md
+++ b/docs/models/bedrock.md
@@ -284,11 +284,11 @@ agent = Agent(model)
 ...
 ```
 
-## Using AWS ApplicationInference Profiles
+## Using AWS Application Inference Profiles
 
-AWS Bedrock supports [custom application inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-create.html) for cost tracking and resource management. When using these profiles, you may want to specify the model name explicitly to maintain Pydantic AI's model and provider inference features.
+AWS Bedrock supports [custom application inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-create.html) for cost tracking and resource management. When using these profiles, you should specify a [model profile](https://ai.pydantic.dev/models/overview/#models-and-providers) to ensure Pydantic AI can correctly identify model capabilities (streaming, tool use, caching, etc.) while still using the custom inference profile for cost tracking.
 
-Without explicit configuration, an inference profile ARN like `arn:aws:bedrock:us-east-2:*****:application-inference-profile/****` doesn't contain enough information for Pydantic AI to determine the underlying model or provider. You can work around this by:
+Without explicit configuration, an inference profile ARN like `arn:aws:bedrock:us-east-2:*****:application-inference-profile/****` doesn't contain enough information for Pydantic AI to determine the underlying model. You can work around this by:
 
 1. Passing the inference profile ARN as the model name to [`BedrockConverseModel`][pydantic_ai.models.bedrock.BedrockConverseModel]
 2. Using the `profile` parameter to specify the logical model name for feature detection
@@ -313,11 +313,6 @@ model = BedrockConverseModel(
 
 agent = Agent(model)
 ```
-
-This approach ensures that:
-
-- Pydantic AI correctly identifies the model capabilities (streaming, tool use, caching, etc.)
-- Your requests use the custom inference profile for cost tracking
 
 ## Configuring Retries
 


### PR DESCRIPTION
## Summary

Add documentation for using AWS Bedrock custom application inference profiles with `BedrockConverseModel`.

## Changes

- Added new "Using AWS ApplicationInference Profiles" section to `docs/models/bedrock.md`
- Explains how to use inference profile ARNs while maintaining model feature detection
- Includes code example showing proper usage of the `profile` parameter

## Context

When using custom application inference profiles for cost tracking, the profile ARN doesn't contain enough information for Pydantic AI to determine the underlying model. This documentation shows users how to:

1. Pass the inference profile ARN as the model name
2. Use the `profile` parameter to specify the logical model name for feature detection

This ensures that Pydantic AI can correctly identify model capabilities (streaming, tool use, caching, etc.) while still using the custom inference profile for cost tracking.