### PR TITLE
Add TextEditorTool builtin for Anthropic

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -15,6 +15,7 @@ from .builtin_tools import (
     ImageGenerationTool,
     MCPServerTool,
     MemoryTool,
+    TextEditorTool,
     UrlContextTool,  # pyright: ignore[reportDeprecated]
     WebFetchTool,
     WebSearchTool,
@@ -248,6 +249,7 @@ __all__ = (
     'ImageGenerationTool',
     'MCPServerTool',
     'MemoryTool',
+    'TextEditorTool',
     'UrlContextTool',
     'WebFetchTool',
     'WebSearchTool',

--- a/pydantic_ai_slim/pydantic_ai/builtin_tools.py
+++ b/pydantic_ai_slim/pydantic_ai/builtin_tools.py
@@ -17,6 +17,7 @@ __all__ = (
     'WebFetchTool',
     'UrlContextTool',
     'ImageGenerationTool',
+    'TextEditorTool',
     'MemoryTool',
     'MCPServerTool',
     'FileSearchTool',
@@ -358,6 +359,32 @@ class ImageGenerationTool(AbstractBuiltinTool):
 
 
 @dataclass(kw_only=True)
+class TextEditorTool(AbstractBuiltinTool):
+    """A builtin tool that allows your agent to view, create, and modify text files.
+
+    Requires a tool named ``str_replace_based_edit_tool`` to be defined that implements
+    the text editor commands (``view``, ``str_replace``, ``create``, ``insert``).
+
+    Supported by:
+
+    * Anthropic
+    """
+
+    max_characters: int | None = None
+    """Maximum number of characters to display when viewing a file.
+
+    If not specified, defaults to displaying the full file.
+
+    Supported by:
+
+    * Anthropic (``text_editor_20250728``)
+    """
+
+    kind: str = 'text_editor'
+    """The kind of tool."""
+
+
+@dataclass(kw_only=True)
 class MemoryTool(AbstractBuiltinTool):
     """A builtin tool that allows your agent to use memory.
 
@@ -478,4 +505,6 @@ DEPRECATED_BUILTIN_TOOLS: frozenset[type[AbstractBuiltinTool]] = frozenset({UrlC
 SUPPORTED_BUILTIN_TOOLS = frozenset(cls for cls in BUILTIN_TOOL_TYPES.values() if cls not in DEPRECATED_BUILTIN_TOOLS)
 """Get the set of all builtin tool types (excluding deprecated tools)."""
 
-BUILTIN_TOOLS_REQUIRING_CONFIG: frozenset[type[AbstractBuiltinTool]] = frozenset({MCPServerTool, MemoryTool})
+BUILTIN_TOOLS_REQUIRING_CONFIG: frozenset[type[AbstractBuiltinTool]] = frozenset(
+    {MCPServerTool, MemoryTool, TextEditorTool}
+)

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -18,6 +18,7 @@ from ..builtin_tools import (
     CodeExecutionTool,
     MCPServerTool,
     MemoryTool,
+    TextEditorTool,
     WebFetchTool,
     WebSearchTool,
 )
@@ -125,6 +126,7 @@ try:
         BetaToolChoiceParam,
         BetaToolParam,
         BetaToolResultBlockParam,
+        BetaToolTextEditor20250728Param,
         BetaToolUnionParam,
         BetaToolUseBlock,
         BetaToolUseBlockParam,
@@ -296,7 +298,7 @@ class AnthropicModel(Model):
     @classmethod
     def supported_builtin_tools(cls) -> frozenset[type[AbstractBuiltinTool]]:
         """The set of builtin tool types this model can handle."""
-        return frozenset({WebSearchTool, CodeExecutionTool, WebFetchTool, MemoryTool, MCPServerTool})
+        return frozenset({WebSearchTool, CodeExecutionTool, WebFetchTool, TextEditorTool, MemoryTool, MCPServerTool})
 
     async def request(
         self,
@@ -680,10 +682,21 @@ class AnthropicModel(Model):
                     )
                 )
                 beta_features.add('web-fetch-2025-09-10')
+            elif isinstance(tool, TextEditorTool):  # pragma: no branch
+                tool_name = 'str_replace_based_edit_tool'
+                if tool_name not in model_request_parameters.tool_defs:
+                    raise UserError(f"Built-in `TextEditorTool` requires a '{tool_name}' tool to be defined.")
+                tools = [t for t in tools if t.get('name') != tool_name]
+                text_editor_param = BetaToolTextEditor20250728Param(
+                    name='str_replace_based_edit_tool',
+                    type='text_editor_20250728',
+                )
+                if tool.max_characters is not None:
+                    text_editor_param['max_characters'] = tool.max_characters
+                tools.append(text_editor_param)
             elif isinstance(tool, MemoryTool):  # pragma: no branch
                 if 'memory' not in model_request_parameters.tool_defs:
                     raise UserError("Built-in `MemoryTool` requires a 'memory' tool to be defined.")
-                # Replace the memory tool definition with the built-in memory tool
                 tools = [tool for tool in tools if tool.get('name') != 'memory']
                 tools.append(BetaMemoryTool20250818Param(name='memory', type='memory_20250818'))
                 beta_features.add('context-management-2025-06-27')

--- a/tests/models/cassettes/test_anthropic/test_anthropic_text_editor_tool.yaml
+++ b/tests/models/cassettes/test_anthropic/test_anthropic_text_editor_tool.yaml
@@ -26,8 +26,7 @@ interactions:
       tool_choice:
         type: auto
       tools:
-      - max_characters: 10000
-        name: str_replace_based_edit_tool
+      - name: str_replace_based_edit_tool
         type: text_editor_20250728
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
@@ -113,8 +112,7 @@ interactions:
       tool_choice:
         type: auto
       tools:
-      - max_characters: 10000
-        name: str_replace_based_edit_tool
+      - name: str_replace_based_edit_tool
         type: text_editor_20250728
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:

--- a/tests/models/cassettes/test_anthropic/test_anthropic_text_editor_tool.yaml
+++ b/tests/models/cassettes/test_anthropic/test_anthropic_text_editor_tool.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '278'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: Use the text editor to view hello.py
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      tool_choice:
+        type: auto
+      tools:
+      - max_characters: 10000
+        name: str_replace_based_edit_tool
+        type: text_editor_20250728
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '520'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      content:
+      - text: I'll view hello.py for you.
+        type: text
+      - id: toolu_01RbLnQWMxRzm4KMditMcRiR
+        input:
+          command: view
+          path: hello.py
+        name: str_replace_based_edit_tool
+        type: tool_use
+      id: msg_01U3ASa9bZk2VwbQBde7mpLm
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_reason: tool_use
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        input_tokens: 325
+        output_tokens: 52
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '620'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: Use the text editor to view hello.py
+          type: text
+        role: user
+      - content:
+        - text: I'll view hello.py for you.
+          type: text
+        - id: toolu_01RbLnQWMxRzm4KMditMcRiR
+          input:
+            command: view
+            path: hello.py
+          name: str_replace_based_edit_tool
+          type: tool_use
+        role: assistant
+      - content:
+        - content: '1: print("Hello, world!")'
+          is_error: false
+          tool_use_id: toolu_01RbLnQWMxRzm4KMditMcRiR
+          type: tool_result
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      tool_choice:
+        type: auto
+      tools:
+      - max_characters: 10000
+        name: str_replace_based_edit_tool
+        type: text_editor_20250728
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '430'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      content:
+      - text: 'The file hello.py contains: print("Hello, world!")'
+        type: text
+      id: msg_01Gz4fVbR5tXkQp7nmHdwSzU
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        input_tokens: 390
+        output_tokens: 22
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -44,14 +44,7 @@ from pydantic_ai import (
     UsageLimitExceeded,
     UserPromptPart,
 )
-from pydantic_ai.builtin_tools import (
-    CodeExecutionTool,
-    MCPServerTool,
-    MemoryTool,
-    TextEditorTool,
-    WebFetchTool,
-    WebSearchTool,
-)
+from pydantic_ai.builtin_tools import CodeExecutionTool, MCPServerTool, MemoryTool, TextEditorTool, WebFetchTool, WebSearchTool
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
     BuiltinToolCallEvent,  # pyright: ignore[reportDeprecated]
@@ -8175,7 +8168,7 @@ async def test_anthropic_text_editor_tool(allow_model_requests: None, anthropic_
         'claude-sonnet-4-5',
         provider=AnthropicProvider(api_key=anthropic_api_key),
     )
-    agent = Agent(anthropic_model, builtin_tools=[TextEditorTool(max_characters=10_000)])
+    agent = Agent(anthropic_model, builtin_tools=[TextEditorTool()])
 
     with pytest.raises(
         UserError, match="Built-in `TextEditorTool` requires a 'str_replace_based_edit_tool' tool to be defined."

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -44,7 +44,14 @@ from pydantic_ai import (
     UsageLimitExceeded,
     UserPromptPart,
 )
-from pydantic_ai.builtin_tools import CodeExecutionTool, MCPServerTool, MemoryTool, WebFetchTool, WebSearchTool
+from pydantic_ai.builtin_tools import (
+    CodeExecutionTool,
+    MCPServerTool,
+    MemoryTool,
+    TextEditorTool,
+    WebFetchTool,
+    WebSearchTool,
+)
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
     BuiltinToolCallEvent,  # pyright: ignore[reportDeprecated]
@@ -8161,6 +8168,29 @@ async def test_anthropic_memory_tool(allow_model_requests: None, anthropic_api_k
 
 According to my memory, you live in **Mexico City**.\
 """)
+
+
+async def test_anthropic_text_editor_tool(allow_model_requests: None, anthropic_api_key: str):
+    anthropic_model = AnthropicModel(
+        'claude-sonnet-4-5',
+        provider=AnthropicProvider(api_key=anthropic_api_key),
+    )
+    agent = Agent(anthropic_model, builtin_tools=[TextEditorTool(max_characters=10_000)])
+
+    with pytest.raises(
+        UserError, match="Built-in `TextEditorTool` requires a 'str_replace_based_edit_tool' tool to be defined."
+    ):
+        await agent.run('Use the text editor to view hello.py')
+
+    @agent.tool_plain
+    def str_replace_based_edit_tool(**command: Any) -> str:
+        cmd = command.get('command')
+        if cmd == 'view':
+            return '1: print("Hello, world!")'
+        return 'OK'  # pragma: no cover
+
+    result = await agent.run('Use the text editor to view hello.py')
+    assert result.output == snapshot('The file hello.py contains: print("Hello, world!")')
 
 
 async def test_anthropic_model_usage_limit_exceeded(

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -44,7 +44,14 @@ from pydantic_ai import (
     UsageLimitExceeded,
     UserPromptPart,
 )
-from pydantic_ai.builtin_tools import CodeExecutionTool, MCPServerTool, MemoryTool, TextEditorTool, WebFetchTool, WebSearchTool
+from pydantic_ai.builtin_tools import (
+    CodeExecutionTool,
+    MCPServerTool,
+    MemoryTool,
+    TextEditorTool,
+    WebFetchTool,
+    WebSearchTool,
+)
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
     BuiltinToolCallEvent,  # pyright: ignore[reportDeprecated]


### PR DESCRIPTION
- Closes #3794

Picks up where #4038 left off. Follows the `MemoryTool` pattern: user defines a `str_replace_based_edit_tool` function tool, pydantic-ai swaps the definition for the API-native `text_editor_20250728` param. Supports optional `max_characters` for truncating `view` output.

Open to moving `TextEditorTool` from `builtin_tools.py` into `models/anthropic.py` per feedback on #4038 if preferred.

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.