### PR TITLE
Fix missing pages in llms.txt and llms-full.txt

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -360,13 +360,13 @@ plugins:
           - troubleshooting.md
         Concepts documentation:
           - a2a.md
-          - ag-ui.md
-          - Agents: agent.md
+          - agent.md
           - builtin-tools.md
           - dependencies.md
           - deferred-tools.md
           - direct.md
           - embeddings.md
+          - gateway.md
           - input.md
           - tools.md
           - common-tools.md
@@ -378,14 +378,17 @@ plugins:
           - third-party-tools.md
           - tools-advanced.md
           - toolsets.md
+          - web.md
         Models:
           - models/*.md
         Graphs:
           - graph.md
+          - graph/*.md
         API Reference:
           - api/*.md
         Evals:
           - evals.md
+          - evals/*.md
         Durable Execution:
           - durable_execution/*.md
         MCP:


### PR DESCRIPTION
The llmstxt plugin config had several issues causing pages to be omitted:
- `Agents: agent.md` used nav-style dict syntax but the plugin interprets dicts as `{file_path: description}`, so it looked for a file called "Agents" instead of "agent.md"
- `ag-ui.md` doesn't exist at the root (it's at `ui/ag-ui.md`), already covered by the `ui/*.md` glob
- `gateway.md` and `web.md` were in the nav but not in llmstxt sections
- Evals subdirectories (16 pages) and graph/beta (5 pages) were not covered by their sections' single-file entries

Closes #4349