### PR TITLE
Let Temporal tool activity config be specified more conveniently via tool metadata

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -103,7 +103,16 @@ from .profiles import (
 )
 from .run import AgentRun, AgentRunResult, AgentRunResultEvent
 from .settings import ModelSettings
-from .tools import DeferredToolRequests, DeferredToolResults, RunContext, Tool, ToolApproved, ToolDefinition, ToolDenied
+from .tools import (
+    DeferredToolRequests,
+    DeferredToolResults,
+    RunContext,
+    Tool,
+    ToolApproved,
+    ToolDefinition,
+    ToolDenied,
+    ToolMetadata,
+)
 from .toolsets import (
     AbstractToolset,
     ApprovalRequiredToolset,
@@ -208,6 +217,7 @@ __all__ = (
     # tools
     'Tool',
     'ToolDefinition',
+    'ToolMetadata',
     'RunContext',
     'DeferredToolRequests',
     'DeferredToolResults',

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_function_toolset.py
@@ -65,7 +65,11 @@ class TemporalFunctionToolset(TemporalWrapperToolset[AgentDepsT]):
         if not workflow.in_workflow():  # pragma: no cover
             return await super().call_tool(name, tool_args, ctx, tool)
 
-        tool_activity_config = self.tool_activity_config.get(name, {})
+        # Get activity config: TemporalAgent constructor config takes precedence over tool metadata
+        tool_activity_config = self.tool_activity_config.get(name)
+        if tool_activity_config is None:
+            # Fall back to tool metadata
+            tool_activity_config = (tool.tool_def.metadata or {}).get('temporal_activity_config', {})
         if tool_activity_config is False:
             assert isinstance(tool, FunctionToolsetTool)
             if not tool.is_async:


### PR DESCRIPTION
Allow specifying Temporal activity configuration for tools via the `metadata` parameter using `@agent.tool(metadata={'temporal_activity_config': ...})`.

Changes:
- Add `ToolMetadata` TypedDict with `temporal_activity_config` field
- Update `_function_toolset.py`, `_dynamic_toolset.py`, and `_mcp.py` to read from tool metadata when constructor config not specified
	- (Douwe: not needed on mcp, as that metadata would be coming from the server, which shouldn't know about temporal)
- Add documentation for tool metadata configuration in temporal.md
- Add documentation for agent delegation with TemporalAgent subagents
- Add tests for metadata-based activity config (WIP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)