### PR TITLE
fix(evals): narrow LLMJudge.evaluate return type to Mapping[str, ...]

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, Literal, cast
@@ -13,7 +14,7 @@ from pydantic_ai.settings import ModelSettings
 
 from ..otel.span_tree import SpanQuery
 from .context import EvaluatorContext
-from .evaluator import EvaluationReason, EvaluationScalar, Evaluator, EvaluatorOutput
+from .evaluator import EvaluationReason, EvaluationScalar, Evaluator
 
 __all__ = (
     'Equals',
@@ -214,7 +215,7 @@ class LLMJudge(Evaluator[object, object, object]):
     async def evaluate(
         self,
         ctx: EvaluatorContext[object, object, object],
-    ) -> EvaluatorOutput:
+    ) -> Mapping[str, EvaluationScalar | EvaluationReason]:
         if self.include_input:
             if self.include_expected_output:
                 from .llm_as_a_judge import judge_input_output_expected


### PR DESCRIPTION
## Summary

`LLMJudge.evaluate` always returns `dict[str, EvaluationScalar | EvaluationReason]` but its declared return type was the overly broad `EvaluatorOutput` union, which also includes bare scalars and `EvaluationReason` values. This forces callers to use `cast`, type-narrowing assertions, or `# type: ignore` comments to safely access the result as a mapping.

## Changes

- `pydantic_evals/pydantic_evals/evaluators/common.py`: Change return annotation of `LLMJudge.evaluate` from `EvaluatorOutput` to `Mapping[str, EvaluationScalar | EvaluationReason]`, which accurately reflects what the method actually returns.
- Add `from collections.abc import Mapping` import.
- Remove now-unused `EvaluatorOutput` from the import in this file.

## Why this matters

Consumers of `LLMJudge.evaluate` in typed code cannot rely on the result being dict-like without a cast:

```python
# Before – type checker sees EvaluatorOutput (can be a scalar), needs a cast:
result: Mapping[str, EvaluationScalar] = cast(Mapping, await self.judge.evaluate(ctx))

# After – annotation matches reality, no cast needed:
result: Mapping[str, EvaluationScalar] = await self.judge.evaluate(ctx)
```

Closes #4552