### PR TITLE
fix: use non-greedy regex in strip_markdown_fences() to respect fence boundaries

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -514,7 +514,8 @@ def validate_empty_kwargs(_kwargs: dict[str, Any]) -> None:
         raise exceptions.UserError(f'Unknown keyword arguments: {unknown_kwargs}')
 
 
-_MARKDOWN_FENCES_PATTERN = re.compile(r'```(?:\w+)?\n(\{.*\})', flags=re.DOTALL)
+_MARKDOWN_FENCES_PATTERN = re.compile(r'```(?:\w+)?\n(.*?)(?:\n```|$)', flags=re.DOTALL)
+_JSON_OBJECT_PATTERN = re.compile(r'(\{.*\})', flags=re.DOTALL)
 
 
 def strip_markdown_fences(text: str) -> str:
@@ -523,7 +524,12 @@ def strip_markdown_fences(text: str) -> str:
 
     match = re.search(_MARKDOWN_FENCES_PATTERN, text)
     if match:
-        return match.group(1)
+        content = match.group(1)
+        # Extract the JSON object from the fenced content
+        json_match = re.search(_JSON_OBJECT_PATTERN, content)
+        if json_match:
+            return json_match.group(1)
+        return content
 
     return text
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -527,6 +527,11 @@ def test_strip_markdown_fences():
         == '{"foo": "bar"}'
     )
     assert strip_markdown_fences('No JSON to be found') == 'No JSON to be found'
+    # Regression test for #4397: greedy regex crossing fence boundaries
+    assert (
+        strip_markdown_fences('```json\n{"result": "pass"}\n```\nThis conforms to the schema {"type": "object"}')
+        == '{"result": "pass"}'
+    )
 
 
 def test_validate_empty_kwargs_empty():


### PR DESCRIPTION
## Summary

Fix greedy regex in `strip_markdown_fences()` that crosses past closing fence boundaries when there are `}` characters in text after the fence.

## Problem

The pattern `r'```(?:\w+)?\n(\{.*\})'` with `re.DOTALL` uses greedy `.*`, which matches from the first `{` to the **last** `}` in the entire string — crossing the closing fence and capturing commentary text as part of the JSON.

```python
text = '```json\n{"result": "pass"}\n```\nThis conforms to the schema {"type": "object"}'
strip_markdown_fences(text)
# Actual:   '{"result": "pass"}\n```\nThis conforms to the schema {"type": "object"}'
# Expected: '{"result": "pass"}'
```

## Fix

Split extraction into two steps:
1. First extract content between fences using a non-greedy match that stops at the closing ``` (or end of string)
2. Then find the JSON object `{...}` within that bounded content

This ensures the regex never crosses fence boundaries regardless of what follows the closing fence.

## Tests

Added regression test for the exact scenario from #4397. All existing tests continue to pass.

Fixes #4397
