### PR TITLE
fix(otel): don't record CallDeferred/ApprovalRequired as span errors

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -8,14 +8,14 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from typing import Any, Generic, Literal
 
-from opentelemetry.trace import Tracer
+from opentelemetry.trace import Span, StatusCode, Tracer
 from pydantic import ValidationError
 from typing_extensions import deprecated
 
 from . import messages as _messages
 from ._instrumentation import InstrumentationNames
 from ._run_context import AgentDepsT, RunContext
-from .exceptions import ModelRetry, ToolRetryError, UnexpectedModelBehavior
+from .exceptions import CallDeferred, ApprovalRequired, ModelRetry, ToolRetryError, UnexpectedModelBehavior
 from .messages import ToolCallPart
 from .tools import ToolDefinition
 from .toolsets.abstract import AbstractToolset, ToolsetTool
@@ -410,13 +410,25 @@ class ToolManager(Generic[AgentDepsT]):
         with tracer.start_as_current_span(
             instrumentation_names.get_tool_span_name(call.tool_name),
             attributes=span_attributes,
+            record_exception=False,
+            set_status_on_exception=False,
         ) as span:
             try:
                 tool_result = await self._execute_tool_call_impl(validated, usage=usage)
+            except (CallDeferred, ApprovalRequired) as e:
+                # These are control-flow signals, not errors; record them as informational
+                # span attributes rather than error events so they don't show up as red
+                # spans in Logfire / other OTel backends.
+                if span.is_recording():
+                    span.set_attribute('pydantic_ai.tool.deferred', type(e).__name__)
+                raise
             except ToolRetryError as e:
                 part = e.tool_retry
                 if include_content and span.is_recording():
                     span.set_attribute(instrumentation_names.tool_result_attr, part.model_response())
+                if span.is_recording():
+                    span.record_exception(e)
+                    span.set_status(StatusCode.ERROR, str(e))
                 raise
 
             if include_content and span.is_recording():


### PR DESCRIPTION
## Problem

`CallDeferred` and `ApprovalRequired` are control-flow signals used to implement deferred and approval-gated tool calls. Because they propagate through the `start_as_current_span` context manager in `_execute_function_tool_call`, they are automatically recorded as error events and the tool span status is set to `ERROR` — making spans appear red in Logfire and other OTel backends even though nothing went wrong.

Closes #4530

## Changes

**`pydantic_ai_slim/pydantic_ai/_tool_manager.py`**

- Pass `record_exception=False` and `set_status_on_exception=False` to `tracer.start_as_current_span` in `_execute_function_tool_call`.
- Add an explicit `except (CallDeferred, ApprovalRequired)` handler that records a `pydantic_ai.tool.deferred` span attribute (informational) and re-raises **without** marking the span as an error.
- Keep `ToolRetryError` handling and add explicit `span.record_exception` + `span.set_status(StatusCode.ERROR)` for it, preserving the existing error-reporting behaviour for genuine tool failures.

## Before / After

| Situation | Before | After |
|-----------|--------|-------|
| Tool raises `CallDeferred` | Span marked `ERROR`, exception event recorded | Span ends normally, `pydantic_ai.tool.deferred=CallDeferred` attribute set |
| Tool raises `ApprovalRequired` | Span marked `ERROR`, exception event recorded | Span ends normally, `pydantic_ai.tool.deferred=ApprovalRequired` attribute set |
| Tool raises `ModelRetry` → `ToolRetryError` | Span marked `ERROR` (via auto-record) | Span marked `ERROR` (via explicit `record_exception` + `set_status`) — same behaviour |
