### PR TITLE
fix: detect `items: {}` as strict-incompatible in OpenAIJsonSchemaTransformer

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -290,6 +290,14 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
             else:
                 self.is_strict_compatible = False
 
+        if schema_type == 'array':
+            # OpenAI strict mode requires `items` to have a `type` key.
+            # A bare `list` (no type parameter) produces `items: {}` which is not strict-compatible.
+            items = schema.get('items')
+            if items is not None and items == {}:
+                if self.strict is None:
+                    self.is_strict_compatible = False
+
         if schema_type == 'object':
             # Always ensure 'properties' key exists - OpenAI drops objects without it
             if 'properties' not in schema:


### PR DESCRIPTION
## Summary

Fixes #4425

- Detect empty `items: {}` in array schemas as strict-incompatible in `OpenAIJsonSchemaTransformer`
- When `strict=None` (auto-detection mode), a bare `list` type that produces `items: {}` now correctly sets `is_strict_compatible = False`, causing the tool to be sent with `strict` unset instead of `strict=True`
- This prevents OpenAI from rejecting the request with "schema must have a 'type' key" error

## Root Cause

A bare `list` parameter (e.g., `def foo(items: list)`) generates the JSON schema `{"type": "array", "items": {}}`. OpenAI strict mode requires `items` to have a `type` key, so `items: {}` is invalid. The transformer already handled other strict-incompatible features (like `default`, `oneOf`, partial `required`, `additionalProperties`) but was missing this case.

## Test plan

- [ ] Verify that a tool with `items: list` no longer causes a 400 error from OpenAI
- [ ] Verify that typed lists like `list[int]` still correctly use `strict=True`
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)