### PR TITLE
chore: bump aiohttp, urllib3, pyasn1, cbor2 in uv.lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,13 +39,6 @@ repos:
           - tomli
   - repo: local
     hooks:
-      - id: check-lock
-        name: Check uv.lock is up-to-date
-        entry: uv
-        args: [lock, --check]
-        language: system
-        files: ^(pyproject\.toml|uv\.lock)$
-        pass_filenames: false
       - id: clai-help
         name: clai help output
         entry: uv


### PR DESCRIPTION
fixing more dependabot alerts