### PR TITLE
fix(evals): SpanQuery has_attributes matches dict/list values against JSON-serialized form

### DIFF
--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -267,7 +267,7 @@ class SpanNode:
 
         # Attribute conditions
         if (has_attributes := query.get('has_attributes')) and not all(
-            self.attributes.get(key) == value for key, value in has_attributes.items()
+            _attribute_matches(self.attributes.get(key), value) for key, value in has_attributes.items()
         ):
             return False
         if (has_attributes_keys := query.get('has_attribute_keys')) and not all(
@@ -539,3 +539,23 @@ class SpanTree:
 
 SPAN_TREE_ADAPTER = TypeAdapter(SpanTree)
 """This adapter can be used to serialize and deserialize `SpanTree` objects to and from JSON."""
+
+
+def _attribute_matches(stored: AttributeValue | None, query_value: Any) -> bool:
+    """Match an attribute value, handling JSON-serialized complex types.
+
+    Logfire stores complex types (dicts, nested lists) as JSON strings.
+    This allows querying with the original Python object by parsing
+    the stored JSON and comparing objects directly.
+    """
+    if stored == query_value:
+        return True
+    if stored is not None and not isinstance(query_value, (str, bool, int, float)):
+        if isinstance(stored, str):
+            try:
+                import json
+
+                return json.loads(stored) == query_value
+            except (json.JSONDecodeError, ValueError):
+                return False
+    return False

--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -223,6 +223,43 @@ async def test_span_node_matches(span_tree: SpanTree):
     assert not child1_node.matches(SpanQuery(name_equals='child1', has_attributes={'type': 'normal'}))
 
 
+async def test_span_query_dict_attribute_matching():
+    """Test that has_attributes matches dict values against their JSON-serialized form.
+
+    Logfire stores complex types (dicts, lists) as JSON strings.
+    SpanQuery should allow querying with the original Python object.
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/4448
+    """
+    data = {'foo': 1, 'bar': True}
+
+    with context_subtree() as tree:
+        with logfire.span('task'):
+            logfire.info('some data', data=data)
+
+    assert isinstance(tree, SpanTree)
+
+    # String query (existing behavior) should still work
+    assert tree.first(SpanQuery(has_attributes={'data': '{"foo":1,"bar":true}'})) is not None
+
+    # Dict query (new behavior) should also match
+    assert tree.first(SpanQuery(has_attributes={'data': data})) is not None
+
+    # Dict with reversed key order should also match
+    assert tree.first(SpanQuery(has_attributes={'data': {'bar': True, 'foo': 1}})) is not None
+
+    # Non-matching dict should NOT match
+    assert tree.first(SpanQuery(has_attributes={'data': {'foo': 2, 'bar': True}})) is None
+
+    # List values should also work
+    with context_subtree() as tree2:
+        with logfire.span('task2'):
+            logfire.info('list data', items=[1, 2, 3])
+
+    assert isinstance(tree2, SpanTree)
+    assert tree2.first(SpanQuery(has_attributes={'items': [1, 2, 3]})) is not None
+    assert tree2.first(SpanQuery(has_attributes={'items': [1, 2, 4]})) is None
+
+
 async def test_span_tree_repr(span_tree: SpanTree):
     assert repr(SpanTree()) == snapshot('<SpanTree />')
     assert str(span_tree) == snapshot('<SpanTree num_roots=1 total_spans=6 />')


### PR DESCRIPTION
## Problem

`SpanQuery(has_attributes={'data': {'foo': 1, 'bar': True}})` returns no match even when the span has a `data` attribute with that exact value.

Logfire stores complex types (dicts, lists) as JSON strings in span attributes. The existing `has_attributes` comparison uses strict `==` equality, which fails because:
- Stored: `'{"foo":1,"bar":true}'` (string)
- Query: `{'foo': 1, 'bar': True}` (dict)

Users must currently query with the raw JSON string, which is unintuitive.

## Solution

When direct equality fails and the query value is a complex type (not str/bool/int/float), parse the stored JSON string and compare Python objects. This correctly handles:
- Dict values with any key ordering
- Nested structures
- List values
- Falls back gracefully if the stored value isn't valid JSON

## Testing

- Added `test_span_query_dict_attribute_matching` covering:
  - String query (existing behavior preserved)
  - Dict query matching
  - Dict with reversed key order matching
  - Non-matching dict rejection
  - List value matching
  - Non-matching list rejection
- All 26 otel tests pass across 2 consecutive clean runs

Fixes #4448