### PR TITLE
fix(anthropic): auto-fallback to streaming for high `max_tokens`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -309,11 +309,21 @@ class AnthropicModel(Model):
             model_settings,
             model_request_parameters,
         )
-        response = await self._messages_create(
-            messages, False, cast(AnthropicModelSettings, model_settings or {}), model_request_parameters
-        )
-        model_response = self._process_response(response)
-        return model_response
+        model_settings = cast(AnthropicModelSettings, model_settings or {})
+        try:
+            response = await self._messages_create(messages, False, model_settings, model_request_parameters)
+            return self._process_response(response)
+        except ValueError as e:
+            if 'Streaming is required' in str(e):
+                # Anthropic SDK requires streaming for high max_tokens; fall back transparently
+                # https://github.com/anthropics/anthropic-sdk-python/blob/49d639a671cb0ac30c767e8e1e68fdd5925205d5/src/anthropic/_base_client.py#L726
+                stream = await self._messages_create(messages, True, model_settings, model_request_parameters)
+                async with stream:
+                    streamed_response = await self._process_streamed_response(stream, model_request_parameters)
+                    async for _ in streamed_response:
+                        pass
+                    return streamed_response.get()
+            raise  # pragma: no cover
 
     async def count_tokens(
         self,

--- a/tests/models/cassettes/test_anthropic/test_request_stream_fallback_for_high_max_tokens.yaml
+++ b/tests/models/cassettes/test_anthropic/test_request_stream_fallback_for_high_max_tokens.yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '183'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 32000
+      messages:
+      - content:
+        - text: What is 1+1? Answer with just the number.
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: true
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: |+
+        event: message_start
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_018E1hg8GoVTGEKQY3ovMcSJ","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}            }
+
+        event: content_block_start
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}        }
+
+        event: ping
+        data: {"type": "ping"}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"2"}      }
+
+        event: content_block_stop
+        data: {"type":"content_block_stop","index":0        }
+
+        event: message_delta
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5}       }
+
+        event: message_stop
+        data: {"type":"message_stop"    }
+
+    headers:
+      cache-control:
+      - no-cache
+      connection:
+      - keep-alive
+      content-length:
+      - '1123'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - text/event-stream; charset=utf-8
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1
+...

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -1099,6 +1099,57 @@ async def test_async_request_text_response(allow_model_requests: None):
     )
 
 
+async def test_request_stream_fallback_for_high_max_tokens(
+    allow_model_requests: None, anthropic_api_key: str, vcr: Any
+):
+    """When the Anthropic SDK raises ValueError for high max_tokens, request() falls back to streaming."""
+    # https://github.com/anthropics/anthropic-sdk-python/blob/49d639a671cb0ac30c767e8e1e68fdd5925205d5/src/anthropic/_base_client.py#L726
+    m = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key=anthropic_api_key))
+    agent = Agent(m)
+
+    result = await agent.run(
+        'What is 1+1? Answer with just the number.', model_settings=ModelSettings(max_tokens=32_000)
+    )
+
+    # Verify the fallback used streaming — the only request recorded should have stream=true
+    assert len(vcr.requests) == 1
+    request_body = json.loads(vcr.requests[0].body)
+    assert request_body['stream'] is True
+    assert request_body['max_tokens'] == 32_000
+
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='What is 1+1? Answer with just the number.', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='2')],
+                usage=RequestUsage(
+                    input_tokens=20,
+                    output_tokens=5,
+                    details={
+                        'cache_creation_input_tokens': 0,
+                        'cache_read_input_tokens': 0,
+                        'input_tokens': 20,
+                        'output_tokens': 5,
+                    },
+                ),
+                model_name='claude-sonnet-4-5-20250929',
+                timestamp=IsDatetime(),
+                provider_name='anthropic',
+                provider_url='https://api.anthropic.com',
+                provider_details={'finish_reason': 'end_turn'},
+                provider_response_id=IsStr(),
+                finish_reason='stop',
+                run_id=IsStr(),
+            ),
+        ]
+    )
+    assert result.output == snapshot('2')
+
+
 async def test_request_structured_response(allow_model_requests: None):
     c = completion_message(
         [BetaToolUseBlock(id='123', input={'response': [1, 2, 3]}, name='final_result', type='tool_use')],


### PR DESCRIPTION
When the Anthropic SDK raises `ValueError("Streaming is required...")` for high `max_tokens` (>~21k), transparently fall back to streaming inside `AnthropicModel.request()` instead of surfacing an opaque error to users.

Fixes #4491