### PR TITLE
fix: copy details dict in Usage.__add__ to prevent mutation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -129,6 +129,7 @@ class RequestUsage(UsageBase):
         **WARNING:** this CANNOT be used to sum multiple requests without breaking some pricing calculations.
         """
         new_usage = copy(self)
+        new_usage.details = self.details.copy()
         new_usage.incr(other)
         return new_usage
 
@@ -217,6 +218,7 @@ class RunUsage(UsageBase):
         This is provided so it's trivial to sum usage information from multiple runs.
         """
         new_usage = copy(self)
+        new_usage.details = self.details.copy()
         new_usage.incr(other)
         return new_usage
 


### PR DESCRIPTION
## Summary

Fixes #4605

`RequestUsage.__add__` and `RunUsage.__add__` use `copy(self)` (shallow copy), which shares the mutable `details` dict between the original and the new object. When `incr()` modifies the new object's `details` via `slf.details[key] = ...`, it also mutates the original's `details` through the shared reference.

This causes two real-world bugs:

1. **`AgentStream.usage()` returns progressively inflated `details` values on each call** — in `result.py:169`, `self._initial_run_ctx_usage + self._raw_stream_response.usage()` mutates `_initial_run_ctx_usage.details` on every call, so reasoning tokens (and other detail keys) double, triple, etc.

2. **`+=` in streaming models creates inconsistent captured references** — scalar fields and `details` dict get out of sync because they point to different objects after the shallow copy.

## Fix

Added `new_usage.details = self.details.copy()` after the `copy(self)` call in both `RequestUsage.__add__` and `RunUsage.__add__`, so the new object gets its own independent copy of the `details` dict before `incr()` modifies it in-place.

## Test plan

- [ ] Verify `u1 + u2` does not mutate `u1.details`
- [ ] Verify `u1.details is not (u1 + u2).details` (no shared reference)
- [ ] Verify repeated `initial + stream` returns consistent results (no inflation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)