### PR TITLE
fix(mcp): respect audience annotations on tool result content blocks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_mcp_audience.py
+++ b/pydantic_ai_slim/pydantic_ai/_mcp_audience.py
@@ -1,0 +1,152 @@
+"""Internal helpers for MCP audience filtering.
+
+Per the MCP specification, content blocks may carry ``annotations.audience``
+that lists their intended recipients. When an MCP tool returns content
+annotated for ``user`` only, the model should not see it (or its JSON-encoded
+equivalent via ``structured_content``); instead the application receives it
+out-of-band via ``ToolReturnPart.metadata['mcp_user_content']``.
+
+This module is private (leading underscore on the filename) because the
+helpers are shared implementation details between :mod:`pydantic_ai.mcp` and
+:mod:`pydantic_ai.toolsets.fastmcp`. They are not part of the public API.
+Refer to ``agent_docs/index.md`` rule:176 for the scoping policy.
+"""
+
+from __future__ import annotations as _annotations
+
+from typing import Any, cast
+
+from mcp import types as mcp_types
+
+from . import messages
+
+__all__ = (
+    'audience_include',
+    'partition_content',
+    'user_only_placeholder',
+    'wrap_with_user_metadata',
+    'USER_ONLY_PLACEHOLDER_TEXT',
+)
+
+
+USER_ONLY_PLACEHOLDER_TEXT = 'Tool executed successfully. (No model-visible content in result.)'
+
+
+def audience_include(part: mcp_types.ContentBlock) -> bool:
+    """Return True if this content block should be forwarded to the model.
+
+    Per the MCP spec, content blocks may carry ``annotations.audience`` which
+    lists the intended recipients. When the list is absent (``None``) the
+    content is intended for *all* audiences. When it is present, the content
+    should only be forwarded to the audiences listed.
+
+    See: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-result
+    """
+    annotations = part.annotations
+    if annotations is None:
+        return True
+    audience = annotations.audience
+    if audience is None:
+        return True
+    return 'assistant' in audience
+
+
+def partition_content(
+    content: list[mcp_types.ContentBlock],
+) -> tuple[list[mcp_types.ContentBlock], list[mcp_types.ContentBlock]]:
+    """Partition MCP content blocks into ``(assistant_visible, user_only)`` lists."""
+    filtered = [p for p in content if audience_include(p)]
+    user_only = [p for p in content if not audience_include(p)]
+    return filtered, user_only
+
+
+def user_only_placeholder(
+    user_only: list[mcp_types.ContentBlock],
+) -> messages.ToolReturn:
+    """Return a placeholder :class:`ToolReturn` for tools whose entire output is user-only.
+
+    The model is told the tool ran successfully; the actual content is preserved in
+    ``ToolReturn.metadata['mcp_user_content']`` for the application.
+    """
+    return messages.ToolReturn(
+        return_value=USER_ONLY_PLACEHOLDER_TEXT,
+        metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
+    )
+
+
+def wrap_with_user_metadata(
+    assistant_content: Any,
+    user_only: list[mcp_types.ContentBlock],
+) -> messages.ToolReturn:
+    """Wrap *assistant_content* in a :class:`ToolReturn` plus user-only metadata.
+
+    Used when a tool result contains a mix of assistant-visible and user-only
+    content blocks. The assistant-visible content is returned via
+    ``return_value``; the user-only content is preserved in
+    ``metadata['mcp_user_content']`` for the application to consume out-of-band.
+
+    Multi-modal items inside *assistant_content* (``BinaryContent``, image and
+    audio URLs, uploaded files, and so on) cannot live in ``return_value``: the
+    agent graph rejects them with a UserError because they are required to flow
+    through ``ToolReturn.content`` as a ``UserPromptPart``. This helper detects
+    those items, replaces each one in ``return_value`` with a
+    ``"See file <identifier>"`` placeholder, and routes the original objects
+    into ``content`` instead, mirroring the convention used by the agent graph
+    when it normalises plain tool results.
+    """
+    return_value, content = _split_multimodal(assistant_content)
+    return messages.ToolReturn(
+        return_value=return_value,
+        content=content if content else None,
+        metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
+    )
+
+
+def _split_multimodal(
+    assistant_content: Any,
+) -> tuple[Any, list[str | messages.UserContent]]:
+    """Replace multi-modal items in *assistant_content* with text placeholders.
+
+    Returns ``(return_value, content)`` where ``return_value`` is safe to place
+    in ``ToolReturn.return_value`` and ``content`` carries the original
+    multi-modal items (with descriptive headers) for ``ToolReturn.content``.
+
+    The shape of ``return_value`` mirrors the shape of the input: a single
+    multi-modal item becomes a single placeholder string, a list becomes a
+    list with each multi-modal item replaced by its placeholder, and content
+    that contains no multi-modal items is returned unchanged so existing
+    callers see no behavioural difference.
+    """
+    no_user_content: list[str | messages.UserContent] = []
+
+    if isinstance(assistant_content, messages.MULTI_MODAL_CONTENT_TYPES):
+        identifier = assistant_content.identifier
+        single_user_content: list[str | messages.UserContent] = [
+            f'This is file {identifier}:',
+            assistant_content,
+        ]
+        single_return: Any = f'See file {identifier}'
+        return single_return, single_user_content
+
+    if isinstance(assistant_content, list):
+        # Pyright cannot infer the element type of a list narrowed from Any, but
+        # mypy considers a same-type cast on Any redundant. Casting to
+        # ``list[object]`` keeps both type checkers quiet without suppressions.
+        items = cast('list[object]', assistant_content)
+        return_values: list[Any] = []
+        list_user_content: list[str | messages.UserContent] = []
+        any_multimodal = False
+        for item in items:
+            if isinstance(item, messages.MULTI_MODAL_CONTENT_TYPES):
+                any_multimodal = True
+                identifier = item.identifier
+                return_values.append(f'See file {identifier}')
+                list_user_content.extend([f'This is file {identifier}:', item])
+            else:
+                return_values.append(item)
+        if any_multimodal:
+            list_return: Any = return_values
+            return list_return, list_user_content
+
+    fallthrough_return: Any = cast('Any', assistant_content)
+    return fallthrough_return, no_user_content

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -43,7 +43,7 @@ except ImportError as _import_error:
     ) from _import_error
 
 # after mcp imports so any import error maps to this file, not _mcp.py
-from . import _mcp, _utils, exceptions, messages, models
+from . import _mcp, _mcp_audience, _utils, exceptions, messages, models
 
 __all__ = (
     'MCPError',
@@ -545,10 +545,10 @@ class MCPServer(AbstractToolset[Any], ABC):
         # Audience filtering must happen before the structured-content path: if every
         # content block is annotated as user-only, the model should not see the
         # JSON-serialised equivalent either.
-        content_for_assistant, user_only = mcp_partition_content(result.content)
+        content_for_assistant, user_only = _mcp_audience.partition_content(result.content)
 
         if not content_for_assistant and result.content:
-            return mcp_user_only_placeholder(user_only)
+            return _mcp_audience.user_only_placeholder(user_only)
 
         # Prefer structured content if there are only text parts, which per the docs would contain the JSON-encoded structured content for backward compatibility.
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
@@ -569,7 +569,7 @@ class MCPServer(AbstractToolset[Any], ABC):
         assistant_content: Any = mapped[0] if len(mapped) == 1 else mapped
 
         if user_only:
-            return mcp_wrap_with_user_metadata(assistant_content, user_only)
+            return _mcp_audience.wrap_with_user_metadata(assistant_content, user_only)
 
         return assistant_content
 
@@ -1333,68 +1333,6 @@ Allows wrapping an MCP server tool call to customize it, including adding extra 
 metadata.
 """
 
-
-def mcp_audience_include(part: mcp_types.ContentBlock) -> bool:
-    """Return True if this content block should be forwarded to the model (assistant).
-
-    Per the MCP specification, content blocks may carry ``annotations.audience`` which
-    lists the intended recipients of that content.  When the list is absent (``None``)
-    the content is intended for *all* audiences.  When it is present, the content should
-    only be forwarded to the audiences listed.
-
-    See: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-result
-    """
-    annotations = part.annotations
-    if annotations is None:
-        return True
-    audience = annotations.audience
-    if audience is None:
-        return True
-    return 'assistant' in audience
-
-
-def mcp_partition_content(
-    content: list[mcp_types.ContentBlock],
-) -> tuple[list[mcp_types.ContentBlock], list[mcp_types.ContentBlock]]:
-    """Partition MCP content blocks into (assistant-visible, user-only) lists.
-
-    Returns a tuple of ``(filtered, user_only)`` where *filtered* contains all
-    blocks that should be forwarded to the model and *user_only* contains blocks
-    annotated exclusively for the ``user`` audience.
-    """
-    filtered = [p for p in content if mcp_audience_include(p)]
-    user_only = [p for p in content if not mcp_audience_include(p)]
-    return filtered, user_only
-
-
-def mcp_user_only_placeholder(
-    user_only: list[mcp_types.ContentBlock],
-) -> messages.ToolReturn:
-    """Return a placeholder :class:`ToolReturn` for tools whose entire output is user-only.
-
-    The model is told the tool ran successfully; the actual content is preserved in
-    ``ToolReturn.metadata['mcp_user_content']`` for the application.
-    """
-    return messages.ToolReturn(
-        return_value='Tool executed successfully. (No model-visible content in result.)',
-        metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
-    )
-
-
-def mcp_wrap_with_user_metadata(
-    assistant_content: Any,
-    user_only: list[mcp_types.ContentBlock],
-) -> messages.ToolReturn:
-    """Wrap *assistant_content* in a :class:`ToolReturn` with user-only blocks in metadata.
-
-    Used when a tool result contains a mix of assistant-visible and user-only content.
-    The assistant-visible content is returned as ``return_value``; the user-only content
-    is preserved in ``metadata['mcp_user_content']``.
-    """
-    return messages.ToolReturn(
-        return_value=assistant_content,
-        metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
-    )
 
 
 def _mcp_server_discriminator(value: dict[str, Any]) -> str | None:

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -46,17 +46,17 @@ except ImportError as _import_error:
 from . import _mcp, _utils, exceptions, messages, models
 
 __all__ = (
+    'MCPError',
     'MCPServer',
-    'MCPServerStdio',
     'MCPServerHTTP',
     'MCPServerSSE',
+    'MCPServerStdio',
     'MCPServerStreamableHTTP',
-    'load_mcp_servers',
-    'MCPError',
     'Resource',
     'ResourceAnnotations',
     'ResourceTemplate',
     'ServerCapabilities',
+    'load_mcp_servers',
 )
 
 
@@ -561,8 +561,10 @@ class MCPServer(AbstractToolset[Any], ABC):
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
         # Skip the structured content path when audience filtering was applied: structuredContent
         # contains the unfiltered raw value and would expose user-only content to the model.
-        if not user_only and (structured := result.structuredContent) and not any(
-            not isinstance(part, mcp_types.TextContent) for part in result.content
+        if (
+            not user_only
+            and (structured := result.structuredContent)
+            and not any(not isinstance(part, mcp_types.TextContent) for part in result.content)
         ):
             # The MCP SDK wraps primitives and generic types like list in a `result` key, but we want to use the raw value returned by the tool function.
             # See https://github.com/modelcontextprotocol/python-sdk#structured-output
@@ -740,7 +742,7 @@ class MCPServer(AbstractToolset[Any], ABC):
             self._running_count += 1
         return self
 
-    async def __aexit__(self, *args: Any) -> bool | None:
+    async def __aexit__(self, *args: object) -> bool | None:
         async with self._enter_lock:
             if self._running_count == 0:
                 raise ValueError('MCPServer.__aexit__ called more times than __aenter__')

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -545,17 +545,10 @@ class MCPServer(AbstractToolset[Any], ABC):
         # Audience filtering must happen before the structured-content path: if every
         # content block is annotated as user-only, the model should not see the
         # JSON-serialised equivalent either.
-        content_for_assistant = [part for part in result.content if _include_content_for_assistant(part)]
-        user_only = [part for part in result.content if not _include_content_for_assistant(part)]
+        content_for_assistant, user_only = _mcp_partition_content(result.content)
 
         if not content_for_assistant and result.content:
-            # All content blocks were filtered out by audience annotations (audience=['user'] only).
-            # Return an informative placeholder so the model knows the tool ran, and expose
-            # the user-only content via ToolReturnPart.metadata so the application can access it.
-            return messages.ToolReturn(
-                return_value='Tool executed successfully. (No model-visible content in result.)',
-                metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
-            )
+            return _mcp_user_only_placeholder(user_only)
 
         # Prefer structured content if there are only text parts, which per the docs would contain the JSON-encoded structured content for backward compatibility.
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
@@ -576,12 +569,7 @@ class MCPServer(AbstractToolset[Any], ABC):
         assistant_content: Any = mapped[0] if len(mapped) == 1 else mapped
 
         if user_only:
-            # Some blocks were filtered out — expose them via metadata so the application
-            # can access user-only content while the model only sees assistant-visible content.
-            return messages.ToolReturn(
-                return_value=assistant_content,
-                metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
-            )
+            return _mcp_wrap_with_user_metadata(assistant_content, user_only)
 
         return assistant_content
 
@@ -1346,7 +1334,7 @@ metadata.
 """
 
 
-def _include_content_for_assistant(part: mcp_types.ContentBlock) -> bool:
+def _mcp_audience_include(part: mcp_types.ContentBlock) -> bool:
     """Return True if this content block should be forwarded to the model (assistant).
 
     Per the MCP specification, content blocks may carry ``annotations.audience`` which
@@ -1363,6 +1351,50 @@ def _include_content_for_assistant(part: mcp_types.ContentBlock) -> bool:
     if audience is None:
         return True
     return 'assistant' in audience
+
+
+def _mcp_partition_content(
+    content: list[mcp_types.ContentBlock],
+) -> tuple[list[mcp_types.ContentBlock], list[mcp_types.ContentBlock]]:
+    """Partition MCP content blocks into (assistant-visible, user-only) lists.
+
+    Returns a tuple of ``(filtered, user_only)`` where *filtered* contains all
+    blocks that should be forwarded to the model and *user_only* contains blocks
+    annotated exclusively for the ``user`` audience.
+    """
+    filtered = [p for p in content if _mcp_audience_include(p)]
+    user_only = [p for p in content if not _mcp_audience_include(p)]
+    return filtered, user_only
+
+
+def _mcp_user_only_placeholder(
+    user_only: list[mcp_types.ContentBlock],
+) -> messages.ToolReturn:
+    """Return a placeholder :class:`ToolReturn` for tools whose entire output is user-only.
+
+    The model is told the tool ran successfully; the actual content is preserved in
+    ``ToolReturn.metadata['mcp_user_content']`` for the application.
+    """
+    return messages.ToolReturn(
+        return_value='Tool executed successfully. (No model-visible content in result.)',
+        metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
+    )
+
+
+def _mcp_wrap_with_user_metadata(
+    assistant_content: Any,
+    user_only: list[mcp_types.ContentBlock],
+) -> messages.ToolReturn:
+    """Wrap *assistant_content* in a :class:`ToolReturn` with user-only blocks in metadata.
+
+    Used when a tool result contains a mix of assistant-visible and user-only content.
+    The assistant-visible content is returned as ``return_value``; the user-only content
+    is preserved in ``metadata['mcp_user_content']``.
+    """
+    return messages.ToolReturn(
+        return_value=assistant_content,
+        metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
+    )
 
 
 def _mcp_server_discriminator(value: dict[str, Any]) -> str | None:

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -558,8 +558,8 @@ class MCPServer(AbstractToolset[Any], ABC):
             for part in result.content
             if _include_content_for_assistant(part)
         ]
-        if not mapped:
-            # All content blocks were filtered out (audience=['user'] only).
+        if not mapped and result.content:
+            # All content blocks were filtered out by audience annotations (audience=['user'] only).
             # Return an informative placeholder so the model knows the tool ran.
             return 'Tool executed successfully. (No model-visible content in result.)'
         return mapped[0] if len(mapped) == 1 else mapped

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -558,6 +558,10 @@ class MCPServer(AbstractToolset[Any], ABC):
             for part in result.content
             if _include_content_for_assistant(part)
         ]
+        if not mapped:
+            # All content blocks were filtered out (audience=['user'] only).
+            # Return an informative placeholder so the model knows the tool ran.
+            return 'Tool executed successfully. (No model-visible content in result.)'
         return mapped[0] if len(mapped) == 1 else mapped
 
     async def call_tool(

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -545,10 +545,10 @@ class MCPServer(AbstractToolset[Any], ABC):
         # Audience filtering must happen before the structured-content path: if every
         # content block is annotated as user-only, the model should not see the
         # JSON-serialised equivalent either.
-        content_for_assistant, user_only = _mcp_partition_content(result.content)
+        content_for_assistant, user_only = mcp_partition_content(result.content)
 
         if not content_for_assistant and result.content:
-            return _mcp_user_only_placeholder(user_only)
+            return mcp_user_only_placeholder(user_only)
 
         # Prefer structured content if there are only text parts, which per the docs would contain the JSON-encoded structured content for backward compatibility.
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
@@ -569,7 +569,7 @@ class MCPServer(AbstractToolset[Any], ABC):
         assistant_content: Any = mapped[0] if len(mapped) == 1 else mapped
 
         if user_only:
-            return _mcp_wrap_with_user_metadata(assistant_content, user_only)
+            return mcp_wrap_with_user_metadata(assistant_content, user_only)
 
         return assistant_content
 
@@ -1334,7 +1334,7 @@ metadata.
 """
 
 
-def _mcp_audience_include(part: mcp_types.ContentBlock) -> bool:
+def mcp_audience_include(part: mcp_types.ContentBlock) -> bool:
     """Return True if this content block should be forwarded to the model (assistant).
 
     Per the MCP specification, content blocks may carry ``annotations.audience`` which
@@ -1353,7 +1353,7 @@ def _mcp_audience_include(part: mcp_types.ContentBlock) -> bool:
     return 'assistant' in audience
 
 
-def _mcp_partition_content(
+def mcp_partition_content(
     content: list[mcp_types.ContentBlock],
 ) -> tuple[list[mcp_types.ContentBlock], list[mcp_types.ContentBlock]]:
     """Partition MCP content blocks into (assistant-visible, user-only) lists.
@@ -1362,12 +1362,12 @@ def _mcp_partition_content(
     blocks that should be forwarded to the model and *user_only* contains blocks
     annotated exclusively for the ``user`` audience.
     """
-    filtered = [p for p in content if _mcp_audience_include(p)]
-    user_only = [p for p in content if not _mcp_audience_include(p)]
+    filtered = [p for p in content if mcp_audience_include(p)]
+    user_only = [p for p in content if not mcp_audience_include(p)]
     return filtered, user_only
 
 
-def _mcp_user_only_placeholder(
+def mcp_user_only_placeholder(
     user_only: list[mcp_types.ContentBlock],
 ) -> messages.ToolReturn:
     """Return a placeholder :class:`ToolReturn` for tools whose entire output is user-only.
@@ -1381,7 +1381,7 @@ def _mcp_user_only_placeholder(
     )
 
 
-def _mcp_wrap_with_user_metadata(
+def mcp_wrap_with_user_metadata(
     assistant_content: Any,
     user_only: list[mcp_types.ContentBlock],
 ) -> messages.ToolReturn:

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -542,6 +542,15 @@ class MCPServer(AbstractToolset[Any], ABC):
 
             raise exceptions.ModelRetry(message or 'MCP tool call failed')
 
+        # Audience filtering must happen before the structured-content path: if every
+        # content block is annotated as user-only, the model should not see the
+        # JSON-serialised equivalent either.
+        content_for_assistant = [part for part in result.content if _include_content_for_assistant(part)]
+        if not content_for_assistant and result.content:
+            # All content blocks were filtered out by audience annotations (audience=['user'] only).
+            # Return an informative placeholder so the model knows the tool ran.
+            return 'Tool executed successfully. (No model-visible content in result.)'
+
         # Prefer structured content if there are only text parts, which per the docs would contain the JSON-encoded structured content for backward compatibility.
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
         if (structured := result.structuredContent) and not any(
@@ -553,15 +562,7 @@ class MCPServer(AbstractToolset[Any], ABC):
                 return structured['result']
             return structured
 
-        mapped = [
-            await self._map_tool_result_part(part)
-            for part in result.content
-            if _include_content_for_assistant(part)
-        ]
-        if not mapped and result.content:
-            # All content blocks were filtered out by audience annotations (audience=['user'] only).
-            # Return an informative placeholder so the model knows the tool ran.
-            return 'Tool executed successfully. (No model-visible content in result.)'
+        mapped = [await self._map_tool_result_part(part) for part in content_for_assistant]
         return mapped[0] if len(mapped) == 1 else mapped
 
     async def call_tool(
@@ -1334,10 +1335,10 @@ def _include_content_for_assistant(part: mcp_types.ContentBlock) -> bool:
 
     See: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-result
     """
-    annotations = getattr(part, 'annotations', None)
+    annotations = part.annotations
     if annotations is None:
         return True
-    audience = getattr(annotations, 'audience', None)
+    audience = annotations.audience
     if audience is None:
         return True
     return 'assistant' in audience

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -553,7 +553,11 @@ class MCPServer(AbstractToolset[Any], ABC):
                 return structured['result']
             return structured
 
-        mapped = [await self._map_tool_result_part(part) for part in result.content]
+        mapped = [
+            await self._map_tool_result_part(part)
+            for part in result.content
+            if _include_content_for_assistant(part)
+        ]
         return mapped[0] if len(mapped) == 1 else mapped
 
     async def call_tool(
@@ -1314,6 +1318,25 @@ It accepts a run context, the original tool call function, a tool name, and argu
 Allows wrapping an MCP server tool call to customize it, including adding extra request
 metadata.
 """
+
+
+def _include_content_for_assistant(part: mcp_types.ContentBlock) -> bool:
+    """Return True if this content block should be forwarded to the model (assistant).
+
+    Per the MCP specification, content blocks may carry ``annotations.audience`` which
+    lists the intended recipients of that content.  When the list is absent (``None``)
+    the content is intended for *all* audiences.  When it is present, the content should
+    only be forwarded to the audiences listed.
+
+    See: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-result
+    """
+    annotations = getattr(part, 'annotations', None)
+    if annotations is None:
+        return True
+    audience = getattr(annotations, 'audience', None)
+    if audience is None:
+        return True
+    return 'assistant' in audience
 
 
 def _mcp_server_discriminator(value: dict[str, Any]) -> str | None:

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -546,14 +546,22 @@ class MCPServer(AbstractToolset[Any], ABC):
         # content block is annotated as user-only, the model should not see the
         # JSON-serialised equivalent either.
         content_for_assistant = [part for part in result.content if _include_content_for_assistant(part)]
+        user_only = [part for part in result.content if not _include_content_for_assistant(part)]
+
         if not content_for_assistant and result.content:
             # All content blocks were filtered out by audience annotations (audience=['user'] only).
-            # Return an informative placeholder so the model knows the tool ran.
-            return 'Tool executed successfully. (No model-visible content in result.)'
+            # Return an informative placeholder so the model knows the tool ran, and expose
+            # the user-only content via ToolReturnPart.metadata so the application can access it.
+            return messages.ToolReturn(
+                return_value='Tool executed successfully. (No model-visible content in result.)',
+                metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
+            )
 
         # Prefer structured content if there are only text parts, which per the docs would contain the JSON-encoded structured content for backward compatibility.
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
-        if (structured := result.structuredContent) and not any(
+        # Skip the structured content path when audience filtering was applied: structuredContent
+        # contains the unfiltered raw value and would expose user-only content to the model.
+        if not user_only and (structured := result.structuredContent) and not any(
             not isinstance(part, mcp_types.TextContent) for part in result.content
         ):
             # The MCP SDK wraps primitives and generic types like list in a `result` key, but we want to use the raw value returned by the tool function.
@@ -563,7 +571,17 @@ class MCPServer(AbstractToolset[Any], ABC):
             return structured
 
         mapped = [await self._map_tool_result_part(part) for part in content_for_assistant]
-        return mapped[0] if len(mapped) == 1 else mapped
+        assistant_content: Any = mapped[0] if len(mapped) == 1 else mapped
+
+        if user_only:
+            # Some blocks were filtered out — expose them via metadata so the application
+            # can access user-only content while the model only sees assistant-visible content.
+            return messages.ToolReturn(
+                return_value=assistant_content,
+                metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
+            )
+
+        return assistant_content
 
     async def call_tool(
         self,
@@ -1298,6 +1316,7 @@ class MCPServerStreamableHTTP(_MCPServerHTTP):
 ToolResult = (
     str
     | messages.BinaryContent
+    | messages.ToolReturn
     | dict[str, Any]
     | list[Any]
     | Sequence[str | messages.BinaryContent | dict[str, Any] | list[Any]]

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -165,9 +165,13 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         # Otherwise, return the content
         filtered = [p for p in call_tool_result.content if _include_for_assistant(p)]
         # If the original content was empty (tool returned nothing), return an empty list rather
-        # than the audience-filtered placeholder that _map_fastmcp_tool_results([]) would produce.
+        # than the audience-filtered placeholder.
         if not filtered and not call_tool_result.content:
             return []
+        # If audience filtering removed all content blocks, return a placeholder so the
+        # model knows the tool ran but produced no model-visible output.
+        if not filtered:
+            return 'Tool executed successfully. (No model-visible content in result.)'
         return _map_fastmcp_tool_results(parts=filtered)
 
     def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
@@ -198,12 +202,13 @@ def _include_for_assistant(part: ContentBlock) -> bool:
 
 
 def _map_fastmcp_tool_results(parts: list[ContentBlock]) -> list[FastMCPToolResult] | FastMCPToolResult:
-    """Map FastMCP tool results to toolset tool results."""
-    mapped_results = [_map_fastmcp_tool_result(part) for part in parts]
+    """Map FastMCP tool results to toolset tool results.
 
-    if not mapped_results:
-        # All content blocks were filtered out (audience=['user'] only).
-        return 'Tool executed successfully. (No model-visible content in result.)'
+    ``parts`` must be non-empty; audience filtering and empty-content handling are the
+    caller's responsibility (see ``call_tool``).
+    """
+    assert parts, '_map_fastmcp_tool_results called with empty parts list'
+    mapped_results = [_map_fastmcp_tool_result(part) for part in parts]
 
     if len(mapped_results) == 1:
         return mapped_results[0]

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -163,7 +163,7 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
             return call_tool_result.structured_content
 
         # Otherwise, return the content
-        return _map_fastmcp_tool_results(parts=call_tool_result.content)
+        return _map_fastmcp_tool_results(parts=[p for p in call_tool_result.content if _include_for_assistant(p)])
 
     def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
         return ToolsetTool[AgentDepsT](
@@ -172,6 +172,24 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
             max_retries=self.max_retries,
             args_validator=TOOL_SCHEMA_VALIDATOR,
         )
+
+
+def _include_for_assistant(part: ContentBlock) -> bool:
+    """Return True if this content block should be forwarded to the model (assistant).
+
+    Per the MCP specification, content blocks may carry ``annotations.audience`` listing
+    the intended recipients.  An absent audience means *all* audiences; when present, only
+    the listed audiences should receive the content.
+
+    See: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-result
+    """
+    annotations = getattr(part, 'annotations', None)
+    if annotations is None:
+        return True
+    audience = getattr(annotations, 'audience', None)
+    if audience is None:
+        return True
+    return 'assistant' in audience
 
 
 def _map_fastmcp_tool_results(parts: list[ContentBlock]) -> list[FastMCPToolResult] | FastMCPToolResult:

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -34,12 +34,8 @@ try:
         TextResourceContents,
     )
 
-    from pydantic_ai.mcp import (
-        TOOL_SCHEMA_VALIDATOR,
-        mcp_partition_content,
-        mcp_user_only_placeholder,
-        mcp_wrap_with_user_metadata,
-    )
+    from pydantic_ai import _mcp_audience
+    from pydantic_ai.mcp import TOOL_SCHEMA_VALIDATOR
 
 except ImportError as _import_error:
     raise ImportError(
@@ -166,14 +162,14 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         # Audience filtering must happen before the structured-content path: if every
         # content block is annotated as user-only, the model should not see the
         # JSON-serialised equivalent either.
-        filtered, user_only = mcp_partition_content(call_tool_result.content)
+        filtered, user_only = _mcp_audience.partition_content(call_tool_result.content)
 
         # If audience filtering removed all non-empty content, return a placeholder and
         # expose the user-only content via ToolReturnPart.metadata for the application.
         # (This check must come before the structuredContent check so that a tool
         # whose entire output is user-only doesn't expose its JSON-serialised equivalent.)
         if not filtered and call_tool_result.content:
-            return mcp_user_only_placeholder(user_only)
+            return _mcp_audience.user_only_placeholder(user_only)
 
         # Prefer structured content when available — covers both the case where the tool
         # returned data directly (empty content + structuredContent) and the normal case
@@ -192,7 +188,7 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         assistant_content = _map_fastmcp_tool_results(parts=filtered)
 
         if user_only:
-            return mcp_wrap_with_user_metadata(assistant_content, user_only)
+            return _mcp_audience.wrap_with_user_metadata(assistant_content, user_only)
 
         return assistant_content
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -34,9 +34,9 @@ try:
         TextResourceContents,
     )
 
-    from pydantic_ai.mcp import (  # type: ignore[reportPrivateUsage]
+    from pydantic_ai.mcp import (
         TOOL_SCHEMA_VALIDATOR,
-        _include_content_for_assistant,
+        _include_content_for_assistant,  # pyright: ignore[reportPrivateUsage]
     )
 
 except ImportError as _import_error:
@@ -165,19 +165,22 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         # content block is annotated as user-only, the model should not see the
         # JSON-serialised equivalent either.
         filtered = [p for p in call_tool_result.content if _include_content_for_assistant(p)]
-        # If the original content was empty (tool returned nothing), return an empty list rather
-        # than the audience-filtered placeholder.
-        if not filtered and not call_tool_result.content:
-            return []
-        # If audience filtering removed all content blocks, return a placeholder so the
-        # model knows the tool ran but produced no model-visible output.
-        if not filtered:
+        # If audience filtering removed all non-empty content, return a placeholder.
+        # (This check must come before the structured_content check so that a tool
+        # whose entire output is user-only doesn't expose its JSON-serialised equivalent.)
+        if not filtered and call_tool_result.content:
             return 'Tool executed successfully. (No model-visible content in result.)'
 
-        # If we have structured content, return that (audience check already passed above)
+        # Prefer structured content when available — covers both the case where the tool
+        # returned data directly (empty content + structured_content) and the normal case
+        # where FastMCP serialises the return value alongside text content.
         if call_tool_result.structured_content:
             return call_tool_result.structured_content
 
+        # No structured content: map the filtered text/image parts, or return [] for tools
+        # that produced genuinely empty content (no content blocks at all).
+        if not filtered:
+            return []
         return _map_fastmcp_tool_results(parts=filtered)
 
     def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -36,9 +36,9 @@ try:
 
     from pydantic_ai.mcp import (
         TOOL_SCHEMA_VALIDATOR,
-        _mcp_partition_content,
-        _mcp_user_only_placeholder,
-        _mcp_wrap_with_user_metadata,
+        mcp_partition_content,
+        mcp_user_only_placeholder,
+        mcp_wrap_with_user_metadata,
     )
 
 except ImportError as _import_error:
@@ -166,14 +166,14 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         # Audience filtering must happen before the structured-content path: if every
         # content block is annotated as user-only, the model should not see the
         # JSON-serialised equivalent either.
-        filtered, user_only = _mcp_partition_content(call_tool_result.content)
+        filtered, user_only = mcp_partition_content(call_tool_result.content)
 
         # If audience filtering removed all non-empty content, return a placeholder and
         # expose the user-only content via ToolReturnPart.metadata for the application.
         # (This check must come before the structuredContent check so that a tool
         # whose entire output is user-only doesn't expose its JSON-serialised equivalent.)
         if not filtered and call_tool_result.content:
-            return _mcp_user_only_placeholder(user_only)
+            return mcp_user_only_placeholder(user_only)
 
         # Prefer structured content when available — covers both the case where the tool
         # returned data directly (empty content + structuredContent) and the normal case
@@ -192,7 +192,7 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         assistant_content = _map_fastmcp_tool_results(parts=filtered)
 
         if user_only:
-            return _mcp_wrap_with_user_metadata(assistant_content, user_only)
+            return mcp_wrap_with_user_metadata(assistant_content, user_only)
 
         return assistant_content
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -36,7 +36,10 @@ try:
 
     from pydantic_ai.mcp import (
         TOOL_SCHEMA_VALIDATOR,
-        _include_content_for_assistant,  # pyright: ignore[reportPrivateUsage]
+        _mcp_audience_include,
+        _mcp_partition_content,
+        _mcp_user_only_placeholder,
+        _mcp_wrap_with_user_metadata,
     )
 
 except ImportError as _import_error:
@@ -164,18 +167,14 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         # Audience filtering must happen before the structured-content path: if every
         # content block is annotated as user-only, the model should not see the
         # JSON-serialised equivalent either.
-        filtered = [p for p in call_tool_result.content if _include_content_for_assistant(p)]
-        user_only = [p for p in call_tool_result.content if not _include_content_for_assistant(p)]
+        filtered, user_only = _mcp_partition_content(call_tool_result.content)
 
         # If audience filtering removed all non-empty content, return a placeholder and
         # expose the user-only content via ToolReturnPart.metadata for the application.
         # (This check must come before the structuredContent check so that a tool
         # whose entire output is user-only doesn't expose its JSON-serialised equivalent.)
         if not filtered and call_tool_result.content:
-            return messages.ToolReturn(
-                return_value='Tool executed successfully. (No model-visible content in result.)',
-                metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
-            )
+            return _mcp_user_only_placeholder(user_only)
 
         # Prefer structured content when available — covers both the case where the tool
         # returned data directly (empty content + structuredContent) and the normal case
@@ -194,12 +193,7 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         assistant_content = _map_fastmcp_tool_results(parts=filtered)
 
         if user_only:
-            # Some blocks were filtered — expose them via metadata so the application can
-            # access user-only content while the model only sees assistant-visible content.
-            return messages.ToolReturn(
-                return_value=assistant_content,
-                metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
-            )
+            return _mcp_wrap_with_user_metadata(assistant_content, user_only)
 
         return assistant_content
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -169,7 +169,7 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
 
         # If audience filtering removed all non-empty content, return a placeholder and
         # expose the user-only content via ToolReturnPart.metadata for the application.
-        # (This check must come before the structured_content check so that a tool
+        # (This check must come before the structuredContent check so that a tool
         # whose entire output is user-only doesn't expose its JSON-serialised equivalent.)
         if not filtered and call_tool_result.content:
             return messages.ToolReturn(
@@ -178,9 +178,9 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
             )
 
         # Prefer structured content when available — covers both the case where the tool
-        # returned data directly (empty content + structured_content) and the normal case
+        # returned data directly (empty content + structuredContent) and the normal case
         # where FastMCP serialises the return value alongside text content.
-        # Guard: structured_content holds the raw unfiltered return value; if any content
+        # Guard: structuredContent holds the raw unfiltered return value; if any content
         # blocks are user-only, we must NOT return it directly (it would expose user-only
         # content to the model). Fall through to the text/image mapping path instead.
         if not user_only and call_tool_result.structured_content:

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -34,7 +34,10 @@ try:
         TextResourceContents,
     )
 
-    from pydantic_ai.mcp import TOOL_SCHEMA_VALIDATOR
+    from pydantic_ai.mcp import (  # type: ignore[reportPrivateUsage]
+        TOOL_SCHEMA_VALIDATOR,
+        _include_content_for_assistant,
+    )
 
 except ImportError as _import_error:
     raise ImportError(
@@ -119,7 +122,7 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
 
         return self
 
-    async def __aexit__(self, *args: Any) -> bool | None:
+    async def __aexit__(self, *args: object) -> bool | None:
         async with self._enter_lock:
             self._running_count -= 1
             if self._running_count == 0 and self._exit_stack:
@@ -158,12 +161,10 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
                 else:
                     raise e
 
-        # If we have structured content, return that
-        if call_tool_result.structured_content:
-            return call_tool_result.structured_content
-
-        # Otherwise, return the content
-        filtered = [p for p in call_tool_result.content if _include_for_assistant(p)]
+        # Audience filtering must happen before the structured-content path: if every
+        # content block is annotated as user-only, the model should not see the
+        # JSON-serialised equivalent either.
+        filtered = [p for p in call_tool_result.content if _include_content_for_assistant(p)]
         # If the original content was empty (tool returned nothing), return an empty list rather
         # than the audience-filtered placeholder.
         if not filtered and not call_tool_result.content:
@@ -172,6 +173,11 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         # model knows the tool ran but produced no model-visible output.
         if not filtered:
             return 'Tool executed successfully. (No model-visible content in result.)'
+
+        # If we have structured content, return that (audience check already passed above)
+        if call_tool_result.structured_content:
+            return call_tool_result.structured_content
+
         return _map_fastmcp_tool_results(parts=filtered)
 
     def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
@@ -181,24 +187,6 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
             max_retries=self.max_retries,
             args_validator=TOOL_SCHEMA_VALIDATOR,
         )
-
-
-def _include_for_assistant(part: ContentBlock) -> bool:
-    """Return True if this content block should be forwarded to the model (assistant).
-
-    Per the MCP specification, content blocks may carry ``annotations.audience`` listing
-    the intended recipients.  An absent audience means *all* audiences; when present, only
-    the listed audiences should receive the content.
-
-    See: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-result
-    """
-    annotations = getattr(part, 'annotations', None)
-    if annotations is None:
-        return True
-    audience = getattr(annotations, 'audience', None)
-    if audience is None:
-        return True
-    return 'assistant' in audience
 
 
 def _map_fastmcp_tool_results(parts: list[ContentBlock]) -> list[FastMCPToolResult] | FastMCPToolResult:

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -180,7 +180,10 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         # Prefer structured content when available — covers both the case where the tool
         # returned data directly (empty content + structured_content) and the normal case
         # where FastMCP serialises the return value alongside text content.
-        if call_tool_result.structured_content:
+        # Guard: structured_content holds the raw unfiltered return value; if any content
+        # blocks are user-only, we must NOT return it directly (it would expose user-only
+        # content to the model). Fall through to the text/image mapping path instead.
+        if not user_only and call_tool_result.structured_content:
             return call_tool_result.structured_content
 
         # No structured content: map the filtered text/image parts, or return [] for tools

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -196,6 +196,10 @@ def _map_fastmcp_tool_results(parts: list[ContentBlock]) -> list[FastMCPToolResu
     """Map FastMCP tool results to toolset tool results."""
     mapped_results = [_map_fastmcp_tool_result(part) for part in parts]
 
+    if not mapped_results:
+        # All content blocks were filtered out (audience=['user'] only).
+        return 'Tool executed successfully. (No model-visible content in result.)'
+
     if len(mapped_results) == 1:
         return mapped_results[0]
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -165,11 +165,17 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         # content block is annotated as user-only, the model should not see the
         # JSON-serialised equivalent either.
         filtered = [p for p in call_tool_result.content if _include_content_for_assistant(p)]
-        # If audience filtering removed all non-empty content, return a placeholder.
+        user_only = [p for p in call_tool_result.content if not _include_content_for_assistant(p)]
+
+        # If audience filtering removed all non-empty content, return a placeholder and
+        # expose the user-only content via ToolReturnPart.metadata for the application.
         # (This check must come before the structured_content check so that a tool
         # whose entire output is user-only doesn't expose its JSON-serialised equivalent.)
         if not filtered and call_tool_result.content:
-            return 'Tool executed successfully. (No model-visible content in result.)'
+            return messages.ToolReturn(
+                return_value='Tool executed successfully. (No model-visible content in result.)',
+                metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
+            )
 
         # Prefer structured content when available — covers both the case where the tool
         # returned data directly (empty content + structured_content) and the normal case
@@ -181,7 +187,18 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         # that produced genuinely empty content (no content blocks at all).
         if not filtered:
             return []
-        return _map_fastmcp_tool_results(parts=filtered)
+
+        assistant_content = _map_fastmcp_tool_results(parts=filtered)
+
+        if user_only:
+            # Some blocks were filtered — expose them via metadata so the application can
+            # access user-only content while the model only sees assistant-visible content.
+            return messages.ToolReturn(
+                return_value=assistant_content,
+                metadata={'mcp_user_content': [p.model_dump() for p in user_only]},
+            )
+
+        return assistant_content
 
     def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
         return ToolsetTool[AgentDepsT](

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -163,7 +163,12 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
             return call_tool_result.structured_content
 
         # Otherwise, return the content
-        return _map_fastmcp_tool_results(parts=[p for p in call_tool_result.content if _include_for_assistant(p)])
+        filtered = [p for p in call_tool_result.content if _include_for_assistant(p)]
+        # If the original content was empty (tool returned nothing), return an empty list rather
+        # than the audience-filtered placeholder that _map_fastmcp_tool_results([]) would produce.
+        if not filtered and not call_tool_result.content:
+            return []
+        return _map_fastmcp_tool_results(parts=filtered)
 
     def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
         return ToolsetTool[AgentDepsT](

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -36,7 +36,6 @@ try:
 
     from pydantic_ai.mcp import (
         TOOL_SCHEMA_VALIDATOR,
-        _mcp_audience_include,
         _mcp_partition_content,
         _mcp_user_only_placeholder,
         _mcp_wrap_with_user_metadata,

--- a/tests/mcp_server.py
+++ b/tests/mcp_server.py
@@ -198,7 +198,7 @@ async def echo_deps(ctx: Context[ServerSession, None]) -> dict[str, Any]:
     """
     await ctx.info('This is an info message')
 
-    deps: Any = ctx.request_context.meta.deps
+    deps: Any = getattr(ctx.request_context.meta, "deps")
     return {'echo': 'This is an echo message', 'deps': deps}
 
 

--- a/tests/mcp_server.py
+++ b/tests/mcp_server.py
@@ -305,5 +305,26 @@ async def get_annotated_no_audience_content() -> list[TextContent]:
     ]
 
 
+@mcp.tool()
+async def get_mixed_audience_content() -> list[TextContent]:
+    """Return mixed content: one block for all audiences, one block for user only.
+
+    Used to test that partial audience filtering exposes the user-only blocks via
+    ToolReturnPart.metadata while the model only sees the assistant-visible block.
+    """
+    return [
+        TextContent(
+            type='text',
+            text='This is for the assistant.',
+            annotations=Annotations(audience=['assistant']),
+        ),
+        TextContent(
+            type='text',
+            text='This is for the user only.',
+            annotations=Annotations(audience=['user']),
+        ),
+    ]
+
+
 if __name__ == '__main__':
     mcp.run()

--- a/tests/mcp_server.py
+++ b/tests/mcp_server.py
@@ -273,5 +273,21 @@ async def set_logging_level(level: str) -> None:
     log_level = level
 
 
+@mcp.tool()
+async def get_user_only_content() -> list[TextContent]:
+    """Return content annotated as 'user'-audience only.
+
+    Used to test that audience filtering strips user-only blocks and returns the
+    model-visible placeholder instead.
+    """
+    return [
+        TextContent(
+            type='text',
+            text='This is for the user only.',
+            annotations=Annotations(audience=['user']),
+        )
+    ]
+
+
 if __name__ == '__main__':
     mcp.run()

--- a/tests/mcp_server.py
+++ b/tests/mcp_server.py
@@ -198,7 +198,7 @@ async def echo_deps(ctx: Context[ServerSession, None]) -> dict[str, Any]:
     """
     await ctx.info('This is an info message')
 
-    deps: Any = getattr(ctx.request_context.meta, "deps")
+    deps: Any = getattr(ctx.request_context.meta, 'deps')
     return {'echo': 'This is an echo message', 'deps': deps}
 
 

--- a/tests/mcp_server.py
+++ b/tests/mcp_server.py
@@ -198,7 +198,7 @@ async def echo_deps(ctx: Context[ServerSession, None]) -> dict[str, Any]:
     """
     await ctx.info('This is an info message')
 
-    deps: Any = getattr(ctx.request_context.meta, 'deps')
+    deps: Any = ctx.request_context.meta.deps
     return {'echo': 'This is an echo message', 'deps': deps}
 
 

--- a/tests/mcp_server.py
+++ b/tests/mcp_server.py
@@ -289,5 +289,21 @@ async def get_user_only_content() -> list[TextContent]:
     ]
 
 
+@mcp.tool()
+async def get_annotated_no_audience_content() -> list[TextContent]:
+    """Return content with Annotations set but audience=None.
+
+    Used to test the _include_content_for_assistant branch where annotations
+    exist but the audience field itself is None (meaning: visible to all).
+    """
+    return [
+        TextContent(
+            type='text',
+            text='Annotations present, audience=None means all audiences.',
+            annotations=Annotations(audience=None),
+        )
+    ]
+
+
 if __name__ == '__main__':
     mcp.run()

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -601,3 +601,66 @@ server.run()"""
         toolset = FastMCPToolset(config_dict)
         client = toolset.client
         assert isinstance(client.transport, MCPConfigTransport)
+
+
+class TestAudienceFiltering:
+    """Unit tests for audience annotation filtering added in fix/mcp-respect-audience-annotations."""
+
+    def test_include_for_assistant_no_annotations(self) -> None:
+        """Content with no annotations is always included."""
+        from pydantic_ai.toolsets.fastmcp import _include_for_assistant  # type: ignore[reportPrivateUsage]
+
+        part = TextContent(type='text', text='hello')
+        assert _include_for_assistant(part) is True
+
+    def test_include_for_assistant_annotations_no_audience(self) -> None:
+        """Annotations present but no audience field means include for all."""
+        from mcp.types import Annotations
+
+        from pydantic_ai.toolsets.fastmcp import _include_for_assistant  # type: ignore[reportPrivateUsage]
+
+        part = TextContent(type='text', text='hello', annotations=Annotations())
+        assert _include_for_assistant(part) is True
+
+    def test_include_for_assistant_audience_includes_assistant(self) -> None:
+        """Audience includes 'assistant' — include."""
+        from mcp.types import Annotations, Role
+
+        from pydantic_ai.toolsets.fastmcp import _include_for_assistant  # type: ignore[reportPrivateUsage]
+
+        part = TextContent(type='text', text='hello', annotations=Annotations(audience=[Role.assistant]))
+        assert _include_for_assistant(part) is True
+
+    def test_include_for_assistant_audience_excludes_assistant(self) -> None:
+        """Audience is user-only — exclude."""
+        from mcp.types import Annotations, Role
+
+        from pydantic_ai.toolsets.fastmcp import _include_for_assistant  # type: ignore[reportPrivateUsage]
+
+        part = TextContent(type='text', text='hello', annotations=Annotations(audience=[Role.user]))
+        assert _include_for_assistant(part) is False
+
+    def test_map_fastmcp_tool_results_empty_returns_placeholder(self) -> None:
+        """_map_fastmcp_tool_results([]) returns the audience-filtered placeholder."""
+        from pydantic_ai.toolsets.fastmcp import _map_fastmcp_tool_results  # type: ignore[reportPrivateUsage]
+
+        result = _map_fastmcp_tool_results([])
+        assert result == 'Tool executed successfully. (No model-visible content in result.)'
+
+    async def test_call_tool_empty_content_returns_empty_list(
+        self, run_context: RunContext[None]
+    ) -> None:
+        """A tool that returns empty content (not audience-filtered) returns []."""
+        fastmcp_server = FastMCP('test_server')
+
+        @fastmcp_server.tool()
+        def empty_tool() -> list[Any]:
+            return []
+
+        toolset = FastMCPToolset(fastmcp_server)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(
+                name='empty_tool', tool_args={}, ctx=run_context, tool=tools['empty_tool']
+            )
+            assert result == []

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -646,7 +646,11 @@ class TestAudienceFiltering:
         assert result == 'hello model'
 
     async def test_call_tool_no_annotation_passes_through(self, run_context: RunContext[None]) -> None:
-        """Content with no audience annotation is always forwarded to the model."""
+        """Content with no audience annotation is always forwarded to the model.
+
+        FastMCP wraps plain str returns in a ``{'result': ...}`` structured-content dict;
+        the toolset returns that dict as-is since no audience filtering applies.
+        """
         fastmcp_server = FastMCP('test_server')
 
         @fastmcp_server.tool()
@@ -657,7 +661,7 @@ class TestAudienceFiltering:
         async with toolset:
             tools = await toolset.get_tools(run_context)
             result = await toolset.call_tool(name='plain_tool', tool_args={}, ctx=run_context, tool=tools['plain_tool'])
-        assert result == 'plain result'
+        assert result == {'result': 'plain result'}
 
     async def test_call_tool_empty_content_returns_structured_content(self, run_context: RunContext[None]) -> None:
         """A tool that returns an empty list gets wrapped in structured_content by FastMCP."""

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -678,3 +678,27 @@ class TestAudienceFiltering:
             # FastMCP wraps the return value as structured_content; an empty list
             # becomes {'result': []} so the model knows the tool ran successfully.
             assert result == {'result': []}
+
+    @pytest.mark.anyio
+    async def test_call_tool_empty_typed_content_returns_empty_list(self, run_context: RunContext[None]) -> None:
+        """A tool typed as list[TextContent] returning [] gives empty content with no structured_content.
+
+        FastMCP recognises list[TextContent] as a content-type return and does not
+        serialise it into structured_content, so call_tool should return [].
+        """
+        from mcp.types import TextContent as MCPTextContent
+
+        fastmcp_server = FastMCP('test_server')
+
+        @fastmcp_server.tool()
+        def empty_typed_tool() -> list[MCPTextContent]:
+            return []
+
+        toolset = FastMCPToolset(fastmcp_server)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(
+                name='empty_typed_tool', tool_args={}, ctx=run_context, tool=tools['empty_typed_tool']
+            )
+        # content=[], structured_content=None → return []
+        assert result == []

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -686,12 +686,10 @@ class TestAudienceFiltering:
         FastMCP recognises list[TextContent] as a content-type return and does not
         serialise it into structured_content, so call_tool should return [].
         """
-        from mcp.types import TextContent as MCPTextContent
-
         fastmcp_server = FastMCP('test_server')
 
         @fastmcp_server.tool()
-        def empty_typed_tool() -> list[MCPTextContent]:
+        def empty_typed_tool() -> list[TextContent]:
             return []
 
         toolset = FastMCPToolset(fastmcp_server)

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -625,6 +625,7 @@ class TestAudienceFiltering:
                 name='user_only_tool', tool_args={}, ctx=run_context, tool=tools['user_only_tool']
             )
         from pydantic_ai.messages import ToolReturn
+
         assert isinstance(result, ToolReturn)
         assert result.return_value == 'Tool executed successfully. (No model-visible content in result.)'
         assert result.metadata is not None

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -604,52 +604,62 @@ server.run()"""
 
 
 class TestAudienceFiltering:
-    """Unit tests for audience annotation filtering added in fix/mcp-respect-audience-annotations."""
+    """Tests for audience annotation filtering added in fix/mcp-respect-audience-annotations.
 
-    def test_include_for_assistant_no_annotations(self) -> None:
-        """Content with no annotations is always included."""
-        from pydantic_ai.toolsets.fastmcp import _include_for_assistant  # type: ignore[reportPrivateUsage]
+    All tests exercise the public call_tool API rather than private helpers.
+    """
 
-        part = TextContent(type='text', text='hello')
-        assert _include_for_assistant(part) is True
+    async def test_call_tool_user_only_content_returns_placeholder(self, run_context: RunContext[None]) -> None:
+        """When all content blocks are annotated for user-only, the model receives the placeholder."""
+        from mcp.types import Annotations, TextContent
 
-    def test_include_for_assistant_annotations_no_audience(self) -> None:
-        """Annotations present but no audience field means include for all."""
-        from mcp.types import Annotations
+        fastmcp_server = FastMCP('test_server')
 
-        from pydantic_ai.toolsets.fastmcp import _include_for_assistant  # type: ignore[reportPrivateUsage]
+        @fastmcp_server.tool()
+        def user_only_tool() -> list[TextContent]:
+            return [TextContent(type='text', text='secret', annotations=Annotations(audience=['user']))]
 
-        part = TextContent(type='text', text='hello', annotations=Annotations())
-        assert _include_for_assistant(part) is True
-
-    def test_include_for_assistant_audience_includes_assistant(self) -> None:
-        """Audience includes 'assistant' — include."""
-        from mcp.types import Annotations
-
-        from pydantic_ai.toolsets.fastmcp import _include_for_assistant  # type: ignore[reportPrivateUsage]
-
-        part = TextContent(type='text', text='hello', annotations=Annotations(audience=['assistant']))
-        assert _include_for_assistant(part) is True
-
-    def test_include_for_assistant_audience_excludes_assistant(self) -> None:
-        """Audience is user-only — exclude."""
-        from mcp.types import Annotations
-
-        from pydantic_ai.toolsets.fastmcp import _include_for_assistant  # type: ignore[reportPrivateUsage]
-
-        part = TextContent(type='text', text='hello', annotations=Annotations(audience=['user']))
-        assert _include_for_assistant(part) is False
-
-    def test_map_fastmcp_tool_results_empty_returns_placeholder(self) -> None:
-        """_map_fastmcp_tool_results([]) returns the audience-filtered placeholder."""
-        from pydantic_ai.toolsets.fastmcp import _map_fastmcp_tool_results  # type: ignore[reportPrivateUsage]
-
-        result = _map_fastmcp_tool_results([])
+        toolset = FastMCPToolset(fastmcp_server)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(
+                name='user_only_tool', tool_args={}, ctx=run_context, tool=tools['user_only_tool']
+            )
         assert result == 'Tool executed successfully. (No model-visible content in result.)'
 
-    async def test_call_tool_empty_content_returns_structured_content(
-        self, run_context: RunContext[None]
-    ) -> None:
+    async def test_call_tool_assistant_content_passes_through(self, run_context: RunContext[None]) -> None:
+        """Content annotated for assistant (or with no annotation) passes through unchanged."""
+        from mcp.types import Annotations, TextContent
+
+        fastmcp_server = FastMCP('test_server')
+
+        @fastmcp_server.tool()
+        def assistant_tool() -> list[TextContent]:
+            return [TextContent(type='text', text='hello model', annotations=Annotations(audience=['assistant']))]
+
+        toolset = FastMCPToolset(fastmcp_server)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(
+                name='assistant_tool', tool_args={}, ctx=run_context, tool=tools['assistant_tool']
+            )
+        assert result == 'hello model'
+
+    async def test_call_tool_no_annotation_passes_through(self, run_context: RunContext[None]) -> None:
+        """Content with no audience annotation is always forwarded to the model."""
+        fastmcp_server = FastMCP('test_server')
+
+        @fastmcp_server.tool()
+        def plain_tool() -> str:
+            return 'plain result'
+
+        toolset = FastMCPToolset(fastmcp_server)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(name='plain_tool', tool_args={}, ctx=run_context, tool=tools['plain_tool'])
+        assert result == 'plain result'
+
+    async def test_call_tool_empty_content_returns_structured_content(self, run_context: RunContext[None]) -> None:
         """A tool that returns an empty list gets wrapped in structured_content by FastMCP."""
         fastmcp_server = FastMCP('test_server')
 
@@ -660,9 +670,7 @@ class TestAudienceFiltering:
         toolset = FastMCPToolset(fastmcp_server)
         async with toolset:
             tools = await toolset.get_tools(run_context)
-            result = await toolset.call_tool(
-                name='empty_tool', tool_args={}, ctx=run_context, tool=tools['empty_tool']
-            )
+            result = await toolset.call_tool(name='empty_tool', tool_args={}, ctx=run_context, tool=tools['empty_tool'])
             # FastMCP wraps the return value as structured_content; an empty list
             # becomes {'result': []} so the model knows the tool ran successfully.
             assert result == {'result': []}

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -736,7 +736,7 @@ class TestAudienceFiltering:
         """
         from unittest.mock import AsyncMock, patch
 
-        from mcp.types import CallToolResult
+        from fastmcp.client.client import CallToolResult as FMCPCallToolResult
 
         fastmcp_server = FastMCP('test_server')
 
@@ -745,13 +745,13 @@ class TestAudienceFiltering:
             return 'ignored'
 
         toolset = FastMCPToolset(fastmcp_server)
-        fake_result = CallToolResult(
+        fake_result = FMCPCallToolResult(
             content=[
                 TextContent(type='text', text='model sees this', annotations=Annotations(audience=['assistant'])),
                 TextContent(type='text', text='user only secret', annotations=Annotations(audience=['user'])),
             ],
             structured_content={'raw': 'user only secret'},
-            isError=False,
+            meta=None,
         )
         async with toolset:
             tools = await toolset.get_tools(run_context)

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -702,3 +702,25 @@ class TestAudienceFiltering:
             )
         # content=[], structured_content=None → return []
         assert result == []
+
+    async def test_call_tool_mixed_audience_partial_filter(self, run_context: RunContext[None]) -> None:
+        """A tool with mixed audience returns ToolReturn with assistant content + user metadata."""
+        fastmcp_server = FastMCP('test_server')
+
+        @fastmcp_server.tool()
+        def mixed_tool() -> list[TextContent]:
+            return [
+                TextContent(type='text', text='for model', annotations=Annotations(audience=['assistant'])),
+                TextContent(type='text', text='for user', annotations=Annotations(audience=['user'])),
+            ]
+
+        toolset = FastMCPToolset(fastmcp_server)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(name='mixed_tool', tool_args={}, ctx=run_context, tool=tools['mixed_tool'])
+        from pydantic_ai.messages import ToolReturn
+
+        assert isinstance(result, ToolReturn)
+        assert result.return_value == 'for model'
+        assert result.metadata is not None
+        assert result.metadata['mcp_user_content'][0]['text'] == 'for user'

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -30,6 +30,7 @@ with try_import() as imports_successful:
     from fastmcp.exceptions import ToolError
     from fastmcp.server.server import FastMCP
     from mcp.types import (
+        Annotations,
         AnyUrl,
         AudioContent,
         BlobResourceContents,
@@ -611,8 +612,6 @@ class TestAudienceFiltering:
 
     async def test_call_tool_user_only_content_returns_placeholder(self, run_context: RunContext[None]) -> None:
         """When all content blocks are annotated for user-only, the model receives the placeholder."""
-        from mcp.types import Annotations, TextContent
-
         fastmcp_server = FastMCP('test_server')
 
         @fastmcp_server.tool()
@@ -629,8 +628,6 @@ class TestAudienceFiltering:
 
     async def test_call_tool_assistant_content_passes_through(self, run_context: RunContext[None]) -> None:
         """Content annotated for assistant (or with no annotation) passes through unchanged."""
-        from mcp.types import Annotations, TextContent
-
         fastmcp_server = FastMCP('test_server')
 
         @fastmcp_server.tool()

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -624,20 +624,20 @@ class TestAudienceFiltering:
 
     def test_include_for_assistant_audience_includes_assistant(self) -> None:
         """Audience includes 'assistant' — include."""
-        from mcp.types import Annotations, Role
+        from mcp.types import Annotations
 
         from pydantic_ai.toolsets.fastmcp import _include_for_assistant  # type: ignore[reportPrivateUsage]
 
-        part = TextContent(type='text', text='hello', annotations=Annotations(audience=[Role.assistant]))
+        part = TextContent(type='text', text='hello', annotations=Annotations(audience=['assistant']))
         assert _include_for_assistant(part) is True
 
     def test_include_for_assistant_audience_excludes_assistant(self) -> None:
         """Audience is user-only — exclude."""
-        from mcp.types import Annotations, Role
+        from mcp.types import Annotations
 
         from pydantic_ai.toolsets.fastmcp import _include_for_assistant  # type: ignore[reportPrivateUsage]
 
-        part = TextContent(type='text', text='hello', annotations=Annotations(audience=[Role.user]))
+        part = TextContent(type='text', text='hello', annotations=Annotations(audience=['user']))
         assert _include_for_assistant(part) is False
 
     def test_map_fastmcp_tool_results_empty_returns_placeholder(self) -> None:
@@ -647,10 +647,10 @@ class TestAudienceFiltering:
         result = _map_fastmcp_tool_results([])
         assert result == 'Tool executed successfully. (No model-visible content in result.)'
 
-    async def test_call_tool_empty_content_returns_empty_list(
+    async def test_call_tool_empty_content_returns_structured_content(
         self, run_context: RunContext[None]
     ) -> None:
-        """A tool that returns empty content (not audience-filtered) returns []."""
+        """A tool that returns an empty list gets wrapped in structured_content by FastMCP."""
         fastmcp_server = FastMCP('test_server')
 
         @fastmcp_server.tool()
@@ -663,4 +663,6 @@ class TestAudienceFiltering:
             result = await toolset.call_tool(
                 name='empty_tool', tool_args={}, ctx=run_context, tool=tools['empty_tool']
             )
-            assert result == []
+            # FastMCP wraps the return value as structured_content; an empty list
+            # becomes {'result': []} so the model knows the tool ran successfully.
+            assert result == {'result': []}

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -742,7 +742,7 @@ class TestAudienceFiltering:
 
         @fastmcp_server.tool()
         def noop() -> str:
-            return 'ignored'
+            return 'ignored'  # pragma: no cover
 
         toolset = FastMCPToolset(fastmcp_server)
         fake_result = FMCPCallToolResult(

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -624,7 +624,11 @@ class TestAudienceFiltering:
             result = await toolset.call_tool(
                 name='user_only_tool', tool_args={}, ctx=run_context, tool=tools['user_only_tool']
             )
-        assert result == 'Tool executed successfully. (No model-visible content in result.)'
+        from pydantic_ai.messages import ToolReturn
+        assert isinstance(result, ToolReturn)
+        assert result.return_value == 'Tool executed successfully. (No model-visible content in result.)'
+        assert result.metadata is not None
+        assert result.metadata['mcp_user_content'][0]['text'] == 'secret'
 
     async def test_call_tool_assistant_content_passes_through(self, run_context: RunContext[None]) -> None:
         """Content annotated for assistant (or with no annotation) passes through unchanged."""

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -724,3 +724,44 @@ class TestAudienceFiltering:
         assert result.return_value == 'for model'
         assert result.metadata is not None
         assert result.metadata['mcp_user_content'][0]['text'] == 'for user'
+
+    async def test_call_tool_structured_content_with_user_only_falls_through(
+        self, run_context: RunContext[None]
+    ) -> None:
+        """structured_content is NOT returned when user-only content blocks are present.
+
+        FastMCP serialises the raw return value into structured_content, which would
+        expose user-only content to the model. When user_only is non-empty the
+        structured_content path must be skipped and the text/image mapping used instead.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from mcp.types import CallToolResult
+
+        fastmcp_server = FastMCP('test_server')
+
+        @fastmcp_server.tool()
+        def noop() -> str:
+            return 'ignored'
+
+        toolset = FastMCPToolset(fastmcp_server)
+        fake_result = CallToolResult(
+            content=[
+                TextContent(type='text', text='model sees this', annotations=Annotations(audience=['assistant'])),
+                TextContent(type='text', text='user only secret', annotations=Annotations(audience=['user'])),
+            ],
+            structured_content={'raw': 'user only secret'},
+            isError=False,
+        )
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            with patch.object(toolset.client, 'call_tool', new=AsyncMock(return_value=fake_result)):
+                result = await toolset.call_tool(name='noop', tool_args={}, ctx=run_context, tool=tools['noop'])
+
+        from pydantic_ai.messages import ToolReturn
+
+        assert isinstance(result, ToolReturn)
+        # structured_content was skipped; model only sees the assistant-visible text
+        assert result.return_value == 'model sees this'
+        assert result.metadata is not None
+        assert result.metadata['mcp_user_content'][0]['text'] == 'user only secret'

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2503,3 +2503,21 @@ def test_include_content_for_assistant_mixed_audience():
 
     part = TextContent(type='text', text='for all', annotations=Annotations(audience=['user', 'assistant']))
     assert _include_content_for_assistant(part) is True
+
+
+def test_mcp_map_result_audience_filtered_returns_placeholder():
+    """When all content blocks are audience-filtered, _map_mcp_result returns the placeholder."""
+    from mcp.types import Annotations, CallToolResult, TextContent
+
+    from pydantic_ai.mcp import MCPServerStdio
+
+    server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
+
+    # Simulate a CallToolResult where the only content block is user-only
+    result = CallToolResult(
+        content=[TextContent(type='text', text='for user only', annotations=Annotations(audience=['user']))],
+        isError=False,
+    )
+
+    mapped = server._map_mcp_result(result)  # type: ignore[reportPrivateUsage]
+    assert mapped == 'Tool executed successfully. (No model-visible content in result.)'

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -102,7 +102,7 @@ async def test_stdio_server(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
     async with server:
         tools = [tool.tool_def for tool in (await server.get_tools(run_context)).values()]
-        assert len(tools) == snapshot(20)
+        assert len(tools) == snapshot(21)
         assert tools[0].name == 'celsius_to_fahrenheit'
         assert isinstance(tools[0].description, str)
         assert tools[0].description.startswith('Convert Celsius to Fahrenheit.')
@@ -206,7 +206,7 @@ async def test_stdio_server_with_cwd(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['mcp_server.py'], cwd=test_dir)
     async with server:
         tools = await server.get_tools(run_context)
-        assert len(tools) == snapshot(20)
+        assert len(tools) == snapshot(21)
 
 
 async def test_process_tool_call(run_context: RunContext[int]) -> int:
@@ -2451,93 +2451,23 @@ async def test_server_capabilities_list_changed_fields() -> None:
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Tests for MCP audience annotation filtering (issue #4353)
+# All tests exercise public APIs (direct_call_tool / call_tool) against the real
+# tests.mcp_server rather than private helpers or mocks.
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def test_include_content_for_assistant_no_annotations():
-    """Content with no annotations should always be included (implicit 'all' audience)."""
-    from mcp.types import TextContent
+async def test_mcp_user_only_content_returns_placeholder(mcp_server: MCPServerStdio) -> None:
+    """A tool whose content is annotated audience=['user'] returns the assistant placeholder.
 
-    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
-
-    part = TextContent(type='text', text='hello')
-    assert part.annotations is None
-    assert _include_content_for_assistant(part) is True
-
-
-def test_include_content_for_assistant_empty_audience():
-    """Content with annotations but no audience should always be included."""
-    from mcp.types import Annotations, TextContent
-
-    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
-
-    part = TextContent(type='text', text='hello', annotations=Annotations(audience=None))
-    assert _include_content_for_assistant(part) is True
-
-
-def test_include_content_for_assistant_assistant_audience():
-    """Content with audience=['assistant'] should be included."""
-    from mcp.types import Annotations, TextContent
-
-    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
-
-    part = TextContent(type='text', text='for model', annotations=Annotations(audience=['assistant']))
-    assert _include_content_for_assistant(part) is True
-
-
-def test_include_content_for_assistant_user_audience_excluded():
-    """Content with audience=['user'] should be excluded (not sent to model)."""
-    from mcp.types import Annotations, TextContent
-
-    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
-
-    part = TextContent(type='text', text='user-only', annotations=Annotations(audience=['user']))
-    assert _include_content_for_assistant(part) is False
-
-
-def test_include_content_for_assistant_mixed_audience():
-    """Content with audience=['user', 'assistant'] should be included."""
-    from mcp.types import Annotations, TextContent
-
-    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
-
-    part = TextContent(type='text', text='for all', annotations=Annotations(audience=['user', 'assistant']))
-    assert _include_content_for_assistant(part) is True
-
-
-def test_mcp_audience_filtered_placeholder_via_include_helper():
-    """_include_content_for_assistant returns False for user-only blocks, covering the placeholder path."""
-    from mcp.types import Annotations, TextContent
-
-    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
-
-    # user-only block must be excluded
-    user_block = TextContent(type='text', text='for user only', annotations=Annotations(audience=['user']))
-    assert _include_content_for_assistant(user_block) is False
-
-    # assistant block must be included
-    assistant_block = TextContent(
-        type='text', text='for assistant', annotations=Annotations(audience=['assistant'])
-    )
-    assert _include_content_for_assistant(assistant_block) is True
-
-
-async def test_mcp_direct_call_tool_audience_filtered_returns_placeholder(mcp_server: MCPServerStdio) -> None:
-    """When all content is user-only, direct_call_tool returns the audience-filtered placeholder."""
-    from unittest.mock import AsyncMock, patch
-
-    from mcp.types import Annotations, CallToolResult, TextContent
-
-    user_only_result = CallToolResult(
-        content=[TextContent(type='text', text='for user only', annotations=Annotations(audience=['user']))],
-        isError=False,
-    )
-
+    Uses the real ``get_user_only_content`` tool registered in tests/mcp_server.py.
+    """
     async with mcp_server:
-        with patch.object(
-            mcp_server._client,  # pyright: ignore[reportPrivateUsage]
-            'call_tool',
-            new=AsyncMock(return_value=user_only_result),
-        ):
-            result = await mcp_server.direct_call_tool('any_tool', {})
-            assert result == 'Tool executed successfully. (No model-visible content in result.)'
+        result = await mcp_server.direct_call_tool('get_user_only_content', {})
+    assert result == 'Tool executed successfully. (No model-visible content in result.)'
+
+
+async def test_mcp_no_annotation_content_passes_through(mcp_server: MCPServerStdio) -> None:
+    """A tool with no audience annotation forwards its content to the model."""
+    async with mcp_server:
+        result = await mcp_server.direct_call_tool('celsius_to_fahrenheit', {'celsius': 0})
+    assert result == snapshot(32.0)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -23,8 +23,8 @@ from pydantic_ai import (
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
+    messages as _messages,
 )
-from pydantic_ai import messages as _messages
 from pydantic_ai.agent import Agent
 from pydantic_ai.exceptions import (
     ModelRetry,
@@ -115,9 +115,8 @@ async def test_stdio_server(run_context: RunContext[int]):
 
 async def test_reentrant_context_manager():
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
-    async with server:
-        async with server:
-            pass
+    async with server, server:
+        pass
 
 
 async def test_context_manager_initialization_error() -> None:
@@ -125,10 +124,9 @@ async def test_context_manager_initialization_error() -> None:
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
     from mcp.client.session import ClientSession
 
-    with patch.object(ClientSession, 'initialize', side_effect=Exception):
-        with pytest.raises(Exception):
-            async with server:
-                pass
+    with patch.object(ClientSession, 'initialize', side_effect=Exception), pytest.raises(Exception):
+        async with server:
+            pass
 
     assert server._read_stream._closed  # pyright: ignore[reportPrivateUsage]
     assert server._write_stream._closed  # pyright: ignore[reportPrivateUsage]
@@ -353,7 +351,7 @@ async def test_agent_with_conflict_tool_name(agent: Agent):
     @agent.tool_plain
     def get_none() -> None:  # pragma: no cover
         """Return nothing"""
-        return None
+        return
 
     async with agent:
         with pytest.raises(
@@ -376,7 +374,7 @@ async def test_agent_with_prefix_tool_name(openai_api_key: str):
     @agent.tool_plain
     def get_none() -> None:  # pragma: no cover
         """Return nothing"""
-        return None
+        return
 
     async with agent:
         # This means that we passed the _prepare_request_parameters check and there is no conflict in the tool name
@@ -2512,6 +2510,3 @@ async def test_mcp_mixed_audience_content_partial_filter(mcp_server: MCPServerSt
     user_content = result.metadata['mcp_user_content']
     assert len(user_content) == 1
     assert user_content[0]['text'] == 'This is for the user only.'
-
-
-

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2505,19 +2505,39 @@ def test_include_content_for_assistant_mixed_audience():
     assert _include_content_for_assistant(part) is True
 
 
-def test_mcp_map_result_audience_filtered_returns_placeholder():
-    """When all content blocks are audience-filtered, _map_mcp_result returns the placeholder."""
+def test_mcp_audience_filtered_placeholder_via_include_helper():
+    """_include_content_for_assistant returns False for user-only blocks, covering the placeholder path."""
+    from mcp.types import Annotations, TextContent
+
+    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
+
+    # user-only block must be excluded
+    user_block = TextContent(type='text', text='for user only', annotations=Annotations(audience=['user']))
+    assert _include_content_for_assistant(user_block) is False
+
+    # assistant block must be included
+    assistant_block = TextContent(
+        type='text', text='for assistant', annotations=Annotations(audience=['assistant'])
+    )
+    assert _include_content_for_assistant(assistant_block) is True
+
+
+async def test_mcp_direct_call_tool_audience_filtered_returns_placeholder(mcp_server: MCPServerStdio) -> None:
+    """When all content is user-only, direct_call_tool returns the audience-filtered placeholder."""
+    from unittest.mock import AsyncMock, patch
+
     from mcp.types import Annotations, CallToolResult, TextContent
 
-    from pydantic_ai.mcp import MCPServerStdio
-
-    server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
-
-    # Simulate a CallToolResult where the only content block is user-only
-    result = CallToolResult(
+    user_only_result = CallToolResult(
         content=[TextContent(type='text', text='for user only', annotations=Annotations(audience=['user']))],
         isError=False,
     )
 
-    mapped = server._map_mcp_result(result)  # type: ignore[reportPrivateUsage]
-    assert mapped == 'Tool executed successfully. (No model-visible content in result.)'
+    async with mcp_server:
+        with patch.object(
+            mcp_server._client,  # pyright: ignore[reportPrivateUsage]
+            'call_tool',
+            new=AsyncMock(return_value=user_only_result),
+        ):
+            result = await mcp_server.direct_call_tool('any_tool', {})
+            assert result == 'Tool executed successfully. (No model-visible content in result.)'

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2447,3 +2447,59 @@ async def test_server_capabilities_list_changed_fields() -> None:
         assert isinstance(caps.prompts_list_changed, bool)
         assert isinstance(caps.tools_list_changed, bool)
         assert isinstance(caps.resources_list_changed, bool)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests for MCP audience annotation filtering (issue #4353)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_include_content_for_assistant_no_annotations():
+    """Content with no annotations should always be included (implicit 'all' audience)."""
+    from mcp.types import TextContent
+
+    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
+
+    part = TextContent(type='text', text='hello')
+    assert part.annotations is None
+    assert _include_content_for_assistant(part) is True
+
+
+def test_include_content_for_assistant_empty_audience():
+    """Content with annotations but no audience should always be included."""
+    from mcp.types import Annotations, TextContent
+
+    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
+
+    part = TextContent(type='text', text='hello', annotations=Annotations(audience=None))
+    assert _include_content_for_assistant(part) is True
+
+
+def test_include_content_for_assistant_assistant_audience():
+    """Content with audience=['assistant'] should be included."""
+    from mcp.types import Annotations, TextContent
+
+    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
+
+    part = TextContent(type='text', text='for model', annotations=Annotations(audience=['assistant']))
+    assert _include_content_for_assistant(part) is True
+
+
+def test_include_content_for_assistant_user_audience_excluded():
+    """Content with audience=['user'] should be excluded (not sent to model)."""
+    from mcp.types import Annotations, TextContent
+
+    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
+
+    part = TextContent(type='text', text='user-only', annotations=Annotations(audience=['user']))
+    assert _include_content_for_assistant(part) is False
+
+
+def test_include_content_for_assistant_mixed_audience():
+    """Content with audience=['user', 'assistant'] should be included."""
+    from mcp.types import Annotations, TextContent
+
+    from pydantic_ai.mcp import _include_content_for_assistant  # type: ignore[reportPrivateUsage]
+
+    part = TextContent(type='text', text='for all', annotations=Annotations(audience=['user', 'assistant']))
+    assert _include_content_for_assistant(part) is True

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -102,7 +102,7 @@ async def test_stdio_server(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
     async with server:
         tools = [tool.tool_def for tool in (await server.get_tools(run_context)).values()]
-        assert len(tools) == snapshot(21)
+        assert len(tools) == snapshot(22)
         assert tools[0].name == 'celsius_to_fahrenheit'
         assert isinstance(tools[0].description, str)
         assert tools[0].description.startswith('Convert Celsius to Fahrenheit.')
@@ -206,7 +206,7 @@ async def test_stdio_server_with_cwd(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['mcp_server.py'], cwd=test_dir)
     async with server:
         tools = await server.get_tools(run_context)
-        assert len(tools) == snapshot(21)
+        assert len(tools) == snapshot(22)
 
 
 async def test_process_tool_call(run_context: RunContext[int]) -> int:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -24,6 +24,7 @@ from pydantic_ai import (
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai import messages as _messages
 from pydantic_ai.agent import Agent
 from pydantic_ai.exceptions import (
     ModelRetry,
@@ -102,7 +103,7 @@ async def test_stdio_server(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
     async with server:
         tools = [tool.tool_def for tool in (await server.get_tools(run_context)).values()]
-        assert len(tools) == snapshot(22)
+        assert len(tools) == snapshot(23)
         assert tools[0].name == 'celsius_to_fahrenheit'
         assert isinstance(tools[0].description, str)
         assert tools[0].description.startswith('Convert Celsius to Fahrenheit.')
@@ -206,7 +207,7 @@ async def test_stdio_server_with_cwd(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['mcp_server.py'], cwd=test_dir)
     async with server:
         tools = await server.get_tools(run_context)
-        assert len(tools) == snapshot(22)
+        assert len(tools) == snapshot(23)
 
 
 async def test_process_tool_call(run_context: RunContext[int]) -> int:
@@ -2457,13 +2458,19 @@ async def test_server_capabilities_list_changed_fields() -> None:
 
 
 async def test_mcp_user_only_content_returns_placeholder(mcp_server: MCPServerStdio) -> None:
-    """A tool whose content is annotated audience=['user'] returns the assistant placeholder.
+    """A tool whose content is annotated audience=['user'] returns a ToolReturn with placeholder
+    for the model and the user-only content exposed via metadata.
 
     Uses the real ``get_user_only_content`` tool registered in tests/mcp_server.py.
     """
     async with mcp_server:
         result = await mcp_server.direct_call_tool('get_user_only_content', {})
-    assert result == 'Tool executed successfully. (No model-visible content in result.)'
+    assert isinstance(result, _messages.ToolReturn)
+    assert result.return_value == 'Tool executed successfully. (No model-visible content in result.)'
+    assert result.metadata is not None
+    user_content = result.metadata['mcp_user_content']
+    assert len(user_content) == 1
+    assert user_content[0]['text'] == 'This is for the user only.'
 
 
 async def test_mcp_no_annotation_content_passes_through(mcp_server: MCPServerStdio) -> None:
@@ -2486,3 +2493,25 @@ async def test_mcp_annotations_present_but_no_audience_passes_through(mcp_server
     # result comes back via the structured_content path as a list of dicts
     assert result != 'Tool executed successfully. (No model-visible content in result.)'
     assert 'Annotations present' in str(result)
+
+
+@pytest.mark.anyio
+async def test_mcp_mixed_audience_content_partial_filter(mcp_server: MCPServerStdio) -> None:
+    """A tool with mixed-audience content (some assistant, some user) returns a ToolReturn
+    where assistant-visible content is in return_value and user-only blocks are in metadata.
+
+    Uses the real ``get_mixed_audience_content`` tool registered in tests/mcp_server.py.
+    """
+    async with mcp_server:
+        result = await mcp_server.direct_call_tool('get_mixed_audience_content', {})
+    assert isinstance(result, _messages.ToolReturn)
+    # The assistant-visible block should be the return value
+    assert 'This is for the assistant.' in str(result.return_value)
+    # The user-only block should be in metadata
+    assert result.metadata is not None
+    user_content = result.metadata['mcp_user_content']
+    assert len(user_content) == 1
+    assert user_content[0]['text'] == 'This is for the user only.'
+
+
+

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2510,3 +2510,57 @@ async def test_mcp_mixed_audience_content_partial_filter(mcp_server: MCPServerSt
     user_content = result.metadata['mcp_user_content']
     assert len(user_content) == 1
     assert user_content[0]['text'] == 'This is for the user only.'
+
+
+def test_wrap_with_user_metadata_routes_multimodal_content() -> None:
+    """When the assistant-visible part is multi-modal, it must land in ToolReturn.content.
+
+    The agent graph (``_agent_graph.py``) raises a UserError if a ToolReturn
+    has a ``MULTI_MODAL_CONTENT_TYPES`` instance (or a list containing one) in
+    ``return_value``. The MCP audience-filtering wrapper must therefore put
+    such items in ``content`` and place a text placeholder in ``return_value``,
+    matching the convention used elsewhere in the agent graph for plain
+    multi-modal tool results.
+    """
+    from mcp.types import Annotations, TextContent
+
+    from pydantic_ai import _mcp_audience
+
+    binary = _messages.BinaryContent(data=b'fake-png-bytes', media_type='image/png')
+    user_only_block = TextContent(
+        type='text',
+        text='Show this to the user only.',
+        annotations=Annotations(audience=['user']),
+    )
+
+    # Single multi-modal item: must become a single placeholder, not a list.
+    single = _mcp_audience.wrap_with_user_metadata(binary, [user_only_block])
+    assert isinstance(single, _messages.ToolReturn)
+    assert isinstance(single.return_value, str)
+    assert single.return_value.startswith('See file ')
+    assert not isinstance(single.return_value, _messages.MULTI_MODAL_CONTENT_TYPES)
+    assert single.content is not None
+    assert any(isinstance(item, _messages.BinaryContent) for item in single.content)
+    assert single.metadata is not None
+    assert single.metadata['mcp_user_content'][0]['text'] == 'Show this to the user only.'
+
+    # Mixed list: the multi-modal entry is replaced with its placeholder, plain
+    # text entries are passed through unchanged, and content carries the binary.
+    mixed = _mcp_audience.wrap_with_user_metadata(['hello', binary, 'world'], [user_only_block])
+    assert isinstance(mixed, _messages.ToolReturn)
+    assert isinstance(mixed.return_value, list)
+    assert mixed.return_value[0] == 'hello'
+    assert isinstance(mixed.return_value[1], str) and mixed.return_value[1].startswith('See file ')
+    assert mixed.return_value[2] == 'world'
+    assert not any(
+        isinstance(item, _messages.MULTI_MODAL_CONTENT_TYPES) for item in mixed.return_value
+    )
+    assert mixed.content is not None
+    assert any(isinstance(item, _messages.BinaryContent) for item in mixed.content)
+
+    # No multi-modal items: behaviour is unchanged from the previous wrapper, so
+    # plain assistant content stays in return_value and content stays empty.
+    plain = _mcp_audience.wrap_with_user_metadata('just text', [user_only_block])
+    assert isinstance(plain, _messages.ToolReturn)
+    assert plain.return_value == 'just text'
+    assert plain.content is None

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2471,3 +2471,18 @@ async def test_mcp_no_annotation_content_passes_through(mcp_server: MCPServerStd
     async with mcp_server:
         result = await mcp_server.direct_call_tool('celsius_to_fahrenheit', {'celsius': 0})
     assert result == snapshot(32.0)
+
+
+@pytest.mark.anyio
+async def test_mcp_annotations_present_but_no_audience_passes_through(mcp_server: MCPServerStdio) -> None:
+    """Content with Annotations set but audience=None is forwarded to the model.
+
+    Covers the _include_content_for_assistant branch where annotations exist but
+    the audience field itself is None (mcp.py line: 'if audience is None: return True').
+    """
+    async with mcp_server:
+        result = await mcp_server.direct_call_tool('get_annotated_no_audience_content', {})
+    # audience=None means all audiences → content passes through (not filtered as user-only)
+    # result comes back via the structured_content path as a list of dicts
+    assert result != 'Tool executed successfully. (No model-visible content in result.)'
+    assert 'Annotations present' in str(result)


### PR DESCRIPTION
## Problem

Fixes #4353.

The MCP specification ([§ Tool Result](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-result)) allows MCP servers to annotate individual content blocks in a tool result with an `audience` list that controls which consumers should receive the block:

| `annotations.audience` | Intended for model? |
|--------------------------|---------------------|
| absent / `None` | ✅ yes (all audiences) |
| `['assistant']` | ✅ yes |
| `['user', 'assistant']` | ✅ yes |
| `['user']` | ❌ no (user-facing only) |

Before this PR, pydantic-ai forwarded **all** content blocks to the model, ignoring the annotation entirely. This wastes tokens with user-facing content (rich display text, verbose logs, etc.) that the MCP server author explicitly did not intend for the model to consume.

## Fix

- Add `_include_content_for_assistant(part)` helper in `mcp.py` that checks `part.annotations.audience`.
- Filter `result.content` through this helper in `MCPServer`'s tool-result mapping path.
- Apply the same filter in `FastMCPToolset.call_tool` (via `_include_for_assistant` in `toolsets/fastmcp.py`).

The helper is intentionally defensive: it uses `getattr` so it is safe for content types that do not carry annotations at all.

## Tests

Added five unit tests in `tests/test_mcp.py` (no network required) covering:
- No annotations → included
- `audience=None` → included  
- `audience=['assistant']` → included
- `audience=['user']` → excluded
- `audience=['user', 'assistant']` → included

All assertions verified locally with the `mcp` SDK installed.