### PR TITLE
fix(usage): avoid mutating usage.details when adding

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -2,6 +2,12 @@ from __future__ import annotations as _annotations
 
 import dataclasses
 from copy import copy
+
+
+def _copy_usage_details(u: "UsageBase") -> dict[str, int]:
+    """Copy details dict to avoid mutating original usage when using shallow copy()."""
+    return u.details.copy()
+
 from dataclasses import dataclass, fields
 from typing import Annotated, Any
 
@@ -129,6 +135,7 @@ class RequestUsage(UsageBase):
         **WARNING:** this CANNOT be used to sum multiple requests without breaking some pricing calculations.
         """
         new_usage = copy(self)
+        new_usage.details = _copy_usage_details(self)
         new_usage.incr(other)
         return new_usage
 
@@ -217,6 +224,7 @@ class RunUsage(UsageBase):
         This is provided so it's trivial to sum usage information from multiple runs.
         """
         new_usage = copy(self)
+        new_usage.details = _copy_usage_details(self)
         new_usage.incr(other)
         return new_usage
 

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -379,6 +379,24 @@ def test_add_usages():
     assert RunUsage() + RunUsage() == RunUsage()
 
 
+
+
+def test_add_usage_does_not_mutate_original_details():
+    """Regression test for shallow-copy details dict mutation in Usage.__add__.
+
+    Adding usage should not mutate the original usage object (particularly the `details` dict).
+    """
+
+    u1 = RunUsage(details={"a": 1})
+    u2 = RunUsage(details={"a": 2, "b": 3})
+
+    u3 = u1 + u2
+
+    assert u3.details == {"a": 3, "b": 3}
+    # Original should be unchanged
+    assert u1.details == {"a": 1}
+
+
 def test_add_usages_with_none_detail_value():
     """Test that None values in details are skipped when incrementing usage."""
     usage = RunUsage(


### PR DESCRIPTION
Fixes #4605.

`RequestUsage.__add__` and `RunUsage.__add__` used `copy(self)` (shallow), which shared the mutable `details` dict with the original instance. When `incr()` updated details, it mutated the original usage object.

This PR copies the `details` dict before incrementing and adds a regression test ensuring `u1.details` is unchanged after `u1 + u2`.