### PR TITLE
Fix greedy regex in strip_markdown_fences() crossing closing fence

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -528,6 +528,17 @@ def test_strip_markdown_fences():
     )
     assert strip_markdown_fences('No JSON to be found') == 'No JSON to be found'
 
+    # Regression test: greedy .* should not cross the closing fence (#4397)
+    assert (
+        strip_markdown_fences('```json\n{"result": "pass"}\n```\nThis matches schema {"type": "object"}')
+        == '{"result": "pass"}'
+    )
+    # Nested JSON within fences should still work
+    assert (
+        strip_markdown_fences('```json\n{"nested": {"k": "v"}}\n```')
+        == '{"nested": {"k": "v"}}'
+    )
+
 
 def test_validate_empty_kwargs_empty():
     """Test that empty dict passes validation."""


### PR DESCRIPTION
## Summary

Fixes #4397.

The `_MARKDOWN_FENCES_PATTERN` regex used `\{.*\}` with `re.DOTALL`, causing it to greedily match from the first `{` to the last `}` in the entire text. When an LLM response included a fenced JSON block followed by text containing braces, the extraction crossed the closing ``` fence and captured malformed content.

**Before:** `{"result": "pass"}\n```\nThis matches schema {"type": "object"}`
**After:** `{"result": "pass"}`

## Fix

Two-step approach:
1. Extract content bounded by markdown fences using non-greedy `.*?` up to the closing ``` (or end-of-string for unclosed fences)
2. Find the JSON object `{...}` within that bounded content

This preserves all existing behavior (nested JSON, unclosed fences, no-fence passthrough) while preventing the greedy match from crossing fence boundaries.

## Test plan

- [x] All existing `test_strip_markdown_fences` assertions pass
- [x] Added regression test for #4397 (braces after closing fence)
- [x] Added test for nested JSON within fences