### PR TITLE
Fix thinking-only responses after tool calls by reusing prior text

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -635,6 +635,9 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
             output_schema = ctx.deps.output_schema
 
             async def _run_stream() -> AsyncIterator[_messages.HandleResponseEvent]:  # noqa: C901
+                has_only_thinking_parts = bool(self.model_response.parts) and all(
+                    isinstance(part, _messages.ThinkingPart) for part in self.model_response.parts
+                )
                 if not self.model_response.parts:
                     # Don't retry if the model returned an empty response because the token limit was exceeded, possibly during thinking.
                     if self.model_response.finish_reason == 'length':
@@ -695,6 +698,27 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                         _messages.ModelRequest(parts=[], instructions=instructions)
                     )
                     return
+
+                # This can happen with models that return text + tool calls in one response,
+                # then return only thinking after tool execution.
+                if has_only_thinking_parts and (text_processor := output_schema.text_processor):
+                    for message in reversed(ctx.state.message_history):
+                        if isinstance(message, _messages.ModelResponse):
+                            text = ''
+                            for part in message.parts:
+                                if isinstance(part, _messages.TextPart):
+                                    text += part.content
+                                elif isinstance(part, _messages.BuiltinToolCallPart):
+                                    # Text parts before a built-in tool call are essentially thoughts,
+                                    # not part of the final result output, so we reset the accumulated text
+                                    text = ''  # pragma: no cover
+                            if text:
+                                try:
+                                    self._next_node = await self._handle_text_response(ctx, text, text_processor)
+                                    return
+                                except ToolRetryError:  # pragma: no cover
+                                    # If the text from the previous response was invalid, ignore it.
+                                    pass
 
                 text = ''
                 tool_calls: list[_messages.ToolCallPart] = []

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -6814,6 +6814,44 @@ async def test_retry_message_no_tools():
     assert retry_parts[0].content == 'Please return text.'
 
 
+async def test_thinking_only_after_tool_call_recovers_previous_text() -> None:
+    """Test that thinking-only responses after tool calls recover previous text instead of retrying."""
+
+    call_count = 0
+
+    async def save_progress() -> str:
+        return 'saved'
+
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal call_count
+        call_count += 1
+
+        if call_count == 1:
+            return ModelResponse(
+                parts=[
+                    ThinkingPart(content='Analyzing...'),
+                    TextPart(content='Final answer'),
+                    ToolCallPart(tool_name='save_progress', args='{}', tool_call_id='call_1'),
+                ]
+            )
+        return ModelResponse(parts=[ThinkingPart(content='Done thinking')])
+
+    agent = Agent(FunctionModel(model_function), tools=[save_progress], output_type=str)
+
+    result = await agent.run('Hello')
+
+    retry_parts = [
+        part
+        for msg in result.all_messages()
+        if isinstance(msg, ModelRequest)
+        for part in msg.parts
+        if isinstance(part, RetryPromptPart)
+    ]
+
+    assert result.output == 'Final answer'
+    assert retry_parts == []
+
+
 async def test_hitl_tool_approval():
     def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if len(messages) == 1:


### PR DESCRIPTION
## Summary
- recover backward-looking text when the current response contains only `ThinkingPart` entries
- keep existing empty-response retry/resubmission behavior unchanged
- add a regression test covering: text+tool-call response followed by thinking-only response should finalize from prior text (no retry prompt)

## Issue linkage
Fixes #4557

## Validation
- `uv run pytest -q tests/test_agent.py -k "thinking_only_response_retry or thinking_only_after_tool_call_recovers_previous_text"`
