### PR TITLE
fix: AG-UI follow-up messages failing after built-in tool use

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -166,7 +166,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 case _:  # pragma: no cover
                                     raise ValueError(f'Unsupported user message part type: {type(part)}')
 
-                        if user_prompt_content:  # pragma: no branch
+                        if user_prompt_content:
                             content_to_add = (
                                 user_prompt_content[0]
                                 if len(user_prompt_content) == 1 and isinstance(user_prompt_content[0], str)
@@ -213,7 +213,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     if tool_call_id.startswith(BUILTIN_TOOL_CALL_ID_PREFIX):
                         _, provider_name, original_id = tool_call_id.split('|', 2)
                         content: Any = tool_msg.content
-                        if isinstance(content, str):  # pragma: no branch
+                        if isinstance(content, str):
                             try:
                                 content = json.loads(content)
                             except (json.JSONDecodeError, ValueError):

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1924,6 +1924,48 @@ async def test_builtin_tool_return_plain_string_content_preserved() -> None:
     assert return_part.content == 'just a plain string, not JSON'
 
 
+async def test_builtin_tool_return_non_string_content_passthrough() -> None:
+    """When ToolMessage.content is already a non-string (e.g. dict), it passes through without JSON parsing."""
+    tool_msg = ToolMessage.model_construct(
+        id='msg_2',
+        content={'type': 'web_fetch_result', 'url': 'https://example.com'},
+        tool_call_id='pyd_ai_builtin|anthropic|srvtoolu_abc789',
+    )
+    messages: list[Message] = [
+        AssistantMessage(
+            id='msg_1',
+            tool_calls=[
+                ToolCall(
+                    id='pyd_ai_builtin|anthropic|srvtoolu_abc789',
+                    function=FunctionCall(
+                        name='web_fetch',
+                        arguments='{"url": "https://example.com"}',
+                    ),
+                ),
+            ],
+        ),
+        tool_msg,
+    ]
+
+    result = AGUIAdapter.load_messages(messages)
+    response = result[0]
+    assert isinstance(response, ModelResponse)
+
+    return_part = response.parts[1]
+    assert isinstance(return_part, BuiltinToolReturnPart)
+    assert return_part.content == {'type': 'web_fetch_result', 'url': 'https://example.com'}
+
+
+async def test_user_message_empty_content_list_skipped() -> None:
+    """A UserMessage with an empty content list produces no UserPromptPart."""
+    messages: list[Message] = [
+        UserMessage(id='msg_1', content=[]),
+    ]
+
+    result = AGUIAdapter.load_messages(messages)
+    assert result == []
+
+
 async def test_builtin_tool_call() -> None:
     """Test back-to-back builtin tool calls share the same parent_message_id.
 


### PR DESCRIPTION
- Closes #4623

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

N/A for docs — no new public API, internal bugfix only.