### PR TITLE
feat: add ModelsLab provider

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -165,6 +165,10 @@ def infer_provider_class(provider: str) -> type[Provider[Any]]:  # noqa: C901
         from .sentence_transformers import SentenceTransformersProvider
 
         return SentenceTransformersProvider
+    elif provider == 'modelslab':
+        from .modelslab import ModelsLabProvider
+
+        return ModelsLabProvider
     elif provider == 'voyageai':
         from .voyageai import VoyageAIProvider
 

--- a/pydantic_ai_slim/pydantic_ai/providers/modelslab.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/modelslab.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from pydantic_ai import ModelProfile
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.models import cached_async_http_client
+from pydantic_ai.profiles.deepseek import deepseek_model_profile
+from pydantic_ai.profiles.meta import meta_model_profile
+from pydantic_ai.profiles.mistral import mistral_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
+from pydantic_ai.providers import Provider
+
+try:
+    from openai import AsyncOpenAI
+except ImportError as _import_error:  # pragma: no cover
+    raise ImportError(
+        'Please install the `openai` package to use the ModelsLab provider, '
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
+    ) from _import_error
+
+__all__ = ['ModelsLabProvider']
+
+
+class ModelsLabProvider(Provider[AsyncOpenAI]):
+    """Provider for ModelsLab's uncensored chat API.
+
+    ModelsLab (https://modelslab.com) provides access to open-source LLMs
+    including Llama, Mistral, DeepSeek, and community models via an
+    OpenAI-compatible endpoint.
+
+    API docs: https://docs.modelslab.com
+    API key: https://modelslab.com/account/api-key
+    """
+
+    @property
+    def name(self) -> str:
+        return 'modelslab'
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        return self._client
+
+    def model_profile(self, model_name: str) -> ModelProfile | None:
+        """Get model profile for ModelsLab models.
+
+        ModelsLab hosts models from multiple families. Profiles are matched
+        based on model name prefixes.
+        """
+        model_name_lower = model_name.lower()
+
+        if 'llama' in model_name_lower or 'meta-llama' in model_name_lower:
+            profile = meta_model_profile(model_name)
+        elif 'deepseek' in model_name_lower:
+            profile = deepseek_model_profile(model_name)
+        elif 'mistral' in model_name_lower or 'mixtral' in model_name_lower:
+            profile = mistral_model_profile(model_name)
+        else:
+            profile = None
+
+        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        openai_client: AsyncOpenAI | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Initialize ModelsLab provider.
+
+        Args:
+            api_key: ModelsLab API key. If not provided, reads from MODELSLAB_API_KEY env var.
+            base_url: Custom API base URL. Defaults to https://modelslab.com/api/uncensored-chat/v1
+            openai_client: Optional pre-configured AsyncOpenAI client.
+            http_client: Optional custom httpx.AsyncClient for making HTTP requests.
+
+        Raises:
+            UserError: If API key is not provided and MODELSLAB_API_KEY env var is not set.
+        """
+        if openai_client is not None:
+            self._client = openai_client
+            self._base_url = str(openai_client.base_url)
+        else:
+            api_key = api_key or os.getenv('MODELSLAB_API_KEY')
+            if not api_key:
+                raise UserError(
+                    'Set the `MODELSLAB_API_KEY` environment variable or pass it via '
+                    '`ModelsLabProvider(api_key=...)` to use the ModelsLab provider.'
+                )
+
+            self._base_url = base_url or os.getenv(
+                'MODELSLAB_BASE_URL',
+                'https://modelslab.com/api/uncensored-chat/v1',
+            )
+
+            http_client = http_client or cached_async_http_client(provider='modelslab')
+            self._client = AsyncOpenAI(base_url=self._base_url, api_key=api_key, http_client=http_client)

--- a/tests/providers/test_modelslab_provider.py
+++ b/tests/providers/test_modelslab_provider.py
@@ -1,0 +1,77 @@
+import httpx
+import pytest
+
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.profiles.openai import OpenAIModelProfile
+
+from ..conftest import TestEnv, try_import
+
+with try_import() as imports_successful:
+    from openai import AsyncOpenAI
+
+    from pydantic_ai.providers.modelslab import ModelsLabProvider
+
+pytestmark = pytest.mark.skipif(not imports_successful(), reason='openai not installed')
+
+DEFAULT_BASE_URL = 'https://modelslab.com/api/uncensored-chat/v1'
+
+
+def test_modelslab_provider_init(env: TestEnv) -> None:
+    env.set('MODELSLAB_API_KEY', 'test-key')
+    provider = ModelsLabProvider()
+    assert provider.name == 'modelslab'
+    assert DEFAULT_BASE_URL in provider.base_url
+    assert isinstance(provider.client, AsyncOpenAI)
+
+
+def test_modelslab_provider_custom_base_url(env: TestEnv) -> None:
+    custom_url = 'https://custom.modelslab.example.com/v1'
+    provider = ModelsLabProvider(api_key='test-key', base_url=custom_url)
+    assert custom_url in provider.base_url
+
+
+def test_modelslab_provider_with_openai_client(env: TestEnv) -> None:
+    client = AsyncOpenAI(api_key='test-key', base_url=DEFAULT_BASE_URL)
+    provider = ModelsLabProvider(openai_client=client)
+    assert provider.client is client
+
+
+def test_modelslab_provider_with_http_client(env: TestEnv) -> None:
+    env.set('MODELSLAB_API_KEY', 'test-key')
+    http_client = httpx.AsyncClient()
+    provider = ModelsLabProvider(http_client=http_client)
+    assert provider.client.http_client is http_client
+
+
+def test_modelslab_provider_no_api_key(env: TestEnv) -> None:
+    env.remove('MODELSLAB_API_KEY')
+    with pytest.raises(UserError, match='MODELSLAB_API_KEY'):
+        ModelsLabProvider()
+
+
+def test_modelslab_model_profile_llama(env: TestEnv) -> None:
+    env.set('MODELSLAB_API_KEY', 'test-key')
+    provider = ModelsLabProvider()
+    profile = provider.model_profile('meta-llama/Meta-Llama-3-8B-Instruct')
+    assert isinstance(profile, OpenAIModelProfile)
+
+
+def test_modelslab_model_profile_deepseek(env: TestEnv) -> None:
+    env.set('MODELSLAB_API_KEY', 'test-key')
+    provider = ModelsLabProvider()
+    profile = provider.model_profile('deepseek-chat')
+    assert isinstance(profile, OpenAIModelProfile)
+
+
+def test_modelslab_model_profile_mistral(env: TestEnv) -> None:
+    env.set('MODELSLAB_API_KEY', 'test-key')
+    provider = ModelsLabProvider()
+    profile = provider.model_profile('mistral-7b-instruct')
+    assert isinstance(profile, OpenAIModelProfile)
+
+
+def test_modelslab_model_profile_unknown(env: TestEnv) -> None:
+    env.set('MODELSLAB_API_KEY', 'test-key')
+    provider = ModelsLabProvider()
+    profile = provider.model_profile('some-custom-model')
+    assert isinstance(profile, OpenAIModelProfile)


### PR DESCRIPTION
## Summary

Adds `ModelsLabProvider` for [ModelsLab](https://modelslab.com)'s OpenAI-compatible chat API, following the **SambaNova** provider pattern exactly.

ModelsLab hosts open-source LLMs (Llama, Mistral, and community models) via an OpenAI-compatible endpoint. It's particularly useful for uncensored/open-weight model access.

## Usage

```python
from pydantic_ai import Agent
from pydantic_ai.providers.modelslab import ModelsLabProvider

agent = Agent(
    'openai:meta-llama/Meta-Llama-3-8B-Instruct',
    model_provider=ModelsLabProvider(api_key='your-key'),
)
# or set MODELSLAB_API_KEY env var
```

## Files (3 files)

| File | Change |
|------|--------|
| `providers/modelslab.py` | New `ModelsLabProvider` class |
| `providers/__init__.py` | Register `'modelslab'` in factory |
| `tests/providers/test_modelslab_provider.py` | Tests (mirrors sambanova pattern) |

## Details

- **Base URL**: `https://modelslab.com/api/uncensored-chat/v1`
- **Auth**: Bearer token (`MODELSLAB_API_KEY` env var)
- **SDK**: OpenAI-compatible (uses `AsyncOpenAI` client)
- **Model profiles**: Llama models use `meta_model_profile`, others use base OpenAI profile
- **API key**: https://modelslab.com/account/api-key
- **Docs**: https://docs.modelslab.com