### PR TITLE
fix: catch ValueError from args_as_dict() on malformed tool args in Anthropic model

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -793,11 +793,19 @@ class AnthropicModel(Model):
                         if response_part.content:
                             assistant_content_params.append(BetaTextBlockParam(text=response_part.content, type='text'))
                     elif isinstance(response_part, ToolCallPart):
+                        try:
+                            tool_call_input = response_part.args_as_dict()
+                        except ValueError:
+                            # When the model produces malformed JSON args (e.g. during a retry
+                            # flow), args_as_dict() raises ValueError. Fall back to passing
+                            # the raw string so the request can still be mapped and the retry
+                            # prompt can reach the model.
+                            tool_call_input = {"__malformed_args__": response_part.args_as_json_str()}
                         tool_use_block_param = BetaToolUseBlockParam(
                             id=_guard_tool_call_id(t=response_part),
                             type='tool_use',
                             name=response_part.tool_name,
-                            input=response_part.args_as_dict(),
+                            input=tool_call_input,
                         )
                         assistant_content_params.append(tool_use_block_param)
                     elif isinstance(response_part, ThinkingPart):


### PR DESCRIPTION
**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

## Summary

Fixes #4430

When a tool call has malformed JSON arguments, Pydantic AI correctly creates a retry prompt (`json_invalid`), but the next Anthropic request mapping crashes before the retry can happen. The Anthropic model mapping path calls `args_as_dict()` which tries to parse the JSON and raises a raw `ValueError` on malformed args.

This is specific to the Anthropic provider — OpenAI, OpenRouter, and other providers use `args_as_json_str()` which doesn't parse and doesn't crash.

## Fix

Wrap the `args_as_dict()` call in a `try/except ValueError`. When parsing fails, fall back to passing the raw malformed args string in a wrapper dict (`{"__malformed_args__": raw_string}`). This allows:

1. The Anthropic API to receive a valid `dict` for the `input` field (which it requires, unlike OpenAI which accepts a string)
2. The request mapping to complete successfully
3. The retry prompt to reach the model so it can self-correct

## Reproduction

```python
from datetime import datetime, timezone
import asyncio
from pydantic_ai import Agent
from pydantic_ai.messages import ModelRequest, ModelResponse, RetryPromptPart, ToolCallPart
from pydantic_ai.models.anthropic import AnthropicModel
from pydantic_ai.providers.anthropic import AnthropicProvider

BAD_ARGS = '{"query": "bad query", "file_ids":[4556]</parameter>\n<parameter name="limit": 8}'

message_history = [
    ModelResponse(
        parts=[ToolCallPart(tool_name="search_knowledge", tool_call_id="toolu_123", args=BAD_ARGS)],
        timestamp=datetime.now(timezone.utc),
    ),
    ModelRequest(
        parts=[RetryPromptPart(
            tool_name="search_knowledge", tool_call_id="toolu_123",
            content=[{"type": "json_invalid", "loc": [], "msg": "Invalid JSON", "input": BAD_ARGS}],
        )]
    ),
]

model = AnthropicModel("claude-sonnet-4-5", provider=AnthropicProvider(api_key="test-key"))
agent = Agent(model)

# Before fix: ValueError: expected ',' or '}' at line 1 column 99
# After fix: Request mapping succeeds, retry prompt reaches the model
```