### PR TITLE
fix: narrow LLMJudge.evaluate return type to dict

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -13,7 +13,7 @@ from pydantic_ai.settings import ModelSettings
 
 from ..otel.span_tree import SpanQuery
 from .context import EvaluatorContext
-from .evaluator import EvaluationReason, EvaluationScalar, Evaluator, EvaluatorOutput
+from .evaluator import EvaluationReason, EvaluationScalar, Evaluator
 
 __all__ = (
     'Equals',
@@ -214,7 +214,7 @@ class LLMJudge(Evaluator[object, object, object]):
     async def evaluate(
         self,
         ctx: EvaluatorContext[object, object, object],
-    ) -> EvaluatorOutput:
+    ) -> dict[str, EvaluationScalar | EvaluationReason]:
         if self.include_input:
             if self.include_expected_output:
                 from .llm_as_a_judge import judge_input_output_expected


### PR DESCRIPTION
**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

## Summary

Fixes #4552

`LLMJudge.evaluate()` always constructs and returns a `dict[str, EvaluationScalar | EvaluationReason]`, but its return type annotation was the broader `EvaluatorOutput` union (`EvaluationScalar | EvaluationReason | Mapping[str, EvaluationScalar | EvaluationReason]`). This forced consumers to type-check, assert, or cast the result even though the method never returns a bare scalar or `EvaluationReason`.

### Changes

- **`pydantic_evals/pydantic_evals/evaluators/common.py`**: Changed the return type annotation of `LLMJudge.evaluate()` from `EvaluatorOutput` to `dict[str, EvaluationScalar | EvaluationReason]`, matching what the method actually returns.
- Removed the now-unused `EvaluatorOutput` import from the same file.

This is a type-annotation-only change with no runtime behavior difference.