### PR TITLE
Github workflow, close duplicate PRs even if issue is unassigned

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -71,7 +71,7 @@ jobs:
 
           # Fetch all open PRs once upfront (the list endpoint includes body and labels).
           # Done outside the loop to avoid repeated paginated calls when multiple issues are referenced.
-          ALL_OPEN_PRS=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate || true)
+          ALL_OPEN_PRS=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate) || ALL_OPEN_PRS="[]"
 
           FOUND_OPEN_ISSUE="false"
           FOUND_CLOSED_ISSUE="false"
@@ -102,53 +102,35 @@ jobs:
 
             FOUND_OPEN_ISSUE="true"
 
-            # Check current assignees
-            ASSIGNEES=$(echo "$ISSUE_JSON" | jq -r '[.assignees[].login] | join(",")')
-            echo "Current assignees: ${ASSIGNEES:-none}"
-
-            if [ -z "$ASSIGNEES" ]; then
-              # No assignee — attempt to assign to PR author
-              try_assign "$ISSUE_NUM" "$PR_AUTHOR" || true
-              continue
-            fi
-
-            # Check if PR author is already assigned
-            if echo ",$ASSIGNEES," | grep -q ",${PR_AUTHOR},"; then
-              echo "Issue #${ISSUE_NUM} is already assigned to ${PR_AUTHOR}."
-              continue
-            fi
-
-            # Issue is assigned to someone else — check for their open PRs
-            echo "Issue #${ISSUE_NUM} is assigned to someone else. Checking for existing PRs..."
+            # Check for duplicate/blocking PRs first — this must run regardless of assignment outcome.
+            # Look for any other open PR (excluding this one) that references this issue.
+            echo "Checking for existing PRs targeting issue #${ISSUE_NUM}..."
 
             BLOCKING_PRS=""
             FOUND_STALE_PR="false"
-            IFS=',' read -ra ASSIGNEE_LIST <<< "$ASSIGNEES"
-            for ASSIGNEE in "${ASSIGNEE_LIST[@]}"; do
-              # Filter to this assignee's PRs that reference the current issue
-              MATCHING_PRS=$(echo "$ALL_OPEN_PRS" | jq -c "[.[] | select(.user.login == \"${ASSIGNEE}\" and (.body // \"\" | test(\"(?i)\\\\b(close[sd]?|fix(es|ed)?|resolve[sd]?)\\\\s+#${ISSUE_NUM}(\\\\s|$|[^0-9])\")))] | .[]")
+            MATCHING_PRS=$(echo "$ALL_OPEN_PRS" | jq -c "[.[] | select(.number != ${PR_NUMBER} and (.body // \"\" | test(\"(?i)\\\\b(close[sd]?|fix(es|ed)?|resolve[sd]?)\\\\s+#${ISSUE_NUM}(\\\\s|$|[^0-9])\")))] | .[]")
 
-              while IFS= read -r PR_JSON; do
-                [ -z "$PR_JSON" ] && continue
-                EXISTING_PR_NUM=$(echo "$PR_JSON" | jq -r '.number')
-                echo "Found PR #${EXISTING_PR_NUM} by ${ASSIGNEE} that references issue #${ISSUE_NUM}."
+            while IFS= read -r PR_JSON; do
+              [ -z "$PR_JSON" ] && continue
+              EXISTING_PR_NUM=$(echo "$PR_JSON" | jq -r '.number')
+              EXISTING_PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
+              echo "Found PR #${EXISTING_PR_NUM} by ${EXISTING_PR_AUTHOR} that references issue #${ISSUE_NUM}."
 
-                # Check if the existing PR has the Stale label
-                HAS_STALE=$(echo "$PR_JSON" | jq '[.labels[].name] | any(. == "Stale")')
-                if [ "$HAS_STALE" = "true" ]; then
-                  echo "PR #${EXISTING_PR_NUM} is stale. Allowing new PR to supersede."
-                  FOUND_STALE_PR="true"
-                  continue
-                fi
+              # Check if the existing PR has the Stale label
+              HAS_STALE=$(echo "$PR_JSON" | jq '[.labels[].name] | any(. == "Stale")')
+              if [ "$HAS_STALE" = "true" ]; then
+                echo "PR #${EXISTING_PR_NUM} is stale. Allowing new PR to supersede."
+                FOUND_STALE_PR="true"
+                continue
+              fi
 
-                # Collect all non-stale blocking PRs
-                if [ -z "$BLOCKING_PRS" ]; then
-                  BLOCKING_PRS="#${EXISTING_PR_NUM}"
-                else
-                  BLOCKING_PRS="${BLOCKING_PRS}, #${EXISTING_PR_NUM}"
-                fi
-              done <<< "$MATCHING_PRS"
-            done
+              # Collect all non-stale blocking PRs
+              if [ -z "$BLOCKING_PRS" ]; then
+                BLOCKING_PRS="#${EXISTING_PR_NUM}"
+              else
+                BLOCKING_PRS="${BLOCKING_PRS}, #${EXISTING_PR_NUM}"
+              fi
+            done <<< "$MATCHING_PRS"
 
             if [ -n "$BLOCKING_PRS" ]; then
               echo "Closing PR #${PR_NUMBER} — issue #${ISSUE_NUM} already has active PRs: ${BLOCKING_PRS}"
@@ -157,27 +139,34 @@ jobs:
                 "Thanks for your interest in this issue! However, there are already open PRs addressing issue #${ISSUE_NUM}: ${BLOCKING_PRS}." \
                 "To avoid duplicate efforts, this PR has been closed. If you'd like to contribute, you can review the existing PRs or share your thoughts on [issue #${ISSUE_NUM}](https://github.com/${REPO}/issues/${ISSUE_NUM})." \
                 "If you believe the existing PRs are inactive, please comment on the issue and a maintainer can reassess.")
-              gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT"
               gh pr close "$PR_NUMBER" --repo "$REPO"
+              gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT" || true
               exit 0
             fi
 
             if [ "$FOUND_STALE_PR" = "true" ]; then
-              # All existing PRs for this issue are stale — allow the new PR through
-              # but don't touch assignments; let maintainers decide.
               echo "All existing PRs for issue #${ISSUE_NUM} are stale. Allowing new PR."
+            fi
+
+            # Now handle assignment (best-effort, does not gate duplicate check above)
+            ASSIGNEES=$(echo "$ISSUE_JSON" | jq -r '[.assignees[].login] | join(",")')
+            echo "Current assignees: ${ASSIGNEES:-none}"
+
+            if [ -z "$ASSIGNEES" ]; then
+              # No assignee — attempt to assign PR author (may fail if user lacks push access)
+              try_assign "$ISSUE_NUM" "$PR_AUTHOR" || true
+            elif echo ",$ASSIGNEES," | grep -q ",${PR_AUTHOR},"; then
+              echo "Issue #${ISSUE_NUM} is already assigned to ${PR_AUTHOR}."
             else
-              # No blocking PR found — assignee may be working without a PR yet,
-              # or their PRs don't reference this issue. Don't block; let maintainers sort it out.
-              echo "No active non-stale PR found from current assignees. Leaving assignment as-is for maintainers to review."
+              echo "Issue #${ISSUE_NUM} is assigned to someone else. Leaving assignment as-is for maintainers to review."
             fi
           done
 
           # If we found closed issues but no open ones, close the PR
           if [ "$FOUND_CLOSED_ISSUE" = "true" ] && [ "$FOUND_OPEN_ISSUE" = "false" ]; then
             echo "All referenced issues are closed. Closing PR."
-            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "All issues referenced by this PR are already closed. If you believe an issue should be reopened, please comment on it first."
             gh pr close "$PR_NUMBER" --repo "$REPO"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "All issues referenced by this PR are already closed. If you believe an issue should be reopened, please comment on it first." || true
           fi
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #<issue>

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **Linting and type checking** pass per `make format` and `make typecheck`.
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
