### PR TITLE
fix: mark array schemas with empty `items` as not strict-compatible

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -313,4 +313,12 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                     for k in schema['properties'].keys():
                         if k not in required:
                             self.is_strict_compatible = False
+
+        if schema_type == 'array':
+            items = schema.get('items')
+            if items is not None and not items:
+                # Empty `items: {}` (from bare `list` without type params) is not
+                # valid in OpenAI strict mode — the `items` schema must have a `type`.
+                self.is_strict_compatible = False
+
         return schema

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4339,6 +4339,37 @@ def test_transformer_adds_properties_to_object_schemas():
     assert result['properties'] == {}
 
 
+def test_transformer_bare_list_not_strict_compatible():
+    """Bare `list` (no type param) produces `items: {}` which is not strict-compatible.
+
+    See https://github.com/pydantic/pydantic-ai/issues/4425
+    """
+    schema = {
+        'type': 'object',
+        'properties': {
+            'items': {'type': 'array', 'items': {}},
+        },
+        'required': ['items'],
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    transformer.walk()
+    assert transformer.is_strict_compatible is False
+
+
+def test_transformer_typed_list_strict_compatible():
+    """A typed list (e.g. `list[str]`) has a proper `items` schema and is strict-compatible."""
+    schema = {
+        'type': 'object',
+        'properties': {
+            'items': {'type': 'array', 'items': {'type': 'string'}},
+        },
+        'required': ['items'],
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    transformer.walk()
+    assert transformer.is_strict_compatible is True
+
+
 def chunk_with_usage(
     delta: list[ChoiceDelta],
     finish_reason: FinishReason | None = None,

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4344,7 +4344,7 @@ def test_transformer_bare_list_not_strict_compatible():
 
     See https://github.com/pydantic/pydantic-ai/issues/4425
     """
-    schema = {
+    schema: dict[str, Any] = {
         'type': 'object',
         'properties': {
             'items': {'type': 'array', 'items': {}},


### PR DESCRIPTION
Fixes #4425

## Problem

When a bare `list` (without type parameters) is used in a tool or output model, pydantic generates:

```json
{"type": "array", "items": {}}
```

OpenAI's strict mode requires `items` to have a `type` key. The `OpenAIJsonSchemaTransformer` didn't check for this case, so `is_strict_compatible` remained `True`, and the schema was sent with `strict=True` — causing a 400 error from the API.

## Fix

Added a check in `OpenAIJsonSchemaTransformer.transform()`: when `schema_type == 'array'` and `items` is an empty dict `{}`, set `is_strict_compatible = False`. This causes the tool to fall back to non-strict mode instead of sending an invalid schema.

## Tests

Added two tests:
- `test_transformer_bare_list_not_strict_compatible`: verifies empty `items: {}` → `is_strict_compatible = False`
- `test_transformer_typed_list_strict_compatible`: verifies typed `items: {"type": "string"}` → `is_strict_compatible = True`