### PR TITLE
Remove `ask` permissions from Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,13 +20,6 @@
       "Bash(gh run list:*)",
       "Bash(uv run:*)",
       "Bash(make:*)"
-    ],
-    "ask": [
-      "Bash(git add:*)",
-      "Bash(git checkout:*)",
-      "Bash(git commit:*)",
-      "Bash(git push:*)",
-      "Bash(gh pr create:*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Removes the `ask` permissions section from `.claude/settings.json`, leaving only the `allow` list

## Test plan

- N/A — settings-only change