### PR TITLE
docs: update RAG info box to mention embeddings support

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,7 +17,7 @@ For more advanced use cases, the [toolsets](toolsets.md) feature lets you manage
 !!! info "Function tools vs. RAG"
     Function tools are basically the "R" of RAG (Retrieval-Augmented Generation) — they augment what the model can do by letting it request extra information.
 
-    The main semantic difference between Pydantic AI Tools and RAG is RAG is synonymous with vector search, while Pydantic AI tools are more general-purpose. (Note: we may add support for vector search functionality in the future, particularly an API for generating embeddings. See [#58](https://github.com/pydantic/pydantic-ai/issues/58))
+    The main semantic difference between Pydantic AI Tools and RAG is RAG is synonymous with vector search, while Pydantic AI tools are more general-purpose. For vector search, you can use our [embeddings](embeddings.md) support to generate embeddings across multiple providers.
 
 !!! info "Function Tools vs. Structured Outputs"
     As the name suggests, function tools use the model's "tools" or "functions" API to let the model know what is available to call. Tools or functions are also used to define the schema(s) for [structured output](output.md) when using the default [tool output mode](output.md#tool-output), thus a model might have access to many tools, some of which call function tools while others end the run and produce a final output.


### PR DESCRIPTION
## Summary
- Updates the "Function tools vs. RAG" info box in `docs/tools.md` to mention the now-available embeddings feature
- Replaces the outdated "we may add support in the future" note with a link to the embeddings documentation

## Test plan
- [x] Verify the info box renders correctly with the new text
- [x] Verify the link to `embeddings.md` is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)