### PR TITLE
fix: copy details dict in Usage.__add__ to avoid mutating original

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -129,6 +129,7 @@ class RequestUsage(UsageBase):
         **WARNING:** this CANNOT be used to sum multiple requests without breaking some pricing calculations.
         """
         new_usage = copy(self)
+        new_usage.details = self.details.copy()  # Avoid mutating original via shallow copy
         new_usage.incr(other)
         return new_usage
 
@@ -217,6 +218,7 @@ class RunUsage(UsageBase):
         This is provided so it's trivial to sum usage information from multiple runs.
         """
         new_usage = copy(self)
+        new_usage.details = self.details.copy()  # Avoid mutating original via shallow copy
         new_usage.incr(other)
         return new_usage
 


### PR DESCRIPTION
Fixes #4605

## Problem

The `UsageBase.__add__` method uses `copy(self)` which creates a shallow copy. This means the mutable `details` dict is shared between the original and the new object. When `incr()` modifies `new_usage.details`, it also mutates the original's `details` through the shared reference.

### Impact

This causes inflated token counts on repeated `StreamedRunResult.usage()` calls:

```python
# In result.py:169
return self._initial_run_ctx_usage + self._raw_stream_response.usage()
```

Each call to `.usage()` mutates `_initial_run_ctx_usage.details`, so the next call adds the stream's details again on top of the already-corrupted values.

For OpenAI reasoning models (o1, o3, GPT-5) that report `reasoning_tokens` in details:
- 1st `.usage()` call: `reasoning_tokens = 150` (correct)
- 2nd `.usage()` call: `reasoning_tokens = 300` (2x inflated)
- 3rd `.usage()` call: `reasoning_tokens = 450` (3x inflated)

## Solution

Explicitly copy the `details` dict after shallow copy to break the shared reference.

### Changes

```python
# Before
new_usage = copy(self)
new_usage.incr(other)
return new_usage

# After
new_usage = copy(self)
new_usage.details = self.details.copy()  # Avoid mutating original
new_usage.incr(other)
return new_usage
```

Applied to both:
- `RequestUsage.__add__`
- `RunUsage.__add__`

## Testing

Verified that repeated `.usage()` calls now return consistent values without mutation.