### PR TITLE
fix(ag-ui): handle_tool_call_end uses prefixed ID for builtin tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
@@ -206,8 +206,12 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
             delta=delta.args_delta if isinstance(delta.args_delta, str) else json.dumps(delta.args_delta),
         )
 
-    async def handle_tool_call_end(self, part: ToolCallPart) -> AsyncIterator[BaseEvent]:
-        yield ToolCallEndEvent(tool_call_id=part.tool_call_id)
+    async def handle_tool_call_end(self, part: ToolCallPart | BuiltinToolCallPart) -> AsyncIterator[BaseEvent]:
+        tool_call_id = part.tool_call_id
+        # Use prefixed ID for builtin tools if available
+        if isinstance(part, BuiltinToolCallPart) and tool_call_id in self._builtin_tool_call_ids:
+            tool_call_id = self._builtin_tool_call_ids[tool_call_id]
+        yield ToolCallEndEvent(tool_call_id=tool_call_id)
 
     async def handle_builtin_tool_call_end(self, part: BuiltinToolCallPart) -> AsyncIterator[BaseEvent]:
         yield ToolCallEndEvent(tool_call_id=self._builtin_tool_call_ids[part.tool_call_id])


### PR DESCRIPTION
- Closes #4098

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

### Changes

When `handle_tool_call_end` is called with a `BuiltinToolCallPart` (either directly or through misuse), it now correctly uses the prefixed ID from `_builtin_tool_call_ids` mapping instead of the original `tool_call_id`.

**Problem:**
The TOOL_CALL_END event was using the original ID for builtin tools while all other events (TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_RESULT) used the prefixed ID. This caused issues when processing streaming events to reconstruct message history.

**Solution:**
Updated `handle_tool_call_end` to:
1. Accept both `ToolCallPart` and `BuiltinToolCallPart`
2. Check if the part is a `BuiltinToolCallPart` and if the ID exists in `_builtin_tool_call_ids`
3. Use the prefixed ID from the mapping for builtin tools

**Testing:**
Added `test_handle_tool_call_end_with_builtin_tool_call_part` that verifies:
- `TOOL_CALL_START` and `TOOL_CALL_END` events now use the same prefixed ID
- The prefixed ID format is `pyd_ai_builtin|provider|id`