### PR TITLE
fix: copy details dict in Usage.__add__ to prevent mutation of original

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -129,6 +129,7 @@ class RequestUsage(UsageBase):
         **WARNING:** this CANNOT be used to sum multiple requests without breaking some pricing calculations.
         """
         new_usage = copy(self)
+        new_usage.details = self.details.copy()
         new_usage.incr(other)
         return new_usage
 
@@ -217,6 +218,7 @@ class RunUsage(UsageBase):
         This is provided so it's trivial to sum usage information from multiple runs.
         """
         new_usage = copy(self)
+        new_usage.details = self.details.copy()
         new_usage.incr(other)
         return new_usage
 


### PR DESCRIPTION
## Summary

- Fix shallow copy bug in `RequestUsage.__add__` and `RunUsage.__add__` where `copy(self)` shares the mutable `details` dict between the original and new object
- When `incr()` modifies the new object's `details`, it also mutates the original's `details` through the shared reference
- Add `new_usage.details = self.details.copy()` after the shallow copy in both methods

## Problem

`copy(self)` only creates a shallow copy, so `self.details` and `new_usage.details` point to the same dict. When `_incr_usage_tokens` updates the dict via `slf.details[key] = slf.details.get(key, 0) + value`, the original object's `details` is mutated.

This causes real-world issues:
1. **`AgentStream.usage()` returns progressively inflated `details` values** — each call to `_initial_run_ctx_usage + _raw_stream_response.usage()` mutates `_initial_run_ctx_usage.details`, so `reasoning_tokens` doubles, triples, etc. on successive calls
2. **`+=` in streaming models creates inconsistent captured references** — scalar fields and `details` dict get out of sync

Fixes #4605

## Test plan

- [x] Verify `u1.details` is unchanged after `u1 + u2` for both `RequestUsage` and `RunUsage`
- [x] Verify `u1.details is not result.details` (no shared reference)
- [x] Verify repeated addition produces consistent results (no accumulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)