### PR TITLE
fix: copy xAI cache tokens from details to top-level usage fields

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -1087,6 +1087,12 @@ def _extract_usage(
     if extracted.output_tokens == 0 and usage_data['completion_tokens']:
         extracted.output_tokens = usage_data['completion_tokens']
 
+    # Copy cache tokens from details to top-level fields if genai-prices didn't map them
+    if not extracted.cache_read_tokens and details.get('cache_read_tokens'):
+        extracted.cache_read_tokens = details['cache_read_tokens']
+    if not extracted.cache_write_tokens and details.get('cache_write_tokens'):
+        extracted.cache_write_tokens = details['cache_write_tokens']
+
     return extracted
 
 


### PR DESCRIPTION
**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

## Summary

Fixes #4360

When using xAI/Grok models, `cache_read_tokens` from the API response ends up only in `usage.details["cache_read_tokens"]` instead of the top-level `usage.cache_read_tokens` field. The xAI provider's `_extract_usage` correctly maps `cached_prompt_text_tokens` to `cache_read_tokens` in the `usage_data` dict, but `RequestUsage.extract()` (via genai-prices) doesn't map it to the top-level field, so it only survives in the `details` dict.

## Fix

After the existing fallback logic that copies `input_tokens`/`output_tokens` when genai-prices extraction fails, add the same pattern for cache tokens:



This ensures `usage.cache_read_tokens` is populated correctly while remaining backwards-compatible (only copies when the top-level field is unset).

## Test plan

- Verified the fix applies to the correct location in `_extract_usage()` in `pydantic_ai_slim/pydantic_ai/models/xai.py`
- When `cached_prompt_text_tokens` is present in the xAI response, `usage.cache_read_tokens` will now be populated
- No behavior change when cache tokens are not present or already mapped by genai-prices