### PR TITLE
feat: add deps_factory to agent.to_a2a() for per-request dependency injection

### DIFF
--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -124,3 +124,67 @@ When using `to_a2a()`, Pydantic AI automatically:
   - String results become `TextPart` artifacts and also appear in the message history
   - Structured data (Pydantic models, dataclasses, tuples, etc.) become `DataPart` artifacts with the data wrapped as `{"result": <your_data>}`
   - Artifacts include metadata with type information and JSON schema when available
+
+### Injecting per-request dependencies
+
+For agents that use [`deps_type`](dependencies.md), you can provide a `deps_factory` callable that is invoked once
+per incoming task with the raw [`TaskSendParams`][fasta2a.schema.TaskSendParams] and returns the deps to inject.
+This is useful for per-request context like auth tokens, database sessions, or user identity.
+
+```python {title="agent_to_a2a_deps.py"}
+from dataclasses import dataclass
+
+from fasta2a.schema import TaskSendParams
+
+from pydantic_ai import Agent, RunContext
+
+
+@dataclass
+class MyDeps:
+    user_id: str
+
+
+agent = Agent('openai:gpt-5.2', deps_type=MyDeps)
+
+
+@agent.system_prompt
+def personalize(ctx: RunContext[MyDeps]) -> str:
+    return f'You are helping user {ctx.deps.user_id}.'
+
+
+def make_deps(params: TaskSendParams) -> MyDeps:
+    # Extract caller-supplied metadata from the incoming message
+    user_id = (params['message'].get('metadata') or {}).get('user_id', 'anonymous')
+    return MyDeps(user_id=user_id)
+
+
+app = agent.to_a2a(deps_factory=make_deps)
+```
+
+The factory can also be `async`:
+
+```python {title="agent_to_a2a_deps_async.py"}
+import asyncio
+from dataclasses import dataclass
+
+from fasta2a.schema import TaskSendParams
+
+from pydantic_ai import Agent
+
+
+@dataclass
+class MyDeps:
+    user_id: str
+
+
+agent = Agent('openai:gpt-5.2', deps_type=MyDeps)
+
+
+async def make_deps(params: TaskSendParams) -> MyDeps:
+    await asyncio.sleep(0)  # simulate async I/O (e.g., a database lookup)
+    user_id = (params['message'].get('metadata') or {}).get('user_id', 'anonymous')
+    return MyDeps(user_id=user_id)
+
+
+app = agent.to_a2a(deps_factory=make_deps)
+```

--- a/pydantic_ai_slim/pydantic_ai/_a2a.py
+++ b/pydantic_ai_slim/pydantic_ai/_a2a.py
@@ -1,8 +1,9 @@
 from __future__ import annotations, annotations as _annotations
 
 import base64
+import inspect
 import uuid
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from functools import partial
@@ -77,6 +78,9 @@ def agent_to_a2a(
     *,
     storage: Storage | None = None,
     broker: Broker | None = None,
+    deps_factory: Callable[[TaskSendParams], AgentDepsT]
+    | Callable[[TaskSendParams], Awaitable[AgentDepsT]]
+    | None = None,
     # Agent card
     name: str | None = None,
     url: str = 'http://localhost:8000',
@@ -94,7 +98,7 @@ def agent_to_a2a(
     """Create a FastA2A server from an agent."""
     storage = storage or InMemoryStorage()
     broker = broker or InMemoryBroker()
-    worker = AgentWorker(agent=agent, broker=broker, storage=storage)
+    worker = AgentWorker(agent=agent, broker=broker, storage=storage, deps_factory=deps_factory)
 
     lifespan = lifespan or partial(worker_lifespan, worker=worker, agent=agent)
 
@@ -120,6 +124,9 @@ class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]
     """A worker that uses an agent to execute tasks."""
 
     agent: AbstractAgent[AgentDepsT, WorkerOutputT]
+    deps_factory: Callable[[TaskSendParams], AgentDepsT] | Callable[[TaskSendParams], Awaitable[AgentDepsT]] | None = (
+        None
+    )
 
     async def run_task(self, params: TaskSendParams) -> None:
         task = await self.storage.load_task(params['id'])
@@ -140,7 +147,12 @@ class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]
         message_history.extend(self.build_message_history(task.get('history', [])))
 
         try:
-            result = await self.agent.run(message_history=message_history)  # type: ignore
+            deps: AgentDepsT | None = None
+            if self.deps_factory is not None:
+                deps_result = self.deps_factory(params)
+                deps = await deps_result if inspect.isawaitable(deps_result) else deps_result
+
+            result = await self.agent.run(deps=deps, message_history=message_history)  # type: ignore
 
             await self.storage.update_context(task['context_id'], result.all_messages())
 

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -48,7 +48,7 @@ from ..usage import RunUsage, UsageLimits
 if TYPE_CHECKING:
     from fasta2a.applications import FastA2A
     from fasta2a.broker import Broker
-    from fasta2a.schema import AgentProvider, Skill
+    from fasta2a.schema import AgentProvider, Skill, TaskSendParams
     from fasta2a.storage import Storage
     from starlette.middleware import Middleware
     from starlette.routing import BaseRoute, Route
@@ -1475,6 +1475,9 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         *,
         storage: Storage | None = None,
         broker: Broker | None = None,
+        deps_factory: Callable[[TaskSendParams], AgentDepsT]
+        | Callable[[TaskSendParams], Awaitable[AgentDepsT]]
+        | None = None,
         # Agent card
         name: str | None = None,
         url: str = 'http://localhost:8000',
@@ -1490,6 +1493,26 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         lifespan: Lifespan[FastA2A] | None = None,
     ) -> FastA2A:
         """Convert the agent to a FastA2A application.
+
+        Args:
+            storage: Storage backend for tasks and conversation context. Defaults to [`InMemoryStorage`][fasta2a.InMemoryStorage].
+            broker: Broker for scheduling tasks. Defaults to [`InMemoryBroker`][fasta2a.InMemoryBroker].
+            deps_factory: Optional callable invoked once per incoming task to produce the agent's dependencies.
+                Receives the [`TaskSendParams`][fasta2a.schema.TaskSendParams] (which includes the incoming message
+                and any caller-supplied metadata) and returns the deps for that request. Both sync and async
+                callables are supported. Use this for per-request context such as auth tokens, user identity,
+                or database sessions. If omitted, `deps=None` is passed to [`agent.run()`][pydantic_ai.Agent.run].
+            name: Agent name for the A2A agent card. Defaults to the agent's name.
+            url: Public URL of the A2A server. Defaults to `'http://localhost:8000'`.
+            version: Agent version for the A2A agent card. Defaults to `'1.0.0'`.
+            description: Agent description for the A2A agent card.
+            provider: Agent provider for the A2A agent card.
+            skills: Agent skills for the A2A agent card.
+            debug: Enable Starlette debug mode.
+            routes: Additional Starlette routes.
+            middleware: Additional Starlette middleware.
+            exception_handlers: Custom exception handlers.
+            lifespan: Custom ASGI lifespan. Defaults to a lifespan that starts the worker.
 
         Example:
         ```python
@@ -1513,6 +1536,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             self,
             storage=storage,
             broker=broker,
+            deps_factory=deps_factory,
             name=name,
             url=url,
             version=version,

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -28,7 +28,7 @@ from .conftest import IsDatetime, IsNow, IsStr, try_import
 
 with try_import() as imports_successful:
     from fasta2a.client import A2AClient
-    from fasta2a.schema import DataPart, FilePart, Message, TextPart
+    from fasta2a.schema import DataPart, FilePart, Message, TaskSendParams, TextPart
     from fasta2a.storage import InMemoryStorage
 
 
@@ -878,6 +878,180 @@ async def test_a2a_multiple_messages():
                     },
                 }
             )
+
+
+async def test_a2a_deps_factory_sync():
+    """Test that a synchronous deps_factory is called per request with the task params."""
+    from dataclasses import dataclass as dc
+
+    @dc
+    class MyDeps:
+        user_id: str
+
+    call_count = 0
+    captured_user_ids: list[str] = []
+
+    agent: Agent[MyDeps, tuple[str, str]] = Agent(model=model, deps_type=MyDeps, output_type=tuple[str, str])
+
+    def make_deps(params: TaskSendParams) -> MyDeps:
+        nonlocal call_count
+        call_count += 1
+        user_id = (params['message'].get('metadata') or {}).get('user_id', 'anonymous')
+        captured_user_ids.append(user_id)
+        return MyDeps(user_id=user_id)
+
+    app = agent.to_a2a(deps_factory=make_deps)
+
+    async with LifespanManager(app):
+        transport = httpx.ASGITransport(app)
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            a2a_client = A2AClient(http_client=http_client)
+
+            message = Message(
+                role='user',
+                parts=[TextPart(text='Hello!', kind='text')],
+                kind='message',
+                message_id=str(uuid.uuid4()),
+                metadata={'user_id': 'alice'},
+            )
+            response = await a2a_client.send_message(message=message)
+            assert 'error' not in response
+            assert 'result' in response
+            result = response['result']
+            assert result['kind'] == 'task'
+            task_id = result['id']
+
+            while task := await a2a_client.get_task(task_id):  # pragma: no branch
+                if 'result' in task and task['result']['status']['state'] in ('completed', 'failed'):
+                    break
+                await anyio.sleep(0.1)
+
+            assert task['result']['status']['state'] == 'completed'
+            assert call_count == 1
+            assert captured_user_ids == ['alice']
+
+
+async def test_a2a_deps_factory_async():
+    """Test that an async deps_factory is awaited and its result is passed as deps."""
+    from dataclasses import dataclass as dc
+
+    @dc
+    class MyDeps:
+        user_id: str
+
+    captured_user_ids: list[str] = []
+
+    agent: Agent[MyDeps, tuple[str, str]] = Agent(model=model, deps_type=MyDeps, output_type=tuple[str, str])
+
+    async def make_deps_async(params: TaskSendParams) -> MyDeps:
+        await anyio.sleep(0)  # yield to event loop
+        user_id = (params['message'].get('metadata') or {}).get('user_id', 'anonymous')
+        captured_user_ids.append(user_id)
+        return MyDeps(user_id=user_id)
+
+    app = agent.to_a2a(deps_factory=make_deps_async)
+
+    async with LifespanManager(app):
+        transport = httpx.ASGITransport(app)
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            a2a_client = A2AClient(http_client=http_client)
+
+            message = Message(
+                role='user',
+                parts=[TextPart(text='Hello!', kind='text')],
+                kind='message',
+                message_id=str(uuid.uuid4()),
+                metadata={'user_id': 'bob'},
+            )
+            response = await a2a_client.send_message(message=message)
+            assert 'error' not in response
+            assert 'result' in response
+            result = response['result']
+            assert result['kind'] == 'task'
+            task_id = result['id']
+
+            while task := await a2a_client.get_task(task_id):  # pragma: no branch
+                if 'result' in task and task['result']['status']['state'] in ('completed', 'failed'):
+                    break
+                await anyio.sleep(0.1)
+
+            assert task['result']['status']['state'] == 'completed'
+            assert captured_user_ids == ['bob']
+
+
+async def test_a2a_deps_factory_receives_task_send_params():
+    """Test that deps_factory receives the correct TaskSendParams object."""
+    received_params: list[TaskSendParams] = []
+
+    agent = Agent(model=model, output_type=tuple[str, str])
+
+    def make_deps(params: TaskSendParams) -> None:
+        received_params.append(params)
+        return None
+
+    app = agent.to_a2a(deps_factory=make_deps)
+
+    async with LifespanManager(app):
+        transport = httpx.ASGITransport(app)
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            a2a_client = A2AClient(http_client=http_client)
+
+            message = Message(
+                role='user',
+                parts=[TextPart(text='Hello!', kind='text')],
+                kind='message',
+                message_id=str(uuid.uuid4()),
+            )
+            response = await a2a_client.send_message(message=message)
+            assert 'error' not in response
+            assert 'result' in response
+            result = response['result']
+            assert result['kind'] == 'task'
+            task_id = result['id']
+
+            while task := await a2a_client.get_task(task_id):  # pragma: no branch
+                if 'result' in task and task['result']['status']['state'] in ('completed', 'failed'):
+                    break
+                await anyio.sleep(0.1)
+
+            assert task['result']['status']['state'] == 'completed'
+            assert len(received_params) == 1
+            assert received_params[0]['id'] == task_id
+
+
+async def test_a2a_deps_factory_raises_marks_task_failed():
+    """Test that if deps_factory raises, the task transitions to 'failed' state."""
+    agent = Agent(model=model, output_type=tuple[str, str])
+
+    def failing_deps(params: TaskSendParams) -> None:
+        raise ValueError('auth failed')
+
+    app = agent.to_a2a(deps_factory=failing_deps)
+
+    async with LifespanManager(app):
+        transport = httpx.ASGITransport(app)
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            a2a_client = A2AClient(http_client=http_client)
+
+            message = Message(
+                role='user',
+                parts=[TextPart(text='Hello!', kind='text')],
+                kind='message',
+                message_id=str(uuid.uuid4()),
+            )
+            response = await a2a_client.send_message(message=message)
+            assert 'error' not in response
+            assert 'result' in response
+            result = response['result']
+            assert result['kind'] == 'task'
+            task_id = result['id']
+
+            while task := await a2a_client.get_task(task_id):  # pragma: no branch
+                if 'result' in task and task['result']['status']['state'] in ('completed', 'failed'):
+                    break
+                await anyio.sleep(0.1)
+
+            assert task['result']['status']['state'] == 'failed'
 
 
 async def test_a2a_multiple_send_task_messages():


### PR DESCRIPTION
## Summary

`agent.to_a2a()` currently calls `agent.run(message_history=...)` with no `deps`, so any agent that uses `deps_type` silently receives `None` for its dependencies. This PR adds a `deps_factory` parameter — a callable invoked once per incoming task that produces the deps for that request.

This is complementary to PR #4177 (static `deps=`). While static deps are useful for shared singletons, `deps_factory` is needed for per-request context: auth tokens extracted from message metadata, per-request database sessions, user identity, etc.

## Changes

- **`pydantic_ai/_a2a.py`**: Add `deps_factory` field to `AgentWorker`; invoke it in `run_task()` before calling `agent.run()`, supporting both sync and async factories via `inspect.isawaitable()`
- **`pydantic_ai/agent/abstract.py`**: Add `deps_factory` parameter to `AbstractAgent.to_a2a()` and pass it through to `agent_to_a2a()`
- **`tests/test_a2a.py`**: Three new tests — sync factory, async factory, factory receives correct `TaskSendParams`
- **`docs/a2a.md`**: Usage example showing per-request auth injection from message metadata

## Usage

```python
from dataclasses import dataclass
from fasta2a.schema import TaskSendParams
from pydantic_ai import Agent, RunContext

@dataclass
class MyDeps:
    user_id: str

agent = Agent('openai:gpt-4o', deps_type=MyDeps)

@agent.system_prompt
def personalize(ctx: RunContext[MyDeps]) -> str:
    return f'You are helping user {ctx.deps.user_id}.'

def make_deps(params: TaskSendParams) -> MyDeps:
    user_id = (params['message'].get('metadata') or {}).get('user_id', 'anonymous')
    return MyDeps(user_id=user_id)

app = agent.to_a2a(deps_factory=make_deps)
```

Async factories are also supported:

```python
async def make_deps(params: TaskSendParams) -> MyDeps:
    user_id = await resolve_from_token(params['message'].get('metadata') or {})
    return MyDeps(user_id=user_id)
```

## Relation to PR #4177

This PR is independent of #4177. Both address the same gap (`deps` not being passed in A2A runs) but from different angles — static shared deps vs. per-request factory. They can coexist: static `deps=` would be used as a fallback when `deps_factory` is not provided.

Fixes the use case described in issue #2910 for A2A servers.

---

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.
