### PR TITLE
ci: Add PR issue guard workflow to prevent duplicate PRs

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -16,6 +16,7 @@ jobs:
   guard:
     name: Guard
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check linked issues and guard against duplicates
         run: |
@@ -72,6 +73,8 @@ jobs:
           # Done outside the loop to avoid repeated paginated calls when multiple issues are referenced.
           ALL_OPEN_PRS=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate || true)
 
+          FOUND_OPEN_ISSUE="false"
+          FOUND_CLOSED_ISSUE="false"
           for ISSUE_NUM in $ISSUE_NUMBERS; do
             echo ""
             echo "--- Checking issue #${ISSUE_NUM} ---"
@@ -88,6 +91,16 @@ jobs:
               echo "#${ISSUE_NUM} is a pull request, not an issue. Skipping."
               continue
             fi
+
+            # Skip closed issues — duplicate check only applies to open issues
+            ISSUE_STATE=$(echo "$ISSUE_JSON" | jq -r '.state')
+            if [ "$ISSUE_STATE" != "open" ]; then
+              echo "Issue #${ISSUE_NUM} is ${ISSUE_STATE}, skipping."
+              FOUND_CLOSED_ISSUE="true"
+              continue
+            fi
+
+            FOUND_OPEN_ISSUE="true"
 
             # Check current assignees
             ASSIGNEES=$(echo "$ISSUE_JSON" | jq -r '[.assignees[].login] | join(",")')
@@ -108,8 +121,7 @@ jobs:
             # Issue is assigned to someone else — check for their open PRs
             echo "Issue #${ISSUE_NUM} is assigned to someone else. Checking for existing PRs..."
 
-            BLOCKING_PR=""
-            ASSIGNEE_WITH_PR=""
+            BLOCKING_PRS=""
             FOUND_STALE_PR="false"
             IFS=',' read -ra ASSIGNEE_LIST <<< "$ASSIGNEES"
             for ASSIGNEE in "${ASSIGNEE_LIST[@]}"; do
@@ -129,22 +141,22 @@ jobs:
                   continue
                 fi
 
-                BLOCKING_PR="$EXISTING_PR_NUM"
-                ASSIGNEE_WITH_PR="$ASSIGNEE"
-                break
+                # Collect all non-stale blocking PRs
+                if [ -z "$BLOCKING_PRS" ]; then
+                  BLOCKING_PRS="#${EXISTING_PR_NUM}"
+                else
+                  BLOCKING_PRS="${BLOCKING_PRS}, #${EXISTING_PR_NUM}"
+                fi
               done <<< "$MATCHING_PRS"
-
-              if [ -n "$BLOCKING_PR" ]; then
-                break
-              fi
             done
 
-            if [ -n "$BLOCKING_PR" ]; then
-              echo "Closing PR #${PR_NUMBER} — issue #${ISSUE_NUM} is already being worked on in PR #${BLOCKING_PR}."
+            if [ -n "$BLOCKING_PRS" ]; then
+              echo "Closing PR #${PR_NUMBER} — issue #${ISSUE_NUM} already has active PRs: ${BLOCKING_PRS}"
 
-              COMMENT=$(printf '%s\n\n%s' \
-                "Thanks for your interest in this issue! However, issue #${ISSUE_NUM} is already assigned to @${ASSIGNEE_WITH_PR}, who has an open PR (#${BLOCKING_PR}) addressing it." \
-                "To avoid duplicate efforts, this PR has been closed. If you believe the existing PR is inactive or you have a different approach to discuss, please comment on [issue #${ISSUE_NUM}](https://github.com/${REPO}/issues/${ISSUE_NUM}).")
+              COMMENT=$(printf '%s\n\n%s\n\n%s' \
+                "Thanks for your interest in this issue! However, there are already open PRs addressing issue #${ISSUE_NUM}: ${BLOCKING_PRS}." \
+                "To avoid duplicate efforts, this PR has been closed. If you'd like to contribute, you can review the existing PRs or share your thoughts on [issue #${ISSUE_NUM}](https://github.com/${REPO}/issues/${ISSUE_NUM})." \
+                "If you believe the existing PRs are inactive, please comment on the issue and a maintainer can reassess.")
               gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT"
               gh pr close "$PR_NUMBER" --repo "$REPO"
               exit 0
@@ -160,6 +172,13 @@ jobs:
               echo "No active non-stale PR found from current assignees. Leaving assignment as-is for maintainers to review."
             fi
           done
+
+          # If we found closed issues but no open ones, close the PR
+          if [ "$FOUND_CLOSED_ISSUE" = "true" ] && [ "$FOUND_OPEN_ISSUE" = "false" ]; then
+            echo "All referenced issues are closed. Closing PR."
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "All issues referenced by this PR are already closed. If you believe an issue should be reopened, please comment on it first."
+            gh pr close "$PR_NUMBER" --repo "$REPO"
+          fi
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- Adds a new `pr-issue-guard.yml` GitHub Actions workflow that auto-assigns issues to PR authors and closes duplicate PRs when someone else is already actively working on the same issue
- Detects all 9 GitHub closing keywords (`close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved`) in PR bodies
- Allows new PRs to supersede stale ones (using the existing `Stale` label from `stale.yml`)
- Maintainers (`MEMBER`, `OWNER`, `COLLABORATOR`) bypass all checks
- Checks user assignability before attempting assignment (GitHub silently ignores non-assignable users)

## Test plan

- [ ] Open a PR with `Closes #N` where N is an unassigned issue → should auto-assign
- [ ] Open a second PR for the same issue → should be closed with comment
- [ ] Open a draft PR → should be ignored entirely
- [ ] Test with a maintainer account → should bypass all checks
- [ ] Test with a stale existing PR → new PR should be allowed and issue reassigned