### PR TITLE
Support CachePoint for OpenRouter models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -653,6 +653,7 @@ class CachePoint:
 
     - Anthropic
     - Amazon Bedrock (Converse API)
+    - OpenRouter (for Anthropic and Gemini models)
     """
 
     kind: Literal['cache-point'] = 'cache-point'

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Discriminator
 from typing_extensions import TypedDict, assert_never, override
 
 from ..builtin_tools import AbstractBuiltinTool, WebSearchTool
-from ..exceptions import ModelHTTPError
+from ..exceptions import ModelHTTPError, UserError
 from ..messages import (
     BinaryContent,
     CachePoint,
@@ -688,10 +688,14 @@ class OpenRouterModel(OpenAIChatModel):
             content = []
             for item in part.content:
                 if isinstance(item, CachePoint):
-                    if content:
-                        # OpenRouter extends OpenAI's content part format with cache_control,
-                        # which isn't in the OpenAI SDK types. At runtime, the SDK accepts it.
-                        cast(dict[str, Any], content[-1])['cache_control'] = {'type': 'ephemeral'}
+                    if not content:
+                        raise UserError(
+                            'CachePoint cannot be the first content in a user message - '
+                            'there must be previous content to attach the CachePoint to.'
+                        )
+                    # OpenRouter extends OpenAI's content part format with cache_control,
+                    # which isn't in the OpenAI SDK types. At runtime, the SDK accepts it.
+                    cast(dict[str, Any], content[-1])['cache_control'] = {'type': 'ephemeral'}
                 else:
                     mapped_item = await self._map_content_item(item)
                     if mapped_item is not None:

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -979,7 +979,9 @@ async def test_openrouter_cache_point() -> None:
 
 
 async def test_openrouter_cache_point_at_start() -> None:
-    """Test that CachePoint at the start of content (no preceding block) is silently ignored."""
+    """Test that CachePoint at the start of content raises UserError."""
+    from pydantic_ai.exceptions import UserError
+
     provider = OpenRouterProvider(api_key='test-key')
     model = OpenRouterModel('anthropic/claude-haiku-4.5', provider=provider)
 
@@ -996,13 +998,8 @@ async def test_openrouter_cache_point_at_start() -> None:
         )
     ]
 
-    mapped_messages = await model._map_messages(messages, ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
-    content = mapped_messages[0].get('content')
-    assert content is not None
-    assert isinstance(content, list)
-
-    assert len(content) == 1
-    assert content[0] == {'type': 'text', 'text': 'This is the question.'}
+    with pytest.raises(UserError, match='CachePoint cannot be the first content in a user message'):
+        await model._map_messages(messages, ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_openrouter_cache_point_string_content() -> None:


### PR DESCRIPTION
## Summary

- Override `_map_user_prompt` in `OpenRouterModel` to translate `CachePoint` into `cache_control: {"type": "ephemeral"}` breakpoints that OpenRouter expects for Anthropic and Gemini prompt caching
- CachePoint at the start of content (no preceding block) is silently ignored, consistent with how unsupported settings are handled across providers
- Adds 3 tests covering: normal cache point, cache point at start, and plain string content

Closes #4392

## Test plan

- [x] `pytest tests/models/test_openrouter.py` — all 36 tests pass (33 existing + 3 new)
- [x] `pyright` — 0 errors
- [x] `ruff check` — passes
- [ ] Manual verification with OpenRouter + Anthropic model to confirm `cache_read_tokens` appear in usage