### PR TITLE
fix(evals): narrow LLMJudge.evaluate return type to mapping

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, Literal, cast
@@ -214,7 +215,7 @@ class LLMJudge(Evaluator[object, object, object]):
     async def evaluate(
         self,
         ctx: EvaluatorContext[object, object, object],
-    ) -> EvaluatorOutput:
+    ) -> Mapping[str, EvaluationScalar | EvaluationReason]:
         if self.include_input:
             if self.include_expected_output:
                 from .llm_as_a_judge import judge_input_output_expected


### PR DESCRIPTION
- Closes #4552\n\n### Pre-Review Checklist\n\n- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.\n- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).\n- [ ] **Linting and type checking** pass per uv run ruff format and PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright .\n- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).\n\n### Pre-Merge Checklist\n\n- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.\n- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.\n\n## Summary\n- Change  return annotation from  (union) to .\n- This matches actual runtime behavior ( is always a dict) and removes unnecessary casts/assertions for consumers.\n\n## Testing\n- Not run locally in this environment: /project tooling are unavailable ( fails because pytest is not installed;  is not installed).\n- Change is annotation-only and does not alter runtime code paths.\n\n## Related\n- Fixes #4552

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed LLMJudge.evaluate return type to Mapping[str, EvaluationScalar | EvaluationReason] to match actual behavior and improve type safety for callers. Annotation-only change (adds collections.abc.Mapping import) with no runtime impact, reducing the need for casts in downstream code.

<sup>Written for commit 7dbcce87510523e53ad502bc82dd2dd45656783b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

