### PR TITLE
fix: only suggest 'call a tool' in retry when tools are registered

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -707,7 +707,7 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                         return
                     elif output_schema.toolset:
                         alternatives.append('include your response in a tool call')
-                    else:
+                    elif ctx.deps.tool_manager.tool_defs:
                         alternatives.append('call a tool')
 
                     if output_schema.allows_image:


### PR DESCRIPTION
## Summary

When `CallToolsNode._run_stream` receives a model response with no tool calls, the structural check falls through to an `else` branch that unconditionally appends `'call a tool'` to the retry alternatives:

```python
if tool_calls:
    async for event in self._handle_tool_calls(ctx, tool_calls):
        yield event
    return
elif output_schema.toolset:
    alternatives.append('include your response in a tool call')
else:
    alternatives.append('call a tool')  # ← always added, even with zero tools
```

If an agent has `output_type=str` and no function tools registered, the retry message becomes `"Please return text or call a tool."` — but there are no tools for the model to call. This can cause the model to attempt tool calls that don't exist, leading to unnecessary retries and wasted tokens before it falls back to returning text.

## Fix

Check `tool_manager.tool_defs` before suggesting tool usage, since it reflects the actual tools available for the current step (after prepare functions and dynamic toolsets have run):

```python
elif ctx.deps.tool_manager.tool_defs:
    alternatives.append('call a tool')
```

This makes the `else` conditional, so the suggestion only appears when function tools actually exist for the current run step — producing a cleaner retry message like `"Please return text."` that guides the model toward a valid response path immediately, avoiding unnecessary retry cycles.