### PR TITLE
Fix OTel attributes for `run_stream_sync` by adding context manager support

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -726,9 +726,9 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         agent = Agent('openai:gpt-4o')
 
         def main():
-            response = agent.run_stream_sync('What is the capital of the UK?')
-            print(response.get_output())
-            #> The capital of the UK is London.
+            with agent.run_stream_sync('What is the capital of the UK?') as response:
+                print(response.get_output())
+                #> The capital of the UK is London.
         ```
 
         Args:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -439,6 +439,7 @@ async def test_streamed_text_stream():
         )
 
 
+@pytest.mark.filterwarnings('ignore:Using run_stream_sync.*:DeprecationWarning')
 def test_streamed_text_stream_sync():
     m = TestModel(custom_output_text='The cat sat on the mat.')
 
@@ -3165,6 +3166,7 @@ async def test_run_stream_events():
     )
 
 
+@pytest.mark.filterwarnings('ignore:Using run_stream_sync.*:DeprecationWarning')
 def test_structured_response_sync_validation():
     async def text_stream(_messages: list[ModelMessage], agent_info: AgentInfo) -> AsyncIterator[DeltaToolCalls]:
         assert agent_info.output_tools is not None
@@ -3312,6 +3314,7 @@ async def test_streamed_run_result_sync_context_manager_with_direct_result():
             )
 
 
+@pytest.mark.filterwarnings('ignore:Using run_stream_sync.*:DeprecationWarning')
 def test_stream_output_after_get_output_sync():
     m = TestModel()
 
@@ -3508,3 +3511,14 @@ def test_run_stream_sync_context_manager_exception_in_stream():
     with pytest.raises(ValueError, match='Stream initialization failed'):
         with agent.run_stream_sync('Hello'):
             pass  # pragma: no cover
+
+
+def test_run_stream_sync_deprecation_warning_without_context_manager():
+    """Test that using run_stream_sync without context manager emits a deprecation warning."""
+    m = TestModel()
+    agent = Agent(m)
+
+    result = agent.run_stream_sync('Hello')
+    with pytest.warns(DeprecationWarning, match='Using run_stream_sync\\(\\) without the context manager pattern'):
+        # Any of the streaming methods should emit the warning
+        list(result.stream_output())


### PR DESCRIPTION
When using Agent.run_stream_sync(), OTel spans were broken because the async context manager lifecycle was split across multiple run_until_complete() calls, causing spans to be entered/exited in different contexts.

The fix adds proper context manager support to StreamedRunResultSync:
- __enter__ runs the entire async streaming lifecycle in a single run_until_complete() call, ensuring OTel spans close properly
- Streamed data is pre-collected and cached for later iteration
- Added asynccontextmanager_from_generator() utility to convert the async generator into a proper async context manager

Usage:
    with agent.run_stream_sync('Hello') as result:
        for chunk in result.stream_output():
            print(chunk)

- Builds on https://github.com/pydantic/pydantic-ai/pull/3716 (which is set to fix https://github.com/pydantic/pydantic-ai/issues/3714)

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #<issue>

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **Linting and type checking** pass per `make format` and `make typecheck`.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
