### PR TITLE
fix: add missing strict-incompatible keys to OpenAIJsonSchemaTransformer

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -177,13 +177,25 @@ def openai_model_profile(model_name: str) -> ModelProfile:
 
 
 _STRICT_INCOMPATIBLE_KEYS = [
+    # String
     'minLength',
     'maxLength',
+    'pattern',
+    # Number / Integer
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+    'multipleOf',
+    # Object
     'patternProperties',
     'unevaluatedProperties',
     'propertyNames',
     'minProperties',
     'maxProperties',
+    # Array
+    'minItems',
+    'maxItems',
     'unevaluatedItems',
     'contains',
     'minContains',

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -2249,8 +2249,16 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                 {
                     'additionalProperties': False,
                     'properties': {
-                        'x': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'integer'}], 'type': 'array'},
-                        'y': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'string'}], 'type': 'array'},
+                        'x': {
+                            'prefixItems': [{'type': 'integer'}],
+                            'type': 'array',
+                            'description': 'minItems=1, maxItems=1',
+                        },
+                        'y': {
+                            'prefixItems': [{'type': 'string'}],
+                            'type': 'array',
+                            'description': 'minItems=1, maxItems=1',
+                        },
                     },
                     'required': ['x', 'y'],
                     'type': 'object',
@@ -2346,10 +2354,9 @@ def test_strict_schema():
                         },
                         'my_recursive': {'anyOf': [{'$ref': '#'}, {'type': 'null'}]},
                         'my_tuple': {
-                            'maxItems': 1,
-                            'minItems': 1,
                             'prefixItems': [{'type': 'integer'}],
                             'type': 'array',
+                            'description': 'minItems=1, maxItems=1',
                         },
                     },
                     'required': ['my_recursive', 'my_patterns', 'my_tuple', 'my_list', 'my_discriminated_union'],
@@ -2365,7 +2372,11 @@ def test_strict_schema():
                     'properties': {},
                     'required': [],
                 },
-                'my_tuple': {'maxItems': 1, 'minItems': 1, 'prefixItems': [{'type': 'integer'}], 'type': 'array'},
+                'my_tuple': {
+                    'prefixItems': [{'type': 'integer'}],
+                    'type': 'array',
+                    'description': 'minItems=1, maxItems=1',
+                },
                 'my_list': {'items': {'type': 'number'}, 'type': 'array'},
                 'my_discriminated_union': {'anyOf': [{'$ref': '#/$defs/Apple'}, {'$ref': '#/$defs/Banana'}]},
             },
@@ -4337,6 +4348,43 @@ def test_transformer_adds_properties_to_object_schemas():
     result = OpenAIJsonSchemaTransformer(schema, strict=None).walk()
 
     assert result['properties'] == {}
+
+
+@pytest.mark.parametrize(
+    'key,value',
+    [
+        ('pattern', r'^[\w.]+@[\w.]+$'),
+        ('minimum', 0),
+        ('maximum', 120),
+        ('exclusiveMinimum', 0),
+        ('exclusiveMaximum', 100),
+        ('multipleOf', 5),
+        ('minItems', 1),
+        ('maxItems', 10),
+    ],
+)
+def test_transformer_detects_strict_incompatible_numeric_and_string_keys(key: str, value: Any):
+    """Keys like pattern, minimum, maximum, minItems, maxItems are not supported in OpenAI strict mode."""
+    prop_schema: dict[str, Any] = {'type': 'string' if key == 'pattern' else 'integer', key: value}
+    if key in ('minItems', 'maxItems'):
+        prop_schema = {'type': 'array', 'items': {'type': 'string'}, key: value}
+
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'field': prop_schema},
+        'required': ['field'],
+        'additionalProperties': False,
+    }
+
+    # strict=None should detect as NOT strict-compatible
+    t1 = OpenAIJsonSchemaTransformer(schema.copy(), strict=None)
+    t1.walk()
+    assert not t1.is_strict_compatible, f'{key} should be detected as strict-incompatible'
+
+    # strict=True should strip the incompatible key
+    t2 = OpenAIJsonSchemaTransformer(schema.copy(), strict=True)
+    result = t2.walk()
+    assert key not in result['properties']['field'], f'{key} should be stripped in strict mode'
 
 
 def chunk_with_usage(


### PR DESCRIPTION
Add `pattern`, `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `minItems`, and `maxItems` to the `_STRICT_INCOMPATIBLE_KEYS` list. These JSON Schema keywords are rejected by OpenAI strict mode but were not being detected or stripped, causing incorrect strict-compatibility classification and API errors when using Pydantic Field constraints like `ge=`, `le=`, `pattern=`, `min_length=`, `max_length=` on tools or outputs.

Fixes #4438
Fix summary:                                                                
                                                                            
 Added 8 missing JSON Schema keywords to _STRICT_INCOMPATIBLE_KEYS in profiles/openai.py:                                                       
                                                                              
  - String: pattern                                                           
  - Number/Integer: minimum, maximum, exclusiveMinimum, exclusiveMaximum,     
  multipleOf                                                                  
  - Array: minItems, maxItems                                                 

  These are commonly generated by Pydantic's Field(ge=, le=, gt=, lt=, pattern=, min_length=, max_length=, multiple_of=) but were not being detected or stripped by the transformer, causing incorrect is_strict_compatible=True classification and OpenAI API rejections in strict mode.

Tests: 8 new parametrized test cases + 2 existing snapshot updates. All 39 strict-mode tests pass.

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #4438

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
