### PR TITLE
fix(bedrock): sanitize hallucinated tool names before Converse API call

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import re
 import typing
 from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
 from contextlib import asynccontextmanager
@@ -953,8 +954,13 @@ class BedrockConverseModel(Model):
 
     @staticmethod
     def _map_tool_call(t: ToolCallPart) -> ContentBlockOutputTypeDef:
+        # Bedrock requires tool names to match [a-zA-Z0-9_-]+.  When the model
+        # hallucinates a name with dots, spaces, or other invalid characters the
+        # Converse API rejects the *entire* subsequent request, making the agent
+        # run unrecoverable.  Sanitize by replacing invalid characters with '_'.
+        safe_name = re.sub(r'[^a-zA-Z0-9_-]', '_', t.tool_name)
         return {
-            'toolUse': {'toolUseId': _utils.guard_tool_call_id(t=t), 'name': t.tool_name, 'input': t.args_as_dict()}
+            'toolUse': {'toolUseId': _utils.guard_tool_call_id(t=t), 'name': safe_name, 'input': t.args_as_dict()}
         }
 
     @staticmethod


### PR DESCRIPTION
## Problem

Bedrock's Converse API requires tool names to match `[a-zA-Z0-9_-]+`. When a model hallucinates a tool name with invalid characters (e.g. `search.evidence` or `module.function`), PydanticAI records the `ToolCallPart` in message history as-is. On the next round-trip the history is serialized back to Bedrock, which rejects the **entire** request:

```
ValidationException: 1 validation error detected: Value at
'messages.N.member.content.M.member.toolUse.name' failed to satisfy
constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+
```

This is unrecoverable — every subsequent request in the same agent run will fail.

Closes #4585

## Fix

In `BedrockConverseModel._map_tool_call`, replace any character outside `[a-zA-Z0-9_-]` with `_` before passing the name to the API. This keeps sanitization at the serialization boundary and leaves the in-memory `ToolCallPart` intact (useful for debugging).

```python
# Before
'name': t.tool_name

# After  
safe_name = re.sub(r'[^a-zA-Z0-9_-]', '_', t.tool_name)
'name': safe_name
```

This mirrors the workaround described in the issue and is the minimal, safe fix — invalid characters that AWS would reject become underscores, which are always valid.
