### PR TITLE
fix: avoid stale client references in model and embedding classes

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
@@ -515,8 +515,6 @@ class BedrockEmbeddingModel(EmbeddingModel):
     ```
     """
 
-    client: BedrockRuntimeClient
-
     _model_name: BedrockEmbeddingModelName = field(repr=False)
     _provider: Provider[BaseClient] = field(repr=False)
     _handler: _BedrockEmbeddingHandler = field(repr=False)
@@ -548,10 +546,13 @@ class BedrockEmbeddingModel(EmbeddingModel):
         if isinstance(provider, str):
             provider = infer_provider(provider)
         self._provider = provider
-        self.client = cast('BedrockRuntimeClient', provider.client)
         self._handler = _get_handler_for_model(model_name)
 
         super().__init__(settings=settings)
+
+    @property
+    def client(self) -> BedrockRuntimeClient:
+        return cast('BedrockRuntimeClient', self._provider.client)
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
@@ -11,7 +11,7 @@ from .result import EmbeddingResult
 from .settings import EmbeddingSettings
 
 try:
-    from cohere import AsyncClientV2
+    from cohere import AsyncClient, AsyncClientV2
     from cohere.core.api_error import ApiError
     from cohere.core.request_options import RequestOptions
     from cohere.types.embed_by_type_response import EmbedByTypeResponse
@@ -125,10 +125,16 @@ class CohereEmbeddingModel(EmbeddingModel):
         if isinstance(provider, str):
             provider = infer_provider(provider)
         self._provider = provider
-        self._client = provider.client
-        self._v1_client = provider.v1_client if isinstance(provider, CohereProvider) else None
 
         super().__init__(settings=settings)
+
+    @property
+    def _client(self) -> AsyncClientV2:
+        return self._provider.client
+
+    @property
+    def _v1_client(self) -> AsyncClient | None:
+        return self._provider.v1_client if isinstance(self._provider, CohereProvider) else None
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -131,9 +131,12 @@ class GoogleEmbeddingModel(EmbeddingModel):
         if isinstance(provider, str):
             provider = infer_provider(provider)
         self._provider = provider
-        self._client = provider.client
 
         super().__init__(settings=settings)
+
+    @property
+    def _client(self) -> Client:
+        return self._provider.client
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -97,9 +97,12 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         if isinstance(provider, str):
             provider = infer_provider(provider)
         self._provider = provider
-        self._client = provider.client
 
         super().__init__(settings=settings)
+
+    @property
+    def _client(self) -> AsyncOpenAI:
+        return self._provider.client
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -318,8 +318,6 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    client: AsyncAnthropicClient = field(repr=False)
-
     _model_name: AnthropicModelName = field(repr=False)
     _provider: Provider[AsyncAnthropicClient] = field(repr=False)
 
@@ -347,9 +345,12 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         if isinstance(provider, str):
             provider = infer_provider('gateway/anthropic' if provider == 'gateway' else provider)
         self._provider = provider
-        self.client = provider.client
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
+
+    @property
+    def client(self) -> AsyncAnthropicClient:
+        return self._provider.client
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -380,8 +380,6 @@ class BedrockModelSettings(ModelSettings, total=False):
 class BedrockConverseModel(Model[BaseClient]):
     """A model that uses the Bedrock Converse API."""
 
-    client: BedrockRuntimeClient
-
     _model_name: BedrockModelName = field(repr=False)
     _provider: Provider[BaseClient] = field(repr=False)
 
@@ -410,9 +408,12 @@ class BedrockConverseModel(Model[BaseClient]):
         if isinstance(provider, str):
             provider = infer_provider('gateway/bedrock' if provider == 'gateway' else provider)
         self._provider = provider
-        self.client = cast('BedrockRuntimeClient', provider.client)
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
+
+    @property
+    def client(self) -> BedrockRuntimeClient:
+        return cast('BedrockRuntimeClient', self._provider.client)
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -108,8 +108,6 @@ class CohereModel(Model[AsyncClientV2]):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    client: AsyncClientV2 = field(repr=False)
-
     _model_name: CohereModelName = field(repr=False)
     _provider: Provider[AsyncClientV2] = field(repr=False)
 
@@ -137,9 +135,12 @@ class CohereModel(Model[AsyncClientV2]):
         if isinstance(provider, str):
             provider = infer_provider(provider)
         self._provider = provider
-        self.client = provider.client
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
+
+    @property
+    def client(self) -> AsyncClientV2:
+        return self._provider.client
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -112,12 +112,9 @@ class GeminiModel(Model[httpx.AsyncClient]):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    client: httpx.AsyncClient = field(repr=False)
-
     _model_name: GeminiModelName = field(repr=False)
     _provider: Provider[httpx.AsyncClient] = field(repr=False)
     _auth: AuthProtocol | None = field(repr=False)
-    _url: str | None = field(repr=False)
 
     def __init__(
         self,
@@ -149,15 +146,16 @@ class GeminiModel(Model[httpx.AsyncClient]):
 
                 provider = GoogleVertexProvider()  # type: ignore[reportDeprecated]
         self._provider = provider
-        self.client = provider.client
-        self._url = str(self.client.base_url)
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
 
     @property
+    def client(self) -> httpx.AsyncClient:
+        return self._provider.client
+
+    @property
     def base_url(self) -> str:
-        assert self._url is not None, 'URL not initialized'
-        return self._url
+        return str(self.client.base_url)
 
     @property
     def model_name(self) -> GeminiModelName:

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -278,8 +278,6 @@ class GoogleModel(Model[Client]):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    client: Client = field(repr=False)
-
     _model_name: GoogleModelName = field(repr=False)
     _provider: Provider[Client] = field(repr=False)
 
@@ -306,9 +304,12 @@ class GoogleModel(Model[Client]):
         if isinstance(provider, str):
             provider = infer_provider('gateway/google-vertex' if provider == 'gateway' else provider)
         self._provider = provider
-        self.client = provider.client
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
+
+    @property
+    def client(self) -> Client:
+        return self._provider.client
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -146,8 +146,6 @@ class GroqModel(Model[AsyncGroq]):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    client: AsyncGroq = field(repr=False)
-
     _model_name: GroqModelName = field(repr=False)
     _provider: Provider[AsyncGroq] = field(repr=False)
 
@@ -175,9 +173,12 @@ class GroqModel(Model[AsyncGroq]):
         if isinstance(provider, str):
             provider = infer_provider('gateway/groq' if provider == 'gateway' else provider)
         self._provider = provider
-        self.client = provider.client
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
+
+    @property
+    def client(self) -> AsyncGroq:
+        return self._provider.client
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -138,8 +138,6 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    client: AsyncInferenceClient = field(repr=False)
-
     _model_name: str = field(repr=False)
     _provider: Provider[AsyncInferenceClient] = field(repr=False)
 
@@ -164,9 +162,12 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
         if isinstance(provider, str):
             provider = infer_provider(provider)
         self._provider = provider
-        self.client = provider.client
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
+
+    @property
+    def client(self) -> AsyncInferenceClient:
+        return self._provider.client
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -145,7 +145,6 @@ class MistralModel(Model[Mistral]):
     [API Documentation](https://docs.mistral.ai/)
     """
 
-    client: Mistral = field(repr=False)
     json_mode_schema_prompt: str
 
     _model_name: MistralModelName = field(repr=False)
@@ -177,9 +176,12 @@ class MistralModel(Model[Mistral]):
         if isinstance(provider, str):
             provider = infer_provider(provider)
         self._provider = provider
-        self.client = provider.client
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
+
+    @property
+    def client(self) -> Mistral:
+        return self._provider.client
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -594,8 +594,6 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
     Apart from `__init__`, all methods are private or match those of the base class.
     """
 
-    client: AsyncOpenAI = field(repr=False)
-
     _model_name: OpenAIModelName = field(repr=False)
     _provider: Provider[AsyncOpenAI] = field(repr=False)
 
@@ -665,12 +663,15 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         if isinstance(provider, str):
             provider = infer_provider('gateway/openai' if provider == 'gateway' else provider)
         self._provider = provider
-        self.client = provider.client
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
 
         if system_prompt_role is not None:
             self.profile = OpenAIModelProfile(openai_system_prompt_role=system_prompt_role).update(self.profile)
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        return self._provider.client
 
     @property
     def base_url(self) -> str:
@@ -1521,8 +1522,6 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
     see the [OpenAI API docs](https://platform.openai.com/docs/guides/responses-vs-chat-completions).
     """
 
-    client: AsyncOpenAI = field(repr=False)
-
     _model_name: OpenAIModelName = field(repr=False)
     _provider: Provider[AsyncOpenAI] = field(repr=False)
 
@@ -1552,9 +1551,12 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         if isinstance(provider, str):
             provider = infer_provider('gateway/openai' if provider == 'gateway' else provider)
         self._provider = provider
-        self.client = provider.client
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        return self._provider.client
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -321,9 +321,12 @@ class XaiModel(Model[AsyncClient]):
         if isinstance(provider, str):
             provider = infer_provider(provider)
         self._provider = provider
-        self.client = provider.client
 
         super().__init__(settings=settings, profile=profile or provider.model_profile(model_name))
+
+    @property
+    def client(self) -> 'AsyncClient':
+        return self._provider.client
 
     @property
     def model_name(self) -> str:

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -148,8 +148,10 @@ T = TypeVar('T')
 
 
 def test_init():
-    m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(api_key='foobar'))
+    provider = AnthropicProvider(api_key='foobar')
+    m = AnthropicModel('claude-haiku-4-5', provider=provider)
     assert isinstance(m.client, AsyncAnthropic)
+    assert m.client is provider.client
     assert m.client.api_key == 'foobar'
     assert m.model_name == 'claude-haiku-4-5'
     assert m.system == 'anthropic'
@@ -213,23 +215,6 @@ class MockAnthropic:
         self.chat_completion_kwargs.append({k: v for k, v in kwargs.items() if v is not NOT_GIVEN})
 
         return BetaMessageTokensCount(input_tokens=10)
-
-
-def test_anthropic_client_property_reflects_provider_changes():
-    class _SwappableAnthropicProvider(AnthropicProvider):
-        @AnthropicProvider.client.setter
-        def client(self, client: AsyncAnthropic) -> None:
-            self._client = client
-
-    client_a = cast(AsyncAnthropic, MockAnthropic())
-    provider = _SwappableAnthropicProvider(anthropic_client=client_a)
-    model = AnthropicModel('claude-haiku-4-5', provider=provider)
-
-    assert model.client is client_a
-
-    client_b = cast(AsyncAnthropic, MockAnthropic())
-    provider.client = client_b
-    assert model.client is client_b
 
 
 def completion_message(content: list[BetaContentBlock], usage: BetaUsage) -> BetaMessage:

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -215,6 +215,23 @@ class MockAnthropic:
         return BetaMessageTokensCount(input_tokens=10)
 
 
+def test_anthropic_client_property_reflects_provider_changes():
+    class _SwappableAnthropicProvider(AnthropicProvider):
+        @AnthropicProvider.client.setter
+        def client(self, client: AsyncAnthropic) -> None:
+            self._client = client
+
+    client_a = cast(AsyncAnthropic, MockAnthropic())
+    provider = _SwappableAnthropicProvider(anthropic_client=client_a)
+    model = AnthropicModel('claude-haiku-4-5', provider=provider)
+
+    assert model.client is client_a
+
+    client_b = cast(AsyncAnthropic, MockAnthropic())
+    provider.client = client_b
+    assert model.client is client_b
+
+
 def completion_message(content: list[BetaContentBlock], usage: BetaUsage) -> BetaMessage:
     return BetaMessage(
         id='123',

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -114,9 +114,26 @@ class _StubBedrockProvider(Provider[Any]):
     def client(self) -> _StubBedrockClient:
         return self._client
 
+    @client.setter
+    def client(self, client: _StubBedrockClient) -> None:
+        self._client = client
+
     @staticmethod
     def model_profile(model_name: str):
         return DEFAULT_PROFILE
+
+
+def test_bedrock_client_property_reflects_provider_changes():
+    error = ClientError({'Error': {'Code': 'Test', 'Message': 'test'}}, 'TestOperation')
+    client_a = _StubBedrockClient(error)
+    provider = _StubBedrockProvider(client_a)
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=provider)
+
+    assert model.client is client_a
+
+    client_b = _StubBedrockClient(error)
+    provider.client = client_b
+    assert model.client is client_b
 
 
 def _bedrock_model_with_client_error(error: ClientError) -> BedrockConverseModel:

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -114,26 +114,14 @@ class _StubBedrockProvider(Provider[Any]):
     def client(self) -> _StubBedrockClient:
         return self._client
 
-    @client.setter
-    def client(self, client: _StubBedrockClient) -> None:
-        self._client = client
-
     @staticmethod
     def model_profile(model_name: str):
         return DEFAULT_PROFILE
 
 
-def test_bedrock_client_property_reflects_provider_changes():
-    error = ClientError({'Error': {'Code': 'Test', 'Message': 'test'}}, 'TestOperation')
-    client_a = _StubBedrockClient(error)
-    provider = _StubBedrockProvider(client_a)
-    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=provider)
-
-    assert model.client is client_a
-
-    client_b = _StubBedrockClient(error)
-    provider.client = client_b
-    assert model.client is client_b
+async def test_bedrock_client_property_delegates_to_provider(bedrock_provider: BedrockProvider):
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    assert model.client is bedrock_provider.client
 
 
 def _bedrock_model_with_client_error(error: ClientError) -> BedrockConverseModel:

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -97,6 +97,23 @@ class MockAsyncClientV2:
         return response
 
 
+def test_cohere_client_property_reflects_provider_changes():
+    class _SwappableCohereProvider(CohereProvider):
+        @CohereProvider.client.setter
+        def client(self, client: AsyncClientV2) -> None:
+            self._client = client
+
+    client_a = MockAsyncClientV2.create_mock(completion_message(AssistantMessageResponse(content=[])))
+    provider = _SwappableCohereProvider(cohere_client=client_a)
+    model = CohereModel('command-r7b-12-2024', provider=provider)
+
+    assert model.client is client_a
+
+    client_b = MockAsyncClientV2.create_mock(completion_message(AssistantMessageResponse(content=[])))
+    provider.client = client_b
+    assert model.client is client_b
+
+
 def completion_message(message: AssistantMessageResponse, *, usage: cohere.Usage | None = None) -> ChatResponse:
     return ChatResponse(
         id='123',

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -60,7 +60,9 @@ pytestmark = [
 
 
 def test_init():
-    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(api_key='foobar'))
+    provider = CohereProvider(api_key='foobar')
+    m = CohereModel('command-r7b-12-2024', provider=provider)
+    assert m.client is provider.client
     assert m.model_name == 'command-r7b-12-2024'
     assert m.system == 'cohere'
     assert m.base_url == 'https://api.cohere.com'
@@ -95,23 +97,6 @@ class MockAsyncClientV2:
             response = cast(ChatResponse, self.completions)
         self.index += 1
         return response
-
-
-def test_cohere_client_property_reflects_provider_changes():
-    class _SwappableCohereProvider(CohereProvider):
-        @CohereProvider.client.setter
-        def client(self, client: AsyncClientV2) -> None:
-            self._client = client
-
-    client_a = MockAsyncClientV2.create_mock(completion_message(AssistantMessageResponse(content=[])))
-    provider = _SwappableCohereProvider(cohere_client=client_a)
-    model = CohereModel('command-r7b-12-2024', provider=provider)
-
-    assert model.client is client_a
-
-    client_b = MockAsyncClientV2.create_mock(completion_message(AssistantMessageResponse(content=[])))
-    provider.client = client_b
-    assert model.client is client_b
 
 
 def completion_message(message: AssistantMessageResponse, *, usage: cohere.Usage | None = None) -> ChatResponse:

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -87,23 +87,11 @@ async def test_model_simple(allow_model_requests: None):
     assert tool_config is None
 
 
-async def test_gemini_client_property_reflects_provider_changes():
-    class _SwappableGoogleGLAProvider(GoogleGLAProvider):
-        @GoogleGLAProvider.client.setter
-        def client(self, client: httpx.AsyncClient) -> None:
-            self._client = client
-
-    provider = _SwappableGoogleGLAProvider(api_key='via-arg')
+def test_gemini_client_property_delegates_to_provider():
+    provider = GoogleGLAProvider(api_key='via-arg')
     model = GeminiModel('gemini-1.5-flash', provider=provider)
-
-    client_a = provider.client
-    assert model.client is client_a
-
-    client_b = httpx.AsyncClient(base_url='https://example.com/')
-    provider.client = client_b
-    assert model.client is client_b
-    assert model.base_url == 'https://example.com/'
-    await client_b.aclose()
+    assert model.client is provider.client
+    assert model.base_url == str(provider.client.base_url)
 
 
 async def test_model_tools(allow_model_requests: None):

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -87,6 +87,25 @@ async def test_model_simple(allow_model_requests: None):
     assert tool_config is None
 
 
+async def test_gemini_client_property_reflects_provider_changes():
+    class _SwappableGoogleGLAProvider(GoogleGLAProvider):
+        @GoogleGLAProvider.client.setter
+        def client(self, client: httpx.AsyncClient) -> None:
+            self._client = client
+
+    provider = _SwappableGoogleGLAProvider(api_key='via-arg')
+    model = GeminiModel('gemini-1.5-flash', provider=provider)
+
+    client_a = provider.client
+    assert model.client is client_a
+
+    client_b = httpx.AsyncClient(base_url='https://example.com/')
+    provider.client = client_b
+    assert model.client is client_b
+    assert model.base_url == 'https://example.com/'
+    await client_b.aclose()
+
+
 async def test_model_tools(allow_model_requests: None):
     m = GeminiModel('gemini-1.5-flash', provider=GoogleGLAProvider(api_key='via-arg'))
     tools = [

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -137,6 +137,23 @@ def google_provider(gemini_api_key: str) -> GoogleProvider:
     return GoogleProvider(api_key=gemini_api_key)
 
 
+def test_google_client_property_reflects_provider_changes(gemini_api_key: str):
+    class _SwappableGoogleProvider(GoogleProvider):
+        @GoogleProvider.client.setter
+        def client(self, client: Any) -> None:
+            self._client = client
+
+    provider = _SwappableGoogleProvider(api_key=gemini_api_key)
+    model = GoogleModel('gemini-2.5-flash', provider=provider)
+
+    client_a = provider.client
+    assert model.client is client_a
+
+    client_b = GoogleProvider(api_key='test-key').client
+    provider.client = client_b
+    assert model.client is client_b
+
+
 async def test_google_model(allow_model_requests: None, google_provider: GoogleProvider):
     model = GoogleModel('gemini-2.5-flash', provider=google_provider)
     assert model.base_url == 'https://generativelanguage.googleapis.com/'

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -137,21 +137,9 @@ def google_provider(gemini_api_key: str) -> GoogleProvider:
     return GoogleProvider(api_key=gemini_api_key)
 
 
-def test_google_client_property_reflects_provider_changes(gemini_api_key: str):
-    class _SwappableGoogleProvider(GoogleProvider):
-        @GoogleProvider.client.setter
-        def client(self, client: Any) -> None:
-            self._client = client
-
-    provider = _SwappableGoogleProvider(api_key=gemini_api_key)
-    model = GoogleModel('gemini-2.5-flash', provider=provider)
-
-    client_a = provider.client
-    assert model.client is client_a
-
-    client_b = GoogleProvider(api_key='test-key').client
-    provider.client = client_b
-    assert model.client is client_b
+def test_google_client_property_delegates_to_provider(google_provider: GoogleProvider):
+    model = GoogleModel('gemini-2.5-flash', provider=google_provider)
+    assert model.client is google_provider.client
 
 
 async def test_google_model(allow_model_requests: None, google_provider: GoogleProvider):

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -95,6 +95,23 @@ def test_init():
     assert m.base_url == 'https://api.groq.com'
 
 
+def test_groq_client_property_reflects_provider_changes():
+    class _SwappableGroqProvider(GroqProvider):
+        @GroqProvider.client.setter
+        def client(self, client: AsyncGroq) -> None:
+            self._client = client
+
+    client_a = cast(AsyncGroq, MockGroq())
+    provider = _SwappableGroqProvider(groq_client=client_a)
+    model = GroqModel('llama-3.3-70b-versatile', provider=provider)
+
+    assert model.client is client_a
+
+    client_b = cast(AsyncGroq, MockGroq())
+    provider.client = client_b
+    assert model.client is client_b
+
+
 @dataclass
 class MockGroq:
     completions: MockChatCompletion | Sequence[MockChatCompletion] | None = None

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -88,28 +88,13 @@ pytestmark = [
 
 
 def test_init():
-    m = GroqModel('llama-3.3-70b-versatile', provider=GroqProvider(api_key='foobar'))
+    provider = GroqProvider(api_key='foobar')
+    m = GroqModel('llama-3.3-70b-versatile', provider=provider)
+    assert m.client is provider.client
     assert m.client.api_key == 'foobar'
     assert m.model_name == 'llama-3.3-70b-versatile'
     assert m.system == 'groq'
     assert m.base_url == 'https://api.groq.com'
-
-
-def test_groq_client_property_reflects_provider_changes():
-    class _SwappableGroqProvider(GroqProvider):
-        @GroqProvider.client.setter
-        def client(self, client: AsyncGroq) -> None:
-            self._client = client
-
-    client_a = cast(AsyncGroq, MockGroq())
-    provider = _SwappableGroqProvider(groq_client=client_a)
-    model = GroqModel('llama-3.3-70b-versatile', provider=provider)
-
-    assert model.client is client_a
-
-    client_b = cast(AsyncGroq, MockGroq())
-    provider.client = client_b
-    assert model.client is client_b
 
 
 @dataclass

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -120,21 +120,10 @@ class MockHuggingFace:
         return response
 
 
-def test_huggingface_client_property_reflects_provider_changes():
-    class _SwappableHuggingFaceProvider(HuggingFaceProvider):
-        @HuggingFaceProvider.client.setter
-        def client(self, client: AsyncInferenceClient) -> None:
-            self._client = client
-
-    client_a = cast(AsyncInferenceClient, MockHuggingFace())
-    provider = _SwappableHuggingFaceProvider(provider_name='nebius', api_key='test-key', hf_client=client_a)
+def test_huggingface_client_property_delegates_to_provider():
+    provider = HuggingFaceProvider(provider_name='nebius', api_key='test-key')
     model = HuggingFaceModel('Qwen/Qwen2.5-72B-Instruct', provider=provider)
-
-    assert model.client is client_a
-
-    client_b = cast(AsyncInferenceClient, MockHuggingFace())
-    provider.client = client_b
-    assert model.client is client_b
+    assert model.client is provider.client
 
 
 def get_mock_chat_completion_kwargs(hf_client: AsyncInferenceClient) -> list[dict[str, Any]]:

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -120,6 +120,23 @@ class MockHuggingFace:
         return response
 
 
+def test_huggingface_client_property_reflects_provider_changes():
+    class _SwappableHuggingFaceProvider(HuggingFaceProvider):
+        @HuggingFaceProvider.client.setter
+        def client(self, client: AsyncInferenceClient) -> None:
+            self._client = client
+
+    client_a = cast(AsyncInferenceClient, MockHuggingFace())
+    provider = _SwappableHuggingFaceProvider(provider_name='nebius', api_key='test-key', hf_client=client_a)
+    model = HuggingFaceModel('Qwen/Qwen2.5-72B-Instruct', provider=provider)
+
+    assert model.client is client_a
+
+    client_b = cast(AsyncInferenceClient, MockHuggingFace())
+    provider.client = client_b
+    assert model.client is client_b
+
+
 def get_mock_chat_completion_kwargs(hf_client: AsyncInferenceClient) -> list[dict[str, Any]]:
     if isinstance(hf_client, MockHuggingFace):
         return hf_client.chat_completion_kwargs

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -138,6 +138,23 @@ class MockMistralAI:
         return response
 
 
+def test_mistral_client_property_reflects_provider_changes():
+    class _SwappableMistralProvider(MistralProvider):
+        @MistralProvider.client.setter
+        def client(self, client: Mistral) -> None:
+            self._client = client
+
+    client_a = cast(Mistral, MockMistralAI())
+    provider = _SwappableMistralProvider(mistral_client=client_a)
+    model = MistralModel('mistral-large', provider=provider)
+
+    assert model.client is client_a
+
+    client_b = cast(Mistral, MockMistralAI())
+    provider.client = client_b
+    assert model.client is client_b
+
+
 def completion_message(
     message: MistralAssistantMessage, *, usage: MistralUsageInfo | None = None, with_created: bool = True
 ) -> MistralChatCompletionResponse:

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -138,23 +138,6 @@ class MockMistralAI:
         return response
 
 
-def test_mistral_client_property_reflects_provider_changes():
-    class _SwappableMistralProvider(MistralProvider):
-        @MistralProvider.client.setter
-        def client(self, client: Mistral) -> None:
-            self._client = client
-
-    client_a = cast(Mistral, MockMistralAI())
-    provider = _SwappableMistralProvider(mistral_client=client_a)
-    model = MistralModel('mistral-large', provider=provider)
-
-    assert model.client is client_a
-
-    client_b = cast(Mistral, MockMistralAI())
-    provider.client = client_b
-    assert model.client is client_b
-
-
 def completion_message(
     message: MistralAssistantMessage, *, usage: MistralUsageInfo | None = None, with_created: bool = True
 ) -> MistralChatCompletionResponse:
@@ -214,7 +197,9 @@ def func_chunk(
 
 
 def test_init():
-    m = MistralModel('mistral-large-latest', provider=MistralProvider(api_key='foobar'))
+    provider = MistralProvider(api_key='foobar')
+    m = MistralModel('mistral-large-latest', provider=provider)
+    assert m.client is provider.client
     assert m.model_name == 'mistral-large-latest'
     assert m.base_url == 'https://api.mistral.ai'
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -116,6 +116,23 @@ def test_init():
     assert m.model_name == 'gpt-4o'
 
 
+def test_openai_chat_client_property_reflects_provider_changes():
+    class _SwappableOpenAIProvider(OpenAIProvider):
+        @OpenAIProvider.client.setter
+        def client(self, client: AsyncOpenAI) -> None:
+            self._client = client
+
+    client_a = cast(AsyncOpenAI, MockOpenAI())
+    provider = _SwappableOpenAIProvider(openai_client=client_a)
+    model = OpenAIChatModel('gpt-4o', provider=provider)
+
+    assert model.client is client_a
+
+    client_b = cast(AsyncOpenAI, MockOpenAI())
+    provider.client = client_b
+    assert model.client is client_b
+
+
 @pytest.mark.parametrize(
     'aspect_ratio,size,expected',
     [

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -110,27 +110,12 @@ pytestmark = [
 
 
 def test_init():
-    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='foobar'))
+    provider = OpenAIProvider(api_key='foobar')
+    m = OpenAIChatModel('gpt-4o', provider=provider)
     assert m.base_url == 'https://api.openai.com/v1/'
+    assert m.client is provider.client
     assert m.client.api_key == 'foobar'
     assert m.model_name == 'gpt-4o'
-
-
-def test_openai_chat_client_property_reflects_provider_changes():
-    class _SwappableOpenAIProvider(OpenAIProvider):
-        @OpenAIProvider.client.setter
-        def client(self, client: AsyncOpenAI) -> None:
-            self._client = client
-
-    client_a = cast(AsyncOpenAI, MockOpenAI())
-    provider = _SwappableOpenAIProvider(openai_client=client_a)
-    model = OpenAIChatModel('gpt-4o', provider=provider)
-
-    assert model.client is client_a
-
-    client_b = cast(AsyncOpenAI, MockOpenAI())
-    provider.client = client_b
-    assert model.client is client_b
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -113,6 +113,23 @@ def test_openai_responses_model(env: TestEnv):
     assert model.client.api_key == 'test'
 
 
+def test_openai_responses_client_property_reflects_provider_changes():
+    class _SwappableOpenAIProvider(OpenAIProvider):
+        @OpenAIProvider.client.setter
+        def client(self, client: AsyncOpenAI) -> None:
+            self._client = client
+
+    client_a = cast(AsyncOpenAI, MockOpenAIResponses())
+    provider = _SwappableOpenAIProvider(openai_client=client_a)
+    model = OpenAIResponsesModel('gpt-4o', provider=provider)
+
+    assert model.client is client_a
+
+    client_b = cast(AsyncOpenAI, MockOpenAIResponses())
+    provider.client = client_b
+    assert model.client is client_b
+
+
 async def test_openai_responses_model_simple_response(allow_model_requests: None, openai_api_key: str):
     model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(api_key=openai_api_key))
     agent = Agent(model=model)

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -106,28 +106,13 @@ async def _cleanup_openai_resources(file: Any, vector_store: Any, async_client: 
 
 def test_openai_responses_model(env: TestEnv):
     env.set('OPENAI_API_KEY', 'test')
-    model = OpenAIResponsesModel('gpt-4o')
+    provider = OpenAIProvider()
+    model = OpenAIResponsesModel('gpt-4o', provider=provider)
     assert model.model_name == 'gpt-4o'
     assert model.system == 'openai'
     assert model.base_url == 'https://api.openai.com/v1/'
+    assert model.client is provider.client
     assert model.client.api_key == 'test'
-
-
-def test_openai_responses_client_property_reflects_provider_changes():
-    class _SwappableOpenAIProvider(OpenAIProvider):
-        @OpenAIProvider.client.setter
-        def client(self, client: AsyncOpenAI) -> None:
-            self._client = client
-
-    client_a = cast(AsyncOpenAI, MockOpenAIResponses())
-    provider = _SwappableOpenAIProvider(openai_client=client_a)
-    model = OpenAIResponsesModel('gpt-4o', provider=provider)
-
-    assert model.client is client_a
-
-    client_b = cast(AsyncOpenAI, MockOpenAIResponses())
-    provider.client = client_b
-    assert model.client is client_b
 
 
 async def test_openai_responses_model_simple_response(allow_model_requests: None, openai_api_key: str):

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -19,7 +19,7 @@ from __future__ import annotations as _annotations
 import json
 from datetime import timezone
 from decimal import Decimal
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from pydantic import BaseModel
@@ -131,6 +131,24 @@ def test_xai_init():
 
     assert m.model_name == XAI_NON_REASONING_MODEL
     assert m.system == 'xai'
+
+
+def test_xai_client_property_reflects_provider_changes():
+    class _SwappableXaiProvider(XaiProvider):
+        @XaiProvider.client.setter
+        def client(self, client: Any) -> None:
+            self._lazy_client = None
+            self._client = client
+
+    client_a = cast(Any, MockXai())
+    provider = _SwappableXaiProvider(xai_client=client_a)
+    m = XaiModel(XAI_NON_REASONING_MODEL, provider=provider)
+
+    assert m.client is client_a
+
+    client_b = cast(Any, MockXai())
+    provider.client = client_b
+    assert m.client is client_b
 
 
 def test_xai_init_with_fixture_api_key(xai_api_key: str):

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -19,7 +19,7 @@ from __future__ import annotations as _annotations
 import json
 from datetime import timezone
 from decimal import Decimal
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from pydantic import BaseModel
@@ -129,26 +129,9 @@ def test_xai_init():
     provider = XaiProvider(api_key='foobar')
     m = XaiModel(XAI_NON_REASONING_MODEL, provider=provider)
 
+    assert m.client is provider.client
     assert m.model_name == XAI_NON_REASONING_MODEL
     assert m.system == 'xai'
-
-
-def test_xai_client_property_reflects_provider_changes():
-    class _SwappableXaiProvider(XaiProvider):
-        @XaiProvider.client.setter
-        def client(self, client: Any) -> None:
-            self._lazy_client = None
-            self._client = client
-
-    client_a = cast(Any, MockXai())
-    provider = _SwappableXaiProvider(xai_client=client_a)
-    m = XaiModel(XAI_NON_REASONING_MODEL, provider=provider)
-
-    assert m.client is client_a
-
-    client_b = cast(Any, MockXai())
-    provider.client = client_b
-    assert m.client is client_b
 
 
 def test_xai_init_with_fixture_api_key(xai_api_key: str):


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #4336

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it is OK for them to be incomplete when review is first requested. -->

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

---

### Summary

Model and embedding classes previously cached a reference to the provider's client via `self.client = provider.client` / `self._client = provider.client` in `__init__`. This is a problem in environments where a provider may be re-initialized or swapped after construction (e.g. durable execution frameworks like Temporal, or tests with dependency injection): the model/embedding keeps using the stale client.

### Changes

- Replaced the cached `client` dataclass field + init assignment with a `@property` that delegates to `self._provider.client` in every affected class:
  - **Models** (11): `OpenAIChatModel`, `OpenAIResponsesModel`, `AnthropicModel`, `GroqModel`, `MistralModel`, `GoogleModel`, `GeminiModel`, `CohereModel`, `HuggingFaceModel`, `BedrockConverseModel`, `XaiModel`.
  - **Embeddings** (4): `OpenAIEmbeddingModel`, `GoogleEmbeddingModel`, `CohereEmbeddingModel`, `BedrockEmbeddingModel`.
- `GeminiModel.base_url` now derives from `self.client.base_url` instead of a cached `self._url`, matching the other models.
- Added `assert model.client is provider.client` identity checks to each model's existing `test_init` (or a new minimal test where none existed), replacing an earlier draft that used a `_SwappableProvider` subclass + private `_client` mutation.