### PR TITLE
Strengthen args_validator test assertions with message snapshots

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3216,9 +3216,48 @@ def test_args_validator_tool_direct():
         tools=[tool],
     )
 
-    agent.run_sync('call add_numbers with x=1 and y=2', deps=42)
+    result = agent.run_sync('call add_numbers with x=1 and y=2', deps=42)
 
     assert validator_called
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='call add_numbers with x=1 and y=2', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='add_numbers', args={'x': 0, 'y': 0}, tool_call_id='pyd_ai_tool_call_id__add_numbers'
+                    )
+                ],
+                usage=RequestUsage(input_tokens=56, output_tokens=6),
+                model_name='test',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='add_numbers',
+                        content=0,
+                        tool_call_id='pyd_ai_tool_call_id__add_numbers',
+                        timestamp=IsDatetime(),
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='{"add_numbers":0}')],
+                usage=RequestUsage(input_tokens=57, output_tokens=9),
+                model_name='test',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+        ]
+    )
 
 
 def test_args_validator_toolset():
@@ -3242,9 +3281,48 @@ def test_args_validator_toolset():
         toolsets=[toolset],
     )
 
-    agent.run_sync('call add_numbers with x=1 and y=2', deps=42)
+    result = agent.run_sync('call add_numbers with x=1 and y=2', deps=42)
 
     assert validator_called
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='call add_numbers with x=1 and y=2', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='add_numbers', args={'x': 0, 'y': 0}, tool_call_id='pyd_ai_tool_call_id__add_numbers'
+                    )
+                ],
+                usage=RequestUsage(input_tokens=56, output_tokens=6),
+                model_name='test',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='add_numbers',
+                        content=0,
+                        tool_call_id='pyd_ai_tool_call_id__add_numbers',
+                        timestamp=IsDatetime(),
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='{"add_numbers":0}')],
+                usage=RequestUsage(input_tokens=57, output_tokens=9),
+                model_name='test',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+        ]
+    )
 
 
 def test_args_validator_tool_plain():
@@ -3265,9 +3343,48 @@ def test_args_validator_tool_plain():
         """Add two numbers."""
         return x + y
 
-    agent.run_sync('call add_numbers with x=1 and y=2', deps=42)
+    result = agent.run_sync('call add_numbers with x=1 and y=2', deps=42)
 
     assert validator_called
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='call add_numbers with x=1 and y=2', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='add_numbers', args={'x': 0, 'y': 0}, tool_call_id='pyd_ai_tool_call_id__add_numbers'
+                    )
+                ],
+                usage=RequestUsage(input_tokens=56, output_tokens=6),
+                model_name='test',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='add_numbers',
+                        content=0,
+                        tool_call_id='pyd_ai_tool_call_id__add_numbers',
+                        timestamp=IsDatetime(),
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='{"add_numbers":0}')],
+                usage=RequestUsage(input_tokens=57, output_tokens=9),
+                model_name='test',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+        ]
+    )
 
 
 def test_args_validator_max_retries_exceeded():


### PR DESCRIPTION
## Summary

- Add `result.all_messages()` snapshot assertion to `test_args_validator_async` — the sync version had a full message snapshot but the async version only checked a side-effect flag
- Add `result.all_messages()` snapshot assertions to `test_args_validator_tool_direct`, `test_args_validator_toolset`, and `test_args_validator_tool_plain` — these only asserted `validator_called` without verifying the execution trace

## Test plan

- [x] All modified tests pass locally
- [x] Pre-commit hooks pass (format, lint, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added result.all_messages() snapshot assertions to test_args_validator_async, test_args_validator_tool_direct, test_args_validator_toolset, and test_args_validator_tool_plain.
This validates the full execution trace and brings parity with the sync path, helping catch regressions.

<sup>Written for commit 5da3f7fe66b24d4617a14f5d5e7ebf8727767fec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

