### PR TITLE
fix: remove unsupported `id` field from Gemini API function call/response dicts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -687,7 +687,6 @@ class GoogleModel(Model):
                                 'function_response': {
                                     'name': part.tool_name,
                                     'response': part.model_response_object(),
-                                    'id': part.tool_call_id,
                                 }
                             }
                         )
@@ -700,7 +699,6 @@ class GoogleModel(Model):
                                     'function_response': {
                                         'name': part.tool_name,
                                         'response': {'error': part.model_response()},
-                                        'id': part.tool_call_id,
                                     }
                                 }
                             )
@@ -1109,7 +1107,7 @@ def _content_model_response(m: ModelResponse, provider_name: str) -> ContentDict
         thinking_part_signature = None
 
         if isinstance(item, ToolCallPart):
-            function_call = FunctionCallDict(name=item.tool_name, args=item.args_as_dict(), id=item.tool_call_id)
+            function_call = FunctionCallDict(name=item.tool_name, args=item.args_as_dict())
             part['function_call'] = function_call
             if function_call_requires_signature and not part.get('thought_signature'):
                 # Per https://ai.google.dev/gemini-api/docs/thought-signatures#faqs:


### PR DESCRIPTION
Hey, this should fix #4645.

The Gemini API doesn't support an `id` field in `function_call` or `function_response` objects — it throws a 400 with "Unknown name "id" at contents[x].parts[y].function_call: Cannot find field."

Looks like the `id` was added to match what other providers (like OpenAI) expect, but Gemini's schema just doesn't have it. Removed it from the three places where it gets included:

- The `FunctionCallDict` construction in `_content_model_response()`
- The `function_response` dict for `ToolReturnPart` in `_map_messages()`
- The `function_response` dict for `RetryPromptPart` in `_map_messages()`

Pretty straightforward — just dropping the unsupported field from outgoing requests. Doesn't affect any internal PydanticAI logic since `tool_call_id` is still tracked internally, it just doesn't get sent to the Gemini API anymore.

Let me know if anything needs adjusting!