### PR TITLE
Revert "Use in-memory SQLite for DBOS tests"

### DIFF
--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -51,8 +51,6 @@ try:
 
     from dbos import DBOS, DBOSConfig, SetWorkflowID
     from packaging.version import Version
-    from sqlalchemy import create_engine
-    from sqlalchemy.pool import StaticPool
 
     from pydantic_ai.durable_exec.dbos import DBOSAgent, DBOSMCPServer, DBOSModel
 
@@ -122,16 +120,13 @@ def workflow_raises(exc_type: type[Exception], exc_message: str) -> Iterator[Non
     assert str(exc_info.value) == exc_message
 
 
-in_memory_engine = create_engine(
-    'sqlite:///:memory:?cache=shared', connect_args={'check_same_thread': False}, poolclass=StaticPool
-)
-
+DBOS_SQLITE_FILE = 'dbostest.sqlite'
 DBOS_CONFIG: DBOSConfig = {
     'name': 'pydantic_dbos_tests',
+    'system_database_url': f'sqlite:///{DBOS_SQLITE_FILE}',
     'run_admin_server': False,
     # enable_otlp requires dbos>1.14
     'enable_otlp': True,
-    'system_database_engine': in_memory_engine,
 }
 
 
@@ -143,6 +138,18 @@ def dbos() -> Generator[DBOS, Any, None]:
         yield dbos
     finally:
         DBOS.destroy()
+
+
+# Automatically clean up old DBOS sqlite files
+@pytest.fixture(autouse=True, scope='module')
+def cleanup_test_sqlite_file() -> Iterator[None]:
+    if os.path.exists(DBOS_SQLITE_FILE):
+        os.remove(DBOS_SQLITE_FILE)  # pragma: lax no cover
+    try:
+        yield
+    finally:
+        if os.path.exists(DBOS_SQLITE_FILE):
+            os.remove(DBOS_SQLITE_FILE)  # pragma: lax no cover
 
 
 model = OpenAIChatModel(


### PR DESCRIPTION
Reverts pydantic/pydantic-ai#3800

@qianl15 it seems the CI has become flaky on dbos tests because of this, I'll revert just to not bother others. But we can work out later - it doesn't need to be in memory, we can also change the fixture to use `tmp_path` instead, so we don't need to check the existence, and pytest will automatically drop the file after the test is completed.