### PR TITLE
fix(bedrock): sanitize hallucinated tool names before sending to Bedrock API

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -952,9 +952,28 @@ class BedrockConverseModel(Model):
         return [{'role': 'user', 'content': content}]
 
     @staticmethod
+    def _sanitize_tool_name(name: str) -> str:
+        """Sanitize a tool name to satisfy Bedrock's [a-zA-Z0-9_-]+ constraint.
+
+        If the model hallucinates a tool name with invalid characters (e.g. dots,
+        spaces), passing it through as-is causes Bedrock to reject every subsequent
+        request in the same run (the invalid name is baked into the message history).
+        Replace any character outside [a-zA-Z0-9_-] with an underscore so that the
+        API call succeeds and the error surface area is a ToolNotFound instead of an
+        unrecoverable ValidationException.
+        """
+        import re as _re
+
+        return _re.sub(r'[^a-zA-Z0-9_\-]', '_', name)
+
+    @staticmethod
     def _map_tool_call(t: ToolCallPart) -> ContentBlockOutputTypeDef:
         return {
-            'toolUse': {'toolUseId': _utils.guard_tool_call_id(t=t), 'name': t.tool_name, 'input': t.args_as_dict()}
+            'toolUse': {
+                'toolUseId': _utils.guard_tool_call_id(t=t),
+                'name': BedrockConverseModel._sanitize_tool_name(t.tool_name),
+                'input': t.args_as_dict(),
+            }
         }
 
     @staticmethod


### PR DESCRIPTION
## Problem

When `BedrockConverseModel` returns a tool name containing characters outside `[a-zA-Z0-9_-]` (e.g. dots from a `module.function` hallucination), the name is passed through verbatim to Bedrock, which rejects the next request with an unrecoverable `ValidationException` (closes #4585):

```
ValidationException: Value at 'messages.N.member.content.M.member.toolUse.name'
failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+
```

The invalid tool name is baked into the message history, so **every subsequent call** in the same agent run fails identically.

## Root cause

`_map_tool_call()` passes `t.tool_name` straight through without validation:

```python
return {'toolUse': {'name': t.tool_name, ...}}  # no sanitization
```

## Fix

Add `_sanitize_tool_name()` that replaces any character outside `[a-zA-Z0-9_-]` with `_`:

```python
@staticmethod
def _sanitize_tool_name(name: str) -> str:
    import re
    return re.sub(r'[^a-zA-Z0-9_\-]', '_', name)
```

The run will still raise `ToolNotFound` (the sanitized name won't match any registered tool), but subsequent requests are no longer poisoned by the invalid name in history.

Closes #4585