### PR TITLE
docs: fix model name typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ class SupportOutput(BaseModel):
 # Agents are generic in the type of dependencies they accept and the type of output they return.
 # In this case, the support agent has type `Agent[SupportDependencies, SupportOutput]`.
 support_agent = Agent(
-    'openai:gpt-5.2',
+    'openai:gpt-4o',
     deps_type=SupportDependencies,
     # The response from the agent will, be guaranteed to be a SupportOutput,
     # if validation fails the agent is prompted to try again.


### PR DESCRIPTION
## Description

Fixed a typo in the README where the example code referenced `openai:gpt-5.2`, which is not a valid OpenAI model.

## Changes
- Changed `openai:gpt-5.2` to `openai:gpt-4o` in the Tools & Dependency Injection example

## Motivation
The example code should use a valid model name to avoid confusion for users trying the example. GPT-5.2 does not exist; the current flagship model is GPT-4o.

## Type of Change
- [x] Documentation fix
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change