### PR TITLE
fix: handle malformed tool args in Anthropic retry path

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -793,11 +793,19 @@ class AnthropicModel(Model):
                         if response_part.content:
                             assistant_content_params.append(BetaTextBlockParam(text=response_part.content, type='text'))
                     elif isinstance(response_part, ToolCallPart):
+                        try:
+                            tool_input = response_part.args_as_dict()
+                        except ValueError:
+                            # If the tool call args are malformed JSON (e.g. from a model
+                            # hallucination), fall back to an empty dict so the retry
+                            # prompt that follows can surface the error to the model
+                            # and let it self-correct.  See #4430.
+                            tool_input = {}
                         tool_use_block_param = BetaToolUseBlockParam(
                             id=_guard_tool_call_id(t=response_part),
                             type='tool_use',
                             name=response_part.tool_name,
-                            input=response_part.args_as_dict(),
+                            input=tool_input,
                         )
                         assistant_content_params.append(tool_use_block_param)
                     elif isinstance(response_part, ThinkingPart):


### PR DESCRIPTION
## Summary

Fixes #4430.

When a model (e.g. Claude Sonnet 4.6) produces malformed JSON in tool call arguments, the Anthropic message-remapping code calls `args_as_dict()` which raises `ValueError` from `pydantic_core.from_json()`. This crashes the agent **before** the retry prompt (which already exists in the message history) can be sent back to the model for self-correction.

- Wraps the `args_as_dict()` call in the `ToolCallPart` branch of `_map_message` with a `try/except ValueError`
- On malformed JSON, falls back to an empty `{}` dict so the Anthropic API call succeeds and the retry prompt reaches the model
- Other providers (OpenAI, OpenRouter) are unaffected because they use `args_as_json_str()` which passes the raw string through

## Test plan

- [ ] Reproduce with the minimal example from #4430 — confirm it no longer raises `ValueError` and instead allows the retry flow
- [ ] Verify normal (valid JSON) tool calls still work correctly
- [ ] Run existing test suite (`tests/test_tools.py`, Anthropic model tests)