### PR TITLE
Build experiment url for the evaluation report

### DIFF
--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -12,7 +12,7 @@ from dirty_equals import HasRepr, IsNumber
 from inline_snapshot import snapshot
 from pydantic import BaseModel, TypeAdapter
 
-from ..conftest import IsStr, try_import
+from ..conftest import IsDatetime, IsStr, try_import
 from .utils import render_table
 
 with try_import() as imports_successful:
@@ -749,6 +749,7 @@ async def test_report_round_trip_serialization(example_dataset: Dataset[TaskInpu
             ],
             span_id='0000000000000001',
             trace_id='00000000000000000000000000000001',
+            start_timestamp=IsDatetime(),
         )
     )
 


### PR DESCRIPTION
We need to find a better way to get the `base_url`, maybe? 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public API surface (`tags` on `Dataset.evaluate*` and `EvaluationReport.experiment_url`) and changes report serialization shape by including a start timestamp. Low operational risk, but consumers relying on exact report equality/serialization may need updates.
> 
> **Overview**
> Evaluation runs can now be **tagged** via a new `tags` parameter on `Dataset.evaluate`/`evaluate_sync`, which forwards tags into the Logfire span attributes.
> 
> `EvaluationReport` now records the evaluation span start time (`start_timestamp`) and exposes `experiment_url()` to build a Logfire compare URL (optionally inferring the project base URL from Logfire credentials). Tests were updated to assert the new timestamp field in report snapshots/round-trip serialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5d1f71351707b76ccf75efd978d67397561c660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->