### PR TITLE
fix: make args_as_dict() resilient to malformed JSON in tool call args

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from dataclasses import field, replace
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeGuard, cast
 
+import pydantic_core
 from opentelemetry.trace import Tracer
 from typing_extensions import TypeVar, assert_never
 
@@ -108,13 +109,14 @@ class GraphAgentState:
                 and model_response.parts
                 and isinstance(tool_call := model_response.parts[-1], _messages.ToolCallPart)
             ):
-                try:
-                    tool_call.args_as_dict()
-                except Exception:
-                    max_tokens = model_settings.get('max_tokens') if model_settings else None
-                    raise exceptions.IncompleteToolCall(
-                        f'Model token limit ({max_tokens or "provider default"}) exceeded while generating a tool call, resulting in incomplete arguments. Increase the `max_tokens` model setting, or simplify the prompt to result in a shorter response that will fit within the limit.'
-                    )
+                if isinstance(tool_call.args, str):
+                    try:
+                        pydantic_core.from_json(tool_call.args)
+                    except ValueError:
+                        max_tokens = model_settings.get('max_tokens') if model_settings else None
+                        raise exceptions.IncompleteToolCall(
+                            f'Model token limit ({max_tokens or "provider default"}) exceeded while generating a tool call, resulting in incomplete arguments. Increase the `max_tokens` model setting, or simplify the prompt to result in a shorter response that will fit within the limit.'
+                        )
             message = f'Exceeded maximum retries ({max_result_retries}) for output validation'
             if error:
                 if isinstance(error, exceptions.UnexpectedModelBehavior) and error.__cause__ is not None:

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1422,12 +1422,19 @@ class BaseToolCallPart:
         """Return the arguments as a Python dictionary.
 
         This is just for convenience with models that require dicts as input.
+
+        Returns `{}` if `args` is falsy or contains invalid JSON, so that
+        malformed tool calls from model responses can be safely included in
+        message history reconstruction without crashing providers.
         """
         if not self.args:
             return {}
         if isinstance(self.args, dict):
             return self.args
-        args = pydantic_core.from_json(self.args)
+        try:
+            args = pydantic_core.from_json(self.args)
+        except ValueError:
+            return {}
         assert isinstance(args, dict), 'args should be a dict'
         return cast(dict[str, Any], args)
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3215,6 +3215,99 @@ def test_tool_exceeds_token_limit_but_complete_args():
     assert result.output == 'done'
 
 
+def test_malformed_tool_args_retry():
+    """When a model returns malformed JSON in tool call args, the agent should retry and recover."""
+
+    def return_malformed_then_correct(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('my_tool', args='{"foo": "bar",')])
+        if len(messages) == 3:
+            return ModelResponse(parts=[ToolCallPart('my_tool', args='{"foo": "bar"}')])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(FunctionModel(return_malformed_then_correct), output_type=str, retries=2)
+
+    @agent.tool_plain
+    def my_tool(foo: str) -> str:
+        return f'tool called with {foo}'
+
+    result = agent.run_sync('Hello')
+    assert result.output == 'done'
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='Hello', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='my_tool',
+                        args='{"foo": "bar",',
+                        tool_call_id=IsStr(),
+                    )
+                ],
+                usage=RequestUsage(input_tokens=51, output_tokens=5),
+                model_name='function:return_malformed_then_correct:',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    RetryPromptPart(
+                        content=[
+                            {
+                                'type': 'json_invalid',
+                                'loc': (),
+                                'msg': 'Invalid JSON: EOF while parsing a value at line 1 column 14',
+                                'input': '{"foo": "bar",',
+                            }
+                        ],
+                        tool_name='my_tool',
+                        tool_call_id=IsStr(),
+                        timestamp=IsDatetime(),
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='my_tool',
+                        args='{"foo": "bar"}',
+                        tool_call_id=IsStr(),
+                    )
+                ],
+                usage=RequestUsage(input_tokens=89, output_tokens=10),
+                model_name='function:return_malformed_then_correct:',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='my_tool',
+                        content='tool called with bar',
+                        tool_call_id=IsStr(),
+                        timestamp=IsDatetime(),
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='done')],
+                usage=RequestUsage(input_tokens=93, output_tokens=11),
+                model_name='function:return_malformed_then_correct:',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+        ]
+    )
+
+
 def test_empty_response_with_finish_reason_length():
     def return_empty_response(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         resp = ModelResponse(parts=[])


### PR DESCRIPTION
## Summary

Fixes #4430 — Anthropic retry path crashes on malformed tool args.

When a model returns malformed JSON in tool call arguments, pydantic-ai correctly creates a `RetryPromptPart` with `json_invalid`. But when building the **next** request, providers call `args_as_dict()` on the previous malformed tool call to rebuild message history, crashing with `ValueError` before the retry prompt ever reaches the model.

**Changes:**

- **`messages.py`**: `args_as_dict()` now catches `ValueError` from `pydantic_core.from_json()` and returns `{}` as fallback. This fixes all 15+ provider call sites (Anthropic, Bedrock, Gemini, Google, Mistral, xAI, etc.) at once without touching any model file.
- **`_agent_graph.py`**: `IncompleteToolCall` detection decoupled from `args_as_dict()` — uses `pydantic_core.from_json()` directly with `except ValueError` (previously used `args_as_dict()` + `except Exception`).
- **`test_agent.py`**: New `test_malformed_tool_args_retry` covering the full retry flow with `snapshot(result.all_messages())`.

## Test plan

- [x] `pytest tests/test_agent.py -k "test_tool_exceeds_token_limit_error"` — existing detection test
- [x] `pytest tests/test_agent.py -k "test_tool_exceeds_token_limit_but_complete_args"` — existing complete-args test
- [x] `pytest tests/test_agent.py -k "test_malformed_tool_args_retry"` — new retry flow test
- [x] `pyright` typecheck — 0 errors
- [x] `ruff check` — all passed
- [ ] `pytest tests/models/test_anthropic.py` — Anthropic regression check (needs API key/cassettes)