### PR TITLE
fix(google): remove unsupported idField from Gemini API requests

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -687,7 +687,6 @@ class GoogleModel(Model):
                                 'function_response': {
                                     'name': part.tool_name,
                                     'response': part.model_response_object(),
-                                    'id': part.tool_call_id,
                                 }
                             }
                         )
@@ -700,7 +699,6 @@ class GoogleModel(Model):
                                     'function_response': {
                                         'name': part.tool_name,
                                         'response': {'error': part.model_response()},
-                                        'id': part.tool_call_id,
                                     }
                                 }
                             )
@@ -1109,7 +1107,7 @@ def _content_model_response(m: ModelResponse, provider_name: str) -> ContentDict
         thinking_part_signature = None
 
         if isinstance(item, ToolCallPart):
-            function_call = FunctionCallDict(name=item.tool_name, args=item.args_as_dict(), id=item.tool_call_id)
+            function_call = FunctionCallDict(name=item.tool_name, args=item.args_as_dict())
             part['function_call'] = function_call
             if function_call_requires_signature and not part.get('thought_signature'):
                 # Per https://ai.google.dev/gemini-api/docs/thought-signatures#faqs:

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -5522,10 +5522,10 @@ def test_google_missing_tool_call_thought_signature():
             'role': 'model',
             'parts': [
                 {
-                    'function_call': {'name': 'tool', 'args': {}, 'id': 'tool_call_id'},
+                    'function_call': {'name': 'tool', 'args': {}},
                     'thought_signature': b'skip_thought_signature_validator',
                 },
-                {'function_call': {'name': 'tool2', 'args': {}, 'id': 'tool_call_id2'}},
+                {'function_call': {'name': 'tool2', 'args': {}}},
             ],
         }
     )
@@ -5801,7 +5801,6 @@ async def test_google_splits_tool_return_from_user_prompt(google_provider: Googl
                         'function_response': {
                             'name': 'final_result',
                             'response': {'return_value': 'Final result processed.'},
-                            'id': 'test_id',
                         }
                     }
                 ],
@@ -5840,14 +5839,12 @@ async def test_google_splits_tool_return_from_user_prompt(google_provider: Googl
                         'function_response': {
                             'name': 'final_result',
                             'response': {'return_value': 'Final result processed.'},
-                            'id': 'test_id_1',
                         }
                     },
                     {
                         'function_response': {
                             'name': 'another_tool',
                             'response': {'error': 'Tool error occurred\n\nFix the errors and try again.'},
-                            'id': 'test_id_2',
                         }
                     },
                 ],
@@ -5886,7 +5883,6 @@ async def test_google_splits_tool_return_from_user_prompt(google_provider: Googl
                         'function_response': {
                             'name': 'final_result',
                             'response': {'return_value': 'Final result processed.'},
-                            'id': 'test_id',
                         }
                     },
                 ],
@@ -5928,7 +5924,7 @@ async def test_google_prepends_empty_user_turn_when_first_content_is_model(googl
                 'role': 'model',
                 'parts': [
                     {
-                        'function_call': {'name': 'generate_topic', 'args': {}, 'id': 'test_id'},
+                        'function_call': {'name': 'generate_topic', 'args': {}},
                         'thought_signature': b'skip_thought_signature_validator',
                     }
                 ],
@@ -5940,7 +5936,6 @@ async def test_google_prepends_empty_user_turn_when_first_content_is_model(googl
                         'function_response': {
                             'name': 'generate_topic',
                             'response': {'return_value': 'penguins'},
-                            'id': 'test_id',
                         }
                     },
                 ],


### PR DESCRIPTION
## Problem
When using Gemini models with pydantic-ai, function calling fails with a 400 error. The Gemini API does not accept an "id" field within the "function_call" and "function_response" objects in the request payload.

Error message from the API:
> Invalid JSON payload received. Unknown name "id" at 'contents[1].parts[0].function_call': Cannot find field.

## Root Cause
The `google.py` model adapter was including `tool_call_id` as an `id` field in three locations:
1. Line ~690: ToolReturnPart function_response
2. Line ~703: RetryPromptPart function_response  
3. Line ~1112: FunctionCallDict constructor

The Gemini API schema does not include an "id" field for these objects, unlike other providers (e.g., OpenAI).

## Change
Remove the "id" field from:
- ToolReturnPart function_response payload (line ~690)
- RetryPromptPart function_response payload (line ~703)
- FunctionCallDict constructor call (line ~1112)

Updated 8 corresponding test assertions in `tests/models/test_google.py` to match the new payload structure.

## Verification
- ✅ Tests pass: `uv run pytest tests/models/test_google.py -k 'test_google_missing_tool_call_thought_signature or test_google_prepends_empty_user_turn'`
- ✅ Git diff --check: No whitespace errors
- ✅ Type checking passes
- ✅ 2 files changed, 4 insertions(+), 11 deletions(-)

## Risk / Edge Cases
- **Breaking change?** No - the "id" field was never accepted by the Gemini API, so this only fixes broken requests.
- **Other models?** No impact - this change is scoped to the Google/Gemini adapter only.
- **Tool call tracking?** Tool call IDs are still tracked internally within pydantic-ai; they are just not sent to the Gemini API.

Fixes #4645