### PR TITLE
fix: sanitize hallucinated Bedrock tool names to prevent unrecoverable crash

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import re
 import typing
 from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
 from contextlib import asynccontextmanager
@@ -951,10 +952,15 @@ class BedrockConverseModel(Model):
                     assert_never(item)
         return [{'role': 'user', 'content': content}]
 
+    _BEDROCK_TOOL_NAME_RE: typing.ClassVar[re.Pattern[str]] = re.compile(r'[^a-zA-Z0-9_-]')
+
     @staticmethod
     def _map_tool_call(t: ToolCallPart) -> ContentBlockOutputTypeDef:
+        # Sanitize tool name to match Bedrock's [a-zA-Z0-9_-]+ constraint.
+        # Models can hallucinate names with dots/spaces that would crash subsequent API calls.
+        tool_name = BedrockConverseModel._BEDROCK_TOOL_NAME_RE.sub('_', t.tool_name)
         return {
-            'toolUse': {'toolUseId': _utils.guard_tool_call_id(t=t), 'name': t.tool_name, 'input': t.args_as_dict()}
+            'toolUse': {'toolUseId': _utils.guard_tool_call_id(t=t), 'name': tool_name, 'input': t.args_as_dict()}
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fixes #4585.

When a Bedrock model hallucinates a tool name containing characters outside `[a-zA-Z0-9_-]` (e.g., `search.evidence`), the invalid name gets recorded in message history. On the next API call, Bedrock rejects the entire request with a `ValidationException`, and since the invalid name is baked into history, **every subsequent request fails** — the agent run is unrecoverable.

## Fix

Sanitize tool names in `_map_tool_call()` before sending them back to Bedrock, replacing invalid characters with `_`:

```python
_BEDROCK_TOOL_NAME_RE: typing.ClassVar[re.Pattern[str]] = re.compile(r'[^a-zA-Z0-9_-]')

@staticmethod
def _map_tool_call(t: ToolCallPart) -> ContentBlockOutputTypeDef:
    tool_name = BedrockConverseModel._BEDROCK_TOOL_NAME_RE.sub('_', t.tool_name)
    return {
        'toolUse': {'toolUseId': _utils.guard_tool_call_id(t=t), 'name': tool_name, 'input': t.args_as_dict()}
    }
```

**`pydantic_ai_slim/pydantic_ai/models/bedrock.py`** — adds `import re` and a compiled regex class variable for the constraint pattern.