### PR TITLE
fix(exceptions): make ModelHTTPError and related exceptions picklable

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -85,6 +85,9 @@ class CallDeferred(Exception):
         self.metadata = metadata
         super().__init__()
 
+    def __reduce__(self) -> tuple[type[CallDeferred], tuple[dict[str, Any] | None]]:
+        return type(self), (self.metadata,)
+
 
 class ApprovalRequired(Exception):
     """Exception to raise when a tool call requires human-in-the-loop approval.
@@ -99,6 +102,9 @@ class ApprovalRequired(Exception):
     def __init__(self, metadata: dict[str, Any] | None = None):
         self.metadata = metadata
         super().__init__()
+
+    def __reduce__(self) -> tuple[type[ApprovalRequired], tuple[dict[str, Any] | None]]:
+        return type(self), (self.metadata,)
 
 
 class UserError(RuntimeError):
@@ -153,6 +159,9 @@ class UnexpectedModelBehavior(AgentRunError):
                 self.body = body
         super().__init__(message)
 
+    def __reduce__(self) -> tuple[type[UnexpectedModelBehavior], tuple[str, str | None]]:
+        return type(self), (self.message, self.body)
+
     def __str__(self) -> str:
         if self.body:
             return f'{self.message}, body:\n{self.body}'
@@ -174,6 +183,9 @@ class ModelAPIError(AgentRunError):
         self.model_name = model_name
         super().__init__(message)
 
+    def __reduce__(self) -> tuple[type[ModelAPIError], tuple[str, str]]:
+        return type(self), (self.model_name, self.message)
+
 
 class ModelHTTPError(ModelAPIError):
     """Raised when an model provider response has a status code of 4xx or 5xx."""
@@ -189,6 +201,9 @@ class ModelHTTPError(ModelAPIError):
         self.body = body
         message = f'status_code: {status_code}, model_name: {model_name}, body: {body}'
         super().__init__(model_name=model_name, message=message)
+
+    def __reduce__(self) -> tuple[type[ModelHTTPError], tuple[int, str, object | None]]:
+        return type(self), (self.status_code, self.model_name, self.body)
 
 
 class FallbackExceptionGroup(ExceptionGroup[Any]):
@@ -206,6 +221,9 @@ class ToolRetryError(Exception):
             else self._format_error_details(tool_retry.content, tool_retry.tool_name)
         )
         super().__init__(message)
+
+    def __reduce__(self) -> tuple[type[ToolRetryError], tuple[RetryPromptPart]]:
+        return type(self), (self.tool_retry,)
 
     @staticmethod
     def _format_error_details(errors: list[pydantic_core.ErrorDetails], tool_name: str | None) -> str:


### PR DESCRIPTION
Fixes #4503\n\nAdds `__reduce__` methods to `ModelHTTPError` and related exception classes so they can be correctly pickled and unpickled. Previously, unpickling raised `TypeError` due to missing positional args.