### PR TITLE
fix(evals): SpanQuery has_attributes now matches JSON-serialised attribute values

### DIFF
--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -550,15 +550,22 @@ def _attribute_matches(attribute_value: Any, query_value: Any) -> bool:
     ``SpanQuery(has_attributes={"key": {"foo": 1}})`` therefore needs to compare
     against the JSON-serialised form of the attribute, not the raw Python object.
 
-    This function first tries a direct equality comparison, and then — when the
-    attribute is a string and the query value is a non-string — attempts to
-    JSON-deserialise the attribute and compare the result to the query value.
+    This function first tries a direct equality comparison.  When the attribute is
+    a JSON string and the query value is a ``dict`` or ``list`` (i.e. a complex
+    object that Logfire would have serialised), it attempts to JSON-deserialise
+    the attribute and compare the result to the query value.
+
+    The JSON fallback is intentionally limited to ``dict``/``list`` query values
+    to avoid surprising matches between plain strings and scalar JSON values
+    (e.g. ``"5"`` matching ``5``, or ``"true"`` matching ``True``).
     """
     if attribute_value == query_value:
         return True
-    # If the attribute is stored as a JSON string but the query value is a
-    # Python object, try to parse the attribute for comparison.
-    if isinstance(attribute_value, str) and not isinstance(query_value, str):
+    # Only try JSON deserialization when the query value is a complex type that
+    # Logfire serialises to a JSON string (dict, list).  Scalars (int, float,
+    # bool) are stored as their native OTEL attribute types, not JSON strings,
+    # so no fallback is needed and we avoid unexpected cross-type matches.
+    if isinstance(attribute_value, str) and isinstance(query_value, (dict, list)):
         try:
             return json.loads(attribute_value) == query_value
         except (json.JSONDecodeError, ValueError):

--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
@@ -267,7 +268,7 @@ class SpanNode:
 
         # Attribute conditions
         if (has_attributes := query.get('has_attributes')) and not all(
-            self.attributes.get(key) == value for key, value in has_attributes.items()
+            _attribute_matches(self.attributes.get(key), value) for key, value in has_attributes.items()
         ):
             return False
         if (has_attributes_keys := query.get('has_attribute_keys')) and not all(
@@ -539,3 +540,27 @@ class SpanTree:
 
 SPAN_TREE_ADAPTER = TypeAdapter(SpanTree)
 """This adapter can be used to serialize and deserialize `SpanTree` objects to and from JSON."""
+
+
+def _attribute_matches(attribute_value: Any, query_value: Any) -> bool:
+    """Check if a span attribute value matches the given query value.
+
+    Logfire (and the OTEL SDK) serialises complex Python objects (dicts, lists of
+    dicts, etc.) to JSON strings before storing them as span attributes.  A
+    ``SpanQuery(has_attributes={"key": {"foo": 1}})`` therefore needs to compare
+    against the JSON-serialised form of the attribute, not the raw Python object.
+
+    This function first tries a direct equality comparison, and then — when the
+    attribute is a string and the query value is a non-string — attempts to
+    JSON-deserialise the attribute and compare the result to the query value.
+    """
+    if attribute_value == query_value:
+        return True
+    # If the attribute is stored as a JSON string but the query value is a
+    # Python object, try to parse the attribute for comparison.
+    if isinstance(attribute_value, str) and not isinstance(query_value, str):
+        try:
+            return json.loads(attribute_value) == query_value
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return False

--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -232,22 +232,28 @@ async def test_has_attributes_json_serialised_values():
     Regression test for https://github.com/pydantic/pydantic-ai/issues/4448.
     """
     import json
+    from datetime import datetime, timezone
 
-    from pydantic_evals.otel.span_tree import SpanNode, SpanTree, SpanQuery
+    from pydantic_evals.otel.span_tree import SpanNode, SpanQuery
 
     data = {'foo': 1, 'bar': True}
     tags = ['alpha', 'beta']
 
+    _ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
     # Build a minimal SpanNode with JSON-serialised attributes (as Logfire would store them)
     node = SpanNode(
         name='test',
+        trace_id=1,
+        span_id=1,
+        parent_span_id=None,
+        start_timestamp=_ts,
+        end_timestamp=_ts,
         attributes={
             'data': json.dumps(data, separators=(',', ':')),  # '{"foo":1,"bar":true}'
             'tags': json.dumps(tags),  # '["alpha", "beta"]'
             'level': '3',  # plain string, not JSON-serialised
         },
-        start_time=None,  # type: ignore[arg-type]
-        end_time=None,  # type: ignore[arg-type]
     )
 
     # Plain string still works
@@ -267,6 +273,7 @@ async def test_has_attributes_json_serialised_values():
     assert node.matches(SpanQuery(has_attributes={'data': json.dumps(data, separators=(',', ':'))}))
 
 
+async def test_span_tree_repr(span_tree: SpanTree):
     assert repr(SpanTree()) == snapshot('<SpanTree />')
     assert str(span_tree) == snapshot('<SpanTree num_roots=1 total_spans=6 />')
     assert repr(span_tree) == snapshot("""\

--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -223,7 +223,50 @@ async def test_span_node_matches(span_tree: SpanTree):
     assert not child1_node.matches(SpanQuery(name_equals='child1', has_attributes={'type': 'normal'}))
 
 
-async def test_span_tree_repr(span_tree: SpanTree):
+async def test_has_attributes_json_serialised_values():
+    """Test that has_attributes matches dict/list values stored as JSON-serialised strings.
+
+    Logfire serialises complex attributes (dicts, lists) to JSON strings.
+    SpanQuery should be able to match the original Python objects, not just the raw strings.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/4448.
+    """
+    import json
+
+    from pydantic_evals.otel.span_tree import SpanNode, SpanTree, SpanQuery
+
+    data = {'foo': 1, 'bar': True}
+    tags = ['alpha', 'beta']
+
+    # Build a minimal SpanNode with JSON-serialised attributes (as Logfire would store them)
+    node = SpanNode(
+        name='test',
+        attributes={
+            'data': json.dumps(data, separators=(',', ':')),  # '{"foo":1,"bar":true}'
+            'tags': json.dumps(tags),  # '["alpha", "beta"]'
+            'level': '3',  # plain string, not JSON-serialised
+        },
+        start_time=None,  # type: ignore[arg-type]
+        end_time=None,  # type: ignore[arg-type]
+    )
+
+    # Plain string still works
+    assert node.matches(SpanQuery(has_attributes={'level': '3'}))
+    assert not node.matches(SpanQuery(has_attributes={'level': 3}))  # int ≠ plain str
+
+    # Dict query matches JSON-serialised string
+    assert node.matches(SpanQuery(has_attributes={'data': data}))
+    assert node.matches(SpanQuery(has_attributes={'data': {'foo': 1, 'bar': True}}))
+    assert not node.matches(SpanQuery(has_attributes={'data': {'foo': 2, 'bar': True}}))
+
+    # List query matches JSON-serialised string
+    assert node.matches(SpanQuery(has_attributes={'tags': tags}))
+    assert not node.matches(SpanQuery(has_attributes={'tags': ['alpha']}))
+
+    # String form of the JSON also still matches (backward-compatible)
+    assert node.matches(SpanQuery(has_attributes={'data': json.dumps(data, separators=(',', ':'))}))
+
+
     assert repr(SpanTree()) == snapshot('<SpanTree />')
     assert str(span_tree) == snapshot('<SpanTree num_roots=1 total_spans=6 />')
     assert repr(span_tree) == snapshot("""\


### PR DESCRIPTION
## Problem

Fixes #4448.

When Logfire (or the OTEL SDK) stores a span attribute that is a complex Python object (dict, list of dicts, etc.), it serialises it to a JSON string. For example:

```python
logfire.info('some data', data={'foo': 1, 'bar': True})
# Stored as: attributes['data'] = '{"foo":1,"bar":true}'   ← JSON string
```

A `SpanQuery(has_attributes={'data': {'foo': 1, 'bar': True}})` would then never match because the stored attribute is `str` while the query value is `dict`.

**Users were forced to use the serialised form:**
```python
SpanQuery(has_attributes={'data': '{"foo":1,"bar":true}'})   # works but unintuitive
SpanQuery(has_attributes={'data': {'foo': 1, 'bar': True}})     # fails (bug)
```

## Fix

Add a small helper `_attribute_matches(attribute_value, query_value)` that:
1. Tries a direct equality comparison first (existing behaviour, fully backward-compatible).
2. When the stored attribute is a `str` and the query value is not a `str`, attempts to JSON-parse the attribute and compare the result to the query value.
3. Any parse failure (non-JSON strings, scalars) falls through to return `False` safely.

## Before / After

```python
DATA = {'foo': 1, 'bar': True}

# Before: only the JSON string form worked
assert tree.first(SpanQuery(has_attributes={'data': '{"foo":1,"bar":true}'})) is not None
assert tree.first(SpanQuery(has_attributes={'data': DATA})) is None  # ← bug

# After: both forms work
assert tree.first(SpanQuery(has_attributes={'data': '{"foo":1,"bar":true}'})) is not None
assert tree.first(SpanQuery(has_attributes={'data': DATA})) is not None  # ← fixed
```