### PR TITLE
Expose `usage_limits` and `model_settings` to users running with `to_cli()`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -351,7 +351,9 @@ async def run_chat(
                 return exit_value
         else:
             try:
-                messages = await ask_agent(agent, text, stream, console, code_theme, deps, messages, model_settings, usage_limits)
+                messages = await ask_agent(
+                    agent, text, stream, console, code_theme, deps, messages, model_settings, usage_limits
+                )
             except CancelledError:  # pragma: no cover
                 console.print('[dim]Interrupted[/dim]')
             except Exception as e:  # pragma: no cover
@@ -382,7 +384,9 @@ async def ask_agent(
         return result.all_messages()
 
     with status, ExitStack() as stack:
-        async with agent.iter(prompt, message_history=messages, deps=deps, model_settings=model_settings, usage_limits=usage_limits) as agent_run:
+        async with agent.iter(
+            prompt, message_history=messages, deps=deps, model_settings=model_settings, usage_limits=usage_limits
+        ) as agent_run:
             live = Live('', refresh_per_second=15, console=console, vertical_overflow='ellipsis')
             async for node in agent_run:
                 if Agent.is_model_request_node(node):

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1476,5 +1476,11 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         ```
         """
         return _utils.get_event_loop().run_until_complete(
-            self.to_cli(deps=deps, prog_name=prog_name, message_history=message_history, model_settings=model_settings, usage_limits=usage_limits)
+            self.to_cli(
+                deps=deps,
+                prog_name=prog_name,
+                message_history=message_history,
+                model_settings=model_settings,
+                usage_limits=usage_limits,
+            )
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -741,4 +741,3 @@ async def test_agent_to_cli_async_with_args(mocker: MockerFixture, env: TestEnv)
         model_settings=model_settings,
         usage_limits=usage_limits,
     )
-


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

I added two optional arguments, `model_settings` and `usage_limits`, to `to_cli` as we discussed in #4118 . If there are more arguments that the maintainers think would be worth forwarding to the agent’s `iter()` method, please mention them and I will be happy to add them, as I think that is well within the spirit of the PR.

I would like the maintainers to advise on how the documentation should be updated to reflect that changes I have made.

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #4118 

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
