### PR TITLE
feat: add 'complete' end_strategy option

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -60,7 +60,7 @@ __all__ = (
 T = TypeVar('T')
 S = TypeVar('S')
 NoneType = type(None)
-EndStrategy = Literal['early', 'exhaustive']
+EndStrategy = Literal['early', 'complete', 'exhaustive']
 DepsT = TypeVar('DepsT')
 OutputT = TypeVar('OutputT')
 
@@ -920,7 +920,7 @@ async def process_tool_calls(  # noqa: C901
             )
             output_parts.append(part)
         # Early strategy is chosen and final result is already set
-        elif ctx.deps.end_strategy == 'early' and final_result:
+        elif (ctx.deps.end_strategy == 'early' or ctx.deps.end_strategy == 'complete') and final_result:
             yield _messages.FunctionToolCallEvent(call)
             part = _messages.ToolReturnPart(
                 tool_name=call.tool_name,


### PR DESCRIPTION
## Summary

Implements #4296 - Add new `'complete'` end_strategy option that executes all function tools but only the first output tool.

## Problem

When using `end_strategy='exhaustive'`, if a model mistakenly calls multiple output tools in a single response:
1. All output tools are fully executed (including side effects like database writes, API calls)
2. But only the first result is used
3. Subsequent results are silently discarded

This can be problematic when output functions have side effects.

## Solution

Add a new `'complete'` end_strategy:

- `'early'`: Stop at first valid output, skip all other tools
- `'complete'`: Execute all function tools, but only first output tool ⭐ **NEW**
- `'exhaustive'`: Execute all tools including multiple output tools

## Changes

### Core Logic

Modified `pydantic_ai_slim/pydantic_ai/_agent_graph.py`:

1. **Line 63**: Updated `EndStrategy` type definition
   ```python
   EndStrategy = Literal['early', 'complete', 'exhaustive']
   ```

2. **Line 923**: Updated output tool handling in `process_tool_calls()`
   ```python
   # Skip subsequent output tools in both 'early' and 'complete' modes
   elif (ctx.deps.end_strategy == 'early' or ctx.deps.end_strategy == 'complete') and final_result:
   ```

3. **Line 980**: Function tool handling unchanged (only 'early' skips function tools)
   ```python
   # Only 'early' skips function tools; 'complete' and 'exhaustive' execute them all
   if final_result and ctx.deps.end_strategy == 'early':
   ```

## Use Cases

### 'early' - Quick Exit
Use when you want to stop immediately upon getting a valid result:
```python
agent = Agent(model, output_type=[...], end_strategy='early')
```

### 'complete' - Complete Function Execution (NEW)
Use when function tools have side effects that should always run:
```python
agent = Agent(model, output_type=[...], end_strategy='complete')
# - All function tools will execute
# - Only the first output tool will execute
```

### 'exhaustive' - Full Execution
Use when output tools have side effects that should all run:
```python
agent = Agent(model, output_type=[...], end_strategy='exhaustive')
# - All tools (function and output) will execute
# - Use with caution if output functions have side effects
```

## Testing

This change is backward compatible:
- Existing code using `'early'` or `'exhaustive'` behaves identically
- New `'complete'` option provides a middle ground

## Related

- Issue: #4296
- Discussion with @DouweM and @Baniskos on the preferred solution
- Builds on PR #3523 which introduced exhaustive mode