### PR TITLE
Fix missing `output_audio_tokens` in usage accumulation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -233,6 +233,7 @@ def _incr_usage_tokens(slf: RunUsage | RequestUsage, incr_usage: RunUsage | Requ
     slf.cache_read_tokens += incr_usage.cache_read_tokens
     slf.input_audio_tokens += incr_usage.input_audio_tokens
     slf.cache_audio_read_tokens += incr_usage.cache_audio_read_tokens
+    slf.output_audio_tokens += incr_usage.output_audio_tokens
     slf.output_tokens += incr_usage.output_tokens
 
     for key, value in incr_usage.details.items():

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -379,6 +379,29 @@ def test_add_usages():
     assert RunUsage() + RunUsage() == RunUsage()
 
 
+def test_output_audio_tokens_increment():
+    """Test that output_audio_tokens is correctly incremented in _incr_usage_tokens."""
+    usage1 = RequestUsage(
+        input_tokens=10,
+        output_tokens=20,
+        output_audio_tokens=15,
+    )
+    usage2 = RequestUsage(
+        input_tokens=5,
+        output_tokens=10,
+        output_audio_tokens=8,
+    )
+    result = usage1 + usage2
+    assert result.output_audio_tokens == 23
+    assert result.input_tokens == 15
+    assert result.output_tokens == 30
+
+    # Also test through RunUsage.incr with RequestUsage
+    run_usage = RunUsage(requests=1, output_audio_tokens=10)
+    run_usage.incr(RequestUsage(output_audio_tokens=5))
+    assert run_usage.output_audio_tokens == 15
+
+
 def test_add_usages_with_none_detail_value():
     """Test that None values in details are skipped when incrementing usage."""
     usage = RunUsage(


### PR DESCRIPTION
## Summary

`_incr_usage_tokens()` in `usage.py` accumulates all token fields when summing `RequestUsage` or `RunUsage` instances, but `output_audio_tokens` was not included.

### Problem

All audio token fields are incremented except `output_audio_tokens`:

```python
def _incr_usage_tokens(slf, incr_usage):
    slf.input_tokens += incr_usage.input_tokens
    slf.cache_write_tokens += incr_usage.cache_write_tokens
    slf.cache_read_tokens += incr_usage.cache_read_tokens
    slf.input_audio_tokens += incr_usage.input_audio_tokens        # ✓
    slf.cache_audio_read_tokens += incr_usage.cache_audio_read_tokens  # ✓
    slf.output_tokens += incr_usage.output_tokens
    # output_audio_tokens is missing!                                   # ✗
```

This means when using audio models (e.g., GPT-4o with audio output), `RunUsage.output_audio_tokens` will always be 0 even if individual requests produced audio output tokens.

### Fix

Add the missing increment line:
```python
slf.output_audio_tokens += incr_usage.output_audio_tokens
```
