### PR TITLE
Improve local test performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,9 @@ typecheck: typecheck-pyright ## Run static type checking
 typecheck-both: typecheck-pyright typecheck-mypy
 
 .PHONY: test
-test: ## Run tests and collect coverage data
+test: ## Run tests without coverage (fast, for local dev)
 	@# To test using a specific version of python, run 'make install-all-python' then set environment variable PYTEST_PYTHON=3.10 or similar
-	COLUMNS=150 $(if $(PYTEST_PYTHON),UV_PROJECT_ENVIRONMENT=.venv$(subst .,,$(PYTEST_PYTHON))) uv run $(if $(PYTEST_PYTHON),--python $(PYTEST_PYTHON)) coverage run -m pytest -n auto --dist=loadgroup --durations=20
-	@uv run coverage combine
-	@uv run coverage report
+	COLUMNS=150 $(if $(PYTEST_PYTHON),UV_PROJECT_ENVIRONMENT=.venv$(subst .,,$(PYTEST_PYTHON))) uv run $(if $(PYTEST_PYTHON),--python $(PYTEST_PYTHON)) pytest -n auto --dist=loadgroup --durations=20
 
 .PHONY: test-all-python
 test-all-python: ## Run tests on Python 3.10 to 3.13
@@ -67,7 +65,11 @@ test-all-python: ## Run tests on Python 3.10 to 3.13
 	@uv run coverage report
 
 .PHONY: testcov
-testcov: test ## Run tests and generate an HTML coverage report
+testcov: ## Run tests with coverage and generate an HTML report
+	@# To test using a specific version of python, run 'make install-all-python' then set environment variable PYTEST_PYTHON=3.10 or similar
+	COLUMNS=150 $(if $(PYTEST_PYTHON),UV_PROJECT_ENVIRONMENT=.venv$(subst .,,$(PYTEST_PYTHON))) uv run $(if $(PYTEST_PYTHON),--python $(PYTEST_PYTHON)) coverage run -m pytest -n auto --dist=loadgroup --durations=20
+	@uv run coverage combine
+	@uv run coverage report
 	@echo "building coverage html"
 	@uv run coverage html
 

--- a/tests/models/test_outlines.py
+++ b/tests/models/test_outlines.py
@@ -127,7 +127,7 @@ def mock_async_model() -> OutlinesModel:
     return OutlinesModel(MockOutlinesAsyncModel(), provider=OutlinesProvider())
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def transformers_model() -> OutlinesModel:
     hf_model = transformers.AutoModelForCausalLM.from_pretrained(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         'erwanf/gpt2-mini',
@@ -143,7 +143,7 @@ def transformers_model() -> OutlinesModel:
     return OutlinesModel(outlines_model, provider=OutlinesProvider())
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def transformers_multimodal_model() -> OutlinesModel:
     hf_model = transformers.LlavaForConditionalGeneration.from_pretrained(  # pyright: ignore[reportUnknownMemberType]
         'trl-internal-testing/tiny-LlavaForConditionalGeneration',
@@ -159,7 +159,7 @@ def transformers_multimodal_model() -> OutlinesModel:
     return OutlinesModel(outlines_model, provider=OutlinesProvider())
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def llamacpp_model() -> OutlinesModel:  # pragma: lax no cover
     outlines_model_llamacpp = outlines.models.llamacpp.from_llamacpp(
         llama_cpp.Llama.from_pretrained(  # pyright: ignore[reportUnknownMemberType]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -112,7 +112,6 @@ def tmp_path_cwd(tmp_path: Path):
         sys.path.remove(str(tmp_path))
 
 
-@pytest.mark.xdist_group(name='doc_tests')
 @pytest.mark.filterwarnings(  # TODO (v2): Remove this once we drop the deprecated events
     'ignore:`BuiltinToolCallEvent` is deprecated', 'ignore:`BuiltinToolResultEvent` is deprecated'
 )


### PR DESCRIPTION
## Summary

- **Decouple coverage from `make test`** — `make test` now runs `pytest` directly (no coverage overhead), making it faster for local dev. `make testcov` is self-contained with coverage run + combine + report + HTML. CI is unaffected — it already invokes `coverage run -m pytest` directly in `.github/workflows/ci.yml`.
- **Scope outlines model fixtures to module level** — `transformers_model`, `transformers_multimodal_model`, and `llamacpp_model` fixtures changed from function scope to `scope='module'` to avoid repeated ~22s model loads. Safe because `OutlinesModel` is immutable after creation and every test creates its own `Agent`.
- **Remove `xdist_group` from `test_examples.py`** — The group forced all ~797 doc example tests onto a single xdist worker. Since each worker is a separate process, `os.chdir()` in `tmp_path_cwd` is already isolated. Removing the group allows tests to parallelize across all workers.

## Local benchmarks

Ran `make test` on both `main` and this branch on the same machine (M-series Mac, 10 xdist workers). The `main` run uses `coverage run -m pytest` while this branch runs `pytest` directly, plus has the xdist_group removal allowing doc tests to parallelize.

```
┌──────────────────────┬─────────────┬───────────────┐
│                      │ Wall clock  │   CPU time    │
├──────────────────────┼─────────────┼───────────────┤
│ main (with coverage) │ 6m 41s      │ 1886s user    │
├──────────────────────┼─────────────┼───────────────┤
│ branch (no coverage) │ 3m 48s      │ 1476s user    │
├──────────────────────┼─────────────┼───────────────┤
│ Speedup              │ ~43% faster │ ~22% less CPU │
└──────────────────────┴─────────────┴───────────────┘
```

The coverage overhead alone accounts for ~3 minutes of wall clock time locally. The higher CPU% on the branch (684% vs 497%) also suggests the xdist_group removal is working — tests are actually parallelizing across more workers now instead of being bottlenecked on one worker running all 797 doc tests serially.

Notable: `test_output_type` from outlines went from 86s to 181s — that seems like noise/contention rather than a regression (model fixtures are module-scoped so it shouldn't be slower). But the overall result is a clear win.

## Test plan

- [x] `make test` runs without coverage and passes
- [x] `make testcov` runs with coverage, generates report and HTML
- [ ] Outlines tests still pass
- [ ] Doc example tests parallelize correctly across xdist workers (this one I'm least confident about — the `xdist_group` was added for a reason, so if tests fail in CI we may need a different approach)
