### PR TITLE
fix: prevent over-matching when using `strip_markdown_fences` by making the regex non-greedy

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -514,7 +514,7 @@ def validate_empty_kwargs(_kwargs: dict[str, Any]) -> None:
         raise exceptions.UserError(f'Unknown keyword arguments: {unknown_kwargs}')
 
 
-_MARKDOWN_FENCES_PATTERN = re.compile(r'```(?:\w+)?\n(\{.*\})', flags=re.DOTALL)
+_MARKDOWN_FENCES_PATTERN = re.compile(r'```(?:\w+)?\n(\{.*?\})\s*(?:```|$)', flags=re.DOTALL)
 
 
 def strip_markdown_fences(text: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -527,6 +527,13 @@ def test_strip_markdown_fences():
         == '{"foo": "bar"}'
     )
     assert strip_markdown_fences('No JSON to be found') == 'No JSON to be found'
+    # Greedy regex bug: trailing braces after closing fence should not be captured
+    assert (
+        strip_markdown_fences('```json\n{"result": "pass"}\n```\nThis conforms to the schema {"type": "object"}')
+        == '{"result": "pass"}'
+    )
+    # Nested braces inside fenced block should still be captured fully
+    assert strip_markdown_fences('```json\n{"a": {"b": 1}}\n```') == '{"a": {"b": 1}}'
 
 
 def test_validate_empty_kwargs_empty():


### PR DESCRIPTION
## Summary

Fixes #4397.

The `.*` quantifier in `_MARKDOWN_FENCES_PATTERN` is greedy. With `re.DOTALL`, it matches from the first `{` to the last `}` in the entire string, crossing past the closing `````` fence and capturing trailing text that contains braces.

### Example

```
Input:  ```json\n{"result": "pass"}\n```\nThis conforms to the schema {"type": "object"}

Before: {"result": "pass"}\n```\nThis conforms to the schema {"type": "object"}
After:  {"result": "pass"}
```

## Fix

Two changes to the regex pattern:

1. `.*` → `.*?` (non-greedy) — stops at the earliest valid `}` rather than the last
2. Added `\s*(?:```|$)` anchor after `}` — ensures the match stops at the closing fence (or end of string for unclosed fences)

Old: `r'```(?:\w+)?\n(\{.*\})'`
New: `r'```(?:\w+)?\n(\{.*?\})\s*(?:```|$)'`

## Tests

Added two test cases:
- Trailing braces after closing fence (the reported bug)
- Nested braces inside fenced block (regression guard)

All existing `test_strip_markdown_fences` tests continue to pass.