### PR TITLE
fix: add `__reduce__` to exception classes for pickle support

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -222,6 +222,9 @@ class ToolRetryError(Exception):
         )
         super().__init__(message)
 
+    def __reduce__(self) -> tuple[type, tuple[Any, ...]]:
+        return self.__class__, (self.tool_retry,)
+
     @staticmethod
     def _format_error_details(errors: list[pydantic_core.ErrorDetails], tool_name: str | None) -> str:
         """Format ErrorDetails as a human-readable message.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -126,6 +126,20 @@ def test_exceptions_pickle_round_trip(exc_factory: Callable[[], Exception], chec
         assert getattr(restored, attr) == expected
 
 
+def test_tool_retry_error_pickle_round_trip():
+    """Test that ToolRetryError survives pickle round-trip with tool_retry preserved."""
+    part = RetryPromptPart(content='retry this', tool_name='my_tool')
+    exc = ToolRetryError(part)
+    restored = pickle.loads(pickle.dumps(exc))
+
+    assert type(restored) is ToolRetryError
+    assert str(restored) == str(exc)
+    assert restored.tool_retry.content == 'retry this'
+    assert restored.tool_retry.tool_name == 'my_tool'
+    assert restored.tool_retry.tool_call_id == part.tool_call_id
+    assert restored.tool_retry.timestamp == part.timestamp
+
+
 def test_tool_retry_error_str_with_string_content():
     """Test that ToolRetryError uses string content as message automatically."""
     part = RetryPromptPart(content='error from tool', tool_name='my_tool')


### PR DESCRIPTION
## Summary

Closes #4503

Several exception classes with custom `__init__` parameters that aren't passed to `super().__init__()` lose attributes during pickle round-trips. This adds `__reduce__` methods to:

- `CallDeferred` — preserves `metadata`
- `ApprovalRequired` — preserves `metadata`
- `UnexpectedModelBehavior` — preserves `message` and `body`
- `ModelAPIError` — preserves `model_name` and `message`
- `ModelHTTPError` — preserves `status_code`, `model_name`, and `body`

Subclasses (`ContentFilterError`, `IncompleteToolCall`) inherit the fix automatically.

## Test plan

- [x] Added parametrized `test_exceptions_pickle_round_trip` covering all 16 exception variants (with/without optional args)
- [x] Asserts `type`, `str()`, and all custom attributes survive `pickle.loads(pickle.dumps(exc))`
- [x] All 30 tests pass (`pytest tests/test_exceptions.py`)
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AI generated code -->