### PR TITLE
fix(anthropic): handle malformed tool args in retry path

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -797,7 +797,7 @@ class AnthropicModel(Model):
                             id=_guard_tool_call_id(t=response_part),
                             type='tool_use',
                             name=response_part.tool_name,
-                            input=response_part.args_as_dict(),
+                            input=_safe_args_as_dict(response_part),
                         )
                         assistant_content_params.append(tool_use_block_param)
                     elif isinstance(response_part, ThinkingPart):
@@ -1506,3 +1506,20 @@ def _map_mcp_server_result_block(
         content=item.model_dump(mode='json', include={'content', 'is_error'}),
         tool_call_id=item.tool_use_id,
     )
+
+
+def _safe_args_as_dict(part: ToolCallPart | BuiltinToolCallPart) -> dict[str, Any]:
+    """Safely extract tool call arguments as a dict.
+
+    When the LLM produces malformed JSON in tool call arguments, `args_as_dict()`
+    raises a `ValueError`. This helper catches that error and returns an empty dict
+    so that the retry flow can proceed — the retry prompt already contains the
+    parse-error details for the model to self-correct.
+
+    See: https://github.com/pydantic/pydantic-ai/issues/4430
+    """
+    try:
+        return part.args_as_dict()
+    except ValueError:
+        return {}
+


### PR DESCRIPTION
## Summary

Fixes #4430

When the LLM produces malformed JSON in tool call arguments (e.g. `{"query": "bad query", "file_ids":[4556]</parameter>\n<parameter name="limit": 8}`), the Anthropic model's history remapping calls `args_as_dict()` which raises a `ValueError` before the retry prompt can be sent to the model. This prevents the model from self-correcting.

**Root cause:** `args_as_dict()` uses `pydantic_core.from_json()` which raises `ValueError` on invalid JSON. The Anthropic mapping path calls this when constructing `BetaToolUseBlockParam(input=...)`. Other model implementations (OpenAI) use `args_as_json_str()` instead, which returns the raw string without parsing.

**Fix:** Add a `_safe_args_as_dict()` helper that catches `ValueError` and returns an empty dict `{}`, allowing the retry flow to proceed. The retry prompt (`RetryPromptPart`) already contains the full parse-error details for the model to self-correct.

- Only the regular `ToolCallPart` mapping (line 800) is affected; `BuiltinToolCallPart` args come from Anthropic's own API and are always valid JSON.

## Test plan

- [ ] Verify the minimal reproduction from #4430 no longer crashes with `ValueError`
- [ ] Verify that the agent retry loop proceeds and the model receives the `RetryPromptPart` with the JSON error details
- [ ] Verify existing Anthropic tool-calling tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)