### PR TITLE
fix(examples): fix question_graph CLI mode prematurely breaking on Answer node

### DIFF
--- a/examples/pydantic_ai_examples/question_graph.py
+++ b/examples/pydantic_ai_examples/question_graph.py
@@ -115,16 +115,13 @@ async def run_as_continuous():
     print('END:', end.output)
 
 
-async def run_as_cli(answer: str | None):
+async def run_as_cli():
     persistence = FileStatePersistence(Path('question_graph.json'))
     persistence.set_graph_types(question_graph)
 
     if snapshot := await persistence.load_next():
         state = snapshot.state
-        assert answer is not None, (
-            'answer required, usage "uv run -m pydantic_ai_examples.question_graph cli <answer>"'
-        )
-        node = Evaluate(answer)
+        node = snapshot.node
     else:
         state = QuestionState()
         node = Ask()
@@ -133,16 +130,13 @@ async def run_as_cli(answer: str | None):
     async with question_graph.iter(node, state=state, persistence=persistence) as run:
         while True:
             node = await run.next()
-            if isinstance(node, End):
-                print('END:', node.data)
-                history = await persistence.load_all()
-                print('history:', '\n'.join(str(e.node) for e in history), sep='\n')
-                print('Finished!')
-                break
-            elif isinstance(node, Answer):
-                print(node.question)
-                break
-            # otherwise just continue
+            if not isinstance(node, End):
+                continue
+            print('END:', node.data)
+            history = await persistence.load_all()
+            print('history:', '\n'.join(str(e.node) for e in history), sep='\n')
+            print('Finished!')
+            break
 
 
 if __name__ == '__main__':
@@ -159,7 +153,7 @@ if __name__ == '__main__':
             'or:\n'
             '  uv run -m pydantic_ai_examples.question_graph continuous\n'
             'or:\n'
-            '  uv run -m pydantic_ai_examples.question_graph cli [answer]',
+            '  uv run -m pydantic_ai_examples.question_graph cli',
             file=sys.stderr,
         )
         sys.exit(1)
@@ -169,5 +163,4 @@ if __name__ == '__main__':
     elif sub_command == 'continuous':
         asyncio.run(run_as_continuous())
     else:
-        a = sys.argv[2] if len(sys.argv) > 2 else None
-        asyncio.run(run_as_cli(a))
+        asyncio.run(run_as_cli())


### PR DESCRIPTION
## Summary

Fixes #4374

### Problem

The `run_as_cli` function in `question_graph.py` had a loop that broke early when it encountered an `Answer` node:

```python
elif isinstance(node, Answer):
    print(node.question)
    break
```

This caused the graph to stop mid-execution and required users to re-run the command with the answer as a CLI argument (`cli <answer>`). This was confusing because:
1. The user had to run the command twice per question
2. The answer was passed via `sys.argv` rather than through the graph's natural `Answer.run()` mechanism
3. The `Answer` node's `input()` call was never actually executed in CLI mode
4. Persistence could accumulate orphaned 'pending' snapshots since the loaded `Answer` snapshot was ignored

### Fix

- Simplify the loop to only break on `End` nodes, letting the graph execute naturally
- `Answer.run()` now runs as expected, prompting for user input inline via `input()`
- When resuming from persistence, use `snapshot.node` directly instead of constructing a new `Evaluate` node from command-line arguments
- Remove the now-unnecessary `answer` parameter from `run_as_cli()`
- Update the usage string to remove the `[answer]` argument

### Before / After

**Before** — user needed two invocations per question:
```
$ uv run -m pydantic_ai_examples.question_graph cli
What is the capital of France?

$ uv run -m pydantic_ai_examples.question_graph cli "Paris"
END: Correct!
```

**After** — single invocation, interactive input:
```
$ uv run -m pydantic_ai_examples.question_graph cli
What is the capital of France?: Paris
END: Correct!
```