### PR TITLE
Extract shared CompletedStreamedResponse from durable_exec wrappers

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_model.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from datetime import datetime
 from typing import Any
 
 from dbos import DBOS
@@ -10,49 +9,14 @@ from dbos import DBOS
 from pydantic_ai import (
     ModelMessage,
     ModelResponse,
-    ModelResponseStreamEvent,
 )
 from pydantic_ai.agent import EventStreamHandler
 from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
-from pydantic_ai.models.wrapper import WrapperModel
+from pydantic_ai.models.wrapper import CompletedStreamedResponse, WrapperModel
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import RunContext
-from pydantic_ai.usage import RequestUsage
 
 from ._utils import StepConfig
-
-
-class DBOSStreamedResponse(StreamedResponse):
-    def __init__(self, model_request_parameters: ModelRequestParameters, response: ModelResponse):
-        super().__init__(model_request_parameters)
-        self.response = response
-
-    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
-        return
-        # noinspection PyUnreachableCode
-        yield
-
-    def get(self) -> ModelResponse:
-        return self.response
-
-    def usage(self) -> RequestUsage:
-        return self.response.usage  # pragma: no cover
-
-    @property
-    def model_name(self) -> str:
-        return self.response.model_name or ''  # pragma: no cover
-
-    @property
-    def provider_name(self) -> str:
-        return self.response.provider_name or ''  # pragma: no cover
-
-    @property
-    def provider_url(self) -> str | None:
-        return self.response.provider_url  # pragma: no cover
-
-    @property
-    def timestamp(self) -> datetime:
-        return self.response.timestamp  # pragma: no cover
 
 
 class DBOSModel(WrapperModel):
@@ -138,4 +102,4 @@ class DBOSModel(WrapperModel):
         response = await self._dbos_wrapped_request_stream_step(
             messages, model_settings, model_request_parameters, run_context
         )
-        yield DBOSStreamedResponse(model_request_parameters, response)
+        yield CompletedStreamedResponse(model_request_parameters, response)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_model.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from datetime import datetime
 from typing import Any
 
 from prefect import task
@@ -11,57 +10,14 @@ from prefect.context import FlowRunContext
 from pydantic_ai import (
     ModelMessage,
     ModelResponse,
-    ModelResponseStreamEvent,
 )
 from pydantic_ai.agent import EventStreamHandler
 from pydantic_ai.models import ModelRequestParameters, StreamedResponse
-from pydantic_ai.models.wrapper import WrapperModel
+from pydantic_ai.models.wrapper import CompletedStreamedResponse, WrapperModel
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import RunContext
-from pydantic_ai.usage import RequestUsage
 
 from ._types import TaskConfig, default_task_config
-
-
-class PrefectStreamedResponse(StreamedResponse):
-    """A non-streaming response wrapper for Prefect tasks.
-
-    When a model request is executed inside a Prefect flow, the entire stream
-    is consumed within the task, and this wrapper is returned containing the
-    final response.
-    """
-
-    def __init__(self, model_request_parameters: ModelRequestParameters, response: ModelResponse):
-        super().__init__(model_request_parameters)
-        self.response = response
-
-    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
-        """Return an empty iterator since the stream has already been consumed."""
-        return
-        # noinspection PyUnreachableCode
-        yield
-
-    def get(self) -> ModelResponse:
-        return self.response
-
-    def usage(self) -> RequestUsage:
-        return self.response.usage  # pragma: no cover
-
-    @property
-    def model_name(self) -> str:
-        return self.response.model_name or ''  # pragma: no cover
-
-    @property
-    def provider_name(self) -> str:
-        return self.response.provider_name or ''  # pragma: no cover
-
-    @property
-    def provider_url(self) -> str | None:
-        return self.response.provider_url  # pragma: no cover
-
-    @property
-    def timestamp(self) -> datetime:
-        return self.response.timestamp  # pragma: no cover
 
 
 class PrefectModel(WrapperModel):
@@ -153,4 +109,4 @@ class PrefectModel(WrapperModel):
         response = await self._wrapped_request_stream.with_options(
             name=f'Model Request (Streaming): {self.wrapped.model_name}', **self.task_config
         )(messages, model_settings, model_request_parameters, run_context)
-        yield PrefectStreamedResponse(model_request_parameters, response)
+        yield CompletedStreamedResponse(model_request_parameters, response)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
@@ -5,24 +5,22 @@ from collections.abc import AsyncIterator, Callable, Iterator, Mapping
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any, cast
 
 from pydantic import ConfigDict, with_config
 from temporalio import activity, workflow
 from temporalio.workflow import ActivityConfig
 
-from pydantic_ai import ModelMessage, ModelResponse, ModelResponseStreamEvent, models
+from pydantic_ai import ModelMessage, ModelResponse, models
 from pydantic_ai._run_context import get_current_run_context
 from pydantic_ai.agent import EventStreamHandler
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse, infer_model_profile, parse_model_id
-from pydantic_ai.models.wrapper import WrapperModel
+from pydantic_ai.models.wrapper import CompletedStreamedResponse, WrapperModel
 from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.providers import Provider
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import AgentDepsT, RunContext
-from pydantic_ai.usage import RequestUsage
 
 from ._run_context import TemporalRunContext
 
@@ -39,39 +37,6 @@ class _RequestParams:
 
 
 TemporalProviderFactory = Callable[[RunContext[AgentDepsT], str], Provider[Any]]
-
-
-class TemporalStreamedResponse(StreamedResponse):
-    def __init__(self, model_request_parameters: ModelRequestParameters, response: ModelResponse):
-        super().__init__(model_request_parameters)
-        self.response = response
-
-    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
-        return
-        # noinspection PyUnreachableCode
-        yield
-
-    def get(self) -> ModelResponse:
-        return self.response
-
-    def usage(self) -> RequestUsage:
-        return self.response.usage  # pragma: no cover
-
-    @property
-    def model_name(self) -> str:
-        return self.response.model_name or ''  # pragma: no cover
-
-    @property
-    def provider_name(self) -> str:
-        return self.response.provider_name or ''  # pragma: no cover
-
-    @property
-    def provider_url(self) -> str | None:
-        return self.response.provider_url  # pragma: no cover
-
-    @property
-    def timestamp(self) -> datetime:
-        return self.response.timestamp  # pragma: no cover
 
 
 class TemporalModel(WrapperModel):
@@ -235,7 +200,7 @@ class TemporalModel(WrapperModel):
             ],
             **activity_config,
         )
-        yield TemporalStreamedResponse(model_request_parameters, response)
+        yield CompletedStreamedResponse(model_request_parameters, response)
 
     def _validate_model_request_parameters(self, model_request_parameters: ModelRequestParameters) -> None:
         if model_request_parameters.allow_image_output:

--- a/pydantic_ai_slim/pydantic_ai/models/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/models/wrapper.py
@@ -3,14 +3,55 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from .._run_context import RunContext
-from ..messages import ModelMessage, ModelResponse
+from ..messages import ModelMessage, ModelResponse, ModelResponseStreamEvent
 from ..profiles import ModelProfile
 from ..settings import ModelSettings
 from ..usage import RequestUsage
 from . import KnownModelName, Model, ModelRequestParameters, StreamedResponse, infer_model
+
+
+class CompletedStreamedResponse(StreamedResponse):
+    """A `StreamedResponse` that wraps an already-completed `ModelResponse`.
+
+    Used by durable execution integrations (Temporal, Prefect, DBOS) where the
+    actual stream is consumed within a task/activity and only the final response
+    is returned.
+    """
+
+    def __init__(self, model_request_parameters: ModelRequestParameters, response: ModelResponse):
+        super().__init__(model_request_parameters)
+        self.response = response
+
+    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+        return
+        # noinspection PyUnreachableCode
+        yield
+
+    def get(self) -> ModelResponse:
+        return self.response
+
+    def usage(self) -> RequestUsage:
+        return self.response.usage  # pragma: no cover
+
+    @property
+    def model_name(self) -> str:
+        return self.response.model_name or ''  # pragma: no cover
+
+    @property
+    def provider_name(self) -> str:
+        return self.response.provider_name or ''  # pragma: no cover
+
+    @property
+    def provider_url(self) -> str | None:
+        return self.response.provider_url  # pragma: no cover
+
+    @property
+    def timestamp(self) -> datetime:
+        return self.response.timestamp  # pragma: no cover
 
 
 @dataclass(init=False)


### PR DESCRIPTION
## Summary

- Extract `CompletedStreamedResponse` in `models/wrapper.py` from three identical duplicate classes:
  - `TemporalStreamedResponse` in `durable_exec/temporal/_model.py`
  - `PrefectStreamedResponse` in `durable_exec/prefect/_model.py`
  - `DBOSStreamedResponse` in `durable_exec/dbos/_model.py`
- All three had identical implementations (init, empty event iterator, get, and 5 property delegates). The only difference was the class name.
- Net: +49 lines (shared class), -123 lines (removed duplicates) = **-74 lines**
- Mechanical refactor: no behavior change

## Test plan

- [x] All three modules import successfully
- [x] Pre-commit hooks pass (format, lint, typecheck)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unified durable execution streamed response wrappers by introducing CompletedStreamedResponse and using it across Temporal, Prefect, and DBOS. This removes duplicate classes and keeps behavior unchanged.

- **Refactors**
  - Added CompletedStreamedResponse in models/wrapper.py.
  - Replaced TemporalStreamedResponse, PrefectStreamedResponse, and DBOSStreamedResponse with the shared class.
  - Net −74 lines; no functional changes.

<sup>Written for commit 799233b93faa4c2ffd1700351f22bfb63da36d16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

