### PR TITLE
fix(tracing): prevent CallDeferred/ApprovalRequired from marking tool spans as errors

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -13,7 +13,8 @@ Versions:
 - 1: Original span/attribute names (e.g. 'agent run', 'tool_arguments').
 - 2: Same names as v1 but with additional attributes.
 - 3: GenAI semantic convention names (e.g. 'invoke_agent', 'gen_ai.tool.call.arguments').
-- 4: Like v3 but CallDeferred/ApprovalRequired no longer produce ERROR spans (opt-in).
+- 4: Like v3 but with GenAI semantic conventions for multimodal content (URI/blob parts, modality fields).
+- 5: Like v4 but CallDeferred/ApprovalRequired no longer produce ERROR spans (opt-in).
 """
 
 

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -7,7 +7,14 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 DEFAULT_INSTRUMENTATION_VERSION = 2
-"""Default instrumentation version for `InstrumentationSettings`."""
+"""Default instrumentation version for `InstrumentationSettings`.
+
+Versions:
+- 1: Original span/attribute names (e.g. 'agent run', 'tool_arguments').
+- 2: Same names as v1 but with additional attributes.
+- 3: GenAI semantic convention names (e.g. 'invoke_agent', 'gen_ai.tool.call.arguments').
+- 4: Like v3 but CallDeferred/ApprovalRequired no longer produce ERROR spans (opt-in).
+"""
 
 
 @dataclass(frozen=True)
@@ -26,12 +33,16 @@ class InstrumentationNames:
     # Output Tool execution span configuration
     output_tool_span_name: str
 
+    # Deferral span attributes (CallDeferred / ApprovalRequired)
+    tool_deferral_name_attr: str
+    tool_deferral_metadata_attr: str
+
     @classmethod
     def for_version(cls, version: int) -> Self:
         """Create instrumentation configuration for a specific version.
 
         Args:
-            version: The instrumentation version (1, 2, or 3+)
+            version: The instrumentation version (1, 2, 3, or 4+)
 
         Returns:
             InstrumentationConfig instance with version-appropriate settings
@@ -44,8 +55,13 @@ class InstrumentationNames:
                 tool_arguments_attr='tool_arguments',
                 tool_result_attr='tool_response',
                 output_tool_span_name='running output function',
+                tool_deferral_name_attr='pydantic_ai.tool.deferral.name',
+                tool_deferral_metadata_attr='pydantic_ai.tool.deferral.metadata',
             )
         else:
+            # Version 3 and 4+ share the same span/attribute names.
+            # The only difference between v3 and v4 is behavioral (gated in _tool_manager.py):
+            # v4 suppresses ERROR status for CallDeferred/ApprovalRequired.
             return cls(
                 agent_run_span_name='invoke_agent',
                 agent_name_attr='gen_ai.agent.name',
@@ -53,6 +69,8 @@ class InstrumentationNames:
                 tool_arguments_attr='gen_ai.tool.call.arguments',
                 tool_result_attr='gen_ai.tool.call.result',
                 output_tool_span_name='execute_tool',
+                tool_deferral_name_attr='pydantic_ai.tool.deferral.name',
+                tool_deferral_metadata_attr='pydantic_ai.tool.deferral.metadata',
             )
 
     def get_agent_run_span_name(self, agent_name: str) -> str:

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -60,9 +60,9 @@ class InstrumentationNames:
                 tool_deferral_metadata_attr='pydantic_ai.tool.deferral.metadata',
             )
         else:
-            # Version 3 and 4+ share the same span/attribute names.
-            # The only difference between v3 and v4 is behavioral (gated in _tool_manager.py):
-            # v4 suppresses ERROR status for CallDeferred/ApprovalRequired.
+            # Version 3, 4, and 5 share the same span/attribute names.
+            # The only difference is behavioral (gated in _tool_manager.py):
+            # v5+ suppresses ERROR status for CallDeferred/ApprovalRequired.
             return cls(
                 agent_run_span_name='invoke_agent',
                 agent_name_attr='gen_ai.agent.name',

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -410,6 +410,8 @@ class ToolManager(Generic[AgentDepsT]):
         with tracer.start_as_current_span(
             instrumentation_names.get_tool_span_name(call.tool_name),
             attributes=span_attributes,
+            record_exception=False,
+            set_status_on_exception=False,
         ) as span:
             try:
                 tool_result = await self._execute_tool_call_impl(validated, usage=usage)
@@ -417,12 +419,20 @@ class ToolManager(Generic[AgentDepsT]):
                 part = e.tool_retry
                 if include_content and span.is_recording():
                     span.set_attribute(instrumentation_names.tool_result_attr, part.model_response())
+                span.record_exception(e)
+                span.set_status(_OtelStatusCode.ERROR)
                 raise
             except (CallDeferred, ApprovalRequired):
                 # CallDeferred and ApprovalRequired are control-flow signals, not errors.
                 # Explicitly mark the span as OK so it doesn't appear as a failure in
                 # tracing UIs (e.g. Logfire), then re-raise to let the agent handle them.
+                # record_exception=False on the span ensures no exception event is recorded,
+                # keeping the span consistent with its OK status.
                 span.set_status(_OtelStatusCode.OK)
+                raise
+            except Exception as exc:
+                span.record_exception(exc)
+                span.set_status(_OtelStatusCode.ERROR)
                 raise
 
             if include_content and span.is_recording():

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -438,6 +438,8 @@ class ToolManager(Generic[AgentDepsT]):
                 if instrumentation_version >= 3:
                     span.set_status(_OtelStatusCode.OK)
                 else:
+                    # Preserve old behaviour: record exception event + ERROR status.
+                    span.record_exception(exc)
                     span.set_status(_OtelStatusCode.ERROR)
                 raise
             except Exception as exc:

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -8,8 +8,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from typing import Any, Generic, Literal
 
-from opentelemetry.trace import Tracer
-from opentelemetry.trace import StatusCode as _OtelStatusCode
+from opentelemetry.trace import StatusCode as _OtelStatusCode, Tracer
 from pydantic import ValidationError
 from typing_extensions import deprecated
 
@@ -423,8 +422,7 @@ class ToolManager(Generic[AgentDepsT]):
                 # CallDeferred and ApprovalRequired are control-flow signals, not errors.
                 # Explicitly mark the span as OK so it doesn't appear as a failure in
                 # tracing UIs (e.g. Logfire), then re-raise to let the agent handle them.
-                if span.is_recording():
-                    span.set_status(_OtelStatusCode.OK)
+                span.set_status(_OtelStatusCode.OK)
                 raise
 
             if include_content and span.is_recording():

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -420,7 +420,7 @@ class ToolManager(Generic[AgentDepsT]):
                 if include_content and span.is_recording():
                     span.set_attribute(instrumentation_names.tool_result_attr, part.model_response())
                 span.record_exception(e)
-                span.set_status(_OtelStatusCode.ERROR)
+                span.set_status(_OtelStatusCode.ERROR, str(e))
                 raise
             except (CallDeferred, ApprovalRequired) as exc:
                 # Always record deferral info as span attributes (queryable regardless of version)
@@ -438,11 +438,11 @@ class ToolManager(Generic[AgentDepsT]):
                     span.set_status(_OtelStatusCode.OK)
                 else:
                     span.record_exception(exc)
-                    span.set_status(_OtelStatusCode.ERROR)
+                    span.set_status(_OtelStatusCode.ERROR, str(exc))
                 raise
             except Exception as exc:
                 span.record_exception(exc)
-                span.set_status(_OtelStatusCode.ERROR)
+                span.set_status(_OtelStatusCode.ERROR, str(exc))
                 raise
 
             if include_content and span.is_recording():

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -425,20 +425,18 @@ class ToolManager(Generic[AgentDepsT]):
             except (CallDeferred, ApprovalRequired) as exc:
                 # Always record deferral info as span attributes (queryable regardless of version)
                 if span.is_recording():
-                    span.set_attribute('pydantic_ai.tool.deferral.name', type(exc).__name__)
-                    metadata = getattr(exc, 'metadata', None)
-                    if metadata is not None:
+                    span.set_attribute(instrumentation_names.tool_deferral_name_attr, type(exc).__name__)
+                    if exc.metadata is not None:
                         try:
-                            span.set_attribute('pydantic_ai.tool.deferral.metadata', json.dumps(metadata))
+                            span.set_attribute(instrumentation_names.tool_deferral_metadata_attr, json.dumps(exc.metadata))
                         except (TypeError, ValueError):
-                            span.set_attribute('pydantic_ai.tool.deferral.metadata', str(metadata))
+                            span.set_attribute(instrumentation_names.tool_deferral_metadata_attr, str(exc.metadata))
 
-                # Gate error-suppression behind instrumentation version 3+ for backwards compat.
-                # Versions 1 and 2 keep the old behaviour where these exceptions appear as errors.
-                if instrumentation_version >= 3:
+                # Gate error-suppression behind version 4+ (new dedicated version for this change).
+                # Versions 1-3 preserve the old behaviour where these exceptions appear as errors.
+                if instrumentation_version >= 4:
                     span.set_status(_OtelStatusCode.OK)
                 else:
-                    # Preserve old behaviour: record exception event + ERROR status.
                     span.record_exception(exc)
                     span.set_status(_OtelStatusCode.ERROR)
                 raise

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -422,13 +422,22 @@ class ToolManager(Generic[AgentDepsT]):
                 span.record_exception(e)
                 span.set_status(_OtelStatusCode.ERROR)
                 raise
-            except (CallDeferred, ApprovalRequired):
-                # CallDeferred and ApprovalRequired are control-flow signals, not errors.
-                # Explicitly mark the span as OK so it doesn't appear as a failure in
-                # tracing UIs (e.g. Logfire), then re-raise to let the agent handle them.
-                # record_exception=False on the span ensures no exception event is recorded,
-                # keeping the span consistent with its OK status.
-                span.set_status(_OtelStatusCode.OK)
+            except (CallDeferred, ApprovalRequired) as exc:
+                # Always record deferral info as span attributes (queryable regardless of version)
+                if span.is_recording():
+                    import json as _json
+
+                    span.set_attribute('pydantic_ai.tool.deferral.name', type(exc).__name__)
+                    metadata = getattr(exc, 'metadata', None)
+                    if metadata is not None:
+                        span.set_attribute('pydantic_ai.tool.deferral.metadata', _json.dumps(metadata))
+
+                # Gate error-suppression behind instrumentation version 3+ for backwards compat.
+                # Versions 1 and 2 keep the old behaviour where these exceptions appear as errors.
+                if instrumentation_version >= 3:
+                    span.set_status(_OtelStatusCode.OK)
+                else:
+                    span.set_status(_OtelStatusCode.ERROR)
                 raise
             except Exception as exc:
                 span.record_exception(exc)

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -9,13 +9,14 @@ from dataclasses import dataclass, field, replace
 from typing import Any, Generic, Literal
 
 from opentelemetry.trace import Tracer
+from opentelemetry.trace import StatusCode as _OtelStatusCode
 from pydantic import ValidationError
 from typing_extensions import deprecated
 
 from . import messages as _messages
 from ._instrumentation import InstrumentationNames
 from ._run_context import AgentDepsT, RunContext
-from .exceptions import ModelRetry, ToolRetryError, UnexpectedModelBehavior
+from .exceptions import ApprovalRequired, CallDeferred, ModelRetry, ToolRetryError, UnexpectedModelBehavior
 from .messages import ToolCallPart
 from .tools import ToolDefinition
 from .toolsets.abstract import AbstractToolset, ToolsetTool
@@ -417,6 +418,13 @@ class ToolManager(Generic[AgentDepsT]):
                 part = e.tool_retry
                 if include_content and span.is_recording():
                     span.set_attribute(instrumentation_names.tool_result_attr, part.model_response())
+                raise
+            except (CallDeferred, ApprovalRequired):
+                # CallDeferred and ApprovalRequired are control-flow signals, not errors.
+                # Explicitly mark the span as OK so it doesn't appear as a failure in
+                # tracing UIs (e.g. Logfire), then re-raise to let the agent handle them.
+                if span.is_recording():
+                    span.set_status(_OtelStatusCode.OK)
                 raise
 
             if include_content and span.is_recording():

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -423,14 +423,14 @@ class ToolManager(Generic[AgentDepsT]):
                 span.set_status(_OtelStatusCode.ERROR, str(e))
                 raise
             except (CallDeferred, ApprovalRequired) as exc:
-                # Always record deferral info as span attributes (queryable regardless of version)
-                if span.is_recording():
-                    span.set_attribute(instrumentation_names.tool_deferral_name_attr, type(exc).__name__)
-                    if exc.metadata is not None:
-                        try:
-                            span.set_attribute(instrumentation_names.tool_deferral_metadata_attr, json.dumps(exc.metadata))
-                        except (TypeError, ValueError):
-                            span.set_attribute(instrumentation_names.tool_deferral_metadata_attr, str(exc.metadata))
+                # Always record deferral info as span attributes (queryable regardless of version).
+                # set_attribute is a no-op on non-recording spans, so no is_recording() guard needed.
+                span.set_attribute(instrumentation_names.tool_deferral_name_attr, type(exc).__name__)
+                if exc.metadata is not None:
+                    try:
+                        span.set_attribute(instrumentation_names.tool_deferral_metadata_attr, json.dumps(exc.metadata))
+                    except (TypeError, ValueError):
+                        span.set_attribute(instrumentation_names.tool_deferral_metadata_attr, str(exc.metadata))
 
                 # Gate error-suppression behind version 4+ (new dedicated version for this change).
                 # Versions 1-3 preserve the old behaviour where these exceptions appear as errors.

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from typing import Any, Generic, Literal
 
-from opentelemetry.trace import StatusCode as _OtelStatusCode, Tracer
+from opentelemetry.trace import StatusCode, Tracer
 from pydantic import ValidationError
 from typing_extensions import deprecated
 
@@ -420,7 +420,7 @@ class ToolManager(Generic[AgentDepsT]):
                 if include_content and span.is_recording():
                     span.set_attribute(instrumentation_names.tool_result_attr, part.model_response())
                 span.record_exception(e)
-                span.set_status(_OtelStatusCode.ERROR, str(e))
+                span.set_status(StatusCode.ERROR, str(e))
                 raise
             except (CallDeferred, ApprovalRequired) as exc:
                 # Always record deferral info as span attributes (queryable regardless of version).
@@ -432,17 +432,17 @@ class ToolManager(Generic[AgentDepsT]):
                     except (TypeError, ValueError):
                         span.set_attribute(instrumentation_names.tool_deferral_metadata_attr, str(exc.metadata))
 
-                # Gate error-suppression behind version 4+ (new dedicated version for this change).
-                # Versions 1-3 preserve the old behaviour where these exceptions appear as errors.
-                if instrumentation_version >= 4:
-                    span.set_status(_OtelStatusCode.OK)
+                # Gate error-suppression behind version 5+ (new dedicated version for this change).
+                # Versions 1-4 preserve the old behaviour where these exceptions appear as errors.
+                if instrumentation_version >= 5:
+                    span.set_status(StatusCode.OK)
                 else:
                     span.record_exception(exc)
-                    span.set_status(_OtelStatusCode.ERROR, str(exc))
+                    span.set_status(StatusCode.ERROR, str(exc))
                 raise
             except Exception as exc:
                 span.record_exception(exc)
-                span.set_status(_OtelStatusCode.ERROR, str(exc))
+                span.set_status(StatusCode.ERROR, str(exc))
                 raise
 
             if include_content and span.is_recording():

--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -425,12 +425,13 @@ class ToolManager(Generic[AgentDepsT]):
             except (CallDeferred, ApprovalRequired) as exc:
                 # Always record deferral info as span attributes (queryable regardless of version)
                 if span.is_recording():
-                    import json as _json
-
                     span.set_attribute('pydantic_ai.tool.deferral.name', type(exc).__name__)
                     metadata = getattr(exc, 'metadata', None)
                     if metadata is not None:
-                        span.set_attribute('pydantic_ai.tool.deferral.metadata', _json.dumps(metadata))
+                        try:
+                            span.set_attribute('pydantic_ai.tool.deferral.metadata', json.dumps(metadata))
+                        except (TypeError, ValueError):
+                            span.set_attribute('pydantic_ai.tool.deferral.metadata', str(metadata))
 
                 # Gate error-suppression behind instrumentation version 3+ for backwards compat.
                 # Versions 1 and 2 keep the old behaviour where these exceptions appear as errors.

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -92,7 +92,7 @@ class InstrumentationSettings:
     event_mode: Literal['attributes', 'logs'] = 'attributes'
     include_binary_content: bool = True
     include_content: bool = True
-    version: Literal[1, 2, 3, 4] = DEFAULT_INSTRUMENTATION_VERSION
+    version: Literal[1, 2, 3, 4, 5] = DEFAULT_INSTRUMENTATION_VERSION
     use_aggregated_usage_attribute_names: bool = False
 
     def __init__(
@@ -102,7 +102,7 @@ class InstrumentationSettings:
         meter_provider: MeterProvider | None = None,
         include_binary_content: bool = True,
         include_content: bool = True,
-        version: Literal[1, 2, 3, 4] = DEFAULT_INSTRUMENTATION_VERSION,
+        version: Literal[1, 2, 3, 4, 5] = DEFAULT_INSTRUMENTATION_VERSION,
         event_mode: Literal['attributes', 'logs'] = 'attributes',
         logger_provider: LoggerProvider | None = None,
         use_aggregated_usage_attribute_names: bool = False,
@@ -132,6 +132,8 @@ class InstrumentationSettings:
                     URL-based media uses type='uri' with uri and mime_type fields (and modality for image/audio/video).
                     Inline binary content uses type='blob' with mime_type and content fields (and modality for image/audio/video).
                     https://opentelemetry.io/docs/specs/semconv/gen-ai/non-normative/examples-llm-calls/#multimodal-inputs-example
+                Version 5 is the same as version 4, but CallDeferred and ApprovalRequired exceptions no longer
+                    produce ERROR spans — the tool span status is OK and no exception event is recorded.
             event_mode: The mode for emitting events in version 1.
                 If `'attributes'`, events are attached to the span as attributes.
                 If `'logs'`, events are emitted as OpenTelemetry log-based events.

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3345,9 +3345,7 @@ def test_call_deferred_span_attributes(capfire: CaptureLogfire, version: int) ->
 
     if is_error:
         # v1-3: exception event must be recorded on the span
-        assert tool_span.get('events') == snapshot(
-            [_exception_event('pydantic_ai.exceptions.CallDeferred')]
-        )
+        assert tool_span.get('events') == snapshot([_exception_event('pydantic_ai.exceptions.CallDeferred')])
     else:
         # v4+: OK status, no exception event
         assert tool_span.get('events', []) == snapshot([])
@@ -3387,14 +3385,9 @@ def test_approval_required_span_attributes(capfire: CaptureLogfire, version: int
     )
 
     if is_error:
-        assert tool_span.get('events') == snapshot(
-            [_exception_event('pydantic_ai.exceptions.ApprovalRequired')]
-        )
+        assert tool_span.get('events') == snapshot([_exception_event('pydantic_ai.exceptions.ApprovalRequired')])
     else:
         assert tool_span.get('events', []) == snapshot([])
-
-
-
 
 
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -11,12 +11,12 @@ from typing_extensions import NotRequired, Self, TypedDict
 
 from pydantic_ai import Agent, ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart, UserPromptPart
 from pydantic_ai._utils import get_traceparent
-from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior
+from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry, UnexpectedModelBehavior
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings, InstrumentedModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.output import PromptedOutput, TextOutput
-from pydantic_ai.tools import RunContext
+from pydantic_ai.tools import DeferredToolRequests, RunContext
 from pydantic_ai.toolsets.abstract import ToolsetTool
 from pydantic_ai.toolsets.function import FunctionToolset
 from pydantic_ai.toolsets.wrapper import WrapperToolset
@@ -3247,3 +3247,73 @@ async def test_run_stream(
                 ]
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for pydantic_ai.tool.deferral span attributes (issue #4530)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.parametrize('version', [2, 3])
+def test_call_deferred_span_attributes(capfire: CaptureLogfire, version: int) -> None:
+    """pydantic_ai.tool.deferral.name/.metadata are always set; error status is version-gated."""
+    settings = InstrumentationSettings(version=version)
+    my_agent = Agent(model=TestModel(), instrument=settings, output_type=[str, DeferredToolRequests])
+
+    @my_agent.tool_plain
+    def deferred_tool(x: int) -> str:
+        raise CallDeferred(metadata={'x': x, 'reason': 'needs review'})
+
+    result = my_agent.run_sync('call deferred_tool')
+    assert isinstance(result.output, DeferredToolRequests)
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    tool_span = next(
+        (s for s in spans if s.get('attributes', {}).get('gen_ai.tool.name') == 'deferred_tool'),
+        None,
+    )
+    assert tool_span is not None, 'expected a tool span for deferred_tool'
+    attrs = tool_span['attributes']
+
+    # Deferral attributes must always be present regardless of version
+    assert attrs.get('pydantic_ai.tool.deferral.name') == 'CallDeferred'
+    assert attrs.get('pydantic_ai.tool.deferral.metadata') == {'x': 0, 'reason': 'needs review'}
+
+    # Error status is only suppressed for version >= 3; version <= 2 uses logfire.level_num=17 (error)
+    if version >= 3:
+        assert attrs.get('logfire.level_num') != 17
+    else:
+        assert attrs.get('logfire.level_num') == 17
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.parametrize('version', [2, 3])
+def test_approval_required_span_attributes(capfire: CaptureLogfire, version: int) -> None:
+    """pydantic_ai.tool.deferral.name/.metadata are set for ApprovalRequired too."""
+    settings = InstrumentationSettings(version=version)
+    my_agent = Agent(model=TestModel(), instrument=settings, output_type=[str, DeferredToolRequests])
+
+    @my_agent.tool_plain
+    def approval_tool(x: int) -> str:
+        raise ApprovalRequired(metadata={'x': x, 'reason': 'sensitive op'})
+
+    result = my_agent.run_sync('call approval_tool')
+    assert isinstance(result.output, DeferredToolRequests)
+
+    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
+    tool_span = next(
+        (s for s in spans if s.get('attributes', {}).get('gen_ai.tool.name') == 'approval_tool'),
+        None,
+    )
+    assert tool_span is not None, 'expected a tool span for approval_tool'
+    attrs = tool_span['attributes']
+
+    assert attrs.get('pydantic_ai.tool.deferral.name') == 'ApprovalRequired'
+    assert attrs.get('pydantic_ai.tool.deferral.metadata') == {'x': 0, 'reason': 'sensitive op'}
+
+    if version >= 3:
+        assert attrs.get('logfire.level_num') != 17
+    else:
+        assert attrs.get('logfire.level_num') == 17
+

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3395,3 +3395,33 @@ def test_approval_required_span_attributes(capfire: CaptureLogfire, version: int
 
 
 
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+def test_call_deferred_non_serializable_metadata(capfire: CaptureLogfire) -> None:
+    """metadata that can't be JSON-serialized falls back to str() for the span attribute."""
+    settings = InstrumentationSettings(version=4)
+    my_agent = Agent(model=TestModel(), instrument=settings, output_type=[str, DeferredToolRequests])
+
+    class _Unserializable:
+        def __repr__(self) -> str:
+            return 'Unserializable()'
+
+    @my_agent.tool_plain
+    def deferred_tool() -> str:
+        raise CallDeferred(metadata={'obj': _Unserializable()})
+
+    result = my_agent.run_sync('call deferred_tool')
+    assert isinstance(result.output, DeferredToolRequests)
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    tool_span = next(
+        (s for s in spans if 'deferred_tool' in s.get('name', '')),
+        None,
+    )
+    assert tool_span is not None
+    attrs = tool_span.get('attributes', {})
+    assert attrs.get('pydantic_ai.tool.deferral.name') == 'CallDeferred'
+    # metadata fell back to str() since _Unserializable is not JSON-serializable
+    metadata_attr = attrs.get('pydantic_ai.tool.deferral.metadata', '')
+    assert 'Unserializable' in metadata_attr

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3250,14 +3250,71 @@ async def test_run_stream(
 
 
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Tests for pydantic_ai.tool.deferral span attributes (issue #4530)
 # ---------------------------------------------------------------------------
 
 
+def _deferral_attrs(
+    tool_name: str,
+    version: int,
+    deferral_exc_name: str,
+    deferral_metadata: dict[str, object],
+    error: bool,
+) -> dict[str, object]:
+    """Build expected tool span attributes for a deferral exception."""
+    if version <= 2:
+        args_key = 'tool_arguments'
+        result_key = 'tool_response'
+    else:
+        args_key = 'gen_ai.tool.call.arguments'
+        result_key = 'gen_ai.tool.call.result'
+
+    # InstrumentationSettings defaults to include_content=True, so args are recorded.
+    # The argument value for deferred_tool(x=0) and approval_tool(x=0) is x=0.
+    tool_args: dict[str, object] = {'x': 0}
+
+    attrs: dict[str, object] = {
+        'gen_ai.tool.name': tool_name,
+        'gen_ai.tool.call.id': IsStr(),
+        args_key: tool_args,
+        'logfire.msg': f'running tool: {tool_name}',
+        'logfire.json_schema': {
+            'type': 'object',
+            'properties': {
+                args_key: {'type': 'object'},
+                result_key: {'type': 'object'},
+                'gen_ai.tool.name': {},
+                'gen_ai.tool.call.id': {},
+            },
+        },
+        'logfire.span_type': 'span',
+        'pydantic_ai.tool.deferral.name': deferral_exc_name,
+        'pydantic_ai.tool.deferral.metadata': deferral_metadata,
+    }
+    if error:
+        attrs['logfire.level_num'] = 17
+    return attrs
+
+
+def _exception_event(exc_type: str) -> dict[str, object]:
+    return {
+        'name': 'exception',
+        'timestamp': IsInt(),
+        'attributes': {
+            'exception.type': exc_type,
+            'exception.message': '',
+            'exception.stacktrace': exc_type,
+            'exception.escaped': 'False',
+        },
+    }
+
+
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('version', [2, 3])
+@pytest.mark.parametrize('version', [1, 2, 3, 4])
 def test_call_deferred_span_attributes(capfire: CaptureLogfire, version: int) -> None:
-    """pydantic_ai.tool.deferral.name/.metadata are always set; error status is version-gated."""
+    """pydantic_ai.tool.deferral.name/.metadata are always set; ERROR status and exception event
+    are present on v1-3 and absent on v4+."""
     settings = InstrumentationSettings(version=version)
     my_agent = Agent(model=TestModel(), instrument=settings, output_type=[str, DeferredToolRequests])
 
@@ -3274,23 +3331,33 @@ def test_call_deferred_span_attributes(capfire: CaptureLogfire, version: int) ->
         None,
     )
     assert tool_span is not None, 'expected a tool span for deferred_tool'
-    attrs = tool_span['attributes']
 
-    # Deferral attributes must always be present regardless of version
-    assert attrs.get('pydantic_ai.tool.deferral.name') == 'CallDeferred'
-    assert attrs.get('pydantic_ai.tool.deferral.metadata') == {'x': 0, 'reason': 'needs review'}
+    is_error = version < 4
+    assert tool_span['attributes'] == snapshot(
+        _deferral_attrs(
+            tool_name='deferred_tool',
+            version=version,
+            deferral_exc_name='CallDeferred',
+            deferral_metadata={'x': 0, 'reason': 'needs review'},
+            error=is_error,
+        )
+    )
 
-    # Error status is only suppressed for version >= 3; version <= 2 uses logfire.level_num=17 (error)
-    if version >= 3:
-        assert attrs.get('logfire.level_num') != 17
+    if is_error:
+        # v1-3: exception event must be recorded on the span
+        assert tool_span.get('events') == snapshot(
+            [_exception_event('pydantic_ai.exceptions.CallDeferred')]
+        )
     else:
-        assert attrs.get('logfire.level_num') == 17
+        # v4+: OK status, no exception event
+        assert tool_span.get('events', []) == snapshot([])
 
 
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('version', [2, 3])
+@pytest.mark.parametrize('version', [1, 2, 3, 4])
 def test_approval_required_span_attributes(capfire: CaptureLogfire, version: int) -> None:
-    """pydantic_ai.tool.deferral.name/.metadata are set for ApprovalRequired too."""
+    """ApprovalRequired is treated identically to CallDeferred: deferral attrs always set,
+    ERROR status + exception event on v1-3, OK status and no exception on v4+."""
     settings = InstrumentationSettings(version=version)
     my_agent = Agent(model=TestModel(), instrument=settings, output_type=[str, DeferredToolRequests])
 
@@ -3307,13 +3374,24 @@ def test_approval_required_span_attributes(capfire: CaptureLogfire, version: int
         None,
     )
     assert tool_span is not None, 'expected a tool span for approval_tool'
-    attrs = tool_span['attributes']
 
-    assert attrs.get('pydantic_ai.tool.deferral.name') == 'ApprovalRequired'
-    assert attrs.get('pydantic_ai.tool.deferral.metadata') == {'x': 0, 'reason': 'sensitive op'}
+    is_error = version < 4
+    assert tool_span['attributes'] == snapshot(
+        _deferral_attrs(
+            tool_name='approval_tool',
+            version=version,
+            deferral_exc_name='ApprovalRequired',
+            deferral_metadata={'x': 0, 'reason': 'sensitive op'},
+            error=is_error,
+        )
+    )
 
-    if version >= 3:
-        assert attrs.get('logfire.level_num') != 17
+    if is_error:
+        assert tool_span.get('events') == snapshot(
+            [_exception_event('pydantic_ai.exceptions.ApprovalRequired')]
+        )
     else:
-        assert attrs.get('logfire.level_num') == 17
+        assert tool_span.get('events', []) == snapshot([])
+
+
 

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3247,31 +3247,3 @@ async def test_run_stream(
                 ]
             )
         )
-
-
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-def test_call_deferred_span_marked_ok(capfire: CaptureLogfire) -> None:
-    """CallDeferred and ApprovalRequired should mark the tool span as OK, not ERROR.
-
-    Regression test for the fix in _tool_manager.py that sets span status to OK
-    when these control-flow exceptions are raised inside a tool.
-    """
-    from pydantic_ai.exceptions import CallDeferred
-
-    agent = Agent(TestModel(), instrument=True)
-
-    @agent.tool_plain
-    def deferred_tool() -> str:
-        raise CallDeferred
-
-    with pytest.raises(CallDeferred):
-        agent.run_sync('run deferred tool')
-
-    spans = capfire.exporter.exported_spans_as_dict()
-    tool_spans = [s for s in spans if 'deferred_tool' in s.get('name', '')]
-    # If the span was recorded, it should be OK (status_code 1), not ERROR (status_code 2)
-    for span in tool_spans:
-        status = span.get('status', {})
-        assert status.get('status_code') != 'ERROR', (
-            f'Tool span for CallDeferred should not have ERROR status, got: {status}'
-        )

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3247,3 +3247,31 @@ async def test_run_stream(
                 ]
             )
         )
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+def test_call_deferred_span_marked_ok(capfire: CaptureLogfire) -> None:
+    """CallDeferred and ApprovalRequired should mark the tool span as OK, not ERROR.
+
+    Regression test for the fix in _tool_manager.py that sets span status to OK
+    when these control-flow exceptions are raised inside a tool.
+    """
+    from pydantic_ai.exceptions import CallDeferred
+
+    agent = Agent(TestModel(), instrument=True)
+
+    @agent.tool_plain
+    def deferred_tool() -> str:
+        raise CallDeferred
+
+    with pytest.raises(CallDeferred):
+        agent.run_sync('run deferred tool')
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    tool_spans = [s for s in spans if 'deferred_tool' in s.get('name', '')]
+    # If the span was recorded, it should be OK (status_code 1), not ERROR (status_code 2)
+    for span in tool_spans:
+        status = span.get('status', {})
+        assert status.get('status_code') != 'ERROR', (
+            f'Tool span for CallDeferred should not have ERROR status, got: {status}'
+        )

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3250,7 +3250,6 @@ async def test_run_stream(
 
 
 # ---------------------------------------------------------------------------
-# ---------------------------------------------------------------------------
 # Tests for pydantic_ai.tool.deferral span attributes (issue #4530)
 # ---------------------------------------------------------------------------
 
@@ -3271,7 +3270,6 @@ def _deferral_attrs(
         result_key = 'gen_ai.tool.call.result'
 
     # InstrumentationSettings defaults to include_content=True, so args are recorded.
-    # The argument value for deferred_tool(x=0) and approval_tool(x=0) is x=0.
     tool_args: dict[str, object] = {'x': 0}
 
     attrs: dict[str, object] = {
@@ -3311,89 +3309,68 @@ def _exception_event(exc_type: str) -> dict[str, object]:
 
 
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('version', [1, 2, 3, 4])
-def test_call_deferred_span_attributes(capfire: CaptureLogfire, version: int) -> None:
+@pytest.mark.parametrize(
+    'exc_class,deferral_exc_name,tool_name,metadata',
+    [
+        (CallDeferred, 'CallDeferred', 'deferred_tool', {'x': 0, 'reason': 'needs review'}),
+        (ApprovalRequired, 'ApprovalRequired', 'approval_tool', {'x': 0, 'reason': 'sensitive op'}),
+    ],
+)
+@pytest.mark.parametrize('version', [1, 2, 3, 4, 5])
+def test_deferral_span_attributes(
+    capfire: CaptureLogfire,
+    version: Literal[1, 2, 3, 4, 5],
+    exc_class: type[CallDeferred | ApprovalRequired],
+    deferral_exc_name: str,
+    tool_name: str,
+    metadata: dict[str, object],
+) -> None:
     """pydantic_ai.tool.deferral.name/.metadata are always set; ERROR status and exception event
-    are present on v1-3 and absent on v4+."""
+    are present on v1-4 and absent on v5+."""
     settings = InstrumentationSettings(version=version)
     my_agent = Agent(model=TestModel(), instrument=settings, output_type=[str, DeferredToolRequests])
 
     @my_agent.tool_plain
     def deferred_tool(x: int) -> str:
-        raise CallDeferred(metadata={'x': x, 'reason': 'needs review'})
-
-    result = my_agent.run_sync('call deferred_tool')
-    assert isinstance(result.output, DeferredToolRequests)
-
-    spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
-    tool_span = next(
-        (s for s in spans if s.get('attributes', {}).get('gen_ai.tool.name') == 'deferred_tool'),
-        None,
-    )
-    assert tool_span is not None, 'expected a tool span for deferred_tool'
-
-    is_error = version < 4
-    assert tool_span['attributes'] == snapshot(
-        _deferral_attrs(
-            tool_name='deferred_tool',
-            version=version,
-            deferral_exc_name='CallDeferred',
-            deferral_metadata={'x': 0, 'reason': 'needs review'},
-            error=is_error,
-        )
-    )
-
-    if is_error:
-        # v1-3: exception event must be recorded on the span
-        assert tool_span.get('events') == snapshot([_exception_event('pydantic_ai.exceptions.CallDeferred')])
-    else:
-        # v4+: OK status, no exception event
-        assert tool_span.get('events', []) == snapshot([])
-
-
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('version', [1, 2, 3, 4])
-def test_approval_required_span_attributes(capfire: CaptureLogfire, version: int) -> None:
-    """ApprovalRequired is treated identically to CallDeferred: deferral attrs always set,
-    ERROR status + exception event on v1-3, OK status and no exception on v4+."""
-    settings = InstrumentationSettings(version=version)
-    my_agent = Agent(model=TestModel(), instrument=settings, output_type=[str, DeferredToolRequests])
+        raise exc_class(metadata={'x': x, 'reason': 'needs review'})
 
     @my_agent.tool_plain
     def approval_tool(x: int) -> str:
-        raise ApprovalRequired(metadata={'x': x, 'reason': 'sensitive op'})
+        raise exc_class(metadata={'x': x, 'reason': 'sensitive op'})
 
-    result = my_agent.run_sync('call approval_tool')
+    result = my_agent.run_sync(f'call {tool_name}')
     assert isinstance(result.output, DeferredToolRequests)
 
     spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
     tool_span = next(
-        (s for s in spans if s.get('attributes', {}).get('gen_ai.tool.name') == 'approval_tool'),
+        (s for s in spans if s.get('attributes', {}).get('gen_ai.tool.name') == tool_name),
         None,
     )
-    assert tool_span is not None, 'expected a tool span for approval_tool'
+    assert tool_span is not None, f'expected a tool span for {tool_name}'
 
-    is_error = version < 4
+    is_error = version < 5
     assert tool_span['attributes'] == snapshot(
         _deferral_attrs(
-            tool_name='approval_tool',
+            tool_name=tool_name,
             version=version,
-            deferral_exc_name='ApprovalRequired',
-            deferral_metadata={'x': 0, 'reason': 'sensitive op'},
+            deferral_exc_name=deferral_exc_name,
+            deferral_metadata=metadata,
             error=is_error,
         )
     )
 
     if is_error:
-        assert tool_span.get('events') == snapshot([_exception_event('pydantic_ai.exceptions.ApprovalRequired')])
+        # v1-4: exception event must be recorded on the span
+        assert tool_span.get('events') == snapshot([_exception_event(f'pydantic_ai.exceptions.{deferral_exc_name}')])
     else:
+        # v5+: OK status, no exception event
         assert tool_span.get('events', []) == snapshot([])
 
 
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
 def test_call_deferred_non_serializable_metadata(capfire: CaptureLogfire) -> None:
     """metadata that can't be JSON-serialized falls back to str() for the span attribute."""
-    settings = InstrumentationSettings(version=4)
+    settings = InstrumentationSettings(version=5)
     my_agent = Agent(model=TestModel(), instrument=settings, output_type=[str, DeferredToolRequests])
 
     class _Unserializable:


### PR DESCRIPTION
## Problem

Fixes #4530.

`CallDeferred` and `ApprovalRequired` are **control-flow signals**, not errors. They're intentionally raised inside tool functions to implement deferred/human-in-the-loop patterns.

However, because they propagate as exceptions out of the `tracer.start_as_current_span` context manager in `_execute_function_tool_call()`, OTEL's default behavior (`set_status_on_exception=True`, `record_exception=True`) marks the span as an error and records the exception. This causes them to appear as red error spans in Logfire and other OTEL backends — confusing and misleading.

## Fix

Add an explicit `except (CallDeferred, ApprovalRequired)` clause in `_execute_function_tool_call()` that:

1. Calls `span.set_status(StatusCode.OK)` to override the automatic error status.
2. Re-raises the exception unchanged so the agent's normal deferred-tool handling continues.

The existing OTEL behavior for real errors (`ModelRetry → ToolRetryError`, `UnexpectedModelBehavior`, unexpected exceptions) is unchanged.

## Before / After

**Before:** Any tool call that raises `CallDeferred` or `ApprovalRequired` produces a red error span in Logfire.

**After:** Such tool calls produce a normal (green/OK) span; the agent continues its deferred-tool workflow as expected.