### PR TITLE
ci: Fix review bot to gather script from base repo for fork compatibility

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -199,7 +199,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Gather PR context
-        run: scripts/gather-review-context.sh ${{ github.event.pull_request.number }} ${{ github.repository }}
+        run: |
+          # Use the script from the base repo (main branch), not the fork
+          gh api repos/${{ github.repository }}/contents/scripts/gather-review-context.sh?ref=${{ github.event.pull_request.base.ref }} --jq .content | base64 -d > /tmp/gather-review-context.sh
+          bash /tmp/gather-review-context.sh ${{ github.event.pull_request.number }} ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Forks that haven't been updated won't have the gather-review-context.sh script. Fetch it from the base branch via the API instead of relying on the checked-out PR branch.
