### PR TITLE
Add builtin-to-custom tool fallback via `prefer_builtin`

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -6,6 +6,8 @@ When using `FallbackModel` or testing across models, agents with builtin tools (
 
 **Core insight**: send BOTH the builtin tool AND its fallback function tool in `ModelRequestParameters`. Each model's `prepare_request` independently decides which to keep via `self.profile.supported_builtin_tools`. Zero changes to `FallbackModel` — each inner model makes the right choice.
 
+**Important**: `prefer_builtin` on a function tool does NOT auto-register the corresponding builtin tool with the agent. The user must still include it in `builtin_tools=[...]`. This is by design — the upcoming `capabilities=[WebSearch()]` API (see Relationship to Deferred Loading below) will handle both sides automatically via `get_toolset()` + `get_builtin_tools()`. This PR provides the low-level primitive that capabilities will build on.
+
 ## Changes
 
 ### 1. `ToolDefinition` — add `prefer_builtin` field
@@ -77,12 +79,21 @@ if params.builtin_tools:
 - `AbstractBuiltinTool` — no `fallback` param (deferred)
 - `ModelProfile` — already has `supported_builtin_tools`
 
+## Relationship to deferred tool loading (#4090, #4167, #3666)
+
+DouweM notes that deferred tool loading (Anthropic tool search) needs the ability to send fundamentally different tool lists depending on model support — e.g. all tools with `defer_loading=True` for native support vs a `search_tools` meta-tool + already-discovered tools for framework-level support. `prefer_builtin` alone doesn't cover that case because it's a 1:1 swap (one function tool ↔ one builtin), not a structural transformation of the entire tool list.
+
+**Why this is fine for our scope**: `prefer_builtin` is the right primitive for builtin-to-custom fallback (web search, code execution, etc.). Deferred tool loading will need an additional mechanism (likely `defer_loading: bool` on `ToolDefinition` + model-level list restructuring), which is a separate feature. These are complementary, not conflicting — both follow the same architectural pattern of model-level resolution in `prepare_request`.
+
+**Forward compatibility**: the `capabilities=[WebSearch()]` API will compose both: `WebSearch.get_toolset()` returns function tools with `prefer_builtin` set, `WebSearch.get_builtin_tools()` returns the builtin. For deferred loading, `SearchableToolset` will add its own fields. Our `prepare_request` swap logic is additive and won't conflict with future deferred loading logic.
+
 ## Deferred to follow-up PRs
 
 - `AbstractBuiltinTool(fallback=...)` — builtin carries its own fallback
 - `MCPServer`/`FastMCPToolset` `prefer_builtin` — toolset-level support
 - `TavilySearchTool(prefer_builtin=True)` — convenience on common tools
 - `BuiltinToolset` — wrapping builtins in the toolset system
+- Deferred tool loading / `SearchableToolset` (#4090, #4167)
 
 ## Testing
 


### PR DESCRIPTION
- Closes #3212

### Pre-Review Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **Linting and type checking** pass per `make format` and `make typecheck`.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

---

## Plan for Review

This PR currently contains only a `PLAN.md` describing the proposed implementation. Looking for feedback on the approach before writing code.

## Summary

When using `FallbackModel` or testing across models, agents with builtin tools (e.g. `WebSearchTool`) fail with `UserError` on models that don't support them. This adds automatic fallback to user-provided function tools.

**Core insight**: send BOTH the builtin tool AND its fallback function tool in `ModelRequestParameters`. Each model's `prepare_request` independently decides which to keep via `self.profile.supported_builtin_tools`. Zero changes to `FallbackModel` — each inner model makes the right choice.

## Proposed Changes

1. **`ToolDefinition`** — add `prefer_builtin: str | None` field matching `AbstractBuiltinTool.unique_id`
2. **`Tool`** — add `prefer_builtin: AbstractBuiltinTool | None` constructor param, resolve to `unique_id`
3. **`Model.prepare_request`** — partition builtins into supported/unsupported, swap with fallback function tools, error only when no fallback exists
4. **Thread through decorators** — `Agent.tool()`, `Agent.tool_plain()`, `FunctionToolset.tool()`, `FunctionToolset.add_function()`

## What does NOT change

- `FallbackModel`, `_agent_graph.py`, `AbstractToolset`/`ToolManager`, provider model implementations, `AbstractBuiltinTool`, `ModelProfile`

## Deferred

- `AbstractBuiltinTool(fallback=...)`, `MCPServer`/`FastMCPToolset` support, `TavilySearchTool(prefer_builtin=True)`, `BuiltinToolset`

See `PLAN.md` for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)