### PR TITLE
docs: improve OpenTelemetry naming clarity in logfire.md

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -302,7 +302,7 @@ Both names are emitted simultaneously so that existing tooling continues to work
 
 #### Migrating between versions
 
-When upgrading your `InstrumentationSettings` version, you may need to update dashboards, alerts, or queries that reference span or attribute names. Here's a checklist:
+When upgrading your [`InstrumentationSettings`][pydantic_ai.models.instrumented.InstrumentationSettings] version, you may need to update dashboards, alerts, or queries that reference span or attribute names. Here's a checklist:
 
 1. **Update span name filters.** If you filter or group by span names:
     - `agent run` → `invoke_agent {agent_name}` (v3+)
@@ -320,7 +320,7 @@ When upgrading your `InstrumentationSettings` version, you may need to update da
 
 4. **Test in parallel.** Consider running the new version alongside the old one in a staging environment before switching in production. You can instrument different agents with different versions:
 
-    ```python
+    ```python {test="skip"}
     from pydantic_ai import Agent
     from pydantic_ai.models.instrumented import InstrumentationSettings
 


### PR DESCRIPTION
Title: docs: improve OpenTelemetry naming clarity

Body:


- Closes #4458

## Summary

- Added a **version comparison table** summarizing span names, attribute names, thinking token support, multimodal handling, and OTel spec compliance across all 4 instrumentation versions
- Added a **"Which version should I use?"** tip box for quick guidance
- Added a **"Why some attributes appear duplicated"** section explaining that `agent_name`/`gen_ai.agent.name` and `gen_ai.system`/`gen_ai.provider.name` coexist for backward compatibility
- Added a **"Migrating between versions"** checklist with concrete steps for updating span name filters, attribute references, multimodal content parsing, and a code example for testing versions in parallel

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for