### PR TITLE
Add verbose tool call logging for Prefect integration

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_logging.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_logging.py
@@ -1,0 +1,47 @@
+"""Logging utilities for Prefect integration."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def format_tool_args(args: dict[str, Any], max_length: int = 500) -> str:
+    """Format tool arguments for logging, truncating if too long.
+
+    Args:
+        args: The tool arguments dictionary.
+        max_length: Maximum length of the formatted string.
+
+    Returns:
+        A JSON-formatted string representation of the arguments.
+    """
+    try:
+        args_str = json.dumps(args, default=str)
+        if len(args_str) > max_length:
+            return args_str[: max_length - 3] + '...'
+        return args_str
+    except Exception:
+        return str(args)[:max_length]
+
+
+def format_tool_result(result: Any, max_length: int = 500) -> str:
+    """Format tool result for logging, truncating if too long.
+
+    Args:
+        result: The tool return value.
+        max_length: Maximum length of the formatted string.
+
+    Returns:
+        A JSON-formatted string representation of the result.
+    """
+    try:
+        if isinstance(result, str):
+            result_str = result
+        else:
+            result_str = json.dumps(result, default=str)
+        if len(result_str) > max_length:
+            return result_str[: max_length - 3] + '...'
+        return result_str
+    except Exception:
+        return str(result)[:max_length]

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_server.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_server.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING, Any
 
-from prefect import task
+from prefect import get_run_logger, task
 from typing_extensions import Self
 
 from pydantic_ai import ToolsetTool
 from pydantic_ai.tools import AgentDepsT, RunContext
 
+from ._logging import format_tool_args, format_tool_result
 from ._toolset import PrefectWrapperToolset
 from ._types import TaskConfig, default_task_config
 
@@ -24,10 +25,12 @@ class PrefectMCPServer(PrefectWrapperToolset[AgentDepsT], ABC):
         wrapped: MCPServer,
         *,
         task_config: TaskConfig,
+        log_tool_calls: bool = False,
     ):
         super().__init__(wrapped)
         self._task_config = default_task_config | (task_config or {})
         self._mcp_id = wrapped.id
+        self._log_tool_calls = log_tool_calls
 
         @task
         async def _call_tool_task(
@@ -36,7 +39,19 @@ class PrefectMCPServer(PrefectWrapperToolset[AgentDepsT], ABC):
             ctx: RunContext[AgentDepsT],
             tool: ToolsetTool[AgentDepsT],
         ) -> ToolResult:
-            return await super(PrefectMCPServer, self).call_tool(tool_name, tool_args, ctx, tool)
+            if self._log_tool_calls:
+                logger = get_run_logger()
+                args_str = format_tool_args(tool_args)
+                logger.info(f'Calling MCP tool: {tool_name} with args: {args_str}')
+
+            result = await super(PrefectMCPServer, self).call_tool(tool_name, tool_args, ctx, tool)
+
+            if self._log_tool_calls:
+                logger = get_run_logger()
+                result_str = format_tool_result(result)
+                logger.info(f'MCP tool {tool_name} returned: {result_str}')
+
+            return result
 
         self._call_tool_task = _call_tool_task
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
@@ -33,6 +33,8 @@ def prefectify_toolset(
     mcp_task_config: TaskConfig,
     tool_task_config: TaskConfig,
     tool_task_config_by_name: dict[str, TaskConfig | None],
+    *,
+    log_tool_calls: bool = False,
 ) -> AbstractToolset[AgentDepsT]:
     """Wrap a toolset to integrate it with Prefect.
 
@@ -41,6 +43,7 @@ def prefectify_toolset(
         mcp_task_config: The Prefect task config to use for MCP server tasks.
         tool_task_config: The default Prefect task config to use for tool calls.
         tool_task_config_by_name: Per-tool task configuration. Keys are tool names, values are TaskConfig or None.
+        log_tool_calls: If True, log tool arguments and results to Prefect logs.
     """
     if isinstance(toolset, FunctionToolset):
         from ._function_toolset import PrefectFunctionToolset
@@ -49,6 +52,7 @@ def prefectify_toolset(
             wrapped=toolset,
             task_config=tool_task_config,
             tool_task_config=tool_task_config_by_name,
+            log_tool_calls=log_tool_calls,
         )
 
     try:
@@ -62,6 +66,7 @@ def prefectify_toolset(
             return PrefectMCPServer(
                 wrapped=toolset,
                 task_config=mcp_task_config,
+                log_tool_calls=log_tool_calls,
             )
 
     return toolset


### PR DESCRIPTION
This PR adds optional detailed logging for tool calls when using `PrefectAgent`, making tool arguments and return values visible in Prefect flow logs.

## Problem

When using `PrefectAgent` to wrap pydantic-ai agents, tool calls appear as Prefect tasks but the logs only show that a tool was called—not *what* arguments were passed or *what* the tool returned. This makes debugging and observability difficult.

## Solution

Add a `log_tool_calls` parameter to `PrefectAgent` (default `False`) that, when enabled, logs:
- Tool arguments (JSON formatted) when the call starts
- Tool return value (JSON formatted) when the call completes
- Both are truncated to 500 characters to avoid log spam

This follows the pattern in Temporal and DBOS implementations where verbose logging is opt-in rather than default behavior.

## Usage

```python
from pydantic_ai import Agent
from pydantic_ai.durable_exec.prefect import PrefectAgent

agent = Agent("openai:gpt-4o", name="my-agent", tools=[...])

# Enable verbose tool call logging
prefect_agent = PrefectAgent(agent, log_tool_calls=True)
```

## Example Output

```
14:42:29.871 | INFO | Task run 'Call Tool: get_weather' - Calling tool: get_weather with args: {"city": "Seattle"}
14:42:29.873 | INFO | Task run 'Call Tool: get_weather' - Tool get_weather returned: Weather in Seattle: 72°F, sunny
```

<details>
<summary><strong>Testing from this branch</strong></summary>

To test this change before it's merged, install directly from the branch:

```bash
# With uv (recommended)
uv run --with "pydantic-ai[prefect] @ git+https://github.com/zzstoatzz/pydantic-ai.git@prefect-tool-call-logging" your_script.py

# Or add to your project
uv add "pydantic-ai[prefect] @ git+https://github.com/zzstoatzz/pydantic-ai.git@prefect-tool-call-logging"

# With pip
pip install "pydantic-ai[prefect] @ git+https://github.com/zzstoatzz/pydantic-ai.git@prefect-tool-call-logging"
```

Example script to verify it works:

```python
import asyncio
from pydantic_ai import Agent
from pydantic_ai.durable_exec.prefect import PrefectAgent
from prefect import flow

def get_weather(city: str) -> str:
    """Get weather for a city."""
    return f"Weather in {city}: 72°F, sunny"

agent = Agent(
    "openai:gpt-4o-mini",
    name="test-agent",
    tools=[get_weather],
)

# Enable verbose logging
prefect_agent = PrefectAgent(agent, log_tool_calls=True)

@flow
async def test_flow():
    result = await prefect_agent.run("What's the weather in Seattle?")
    print(f"Result: {result.output}")

if __name__ == "__main__":
    asyncio.run(test_flow())
```

You should see tool arguments and results in the Prefect logs.

</details>

## Changes

- **`_logging.py`** (new): Helper functions `format_tool_args` and `format_tool_result` with truncation
- **`_agent.py`**: Add `log_tool_calls: bool = False` parameter
- **`_toolset.py`**: Pass `log_tool_calls` through to toolset wrappers  
- **`_function_toolset.py`**: Conditionally log args/results based on flag
- **`_mcp_server.py`**: Same conditional logging for MCP tools