### PR TITLE
fix: use global retry count for output validators on tool output path

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -970,7 +970,10 @@ async def process_tool_calls(  # noqa: C901
             # Validate and execute the output tool call — unlike deferred tools,
             # output tools track retries and can be skipped if a final_result exists.
             try:
-                validated = await tool_manager.validate_tool_call(call)
+                validated = await tool_manager.validate_tool_call(
+                    call,
+                    retry_override=ctx.state.retries,
+                )
             except exceptions.UnexpectedModelBehavior as e:
                 # If we already have a valid final result, don't fail the entire run
                 # This allows exhaustive strategy to complete successfully when at least one output tool is valid

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -168,6 +168,7 @@ class ToolManager(Generic[AgentDepsT]):
         allow_partial: bool,
         approved: bool = False,
         metadata: Any = None,
+        retry_override: int | None = None,
     ) -> RunContext[AgentDepsT]:
         """Build the execution context for a tool call."""
         assert self.ctx is not None
@@ -175,7 +176,7 @@ class ToolManager(Generic[AgentDepsT]):
             self.ctx,
             tool_name=call.tool_name,
             tool_call_id=call.tool_call_id,
-            retry=self.ctx.retries.get(call.tool_name, 0),
+            retry=retry_override if retry_override is not None else self.ctx.retries.get(call.tool_name, 0),
             max_retries=tool.max_retries,
             tool_call_approved=approved,
             tool_call_metadata=metadata,
@@ -225,6 +226,7 @@ class ToolManager(Generic[AgentDepsT]):
         wrap_validation_errors: bool = True,
         approved: bool = False,
         metadata: Any = None,
+        retry_override: int | None = None,
     ) -> ValidatedToolCall[AgentDepsT]:
         """Validate tool arguments without executing the tool.
 
@@ -239,6 +241,10 @@ class ToolManager(Generic[AgentDepsT]):
             wrap_validation_errors: Whether to wrap validation errors in ToolRetryError.
             approved: Whether the tool call has been approved.
             metadata: Additional metadata from DeferredToolResults.metadata.
+            retry_override: When set, use this value for ``ctx.retry`` instead of
+                the per-tool retry count.  Used for output tools so that
+                ``@agent.output_validator`` sees the global output-validation
+                retry counter.
 
         Returns:
             ValidatedToolCall with validation results, ready for execution via execute_tool_call().
@@ -259,7 +265,12 @@ class ToolManager(Generic[AgentDepsT]):
                 raise ModelRetry(f'Unknown tool name: {name!r}. {msg}')
 
             ctx = self._build_tool_context(
-                call, tool, allow_partial=allow_partial, approved=approved, metadata=metadata
+                call,
+                tool,
+                allow_partial=allow_partial,
+                approved=approved,
+                metadata=metadata,
+                retry_override=retry_override,
             )
             validated_args = await self._validate_tool_args(call, tool, ctx, allow_partial=allow_partial)
             return ValidatedToolCall(


### PR DESCRIPTION
## Problem

`@agent.output_validator` receives inconsistent `ctx.retry` values depending on whether the model returned output as plain text or via a tool call:

- **Text path** (`_handle_text_response`): `ctx.retry = ctx.state.retries` (global output-validation counter)
- **Tool path** (`_build_tool_context`): `ctx.retry = ctx.retries.get(tool_name, 0)` (per-tool counter)

This means output validators checking `ctx.retry` to implement "lenient on last attempt" logic are blind to retry budget consumed by unrelated failures (empty response, unknown tool call, text validation failure) on the tool path.

Fixes #4385

## Solution

Add `retry_override` parameter to `ToolManager._build_tool_context()` and `validate_tool_call()`. When processing output tool calls in `process_tool_calls()`, pass the global retry counter (`ctx.state.retries`) as the override so the output validator sees the same retry value regardless of output path.

## Changes

- `pydantic_ai_slim/pydantic_ai/_tool_manager.py`: Add `retry_override` parameter to `_build_tool_context` and `validate_tool_call`
- `pydantic_ai_slim/pydantic_ai/_agent_graph.py`: Pass `retry_override=ctx.state.retries` when validating output tool calls

## Testing

- All 197 agent tests pass
- All 72 output-validator/retry-related tests pass (2 consecutive clean runs)
- `ruff check` passes