### PR TITLE
fix(openrouter): handle null top-level fields when response is nested in provider field

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -513,8 +513,7 @@ def _map_openrouter_provider_details(
 ) -> dict[str, Any]:
     provider_details: dict[str, Any] = {}
 
-    if response.provider is not None:
-        provider_details['downstream_provider'] = response.provider
+    provider_details['downstream_provider'] = response.provider
     if native_finish_reason := response.choices[0].native_finish_reason:
         provider_details['finish_reason'] = native_finish_reason
 

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -483,6 +483,33 @@ class _OpenRouterChatCompletion(chat.ChatCompletion):
     """OpenRouter specific usage attribute."""
 
 
+class _OpenRouterErrorResponse(BaseModel):
+    """OpenRouter error response with null standard fields (see #3994)."""
+
+    choices: None
+    error: _OpenRouterError
+    model: str | None = None
+
+
+class _OpenRouterNestedCompletion(BaseModel, extra='allow'):
+    """The nested completion data inside the ``provider`` field (see #3994).
+
+    Uses ``extra='allow'`` to preserve all fields for re-validation
+    as :class:`_OpenRouterChatCompletion`.
+    """
+
+    choices: list[Any]
+    provider: str | None = None
+
+
+class _OpenRouterNestedProviderResponse(BaseModel):
+    """OpenRouter response where the real completion is nested in ``provider`` (see #3994)."""
+
+    choices: None
+    provider: _OpenRouterNestedCompletion
+    created: int
+
+
 def _map_openrouter_provider_details(
     response: _OpenRouterChatCompletion | _OpenRouterChatCompletionChunk,
 ) -> dict[str, Any]:
@@ -594,33 +621,27 @@ class OpenRouterModel(OpenAIChatModel):
     def _validate_completion(self, response: chat.ChatCompletion) -> _OpenRouterChatCompletion:
         response_dict = response.model_dump()
 
-        # OpenRouter intermittently returns responses with null standard fields.
-        # Handle the two known cases before validation (see #3994).
-        if response_dict.get('choices') is None:
-            # Case 1: Error response — surface as ModelHTTPError instead of a
-            # confusing ValidationError about null fields.
-            if error_data := response_dict.get('error'):
-                try:
-                    error = _OpenRouterError.model_validate(error_data)
-                except (TypeError, ValueError, ValidationError):
-                    pass
-                else:
-                    raise ModelHTTPError(
-                        status_code=error.code,
-                        model_name=response_dict.get('model') or self.model_name,
-                        body=error.message,
-                    )
+        # OpenRouter intermittently returns responses with null standard fields (#3994).
+        # Check for known quirky response shapes before normal validation.
+        try:
+            error_response = _OpenRouterErrorResponse.model_validate(response_dict)
+        except ValidationError:
+            pass
+        else:
+            raise ModelHTTPError(
+                status_code=error_response.error.code,
+                model_name=error_response.model or self.model_name,
+                body=error_response.error.message,
+            )
 
-            # Case 2: Nested provider response — the real completion is inside
-            # the `provider` dict; use it as the top-level response.
-            raw_provider = response_dict.get('provider')
-            if isinstance(raw_provider, dict):
-                nested = cast(dict[str, Any], raw_provider)
-                if isinstance(nested.get('choices'), list):
-                    provider_name = nested.pop('provider', None) or 'unknown'
-                    nested.setdefault('created', response_dict.get('created'))
-                    nested['provider'] = provider_name
-                    response_dict = nested
+        try:
+            nested = _OpenRouterNestedProviderResponse.model_validate(response_dict)
+        except ValidationError:
+            pass
+        else:
+            response_dict = nested.provider.model_dump()
+            response_dict['provider'] = nested.provider.provider or 'unknown'
+            response_dict.setdefault('created', nested.created)
 
         validated = _OpenRouterChatCompletion.model_validate(response_dict)
 

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias, cast
 
-from pydantic import BaseModel, Discriminator, ValidationError
+from pydantic import BaseModel, Discriminator, ValidationError, field_validator
 from typing_extensions import TypedDict, assert_never, override
 
 from ..builtin_tools import AbstractBuiltinTool, WebSearchTool
@@ -483,31 +483,29 @@ class _OpenRouterChatCompletion(chat.ChatCompletion):
     """OpenRouter specific usage attribute."""
 
 
-class _OpenRouterErrorResponse(BaseModel):
+class _OpenRouterErrorResponse(BaseModel, extra='allow'):
     """OpenRouter error response with null standard fields (see #3994)."""
 
-    choices: None
     error: _OpenRouterError
     model: str | None = None
 
 
-class _OpenRouterNestedCompletion(BaseModel, extra='allow'):
-    """The nested completion data inside the ``provider`` field (see #3994).
+class _OpenRouterNestedCompletion(_OpenRouterChatCompletion):
+    """Completion nested in the `provider` field where provider name may be null (see #3994)."""
 
-    Uses ``extra='allow'`` to preserve all fields for re-validation
-    as :class:`_OpenRouterChatCompletion`.
-    """
+    provider: str = 'unknown'
+    created: int = 0
 
-    choices: list[Any]
-    provider: str | None = None
+    @field_validator('provider', mode='before')
+    @classmethod
+    def _coerce_null_provider(cls, v: Any) -> str:
+        return v if isinstance(v, str) else 'unknown'
 
 
-class _OpenRouterNestedProviderResponse(BaseModel):
-    """OpenRouter response where the real completion is nested in ``provider`` (see #3994)."""
+class _OpenRouterNestedProviderResponse(BaseModel, extra='allow'):
+    """OpenRouter response where the real completion is nested in `provider` (see #3994)."""
 
-    choices: None
     provider: _OpenRouterNestedCompletion
-    created: int
 
 
 def _map_openrouter_provider_details(
@@ -621,29 +619,30 @@ class OpenRouterModel(OpenAIChatModel):
     def _validate_completion(self, response: chat.ChatCompletion) -> _OpenRouterChatCompletion:
         response_dict = response.model_dump()
 
-        # OpenRouter intermittently returns responses with null standard fields (#3994).
-        # Check for known quirky response shapes before normal validation.
         try:
-            error_response = _OpenRouterErrorResponse.model_validate(response_dict)
-        except ValidationError:
-            pass
-        else:
-            raise ModelHTTPError(
-                status_code=error_response.error.code,
-                model_name=error_response.model or self.model_name,
-                body=error_response.error.message,
-            )
+            validated = _OpenRouterChatCompletion.model_validate(response_dict)
+        except ValidationError as exc:
+            # OpenRouter intermittently returns responses with null standard fields (#3994).
+            # Try known quirky response shapes before giving up.
+            try:
+                error_response = _OpenRouterErrorResponse.model_validate(response_dict)
+            except ValidationError:
+                pass
+            else:
+                raise ModelHTTPError(
+                    status_code=error_response.error.code,
+                    model_name=error_response.model or self.model_name,
+                    body=error_response.error.message,
+                )
 
-        try:
-            nested = _OpenRouterNestedProviderResponse.model_validate(response_dict)
-        except ValidationError:
-            pass
-        else:
-            response_dict = nested.provider.model_dump()
-            response_dict['provider'] = nested.provider.provider or 'unknown'
-            response_dict.setdefault('created', nested.created)
+            try:
+                nested = _OpenRouterNestedProviderResponse.model_validate(response_dict)
+            except ValidationError:
+                raise exc
 
-        validated = _OpenRouterChatCompletion.model_validate(response_dict)
+            validated = nested.provider
+            if not validated.created:
+                validated.created = response_dict.get('created') or 0
 
         if error := validated.error:
             raise ModelHTTPError(status_code=error.code, model_name=validated.model, body=error.message)

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -421,10 +421,10 @@ class _OpenRouterChoice(chat_completion.Choice):
     native_finish_reason: str | None = None
     """The provided finish reason by the downstream provider from OpenRouter."""
 
-    finish_reason: Literal['stop', 'length', 'tool_calls', 'content_filter', 'error'] | None = None  # type: ignore[reportIncompatibleVariableOverride]
+    finish_reason: Literal['stop', 'length', 'tool_calls', 'content_filter', 'error']  # type: ignore[reportIncompatibleVariableOverride]
     """OpenRouter specific finish reasons.
 
-    Notably, removes 'function_call' and adds 'error'  finish reasons.
+    Notably, removes 'function_call' and adds 'error' finish reasons.
     """
 
     message: _OpenRouterCompletionMessage  # type: ignore[reportIncompatibleVariableOverride]
@@ -544,14 +544,13 @@ def _normalize_openrouter_response(
 
 
 def _openrouter_settings_to_openai_settings(
-    model_settings: OpenRouterModelSettings, model_request_parameters: ModelRequestParameters | None = None
+    model_settings: OpenRouterModelSettings, model_request_parameters: ModelRequestParameters
 ) -> OpenAIChatModelSettings:
     """Transforms a 'OpenRouterModelSettings' object into an 'OpenAIChatModelSettings' object.
 
     Args:
         model_settings: The 'OpenRouterModelSettings' object to transform.
-        model_request_parameters: Optional request parameters used to inject builtin tool settings
-            (e.g. web search plugins) into the request body.
+        model_request_parameters: The 'ModelRequestParameters' object to use for the transformation.
 
     Returns:
         An 'OpenAIChatModelSettings' object with equivalent settings.
@@ -571,11 +570,10 @@ def _openrouter_settings_to_openai_settings(
     if usage := model_settings.pop('openrouter_usage', None):
         extra_body['usage'] = usage
 
-    if model_request_parameters is not None:
-        for builtin_tool in model_request_parameters.builtin_tools:
-            if isinstance(builtin_tool, WebSearchTool):
-                extra_body.setdefault('plugins', []).append({'id': 'web'})
-                extra_body['web_search_options'] = {'search_context_size': builtin_tool.search_context_size}
+    for builtin_tool in model_request_parameters.builtin_tools:
+        if isinstance(builtin_tool, WebSearchTool):
+            extra_body.setdefault('plugins', []).append({'id': 'web'})
+            extra_body['web_search_options'] = {'search_context_size': builtin_tool.search_context_size}
 
     model_settings['extra_body'] = extra_body
 
@@ -633,20 +631,20 @@ class OpenRouterModel(OpenAIChatModel):
     def _validate_completion(self, response: chat.ChatCompletion) -> _OpenRouterChatCompletion:
         response_dict = response.model_dump()
 
-        # Surface structured errors before normalization so we get a clean ModelHTTPError.
+        # Surface structured errors before normalization so we get a clean ModelHTTPError
+        # instead of a confusing ValidationError when choices is null.
         if response_dict.get('choices') is None and (error_data := response_dict.get('error')):
             try:
                 error = _OpenRouterError.model_validate(error_data)
+            except (TypeError, ValueError, ValidationError):
+                # Malformed error_data — fall through and let model_validate produce a clearer error.
+                pass
+            else:
                 raise ModelHTTPError(
                     status_code=error.code,
                     model_name=response_dict.get('model') or self.model_name,
                     body=error.message,
                 )
-            except ModelHTTPError:
-                raise
-            except (TypeError, ValueError, ValidationError):
-                # Malformed error_data — fall through and let model_validate produce a clearer error.
-                pass
 
         response_dict = _normalize_openrouter_response(response_dict, self.model_name, 'chat.completion')
         validated = _OpenRouterChatCompletion.model_validate(response_dict)

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal, TypeAlias, cast
 
-from pydantic import BaseModel, Discriminator
+from pydantic import BaseModel, Discriminator, ValidationError
 from typing_extensions import TypedDict, assert_never, override
 
 from ..builtin_tools import AbstractBuiltinTool, WebSearchTool
@@ -418,10 +418,10 @@ class _OpenRouterCompletionMessage(chat.ChatCompletionMessage):
 class _OpenRouterChoice(chat_completion.Choice):
     """Wraps OpenAI chat completion choice with OpenRouter specific attributes."""
 
-    native_finish_reason: str | None
+    native_finish_reason: str | None = None
     """The provided finish reason by the downstream provider from OpenRouter."""
 
-    finish_reason: Literal['stop', 'length', 'tool_calls', 'content_filter', 'error']  # type: ignore[reportIncompatibleVariableOverride]
+    finish_reason: Literal['stop', 'length', 'tool_calls', 'content_filter', 'error'] | None = None  # type: ignore[reportIncompatibleVariableOverride]
     """OpenRouter specific finish reasons.
 
     Notably, removes 'function_call' and adds 'error'  finish reasons.
@@ -505,14 +505,53 @@ def _map_openrouter_provider_details(
     return provider_details
 
 
+def _normalize_openrouter_response(
+    response_dict: dict[str, Any], model_name: str, fallback_object_type: str
+) -> dict[str, Any]:
+    """Normalize an OpenRouter response dict before Pydantic validation.
+
+    Handles two known quirks:
+    1. Some providers (e.g. Google via OpenRouter) nest the real completion inside
+       the ``provider`` field when top-level ``choices`` is null.
+    2. Metadata fields (``id``, ``model``, ``object``, ``provider``) can be null
+       in early or error responses; fill them with safe fallbacks so Pydantic validation
+       doesn't reject the response outright.
+
+    Works for both regular completions and streaming chunks.
+    """
+    # 1. Unwrap nested provider data
+    raw_provider: Any = response_dict.get('provider')
+    if isinstance(raw_provider, dict) and response_dict.get('choices') is None:
+        provider_data = cast(dict[str, Any], raw_provider)
+        if isinstance(provider_data.get('choices'), list):
+            # pop returns None when the key exists but its value is None, so
+            # use `or 'unknown'` to normalise both missing-key and None-value.
+            nested_provider_name: str = cast(str, provider_data.pop('provider', None) or 'unknown')
+            response_dict.update(provider_data)
+            response_dict['provider'] = nested_provider_name
+
+    # 2. Sanitize missing metadata
+    if response_dict.get('id') is None:
+        response_dict['id'] = 'openrouter-fallback-id'
+    if response_dict.get('model') is None:
+        response_dict['model'] = model_name
+    if response_dict.get('object') is None:
+        response_dict['object'] = fallback_object_type
+    if not isinstance(response_dict.get('provider'), str):
+        response_dict['provider'] = 'unknown'
+
+    return response_dict
+
+
 def _openrouter_settings_to_openai_settings(
-    model_settings: OpenRouterModelSettings, model_request_parameters: ModelRequestParameters
+    model_settings: OpenRouterModelSettings, model_request_parameters: ModelRequestParameters | None = None
 ) -> OpenAIChatModelSettings:
     """Transforms a 'OpenRouterModelSettings' object into an 'OpenAIChatModelSettings' object.
 
     Args:
         model_settings: The 'OpenRouterModelSettings' object to transform.
-        model_request_parameters: The 'ModelRequestParameters' object to use for the transformation.
+        model_request_parameters: Optional request parameters used to inject builtin tool settings
+            (e.g. web search plugins) into the request body.
 
     Returns:
         An 'OpenAIChatModelSettings' object with equivalent settings.
@@ -532,10 +571,11 @@ def _openrouter_settings_to_openai_settings(
     if usage := model_settings.pop('openrouter_usage', None):
         extra_body['usage'] = usage
 
-    for builtin_tool in model_request_parameters.builtin_tools:
-        if isinstance(builtin_tool, WebSearchTool):
-            extra_body.setdefault('plugins', []).append({'id': 'web'})
-            extra_body['web_search_options'] = {'search_context_size': builtin_tool.search_context_size}
+    if model_request_parameters is not None:
+        for builtin_tool in model_request_parameters.builtin_tools:
+            if isinstance(builtin_tool, WebSearchTool):
+                extra_body.setdefault('plugins', []).append({'id': 'web'})
+                extra_body['web_search_options'] = {'search_context_size': builtin_tool.search_context_size}
 
     model_settings['extra_body'] = extra_body
 
@@ -580,7 +620,7 @@ class OpenRouterModel(OpenAIChatModel):
     ) -> tuple[ModelSettings | None, ModelRequestParameters]:
         merged_settings, customized_parameters = super().prepare_request(model_settings, model_request_parameters)
         new_settings = _openrouter_settings_to_openai_settings(
-            cast(OpenRouterModelSettings, merged_settings or {}), model_request_parameters
+            cast(OpenRouterModelSettings, merged_settings or {}), customized_parameters
         )
         return new_settings, customized_parameters
 
@@ -591,12 +631,30 @@ class OpenRouterModel(OpenAIChatModel):
 
     @override
     def _validate_completion(self, response: chat.ChatCompletion) -> _OpenRouterChatCompletion:
-        response = _OpenRouterChatCompletion.model_validate(response.model_dump())
+        response_dict = response.model_dump()
 
-        if error := response.error:
-            raise ModelHTTPError(status_code=error.code, model_name=response.model, body=error.message)
+        # Surface structured errors before normalization so we get a clean ModelHTTPError.
+        if response_dict.get('choices') is None and (error_data := response_dict.get('error')):
+            try:
+                error = _OpenRouterError.model_validate(error_data)
+                raise ModelHTTPError(
+                    status_code=error.code,
+                    model_name=response_dict.get('model') or self.model_name,
+                    body=error.message,
+                )
+            except ModelHTTPError:
+                raise
+            except (TypeError, ValueError, ValidationError):
+                # Malformed error_data — fall through and let model_validate produce a clearer error.
+                pass
 
-        return response
+        response_dict = _normalize_openrouter_response(response_dict, self.model_name, 'chat.completion')
+        validated = _OpenRouterChatCompletion.model_validate(response_dict)
+
+        if error := validated.error:
+            raise ModelHTTPError(status_code=error.code, model_name=validated.model, body=error.message)
+
+        return validated
 
     @override
     def _process_thinking(self, message: chat.ChatCompletionMessage) -> list[ThinkingPart] | None:
@@ -704,8 +762,12 @@ class _OpenRouterChunkChoice(chat_completion_chunk.Choice):
 class _OpenRouterChatCompletionChunk(chat.ChatCompletionChunk):
     """Wraps OpenAI chat completion with OpenRouter specific attributes."""
 
-    provider: str
-    """The downstream provider that was used by OpenRouter."""
+    provider: str | None = None
+    """The downstream provider that was used by OpenRouter.
+
+    May be absent in early streaming chunks; only the final chunk typically carries
+    the provider name.
+    """
 
     choices: list[_OpenRouterChunkChoice]  # type: ignore[reportIncompatibleVariableOverride]
     """A list of chat completion chunk choices modified with OpenRouter specific attributes."""
@@ -722,7 +784,10 @@ class OpenRouterStreamedResponse(OpenAIStreamedResponse):
     async def _validate_response(self):
         try:
             async for chunk in self._response:
-                yield _OpenRouterChatCompletionChunk.model_validate(chunk.model_dump())
+                chunk_dict = _normalize_openrouter_response(
+                    chunk.model_dump(), self._model_name, 'chat.completion.chunk'
+                )
+                yield _OpenRouterChatCompletionChunk.model_validate(chunk_dict)
         except APIError as e:
             error = _OpenRouterError.model_validate(e.body)
             raise ModelHTTPError(status_code=error.code, model_name=self._model_name, body=error.message)

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -488,7 +488,8 @@ def _map_openrouter_provider_details(
 ) -> dict[str, Any]:
     provider_details: dict[str, Any] = {}
 
-    provider_details['downstream_provider'] = response.provider
+    if response.provider is not None:
+        provider_details['downstream_provider'] = response.provider
     if native_finish_reason := response.choices[0].native_finish_reason:
         provider_details['finish_reason'] = native_finish_reason
 

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -505,44 +505,6 @@ def _map_openrouter_provider_details(
     return provider_details
 
 
-def _normalize_openrouter_response(
-    response_dict: dict[str, Any], model_name: str, fallback_object_type: str
-) -> dict[str, Any]:
-    """Normalize an OpenRouter response dict before Pydantic validation.
-
-    Handles two known quirks:
-    1. Some providers (e.g. Google via OpenRouter) nest the real completion inside
-       the ``provider`` field when top-level ``choices`` is null.
-    2. Metadata fields (``id``, ``model``, ``object``, ``provider``) can be null
-       in early or error responses; fill them with safe fallbacks so Pydantic validation
-       doesn't reject the response outright.
-
-    Works for both regular completions and streaming chunks.
-    """
-    # 1. Unwrap nested provider data
-    raw_provider: Any = response_dict.get('provider')
-    if isinstance(raw_provider, dict) and response_dict.get('choices') is None:
-        provider_data = cast(dict[str, Any], raw_provider)
-        if isinstance(provider_data.get('choices'), list):
-            # pop returns None when the key exists but its value is None, so
-            # use `or 'unknown'` to normalise both missing-key and None-value.
-            nested_provider_name: str = cast(str, provider_data.pop('provider', None) or 'unknown')
-            response_dict.update(provider_data)
-            response_dict['provider'] = nested_provider_name
-
-    # 2. Sanitize missing metadata
-    if response_dict.get('id') is None:
-        response_dict['id'] = 'openrouter-fallback-id'
-    if response_dict.get('model') is None:
-        response_dict['model'] = model_name
-    if response_dict.get('object') is None:
-        response_dict['object'] = fallback_object_type
-    if not isinstance(response_dict.get('provider'), str):
-        response_dict['provider'] = 'unknown'
-
-    return response_dict
-
-
 def _openrouter_settings_to_openai_settings(
     model_settings: OpenRouterModelSettings, model_request_parameters: ModelRequestParameters
 ) -> OpenAIChatModelSettings:
@@ -631,22 +593,34 @@ class OpenRouterModel(OpenAIChatModel):
     def _validate_completion(self, response: chat.ChatCompletion) -> _OpenRouterChatCompletion:
         response_dict = response.model_dump()
 
-        # Surface structured errors before normalization so we get a clean ModelHTTPError
-        # instead of a confusing ValidationError when choices is null.
-        if response_dict.get('choices') is None and (error_data := response_dict.get('error')):
-            try:
-                error = _OpenRouterError.model_validate(error_data)
-            except (TypeError, ValueError, ValidationError):
-                # Malformed error_data — fall through and let model_validate produce a clearer error.
-                pass
-            else:
-                raise ModelHTTPError(
-                    status_code=error.code,
-                    model_name=response_dict.get('model') or self.model_name,
-                    body=error.message,
-                )
+        # OpenRouter intermittently returns responses with null standard fields.
+        # Handle the two known cases before validation (see #3994).
+        if response_dict.get('choices') is None:
+            # Case 1: Error response — surface as ModelHTTPError instead of a
+            # confusing ValidationError about null fields.
+            if error_data := response_dict.get('error'):
+                try:
+                    error = _OpenRouterError.model_validate(error_data)
+                except (TypeError, ValueError, ValidationError):
+                    pass
+                else:
+                    raise ModelHTTPError(
+                        status_code=error.code,
+                        model_name=response_dict.get('model') or self.model_name,
+                        body=error.message,
+                    )
 
-        response_dict = _normalize_openrouter_response(response_dict, self.model_name, 'chat.completion')
+            # Case 2: Nested provider response — the real completion is inside
+            # the `provider` dict; use it as the top-level response.
+            raw_provider = response_dict.get('provider')
+            if isinstance(raw_provider, dict):
+                nested = cast(dict[str, Any], raw_provider)
+                if isinstance(nested.get('choices'), list):
+                    provider_name = nested.pop('provider', None) or 'unknown'
+                    nested.setdefault('created', response_dict.get('created'))
+                    nested['provider'] = provider_name
+                    response_dict = nested
+
         validated = _OpenRouterChatCompletion.model_validate(response_dict)
 
         if error := validated.error:
@@ -782,10 +756,7 @@ class OpenRouterStreamedResponse(OpenAIStreamedResponse):
     async def _validate_response(self):
         try:
             async for chunk in self._response:
-                chunk_dict = _normalize_openrouter_response(
-                    chunk.model_dump(), self._model_name, 'chat.completion.chunk'
-                )
-                yield _OpenRouterChatCompletionChunk.model_validate(chunk_dict)
+                yield _OpenRouterChatCompletionChunk.model_validate(chunk.model_dump())
         except APIError as e:
             error = _OpenRouterError.model_validate(e.body)
             raise ModelHTTPError(status_code=error.code, model_name=self._model_name, body=error.message)

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1168,3 +1168,12 @@ def test_openrouter_validate_completion_nested_response() -> None:
     model_response = model._process_response(nested_completion)  # type: ignore[reportPrivateUsage]
 
     assert any(isinstance(part, TextPart) and part.content == 'Hello from nested!' for part in model_response.parts)
+
+
+def test_openrouter_settings_to_openai_settings_without_model_request_parameters() -> None:
+    """Test _openrouter_settings_to_openai_settings when model_request_parameters is None (no plugins injected)."""
+    settings = OpenRouterModelSettings()
+    result = _openrouter_settings_to_openai_settings(settings, None)
+    extra_body = cast(dict[str, Any], result.get('extra_body', {}))
+    assert 'plugins' not in extra_body
+    assert 'web_search_options' not in extra_body

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -949,13 +949,14 @@ async def test_openrouter_prepare_request_loop_with_non_websearch_first(openrout
     assert extra_body['web_search_options'] == {'search_context_size': 'medium'}
 
 
-def test_openrouter_normalize_null_metadata_fallbacks() -> None:
-    """_normalize_openrouter_response fills in null id/model/object/provider fields."""
+def test_openrouter_null_metadata_fallbacks() -> None:
+    """Null metadata fields (id, model, object, provider) are filled with safe defaults.
 
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/3994.
+    """
     provider = OpenRouterProvider(api_key='test-key')
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
 
-    # All metadata fields null — the normalizer should fill in safe defaults.
     completion = ChatCompletion.model_construct(
         id=None,
         choices=[
@@ -976,169 +977,24 @@ def test_openrouter_normalize_null_metadata_fallbacks() -> None:
 
     model_response = model._process_response(completion)  # type: ignore[reportPrivateUsage]
 
-    assert any(isinstance(p, TextPart) and p.content == 'Hi' for p in model_response.parts)
-
-
-def test_openrouter_process_response_nested_provider_null_name_uses_unknown() -> None:
-    """Nested provider dict with provider=None: provider name falls back to 'unknown'.
-
-    Covers the 'provider_data.pop(provider, None) or unknown' normalisation path.
-    """
-    provider_instance = OpenRouterProvider(api_key='test-key')
-    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider_instance)
-    completion = ChatCompletion.model_construct(
-        id=None,
-        choices=None,
-        model=None,
-        object=None,
-        provider={
-            'id': 'nested-gen-1',
-            'choices': [
-                {
-                    'index': 0,
-                    'message': {'role': 'assistant', 'content': 'Hi'},
-                    'finish_reason': 'stop',
-                    'native_finish_reason': 'STOP',
-                    'logprobs': None,
-                }
-            ],
-            'model': 'openai/gpt-4.1-mini',
-            'object': 'chat.completion',
-            'provider': None,  # key exists but value is None → normalised to 'unknown'
-            'created': 1234567890,
-            'usage': {'prompt_tokens': 10, 'completion_tokens': 5, 'total_tokens': 15},
-        },
-        created=1234567890,
-    )
-    result = model._process_response(completion)  # type: ignore[reportPrivateUsage]
-    details = result.provider_details or {}
-    assert details.get('downstream_provider') == 'unknown'
-
-
-def test_openrouter_process_response_provider_dict_without_choices_raises() -> None:
-    """Provider is a dict with no 'choices' key: normalization skips nested unwrap.
-
-    The top-level choices remains None so _process_response raises UnexpectedModelBehavior.
-    Covers the false branch of 'if isinstance(provider_data.get(choices), list)'.
-    """
-    provider_instance = OpenRouterProvider(api_key='test-key')
-    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider_instance)
-    completion = ChatCompletion.model_construct(
-        id=None,
-        choices=None,
-        model=None,
-        object=None,
-        provider={'some_key': 'some_value'},  # dict but no 'choices' → skip unwrap
-        created=1234567890,
-    )
-    with pytest.raises(UnexpectedModelBehavior):
-        model._process_response(completion)  # type: ignore[reportPrivateUsage]
-
-
-def test_openrouter_provider_details_null_provider() -> None:
-    """When provider is None, _normalize_openrouter_response fills it with 'unknown'.
-
-    The normalizer always sets a string provider fallback so Pydantic validation passes.
-    _map_openrouter_provider_details then records downstream_provider='unknown'.
-    """
-
-    provider = OpenRouterProvider(api_key='test-key')
-    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
-
-    completion = ChatCompletion.model_construct(
-        id='gen-test',
-        choices=[
-            {
-                'index': 0,
-                'message': {'role': 'assistant', 'content': 'Hello'},
-                'finish_reason': 'stop',
-                'native_finish_reason': None,
-                'logprobs': None,
-            }
-        ],
-        model='openai/gpt-4.1-mini',
-        object='chat.completion',
-        provider=None,
-        created=1234567890,
-        usage=None,
+    assert model_response.parts == snapshot([TextPart(content='Hi')])
+    assert model_response.provider_details == snapshot(
+        {
+            'finish_reason': 'stop',
+            'downstream_provider': 'unknown',
+            'timestamp': datetime.datetime(2009, 2, 13, 23, 31, 30, tzinfo=datetime.timezone.utc),
+        }
     )
 
-    model_response = model._process_response(completion)  # type: ignore[reportPrivateUsage]
-    # The normalizer fills provider=None with the 'unknown' sentinel, so
-    # downstream_provider will be 'unknown' rather than absent.
-    details = model_response.provider_details or {}
-    assert details.get('downstream_provider') == 'unknown'
 
-
-def test_openrouter_validate_completion_error_with_null_fields() -> None:
-    """Test that _process_response raises ModelHTTPError for error responses with null fields.
+def test_openrouter_nested_provider_response() -> None:
+    """OpenRouter sometimes nests the real response inside the 'provider' dict.
 
     Regression test for https://github.com/pydantic/pydantic-ai/issues/3994.
     """
-
     provider = OpenRouterProvider(api_key='test-key')
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
 
-    error_completion = ChatCompletion.model_construct(
-        id=None,
-        choices=None,
-        model=None,
-        object=None,
-        provider=None,
-        created=1234567890,
-        usage=None,
-        error={'code': 400, 'message': 'Invalid request parameters'},
-    )
-
-    with pytest.raises(ModelHTTPError) as exc_info:
-        model._process_response(error_completion)  # type: ignore[reportPrivateUsage]
-
-    assert exc_info.value.status_code == 400
-    assert 'Invalid request parameters' in str(exc_info.value)
-
-
-def test_openrouter_validate_completion_malformed_error_fallthrough() -> None:
-    """Malformed error_data falls through the except clause and surfaces as UnexpectedModelBehavior.
-
-    When error is a plain string, _OpenRouterError.model_validate() raises ValidationError
-    which is caught; then _OpenRouterChatCompletion.model_validate() raises ValidationError
-    which _process_response (in the parent openai.py) wraps as UnexpectedModelBehavior.
-    """
-
-    provider = OpenRouterProvider(api_key='test-key')
-    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
-
-    # error is a plain string — _OpenRouterError.model_validate() will raise ValidationError
-    # which is caught; the fall-through to _OpenRouterChatCompletion.model_validate() then
-    # fails with ValidationError, which _process_response wraps as UnexpectedModelBehavior.
-    completion = ChatCompletion.model_construct(
-        id=None,
-        choices=None,
-        model=None,
-        object=None,
-        provider=None,
-        created=1234567890,
-        usage=None,
-        error='something went wrong',
-    )
-
-    with pytest.raises(UnexpectedModelBehavior):
-        model._process_response(completion)  # type: ignore[reportPrivateUsage]
-
-
-def test_openrouter_validate_completion_nested_response() -> None:
-    """Test that _process_response handles nested response in provider field.
-
-    OpenRouter occasionally returns a response where top-level fields (id, choices,
-    model, object) are null but the real response is nested inside the 'provider' dict.
-    Regression test for https://github.com/pydantic/pydantic-ai/issues/3994.
-    """
-
-    provider = OpenRouterProvider(api_key='test-key')
-    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
-
-    # Simulate the nested-response format: top-level fields are null,
-    # real data is nested inside 'provider'.
     nested_completion = ChatCompletion.model_construct(
         id=None,
         choices=None,
@@ -1163,17 +1019,112 @@ def test_openrouter_validate_completion_nested_response() -> None:
         usage=None,
     )
 
-    # Use _process_response (one level above _validate_completion) to test through
-    # a higher-level entry point while still avoiding a full HTTP round-trip.
     model_response = model._process_response(nested_completion)  # type: ignore[reportPrivateUsage]
 
-    assert any(isinstance(part, TextPart) and part.content == 'Hello from nested!' for part in model_response.parts)
+    assert model_response.parts == snapshot([TextPart(content='Hello from nested!')])
+    assert model_response.provider_details == snapshot(
+        {
+            'downstream_provider': 'Google',
+            'finish_reason': 'STOP',
+            'timestamp': datetime.datetime(2009, 2, 13, 23, 31, 30, tzinfo=datetime.timezone.utc),
+        }
+    )
 
 
-def test_openrouter_settings_to_openai_settings_without_model_request_parameters() -> None:
-    """Test _openrouter_settings_to_openai_settings when model_request_parameters is None (no plugins injected)."""
-    settings = OpenRouterModelSettings()
-    result = _openrouter_settings_to_openai_settings(settings, None)
-    extra_body = cast(dict[str, Any], result.get('extra_body', {}))
-    assert 'plugins' not in extra_body
-    assert 'web_search_options' not in extra_body
+def test_openrouter_nested_provider_null_name() -> None:
+    """Nested provider dict with provider=None falls back to 'unknown'."""
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider={
+            'id': 'nested-gen-1',
+            'choices': [
+                {
+                    'index': 0,
+                    'message': {'role': 'assistant', 'content': 'Hi'},
+                    'finish_reason': 'stop',
+                    'native_finish_reason': 'STOP',
+                    'logprobs': None,
+                }
+            ],
+            'model': 'openai/gpt-4.1-mini',
+            'object': 'chat.completion',
+            'provider': None,
+            'created': 1234567890,
+            'usage': {'prompt_tokens': 10, 'completion_tokens': 5, 'total_tokens': 15},
+        },
+        created=1234567890,
+    )
+
+    result = model._process_response(completion)  # type: ignore[reportPrivateUsage]
+    details = result.provider_details or {}
+    assert details.get('downstream_provider') == 'unknown'
+
+
+def test_openrouter_provider_dict_without_choices_raises() -> None:
+    """Provider is a dict with no 'choices' key — normalization skips unwrap, validation fails."""
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider={'some_key': 'some_value'},
+        created=1234567890,
+    )
+
+    with pytest.raises(UnexpectedModelBehavior):
+        model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+
+def test_openrouter_error_with_null_fields() -> None:
+    """Error responses with null standard fields raise ModelHTTPError.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/3994.
+    """
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    error_completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider=None,
+        created=1234567890,
+        usage=None,
+        error={'code': 400, 'message': 'Invalid request parameters'},
+    )
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        model._process_response(error_completion)  # type: ignore[reportPrivateUsage]
+
+    assert exc_info.value.status_code == 400
+    assert 'Invalid request parameters' in str(exc_info.value)
+
+
+def test_openrouter_malformed_error_fallthrough() -> None:
+    """Malformed error data falls through to validation, surfacing as UnexpectedModelBehavior."""
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider=None,
+        created=1234567890,
+        usage=None,
+        error='something went wrong',
+    )
+
+    with pytest.raises(UnexpectedModelBehavior):
+        model._process_response(completion)  # type: ignore[reportPrivateUsage]

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1095,3 +1095,36 @@ def test_openrouter_malformed_error_fallthrough() -> None:
 
     with pytest.raises(UnexpectedModelBehavior):
         model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+
+def test_openrouter_error_with_metadata() -> None:
+    """Real-world error response with metadata field from #3994.
+
+    OpenRouter returns error code 524 with extra metadata including the raw
+    error and provider name. The extra fields should be ignored.
+    """
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('google/gemini-3-flash-preview', provider=provider)
+
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        created=1768361801,
+        model=None,
+        object=None,
+        service_tier=None,
+        system_fingerprint=None,
+        usage=None,
+        error={
+            'message': 'Provider returned error',
+            'code': 524,
+            'metadata': {'raw': 'error code: 524', 'provider_name': 'Google'},
+        },
+        user_id='org_xxx',
+    )
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+    assert exc_info.value.status_code == 524
+    assert 'Provider returned error' in str(exc_info.value)

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -949,44 +949,6 @@ async def test_openrouter_prepare_request_loop_with_non_websearch_first(openrout
     assert extra_body['web_search_options'] == {'search_context_size': 'medium'}
 
 
-def test_openrouter_null_metadata_fallbacks() -> None:
-    """Null metadata fields (id, model, object, provider) are filled with safe defaults.
-
-    Regression test for https://github.com/pydantic/pydantic-ai/issues/3994.
-    """
-    provider = OpenRouterProvider(api_key='test-key')
-    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
-
-    completion = ChatCompletion.model_construct(
-        id=None,
-        choices=[
-            {
-                'index': 0,
-                'message': {'role': 'assistant', 'content': 'Hi'},
-                'finish_reason': 'stop',
-                'native_finish_reason': None,
-                'logprobs': None,
-            }
-        ],
-        model=None,
-        object=None,
-        provider=None,
-        created=1234567890,
-        usage=None,
-    )
-
-    model_response = model._process_response(completion)  # type: ignore[reportPrivateUsage]
-
-    assert model_response.parts == snapshot([TextPart(content='Hi')])
-    assert model_response.provider_details == snapshot(
-        {
-            'finish_reason': 'stop',
-            'downstream_provider': 'unknown',
-            'timestamp': datetime.datetime(2009, 2, 13, 23, 31, 30, tzinfo=datetime.timezone.utc),
-        }
-    )
-
-
 def test_openrouter_nested_provider_response() -> None:
     """OpenRouter sometimes nests the real response inside the 'provider' dict.
 
@@ -1067,7 +1029,7 @@ def test_openrouter_nested_provider_null_name() -> None:
 
 
 def test_openrouter_provider_dict_without_choices_raises() -> None:
-    """Provider is a dict with no 'choices' key — normalization skips unwrap, validation fails."""
+    """Provider is a dict with no 'choices' key — no unwrap happens, validation fails."""
     provider = OpenRouterProvider(api_key='test-key')
     model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
 

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -947,3 +947,224 @@ async def test_openrouter_prepare_request_loop_with_non_websearch_first(openrout
     assert 'plugins' in extra_body
     assert extra_body['plugins'] == [{'id': 'web'}]
     assert extra_body['web_search_options'] == {'search_context_size': 'medium'}
+
+
+def test_openrouter_normalize_null_metadata_fallbacks() -> None:
+    """_normalize_openrouter_response fills in null id/model/object/provider fields."""
+
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    # All metadata fields null — the normalizer should fill in safe defaults.
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=[
+            {
+                'index': 0,
+                'message': {'role': 'assistant', 'content': 'Hi'},
+                'finish_reason': 'stop',
+                'native_finish_reason': None,
+                'logprobs': None,
+            }
+        ],
+        model=None,
+        object=None,
+        provider=None,
+        created=1234567890,
+        usage=None,
+    )
+
+    model_response = model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+    assert any(isinstance(p, TextPart) and p.content == 'Hi' for p in model_response.parts)
+
+
+def test_openrouter_process_response_nested_provider_null_name_uses_unknown() -> None:
+    """Nested provider dict with provider=None: provider name falls back to 'unknown'.
+
+    Covers the 'provider_data.pop(provider, None) or unknown' normalisation path.
+    """
+    provider_instance = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider_instance)
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider={
+            'id': 'nested-gen-1',
+            'choices': [
+                {
+                    'index': 0,
+                    'message': {'role': 'assistant', 'content': 'Hi'},
+                    'finish_reason': 'stop',
+                    'native_finish_reason': 'STOP',
+                    'logprobs': None,
+                }
+            ],
+            'model': 'openai/gpt-4.1-mini',
+            'object': 'chat.completion',
+            'provider': None,  # key exists but value is None → normalised to 'unknown'
+            'created': 1234567890,
+            'usage': {'prompt_tokens': 10, 'completion_tokens': 5, 'total_tokens': 15},
+        },
+        created=1234567890,
+    )
+    result = model._process_response(completion)  # type: ignore[reportPrivateUsage]
+    details = result.provider_details or {}
+    assert details.get('downstream_provider') == 'unknown'
+
+
+def test_openrouter_process_response_provider_dict_without_choices_raises() -> None:
+    """Provider is a dict with no 'choices' key: normalization skips nested unwrap.
+
+    The top-level choices remains None so _process_response raises UnexpectedModelBehavior.
+    Covers the false branch of 'if isinstance(provider_data.get(choices), list)'.
+    """
+    provider_instance = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider_instance)
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider={'some_key': 'some_value'},  # dict but no 'choices' → skip unwrap
+        created=1234567890,
+    )
+    with pytest.raises(UnexpectedModelBehavior):
+        model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+
+def test_openrouter_provider_details_null_provider() -> None:
+    """When provider is None, _normalize_openrouter_response fills it with 'unknown'.
+
+    The normalizer always sets a string provider fallback so Pydantic validation passes.
+    _map_openrouter_provider_details then records downstream_provider='unknown'.
+    """
+
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    completion = ChatCompletion.model_construct(
+        id='gen-test',
+        choices=[
+            {
+                'index': 0,
+                'message': {'role': 'assistant', 'content': 'Hello'},
+                'finish_reason': 'stop',
+                'native_finish_reason': None,
+                'logprobs': None,
+            }
+        ],
+        model='openai/gpt-4.1-mini',
+        object='chat.completion',
+        provider=None,
+        created=1234567890,
+        usage=None,
+    )
+
+    model_response = model._process_response(completion)  # type: ignore[reportPrivateUsage]
+    # The normalizer fills provider=None with the 'unknown' sentinel, so
+    # downstream_provider will be 'unknown' rather than absent.
+    details = model_response.provider_details or {}
+    assert details.get('downstream_provider') == 'unknown'
+
+
+def test_openrouter_validate_completion_error_with_null_fields() -> None:
+    """Test that _process_response raises ModelHTTPError for error responses with null fields.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/3994.
+    """
+
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    error_completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider=None,
+        created=1234567890,
+        usage=None,
+        error={'code': 400, 'message': 'Invalid request parameters'},
+    )
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        model._process_response(error_completion)  # type: ignore[reportPrivateUsage]
+
+    assert exc_info.value.status_code == 400
+    assert 'Invalid request parameters' in str(exc_info.value)
+
+
+def test_openrouter_validate_completion_malformed_error_fallthrough() -> None:
+    """Malformed error_data falls through the except clause and surfaces as UnexpectedModelBehavior.
+
+    When error is a plain string, _OpenRouterError.model_validate() raises ValidationError
+    which is caught; then _OpenRouterChatCompletion.model_validate() raises ValidationError
+    which _process_response (in the parent openai.py) wraps as UnexpectedModelBehavior.
+    """
+
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    # error is a plain string — _OpenRouterError.model_validate() will raise ValidationError
+    # which is caught; the fall-through to _OpenRouterChatCompletion.model_validate() then
+    # fails with ValidationError, which _process_response wraps as UnexpectedModelBehavior.
+    completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider=None,
+        created=1234567890,
+        usage=None,
+        error='something went wrong',
+    )
+
+    with pytest.raises(UnexpectedModelBehavior):
+        model._process_response(completion)  # type: ignore[reportPrivateUsage]
+
+
+def test_openrouter_validate_completion_nested_response() -> None:
+    """Test that _process_response handles nested response in provider field.
+
+    OpenRouter occasionally returns a response where top-level fields (id, choices,
+    model, object) are null but the real response is nested inside the 'provider' dict.
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/3994.
+    """
+
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('openai/gpt-4.1-mini', provider=provider)
+
+    # Simulate the nested-response format: top-level fields are null,
+    # real data is nested inside 'provider'.
+    nested_completion = ChatCompletion.model_construct(
+        id=None,
+        choices=None,
+        model=None,
+        object=None,
+        provider={
+            'id': 'gen-123',
+            'choices': [
+                {
+                    'index': 0,
+                    'message': {'role': 'assistant', 'content': 'Hello from nested!'},
+                    'finish_reason': 'stop',
+                    'native_finish_reason': 'STOP',
+                    'logprobs': None,
+                }
+            ],
+            'model': 'google/gemini-3-flash-preview',
+            'object': 'chat.completion',
+            'provider': 'Google',
+        },
+        created=1234567890,
+        usage=None,
+    )
+
+    # Use _process_response (one level above _validate_completion) to test through
+    # a higher-level entry point while still avoiding a full HTTP round-trip.
+    model_response = model._process_response(nested_completion)  # type: ignore[reportPrivateUsage]
+
+    assert any(isinstance(part, TextPart) and part.content == 'Hello from nested!' for part in model_response.parts)

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1024,8 +1024,13 @@ def test_openrouter_nested_provider_null_name() -> None:
     )
 
     result = model._process_response(completion)  # type: ignore[reportPrivateUsage]
-    details = result.provider_details or {}
-    assert details.get('downstream_provider') == 'unknown'
+    assert result.provider_details == snapshot(
+        {
+            'downstream_provider': 'unknown',
+            'finish_reason': 'STOP',
+            'timestamp': datetime.datetime(2009, 2, 13, 23, 31, 30, tzinfo=datetime.timezone.utc),
+        }
+    )
 
 
 def test_openrouter_provider_dict_without_choices_raises() -> None:


### PR DESCRIPTION
## Problem

Fixes #3994.

OpenRouter intermittently returns responses where the standard top-level fields (`id`, `choices`, `model`, `object`) are `null` while the actual completion is nested inside the `provider` dict:

```json
{
  "id": null, "choices": null, "model": null, "object": null,
  "provider": {
    "id": "gen-123",
    "choices": [{"message": {"content": "..."}, "finish_reason": "stop", ...}],
    "model": "google/gemini-3-flash-preview",
    "provider": "Google"
  }
}
```

The OpenAI client wraps these via `model_construct()`, preserving extra fields but with null standard fields. pydantic-ai's strict `model_validate()` in `_validate_completion` then raised 5 Pydantic validation errors because `provider` expected `str` (got `dict`) and `choices` expected `list` (got `None`).

A second pattern that also fails: error responses with null fields:
```json
{"id": null, "choices": null, "error": {"message": "...", "code": 400}, "user_id": "org_xxx"}
```

## Fix

In `_validate_completion`, before calling `model_validate()`:
1. **Detect nested response**: if `choices` is `None` and `provider` is a dict containing a `choices` list, unwrap the nested data into the top-level dict and extract the downstream provider name string.
2. **Handle error with null fields**: if `choices` is still `None` but an `error` field is present, raise `ModelHTTPError` directly rather than letting `model_validate()` fail.

## Tests

Added two unit tests (no network required):
- `test_openrouter_validate_completion_nested_response`: verifies the nested-provider unwrap succeeds and content is accessible
- `test_openrouter_validate_completion_error_with_null_fields`: verifies a `ModelHTTPError` is raised for the error-with-null-fields pattern