### PR TITLE
Fix LLMJudge.evaluate return type annotation to dict output

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -214,7 +214,7 @@ class LLMJudge(Evaluator[object, object, object]):
     async def evaluate(
         self,
         ctx: EvaluatorContext[object, object, object],
-    ) -> EvaluatorOutput:
+    ) -> dict[str, EvaluationScalar | EvaluationReason]:
         if self.include_input:
             if self.include_expected_output:
                 from .llm_as_a_judge import judge_input_output_expected

--- a/tests/evals/test_evaluator_common.py
+++ b/tests/evals/test_evaluator_common.py
@@ -498,3 +498,7 @@ async def test_span_query_evaluator(capfire: CaptureLogfire):
     # Test non-matching attributes
     evaluator = HasMatchingSpan(query=SpanQuery(name_equals='child1', has_attributes={'wrong': 'value'}))
     assert evaluator.evaluate(ctx) is False
+
+
+def test_llmjudge_evaluate_return_type_hint() -> None:
+    assert "dict[str, EvaluationScalar | EvaluationReason]" in str(LLMJudge.evaluate.__annotations__["return"])


### PR DESCRIPTION
- Closes #4552

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

## Summary
- Narrow `LLMJudge.evaluate` return annotation from `EvaluatorOutput` to `dict[str, EvaluationScalar | EvaluationReason]`.
- This matches the actual runtime behavior, where the method always returns a dict keyed by evaluation name.
- Added a regression test asserting the method annotation reflects this concrete dict shape.

## Testing
- `uv run pytest tests/evals/test_evaluator_common.py::test_llmjudge_evaluate_return_type_hint -q`

## Related
- Fixes #4552
