### PR TITLE
Add first-class toolset instructions support

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
@@ -109,6 +109,14 @@ class AbstractToolset(ABC, Generic[AgentDepsT]):
         """
         return None
 
+    async def get_instructions(self, ctx: RunContext[AgentDepsT]) -> str | None:
+        """Return instructions for this toolset, included automatically in the model request.
+
+        Override to provide context-dependent instructions that help the model
+        use this toolset's tools effectively.
+        """
+        return None
+
     @abstractmethod
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         """The tools that are available in this toolset."""

--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -60,6 +60,11 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
                 await self._exit_stack.aclose()
                 self._exit_stack = None
 
+    async def get_instructions(self, ctx: RunContext[AgentDepsT]) -> str | None:
+        results = await asyncio.gather(*(ts.get_instructions(ctx) for ts in self.toolsets))
+        parts = [r for r in results if r]
+        return '\n\n'.join(parts).strip() or None
+
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         toolsets_tools = await asyncio.gather(*(toolset.get_tools(ctx) for toolset in self.toolsets))
         all_tools: dict[str, ToolsetTool[AgentDepsT]] = {}

--- a/pydantic_ai_slim/pydantic_ai/toolsets/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/wrapper.py
@@ -34,6 +34,9 @@ class WrapperToolset(AbstractToolset[AgentDepsT]):
     async def __aexit__(self, *args: Any) -> bool | None:
         return await self.wrapped.__aexit__(*args)
 
+    async def get_instructions(self, ctx: RunContext[AgentDepsT]) -> str | None:
+        return await self.wrapped.get_instructions(ctx)
+
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         return await self.wrapped.get_tools(ctx)
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -891,3 +891,310 @@ def test_agent_toolset_decorator_id():
     # Third toolset should have explicit id
     assert isinstance(toolsets[2], DynamicToolset)
     assert toolsets[2].id == 'custom_id'
+
+
+# ── Toolset instructions tests ───────────────────────────────────────────
+
+
+async def test_function_toolset_get_instructions_string():
+    """FunctionToolset with a string instruction returns it via get_instructions."""
+    toolset = FunctionToolset(instructions='Always use tool X for math.')
+
+    @toolset.tool
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    ctx = build_run_context(None)
+    result = await toolset.get_instructions(ctx)
+    assert result == 'Always use tool X for math.'
+
+
+async def test_function_toolset_get_instructions_function():
+    """FunctionToolset with a function instruction calls it via get_instructions."""
+    toolset = FunctionToolset(instructions=lambda: 'Use search for lookups.')
+
+    ctx = build_run_context(None)
+    result = await toolset.get_instructions(ctx)
+    assert result == 'Use search for lookups.'
+
+
+async def test_function_toolset_get_instructions_with_ctx():
+    """FunctionToolset instruction function can access RunContext."""
+
+    def my_instructions(ctx: RunContext[str]) -> str:
+        return f'Deps are: {ctx.deps}'
+
+    toolset = FunctionToolset[str](instructions=my_instructions)
+
+    ctx = build_run_context('hello')
+    result = await toolset.get_instructions(ctx)
+    assert result == 'Deps are: hello'
+
+
+async def test_function_toolset_get_instructions_async():
+    """FunctionToolset with an async instruction function works."""
+
+    async def my_instructions() -> str:
+        return 'Async instructions here.'
+
+    toolset = FunctionToolset(instructions=my_instructions)
+
+    ctx = build_run_context(None)
+    result = await toolset.get_instructions(ctx)
+    assert result == 'Async instructions here.'
+
+
+async def test_function_toolset_get_instructions_multiple():
+    """FunctionToolset with a sequence of instructions joins them."""
+    toolset = FunctionToolset(instructions=['First instruction.', lambda: 'Second instruction.'])
+
+    ctx = build_run_context(None)
+    result = await toolset.get_instructions(ctx)
+    assert result == 'First instruction.\n\nSecond instruction.'
+
+
+async def test_function_toolset_get_instructions_none_default():
+    """FunctionToolset without instructions returns None."""
+    toolset = FunctionToolset()
+
+    @toolset.tool
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    ctx = build_run_context(None)
+    result = await toolset.get_instructions(ctx)
+    assert result is None
+
+
+async def test_function_toolset_instructions_decorator():
+    """The @toolset.instructions decorator registers instruction functions."""
+    toolset = FunctionToolset()
+
+    @toolset.instructions
+    def my_instructions() -> str:
+        return 'Use tool Y for data processing.'
+
+    ctx = build_run_context(None)
+    result = await toolset.get_instructions(ctx)
+    assert result == 'Use tool Y for data processing.'
+
+
+async def test_function_toolset_instructions_decorator_with_ctx():
+    """The @toolset.instructions decorator works with RunContext."""
+    toolset = FunctionToolset[int]()
+
+    @toolset.instructions
+    def my_instructions(ctx: RunContext[int]) -> str:
+        return f'Dep value: {ctx.deps}'
+
+    ctx = build_run_context(42)
+    result = await toolset.get_instructions(ctx)
+    assert result == 'Dep value: 42'
+
+
+async def test_function_toolset_instructions_decorator_combined_with_constructor():
+    """Constructor instructions and decorator instructions are combined."""
+    toolset = FunctionToolset(instructions='From constructor.')
+
+    @toolset.instructions
+    def extra() -> str:
+        return 'From decorator.'
+
+    ctx = build_run_context(None)
+    result = await toolset.get_instructions(ctx)
+    assert result == 'From constructor.\n\nFrom decorator.'
+
+
+async def test_function_toolset_instructions_none_filtered():
+    """Instructions returning None are excluded."""
+
+    # lambda returning None doesn't match SystemPromptFunc's return type (str), but we test the filtering behavior
+    toolset = FunctionToolset(instructions=[lambda: None, 'Only this.'])  # type: ignore[arg-type]
+
+    ctx = build_run_context(None)
+    result = await toolset.get_instructions(ctx)
+    assert result == 'Only this.'
+
+
+async def test_wrapper_toolset_passes_through_instructions():
+    """WrapperToolset delegates get_instructions to wrapped toolset."""
+    inner = FunctionToolset(instructions='Inner instructions.')
+    wrapped = inner.prefixed('my')
+
+    ctx = build_run_context(None)
+    result = await wrapped.get_instructions(ctx)
+    assert result == 'Inner instructions.'
+
+
+async def test_combined_toolset_aggregates_instructions():
+    """CombinedToolset gathers instructions from all children."""
+    ts1 = FunctionToolset(instructions='Toolset 1 instructions.')
+
+    @ts1.tool
+    def tool_a() -> str:
+        return 'a'
+
+    ts2 = FunctionToolset(instructions='Toolset 2 instructions.')
+
+    @ts2.tool
+    def tool_b() -> str:
+        return 'b'
+
+    combined = CombinedToolset([ts1, ts2])
+
+    ctx = build_run_context(None)
+    result = await combined.get_instructions(ctx)
+    assert result == 'Toolset 1 instructions.\n\nToolset 2 instructions.'
+
+
+async def test_combined_toolset_skips_none_instructions():
+    """CombinedToolset skips toolsets that return None for instructions."""
+    ts1 = FunctionToolset(instructions='Only from ts1.')
+
+    @ts1.tool
+    def tool_a() -> str:
+        return 'a'
+
+    ts2 = FunctionToolset()  # No instructions
+
+    @ts2.tool
+    def tool_b() -> str:
+        return 'b'
+
+    combined = CombinedToolset([ts1, ts2])
+
+    ctx = build_run_context(None)
+    result = await combined.get_instructions(ctx)
+    assert result == 'Only from ts1.'
+
+
+async def test_combined_toolset_all_none_returns_none():
+    """CombinedToolset returns None when all children return None."""
+    ts1 = FunctionToolset()
+
+    @ts1.tool
+    def tool_a() -> str:
+        return 'a'
+
+    ts2 = FunctionToolset()
+
+    @ts2.tool
+    def tool_b() -> str:
+        return 'b'
+
+    combined = CombinedToolset([ts1, ts2])
+
+    ctx = build_run_context(None)
+    result = await combined.get_instructions(ctx)
+    assert result is None
+
+
+async def test_dynamic_toolset_instructions_before_resolution():
+    """DynamicToolset returns None for instructions before get_tools resolves it."""
+
+    def make_toolset(ctx: RunContext[None]) -> FunctionToolset[None]:
+        return FunctionToolset(instructions='Dynamic instructions.')
+
+    dynamic = DynamicToolset(make_toolset)
+
+    ctx = build_run_context(None)
+    # Before get_tools is called, _toolset is None
+    result = await dynamic.get_instructions(ctx)
+    assert result is None
+
+
+async def test_dynamic_toolset_instructions_after_resolution():
+    """DynamicToolset delegates instructions after get_tools resolves it."""
+
+    def make_toolset(ctx: RunContext[None]) -> FunctionToolset[None]:
+        ts = FunctionToolset[None](instructions='Dynamic instructions.')
+
+        @ts.tool
+        def my_tool() -> str:
+            return 'result'
+
+        return ts
+
+    dynamic = DynamicToolset(make_toolset)
+
+    ctx = build_run_context(None)
+    # get_tools triggers resolution
+    await dynamic.get_tools(ctx)
+    result = await dynamic.get_instructions(ctx)
+    assert result == 'Dynamic instructions.'
+
+
+async def test_toolset_instructions_in_agent():
+    """Toolset instructions appear in the model request when added to an agent."""
+    from pydantic_ai import Agent
+
+    toolset = FunctionToolset(instructions='Always use my_tool correctly.')
+
+    @toolset.tool
+    def my_tool() -> str:
+        """A simple tool."""
+        return 'done'
+
+    agent = Agent(TestModel(), toolsets=[toolset])
+    result = await agent.run('Hello')
+    first_message = result.all_messages()[0]
+    assert first_message.instructions == 'Always use my_tool correctly.'  # type: ignore[union-attr]
+
+
+async def test_toolset_instructions_combined_with_agent_instructions():
+    """Toolset instructions are appended after agent-level instructions."""
+    from pydantic_ai import Agent
+
+    toolset = FunctionToolset(instructions='Use search for lookups.')
+
+    @toolset.tool
+    def search() -> str:
+        """Search for information."""
+        return 'results'
+
+    agent = Agent(TestModel(), instructions='You are a helpful assistant.', toolsets=[toolset])
+    result = await agent.run('Hello')
+    first_message = result.all_messages()[0]
+    assert first_message.instructions == 'You are a helpful assistant.\n\nUse search for lookups.'  # type: ignore[union-attr]
+
+
+async def test_multiple_toolset_instructions_in_agent():
+    """Multiple toolsets with instructions are all included."""
+    from pydantic_ai import Agent
+
+    ts1 = FunctionToolset(instructions='Use calculator for math.')
+
+    @ts1.tool
+    def calculator() -> str:
+        """Evaluate a math expression."""
+        return '4'
+
+    ts2 = FunctionToolset(instructions='Use search for lookups.')
+
+    @ts2.tool
+    def search() -> str:
+        """Search for information."""
+        return 'results'
+
+    agent = Agent(TestModel(), toolsets=[ts1, ts2])
+    result = await agent.run('Hello')
+    first_message = result.all_messages()[0]
+    assert first_message.instructions == 'Use calculator for math.\n\nUse search for lookups.'  # type: ignore[union-attr]
+
+
+async def test_function_toolset_empty_string_instructions():
+    """Empty string instructions are treated as no instructions."""
+    toolset = FunctionToolset(instructions='')
+
+    ctx = build_run_context(None)
+    result = await toolset.get_instructions(ctx)
+    assert result is None
+
+
+async def test_function_toolset_whitespace_only_instructions():
+    """Whitespace-only instructions are treated as no instructions."""
+    toolset = FunctionToolset(instructions='   \n\n  ')
+
+    ctx = build_run_context(None)
+    result = await toolset.get_instructions(ctx)
+    assert result is None


### PR DESCRIPTION
## Motivation

A common pattern in pydantic-ai toolsets is that each toolset needs its own usage instructions alongside its tools. Today this requires manually wiring instructions into both `toolsets=[...]` and `instructions=[...]` on the Agent — repetitive, error-prone, and leaking toolset implementation details into the agent factory.

This pattern is widely used in the ecosystem:

- **[pydantic-ai-todo](https://github.com/vstorm-co/pydantic-ai-todo)** exports `create_todo_toolset()` for tools AND `get_todo_system_prompt()` / `TODO_SYSTEM_PROMPT` for instructions separately — consumers must wire both.
- **[pydantic-deepagents](https://github.com/vstorm-co/pydantic-deepagents)** builds agents by collecting toolsets into `all_toolsets` and then manually assembling a `@agent.instructions` function that calls `get_todo_system_prompt()`, `get_console_system_prompt()`, `get_subagent_system_prompt()`, and `get_skills_system_prompt()` from each toolset package.
- **Our own production agents** wire 10+ toolset `get_instructions` static methods manually into the agent's `instructions=[...]` list alongside the toolsets.

This PR adds first-class support so toolsets carry their own instructions and they're automatically included in model requests.

## Changes

### API Surface

- **`AbstractToolset.get_instructions(ctx)`** — new async method with no-op default returning `None`
- **`FunctionToolset(instructions=...)`** — constructor param accepting strings, functions (sync/async, with or without `RunContext`), or a sequence of these
- **`@toolset.instructions`** — decorator to register dynamic instruction functions
- **`CombinedToolset`** — gathers all children's instructions via `asyncio.gather`
- **`WrapperToolset`** — passes through to wrapped toolset
- **`DynamicToolset`** — delegates after resolution, returns `None` before

### Integration Point

The `get_instructions` closure in `Agent.iter()` now also calls `toolset.get_instructions(run_context)` and appends the result. All existing call sites in `_agent_graph.py` automatically pick up toolset instructions with zero changes to the graph.

### Backward Compatibility

Fully backward compatible — existing toolsets without instructions continue to work identically (`get_instructions` returns `None` by default).

### Pre-Review Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.