### PR TITLE
Use FastAPI `EventSourceResponse` in `streaming_response()`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_event_stream.py
@@ -123,19 +123,21 @@ class UIEventStream(ABC, Generic[RunInputT, EventT, AgentDepsT, OutputDataT]):
     def streaming_response(self, stream: AsyncIterator[EventT]) -> StreamingResponse:
         """Generate a streaming response from a stream of protocol-specific events.
 
-        When FastAPI >= 0.135.0 is available, uses `EventSourceResponse` for Rust-side
-        serialization and automatic keep-alive pings. Falls back to Starlette's
-        `StreamingResponse` otherwise.
+        When FastAPI >= 0.135.0 is available and the content type is SSE, uses
+        `EventSourceResponse` to integrate with FastAPI's SSE handling (including
+        automatic keep-alive pings and appropriate headers). Falls back to Starlette's
+        `StreamingResponse` otherwise. Serialization/encoding of events is still
+        handled by `encode_event()`.
         """
-        # Prefer FastAPI's EventSourceResponse for Rust-side serialization + keep-alive
-        if fastapi_sse := _get_fastapi_sse():
+        # Prefer FastAPI's EventSourceResponse for keep-alive pings and SSE headers
+        if self.content_type == SSE_CONTENT_TYPE and (fastapi_sse := _get_fastapi_sse()):
             EventSourceResponse, ServerSentEvent = fastapi_sse
 
             async def sse_stream() -> AsyncIterator[ServerSentEvent]:
                 async for event in stream:
                     yield ServerSentEvent(raw_data=self.encode_event(event))
 
-            return EventSourceResponse(  # type: ignore[return-value]
+            return EventSourceResponse(
                 sse_stream(),
                 headers=self.response_headers,
             )

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -722,3 +722,93 @@ def test_dummy_adapter_dump_messages():
     messages = [ModelRequest(parts=[UserPromptPart(content='Hello')])]
     result = DummyUIAdapter.dump_messages(messages)
     assert result == messages
+
+
+async def test_streaming_response_uses_fastapi_sse_when_available(monkeypatch: pytest.MonkeyPatch):
+    """When FastAPI SSE classes are available and content type is SSE, uses EventSourceResponse."""
+    from unittest.mock import MagicMock
+
+    from pydantic_ai.ui._event_stream import _get_fastapi_sse
+
+    MockServerSentEvent = MagicMock(name='ServerSentEvent')
+
+    class MockEventSourceResponse(StreamingResponse):
+        """Mock that tracks it was used."""
+
+        was_used = False
+
+        def __init__(self, *args: Any, **kwargs: Any):
+            MockEventSourceResponse.was_used = True
+            # Don't call super — just record that this path was taken
+
+    _get_fastapi_sse.cache_clear()
+    monkeypatch.setattr(
+        'pydantic_ai.ui._event_stream._get_fastapi_sse',
+        lambda: (MockEventSourceResponse, MockServerSentEvent),
+    )
+
+    async def dummy_stream() -> AsyncIterator[str]:
+        yield 'event1'
+
+    event_stream = DummyUIEventStream[None, str](DummyUIRunInput())
+    response = event_stream.streaming_response(dummy_stream())
+
+    assert isinstance(response, MockEventSourceResponse)
+    assert MockEventSourceResponse.was_used
+
+    # Restore cache
+    _get_fastapi_sse.cache_clear()
+
+
+async def test_streaming_response_falls_back_for_non_sse_content_type(monkeypatch: pytest.MonkeyPatch):
+    """When content type is not SSE, falls back to StreamingResponse even if FastAPI SSE is available."""
+    from unittest.mock import MagicMock
+
+    from pydantic_ai.ui._event_stream import _get_fastapi_sse
+
+    MockServerSentEvent = MagicMock(name='ServerSentEvent')
+    MockEventSourceResponse = MagicMock(name='EventSourceResponse')
+
+    _get_fastapi_sse.cache_clear()
+    monkeypatch.setattr(
+        'pydantic_ai.ui._event_stream._get_fastapi_sse',
+        lambda: (MockEventSourceResponse, MockServerSentEvent),
+    )
+
+    async def dummy_stream() -> AsyncIterator[str]:
+        yield 'event1'
+
+    event_stream = DummyUIEventStream[None, str](DummyUIRunInput())
+    # Override content_type to simulate a non-SSE subclass (e.g., AG-UI)
+    monkeypatch.setattr(type(event_stream), 'content_type', property(lambda self: 'application/json'))
+
+    response = event_stream.streaming_response(dummy_stream())
+
+    assert isinstance(response, StreamingResponse)
+    MockEventSourceResponse.assert_not_called()
+
+    # Restore cache
+    _get_fastapi_sse.cache_clear()
+
+
+async def test_streaming_response_falls_back_when_fastapi_unavailable(monkeypatch: pytest.MonkeyPatch):
+    """When FastAPI SSE is not available, uses Starlette StreamingResponse."""
+    from pydantic_ai.ui._event_stream import _get_fastapi_sse
+
+    _get_fastapi_sse.cache_clear()
+    monkeypatch.setattr(
+        'pydantic_ai.ui._event_stream._get_fastapi_sse',
+        lambda: None,
+    )
+
+    async def dummy_stream() -> AsyncIterator[str]:
+        yield 'event1'
+
+    event_stream = DummyUIEventStream[None, str](DummyUIRunInput())
+    response = event_stream.streaming_response(dummy_stream())
+
+    assert isinstance(response, StreamingResponse)
+    assert response.media_type == 'text/event-stream'
+
+    # Restore cache
+    _get_fastapi_sse.cache_clear()


### PR DESCRIPTION
## Summary

Hey team! 

Love the project and everything pydantic does, please let me know if I missed something.

This is a small, backward-compatible change to `UIEventStream.streaming_response()` that uses FastAPI's `EventSourceResponse` when available (FastAPI >= 0.135.0), falling back to the existing Starlette `StreamingResponse` otherwise.

### What this improves

- **Automatic keep-alive pings** — 15-second ping comments prevent proxy/CDN timeouts during long LLM generations (common with tool-heavy agents)
- **Automatic SSE headers** — `Cache-Control: no-cache` and `X-Accel-Buffering: no` (Nginx compatibility) are set automatically
- **Cached import check** using `@lru_cache` — the FastAPI SSE classes are resolved once per process, zero overhead after the first call
- Uses `raw_data=` (not `data=`) since `encode_event()` already returns a fully-formatted SSE string, avoiding double-encoding

### What this does NOT do

This PR doesn't provide a serialization speedup — we still call `encode_event()` on the Python side before passing the string to `ServerSentEvent(raw_data=...)`. The Rust-side serialization benefit would require a deeper refactor where `encode_event()` is bypassed entirely and Pydantic models are passed via `ServerSentEvent(data=model)`. That's a much bigger change affecting all subclasses (VercelAI, AG-UI, etc.) and could be explored as a follow-up.

### Questions for reviewers

I'd love to get your thoughts on the approach — in particular:
- Is the `lru_cache` pattern the right way to handle the optional FastAPI dependency here, or would you prefer something different?
- Should we gate this on detecting a FastAPI app (via the request) rather than just checking if `fastapi.sse` is importable?
- Any concerns about depending on the `raw_data` parameter of `ServerSentEvent`?

Happy to adjust based on your feedback!

Closes #4493

## Test plan

- [x] All 121 existing UI tests pass (`test_ui.py`, `test_vercel_ai.py`, `test_ag_ui.py`)
- [ ] Manual testing with a FastAPI app to verify `EventSourceResponse` path
- [ ] Manual testing with plain Starlette to verify fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)