### PR TITLE
Enable native structured output support for Ollama provider

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -66,6 +66,7 @@ class OllamaProvider(Provider[AsyncOpenAI]):
             json_schema_transformer=OpenAIJsonSchemaTransformer,
             openai_chat_thinking_field='reasoning',
             supports_json_schema_output=True,
+            supports_json_object_output=True,
         ).update(profile)
 
     def __init__(

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -144,3 +144,4 @@ def test_ollama_provider_model_profile(mocker: MockerFixture):
     assert unknown_profile is not None
     assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
     assert unknown_profile.supports_json_schema_output is True
+    assert unknown_profile.supports_json_object_output is True


### PR DESCRIPTION
- Closes #4508

### Pre-Review Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

## Summary

Ollama has supported native JSON schema structured output since [v0.5](https://ollama.com/blog/structured-outputs) via its OpenAI-compatible API. However, the `OllamaProvider.model_profile()` method was returning an `OpenAIModelProfile` with the default `supports_json_schema_output=False`, which prevented users from using `NativeOutput` without manually overriding the profile.

This PR adds `supports_json_schema_output=True` to the default `OpenAIModelProfile` returned by `OllamaProvider.model_profile()`. Since this is set at the provider level (not the model level), it correctly reflects that Ollama itself handles structured output enforcement regardless of the underlying model.

### Changes

- **`pydantic_ai_slim/pydantic_ai/providers/ollama.py`**: Added `supports_json_schema_output=True` to the base `OpenAIModelProfile` in `OllamaProvider.model_profile()`.
- **`tests/providers/test_ollama.py`**: Updated test assertions to reflect the new default and added an explicit assertion for unknown models.