### PR TITLE
Add social media links to docs footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -209,6 +209,15 @@ nav:
 extra:
   # hide the "Made with Material for MkDocs" message
   generator: false
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/pydantic/pydantic-ai
+    - icon: fontawesome/brands/bluesky
+      link: https://bsky.app/profile/pydantic.dev
+    - icon: fontawesome/brands/x-twitter
+      link: https://x.com/pydantic
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/company/pydantic
 
 theme:
   name: "material"


### PR DESCRIPTION
## Summary

- Add GitHub, Bluesky, X, and LinkedIn social icons to the docs footer via mkdocs-material's `extra.social` config

## Test plan

- [ ] Run `make docs-serve` and verify icons appear in the footer
- [ ] Confirm each link points to the correct Pydantic account