### PR TITLE
ci: Remove 15-minute sleep delay from review workflow

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,10 +17,6 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - name: Wait for push activity to settle
-        if: github.event.action == 'synchronize'
-        run: sleep 900  # 15 minutes
-
       - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
The concurrency group with cancel-in-progress already cancels previous runs on new pushes, making the sleep-based debounce redundant. This removes the unnecessary 15-minute delay on every review.