### PR TITLE
Replace asyncio with anyio for async task management

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1134,8 +1134,10 @@ async def _call_tools(  # noqa: C901
                     yield event
 
         else:
+            # TODO: Replace with `anyio.create_task_group` once `anyio.as_completed()` is available.
+            # See https://github.com/agronholm/anyio/pull/890
             tasks = [
-                asyncio.create_task(
+                asyncio.create_task(  # noqa: TID251
                     _call_tool(tool_manager, call, tool_call_results.get(call.tool_call_id), tool_call_metadata),
                     name=call.tool_name,
                 )

--- a/pydantic_ai_slim/pydantic_ai/_anyio.py
+++ b/pydantic_ai_slim/pydantic_ai/_anyio.py
@@ -1,0 +1,39 @@
+from __future__ import annotations as _annotations
+
+import sys
+from collections.abc import Awaitable
+from typing import TypeVar, cast
+
+import anyio
+
+if sys.version_info >= (3, 11):
+    from builtins import BaseExceptionGroup
+else:
+    from exceptiongroup import BaseExceptionGroup
+
+T = TypeVar('T')
+
+
+async def gather(*awaitables: Awaitable[T]) -> list[T]:
+    """Run multiple awaitables concurrently using an AnyIO task group.
+
+    Unlike `asyncio.gather`, AnyIO task groups wrap exceptions in `ExceptionGroup`.
+    To preserve `asyncio.gather`-like behavior, if the group contains a single
+    exception, it is unwrapped and re-raised directly.
+    """
+    # We initialize the list, so we can insert the results in the correct order.
+    results: list[T] = cast(list[T], [None] * len(awaitables))
+
+    async def run_and_store(coro: Awaitable[T], index: int) -> None:
+        results[index] = await coro
+
+    try:
+        async with anyio.create_task_group() as tg:
+            for i, c in enumerate(awaitables):
+                tg.start_soon(run_and_store, c, i)
+    except BaseExceptionGroup as eg:
+        if len(eg.exceptions) == 1:
+            raise eg.exceptions[0] from None
+        raise
+
+    return results

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -3,13 +3,13 @@ from __future__ import annotations as _annotations
 import argparse
 import asyncio
 import sys
-from asyncio import CancelledError
 from collections.abc import Sequence
 from contextlib import ExitStack
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import anyio
 from pydantic import ImportString, TypeAdapter, ValidationError
 from typing_inspection.introspection import get_literal_values
 
@@ -359,7 +359,7 @@ async def run_chat(
                 messages = await ask_agent(
                     agent, text, stream, console, code_theme, deps, messages, model_settings, usage_limits
                 )
-            except CancelledError:  # pragma: no cover
+            except anyio.get_cancelled_exc_class():  # pragma: no cover
                 console.print('[dim]Interrupted[/dim]')
             except Exception as e:  # pragma: no cover
                 cause = getattr(e, '__cause__', None)

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import argparse
-import asyncio
 import sys
 from collections.abc import Sequence
 from contextlib import ExitStack
@@ -308,13 +307,13 @@ def _run_chat_command(
 
     if args.prompt:
         try:
-            asyncio.run(ask_agent(agent, args.prompt, stream, console, code_theme))
+            anyio.run(ask_agent, agent, args.prompt, stream, console, code_theme)
         except KeyboardInterrupt:
             pass
         return 0
 
     try:
-        return asyncio.run(run_chat(stream, agent, console, code_theme, prog_name))
+        return anyio.run(run_chat, stream, agent, console, code_theme, prog_name)
     except KeyboardInterrupt:  # pragma: no cover
         return 0
 

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -220,7 +220,7 @@ async def group_by_temporal(
             if task is None:
                 # anext(aiter) returns an Awaitable[T], not a Coroutine which asyncio.create_task expects
                 # so far, this doesn't seem to be a problem
-                task = asyncio.create_task(anext(aiterator))  # pyright: ignore[reportArgumentType,reportUnknownVariableType]
+                task = asyncio.create_task(anext(aiterator))  # noqa: TID251  # pyright: ignore[reportArgumentType,reportUnknownVariableType]
 
             # we use asyncio.wait to avoid cancelling the coroutine if it's not done
             done, _ = await asyncio.wait((task,), timeout=wait_time)

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -197,7 +197,9 @@ async def group_by_temporal(
         yield async_iter_groups_noop()
         return
 
-    # we might wait for the next item more than once, so we store the task to await next time
+    # We use asyncio.create_task and asyncio.wait here (not anyio) because this
+    # async generator is consumed by sync_async_iterator via loop.run_until_complete(),
+    # which is incompatible with anyio cancel scopes that span across yield points.
     task: asyncio.Task[T] | None = None
 
     async def async_iter_groups() -> AsyncIterator[list[T]]:

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -4,13 +4,13 @@ import dataclasses
 import inspect
 import json
 import warnings
-from asyncio import Lock
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequence
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, overload
 
+import anyio
 from opentelemetry.trace import NoOpTracer, use_span
 from pydantic.json_schema import GenerateJsonSchema
 from typing_extensions import Self, TypeVar, deprecated
@@ -170,7 +170,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
     _concurrency_limiter: _concurrency.AbstractConcurrencyLimiter | None = dataclasses.field(repr=False)
 
-    _enter_lock: Lock = dataclasses.field(repr=False)
+    _enter_lock: anyio.Lock = dataclasses.field(repr=False)
     _entered_count: int = dataclasses.field(repr=False)
     _exit_stack: AsyncExitStack | None = dataclasses.field(repr=False)
 
@@ -413,7 +413,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             '_override_metadata', default=None
         )
 
-        self._enter_lock = Lock()
+        self._enter_lock = anyio.Lock()
         self._entered_count = 0
         self._exit_stack = None
 

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -964,7 +964,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                     event_stream_handler=event_stream_handler,
                 )
 
-        task = asyncio.create_task(run_agent())
+        task = asyncio.create_task(run_agent())  # noqa: TID251
 
         try:
             async with receive_stream:

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
-import asyncio
 import inspect
+import sys
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Iterator, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, contextmanager
@@ -11,6 +11,11 @@ from typing import TYPE_CHECKING, Any, Generic, TypeAlias, cast, overload
 import anyio
 from pydantic import TypeAdapter
 from typing_extensions import Self, TypeIs, TypeVar, deprecated
+
+if sys.version_info >= (3, 11):
+    from builtins import BaseExceptionGroup
+else:
+    from exceptiongroup import BaseExceptionGroup
 
 from pydantic_graph import End
 
@@ -944,9 +949,12 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             async for event in events:
                 await send_stream.send(event)
 
-        async def run_agent() -> AgentRunResult[Any]:
+        agent_result: AgentRunResult[Any] | None = None
+
+        async def run_agent() -> None:
+            nonlocal agent_result
             async with send_stream:
-                return await self.run(
+                agent_result = await self.run(
                     user_prompt,
                     output_type=output_type,
                     message_history=message_history,
@@ -964,20 +972,19 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                     event_stream_handler=event_stream_handler,
                 )
 
-        task = asyncio.create_task(run_agent())  # noqa: TID251
-
         try:
-            async with receive_stream:
-                async for message in receive_stream:
-                    yield message
-
-            result = await task
-
-        except asyncio.CancelledError as e:
-            task.cancel(msg=e.args[0] if len(e.args) != 0 else None)
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(run_agent)
+                async with receive_stream:
+                    async for message in receive_stream:
+                        yield message
+        except BaseExceptionGroup as eg:
+            if len(eg.exceptions) == 1:
+                raise eg.exceptions[0] from None
             raise
 
-        yield AgentRunResultEvent(result)
+        assert agent_result is not None
+        yield AgentRunResultEvent(agent_result)
 
     @overload
     def iter(

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -5,7 +5,6 @@ import os
 import re
 import warnings
 from abc import ABC, abstractmethod
-from asyncio import Lock
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field, replace
@@ -356,7 +355,7 @@ class MCPServer(AbstractToolset[Any], ABC):
 
     _id: str | None
 
-    _enter_lock: Lock = field(compare=False)
+    _enter_lock: anyio.Lock = field(compare=False)
     _running_count: int
     _exit_stack: AsyncExitStack | None
 
@@ -408,7 +407,7 @@ class MCPServer(AbstractToolset[Any], ABC):
         self.__post_init__()
 
     def __post_init__(self):
-        self._enter_lock = Lock()
+        self._enter_lock = anyio.Lock()
         self._running_count = 0
         self._exit_stack = None
         self._cached_tools = None

--- a/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
@@ -1,11 +1,11 @@
 from __future__ import annotations as _annotations
 
-import asyncio
 import functools
 from collections.abc import AsyncGenerator, Mapping
 from pathlib import Path
 from typing import Literal, overload
 
+import anyio
 import anyio.to_thread
 import httpx
 from typing_extensions import deprecated
@@ -119,7 +119,7 @@ class GoogleVertexProvider(Provider[httpx.AsyncClient]):
 class _VertexAIAuth(httpx.Auth):
     """Auth class for Vertex AI API."""
 
-    _refresh_lock: asyncio.Lock = asyncio.Lock()  # noqa: TID251
+    _refresh_lock: anyio.Lock = anyio.Lock()
 
     credentials: BaseCredentials | ServiceAccountCredentials | None
 

--- a/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
+import asyncio
 import functools
-from asyncio import Lock
 from collections.abc import AsyncGenerator, Mapping
 from pathlib import Path
 from typing import Literal, overload
@@ -119,7 +119,7 @@ class GoogleVertexProvider(Provider[httpx.AsyncClient]):
 class _VertexAIAuth(httpx.Auth):
     """Auth class for Vertex AI API."""
 
-    _refresh_lock: Lock = Lock()
+    _refresh_lock: asyncio.Lock = asyncio.Lock()  # noqa: TID251
 
     credentials: BaseCredentials | ServiceAccountCredentials | None
 

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -99,9 +99,8 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
                 yield msg
                 break
 
-        async with _utils.group_by_temporal(self, debounce_by) as group_iter:
-            async for _items in group_iter:
-                yield self.response  # current state of the response
+        async for _items in _utils.group_by_temporal(self, debounce_by):
+            yield self.response  # current state of the response
 
     async def stream_text(self, *, delta: bool = False, debounce_by: float | None = 0.1) -> AsyncIterator[str]:
         """Stream the text result as an async iterable.
@@ -284,10 +283,9 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
                     last_text_index = None
 
         async def _stream_text_deltas() -> AsyncIterator[str]:
-            async with _utils.group_by_temporal(_stream_text_deltas_ungrouped(), debounce_by) as group_iter:
-                async for items in group_iter:
-                    # Note: we are currently just dropping the part index on the group here
-                    yield ''.join([content for content, _ in items])
+            async for items in _utils.group_by_temporal(_stream_text_deltas_ungrouped(), debounce_by):
+                # Note: we are currently just dropping the part index on the group here
+                yield ''.join([content for content, _ in items])
 
         if delta:
             async for text in _stream_text_deltas():

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import base64
-from asyncio import Lock
 from contextlib import AsyncExitStack
 from dataclasses import KW_ONLY, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+import anyio
 from pydantic import AnyUrl
 from typing_extensions import Self, assert_never
 
@@ -101,7 +101,7 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         self.max_retries = max_retries
         self.tool_error_behavior = tool_error_behavior
 
-        self._enter_lock: Lock = Lock()
+        self._enter_lock: anyio.Lock = anyio.Lock()
         self._running_count: int = 0
         self._exit_stack: AsyncExitStack | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,9 @@ convention = "google"
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "typing.TypedDict".msg = "Use typing_extensions.TypedDict instead."
 "typing.assert_never".msg = "Use typing_extensions.assert_never instead."
+"asyncio.Lock".msg = "Use `anyio.Lock` instead."
+"asyncio.gather".msg = "Use `pydantic_ai._anyio.gather` instead."
+"asyncio.create_task".msg = "Use `anyio.create_task_group` instead."
 
 [tool.ruff.format]
 # don't format python in docstrings, pytest-examples takes care of it

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,9 +47,8 @@ async def test_group_by_temporal(interval: float | None, expected: list[list[int
         yield 3
         await asyncio.sleep(0.02)
 
-    async with group_by_temporal(yield_groups(), soft_max_interval=interval) as groups_iter:
-        groups: list[list[int]] = [g async for g in groups_iter]
-        assert groups == expected
+    groups: list[list[int]] = [g async for g in group_by_temporal(yield_groups(), soft_max_interval=interval)]
+    assert groups == expected
 
 
 def test_check_object_json_schema():


### PR DESCRIPTION
- Closes #<issue>

### Summary

This PR replaces `asyncio` with `anyio` throughout the codebase for async task management, improving compatibility with different async backends and providing a more consistent API.

### Key Changes

1. **Agent Graph (`_agent_graph.py`)**
   - Replaced `asyncio.create_task()` and `asyncio.wait()` with `anyio.create_task_group()`
   - Refactored `_call_tools()` to use anyio's task groups for both sequential and parallel execution modes
   - Implemented memory object streams for unordered parallel execution with event streaming
   - Added proper exception handling for `BaseExceptionGroup` with single-exception unwrapping

2. **Utilities (`_utils.py`)**
   - Refactored `group_by_temporal()` to use anyio memory object streams instead of asyncio tasks
   - Replaced `asyncio.wait()` with `anyio.move_on_after()` for timeout-based batching
   - Kept `asyncio.create_task()` for the background feed task (documented why in comments)

3. **New Module (`_anyio.py`)**
   - Added `gather()` function as an anyio equivalent to `asyncio.gather()`
   - Handles `BaseExceptionGroup` unwrapping for single exceptions

4. **Agent Abstract (`agent/abstract.py`)**
   - Replaced `asyncio.create_task()` with `anyio.create_task_group()` in `event_stream()`
   - Updated exception handling for `BaseExceptionGroup`

5. **CLI (`_cli/__init__.py`)**
   - Replaced `asyncio.run()` with `anyio.run()` for running async functions

6. **Locks and Synchronization**
   - Replaced `asyncio.Lock` with `anyio.Lock` in:
     - `toolsets/combined.py`
     - `agent/__init__.py`
     - `mcp.py`
     - `toolsets/fastmcp.py`

7. **Tests (`test_cli.py`)**
   - Added `_reset_sniffio()` fixture to handle sniffio context in sync tests
   - Updated mocks to work with `anyio.run()` instead of `asyncio.run()`

8. **Linting Rules (`pyproject.toml`)**
   - Added banned API rules to discourage direct use of `asyncio.Lock` and `asyncio.gather`

### Benefits

- **Backend Agnostic**: anyio works with both asyncio and trio async backends
- **Consistent API**: Unified task group interface across the codebase
- **Better Exception Handling**: Proper handling of exception groups with automatic unwrapping
- **Improved Testability**: anyio's memory object streams provide cleaner abstractions

### Pre-Review Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **Linting and type checking** pass per `make format` and `make typecheck`.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

https://claude.ai/code/session_01EYcsjKhmNmxcdrCBZDtpYc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core concurrency paths (tool execution, streaming, and debouncing) where subtle ordering/cancellation and exception-group behavior changes could surface as runtime edge cases, though the change is largely mechanical and covered by updated tests/linting.
> 
> **Overview**
> **Migrates async task management from `asyncio` to `anyio` across core execution paths.** Tool-call execution in `_agent_graph.py` is refactored to use `anyio.create_task_group()` plus memory object streams for unordered completion, while preserving ordered output/event behavior and explicitly unwrapping single-item `BaseExceptionGroup`s.
> 
> Adds `pydantic_ai._anyio.gather()` as an `asyncio.gather`-like helper (ordered results + single-exception unwrapping), replaces `asyncio.run()` with `anyio.run()` in the CLI (with a test fixture resetting `sniffio` state), converts multiple internal locks to `anyio.Lock`, and rewrites `_utils.group_by_temporal()` from an async context manager to a plain async generator (updating call sites). Ruff is updated to ban direct use of `asyncio.Lock`, `asyncio.gather`, and `asyncio.create_task`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6f3cc04ae3185d82081e416b6849552937a0967. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->