### PR TITLE
ci: Disable Gemini Code Assist auto-review on PR open

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,2 @@
+code_review:
+  disable: true


### PR DESCRIPTION
## Summary
- Adds `.gemini/config.yaml` to disable automatic code reviews and summaries when PRs are opened