### PR TITLE
chore: make support for `AWS_BEARER_TOKEN_BEDROCK` environment variable explicit

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -191,6 +191,7 @@ class BedrockProvider(Provider[BaseClient]):
                 'read_timeout': read_timeout,
                 'connect_timeout': connect_timeout,
             }
+            api_key = api_key or os.getenv('AWS_BEARER_TOKEN_BEDROCK')
             try:
                 if api_key is not None:
                     session = boto3.Session(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -433,15 +433,24 @@ def bedrock_provider():
 
         from pydantic_ai.providers.bedrock import BedrockProvider
 
-        bedrock_client = boto3.client(
-            'bedrock-runtime',
-            region_name=os.getenv('AWS_REGION', 'us-east-1'),
-            aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID', 'AKIA6666666666666666'),
-            aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY', '6666666666666666666666666666666666666666'),
-            aws_session_token=os.getenv('AWS_SESSION_TOKEN', None),
-        )
-        yield BedrockProvider(bedrock_client=bedrock_client)
-        bedrock_client.close()
+        bearer_token = os.getenv('AWS_BEARER_TOKEN_BEDROCK')
+        if bearer_token:  # pragma: no cover
+            provider = BedrockProvider(
+                api_key=bearer_token,
+                region_name=os.getenv('AWS_REGION', 'us-east-1'),
+            )
+            yield provider
+            provider.client.close()
+        else:
+            bedrock_client = boto3.client(
+                'bedrock-runtime',
+                region_name=os.getenv('AWS_REGION', 'us-east-1'),
+                aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID', 'AKIA6666666666666666'),
+                aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY', '6666666666666666666666666666666666666666'),
+                aws_session_token=os.getenv('AWS_SESSION_TOKEN', None),
+            )
+            yield BedrockProvider(bedrock_client=bedrock_client)
+            bedrock_client.close()
     except ImportError:  # pragma: lax no cover
         pytest.skip('boto3 is not installed')
 

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -33,6 +33,19 @@ def test_bedrock_provider(env: TestEnv):
     assert provider.base_url == 'https://bedrock-runtime.us-east-1.amazonaws.com'
 
 
+def test_bedrock_provider_bearer_token_env_var(env: TestEnv, mocker: MockerFixture):
+    """Test that AWS_BEARER_TOKEN_BEDROCK env var is used for bearer token auth."""
+    env.set('AWS_DEFAULT_REGION', 'us-east-1')
+    env.set('AWS_BEARER_TOKEN_BEDROCK', 'test-bearer-token')
+
+    mock_session = mocker.patch('pydantic_ai.providers.bedrock._BearerTokenSession')
+
+    provider = BedrockProvider()
+
+    mock_session.assert_called_once_with('test-bearer-token')
+    assert provider.name == 'bedrock'
+
+
 def test_bedrock_provider_timeout(env: TestEnv):
     env.set('AWS_DEFAULT_REGION', 'us-east-1')
     env.set('AWS_READ_TIMEOUT', '1')


### PR DESCRIPTION
## Summary

- Implement the documented but missing `AWS_BEARER_TOKEN_BEDROCK` environment variable fallback for bearer token authentication
- Update the test fixture to support bearer token auth when this env var is set

The docstring already documented that `AWS_BEARER_TOKEN_BEDROCK` would be used as a fallback for the `api_key` parameter, but the implementation was missing.

## Test plan

- [x] Added unit test for the env var fallback behavior
- [x] Existing bedrock tests pass
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)