### PR TITLE
Match Vercel AI SDK types with AI SDK v6

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -42,7 +42,6 @@ from ._utils import dump_provider_metadata, load_provider_metadata
 from .request_types import (
     DataUIPart,
     DynamicToolInputAvailablePart,
-    DynamicToolInputStreamingPart,
     DynamicToolOutputAvailablePart,
     DynamicToolOutputErrorPart,
     DynamicToolUIPart,
@@ -55,7 +54,6 @@ from .request_types import (
     StepStartUIPart,
     TextUIPart,
     ToolInputAvailablePart,
-    ToolInputStreamingPart,
     ToolOutputAvailablePart,
     ToolOutputErrorPart,
     ToolUIPart,
@@ -195,13 +193,10 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                         else:
                             assert_never(args)
 
-                        provider_meta = {}
-                        part_id = provider_name = provider_details = None
-                        if not isinstance(part, (DynamicToolInputStreamingPart, ToolInputStreamingPart)):
-                            provider_meta = load_provider_metadata(part.call_provider_metadata)
-                            part_id = provider_meta.get('id')
-                            provider_name = provider_meta.get('provider_name')
-                            provider_details = provider_meta.get('provider_details')
+                        provider_meta = load_provider_metadata(part.call_provider_metadata)
+                        part_id = provider_meta.get('id')
+                        provider_name = provider_meta.get('provider_name')
+                        provider_details = provider_meta.get('provider_details')
 
                         if builtin_tool:
                             # For builtin tools, we need to create 2 parts (BuiltinToolCall & BuiltinToolReturn) for a single Vercel ToolOutput

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
@@ -105,7 +105,7 @@ class VercelAIEventStream(UIEventStream[RequestData, BaseChunk, AgentDepsT, Outp
     async def handle_run_result(self, event: AgentRunResultEvent) -> AsyncIterator[BaseChunk]:
         pydantic_reason = event.result.response.finish_reason
         if pydantic_reason:
-            self._finish_reason = _FINISH_REASON_MAP.get(pydantic_reason)
+            self._finish_reason = _FINISH_REASON_MAP.get(pydantic_reason, 'other')
         return
         yield
 
@@ -193,6 +193,9 @@ class VercelAIEventStream(UIEventStream[RequestData, BaseChunk, AgentDepsT, Outp
             tool_call_id=tool_call_id,
             tool_name=part.tool_name,
             provider_executed=provider_executed,
+            provider_metadata=dump_provider_metadata(
+                id=part.id, provider_name=part.provider_name, provider_details=part.provider_details
+            ),
         )
         if part.args:
             yield ToolInputDeltaChunk(tool_call_id=tool_call_id, input_text_delta=part.args_as_json_str())

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
@@ -1,7 +1,7 @@
 """Vercel AI request types (UI messages).
 
 Converted to Python from:
-https://github.com/vercel/ai/blob/ai%405.0.59/packages/ai/src/ui/ui-messages.ts
+https://github.com/vercel/ai/blob/ai%406.0.57/packages/ai/src/ui/ui-messages.ts
 """
 
 from abc import ABC
@@ -119,6 +119,7 @@ class ToolInputStreamingPart(BaseUIPart):
     state: Literal['input-streaming'] = 'input-streaming'
     input: Any | None = None
     provider_executed: bool | None = None
+    call_provider_metadata: ProviderMetadata | None = None
 
 
 class ToolInputAvailablePart(BaseUIPart):
@@ -171,6 +172,7 @@ class DynamicToolInputStreamingPart(BaseUIPart):
     tool_call_id: str
     state: Literal['input-streaming'] = 'input-streaming'
     input: Any | None = None
+    call_provider_metadata: ProviderMetadata | None = None
 
 
 class DynamicToolInputAvailablePart(BaseUIPart):

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/response_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/response_types.py
@@ -1,7 +1,7 @@
 """Vercel AI response types (SSE chunks).
 
 Converted to Python from:
-https://github.com/vercel/ai/blob/ai%405.0.59/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+https://github.com/vercel/ai/blob/ai%406.0.57/packages/ai/src/ui-message-stream/ui-message-chunks.ts
 """
 
 from abc import ABC
@@ -16,7 +16,7 @@ JSONValue = Any
 ProviderMetadata = dict[str, dict[str, JSONValue]]
 """Provider metadata."""
 
-FinishReason = Literal['stop', 'length', 'content-filter', 'tool-calls', 'error', 'other', 'unknown'] | None
+FinishReason = Literal['stop', 'length', 'content-filter', 'tool-calls', 'error', 'other'] | None
 """Reason why the model finished generating."""
 
 
@@ -91,6 +91,7 @@ class ToolInputStartChunk(BaseChunk):
     tool_call_id: str
     tool_name: str
     provider_executed: bool | None = None
+    provider_metadata: ProviderMetadata | None = None
     dynamic: bool | None = None
 
 
@@ -233,6 +234,7 @@ class AbortChunk(BaseChunk):
     """Abort chunk."""
 
     type: Literal['abort'] = 'abort'
+    reason: str | None = None
 
 
 class MessageMetadataChunk(BaseChunk):

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -308,7 +308,13 @@ I'd be happy to help you use a tool! However, I need more information about what
                     }
                 },
             },
-            {'type': 'tool-input-start', 'toolCallId': IsStr(), 'toolName': 'web_search', 'providerExecuted': True},
+            {
+                'type': 'tool-input-start',
+                'toolCallId': IsStr(),
+                'toolName': 'web_search',
+                'providerExecuted': True,
+                'providerMetadata': {'pydantic_ai': {'provider_name': 'openai'}},
+            },
             {
                 'type': 'tool-input-delta',
                 'toolCallId': IsStr(),
@@ -353,7 +359,13 @@ I'd be happy to help you use a tool! However, I need more information about what
                     }
                 },
             },
-            {'type': 'tool-input-start', 'toolCallId': IsStr(), 'toolName': 'web_search', 'providerExecuted': True},
+            {
+                'type': 'tool-input-start',
+                'toolCallId': IsStr(),
+                'toolName': 'web_search',
+                'providerExecuted': True,
+                'providerMetadata': {'pydantic_ai': {'provider_name': 'openai'}},
+            },
             {
                 'type': 'tool-input-delta',
                 'toolCallId': IsStr(),
@@ -395,7 +407,13 @@ I'd be happy to help you use a tool! However, I need more information about what
                     }
                 },
             },
-            {'type': 'tool-input-start', 'toolCallId': IsStr(), 'toolName': 'web_search', 'providerExecuted': True},
+            {
+                'type': 'tool-input-start',
+                'toolCallId': IsStr(),
+                'toolName': 'web_search',
+                'providerExecuted': True,
+                'providerMetadata': {'pydantic_ai': {'provider_name': 'openai'}},
+            },
             {
                 'type': 'tool-input-delta',
                 'toolCallId': IsStr(),
@@ -437,7 +455,13 @@ I'd be happy to help you use a tool! However, I need more information about what
                     }
                 },
             },
-            {'type': 'tool-input-start', 'toolCallId': IsStr(), 'toolName': 'web_search', 'providerExecuted': True},
+            {
+                'type': 'tool-input-start',
+                'toolCallId': IsStr(),
+                'toolName': 'web_search',
+                'providerExecuted': True,
+                'providerMetadata': {'pydantic_ai': {'provider_name': 'openai'}},
+            },
             {
                 'type': 'tool-input-delta',
                 'toolCallId': IsStr(),
@@ -482,7 +506,13 @@ I'd be happy to help you use a tool! However, I need more information about what
                     }
                 },
             },
-            {'type': 'tool-input-start', 'toolCallId': IsStr(), 'toolName': 'web_search', 'providerExecuted': True},
+            {
+                'type': 'tool-input-start',
+                'toolCallId': IsStr(),
+                'toolName': 'web_search',
+                'providerExecuted': True,
+                'providerMetadata': {'pydantic_ai': {'provider_name': 'openai'}},
+            },
             {
                 'type': 'tool-input-delta',
                 'toolCallId': IsStr(),
@@ -524,7 +554,13 @@ I'd be happy to help you use a tool! However, I need more information about what
                     }
                 },
             },
-            {'type': 'tool-input-start', 'toolCallId': IsStr(), 'toolName': 'web_search', 'providerExecuted': True},
+            {
+                'type': 'tool-input-start',
+                'toolCallId': IsStr(),
+                'toolName': 'web_search',
+                'providerExecuted': True,
+                'providerMetadata': {'pydantic_ai': {'provider_name': 'openai'}},
+            },
             {
                 'type': 'tool-input-delta',
                 'toolCallId': IsStr(),
@@ -566,7 +602,13 @@ I'd be happy to help you use a tool! However, I need more information about what
                     }
                 },
             },
-            {'type': 'tool-input-start', 'toolCallId': IsStr(), 'toolName': 'web_search', 'providerExecuted': True},
+            {
+                'type': 'tool-input-start',
+                'toolCallId': IsStr(),
+                'toolName': 'web_search',
+                'providerExecuted': True,
+                'providerMetadata': {'pydantic_ai': {'provider_name': 'openai'}},
+            },
             {
                 'type': 'tool-input-delta',
                 'toolCallId': IsStr(),
@@ -1473,7 +1515,13 @@ async def test_run_stream_builtin_tool_call():
         [
             {'type': 'start'},
             {'type': 'start-step'},
-            {'type': 'tool-input-start', 'toolCallId': 'search_1', 'toolName': 'web_search', 'providerExecuted': True},
+            {
+                'type': 'tool-input-start',
+                'toolCallId': 'search_1',
+                'toolName': 'web_search',
+                'providerExecuted': True,
+                'providerMetadata': {'pydantic_ai': {'provider_name': 'function'}},
+            },
             {'type': 'tool-input-delta', 'toolCallId': 'search_1', 'inputTextDelta': '{"query":'},
             {'type': 'tool-input-delta', 'toolCallId': 'search_1', 'inputTextDelta': '"Hello world"}'},
             {
@@ -4039,7 +4087,18 @@ async def test_event_stream_tool_call_end_with_provider_metadata():
         [
             {'type': 'start'},
             {'type': 'start-step'},
-            {'type': 'tool-input-start', 'toolCallId': 'tc_meta', 'toolName': 'my_tool'},
+            {
+                'type': 'tool-input-start',
+                'toolCallId': 'tc_meta',
+                'toolName': 'my_tool',
+                'providerMetadata': {
+                    'pydantic_ai': {
+                        'id': 'tool_call_id_123',
+                        'provider_name': 'anthropic',
+                        'provider_details': {'tool_index': 0},
+                    }
+                },
+            },
             {'type': 'tool-input-delta', 'toolCallId': 'tc_meta', 'inputTextDelta': '{"key":"value"}'},
             {
                 'type': 'tool-input-available',
@@ -4096,7 +4155,19 @@ async def test_event_stream_builtin_tool_call_end_with_provider_metadata():
         [
             {'type': 'start'},
             {'type': 'start-step'},
-            {'type': 'tool-input-start', 'toolCallId': 'btc_meta', 'toolName': 'web_search', 'providerExecuted': True},
+            {
+                'type': 'tool-input-start',
+                'toolCallId': 'btc_meta',
+                'toolName': 'web_search',
+                'providerExecuted': True,
+                'providerMetadata': {
+                    'pydantic_ai': {
+                        'id': 'builtin_call_id_456',
+                        'provider_name': 'openai',
+                        'provider_details': {'tool_type': 'web_search_preview'},
+                    }
+                },
+            },
             {'type': 'tool-input-delta', 'toolCallId': 'btc_meta', 'inputTextDelta': '{"query":"test"}'},
             {
                 'type': 'tool-input-available',


### PR DESCRIPTION
Match Vercel AI SDK type definitions with the stable `ai@6.0.57` release, previously tracking the `ai@5.0.59` beta. Extracted from #3772—none of these types are related to tool approval, so I split it out.

## Changes

- Remove `'unknown'` from `FinishReason` union, consolidating on `'other'` as the sole fallback for unmapped finish reasons
  - [`FinishReason` type](https://github.com/vercel/ai/blob/ai%406.0.57/packages/ai/src/types/language-model.ts#L72-L78)
- Add `provider_metadata` to `ToolInputStartChunk` so provider-specific metadata is available as soon as a tool call starts streaming, not only after input is fully available
  - [`tool-input-start` chunk](https://github.com/vercel/ai/blob/a6486cd9def5ae23f179bcb5795803206b280f48/packages/ai/src/ui-message-stream/ui-message-chunks.ts#L281)
- Add optional `reason` field to `AbortChunk` for communicating why a stream was aborted
  - [`abort` chunk](https://github.com/vercel/ai/blob/a6486cd9def5ae23f179bcb5795803206b280f48/packages/ai/src/ui-message-stream/ui-message-chunks.ts#L330)
- Add `call_provider_metadata` to `ToolInputStreamingPart` and `DynamicToolInputStreamingPart`, matching the `input-available` and later states, and remove the `isinstance` guard in the adapter that previously skipped metadata for streaming parts
  - [`ToolUIPart` input-streaming](https://github.com/vercel/ai/blob/ai%406.0.57/packages/ai/src/ui/ui-messages.ts#L236), [`DynamicToolUIPart` input-streaming](https://github.com/vercel/ai/blob/ai%406.0.57/packages/ai/src/ui/ui-messages.ts#L341)

## Testing

- Inline snapshots updated to reflect `providerMetadata` now appearing on `tool-input-start` chunks
