### PR TITLE
ui/vercel: support tool approval requests and approval responses

### DIFF
--- a/docs/deferred-tools.md
+++ b/docs/deferred-tools.md
@@ -385,3 +385,4 @@ _(This example is complete, it can be run "as is" — you'll need to add `asynci
 - [Advanced Tool Features](tools-advanced.md) - Custom schemas, dynamic tools, and execution details
 - [Toolsets](toolsets.md) - Managing collections of tools, including `ExternalToolset` for external tools
 - [Message History](message-history.md) - Understanding how to work with message history for deferred tools
+- [Vercel AI Integration](ui/vercel-ai.md#tool-approval) - Tool approval with Vercel AI frontends

--- a/docs/ui/vercel-ai.md
+++ b/docs/ui/vercel-ai.md
@@ -84,3 +84,7 @@ async def chat(request: Request) -> Response:
     sse_event_stream = adapter.encode_stream(event_stream)
     return StreamingResponse(sse_event_stream, media_type=accept)
 ```
+
+## Tool Approval
+
+The adapter supports [human-in-the-loop tool approval](../deferred-tools.md#human-in-the-loop-tool-approval). When an agent returns [`DeferredToolRequests`][pydantic_ai.output.DeferredToolRequests], the adapter streams `tool-approval-request` events to the frontend. When the frontend sends back `approval-responded` parts, the adapter automatically converts them into [`DeferredToolResults`][pydantic_ai.tools.DeferredToolResults] and passes them to the next agent run.

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
@@ -25,7 +25,7 @@ from ...messages import (
 )
 from ...output import OutputDataT
 from ...run import AgentRunResultEvent
-from ...tools import AgentDepsT
+from ...tools import AgentDepsT, DeferredToolRequests
 from .. import UIEventStream
 from ._utils import dump_provider_metadata
 from .request_types import RequestData
@@ -45,6 +45,7 @@ from .response_types import (
     TextDeltaChunk,
     TextEndChunk,
     TextStartChunk,
+    ToolApprovalRequestChunk,
     ToolInputAvailableChunk,
     ToolInputDeltaChunk,
     ToolInputStartChunk,
@@ -110,8 +111,14 @@ class VercelAIEventStream(UIEventStream[RequestData, BaseChunk, AgentDepsT, Outp
         pydantic_reason = event.result.response.finish_reason
         if pydantic_reason:
             self._finish_reason = _FINISH_REASON_MAP.get(pydantic_reason, 'other')
-        return
-        yield
+
+        output = event.result.output
+        if isinstance(output, DeferredToolRequests):
+            for approval in output.approvals:
+                yield ToolApprovalRequestChunk(
+                    approval_id=approval.tool_call_id,
+                    tool_call_id=approval.tool_call_id,
+                )
 
     async def on_error(self, error: Exception) -> AsyncIterator[BaseChunk]:
         self._finish_reason = 'error'

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
@@ -159,7 +159,33 @@ class ToolOutputErrorPart(BaseUIPart):
     call_provider_metadata: ProviderMetadata | None = None
 
 
-ToolUIPart = ToolInputStreamingPart | ToolInputAvailablePart | ToolOutputAvailablePart | ToolOutputErrorPart
+class ToolApproval(CamelBaseModel):
+    """Approval decision for a tool invocation."""
+
+    id: str
+    approved: bool = True
+    reason: str | None = None
+
+
+class ToolApprovalRespondedPart(BaseUIPart):
+    """Tool part in approval-responded state."""
+
+    type: Annotated[str, Field(pattern=r'^tool-')]
+    tool_call_id: str
+    state: Literal['approval-responded'] = 'approval-responded'
+    input: Any | None = None
+    approval: ToolApproval
+    provider_executed: bool | None = None
+    call_provider_metadata: ProviderMetadata | None = None
+
+
+ToolUIPart = (
+    ToolInputStreamingPart
+    | ToolInputAvailablePart
+    | ToolOutputAvailablePart
+    | ToolOutputErrorPart
+    | ToolApprovalRespondedPart
+)
 """Union of all tool part types."""
 
 
@@ -211,11 +237,24 @@ class DynamicToolOutputErrorPart(BaseUIPart):
     call_provider_metadata: ProviderMetadata | None = None
 
 
+class DynamicToolApprovalRespondedPart(BaseUIPart):
+    """Dynamic tool part in approval-responded state."""
+
+    type: Literal['dynamic-tool'] = 'dynamic-tool'
+    tool_name: str
+    tool_call_id: str
+    state: Literal['approval-responded'] = 'approval-responded'
+    input: Any | None = None
+    approval: ToolApproval
+    call_provider_metadata: ProviderMetadata | None = None
+
+
 DynamicToolUIPart = (
     DynamicToolInputStreamingPart
     | DynamicToolInputAvailablePart
     | DynamicToolOutputAvailablePart
     | DynamicToolOutputErrorPart
+    | DynamicToolApprovalRespondedPart
 )
 """Union of all dynamic tool part types."""
 


### PR DESCRIPTION
- Closes #4279
- Emit `ToolApprovalRequestChunk` when an agent returns `DeferredToolRequests` (one chunk per approval).
- Parse `approval-responded` UI parts into `DeferredToolResults` (schema matches Vercel AI SDK nested `approval {id, approved, reason}`).
- Auto-wire parsed approval results in `run_stream_native` when `deferred_tool_results` is not explicitly provided.
- Add tests for streaming emission, builtin/dynamic parsing, approved/denied extraction, and empty case.

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.
