### PR TITLE
feat: add OpenAI token counting using tiktoken

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -646,6 +646,47 @@ class OpenAIChatModel(Model):
         async with response:
             yield await self._process_streamed_response(response, model_request_parameters, model_settings_cast)
 
+    async def count_tokens(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> usage.RequestUsage:
+        """Count the number of tokens in the messages using tiktoken.
+
+        This uses the tiktoken library to count tokens locally, following the algorithm
+        described in the [OpenAI cookbook](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken).
+
+        Note: the exact token count may vary slightly from the API's count, especially
+        for messages with non-text content (images, etc.) which are skipped in counting.
+        """
+        import tiktoken
+
+        check_allow_model_requests()
+        model_settings, model_request_parameters = self.prepare_request(
+            model_settings,
+            model_request_parameters,
+        )
+        openai_messages = await self._map_messages(messages, model_request_parameters)
+
+        try:
+            encoding = tiktoken.encoding_for_model(self._model_name)
+        except KeyError:
+            encoding = tiktoken.get_encoding('o200k_base')
+
+        tokens_per_message = 3
+        tokens_per_name = 1
+        num_tokens = 0
+        for message in openai_messages:
+            num_tokens += tokens_per_message
+            for key, value in message.items():
+                if isinstance(value, str):
+                    num_tokens += len(encoding.encode(value))
+                    if key == 'name':
+                        num_tokens += tokens_per_name
+        num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
+        return usage.RequestUsage(input_tokens=num_tokens)
+
     @overload
     async def _completions_create(
         self,

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4555,3 +4555,60 @@ async def test_openai_chat_refusal_streaming(allow_model_requests: None):
     assert response_msg['parts'] == []
     assert response_msg['finish_reason'] == 'content_filter'
     assert response_msg['provider_details']['refusal'] == "I'm sorry, I can't help with that."
+
+
+
+async def test_openai_count_tokens(allow_model_requests: None):
+    """Test that count_tokens returns a valid RequestUsage with input_tokens > 0."""
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    # Mock tiktoken to avoid network calls for encoding download
+    mock_encoding = AsyncMock()
+    mock_encoding.encode = lambda text: list(range(len(text.split())))
+
+    with patch('tiktoken.encoding_for_model', return_value=mock_encoding):
+        result = await m.count_tokens(
+            [ModelRequest.user_text_prompt('hello')],
+            None,
+            ModelRequestParameters(),
+        )
+
+    # tiktoken should count some tokens for the message
+    assert result.input_tokens > 0
+
+
+async def test_openai_count_tokens_with_usage_limits(allow_model_requests: None):
+    """Test that count_tokens_before_request works end-to-end with OpenAI model."""
+    from pydantic_ai.exceptions import UsageLimitExceeded
+    from pydantic_ai.usage import UsageLimits
+
+    c = completion_message(
+        ChatCompletionMessage(content='world', role='assistant'),
+        usage=CompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+    )
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    # Mock tiktoken to avoid network calls for encoding download
+    mock_encoding = AsyncMock()
+    mock_encoding.encode = lambda text: list(range(len(text.split())))
+
+    with patch('tiktoken.encoding_for_model', return_value=mock_encoding):
+        # With a very low limit, it should raise UsageLimitExceeded
+        with pytest.raises(UsageLimitExceeded):
+            await agent.run(
+                'The quick brown fox jumps over the lazy dog.',
+                usage_limits=UsageLimits(input_tokens_limit=1, count_tokens_before_request=True),
+            )
+
+        # With a generous limit, it should succeed
+        mock_client.index = 0  # type: ignore
+        result = await agent.run(
+            'hello',
+            usage_limits=UsageLimits(input_tokens_limit=100, count_tokens_before_request=True),
+        )
+        assert result.output == 'world'
+


### PR DESCRIPTION
## Summary

Implement `count_tokens()` for `OpenAIChatModel` using the `tiktoken` library, following the [OpenAI cookbook algorithm](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken#6-counting-tokens-for-chat-completions-api-calls).

This enables `UsageLimits.count_tokens_before_request` to work with OpenAI models, matching existing implementations for `GoogleModel`, `AnthropicModel`, and `BedrockConverseModel`.

## Changes

- **`pydantic_ai_slim/pydantic_ai/models/openai.py`**: Added `count_tokens()` method to `OpenAIChatModel` that:
  - Reuses existing `_map_messages()` to convert messages to OpenAI format
  - Uses `tiktoken.encoding_for_model()` to get the right tokenizer (with `o200k_base` fallback)
  - Follows the OpenAI cookbook algorithm: 3 tokens per message overhead + 1 per name field + 3 for reply priming
  - Returns `RequestUsage(input_tokens=total)`

- **`tests/models/test_openai.py`**: Added two tests:
  - `test_openai_count_tokens` — verifies `count_tokens()` returns valid `RequestUsage`
  - `test_openai_count_tokens_with_usage_limits` — verifies end-to-end integration with `UsageLimits(count_tokens_before_request=True)`

## Related Issue

Closes #3430