### PR TITLE
fix: exclude outlines-vllm-offline extra from CI and dev sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           cache-suffix: lint
 
       - name: Install dependencies
-        run: uv sync --all-extras --all-packages --group lint
+        run: uv sync --all-extras --no-extra outlines-vllm-offline --all-packages --group lint
 
       - uses: pre-commit/action@v3.0.0
         with:
@@ -113,7 +113,7 @@ jobs:
           - name: standard
             command: ""
           - name: all-extras
-            command: "--all-extras"
+            command: "--all-extras --no-extra outlines-vllm-offline"
     env:
       CI: true
       COVERAGE_PROCESS_START: ./pyproject.toml
@@ -194,7 +194,7 @@ jobs:
 
       - run: unset UV_FROZEN
 
-      - run: uv run --all-extras --resolution lowest-direct coverage run -m pytest --durations=100 -n auto --dist=loadgroup
+      - run: uv run --all-extras --no-extra outlines-vllm-offline --resolution lowest-direct coverage run -m pytest --durations=100 -n auto --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{matrix.python-version}}-lowest-versions
 
@@ -232,7 +232,7 @@ jobs:
           restore-keys: |
             hf-${{ runner.os }}-
 
-      - run: uv run --all-extras python tests/import_examples.py
+      - run: uv run --all-extras --no-extra outlines-vllm-offline python tests/import_examples.py
 
   coverage:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -10,19 +10,19 @@
 
 .PHONY: install
 install: .uv .pre-commit ## Install the package, dependencies, and pre-commit for local development
-	uv sync --frozen --all-extras --all-packages --group lint --group docs
+	uv sync --frozen --all-extras --no-extra outlines-vllm-offline --all-packages --group lint --group docs
 	pre-commit install --install-hooks
 
 .PHONY: install-all-python
 install-all-python: ## Install and synchronize an interpreter for every python version
-	UV_PROJECT_ENVIRONMENT=.venv310 uv sync --python 3.10 --frozen --all-extras --all-packages --group lint --group docs
-	UV_PROJECT_ENVIRONMENT=.venv311 uv sync --python 3.11 --frozen --all-extras --all-packages --group lint --group docs
-	UV_PROJECT_ENVIRONMENT=.venv312 uv sync --python 3.12 --frozen --all-extras --all-packages --group lint --group docs
-	UV_PROJECT_ENVIRONMENT=.venv313 uv sync --python 3.13 --frozen --all-extras --all-packages --group lint --group docs
+	UV_PROJECT_ENVIRONMENT=.venv310 uv sync --python 3.10 --frozen --all-extras --no-extra outlines-vllm-offline --all-packages --group lint --group docs
+	UV_PROJECT_ENVIRONMENT=.venv311 uv sync --python 3.11 --frozen --all-extras --no-extra outlines-vllm-offline --all-packages --group lint --group docs
+	UV_PROJECT_ENVIRONMENT=.venv312 uv sync --python 3.12 --frozen --all-extras --no-extra outlines-vllm-offline --all-packages --group lint --group docs
+	UV_PROJECT_ENVIRONMENT=.venv313 uv sync --python 3.13 --frozen --all-extras --no-extra outlines-vllm-offline --all-packages --group lint --group docs
 
 .PHONY: sync
 sync: .uv ## Update local packages and uv.lock
-	uv sync --all-extras --all-packages --group lint --group docs
+	uv sync --all-extras --no-extra outlines-vllm-offline --all-packages --group lint --group docs
 
 .PHONY: format
 format: ## Format the code
@@ -57,10 +57,10 @@ test: ## Run tests without coverage (fast, for local dev)
 
 .PHONY: test-all-python
 test-all-python: ## Run tests on Python 3.10 to 3.13
-	COLUMNS=150 UV_PROJECT_ENVIRONMENT=.venv310 uv run --python 3.10 --all-extras --all-packages coverage run -p -m pytest
-	COLUMNS=150 UV_PROJECT_ENVIRONMENT=.venv311 uv run --python 3.11 --all-extras --all-packages coverage run -p -m pytest
-	COLUMNS=150 UV_PROJECT_ENVIRONMENT=.venv312 uv run --python 3.12 --all-extras --all-packages coverage run -p -m pytest
-	COLUMNS=150 UV_PROJECT_ENVIRONMENT=.venv313 uv run --python 3.13 --all-extras --all-packages coverage run -p -m pytest
+	COLUMNS=150 UV_PROJECT_ENVIRONMENT=.venv310 uv run --python 3.10 --all-extras --no-extra outlines-vllm-offline --all-packages coverage run -p -m pytest
+	COLUMNS=150 UV_PROJECT_ENVIRONMENT=.venv311 uv run --python 3.11 --all-extras --no-extra outlines-vllm-offline --all-packages coverage run -p -m pytest
+	COLUMNS=150 UV_PROJECT_ENVIRONMENT=.venv312 uv run --python 3.12 --all-extras --no-extra outlines-vllm-offline --all-packages coverage run -p -m pytest
+	COLUMNS=150 UV_PROJECT_ENVIRONMENT=.venv313 uv run --python 3.13 --all-extras --no-extra outlines-vllm-offline --all-packages coverage run -p -m pytest
 	@uv run coverage combine
 	@uv run coverage report
 

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -139,5 +139,15 @@ pai = "pydantic_ai._cli:cli_exit" # TODO remove this when clai has been out for 
 [tool.hatch.build.targets.wheel]
 packages = ["pydantic_ai"]
 
+# Remove when https://github.com/vllm-project/vllm/pull/30566 is merged.
+# Check compatibility with `uv lock --upgrade-package vllm --upgrade-package transformers`.
+[tool.uv]
+conflicts = [
+    [
+        { extra = "huggingface" },
+        { extra = "outlines-vllm-offline" },
+    ],
+]
+
 [tool.uv.sources]
 pydantic-graph = { workspace = true }


### PR DESCRIPTION
## Summary
- Add `[tool.uv] conflicts` in `pydantic_ai_slim/pyproject.toml` declaring `huggingface` and `outlines-vllm-offline` as conflicting extras (pending [vllm#30566](https://github.com/vllm-project/vllm/pull/30566))
- Add `--no-extra outlines-vllm-offline` to all `uv sync` / `uv run --all-extras` invocations in `Makefile` and `.github/workflows/ci.yml`

## Test plan
- [ ] `make install` succeeds without dependency resolution errors
- [ ] CI workflows pass with the `--no-extra` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)