### PR TITLE
Use streaming in LLMJudge to avoid Anthropic SDK timeout error

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
+++ b/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
@@ -65,9 +65,10 @@ async def judge_output(
     but this can be changed using the `set_default_judge_model` function.
     """
     user_prompt = _build_prompt(output=output, rubric=rubric)
-    return (
-        await _judge_output_agent.run(user_prompt, model=model or _default_model, model_settings=model_settings)
-    ).output
+    async with _judge_output_agent.run_stream(
+        user_prompt, model=model or _default_model, model_settings=model_settings
+    ) as stream:
+        return await stream.get_output()
 
 
 _judge_input_output_agent = Agent(
@@ -107,9 +108,10 @@ async def judge_input_output(
     """
     user_prompt = _build_prompt(inputs=inputs, output=output, rubric=rubric)
 
-    return (
-        await _judge_input_output_agent.run(user_prompt, model=model or _default_model, model_settings=model_settings)
-    ).output
+    async with _judge_input_output_agent.run_stream(
+        user_prompt, model=model or _default_model, model_settings=model_settings
+    ) as stream:
+        return await stream.get_output()
 
 
 _judge_input_output_expected_agent = Agent(
@@ -152,11 +154,10 @@ async def judge_input_output_expected(
     """
     user_prompt = _build_prompt(inputs=inputs, output=output, rubric=rubric, expected_output=expected_output)
 
-    return (
-        await _judge_input_output_expected_agent.run(
-            user_prompt, model=model or _default_model, model_settings=model_settings
-        )
-    ).output
+    async with _judge_input_output_expected_agent.run_stream(
+        user_prompt, model=model or _default_model, model_settings=model_settings
+    ) as stream:
+        return await stream.get_output()
 
 
 _judge_output_expected_agent = Agent(
@@ -195,11 +196,10 @@ async def judge_output_expected(
     but this can be changed using the `set_default_judge_model` function.
     """
     user_prompt = _build_prompt(output=output, rubric=rubric, expected_output=expected_output)
-    return (
-        await _judge_output_expected_agent.run(
-            user_prompt, model=model or _default_model, model_settings=model_settings
-        )
-    ).output
+    async with _judge_output_expected_agent.run_stream(
+        user_prompt, model=model or _default_model, model_settings=model_settings
+    ) as stream:
+        return await stream.get_output()
 
 
 def set_default_judge_model(model: models.Model | models.KnownModelName) -> None:

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -20,6 +20,18 @@ with try_import() as imports_successful:
 pytestmark = [pytest.mark.skipif(not imports_successful(), reason='pydantic-evals not installed'), pytest.mark.anyio]
 
 
+def _mock_run_stream(mocker: MockerFixture, grading_output: GradingOutput):
+    """Mock AbstractAgent.run_stream to return the given GradingOutput."""
+    mock_stream = mocker.MagicMock()
+    mock_stream.get_output = mocker.AsyncMock(return_value=grading_output)
+
+    mock_run_stream = mocker.patch('pydantic_ai.agent.AbstractAgent.run_stream')
+    mock_run_stream.return_value.__aenter__ = mocker.AsyncMock(return_value=mock_stream)
+    mock_run_stream.return_value.__aexit__ = mocker.AsyncMock(return_value=False)
+
+    return mock_run_stream
+
+
 def test_grading_output():
     """Test GradingOutput model."""
     # Test with pass=True
@@ -72,10 +84,7 @@ def test_stringify():
 @pytest.mark.anyio
 async def test_judge_output_mock(mocker: MockerFixture):
     """Test judge_output function with mocked agent."""
-    # Mock the agent run method
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed', pass_=True, score=1.0))
 
     # Test with string output
     grading_output = await judge_output('Hello world', 'Content contains a greeting')
@@ -94,9 +103,7 @@ async def test_judge_output_mock(mocker: MockerFixture):
 @pytest.mark.anyio
 async def test_judge_output_with_model_settings_mock(mocker: MockerFixture):
     """Test judge_output function with model_settings and mocked agent."""
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed with settings', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed with settings', pass_=True, score=1.0))
 
     test_model_settings = ModelSettings(temperature=1)
 
@@ -122,10 +129,7 @@ async def test_judge_output_with_model_settings_mock(mocker: MockerFixture):
 @pytest.mark.anyio
 async def test_judge_input_output_mock(mocker: MockerFixture):
     """Test judge_input_output function with mocked agent."""
-    # Mock the agent run method
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed', pass_=True, score=1.0))
 
     # Test with string input and output
     result = await judge_input_output('Hello', 'Hello world', 'Output contains input')
@@ -144,10 +148,7 @@ async def test_judge_input_output_mock(mocker: MockerFixture):
 
 async def test_judge_input_output_binary_content_list_mock(mocker: MockerFixture, image_content: BinaryContent):
     """Test judge_input_output function with mocked agent."""
-    # Mock the agent run method
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed', pass_=True, score=1.0))
 
     result = await judge_input_output([image_content, image_content], 'Hello world', 'Output contains input')
     assert isinstance(result, GradingOutput)
@@ -168,10 +169,7 @@ async def test_judge_input_output_binary_content_list_mock(mocker: MockerFixture
 
 async def test_judge_binary_output_mock(mocker: MockerFixture, image_content: BinaryContent) -> None:
     """Test judge_output function when binary content is to be judged"""
-    # Mock the agent run method
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed', pass_=True, score=1.0))
 
     result = await judge_output(output=image_content, rubric='dummy rubric')
     assert isinstance(result, GradingOutput)
@@ -188,10 +186,7 @@ async def test_judge_binary_output_mock(mocker: MockerFixture, image_content: Bi
 
 async def test_judge_input_output_binary_content_mock(mocker: MockerFixture, image_content: BinaryContent):
     """Test judge_input_output function with mocked agent."""
-    # Mock the agent run method
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed', pass_=True, score=1.0))
 
     result = await judge_input_output(image_content, 'Hello world', 'Output contains input')
     assert isinstance(result, GradingOutput)
@@ -213,9 +208,7 @@ async def test_judge_input_output_binary_content_mock(mocker: MockerFixture, ima
 @pytest.mark.anyio
 async def test_judge_input_output_with_model_settings_mock(mocker: MockerFixture):
     """Test judge_input_output function with model_settings and mocked agent."""
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed with settings', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed with settings', pass_=True, score=1.0))
 
     test_model_settings = ModelSettings(temperature=1)
 
@@ -243,10 +236,7 @@ async def test_judge_input_output_with_model_settings_mock(mocker: MockerFixture
 @pytest.mark.anyio
 async def test_judge_input_output_expected_mock(mocker: MockerFixture, image_content: BinaryContent):
     """Test judge_input_output_expected function with mocked agent."""
-    # Mock the agent run method
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed', pass_=True, score=1.0))
 
     # Test with string input and output
     result = await judge_input_output_expected('Hello', 'Hello world', 'Hello', 'Output contains input')
@@ -308,9 +298,7 @@ async def test_judge_input_output_expected_with_model_settings_mock(
     mocker: MockerFixture, image_content: BinaryContent
 ):
     """Test judge_input_output_expected function with model_settings and mocked agent."""
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed with settings', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed with settings', pass_=True, score=1.0))
 
     test_model_settings = ModelSettings(temperature=1)
 
@@ -457,10 +445,7 @@ Hello
 @pytest.mark.anyio
 async def test_judge_output_expected_mock(mocker: MockerFixture):
     """Test judge_output_expected function with mocked agent."""
-    # Mock the agent run method
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed', pass_=True, score=1.0))
 
     # Test with string output and expected output
     result = await judge_output_expected('Hello world', 'Hello', 'Output contains input')
@@ -480,9 +465,7 @@ async def test_judge_output_expected_mock(mocker: MockerFixture):
 @pytest.mark.anyio
 async def test_judge_output_expected_with_model_settings_mock(mocker: MockerFixture, image_content: BinaryContent):
     """Test judge_output_expected function with model_settings and mocked agent."""
-    mock_result = mocker.MagicMock()
-    mock_result.output = GradingOutput(reason='Test passed with settings', pass_=True, score=1.0)
-    mock_run = mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+    mock_run = _mock_run_stream(mocker, GradingOutput(reason='Test passed with settings', pass_=True, score=1.0))
 
     test_model_settings = ModelSettings(temperature=1)
 


### PR DESCRIPTION
- Closes #4491

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.