### PR TITLE
Bump auto-review timeout to 60 minutes

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -152,7 +152,7 @@ jobs:
       !failure() && !cancelled() &&
       github.event.action == 'labeled' && github.event.label.name == 'auto-review'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
## Summary
- Increases the auto-review job timeout from 30 to 60 minutes to match the `@claude` workflow timeouts and prevent premature cancellation on larger PRs

## Test plan
- [x] Verify the workflow YAML is valid