### PR TITLE
Review all PRs with Opus 4.5, remove `auto-review` label gating

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,7 +1,7 @@
 name: Auto Review
 on:
   pull_request_target:
-    types: [opened, synchronize, labeled]
+    types: [opened, synchronize]
 
 concurrency:
   group: review-${{ github.event.pull_request.number }}
@@ -10,9 +10,6 @@ concurrency:
 jobs:
 
   review:
-    if: >-
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'auto-review')) ||
-      (github.event.action == 'labeled' && github.event.label.name == 'auto-review')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -49,7 +46,7 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-5
             --allowedTools "TodoWrite,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh api:*),Bash(git log:*),Bash(git diff:*),Bash(git grep:*),Bash(git show:*),Bash(git status:*),Bash(jq:*),Bash(cat:*),Bash(rg:*),Bash(ls:*),Bash(tree:*),Bash(grep:*),WebSearch,WebFetch"
 
           prompt: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ In this case, unless the user appears to be uniquely well-suited to build a feat
 
 Pydantic AI is meant to be a light-weight library that any Python developer who wants to work with LLMs and agents (whether simple or complex) should feel no hesitation to pull into their project. It's not meant to be everything to everyone, but it should enable people to build just about anything.
 
-As such, we prefer strong primitives, powerful abstractions, and general solutions and extension points that enable people to build things that we hadn't even thought of, over narrow solutions for specific use cases, opinionated solutions that push a particular approach to agent design that hasn't yet stood the test of time, or generally "all batteries included" solutions that make the library unnecessarily bloated.
+As such, we prefer strong primitives, powerful abstractions, and general solutions and extension points that enable people to build things that we hadn't even thought of, over narrow solutions for specific use cases, opinionated solutions that push a particular approach to agent design that hasn't yet stood the test of time, or generally "every single possible battery included" solutions that make the library unnecessarily bloated.
 
 # Requirements of all contributions
 


### PR DESCRIPTION
- Remove `labeled` trigger and `auto-review` label condition so all PRs get reviewed
- Switch review model from `claude-opus-4-6` to `claude-opus-4-5`
- Minor wording tweak in AGENTS.md philosophy section
