### PR TITLE
Add OpenTelemetry instrumentation to realtime models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1688,6 +1688,15 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 except Exception as e:
                     return f'Error: {e}'
 
+            # Instrument the realtime model if configured
+            from ..realtime.instrumented import instrument_realtime_model
+
+            instrument = self.instrument
+            if instrument is None:
+                instrument = self._instrument_default
+            if instrument:
+                model = instrument_realtime_model(model, instrument)
+
             async with model.connect(
                 instructions=instructions,
                 tools=tool_defs,

--- a/pydantic_ai_slim/pydantic_ai/realtime/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/__init__.py
@@ -20,12 +20,14 @@ from ._base import (
     TurnComplete,
 )
 from ._session import RealtimeSession, ToolRunner
+from .instrumented import InstrumentedRealtimeModel, instrument_realtime_model
 
 __all__ = (
     'AudioDelta',
     'AudioInput',
     'ImageInput',
     'InputTranscript',
+    'InstrumentedRealtimeModel',
     'RealtimeConnection',
     'RealtimeEvent',
     'RealtimeInput',
@@ -41,4 +43,5 @@ __all__ = (
     'ToolRunner',
     'Transcript',
     'TurnComplete',
+    'instrument_realtime_model',
 )

--- a/pydantic_ai_slim/pydantic_ai/realtime/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/_base.py
@@ -215,3 +215,19 @@ class RealtimeModel(ABC):
     def model_name(self) -> str:
         """The model name, e.g. ``'gpt-4o-realtime'``."""
         raise NotImplementedError
+
+    @property
+    def system(self) -> str:
+        """The provider name for OpenTelemetry semantic conventions.
+
+        Use to populate the ``gen_ai.system`` attribute. Should use well-known values listed in
+        https://opentelemetry.io/docs/specs/semconv/attributes-registry/gen-ai/#gen-ai-system
+
+        By default, infers from the class name by stripping ``RealtimeModel`` / ``Model`` suffixes.
+        """
+        name = type(self).__name__.lower()
+        for suffix in ('realtimemodel', 'model'):
+            if name.endswith(suffix):
+                name = name[: -len(suffix)]
+                break
+        return name or 'unknown'

--- a/pydantic_ai_slim/pydantic_ai/realtime/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/gemini.py
@@ -190,6 +190,10 @@ class GeminiRealtimeModel(RealtimeModel):
     def model_name(self) -> str:
         return self.model
 
+    @property
+    def system(self) -> str:
+        return 'google'
+
     def _get_client(self) -> GenaiClient:
         if self.client is not None:
             return self.client

--- a/pydantic_ai_slim/pydantic_ai/realtime/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/instrumented.py
@@ -1,0 +1,96 @@
+"""OpenTelemetry instrumentation for realtime model sessions."""
+
+from __future__ import annotations as _annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from urllib.parse import urlparse
+
+from opentelemetry.trace import SpanKind
+from opentelemetry.util.types import AttributeValue
+
+from ..models.instrumented import InstrumentationSettings
+from ..settings import ModelSettings
+from ..tools import ToolDefinition
+from ._base import RealtimeConnection, RealtimeModel
+
+__all__ = ('InstrumentedRealtimeModel', 'instrument_realtime_model')
+
+
+def instrument_realtime_model(model: RealtimeModel, instrument: InstrumentationSettings | bool) -> RealtimeModel:
+    """Wrap a realtime model with OpenTelemetry instrumentation if not already wrapped."""
+    if instrument and not isinstance(model, InstrumentedRealtimeModel):
+        if instrument is True:
+            instrument = InstrumentationSettings()
+        model = InstrumentedRealtimeModel(model, instrument)
+    return model
+
+
+class InstrumentedRealtimeModel(RealtimeModel):
+    """Wraps a `RealtimeModel` so that `connect()` creates an OpenTelemetry span covering the session."""
+
+    def __init__(self, wrapped: RealtimeModel, settings: InstrumentationSettings) -> None:
+        self._wrapped = wrapped
+        self._settings = settings
+
+    @property
+    def model_name(self) -> str:
+        return self._wrapped.model_name
+
+    @property
+    def system(self) -> str:
+        return self._wrapped.system
+
+    @asynccontextmanager
+    async def connect(
+        self,
+        *,
+        instructions: str,
+        tools: list[ToolDefinition] | None = None,
+        model_settings: ModelSettings | None = None,
+    ) -> AsyncIterator[RealtimeConnection]:
+        operation = 'realtime'
+        span_name = f'{operation} {self._wrapped.model_name}'
+
+        attributes: dict[str, AttributeValue] = {
+            'gen_ai.operation.name': operation,
+            'gen_ai.provider.name': self._wrapped.system,
+            'gen_ai.system': self._wrapped.system,
+            'gen_ai.request.model': self._wrapped.model_name,
+        }
+
+        base_url: str | None = getattr(self._wrapped, 'base_url', None)
+        if base_url:
+            try:
+                parsed = urlparse(base_url)
+            except Exception:  # pragma: no cover
+                pass
+            else:
+                if parsed.hostname:  # pragma: no branch
+                    attributes['server.address'] = parsed.hostname
+                if parsed.port:
+                    attributes['server.port'] = parsed.port
+
+        if tools:
+            tool_definitions: list[dict[str, Any]] = []
+            for tool in tools:
+                tool_def: dict[str, Any] = {'type': 'function', 'name': tool.name}
+                if tool.description:
+                    tool_def['description'] = tool.description
+                if tool.parameters_json_schema:
+                    tool_def['parameters'] = tool.parameters_json_schema
+                tool_definitions.append(tool_def)
+            attributes['gen_ai.tool.definitions'] = json.dumps(tool_definitions)
+
+        if instructions and self._settings.include_content:
+            attributes['gen_ai.system_instructions'] = instructions
+
+        with self._settings.tracer.start_as_current_span(span_name, attributes=attributes, kind=SpanKind.CLIENT):
+            async with self._wrapped.connect(
+                instructions=instructions,
+                tools=tools,
+                model_settings=model_settings,
+            ) as connection:
+                yield connection

--- a/pydantic_ai_slim/pydantic_ai/realtime/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/openai.py
@@ -186,6 +186,10 @@ class OpenAIRealtimeModel(RealtimeModel):
     def model_name(self) -> str:
         return self.model
 
+    @property
+    def system(self) -> str:
+        return 'openai'
+
     @asynccontextmanager
     async def connect(
         self,

--- a/tests/realtime/conftest.py
+++ b/tests/realtime/conftest.py
@@ -1,4 +1,4 @@
-"""Fixtures for realtime WebSocket cassette recording/replay."""
+"""Fixtures and shared fakes for realtime tests."""
 
 from __future__ import annotations as _annotations
 
@@ -11,7 +11,56 @@ from unittest.mock import patch
 
 import pytest
 
+from pydantic_ai.realtime import RealtimeConnection, RealtimeEvent, RealtimeInput, RealtimeModel
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai.tools import ToolDefinition
+
 from ..conftest import sanitize_filename, try_import
+
+# ---------------------------------------------------------------------------
+# Fake implementations for testing
+# ---------------------------------------------------------------------------
+
+
+class FakeRealtimeConnection(RealtimeConnection):
+    """A fake connection that yields pre-configured events."""
+
+    def __init__(self, events: list[RealtimeEvent]) -> None:
+        self._events = events
+        self.sent: list[RealtimeInput] = []
+
+    async def send(self, content: RealtimeInput) -> None:
+        self.sent.append(content)
+
+    async def __aiter__(self) -> AsyncIterator[RealtimeEvent]:
+        for event in self._events:
+            yield event
+
+
+class FakeRealtimeModel(RealtimeModel):
+    """A fake model that yields a pre-configured connection."""
+
+    def __init__(self, connection: FakeRealtimeConnection) -> None:
+        self._connection = connection
+        self.last_instructions: str | None = None
+        self.last_tools: list[ToolDefinition] | None = None
+
+    @property
+    def model_name(self) -> str:
+        return 'fake-realtime'
+
+    @asynccontextmanager
+    async def connect(
+        self,
+        *,
+        instructions: str,
+        tools: list[ToolDefinition] | None = None,
+        model_settings: ModelSettings | None = None,
+    ) -> AsyncIterator[FakeRealtimeConnection]:
+        self.last_instructions = instructions
+        self.last_tools = tools
+        yield self._connection
+
 
 with try_import() as imports_successful:
     from websockets.asyncio.client import connect as _real_ws_connect

--- a/tests/realtime/test_instrumented.py
+++ b/tests/realtime/test_instrumented.py
@@ -1,0 +1,221 @@
+"""Tests for realtime model OpenTelemetry instrumentation."""
+
+from __future__ import annotations as _annotations
+
+import pytest
+
+from ..conftest import try_import
+
+with try_import() as logfire_imports_successful:
+    from logfire.testing import CaptureLogfire
+
+from pydantic_ai import Agent
+from pydantic_ai.models.instrumented import InstrumentationSettings
+from pydantic_ai.realtime import (
+    InstrumentedRealtimeModel,
+    ToolCall,
+    ToolCallCompleted,
+    ToolCallStarted,
+    TurnComplete,
+    instrument_realtime_model,
+)
+from pydantic_ai.tools import ToolDefinition
+
+from .conftest import FakeRealtimeConnection, FakeRealtimeModel
+
+pytestmark = pytest.mark.skipif(not logfire_imports_successful(), reason='logfire not installed')
+
+
+@pytest.mark.anyio
+async def test_session_span_attributes(capfire: CaptureLogfire) -> None:
+    """Session span is created with correct name and OTel attributes."""
+    conn = FakeRealtimeConnection([TurnComplete()])
+    model = FakeRealtimeModel(conn)
+    instrumented = InstrumentedRealtimeModel(model, InstrumentationSettings())
+
+    async with instrumented.connect(instructions='Be helpful') as connection:
+        events = [e async for e in connection]
+
+    assert len(events) == 1
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    span = next(s for s in spans if 'realtime' in s['name'])
+
+    assert span['name'] == 'realtime fake-realtime'
+    attrs = span['attributes']
+    assert attrs['gen_ai.operation.name'] == 'realtime'
+    assert attrs['gen_ai.provider.name'] == 'fake'
+    assert attrs['gen_ai.system'] == 'fake'
+    assert attrs['gen_ai.request.model'] == 'fake-realtime'
+
+
+@pytest.mark.anyio
+async def test_tool_definitions_in_span(capfire: CaptureLogfire) -> None:
+    """Tool definitions appear in span attributes as JSON."""
+    conn = FakeRealtimeConnection([TurnComplete()])
+    model = FakeRealtimeModel(conn)
+    instrumented = InstrumentedRealtimeModel(model, InstrumentationSettings())
+
+    tools = [
+        ToolDefinition(
+            name='get_weather',
+            description='Get the weather',
+            parameters_json_schema={'type': 'object', 'properties': {'city': {'type': 'string'}}},
+        )
+    ]
+
+    async with instrumented.connect(instructions='', tools=tools) as connection:
+        _ = [e async for e in connection]
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    span = next(s for s in spans if 'realtime' in s['name'])
+    tool_defs = span['attributes']['gen_ai.tool.definitions']
+
+    assert len(tool_defs) == 1
+    assert tool_defs[0]['name'] == 'get_weather'
+    assert tool_defs[0]['description'] == 'Get the weather'
+
+
+@pytest.mark.anyio
+async def test_system_instructions_included(capfire: CaptureLogfire) -> None:
+    """System instructions appear when `include_content=True` (default)."""
+    conn = FakeRealtimeConnection([TurnComplete()])
+    model = FakeRealtimeModel(conn)
+    instrumented = InstrumentedRealtimeModel(model, InstrumentationSettings(include_content=True))
+
+    async with instrumented.connect(instructions='Talk like a pirate') as connection:
+        _ = [e async for e in connection]
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    span = next(s for s in spans if 'realtime' in s['name'])
+    assert span['attributes']['gen_ai.system_instructions'] == 'Talk like a pirate'
+
+
+@pytest.mark.anyio
+async def test_system_instructions_omitted_when_disabled(capfire: CaptureLogfire) -> None:
+    """System instructions are omitted when `include_content=False`."""
+    conn = FakeRealtimeConnection([TurnComplete()])
+    model = FakeRealtimeModel(conn)
+    instrumented = InstrumentedRealtimeModel(model, InstrumentationSettings(include_content=False))
+
+    async with instrumented.connect(instructions='Secret instructions') as connection:
+        _ = [e async for e in connection]
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    span = next(s for s in spans if 'realtime' in s['name'])
+    assert 'gen_ai.system_instructions' not in span['attributes']
+
+
+@pytest.mark.anyio
+async def test_instrument_realtime_model_idempotent() -> None:
+    """Wrapping an already-instrumented model returns it unchanged."""
+    conn = FakeRealtimeConnection([])
+    model = FakeRealtimeModel(conn)
+    settings = InstrumentationSettings()
+
+    wrapped = instrument_realtime_model(model, settings)
+    assert isinstance(wrapped, InstrumentedRealtimeModel)
+
+    double_wrapped = instrument_realtime_model(wrapped, settings)
+    assert double_wrapped is wrapped
+
+
+@pytest.mark.anyio
+async def test_instrument_realtime_model_bool_creates_defaults() -> None:
+    """`instrument_realtime_model(model, True)` creates default settings."""
+    conn = FakeRealtimeConnection([])
+    model = FakeRealtimeModel(conn)
+
+    wrapped = instrument_realtime_model(model, True)
+    assert isinstance(wrapped, InstrumentedRealtimeModel)
+
+
+@pytest.mark.anyio
+async def test_instrument_realtime_model_false_noop() -> None:
+    """`instrument_realtime_model(model, False)` returns the model unchanged."""
+    conn = FakeRealtimeConnection([])
+    model = FakeRealtimeModel(conn)
+
+    result = instrument_realtime_model(model, False)
+    assert result is model
+
+
+@pytest.mark.anyio
+async def test_session_exception_recorded(capfire: CaptureLogfire) -> None:
+    """Exceptions during the session are recorded on the span."""
+    conn = FakeRealtimeConnection([])
+    model = FakeRealtimeModel(conn)
+    instrumented = InstrumentedRealtimeModel(model, InstrumentationSettings())
+
+    with pytest.raises(ValueError, match='boom'):
+        async with instrumented.connect(instructions='') as _connection:
+            raise ValueError('boom')
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    span = next(s for s in spans if 'realtime' in s['name'])
+    events = span.get('events', [])
+    assert any(e['name'] == 'exception' for e in events)
+    exception_event = next(e for e in events if e['name'] == 'exception')
+    assert exception_event['attributes']['exception.type'] == 'ValueError'
+
+
+@pytest.mark.anyio
+async def test_agent_realtime_session_instruments(capfire: CaptureLogfire) -> None:
+    """Agent.realtime_session() instruments when `instrument=True`."""
+    agent: Agent[None, str] = Agent(instrument=True)
+
+    conn = FakeRealtimeConnection([TurnComplete()])
+    model = FakeRealtimeModel(conn)
+
+    async with agent.realtime_session(model=model) as session:
+        _ = [e async for e in session]
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    realtime_spans = [s for s in spans if 'realtime' in s['name']]
+    assert len(realtime_spans) == 1
+    assert realtime_spans[0]['attributes']['gen_ai.operation.name'] == 'realtime'
+
+
+@pytest.mark.anyio
+async def test_agent_instrument_all_enables_realtime(capfire: CaptureLogfire) -> None:
+    """`Agent.instrument_all()` enables instrumentation for realtime sessions."""
+    Agent.instrument_all()
+    try:
+        agent: Agent[None, str] = Agent()
+
+        conn = FakeRealtimeConnection([TurnComplete()])
+        model = FakeRealtimeModel(conn)
+
+        async with agent.realtime_session(model=model) as session:
+            _ = [e async for e in session]
+
+        spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+        realtime_spans = [s for s in spans if 'realtime' in s['name']]
+        assert len(realtime_spans) == 1
+    finally:
+        Agent.instrument_all(False)
+
+
+@pytest.mark.anyio
+async def test_agent_realtime_session_tools_in_span(capfire: CaptureLogfire) -> None:
+    """Tool definitions from the agent appear in the instrumentation span."""
+    agent: Agent[None, str] = Agent(instrument=True)
+
+    @agent.tool_plain
+    def greet(name: str) -> str:
+        """Greet someone."""
+        return f'Hello {name}!'
+
+    tool_call = ToolCall(tool_call_id='tc_1', tool_name='greet', args='{"name": "Alice"}')
+    conn = FakeRealtimeConnection([tool_call, TurnComplete()])
+    model = FakeRealtimeModel(conn)
+
+    async with agent.realtime_session(model=model) as session:
+        events = [e async for e in session]
+
+    assert isinstance(events[0], ToolCallStarted)
+    assert isinstance(events[1], ToolCallCompleted)
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    span = next(s for s in spans if 'realtime' in s['name'])
+    tool_defs = span['attributes']['gen_ai.tool.definitions']
+    assert any(t['name'] == 'greet' for t in tool_defs)

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations as _annotations
 
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from typing import Any
 
 import pytest
@@ -13,10 +11,7 @@ from pydantic_ai.realtime import (
     AudioDelta,
     AudioInput,
     InputTranscript,
-    RealtimeConnection,
     RealtimeEvent,
-    RealtimeInput,
-    RealtimeModel,
     RealtimeSession,
     SessionError,
     ToolCall,
@@ -26,53 +21,8 @@ from pydantic_ai.realtime import (
     Transcript,
     TurnComplete,
 )
-from pydantic_ai.settings import ModelSettings
-from pydantic_ai.tools import ToolDefinition
 
-# ---------------------------------------------------------------------------
-# Fake implementations for testing
-# ---------------------------------------------------------------------------
-
-
-class FakeRealtimeConnection(RealtimeConnection):
-    """A fake connection that yields pre-configured events."""
-
-    def __init__(self, events: list[RealtimeEvent]) -> None:
-        self._events = events
-        self.sent: list[RealtimeInput] = []
-
-    async def send(self, content: RealtimeInput) -> None:
-        self.sent.append(content)
-
-    async def __aiter__(self) -> AsyncIterator[RealtimeEvent]:
-        for event in self._events:
-            yield event
-
-
-class FakeRealtimeModel(RealtimeModel):
-    """A fake model that yields a pre-configured connection."""
-
-    def __init__(self, connection: FakeRealtimeConnection) -> None:
-        self._connection = connection
-        self.last_instructions: str | None = None
-        self.last_tools: list[ToolDefinition] | None = None
-
-    @property
-    def model_name(self) -> str:
-        return 'fake-realtime'
-
-    @asynccontextmanager
-    async def connect(
-        self,
-        *,
-        instructions: str,
-        tools: list[ToolDefinition] | None = None,
-        model_settings: ModelSettings | None = None,
-    ) -> AsyncIterator[FakeRealtimeConnection]:
-        self.last_instructions = instructions
-        self.last_tools = tools
-        yield self._connection
-
+from .conftest import FakeRealtimeConnection, FakeRealtimeModel
 
 # ---------------------------------------------------------------------------
 # RealtimeSession passthrough tests


### PR DESCRIPTION
## Summary

- Add session-level OTel span for realtime sessions (`realtime {model_name}`) with gen_ai semantic convention attributes
- Add `system` property to `RealtimeModel` ABC with provider overrides (`google`, `openai`)
- Create `InstrumentedRealtimeModel` wrapper in `realtime/instrumented.py` following the `InstrumentedModel` pattern
- Wire into `Agent.realtime_session()` respecting `instrument` / `instrument_all()` settings
- Extract shared test fakes to `conftest.py` and add 11 instrumentation tests

## Test plan

- [x] All 65 realtime tests pass (including 11 new instrumentation tests)
- [x] All 58 existing logfire tests pass (no regressions)
- [x] pyright: 0 errors on all changed files
- [x] ruff: clean
- [ ] Verify `realtime gemini-live-2.5-flash-native-audio` span appears in Logfire with Roberto webcam example

🤖 Generated with [Claude Code](https://claude.com/claude-code)