### PR TITLE
Add some references to logfire where helpful in the docs

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1060,11 +1060,13 @@ user_id=123 message='Hello John, would you be free for coffee sometime next week
 
 ## Debugging and Monitoring
 
-Understanding what your agent is doing, and why, is essential for development and production operation.
+Agents require a different approach to observability than traditional software. With traditional web endpoints or data pipelines, you can largely predict behavior by reading the code. With agents, this is much harder. The model's decisions are stochastic, and that stochasticity compounds through the agentic loop as the agent reasons, calls tools, observes results, and reasons again. You need to actually see what happened.
+
+This means setting up your application to record what's happening in a way you can review afterward, both during development (to understand and iterate) and in production (to debug issues and monitor behavior). The ergonomics matter too: a plaintext dump of everything that happened isn't a practical way to review agent behavior, even during development. You want tooling that lets you step through each decision and tool call interactively.
+
+We recommend [Pydantic Logfire](https://logfire.pydantic.dev/docs/), which has been designed with Pydantic AI workflows in mind.
 
 ### Tracing with Logfire
-
-[Pydantic Logfire](https://pydantic.dev/logfire) provides specialized tooling for PydanticAI agents:
 
 ```python
 import logfire
@@ -1073,7 +1075,7 @@ logfire.configure()
 logfire.instrument_pydantic_ai()
 ```
 
-With Logfire instrumented, every agent run creates a detailed trace showing:
+With Logfire instrumentation enabled, every agent run creates a detailed trace showing:
 
 - **Messages exchanged** with the model (system, user, assistant)
 - **Tool calls** including arguments and return values
@@ -1092,7 +1094,7 @@ This visibility is invaluable for:
 
 For systematic evaluation of agent behavior beyond runtime debugging, [Pydantic Evals](evals.md) provides a code-first framework for testing AI systems:
 
-```python
+```python {test="skip" lint="skip" format="skip"}
 from pydantic_evals import Case, Dataset
 
 dataset = Dataset(
@@ -1107,7 +1109,7 @@ Evals let you define test cases, run them against your agent, and score the resu
 
 ### Using Other Backends
 
-PydanticAI's instrumentation is built on [OpenTelemetry](https://opentelemetry.io/), so you can send traces to any compatible backend—including Jaeger, Zipkin, and Grafana Tempo. Even if you use the Logfire SDK for its convenience, you can configure it to send data to other backends. See [alternative backends](logfire.md#using-opentelemetry) for setup instructions.
+Pydantic AI's instrumentation is built on [OpenTelemetry](https://opentelemetry.io/), so you can send traces to any compatible backend. Even if you use the Logfire SDK for its convenience, you can configure it to send data to other backends. See [alternative backends](logfire.md#using-opentelemetry) for setup instructions.
 
 [Full Logfire integration guide →](logfire.md)
 

--- a/docs/multi-agent-applications.md
+++ b/docs/multi-agent-applications.md
@@ -341,7 +341,7 @@ In addition, the community maintains packages that bring these concepts together
 
 ## Observing Multi-Agent Systems
 
-Multi-agent systems can be challenging to debug due to their complexity—when multiple agents interact, understanding the flow of execution becomes essential.
+Multi-agent systems can be challenging to debug due to their complexity; when multiple agents interact, understanding the flow of execution becomes essential.
 
 ### Tracing Agent Delegation
 
@@ -362,8 +362,10 @@ Logfire shows you:
 - **Delegation decisions**—when and why one agent called another
 - **End-to-end latency** broken down by agent
 - **Token usage and costs** per agent
+- **What triggered the agent run**—the HTTP request, scheduled job, or user action that started it all
+- **What happened inside tool calls**—database queries, HTTP requests, file operations, and any other instrumented code that tools execute
 
-This is essential for understanding and optimizing complex agent workflows. When something goes wrong in a multi-agent system, you'll see exactly which agent failed and what it was trying to do.
+This is essential for understanding and optimizing complex agent workflows. When something goes wrong in a multi-agent system, you'll see exactly which agent failed and what it was trying to do, and whether the problem was in the agent's reasoning or in the backend systems it called.
 
 ### Full-Stack Visibility
 

--- a/docs/retries.md
+++ b/docs/retries.md
@@ -323,7 +323,7 @@ agent = Agent(model)
     - Monitor retry frequency over time
     - Identify opportunities to reduce retries
 
-    With [HTTPX instrumentation](logfire.md#monitoring-http-requests) enabled, retry attempts are automatically captured in your traces. PydanticAI's instrumentation is built on OpenTelemetry, so you can also use other compatible backends.
+    With [HTTPX instrumentation](logfire.md#monitoring-http-requests) enabled, retry attempts are automatically captured in your traces.
 
 ## Error Handling
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -368,7 +368,7 @@ _(This example is complete, it can be run "as is")_
     - How long each tool took to execute
     - Any errors that occurred
 
-    This visibility helps you understand why an agent made specific decisions and identify issues in tool implementations. PydanticAI's instrumentation is built on OpenTelemetry, so you can also use other compatible backends.
+    This visibility helps you understand why an agent made specific decisions and identify issues in tool implementations.
 
 ## See Also
 


### PR DESCRIPTION
- Add "Debugging and Monitoring" section to agents.md covering Logfire tracing, systematic testing with evals, and OpenTelemetry compatibility
- Add "Observing Multi-Agent Systems" section to multi-agent-applications.md explaining how to trace agent delegation and get full-stack visibility
- Add tip callout to retries.md about monitoring retry patterns in production
- Add tip callout to tools.md about debugging tool calls with Logfire
