### PR TITLE
fix: output_validator ctx.retry reflects global retry counter, not per-tool count

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1004,6 +1004,16 @@ async def process_tool_calls(  # noqa: C901
                 continue
 
             # Validation passed - execute the tool
+            # Override ctx.retry with the global output-validation retry counter so that
+            # @agent.output_validator functions see the correct attempt number regardless
+            # of how many per-tool retries occurred for other tools.  The global counter
+            # (ctx.state.retries) tracks all retry-consuming events (empty responses,
+            # unknown tool calls, text validation failures), giving the validator an
+            # accurate picture of how much of the retry budget has been consumed.
+            validated = replace(
+                validated,
+                ctx=replace(validated.ctx, retry=ctx.state.retries, max_retries=ctx.deps.max_result_retries),
+            )
             try:
                 result_data = await tool_manager.execute_tool_call(validated)
             except exceptions.UnexpectedModelBehavior as e:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -455,6 +455,47 @@ def test_tool_output_function_retries():
     assert max_retries_log == [target_retries] * (target_retries + 1)
 
 
+def test_output_validator_sees_global_retry_count():
+    """output_validator ctx.retry should reflect the global retry counter, not a per-tool counter.
+
+    When an empty response (or another retry-consuming event) happens *before* the output tool
+    is called, the global ctx.state.retries is already > 0.  Before the fix the validator
+    received ctx.retry = 0 (per-tool count), while the actual attempt number was 1.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/4385.
+    """
+    retry_values_seen: list[int] = []
+
+    call_count = 0
+
+    def return_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal call_count
+        call_count += 1
+        # First call: return empty response → global retries increments to 1
+        if call_count == 1:
+            return ModelResponse(parts=[])
+        # Second call: return the output tool call
+        assert info.output_tools is not None
+        return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, '{"a": 1, "b": "foo"}')])
+
+    agent = Agent(FunctionModel(return_model), output_type=Foo, output_retries=3)
+
+    @agent.output_validator
+    def validate_output(ctx: RunContext[None], o: Foo) -> Foo:
+        retry_values_seen.append(ctx.retry)
+        return o
+
+    result = agent.run_sync('Hello')
+    assert isinstance(result.output, Foo)
+
+    # The output validator is called once, after one empty-response retry.
+    # With the fix, ctx.retry reflects the global counter (=1), not the per-tool counter (=0).
+    assert retry_values_seen == [1], (
+        f'Expected ctx.retry=[1] (global counter), got {retry_values_seen}. '
+        'output_validator should receive the global retry count, not the per-tool count.'
+    )
+
+
 class TestPartialOutput:
     """Tests for `ctx.partial_output` flag in output validators and output functions."""
 


### PR DESCRIPTION
## Problem

Fixes #4385.

`@agent.output_validator` functions received a `ctx.retry` that was set by the `ToolManager`'s `_build_tool_execution_context`:

```python
retry=self.ctx.retries.get(call.tool_name, 0)  # per-tool retry count
```

This is correct for function tools (each tool has its own retry budget) but wrong for output validators, which share the **global** output-validation budget (`output_retries` / `max_result_retries`).

The discrepancy means: if any retry-consuming event occurred **before** the output tool is called — empty model response, unknown tool call, text validation failure — the global counter is already `> 0` but the validator still sees `ctx.retry = 0`. Validators that use `ctx.retry` to adjust behavior on the last attempt are blind to the already-consumed retry budget.

The text-output path already does the right thing (line 821 of `_agent_graph.py`):

```python
run_context = replace(run_context, retry=ctx.state.retries, max_retries=ctx.deps.max_result_retries)
```

The tool-output path was missing this step.

## Fix

Immediately before calling `tool_manager.execute_tool_call` for an output tool, replace `validated.ctx` with a copy whose `retry`/`max_retries` reflect the global state:

```python
validated = replace(
    validated,
    ctx=replace(validated.ctx, retry=ctx.state.retries, max_retries=ctx.deps.max_result_retries),
)
```

## Test

Added `test_output_validator_sees_global_retry_count` which:
1. First model call returns an empty `ModelResponse(parts=[]))` — this consumes 1 global retry
2. Second call returns the output tool call
3. Asserts the output validator sees `ctx.retry == 1` (global), not `ctx.retry == 0` (per-tool)