### PR TITLE
fix(bedrock): narrow cache point workaround to binary content only

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -746,9 +746,12 @@ class BedrockConverseModel(Model):
         if processed_messages and settings.get('bedrock_cache_messages') and profile.bedrock_supports_prompt_caching:
             last_user_content = self._get_last_user_message_content(processed_messages)
             if last_user_content is not None:
-                # AWS currently rejects cache points that directly follow non-text content.
-                # Insert a newline text block as a workaround.
-                if 'text' not in last_user_content[-1]:
+                # AWS currently rejects cache points that directly follow binary content (document, image, video).
+                # Insert a newline text block as a workaround only for these specific content types.
+                # We avoid adding this workaround for other non-text content like toolResult, as the
+                # non-persisted newline causes cache misses on subsequent calls (see #4121).
+                last_block = last_user_content[-1]
+                if any(key in last_block for key in ('document', 'image', 'video')):
                     last_user_content.append({'text': '\n'})
                 last_user_content.append({'cachePoint': {'type': 'default'}})
 
@@ -860,10 +863,13 @@ class BedrockConverseModel(Model):
                             'CachePoint cannot be the first content in a user message - there must be previous content to cache when using Bedrock. '
                             'To cache system instructions or tool definitions, use the `bedrock_cache_instructions` or `bedrock_cache_tool_definitions` settings instead.'
                         )
-                    if 'text' not in content[-1]:
-                        # AWS currently rejects cache points that directly follow non-text content.
-                        # Insert an empty text block as a workaround (see https://github.com/pydantic/pydantic-ai/issues/3418
-                        # and https://github.com/pydantic/pydantic-ai/pull/2560#discussion_r2349209916).
+                    # AWS currently rejects cache points that directly follow binary content (document, image, video).
+                    # Insert a newline text block as a workaround only for these specific content types.
+                    # We avoid adding this workaround for other non-text content like toolResult, as the
+                    # non-persisted newline causes cache misses on subsequent calls (see #4121).
+                    # See also https://github.com/pydantic/pydantic-ai/issues/3418 and
+                    # https://github.com/pydantic/pydantic-ai/pull/2560#discussion_r2349209916.
+                    if any(key in content[-1] for key in ('document', 'image', 'video')):
                         content.append({'text': '\n'})
                     content.append({'cachePoint': {'type': 'default'}})
                 else:


### PR DESCRIPTION
Closes #4121

## Summary
- Narrow the cache point newline workaround to only binary content types (`document`, `image`, `video`)
- Previously triggered for any content without `text` key (including `toolResult`)
- Non-persisted workaround was breaking cache hits by changing message positions on subsequent calls

## Root Cause
The existing workaround adds `{'text': '\n'}` before cache points when the last content block doesn't have a `text` key. This is too broad - it triggers for tool results and other non-text content that AWS Bedrock doesn't actually require the buffer for.

More importantly, because this workaround isn't persisted in pydantic's message history, it moves around on subsequent API calls, invalidating the cache.

## Impact
Reporter tested removing the workaround entirely and saw cache hits improve from **38% → 94.5%**

## Changes
- `bedrock.py:749-756`: Check for specific binary content types instead of `'text' not in`
- `bedrock.py:863-871`: Same fix in `_map_user_prompt` for explicit `CachePoint()` usage

## Test Plan
- [x] Existing `test_bedrock_cache_messages` passes (text content - no workaround)
- [x] Existing `test_bedrock_cache_messages_with_binary_content` passes (document - workaround added)
- [x] Ran `make format lint typecheck-pyright` - all pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)