### PR TITLE
fix(xai): promote cache_read_tokens from details to top-level usage field

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -1087,6 +1087,12 @@ def _extract_usage(
     if extracted.output_tokens == 0 and usage_data['completion_tokens']:
         extracted.output_tokens = usage_data['completion_tokens']
 
+    # Promote cache tokens to top-level fields if genai-prices didn't map them
+    if not extracted.cache_read_tokens and 'cache_read_tokens' in usage_data:
+        extracted.cache_read_tokens = usage_data['cache_read_tokens']
+    if not extracted.cache_write_tokens and 'cache_write_tokens' in usage_data:
+        extracted.cache_write_tokens = usage_data['cache_write_tokens']
+
     return extracted
 
 

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -255,7 +255,9 @@ async def test_xai_request_structured_response_tool_output(allow_model_requests:
             ),
             ModelResponse(
                 parts=[ToolCallPart(tool_name='get_user_country', args='{}', tool_call_id=IsStr())],
-                usage=RequestUsage(input_tokens=420, output_tokens=16, details={'cache_read_tokens': 157}),
+                usage=RequestUsage(
+                    input_tokens=420, cache_read_tokens=157, output_tokens=16, details={'cache_read_tokens': 157}
+                ),
                 model_name='grok-4-fast-non-reasoning',
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -285,7 +287,9 @@ async def test_xai_request_structured_response_tool_output(allow_model_requests:
                         tool_call_id=IsStr(),
                     )
                 ],
-                usage=RequestUsage(input_tokens=448, output_tokens=36, details={'cache_read_tokens': 436}),
+                usage=RequestUsage(
+                    input_tokens=448, cache_read_tokens=436, output_tokens=36, details={'cache_read_tokens': 436}
+                ),
                 model_name='grok-4-fast-non-reasoning',
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -558,7 +562,9 @@ async def test_xai_request_structured_response_native_output(allow_model_request
             ),
             ModelResponse(
                 parts=[ToolCallPart(tool_name='get_user_country', args='{}', tool_call_id=IsStr())],
-                usage=RequestUsage(input_tokens=439, output_tokens=16, details={'cache_read_tokens': 314}),
+                usage=RequestUsage(
+                    input_tokens=439, cache_read_tokens=314, output_tokens=16, details={'cache_read_tokens': 314}
+                ),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -581,7 +587,9 @@ async def test_xai_request_structured_response_native_output(allow_model_request
             ),
             ModelResponse(
                 parts=[TextPart(content='{"city": "Mexico City", "country": "Mexico"}')],
-                usage=RequestUsage(input_tokens=467, output_tokens=13, details={'cache_read_tokens': 455}),
+                usage=RequestUsage(
+                    input_tokens=467, cache_read_tokens=455, output_tokens=13, details={'cache_read_tokens': 455}
+                ),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -620,7 +628,10 @@ async def test_xai_request_tool_call(allow_model_requests: None, xai_provider: X
                     ToolCallPart(tool_name='get_location', args='{"loc_name":"London"}', tool_call_id=IsStr()),
                 ],
                 usage=RequestUsage(
-                    input_tokens=351, output_tokens=53, details={'reasoning_tokens': 223, 'cache_read_tokens': 148}
+                    input_tokens=351,
+                    cache_read_tokens=148,
+                    output_tokens=53,
+                    details={'reasoning_tokens': 223, 'cache_read_tokens': 148},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -655,7 +666,10 @@ async def test_xai_request_tool_call(allow_model_requests: None, xai_provider: X
                     )
                 ],
                 usage=RequestUsage(
-                    input_tokens=670, output_tokens=63, details={'reasoning_tokens': 83, 'cache_read_tokens': 601}
+                    input_tokens=670,
+                    cache_read_tokens=601,
+                    output_tokens=63,
+                    details={'reasoning_tokens': 83, 'cache_read_tokens': 601},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -670,6 +684,7 @@ async def test_xai_request_tool_call(allow_model_requests: None, xai_provider: X
     assert result.usage() == snapshot(
         RunUsage(
             requests=2,
+            cache_read_tokens=749,
             input_tokens=1021,
             details={'reasoning_tokens': 306, 'cache_read_tokens': 749},
             output_tokens=116,
@@ -1066,7 +1081,9 @@ async def test_xai_instructions(allow_model_requests: None, xai_provider: XaiPro
                         content="Paris is the capital of France. It's the largest city in the country and a major global center for art, fashion, and culture."
                     )
                 ],
-                usage=RequestUsage(input_tokens=181, output_tokens=27, details={'cache_read_tokens': 162}),
+                usage=RequestUsage(
+                    input_tokens=181, cache_read_tokens=162, output_tokens=27, details={'cache_read_tokens': 162}
+                ),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1102,7 +1119,9 @@ async def test_xai_system_prompt(allow_model_requests: None, xai_provider: XaiPr
                         content="Paris is the capital of France. It's the largest city in the country and a major global center for art, fashion, and culture."
                     )
                 ],
-                usage=RequestUsage(input_tokens=181, output_tokens=27, details={'cache_read_tokens': 180}),
+                usage=RequestUsage(
+                    input_tokens=181, cache_read_tokens=180, output_tokens=27, details={'cache_read_tokens': 180}
+                ),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1223,7 +1242,9 @@ async def test_xai_image_url_tool_response(allow_model_requests: None, xai_provi
             ),
             ModelResponse(
                 parts=[ToolCallPart(tool_name='get_image', args='{}', tool_call_id=IsStr())],
-                usage=RequestUsage(input_tokens=356, output_tokens=15, details={'cache_read_tokens': 314}),
+                usage=RequestUsage(
+                    input_tokens=356, cache_read_tokens=314, output_tokens=15, details={'cache_read_tokens': 314}
+                ),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1255,7 +1276,9 @@ async def test_xai_image_url_tool_response(allow_model_requests: None, xai_provi
             ),
             ModelResponse(
                 parts=[TextPart(content='The image shows a single raw potato.')],
-                usage=RequestUsage(input_tokens=657, output_tokens=8, details={'cache_read_tokens': 371}),
+                usage=RequestUsage(
+                    input_tokens=657, cache_read_tokens=371, output_tokens=8, details={'cache_read_tokens': 371}
+                ),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1296,7 +1319,9 @@ async def test_xai_image_as_binary_content_tool_response(
             ),
             ModelResponse(
                 parts=[ToolCallPart(tool_name='get_image', args='{}', tool_call_id=IsStr())],
-                usage=RequestUsage(input_tokens=356, output_tokens=15, details={'cache_read_tokens': 314}),
+                usage=RequestUsage(
+                    input_tokens=356, cache_read_tokens=314, output_tokens=15, details={'cache_read_tokens': 314}
+                ),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1326,7 +1351,9 @@ async def test_xai_image_as_binary_content_tool_response(
             ),
             ModelResponse(
                 parts=[TextPart(content='Kiwi')],
-                usage=RequestUsage(input_tokens=657, output_tokens=2, details={'cache_read_tokens': 371}),
+                usage=RequestUsage(
+                    input_tokens=657, cache_read_tokens=371, output_tokens=2, details={'cache_read_tokens': 371}
+                ),
                 model_name=XAI_NON_REASONING_MODEL,
                 timestamp=IsDatetime(),
                 provider_name='xai',
@@ -1757,6 +1784,7 @@ async def test_xai_builtin_web_search_tool(allow_model_requests: None, xai_provi
                 ],
                 usage=RequestUsage(
                     input_tokens=2332,
+                    cache_read_tokens=1540,
                     output_tokens=38,
                     details={'reasoning_tokens': 310, 'cache_read_tokens': 1540, 'server_side_tools_web_search': 1},
                 ),
@@ -1847,6 +1875,7 @@ async def test_xai_builtin_web_search_tool_stream(allow_model_requests: None, xa
                 ],
                 usage=RequestUsage(
                     input_tokens=4441,
+                    cache_read_tokens=2530,
                     output_tokens=135,
                     details={'reasoning_tokens': 631, 'cache_read_tokens': 2530, 'server_side_tools_web_search': 2},
                 ),
@@ -2099,6 +2128,7 @@ async def test_xai_builtin_code_execution_tool(allow_model_requests: None, xai_p
                 ],
                 usage=RequestUsage(
                     input_tokens=1889,
+                    cache_read_tokens=1347,
                     output_tokens=52,
                     details={'reasoning_tokens': 161, 'cache_read_tokens': 1347, 'server_side_tools_code_execution': 1},
                 ),
@@ -2166,6 +2196,7 @@ async def test_xai_builtin_code_execution_tool_stream(allow_model_requests: None
                 ],
                 usage=RequestUsage(
                     input_tokens=1718,
+                    cache_read_tokens=1037,
                     output_tokens=31,
                     details={'cache_read_tokens': 1037, 'server_side_tools_code_execution': 1},
                 ),
@@ -2312,6 +2343,7 @@ Return just the final number with no other text.\
                 ],
                 usage=RequestUsage(
                     input_tokens=11140,
+                    cache_read_tokens=6347,
                     output_tokens=68,
                     details={
                         'cache_read_tokens': 6347,
@@ -2393,7 +2425,10 @@ async def test_xai_builtin_tools_with_custom_tools(allow_model_requests: None, x
                     ToolCallPart(tool_name='guess_city', args='{}', tool_call_id=IsStr()),
                 ],
                 usage=RequestUsage(
-                    input_tokens=743, output_tokens=15, details={'reasoning_tokens': 483, 'cache_read_tokens': 170}
+                    input_tokens=743,
+                    cache_read_tokens=170,
+                    output_tokens=15,
+                    details={'reasoning_tokens': 483, 'cache_read_tokens': 170},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),
@@ -2452,6 +2487,7 @@ async def test_xai_builtin_tools_with_custom_tools(allow_model_requests: None, x
                 ],
                 usage=RequestUsage(
                     input_tokens=2973,
+                    cache_read_tokens=1506,
                     output_tokens=150,
                     details={'reasoning_tokens': 168, 'cache_read_tokens': 1506, 'server_side_tools_web_search': 1},
                 ),
@@ -2587,6 +2623,7 @@ View this search on DeepWiki: https://deepwiki.com/search/what-is-this-repositor
                 ],
                 usage=RequestUsage(
                     input_tokens=1844,
+                    cache_read_tokens=771,
                     output_tokens=140,
                     details={'reasoning_tokens': 202, 'cache_read_tokens': 771, 'server_side_tools_mcp_server': 1},
                 ),
@@ -2706,6 +2743,7 @@ View this search on DeepWiki: https://deepwiki.com/search/provide-a-short-summar
                 ],
                 usage=RequestUsage(
                     input_tokens=1783,
+                    cache_read_tokens=853,
                     output_tokens=141,
                     details={'reasoning_tokens': 262, 'cache_read_tokens': 853, 'server_side_tools_mcp_server': 1},
                 ),
@@ -3179,7 +3217,10 @@ The first 10 prime numbers are: 2, 3, 5, 7, 11, 13, 17, 19, 23, 29.\
                     ),
                 ],
                 usage=RequestUsage(
-                    input_tokens=165, output_tokens=40, details={'reasoning_tokens': 121, 'cache_read_tokens': 151}
+                    input_tokens=165,
+                    cache_read_tokens=151,
+                    output_tokens=40,
+                    details={'reasoning_tokens': 121, 'cache_read_tokens': 151},
                 ),
                 model_name='grok-4-fast-reasoning',
                 timestamp=IsDatetime(),


### PR DESCRIPTION
- Closes #4360

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

### Summary

`usage.cache_read_tokens` is always 0 for xAI models because genai-prices doesn't map the value to the top-level field (provider config mismatch). The value only survives in `usage.details['cache_read_tokens']`.

Adds explicit fallback to promote `cache_read_tokens` and `cache_write_tokens` from `usage_data` to the top-level `RequestUsage` fields after genai-prices extraction, matching the existing pattern used for `input_tokens`/`output_tokens` at the same call site.