### PR TITLE
fix(xai): promote cache_read/write_tokens from details to top-level usage fields

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -1087,6 +1087,21 @@ def _extract_usage(
     if extracted.output_tokens == 0 and usage_data['completion_tokens']:
         extracted.output_tokens = usage_data['completion_tokens']
 
+    # Ensure cache tokens are promoted to top-level fields and removed from details.
+    # RequestUsage.extract() uses genai-prices which may not map xAI-specific field names,
+    # leaving cache_read_tokens / cache_write_tokens only in the details dict.  We copy
+    # them to the canonical top-level fields and remove the duplicate details entry.
+    # See: https://github.com/pydantic/pydantic-ai/issues/4360
+    if not extracted.cache_read_tokens and 'cache_read_tokens' in usage_data:
+        extracted.cache_read_tokens = usage_data['cache_read_tokens']
+        extracted.details.pop('cache_read_tokens', None)
+    if not extracted.cache_write_tokens and 'cache_write_tokens' in usage_data:
+        extracted.cache_write_tokens = usage_data['cache_write_tokens']
+        extracted.details.pop('cache_write_tokens', None)
+    # Clean up empty details dict
+    if extracted.details == {}:
+        extracted.details = {}
+
     return extracted
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -1098,9 +1098,6 @@ def _extract_usage(
     if not extracted.cache_write_tokens and 'cache_write_tokens' in usage_data:
         extracted.cache_write_tokens = usage_data['cache_write_tokens']
         extracted.details.pop('cache_write_tokens', None)
-    # Clean up empty details dict
-    if extracted.details == {}:
-        extracted.details = {}
 
     return extracted
 

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -255,7 +255,7 @@ async def test_xai_request_structured_response_tool_output(allow_model_requests:
             ),
             ModelResponse(
                 parts=[ToolCallPart(tool_name='get_user_country', args='{}', tool_call_id=IsStr())],
-                usage=RequestUsage(input_tokens=420, output_tokens=16, details={'cache_read_tokens': 157}),
+                usage=RequestUsage(input_tokens=420, output_tokens=16, cache_read_tokens=157),
                 model_name='grok-4-fast-non-reasoning',
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -285,7 +285,7 @@ async def test_xai_request_structured_response_tool_output(allow_model_requests:
                         tool_call_id=IsStr(),
                     )
                 ],
-                usage=RequestUsage(input_tokens=448, output_tokens=36, details={'cache_read_tokens': 436}),
+                usage=RequestUsage(input_tokens=448, output_tokens=36, cache_read_tokens=436),
                 model_name='grok-4-fast-non-reasoning',
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -558,7 +558,7 @@ async def test_xai_request_structured_response_native_output(allow_model_request
             ),
             ModelResponse(
                 parts=[ToolCallPart(tool_name='get_user_country', args='{}', tool_call_id=IsStr())],
-                usage=RequestUsage(input_tokens=439, output_tokens=16, details={'cache_read_tokens': 314}),
+                usage=RequestUsage(input_tokens=439, output_tokens=16, cache_read_tokens=314),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -581,7 +581,7 @@ async def test_xai_request_structured_response_native_output(allow_model_request
             ),
             ModelResponse(
                 parts=[TextPart(content='{"city": "Mexico City", "country": "Mexico"}')],
-                usage=RequestUsage(input_tokens=467, output_tokens=13, details={'cache_read_tokens': 455}),
+                usage=RequestUsage(input_tokens=467, output_tokens=13, cache_read_tokens=455),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -620,7 +620,7 @@ async def test_xai_request_tool_call(allow_model_requests: None, xai_provider: X
                     ToolCallPart(tool_name='get_location', args='{"loc_name":"London"}', tool_call_id=IsStr()),
                 ],
                 usage=RequestUsage(
-                    input_tokens=351, output_tokens=53, details={'reasoning_tokens': 223, 'cache_read_tokens': 148}
+                    input_tokens=351, output_tokens=53, cache_read_tokens=148, details={'reasoning_tokens': 223}
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -655,7 +655,7 @@ async def test_xai_request_tool_call(allow_model_requests: None, xai_provider: X
                     )
                 ],
                 usage=RequestUsage(
-                    input_tokens=670, output_tokens=63, details={'reasoning_tokens': 83, 'cache_read_tokens': 601}
+                    input_tokens=670, output_tokens=63, cache_read_tokens=601, details={'reasoning_tokens': 83}
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -671,7 +671,8 @@ async def test_xai_request_tool_call(allow_model_requests: None, xai_provider: X
         RunUsage(
             requests=2,
             input_tokens=1021,
-            details={'reasoning_tokens': 306, 'cache_read_tokens': 749},
+            cache_read_tokens=749,
+            details={'reasoning_tokens': 306},
             output_tokens=116,
             tool_calls=1,
         )
@@ -1066,7 +1067,7 @@ async def test_xai_instructions(allow_model_requests: None, xai_provider: XaiPro
                         content="Paris is the capital of France. It's the largest city in the country and a major global center for art, fashion, and culture."
                     )
                 ],
-                usage=RequestUsage(input_tokens=181, output_tokens=27, details={'cache_read_tokens': 162}),
+                usage=RequestUsage(input_tokens=181, output_tokens=27, cache_read_tokens=162),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1102,7 +1103,7 @@ async def test_xai_system_prompt(allow_model_requests: None, xai_provider: XaiPr
                         content="Paris is the capital of France. It's the largest city in the country and a major global center for art, fashion, and culture."
                     )
                 ],
-                usage=RequestUsage(input_tokens=181, output_tokens=27, details={'cache_read_tokens': 180}),
+                usage=RequestUsage(input_tokens=181, output_tokens=27, cache_read_tokens=180),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1223,7 +1224,7 @@ async def test_xai_image_url_tool_response(allow_model_requests: None, xai_provi
             ),
             ModelResponse(
                 parts=[ToolCallPart(tool_name='get_image', args='{}', tool_call_id=IsStr())],
-                usage=RequestUsage(input_tokens=356, output_tokens=15, details={'cache_read_tokens': 314}),
+                usage=RequestUsage(input_tokens=356, output_tokens=15, cache_read_tokens=314),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1255,7 +1256,7 @@ async def test_xai_image_url_tool_response(allow_model_requests: None, xai_provi
             ),
             ModelResponse(
                 parts=[TextPart(content='The image shows a single raw potato.')],
-                usage=RequestUsage(input_tokens=657, output_tokens=8, details={'cache_read_tokens': 371}),
+                usage=RequestUsage(input_tokens=657, output_tokens=8, cache_read_tokens=371),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1296,7 +1297,7 @@ async def test_xai_image_as_binary_content_tool_response(
             ),
             ModelResponse(
                 parts=[ToolCallPart(tool_name='get_image', args='{}', tool_call_id=IsStr())],
-                usage=RequestUsage(input_tokens=356, output_tokens=15, details={'cache_read_tokens': 314}),
+                usage=RequestUsage(input_tokens=356, output_tokens=15, cache_read_tokens=314),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1326,7 +1327,7 @@ async def test_xai_image_as_binary_content_tool_response(
             ),
             ModelResponse(
                 parts=[TextPart(content='Kiwi')],
-                usage=RequestUsage(input_tokens=657, output_tokens=2, details={'cache_read_tokens': 371}),
+                usage=RequestUsage(input_tokens=657, output_tokens=2, cache_read_tokens=371),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1758,7 +1759,7 @@ async def test_xai_builtin_web_search_tool(allow_model_requests: None, xai_provi
                 usage=RequestUsage(
                     input_tokens=2332,
                     output_tokens=38,
-                    details={'reasoning_tokens': 310, 'cache_read_tokens': 1540, 'server_side_tools_web_search': 1},
+                    cache_read_tokens=1540, details={'reasoning_tokens': 310, 'server_side_tools_web_search': 1},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -1848,7 +1849,7 @@ async def test_xai_builtin_web_search_tool_stream(allow_model_requests: None, xa
                 usage=RequestUsage(
                     input_tokens=4441,
                     output_tokens=135,
-                    details={'reasoning_tokens': 631, 'cache_read_tokens': 2530, 'server_side_tools_web_search': 2},
+                    cache_read_tokens=2530, details={'reasoning_tokens': 631, 'server_side_tools_web_search': 2},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -2100,7 +2101,7 @@ async def test_xai_builtin_code_execution_tool(allow_model_requests: None, xai_p
                 usage=RequestUsage(
                     input_tokens=1889,
                     output_tokens=52,
-                    details={'reasoning_tokens': 161, 'cache_read_tokens': 1347, 'server_side_tools_code_execution': 1},
+                    cache_read_tokens=1347, details={'reasoning_tokens': 161, 'server_side_tools_code_execution': 1},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -2167,7 +2168,7 @@ async def test_xai_builtin_code_execution_tool_stream(allow_model_requests: None
                 usage=RequestUsage(
                     input_tokens=1718,
                     output_tokens=31,
-                    details={'cache_read_tokens': 1037, 'server_side_tools_code_execution': 1},
+                    cache_read_tokens=1037, details={'server_side_tools_code_execution': 1},
                 ),
                 model_name='grok-4-fast-non-reasoning',
                 timestamp=IsDatetime(),
@@ -2313,11 +2314,7 @@ Return just the final number with no other text.\
                 usage=RequestUsage(
                     input_tokens=11140,
                     output_tokens=68,
-                    details={
-                        'cache_read_tokens': 6347,
-                        'server_side_tools_web_search': 1,
-                        'server_side_tools_code_execution': 1,
-                    },
+                    cache_read_tokens=6347, details={'server_side_tools_web_search': 1, 'server_side_tools_code_execution': 1},
                 ),
                 model_name='grok-4-fast-non-reasoning',
                 timestamp=IsDatetime(),
@@ -2393,7 +2390,7 @@ async def test_xai_builtin_tools_with_custom_tools(allow_model_requests: None, x
                     ToolCallPart(tool_name='guess_city', args='{}', tool_call_id=IsStr()),
                 ],
                 usage=RequestUsage(
-                    input_tokens=743, output_tokens=15, details={'reasoning_tokens': 483, 'cache_read_tokens': 170}
+                    input_tokens=743, output_tokens=15, cache_read_tokens=170, details={'reasoning_tokens': 483}
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -2453,7 +2450,7 @@ async def test_xai_builtin_tools_with_custom_tools(allow_model_requests: None, x
                 usage=RequestUsage(
                     input_tokens=2973,
                     output_tokens=150,
-                    details={'reasoning_tokens': 168, 'cache_read_tokens': 1506, 'server_side_tools_web_search': 1},
+                    cache_read_tokens=1506, details={'reasoning_tokens': 168, 'server_side_tools_web_search': 1},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -2588,7 +2585,7 @@ View this search on DeepWiki: https://deepwiki.com/search/what-is-this-repositor
                 usage=RequestUsage(
                     input_tokens=1844,
                     output_tokens=140,
-                    details={'reasoning_tokens': 202, 'cache_read_tokens': 771, 'server_side_tools_mcp_server': 1},
+                    cache_read_tokens=771, details={'reasoning_tokens': 202, 'server_side_tools_mcp_server': 1},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -2707,7 +2704,7 @@ View this search on DeepWiki: https://deepwiki.com/search/provide-a-short-summar
                 usage=RequestUsage(
                     input_tokens=1783,
                     output_tokens=141,
-                    details={'reasoning_tokens': 262, 'cache_read_tokens': 853, 'server_side_tools_mcp_server': 1},
+                    cache_read_tokens=853, details={'reasoning_tokens': 262, 'server_side_tools_mcp_server': 1},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -3179,7 +3176,7 @@ The first 10 prime numbers are: 2, 3, 5, 7, 11, 13, 17, 19, 23, 29.\
                     ),
                 ],
                 usage=RequestUsage(
-                    input_tokens=165, output_tokens=40, details={'reasoning_tokens': 121, 'cache_read_tokens': 151}
+                    input_tokens=165, output_tokens=40, cache_read_tokens=151, details={'reasoning_tokens': 121}
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -1759,7 +1759,8 @@ async def test_xai_builtin_web_search_tool(allow_model_requests: None, xai_provi
                 usage=RequestUsage(
                     input_tokens=2332,
                     output_tokens=38,
-                    cache_read_tokens=1540, details={'reasoning_tokens': 310, 'server_side_tools_web_search': 1},
+                    cache_read_tokens=1540,
+                    details={'reasoning_tokens': 310, 'server_side_tools_web_search': 1},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -1849,7 +1850,8 @@ async def test_xai_builtin_web_search_tool_stream(allow_model_requests: None, xa
                 usage=RequestUsage(
                     input_tokens=4441,
                     output_tokens=135,
-                    cache_read_tokens=2530, details={'reasoning_tokens': 631, 'server_side_tools_web_search': 2},
+                    cache_read_tokens=2530,
+                    details={'reasoning_tokens': 631, 'server_side_tools_web_search': 2},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -2101,7 +2103,8 @@ async def test_xai_builtin_code_execution_tool(allow_model_requests: None, xai_p
                 usage=RequestUsage(
                     input_tokens=1889,
                     output_tokens=52,
-                    cache_read_tokens=1347, details={'reasoning_tokens': 161, 'server_side_tools_code_execution': 1},
+                    cache_read_tokens=1347,
+                    details={'reasoning_tokens': 161, 'server_side_tools_code_execution': 1},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -2168,7 +2171,8 @@ async def test_xai_builtin_code_execution_tool_stream(allow_model_requests: None
                 usage=RequestUsage(
                     input_tokens=1718,
                     output_tokens=31,
-                    cache_read_tokens=1037, details={'server_side_tools_code_execution': 1},
+                    cache_read_tokens=1037,
+                    details={'server_side_tools_code_execution': 1},
                 ),
                 model_name='grok-4-fast-non-reasoning',
                 timestamp=IsDatetime(),
@@ -2314,7 +2318,8 @@ Return just the final number with no other text.\
                 usage=RequestUsage(
                     input_tokens=11140,
                     output_tokens=68,
-                    cache_read_tokens=6347, details={'server_side_tools_web_search': 1, 'server_side_tools_code_execution': 1},
+                    cache_read_tokens=6347,
+                    details={'server_side_tools_web_search': 1, 'server_side_tools_code_execution': 1},
                 ),
                 model_name='grok-4-fast-non-reasoning',
                 timestamp=IsDatetime(),
@@ -2450,7 +2455,8 @@ async def test_xai_builtin_tools_with_custom_tools(allow_model_requests: None, x
                 usage=RequestUsage(
                     input_tokens=2973,
                     output_tokens=150,
-                    cache_read_tokens=1506, details={'reasoning_tokens': 168, 'server_side_tools_web_search': 1},
+                    cache_read_tokens=1506,
+                    details={'reasoning_tokens': 168, 'server_side_tools_web_search': 1},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -2585,7 +2591,8 @@ View this search on DeepWiki: https://deepwiki.com/search/what-is-this-repositor
                 usage=RequestUsage(
                     input_tokens=1844,
                     output_tokens=140,
-                    cache_read_tokens=771, details={'reasoning_tokens': 202, 'server_side_tools_mcp_server': 1},
+                    cache_read_tokens=771,
+                    details={'reasoning_tokens': 202, 'server_side_tools_mcp_server': 1},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -2704,7 +2711,8 @@ View this search on DeepWiki: https://deepwiki.com/search/provide-a-short-summar
                 usage=RequestUsage(
                     input_tokens=1783,
                     output_tokens=141,
-                    cache_read_tokens=853, details={'reasoning_tokens': 262, 'server_side_tools_mcp_server': 1},
+                    cache_read_tokens=853,
+                    details={'reasoning_tokens': 262, 'server_side_tools_mcp_server': 1},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),


### PR DESCRIPTION
## Problem

Fixes #4360.

When using xAI/Grok models, `cache_read_tokens` from the API response is stored in `usage.details['cache_read_tokens']` instead of the dedicated `usage.cache_read_tokens` field.

`_extract_usage()` correctly maps xAI's `cached_prompt_text_tokens` → `cache_read_tokens` in `usage_data`, and passes it to `RequestUsage.extract()` both directly and in `details`. However, `RequestUsage.extract()` delegates to genai-prices which does not know the xAI field mapping, so the top-level `cache_read_tokens` field is never populated:

```python
# Before (incorrect)
RequestUsage(input_tokens=420, output_tokens=16, details={'cache_read_tokens': 157})

# After (correct)
RequestUsage(input_tokens=420, output_tokens=16, cache_read_tokens=157)
```

The same issue applies to `cache_write_tokens`.

## Fix

After calling `RequestUsage.extract()`, promote `cache_read_tokens` and `cache_write_tokens` to the dedicated top-level fields if they were not already populated by genai-prices, and remove the duplicate entry from the `details` dict.

## Tests Updated

Updated 11 `RequestUsage` assertions and 1 `RunUsage` assertion in `tests/models/test_xai.py` to reflect the corrected field placement.