### PR TITLE
fix: use non-greedy regex in `strip_markdown_fences` to stop at closing fence

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -514,7 +514,7 @@ def validate_empty_kwargs(_kwargs: dict[str, Any]) -> None:
         raise exceptions.UserError(f'Unknown keyword arguments: {unknown_kwargs}')
 
 
-_MARKDOWN_FENCES_PATTERN = re.compile(r'```(?:\w+)?\n(\{.*\})', flags=re.DOTALL)
+_MARKDOWN_FENCES_PATTERN = re.compile(r'```(?:\w+)?\n(\{.*?\})\s*(?:\n?```|\Z)', flags=re.DOTALL)
 
 
 def strip_markdown_fences(text: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -527,6 +527,15 @@ def test_strip_markdown_fences():
         == '{"foo": "bar"}'
     )
     assert strip_markdown_fences('No JSON to be found') == 'No JSON to be found'
+    # Content after closing fence with braces should not be captured (issue #4397)
+    assert strip_markdown_fences('```json\n{"a": 1}\n```\nContext: {"b": 2}') == '{"a": 1}'
+    assert (
+        strip_markdown_fences('```json\n{"result": "pass"}\n```\nThis matches schema {"type": "object"}')
+        == '{"result": "pass"}'
+    )
+    # Nested JSON objects should still be fully captured
+    assert strip_markdown_fences('```json\n{"nested": {"key": "value"}}\n```') == '{"nested": {"key": "value"}}'
+    assert strip_markdown_fences('```json\n{"a": {"b": {"c": 1}}}\n```') == '{"a": {"b": {"c": 1}}}'
 
 
 def test_validate_empty_kwargs_empty():


### PR DESCRIPTION
… fence

The greedy `.*` in the markdown fence regex matched from the first `{` to the last `}` in the entire text, crossing past the closing ``` fence when the text after the fence contained `}` characters. This produced malformed JSON that failed downstream validation.

Switch to non-greedy `.*?` anchored on the closing fence boundary `(?:\n?```|\Z)` so the match stops at the fence. Nested JSON objects still work correctly because the regex backtracks past intermediate `}` characters when the fence anchor doesn't match.

**Fix summary:**                                                                
                                                                              
  The regex pattern in strip_markdown_fences() used a greedy .* which matched  from the first { to the last } in the entire text, overshooting past the closing ``` fence when subsequent text contained } characters.

 Change: (\{.*\}) → (\{.*?\})\s*(?:\n?```|\Z)

  - Non-greedy .*? stops at the earliest valid }
  - Anchored on the closing fence (?:\n?```|\Z) to ensure correctness
  - Nested JSON still works — regex backtracks past intermediate } when the fence anchor doesn't match

  Tests added: 4 new cases covering post-fence braces and nested objects. All 19 existing tests pass unchanged.

Fixes #4397

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #4397 

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
