### PR TITLE
fix: convert tool call/return history to text for Gemini image models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -935,6 +935,20 @@ class BaseToolReturnPart:
         """Return `True` if the tool return has content."""
         return self.content is not None  # pragma: no cover
 
+    def as_text(self) -> str:
+        """Convert this tool return to a text representation.
+
+        This is used when sending message history to models that don't support tool calls,
+        such as image generation models.
+        """
+        return '\n'.join(
+            [
+                f'-----BEGIN TOOL_RETURN id="{self.tool_call_id}" name="{self.tool_name}"-----',
+                self.model_response_str(),
+                '-----END TOOL_RETURN-----',
+            ]
+        )
+
     __repr__ = _utils.dataclasses_no_defaults_repr
 
 
@@ -1305,6 +1319,20 @@ class BaseToolCallPart:
             return any(self.args.values())
         else:
             return bool(self.args)
+
+    def as_text(self) -> str:
+        """Convert this tool call to a text representation.
+
+        This is used when sending message history to models that don't support tool calls,
+        such as image generation models.
+        """
+        return '\n'.join(
+            [
+                f'-----BEGIN TOOL_CALL id="{self.tool_call_id}" name="{self.tool_name}"-----',
+                self.args_as_json_str(),
+                '-----END TOOL_CALL-----',
+            ]
+        )
 
     __repr__ = _utils.dataclasses_no_defaults_repr
 

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -679,17 +679,20 @@ class GoogleModel(Model):
                     elif isinstance(part, UserPromptPart):
                         message_parts.extend(await self._map_user_prompt(part))
                     elif isinstance(part, ToolReturnPart):
-                        message_parts.append(
-                            {
-                                'function_response': {
-                                    'name': part.tool_name,
-                                    'response': part.model_response_object(),
-                                    'id': part.tool_call_id,
+                        if self.profile.supports_tools:
+                            message_parts.append(
+                                {
+                                    'function_response': {
+                                        'name': part.tool_name,
+                                        'response': part.model_response_object(),
+                                        'id': part.tool_call_id,
+                                    }
                                 }
-                            }
-                        )
+                            )
+                        else:
+                            message_parts.append({'text': part.as_text()})
                     elif isinstance(part, RetryPromptPart):
-                        if part.tool_name is None:
+                        if part.tool_name is None or not self.profile.supports_tools:
                             message_parts.append({'text': part.model_response()})
                         else:
                             message_parts.append(
@@ -727,7 +730,7 @@ class GoogleModel(Model):
 
                     contents.append({'role': 'user', 'parts': content_parts})
             elif isinstance(m, ModelResponse):
-                maybe_content = _content_model_response(m, self.system)
+                maybe_content = _content_model_response(m, self.system, supports_tools=self.profile.supports_tools)
                 if maybe_content:
                     contents.append(maybe_content)
             else:
@@ -1062,45 +1065,50 @@ class GeminiStreamedResponse(StreamedResponse):
         return self._timestamp
 
 
-def _content_model_response(m: ModelResponse, provider_name: str) -> ContentDict | None:  # noqa: C901
+def _content_model_response(m: ModelResponse, provider_name: str, *, supports_tools: bool = True) -> ContentDict | None:  # noqa: C901
     parts: list[PartDict] = []
     thinking_part_signature: str | None = None
     function_call_requires_signature: bool = True
     for item in m.parts:
         part: PartDict = {}
-        if (
-            item.provider_details
-            and (thought_signature := item.provider_details.get('thought_signature'))
-            and (m.provider_name == provider_name or item.provider_name == provider_name)
-        ):
-            part['thought_signature'] = base64.b64decode(thought_signature)
-        elif thinking_part_signature:
-            part['thought_signature'] = base64.b64decode(thinking_part_signature)
+        if supports_tools:
+            if (
+                item.provider_details
+                and (thought_signature := item.provider_details.get('thought_signature'))
+                and (m.provider_name == provider_name or item.provider_name == provider_name)
+            ):
+                part['thought_signature'] = base64.b64decode(thought_signature)
+            elif thinking_part_signature:
+                part['thought_signature'] = base64.b64decode(thinking_part_signature)
         thinking_part_signature = None
 
         if isinstance(item, ToolCallPart):
-            function_call = FunctionCallDict(name=item.tool_name, args=item.args_as_dict(), id=item.tool_call_id)
-            part['function_call'] = function_call
-            if function_call_requires_signature and not part.get('thought_signature'):
-                # Per https://ai.google.dev/gemini-api/docs/thought-signatures#faqs:
-                # > You can set the following dummy signatures of either "context_engineering_is_the_way_to_go"
-                # > or "skip_thought_signature_validator"
-                # Per https://cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures#using-rest-or-manual-handling:
-                # > You can set thought_signature to skip_thought_signature_validator
-                # We use "skip_thought_signature_validator" as it works for both Gemini API and Vertex AI.
-                part['thought_signature'] = b'skip_thought_signature_validator'
-            # Only the first function call requires a signature
-            function_call_requires_signature = False
+            if supports_tools:
+                function_call = FunctionCallDict(name=item.tool_name, args=item.args_as_dict(), id=item.tool_call_id)
+                part['function_call'] = function_call
+                if function_call_requires_signature and not part.get('thought_signature'):
+                    # Per https://ai.google.dev/gemini-api/docs/thought-signatures#faqs:
+                    # > You can set the following dummy signatures of either "context_engineering_is_the_way_to_go"
+                    # > or "skip_thought_signature_validator"
+                    # Per https://cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures#using-rest-or-manual-handling:
+                    # > You can set thought_signature to skip_thought_signature_validator
+                    # We use "skip_thought_signature_validator" as it works for both Gemini API and Vertex AI.
+                    part['thought_signature'] = b'skip_thought_signature_validator'
+                # Only the first function call requires a signature
+                function_call_requires_signature = False
+            else:
+                part['text'] = item.as_text()
         elif isinstance(item, TextPart):
             part['text'] = item.content
         elif isinstance(item, ThinkingPart):
-            if item.provider_name == provider_name and item.signature:
+            if supports_tools and item.provider_name == provider_name and item.signature:
                 # The thought signature is to be included on the _next_ part, not the thinking part itself
                 thinking_part_signature = item.signature
 
             if item.content:
                 part['text'] = item.content
-                part['thought'] = True
+                if supports_tools:
+                    part['thought'] = True
         elif isinstance(item, BuiltinToolCallPart):
             if item.provider_name == provider_name:
                 if item.tool_name == CodeExecutionTool.kind:

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -6042,3 +6042,82 @@ async def test_google_prompt_feedback_streaming(
         assert response_msg['provider_details']['safety_ratings'][0]['category'] == 'HARM_CATEGORY_DANGEROUS_CONTENT'
         assert response_msg['provider_details']['safety_ratings'][0]['probability'] == 'HIGH'
         assert response_msg['provider_details']['safety_ratings'][0]['blocked'] is True
+
+
+def test_tool_call_part_as_text():
+    part = ToolCallPart(tool_name='get_weather', args={'city': 'Paris'}, tool_call_id='call_123')
+    assert part.as_text() == snapshot(
+        '-----BEGIN TOOL_CALL id="call_123" name="get_weather"-----\n{"city":"Paris"}\n-----END TOOL_CALL-----'
+    )
+
+
+def test_tool_call_part_as_text_no_args():
+    part = ToolCallPart(tool_name='get_time', args=None, tool_call_id='call_456')
+    assert part.as_text() == snapshot(
+        '-----BEGIN TOOL_CALL id="call_456" name="get_time"-----\n{}\n-----END TOOL_CALL-----'
+    )
+
+
+def test_tool_return_part_as_text():
+    part = ToolReturnPart(tool_name='get_weather', content='Sunny, 25°C', tool_call_id='call_123')
+    assert part.as_text() == snapshot(
+        '-----BEGIN TOOL_RETURN id="call_123" name="get_weather"-----\nSunny, 25°C\n-----END TOOL_RETURN-----'
+    )
+
+
+def test_tool_return_part_as_text_dict_content():
+    part = ToolReturnPart(tool_name='get_weather', content={'temp': 25, 'condition': 'sunny'}, tool_call_id='call_789')
+    assert part.as_text() == snapshot(
+        '-----BEGIN TOOL_RETURN id="call_789" name="get_weather"-----\n{"temp":25,"condition":"sunny"}\n-----END TOOL_RETURN-----'
+    )
+
+
+def test_google_content_model_response_no_tool_support():
+    """When supports_tools=False, ToolCallPart should be converted to text."""
+    response = _content_model_response(
+        ModelResponse(
+            parts=[
+                ToolCallPart(tool_name='get_weather', args={'city': 'Paris'}, tool_call_id='call_123'),
+            ],
+            provider_name='google-gla',
+        ),
+        'google-gla',
+        supports_tools=False,
+    )
+    assert response == snapshot(
+        {
+            'role': 'model',
+            'parts': [
+                {
+                    'text': '-----BEGIN TOOL_CALL id="call_123" name="get_weather"-----\n{"city":"Paris"}\n-----END TOOL_CALL-----'
+                }
+            ],
+        }
+    )
+
+
+def test_google_content_model_response_no_tool_support_with_thinking():
+    """When supports_tools=False, thinking signatures should be omitted and thinking parts become plain text."""
+    signature = base64.b64encode(b'signature').decode('utf-8')
+    response = _content_model_response(
+        ModelResponse(
+            parts=[
+                ThinkingPart(content='Let me think about this...', signature=signature, provider_name='google-gla'),
+                ToolCallPart(tool_name='get_weather', args={'city': 'Paris'}, tool_call_id='call_123'),
+            ],
+            provider_name='google-gla',
+        ),
+        'google-gla',
+        supports_tools=False,
+    )
+    assert response == snapshot(
+        {
+            'role': 'model',
+            'parts': [
+                {'text': 'Let me think about this...'},
+                {
+                    'text': '-----BEGIN TOOL_CALL id="call_123" name="get_weather"-----\n{"city":"Paris"}\n-----END TOOL_CALL-----'
+                },
+            ],
+        }
+    )

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -6096,6 +6096,38 @@ def test_google_content_model_response_no_tool_support():
     )
 
 
+async def test_google_map_messages_tool_return_no_tool_support(google_provider: GoogleProvider):
+    """When supports_tools=False, ToolReturnPart in _map_messages should be converted to text."""
+    m = GoogleModel('gemini-2.5-flash-image', provider=google_provider)
+
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name='get_weather', content='Sunny, 25°C', tool_call_id='call_123'),
+                UserPromptPart(content='Describe the weather'),
+            ]
+        )
+    ]
+
+    _, contents = await m._map_messages(messages, ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
+
+    assert contents == snapshot(
+        [
+            {
+                'role': 'user',
+                'parts': [
+                    {
+                        'text': '-----BEGIN TOOL_RETURN id="call_123" name="get_weather"-----\nSunny, 25°C\n-----END TOOL_RETURN-----'
+                    },
+                    {
+                        'text': 'Describe the weather',
+                    },
+                ],
+            },
+        ]
+    )
+
+
 def test_google_content_model_response_no_tool_support_with_thinking():
     """When supports_tools=False, thinking signatures should be omitted and thinking parts become plain text."""
     signature = base64.b64encode(b'signature').decode('utf-8')


### PR DESCRIPTION
- Closes #3149

## Summary

Gemini image models (e.g. `gemini-2.0-flash-preview-image-generation`) reject `FunctionCall`/`FunctionResponse` parts in request content. When an agent has tool call history and then calls such a model, the API returns an error.

This PR adds a `supports_tools` parameter to `_map_messages()` and `_content_model_response()`. When `supports_tools=False`:

- `ToolCallPart` and `ToolReturnPart` are converted to plain text via new `as_text()` methods on `BaseToolCallPart` and `BaseToolReturnPart`
- The text format uses a fenced block style that preserves `tool_call_id` for parallel tool call disambiguation:
  ```
  -----BEGIN TOOL_CALL id="call_123" name="get_weather"-----
  {"city": "London"}
  -----END TOOL_CALL-----
  ```
- Thinking part signatures and thought flags are omitted (image models don't use them)

This follows the approach discussed in #3591 review comments:
- `as_text()` on the part classes (not inline in google.py)
- Include `tool_call_id` (parallel calls may share names)
- Fenced block format similar to OpenAI text files
- Use `model_response_str()` without prefixes for args

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.