### PR TITLE
Fix OpenAIJsonSchemaTransformer: bare `list` type sends `items: {}`, breaking strict mode

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -313,4 +313,12 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                     for k in schema['properties'].keys():
                         if k not in required:
                             self.is_strict_compatible = False
+
+        if schema_type == 'array':
+            items = schema.get('items')
+            if items == {}:
+                if self.strict is True:
+                    schema.pop('items')
+                elif self.strict is None:  # pragma: no branch
+                    self.is_strict_compatible = False
         return schema

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -14,7 +14,8 @@ import pytest
 from ..conftest import try_import
 
 with try_import() as imports_successful:
-    from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
+    from pydantic_ai._json_schema import JsonSchema
+    from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='openai not installed'),
@@ -80,3 +81,25 @@ class TestEncryptedReasoningContent:
             profile = openai_model_profile(model)
             assert isinstance(profile, OpenAIModelProfile)
             assert profile.openai_supports_encrypted_reasoning_content is False
+
+
+class TestOpenAIJsonSchemaTransformerBareList:
+    """Regression tests for bare list type (items: {}) strict compatibility."""
+
+    def test_bare_list_items_marks_not_strict_compatible(self):
+        schema: JsonSchema = {'type': 'array', 'items': {}}
+        transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+        transformer.walk()
+        assert transformer.is_strict_compatible is False
+
+    def test_bare_list_items_removed_in_strict_mode(self):
+        schema: JsonSchema = {'type': 'array', 'items': {}}
+        transformer = OpenAIJsonSchemaTransformer(schema, strict=True)
+        result = transformer.walk()
+        assert 'items' not in result
+
+    def test_typed_list_items_stays_strict_compatible(self):
+        schema = {'type': 'array', 'items': {'type': 'string'}}
+        transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+        transformer.walk()
+        assert transformer.is_strict_compatible is True


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #4425

### Summary

When a tool has a bare `list` parameter (e.g. `def foo(items: list)`), Pydantic generates
the JSON schema `{"type": "array", "items": {}}`. The OpenAIJsonSchemaTransformer.transform()
method never checks whether `items` is an empty dict, so the schema gets sent to OpenAI with
`strict=True` and the API rejects `items: {}` as invalid.

This PR adds a check in transform() for array schemas with empty `items`:
- **`strict=True`**: removes `items: {}` (invalid in strict mode, redundant for bare arrays)
- **`strict=None`**: sets `self.is_strict_compatible = False` (silent fallback, matching every other incompatibility pattern)

No changes to the base class _handle_array() in _json_schema.py - the fix is scoped entirely to the OpenAI transformer.

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.