### PR TITLE
fix: don't record control flow exceptions as errors in OTel spans

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -8,14 +8,14 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from typing import Any, Generic, Literal
 
-from opentelemetry.trace import Tracer
+from opentelemetry.trace import StatusCode, Tracer
 from pydantic import ValidationError
 from typing_extensions import deprecated
 
 from . import messages as _messages
 from ._instrumentation import InstrumentationNames
 from ._run_context import AgentDepsT, RunContext
-from .exceptions import ModelRetry, ToolRetryError, UnexpectedModelBehavior
+from .exceptions import ApprovalRequired, CallDeferred, ModelRetry, ToolRetryError, UnexpectedModelBehavior
 from .messages import ToolCallPart
 from .tools import ToolDefinition
 from .toolsets.abstract import AbstractToolset, ToolsetTool
@@ -407,16 +407,42 @@ class ToolManager(Generic[AgentDepsT]):
             ),
         }
 
+        # Use record_exception=False so we can handle exception recording manually.
+        # Control flow exceptions (CallDeferred, ApprovalRequired) should not be
+        # recorded as errors on the span — they are normal control flow, not failures.
         with tracer.start_as_current_span(
             instrumentation_names.get_tool_span_name(call.tool_name),
             attributes=span_attributes,
+            record_exception=False,
+            set_status_on_exception=False,
         ) as span:
             try:
                 tool_result = await self._execute_tool_call_impl(validated, usage=usage)
+            except (CallDeferred, ApprovalRequired) as e:
+                # These are control flow exceptions, not real errors.
+                # Record the exception type and metadata as regular span attributes
+                # so the info is queryable, but do NOT mark the span as an error.
+                if span.is_recording():
+                    exc_type = type(e).__name__
+                    span.set_attribute('pydantic_ai.tool.control_flow', exc_type)
+                    if hasattr(e, 'metadata') and e.metadata is not None:
+                        span.set_attribute('pydantic_ai.tool.control_flow.metadata', json.dumps(e.metadata))
+                    span.set_status(StatusCode.OK)
+                raise
             except ToolRetryError as e:
                 part = e.tool_retry
                 if include_content and span.is_recording():
                     span.set_attribute(instrumentation_names.tool_result_attr, part.model_response())
+                # Record retry errors as exceptions on the span since they represent real issues
+                if span.is_recording():
+                    span.record_exception(e)
+                    span.set_status(StatusCode.ERROR, str(e))
+                raise
+            except BaseException as e:
+                # Record all other exceptions as errors on the span
+                if span.is_recording():
+                    span.record_exception(e)
+                    span.set_status(StatusCode.ERROR, str(e))
                 raise
 
             if include_content and span.is_recording():


### PR DESCRIPTION
## Summary

Fixes #4530

Control flow exceptions (`CallDeferred`, `ApprovalRequired`) are currently recorded as errors on OpenTelemetry spans by `tracer.start_as_current_span`, causing them to show up as red/error in Logfire and other OTel backends. These exceptions represent normal control flow for deferred tools and human-in-the-loop approval, not actual failures.

## Changes

- Disable automatic exception recording on tool execution spans by passing `record_exception=False` and `set_status_on_exception=False` to `start_as_current_span`
- Catch `CallDeferred` and `ApprovalRequired` separately and:
  - Record the exception type as a regular span attribute (`pydantic_ai.tool.control_flow`) so it remains queryable
  - Record any metadata as `pydantic_ai.tool.control_flow.metadata`
  - Set span status to `OK` instead of `ERROR`
- Explicitly handle `ToolRetryError` and other `BaseException` cases to preserve existing error recording behavior

## Test plan

- [ ] Verify that `CallDeferred` exceptions no longer appear as errors in OTel spans
- [ ] Verify that `ApprovalRequired` exceptions no longer appear as errors in OTel spans
- [ ] Verify that real errors (e.g. `ToolRetryError`, unexpected exceptions) are still recorded as errors
- [ ] Verify that control flow exception type and metadata are recorded as span attributes
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)