### PR TITLE
Capture cached token usage in separate OTel histograms

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -186,6 +186,24 @@ class InstrumentationSettings:
             self.tokens_histogram = self.meter.create_histogram(
                 **tokens_histogram_kwargs,  # pyright: ignore
             )
+        # Custom metric for cache token breakdown, separate from the standard
+        # gen_ai.client.token.usage to avoid double-counting (cache tokens are
+        # already included in input/output totals).
+        cached_tokens_histogram_kwargs = dict(
+            name='gen_ai.client.cached_token.usage',
+            unit='{token}',
+            description='Measures number of cached read and write tokens',
+        )
+        try:
+            self.cached_tokens_histogram = self.meter.create_histogram(
+                **cached_tokens_histogram_kwargs,
+                explicit_bucket_boundaries_advisory=TOKEN_HISTOGRAM_BOUNDARIES,
+            )
+        except TypeError:  # pragma: lax no cover
+            # Older OTel/logfire versions don't support explicit_bucket_boundaries_advisory
+            self.cached_tokens_histogram = self.meter.create_histogram(
+                **cached_tokens_histogram_kwargs,  # pyright: ignore
+            )
         self.cost_histogram = self.meter.create_histogram(
             'operation.cost',
             unit='{USD}',
@@ -351,6 +369,12 @@ class InstrumentationSettings:
             if price_calculation:
                 cost = float(getattr(price_calculation, f'{typ}_price'))
                 self.cost_histogram.record(cost, token_attributes)
+
+        for cache_typ in ['cache_read', 'cache_write']:
+            if not (tokens := getattr(response.usage, f'{cache_typ}_tokens', 0)):
+                continue
+            cache_token_attributes = {**attributes, 'gen_ai.token.type': cache_typ}
+            self.cached_tokens_histogram.record(tokens, cache_token_attributes)
 
 
 GEN_AI_SYSTEM_ATTRIBUTE = 'gen_ai.system'

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -993,8 +993,110 @@ Fix the errors and try again.\
                     'aggregation_temporality': 1,
                 },
             },
+            {
+                'name': 'gen_ai.client.cached_token.usage',
+                'description': 'Measures number of cached read and write tokens',
+                'unit': '{token}',
+                'data': {
+                    'data_points': [
+                        {
+                            'attributes': {
+                                'gen_ai.provider.name': 'openai',
+                                'gen_ai.system': 'openai',
+                                'gen_ai.operation.name': 'chat',
+                                'gen_ai.request.model': 'gpt-4o',
+                                'gen_ai.response.model': 'gpt-4o-2024-11-20',
+                                'gen_ai.token.type': 'cache_read',
+                            },
+                            'start_time_unix_nano': IsInt(),
+                            'time_unix_nano': IsInt(),
+                            'count': 1,
+                            'sum': 20,
+                            'scale': 20,
+                            'zero_count': 0,
+                            'positive': {'offset': 4531870, 'bucket_counts': [1]},
+                            'negative': {'offset': 0, 'bucket_counts': [0]},
+                            'flags': 0,
+                            'min': 20,
+                            'max': 20,
+                            'exemplars': [],
+                        },
+                        {
+                            'attributes': {
+                                'gen_ai.provider.name': 'openai',
+                                'gen_ai.system': 'openai',
+                                'gen_ai.operation.name': 'chat',
+                                'gen_ai.request.model': 'gpt-4o',
+                                'gen_ai.response.model': 'gpt-4o-2024-11-20',
+                                'gen_ai.token.type': 'cache_write',
+                            },
+                            'start_time_unix_nano': IsInt(),
+                            'time_unix_nano': IsInt(),
+                            'count': 1,
+                            'sum': 10,
+                            'scale': 20,
+                            'zero_count': 0,
+                            'positive': {'offset': 3483294, 'bucket_counts': [1]},
+                            'negative': {'offset': 0, 'bucket_counts': [0]},
+                            'flags': 0,
+                            'min': 10,
+                            'max': 10,
+                            'exemplars': [],
+                        },
+                    ],
+                    'aggregation_temporality': 1,
+                },
+            },
         ]
     )
+
+
+class ModelWithNoCacheTokens(Model):
+    """Model that returns responses with no cache token usage."""
+
+    @property
+    def system(self) -> str:
+        return 'openai'
+
+    @property
+    def model_name(self) -> str:
+        return 'gpt-4o'
+
+    async def request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        return ModelResponse(
+            parts=[TextPart('response')],
+            usage=RequestUsage(input_tokens=50, output_tokens=100),
+            model_name='gpt-4o-2024-11-20',
+        )
+
+
+async def test_no_cached_token_metrics_when_zero(capfire: CaptureLogfire):
+    """When cache tokens are 0, no cached_token histogram entries should be recorded."""
+    model = InstrumentedModel(ModelWithNoCacheTokens(), InstrumentationSettings())
+
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('hello')], timestamp=IsDatetime())]
+
+    await model.request(
+        messages,
+        model_settings=ModelSettings(),
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[],
+            allow_text_output=True,
+            output_tools=[],
+            output_mode='text',
+            output_object=None,
+        ),
+    )
+
+    metrics = capfire.get_collected_metrics()
+    metric_names = [m['name'] for m in metrics]
+    assert 'gen_ai.client.token.usage' in metric_names
+    assert 'gen_ai.client.cached_token.usage' not in metric_names
 
 
 def test_messages_to_otel_events_serialization_errors():


### PR DESCRIPTION
- Closes #4074

Records `cache_read` and `cache_write` tokens in a separate `gen_ai.client.cached_token.usage` histogram. Uses a dedicated metric rather than mixing into `gen_ai.client.token.usage` since cache tokens are a subset of input/output totals and combining them would break sum aggregation (per feedback on #4075).

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.