### PR TITLE
fix: use non-greedy regex in `strip_markdown_fences` to respect fence boundaries

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -514,7 +514,8 @@ def validate_empty_kwargs(_kwargs: dict[str, Any]) -> None:
         raise exceptions.UserError(f'Unknown keyword arguments: {unknown_kwargs}')
 
 
-_MARKDOWN_FENCES_PATTERN = re.compile(r'```(?:\w+)?\n(\{.*\})', flags=re.DOTALL)
+_MARKDOWN_FENCES_PATTERN = re.compile(r'```(?:\w+)?\n(.*?)(?:\n```|$)', flags=re.DOTALL)
+_JSON_OBJECT_PATTERN = re.compile(r'(\{.*\})', flags=re.DOTALL)
 
 
 def strip_markdown_fences(text: str) -> str:
@@ -523,7 +524,12 @@ def strip_markdown_fences(text: str) -> str:
 
     match = re.search(_MARKDOWN_FENCES_PATTERN, text)
     if match:
-        return match.group(1)
+        fence_content = match.group(1)
+        # Find the JSON object within the fence content
+        json_match = re.search(_JSON_OBJECT_PATTERN, fence_content)
+        if json_match:
+            return json_match.group(1)
+        return fence_content
 
     return text
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -527,6 +527,13 @@ def test_strip_markdown_fences():
         == '{"foo": "bar"}'
     )
     assert strip_markdown_fences('No JSON to be found') == 'No JSON to be found'
+    # Greedy regex bug: should not consume past closing fence into trailing text with braces
+    assert (
+        strip_markdown_fences('```json\n{"foo": "bar"}\n```\nSome text with a } here')
+        == '{"foo": "bar"}'
+    )
+    # Nested JSON objects should be preserved
+    assert strip_markdown_fences('```json\n{"a": {"b": "c"}}\n```') == '{"a": {"b": "c"}}'
 
 
 def test_validate_empty_kwargs_empty():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -528,10 +528,7 @@ def test_strip_markdown_fences():
     )
     assert strip_markdown_fences('No JSON to be found') == 'No JSON to be found'
     # Greedy regex bug: should not consume past closing fence into trailing text with braces
-    assert (
-        strip_markdown_fences('```json\n{"foo": "bar"}\n```\nSome text with a } here')
-        == '{"foo": "bar"}'
-    )
+    assert strip_markdown_fences('```json\n{"foo": "bar"}\n```\nSome text with a } here') == '{"foo": "bar"}'
     # Nested JSON objects should be preserved
     assert strip_markdown_fences('```json\n{"a": {"b": "c"}}\n```') == '{"a": {"b": "c"}}'
 


### PR DESCRIPTION
## Summary

`strip_markdown_fences()` in `_utils.py` uses a greedy `.*` in the regex pattern with `re.DOTALL`, which causes it to match past the closing ``````` fence marker when trailing text contains `}` characters. This results in invalid JSON extraction that breaks downstream parsing.

## Problem

The pattern `r'```(?:\w+)?\n(\{.*\})`` with `re.DOTALL` is greedy — `.*` consumes everything including the closing fence and any subsequent text up to the last `}` in the string.

Example:
```
``json
{"foo": "bar"}
``
Some text with a } here
```

**Before (bug):** returns `{"foo": "bar"}\n```\nSome text with a }`
**After (fix):** returns `{"foo": "bar"}`

## Fix

Split extraction into two steps:
1. Use a non-greedy match to extract content within fence boundaries (``````` ... ``````` or end of string)
2. Find the JSON object (`{...}`) within the extracted fence content

This ensures trailing text after the closing fence is never included in the result.

## Tests

Added two test cases:
- Greedy regex bug case: text after closing fence with `}` characters
- Nested JSON objects within fences

Fixes #4397