### PR TITLE
fix(otel): don't record control flow exceptions as errors in tool spans

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -15,16 +15,22 @@ from typing_extensions import deprecated
 from . import messages as _messages
 from ._instrumentation import InstrumentationNames
 from ._run_context import AgentDepsT, RunContext
-from .exceptions import ModelRetry, ToolRetryError, UnexpectedModelBehavior
+from .exceptions import (
+    ApprovalRequired,
+    CallDeferred,
+    ModelRetry,
+    ToolRetryError,
+    UnexpectedModelBehavior,
+)
 from .messages import ToolCallPart
 from .tools import ToolDefinition
 from .toolsets.abstract import AbstractToolset, ToolsetTool
 from .usage import RunUsage
 
-ParallelExecutionMode = Literal['parallel', 'sequential', 'parallel_ordered_events']
+ParallelExecutionMode = Literal["parallel", "sequential", "parallel_ordered_events"]
 
 _parallel_execution_mode_ctx_var: ContextVar[ParallelExecutionMode] = ContextVar(
-    'parallel_execution_mode', default='parallel'
+    "parallel_execution_mode", default="parallel"
 )
 
 
@@ -69,7 +75,9 @@ class ToolManager(Generic[AgentDepsT]):
 
     @classmethod
     @contextmanager
-    def parallel_execution_mode(cls, mode: ParallelExecutionMode = 'parallel') -> Iterator[None]:
+    def parallel_execution_mode(
+        cls, mode: ParallelExecutionMode = "parallel"
+    ) -> Iterator[None]:
         """Set the parallel execution mode during the context.
 
         Args:
@@ -89,10 +97,12 @@ class ToolManager(Generic[AgentDepsT]):
     @deprecated('Use `parallel_execution_mode("sequential")` instead.')
     def sequential_tool_calls(cls) -> Iterator[None]:
         """Run tool calls sequentially during the context."""
-        with cls.parallel_execution_mode('sequential'):
+        with cls.parallel_execution_mode("sequential"):
             yield
 
-    async def for_run_step(self, ctx: RunContext[AgentDepsT]) -> ToolManager[AgentDepsT]:
+    async def for_run_step(
+        self, ctx: RunContext[AgentDepsT]
+    ) -> ToolManager[AgentDepsT]:
         """Build a new tool manager for the next run step, carrying over the retries from the current run step."""
         if self.ctx is not None:
             if ctx.run_step == self.ctx.run_step:
@@ -115,11 +125,15 @@ class ToolManager(Generic[AgentDepsT]):
     def tool_defs(self) -> list[ToolDefinition]:
         """The tool definitions for the tools in this tool manager."""
         if self.tools is None:
-            raise ValueError('ToolManager has not been prepared for a run step yet')  # pragma: no cover
+            raise ValueError(
+                "ToolManager has not been prepared for a run step yet"
+            )  # pragma: no cover
 
         return [tool.tool_def for tool in self.tools.values()]
 
-    def get_parallel_execution_mode(self, calls: list[ToolCallPart]) -> ParallelExecutionMode:
+    def get_parallel_execution_mode(
+        self, calls: list[ToolCallPart]
+    ) -> ParallelExecutionMode:
         """Get the effective parallel execution mode for a list of tool calls.
 
         This takes into account both the context variable and whether any tool
@@ -127,8 +141,12 @@ class ToolManager(Generic[AgentDepsT]):
         returns `'sequential'` regardless of the context variable.
         """
         # Check if any tool requires sequential execution
-        if any(tool_def.sequential for call in calls if (tool_def := self.get_tool_def(call.tool_name))):
-            return 'sequential'
+        if any(
+            tool_def.sequential
+            for call in calls
+            if (tool_def := self.get_tool_def(call.tool_name))
+        ):
+            return "sequential"
 
         mode = _parallel_execution_mode_ctx_var.get()
 
@@ -137,7 +155,9 @@ class ToolManager(Generic[AgentDepsT]):
     def get_tool_def(self, name: str) -> ToolDefinition | None:
         """Get the tool definition for a given tool name, or `None` if the tool is unknown."""
         if self.tools is None:
-            raise ValueError('ToolManager has not been prepared for a run step yet')  # pragma: no cover
+            raise ValueError(
+                "ToolManager has not been prepared for a run step yet"
+            )  # pragma: no cover
 
         try:
             return self.tools[name].tool_def
@@ -148,16 +168,24 @@ class ToolManager(Generic[AgentDepsT]):
         """Raise UnexpectedModelBehavior if the tool has exceeded its max retries."""
         assert self.ctx is not None
         if self.ctx.retries.get(name, 0) == max_retries:
-            raise UnexpectedModelBehavior(f'Tool {name!r} exceeded max retries count of {max_retries}') from error
+            raise UnexpectedModelBehavior(
+                f"Tool {name!r} exceeded max retries count of {max_retries}"
+            ) from error
 
     @staticmethod
-    def _wrap_error_as_retry(name: str, call: ToolCallPart, error: ValidationError | ModelRetry) -> ToolRetryError:
+    def _wrap_error_as_retry(
+        name: str, call: ToolCallPart, error: ValidationError | ModelRetry
+    ) -> ToolRetryError:
         """Convert a ValidationError or ModelRetry to a ToolRetryError with a RetryPromptPart."""
         if isinstance(error, ValidationError):
-            content: list[Any] | str = error.errors(include_url=False, include_context=False)
+            content: list[Any] | str = error.errors(
+                include_url=False, include_context=False
+            )
         else:
             content = error.message
-        m = _messages.RetryPromptPart(tool_name=name, content=content, tool_call_id=call.tool_call_id)
+        m = _messages.RetryPromptPart(
+            tool_name=name, content=content, tool_call_id=call.tool_call_id
+        )
         return ToolRetryError(m)
 
     def _build_tool_context(
@@ -199,15 +227,19 @@ class ToolManager(Generic[AgentDepsT]):
             ValidationError: If argument validation fails.
             ModelRetry: If argument validation fails with a retry request.
         """
-        pyd_allow_partial = 'trailing-strings' if allow_partial else 'off'
+        pyd_allow_partial = "trailing-strings" if allow_partial else "off"
         validator = tool.args_validator
         if isinstance(call.args, str):
             args_dict = validator.validate_json(
-                call.args or '{}', allow_partial=pyd_allow_partial, context=ctx.validation_context
+                call.args or "{}",
+                allow_partial=pyd_allow_partial,
+                context=ctx.validation_context,
             )
         else:
             args_dict = validator.validate_python(
-                call.args or {}, allow_partial=pyd_allow_partial, context=ctx.validation_context
+                call.args or {},
+                allow_partial=pyd_allow_partial,
+                context=ctx.validation_context,
             )
 
         if tool.args_validator_func is not None:
@@ -244,7 +276,9 @@ class ToolManager(Generic[AgentDepsT]):
             ValidatedToolCall with validation results, ready for execution via execute_tool_call().
         """
         if self.tools is None or self.ctx is None:
-            raise ValueError('ToolManager has not been prepared for a run step yet')  # pragma: no cover
+            raise ValueError(
+                "ToolManager has not been prepared for a run step yet"
+            )  # pragma: no cover
 
         name = call.tool_name
         tool = self.tools.get(name)
@@ -255,13 +289,19 @@ class ToolManager(Generic[AgentDepsT]):
                 if self.tools:
                     msg = f'Available tools: {", ".join(f"{n!r}" for n in self.tools)}'
                 else:
-                    msg = 'No tools available.'
-                raise ModelRetry(f'Unknown tool name: {name!r}. {msg}')
+                    msg = "No tools available."
+                raise ModelRetry(f"Unknown tool name: {name!r}. {msg}")
 
             ctx = self._build_tool_context(
-                call, tool, allow_partial=allow_partial, approved=approved, metadata=metadata
+                call,
+                tool,
+                allow_partial=allow_partial,
+                approved=approved,
+                metadata=metadata,
             )
-            validated_args = await self._validate_tool_args(call, tool, ctx, allow_partial=allow_partial)
+            validated_args = await self._validate_tool_args(
+                call, tool, ctx, allow_partial=allow_partial
+            )
             return ValidatedToolCall(
                 call=call,
                 tool=tool,
@@ -271,7 +311,9 @@ class ToolManager(Generic[AgentDepsT]):
                 validation_error=None,
             )
         except (ValidationError, ModelRetry) as e:
-            max_retries = tool.max_retries if tool is not None else self.default_max_retries
+            max_retries = (
+                tool.max_retries if tool is not None else self.default_max_retries
+            )
             self._check_max_retries(name, max_retries, e)
 
             if not allow_partial:
@@ -312,9 +354,11 @@ class ToolManager(Generic[AgentDepsT]):
             RuntimeError: If trying to execute an external tool.
         """
         if self.ctx is None:
-            raise ValueError('ToolManager has not been prepared for a run step yet')  # pragma: no cover
+            raise ValueError(
+                "ToolManager has not been prepared for a run step yet"
+            )  # pragma: no cover
 
-        if validated.tool is not None and validated.tool.tool_def.kind == 'output':
+        if validated.tool is not None and validated.tool.tool_def.kind == "output":
             return await self._execute_tool_call_impl(validated)
 
         return await self._execute_function_tool_call(
@@ -344,8 +388,8 @@ class ToolManager(Generic[AgentDepsT]):
         assert validated.tool is not None
         assert validated.validated_args is not None
 
-        if validated.tool.tool_def.kind == 'external':
-            raise RuntimeError('External tools cannot be called')
+        if validated.tool.tool_def.kind == "external":
+            raise RuntimeError("External tools cannot be called")
 
         name = validated.call.tool_name
         try:
@@ -378,34 +422,47 @@ class ToolManager(Generic[AgentDepsT]):
 
         See <https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span>.
         """
-        instrumentation_names = InstrumentationNames.for_version(instrumentation_version)
+        instrumentation_names = InstrumentationNames.for_version(
+            instrumentation_version
+        )
         call = validated.call
 
         span_attributes = {
-            'gen_ai.tool.name': call.tool_name,
+            "gen_ai.tool.name": call.tool_name,
             # NOTE: this means `gen_ai.tool.call.id` will be included even if it was generated by pydantic-ai
-            'gen_ai.tool.call.id': call.tool_call_id,
-            **({instrumentation_names.tool_arguments_attr: call.args_as_json_str()} if include_content else {}),
-            'logfire.msg': f'running tool: {call.tool_name}',
+            "gen_ai.tool.call.id": call.tool_call_id,
+            **(
+                {instrumentation_names.tool_arguments_attr: call.args_as_json_str()}
+                if include_content
+                else {}
+            ),
+            "logfire.msg": f"running tool: {call.tool_name}",
             # add the JSON schema so these attributes are formatted nicely in Logfire
-            'logfire.json_schema': json.dumps(
+            "logfire.json_schema": json.dumps(
                 {
-                    'type': 'object',
-                    'properties': {
+                    "type": "object",
+                    "properties": {
                         **(
                             {
-                                instrumentation_names.tool_arguments_attr: {'type': 'object'},
-                                instrumentation_names.tool_result_attr: {'type': 'object'},
+                                instrumentation_names.tool_arguments_attr: {
+                                    "type": "object"
+                                },
+                                instrumentation_names.tool_result_attr: {
+                                    "type": "object"
+                                },
                             }
                             if include_content
                             else {}
                         ),
-                        'gen_ai.tool.name': {},
-                        'gen_ai.tool.call.id': {},
+                        "gen_ai.tool.name": {},
+                        "gen_ai.tool.call.id": {},
                     },
                 }
             ),
         }
+
+        deferred_exc: CallDeferred | ApprovalRequired | None = None
+        tool_result: Any = None
 
         with tracer.start_as_current_span(
             instrumentation_names.get_tool_span_name(call.tool_name),
@@ -416,16 +473,37 @@ class ToolManager(Generic[AgentDepsT]):
             except ToolRetryError as e:
                 part = e.tool_retry
                 if include_content and span.is_recording():
-                    span.set_attribute(instrumentation_names.tool_result_attr, part.model_response())
+                    span.set_attribute(
+                        instrumentation_names.tool_result_attr, part.model_response()
+                    )
                 raise
+            except CallDeferred as e:
+                # CallDeferred is a control flow mechanism, not an error — record it as a
+                # span attribute so it doesn't appear as a failure in OTel backends.
+                if span.is_recording():
+                    span.set_attribute("pydantic_ai.call_deferred", True)
+                deferred_exc = e
+            except ApprovalRequired as e:
+                # ApprovalRequired is a control flow mechanism, not an error — record it as a
+                # span attribute so it doesn't appear as a failure in OTel backends.
+                if span.is_recording():
+                    span.set_attribute("pydantic_ai.approval_required", True)
+                deferred_exc = e
+            else:
+                if include_content and span.is_recording():
+                    span.set_attribute(
+                        instrumentation_names.tool_result_attr,
+                        (
+                            tool_result
+                            if isinstance(tool_result, str)
+                            else _messages.tool_return_ta.dump_json(
+                                tool_result
+                            ).decode()
+                        ),
+                    )
 
-            if include_content and span.is_recording():
-                span.set_attribute(
-                    instrumentation_names.tool_result_attr,
-                    tool_result
-                    if isinstance(tool_result, str)
-                    else _messages.tool_return_ta.dump_json(tool_result).decode(),
-                )
+        if deferred_exc is not None:
+            raise deferred_exc
 
         return tool_result
 

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -9,14 +9,27 @@ from dirty_equals import IsInt, IsJson, IsList
 from pydantic import BaseModel
 from typing_extensions import NotRequired, Self, TypedDict
 
-from pydantic_ai import Agent, ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart, UserPromptPart
+from pydantic_ai import (
+    Agent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    UserPromptPart,
+)
 from pydantic_ai._utils import get_traceparent
-from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior
+from pydantic_ai.exceptions import (
+    ApprovalRequired,
+    CallDeferred,
+    ModelRetry,
+    UnexpectedModelBehavior,
+)
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings, InstrumentedModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.output import PromptedOutput, TextOutput
-from pydantic_ai.tools import RunContext
+from pydantic_ai.tools import DeferredToolRequests, RunContext
 from pydantic_ai.toolsets.abstract import ToolsetTool
 from pydantic_ai.toolsets.function import FunctionToolset
 from pydantic_ai.toolsets.wrapper import WrapperToolset
@@ -48,21 +61,23 @@ class LogfireSummary:
 
     def __init__(self, capfire: CaptureLogfire):
         spans = capfire.exporter.exported_spans_as_dict()
-        spans.sort(key=lambda s: s['start_time'])
+        spans.sort(key=lambda s: s["start_time"])
         self.traces = []
         span_lookup: dict[tuple[str, str], SpanSummary] = {}
         self.attributes = {}
         id_counter = 0
         for span in spans:
-            tid = span['context']['trace_id'], span['context']['span_id']
+            tid = span["context"]["trace_id"], span["context"]["span_id"]
             span_lookup[tid] = span_summary = SpanSummary(
-                id=id_counter, name=span['name'], message=span['attributes']['logfire.msg']
+                id=id_counter,
+                name=span["name"],
+                message=span["attributes"]["logfire.msg"],
             )
-            self.attributes[id_counter] = span['attributes']
+            self.attributes[id_counter] = span["attributes"]
             id_counter += 1
-            if parent := span['parent']:
-                parent_span = span_lookup[(parent['trace_id'], parent['span_id'])]
-                parent_span.setdefault('children', []).append(span_summary)
+            if parent := span["parent"]:
+                parent_span = span_lookup[(parent["trace_id"], parent["span_id"])]
+                parent_span.setdefault("children", []).append(span_summary)
             else:
                 self.traces.append(span_summary)
 
@@ -75,14 +90,14 @@ def get_logfire_summary(capfire: CaptureLogfire) -> Callable[[], LogfireSummary]
     return get_summary
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
 @pytest.mark.parametrize(
-    'instrument',
+    "instrument",
     [
         True,
         False,
-        InstrumentationSettings(version=1, event_mode='attributes'),
-        InstrumentationSettings(version=1, event_mode='logs'),
+        InstrumentationSettings(version=1, event_mode="attributes"),
+        InstrumentationSettings(version=1, event_mode="logs"),
         InstrumentationSettings(version=2),
         InstrumentationSettings(version=3),
     ],
@@ -94,18 +109,28 @@ def test_logfire(
 ) -> None:
     class InstrumentedToolset(WrapperToolset):
         async def __aenter__(self) -> Self:
-            with logfire.span('toolset_enter'):  # pyright: ignore[reportPossiblyUnboundVariable]
+            with logfire.span(
+                "toolset_enter"
+            ):  # pyright: ignore[reportPossiblyUnboundVariable]
                 await super().__aenter__()
                 return self
 
         async def __aexit__(self, *args: Any) -> bool | None:
-            with logfire.span('toolset_exit'):  # pyright: ignore[reportPossiblyUnboundVariable]
+            with logfire.span(
+                "toolset_exit"
+            ):  # pyright: ignore[reportPossiblyUnboundVariable]
                 return await super().__aexit__(*args)
 
         async def call_tool(
-            self, name: str, tool_args: dict[str, Any], ctx: RunContext[Any], tool: ToolsetTool[Any]
+            self,
+            name: str,
+            tool_args: dict[str, Any],
+            ctx: RunContext[Any],
+            tool: ToolsetTool[Any],
         ) -> Any:
-            with logfire.span('toolset_call_tool {name}', name=name):  # pyright: ignore[reportPossiblyUnboundVariable]
+            with logfire.span(
+                "toolset_call_tool {name}", name=name
+            ):  # pyright: ignore[reportPossiblyUnboundVariable]
                 return await super().call_tool(name, tool_args, ctx, tool)
 
     toolset = FunctionToolset()
@@ -121,10 +146,10 @@ def test_logfire(
         model=TestModel(),
         toolsets=[toolset],
         instrument=instrument,
-        metadata={'env': 'test'},
+        metadata={"env": "test"},
     )
 
-    result = my_agent.run_sync('Hello')
+    result = my_agent.run_sync("Hello")
     assert result.output == snapshot('{"my_ret":"1"}')
 
     summary = get_logfire_summary()
@@ -136,22 +161,26 @@ def test_logfire(
         assert summary.traces == snapshot(
             [
                 {
-                    'id': 0,
-                    'name': 'invoke_agent my_agent',
-                    'message': 'my_agent run',
-                    'children': [
-                        {'id': 1, 'name': 'toolset_enter', 'message': 'toolset_enter'},
-                        {'id': 2, 'name': 'chat test', 'message': 'chat test'},
+                    "id": 0,
+                    "name": "invoke_agent my_agent",
+                    "message": "my_agent run",
+                    "children": [
+                        {"id": 1, "name": "toolset_enter", "message": "toolset_enter"},
+                        {"id": 2, "name": "chat test", "message": "chat test"},
                         {
-                            'id': 3,
-                            'name': 'execute_tool my_ret',
-                            'message': 'running tool: my_ret',
-                            'children': [
-                                {'id': 4, 'name': 'toolset_call_tool {name}', 'message': 'toolset_call_tool my_ret'}
+                            "id": 3,
+                            "name": "execute_tool my_ret",
+                            "message": "running tool: my_ret",
+                            "children": [
+                                {
+                                    "id": 4,
+                                    "name": "toolset_call_tool {name}",
+                                    "message": "toolset_call_tool my_ret",
+                                }
                             ],
                         },
-                        {'id': 5, 'name': 'chat test', 'message': 'chat test'},
-                        {'id': 6, 'name': 'toolset_exit', 'message': 'toolset_exit'},
+                        {"id": 5, "name": "chat test", "message": "chat test"},
+                        {"id": 6, "name": "toolset_exit", "message": "toolset_exit"},
                     ],
                 }
             ]
@@ -160,49 +189,71 @@ def test_logfire(
         assert summary.traces == snapshot(
             [
                 {
-                    'id': 0,
-                    'name': 'agent run',
-                    'message': 'my_agent run',
-                    'children': [
-                        {'id': 1, 'name': 'toolset_enter', 'message': 'toolset_enter'},
-                        {'id': 2, 'name': 'chat test', 'message': 'chat test'},
+                    "id": 0,
+                    "name": "agent run",
+                    "message": "my_agent run",
+                    "children": [
+                        {"id": 1, "name": "toolset_enter", "message": "toolset_enter"},
+                        {"id": 2, "name": "chat test", "message": "chat test"},
                         {
-                            'id': 3,
-                            'name': 'running tool',
-                            'message': 'running tool: my_ret',
-                            'children': [
-                                {'id': 4, 'name': 'toolset_call_tool {name}', 'message': 'toolset_call_tool my_ret'}
+                            "id": 3,
+                            "name": "running tool",
+                            "message": "running tool: my_ret",
+                            "children": [
+                                {
+                                    "id": 4,
+                                    "name": "toolset_call_tool {name}",
+                                    "message": "toolset_call_tool my_ret",
+                                }
                             ],
                         },
-                        {'id': 5, 'name': 'chat test', 'message': 'chat test'},
-                        {'id': 6, 'name': 'toolset_exit', 'message': 'toolset_exit'},
+                        {"id": 5, "name": "chat test", "message": "chat test"},
+                        {"id": 6, "name": "toolset_exit", "message": "toolset_exit"},
                     ],
                 }
             ]
         )
 
-    if instrument is True or (isinstance(instrument, InstrumentationSettings) and instrument.version in (2, 3)):
-        if instrument is True or isinstance(instrument, InstrumentationSettings) and instrument.version == 2:
+    if instrument is True or (
+        isinstance(instrument, InstrumentationSettings) and instrument.version in (2, 3)
+    ):
+        if (
+            instrument is True
+            or isinstance(instrument, InstrumentationSettings)
+            and instrument.version == 2
+        ):
             # default instrumentation settings
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'agent run',
-                        'message': 'my_agent run',
-                        'children': [
-                            {'id': 1, 'name': 'toolset_enter', 'message': 'toolset_enter'},
-                            {'id': 2, 'name': 'chat test', 'message': 'chat test'},
+                        "id": 0,
+                        "name": "agent run",
+                        "message": "my_agent run",
+                        "children": [
                             {
-                                'id': 3,
-                                'name': 'running tool',
-                                'message': 'running tool: my_ret',
-                                'children': [
-                                    {'id': 4, 'name': 'toolset_call_tool {name}', 'message': 'toolset_call_tool my_ret'}
+                                "id": 1,
+                                "name": "toolset_enter",
+                                "message": "toolset_enter",
+                            },
+                            {"id": 2, "name": "chat test", "message": "chat test"},
+                            {
+                                "id": 3,
+                                "name": "running tool",
+                                "message": "running tool: my_ret",
+                                "children": [
+                                    {
+                                        "id": 4,
+                                        "name": "toolset_call_tool {name}",
+                                        "message": "toolset_call_tool my_ret",
+                                    }
                                 ],
                             },
-                            {'id': 5, 'name': 'chat test', 'message': 'chat test'},
-                            {'id': 6, 'name': 'toolset_exit', 'message': 'toolset_exit'},
+                            {"id": 5, "name": "chat test", "message": "chat test"},
+                            {
+                                "id": 6,
+                                "name": "toolset_exit",
+                                "message": "toolset_exit",
+                            },
                         ],
                     }
                 ]
@@ -211,22 +262,34 @@ def test_logfire(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'invoke_agent my_agent',
-                        'message': 'my_agent run',
-                        'children': [
-                            {'id': 1, 'name': 'toolset_enter', 'message': 'toolset_enter'},
-                            {'id': 2, 'name': 'chat test', 'message': 'chat test'},
+                        "id": 0,
+                        "name": "invoke_agent my_agent",
+                        "message": "my_agent run",
+                        "children": [
                             {
-                                'id': 3,
-                                'name': 'execute_tool my_ret',
-                                'message': 'running tool: my_ret',
-                                'children': [
-                                    {'id': 4, 'name': 'toolset_call_tool {name}', 'message': 'toolset_call_tool my_ret'}
+                                "id": 1,
+                                "name": "toolset_enter",
+                                "message": "toolset_enter",
+                            },
+                            {"id": 2, "name": "chat test", "message": "chat test"},
+                            {
+                                "id": 3,
+                                "name": "execute_tool my_ret",
+                                "message": "running tool: my_ret",
+                                "children": [
+                                    {
+                                        "id": 4,
+                                        "name": "toolset_call_tool {name}",
+                                        "message": "toolset_call_tool my_ret",
+                                    }
                                 ],
                             },
-                            {'id': 5, 'name': 'chat test', 'message': 'chat test'},
-                            {'id': 6, 'name': 'toolset_exit', 'message': 'toolset_exit'},
+                            {"id": 5, "name": "chat test", "message": "chat test"},
+                            {
+                                "id": 6,
+                                "name": "toolset_exit",
+                                "message": "toolset_exit",
+                            },
                         ],
                     }
                 ]
@@ -234,53 +297,61 @@ def test_logfire(
 
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'final_result': '{"my_ret":"1"}',
-                'gen_ai.usage.input_tokens': 103,
-                'gen_ai.usage.output_tokens': 12,
-                'pydantic_ai.all_messages': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "final_result": '{"my_ret":"1"}',
+                "gen_ai.usage.input_tokens": 103,
+                "gen_ai.usage.output_tokens": 12,
+                "pydantic_ai.all_messages": IsJson(
                     snapshot(
                         [
-                            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]},
                             {
-                                'role': 'assistant',
-                                'parts': [
+                                "role": "user",
+                                "parts": [{"type": "text", "content": "Hello"}],
+                            },
+                            {
+                                "role": "assistant",
+                                "parts": [
                                     {
-                                        'type': 'tool_call',
-                                        'id': IsStr(),
-                                        'name': 'my_ret',
-                                        'arguments': {'x': 0},
+                                        "type": "tool_call",
+                                        "id": IsStr(),
+                                        "name": "my_ret",
+                                        "arguments": {"x": 0},
                                     }
                                 ],
                             },
                             {
-                                'role': 'user',
-                                'parts': [
+                                "role": "user",
+                                "parts": [
                                     {
-                                        'type': 'tool_call_response',
-                                        'id': IsStr(),
-                                        'name': 'my_ret',
-                                        'result': '1',
+                                        "type": "tool_call_response",
+                                        "id": IsStr(),
+                                        "name": "my_ret",
+                                        "result": "1",
                                     }
                                 ],
                             },
-                            {'role': 'assistant', 'parts': [{'type': 'text', 'content': '{"my_ret":"1"}'}]},
+                            {
+                                "role": "assistant",
+                                "parts": [
+                                    {"type": "text", "content": '{"my_ret":"1"}'}
+                                ],
+                            },
                         ]
                     )
                 ),
-                'metadata': '{"env": "test"}',
-                'logfire.json_schema': IsJson(
+                "metadata": '{"env": "test"}',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'pydantic_ai.all_messages': {'type': 'array'},
-                                'metadata': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "pydantic_ai.all_messages": {"type": "array"},
+                                "metadata": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -290,64 +361,64 @@ def test_logfire(
     else:
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'gen_ai.usage.input_tokens': 103,
-                'gen_ai.usage.output_tokens': 12,
-                'all_messages_events': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "gen_ai.usage.input_tokens": 103,
+                "gen_ai.usage.output_tokens": 12,
+                "all_messages_events": IsJson(
                     snapshot(
                         [
                             {
-                                'content': 'Hello',
-                                'role': 'user',
-                                'gen_ai.message.index': 0,
-                                'event.name': 'gen_ai.user.message',
+                                "content": "Hello",
+                                "role": "user",
+                                "gen_ai.message.index": 0,
+                                "event.name": "gen_ai.user.message",
                             },
                             {
-                                'role': 'assistant',
-                                'tool_calls': [
+                                "role": "assistant",
+                                "tool_calls": [
                                     {
-                                        'id': IsStr(),
-                                        'type': 'function',
-                                        'function': {
-                                            'name': 'my_ret',
-                                            'arguments': {'x': 0},
+                                        "id": IsStr(),
+                                        "type": "function",
+                                        "function": {
+                                            "name": "my_ret",
+                                            "arguments": {"x": 0},
                                         },
                                     }
                                 ],
-                                'gen_ai.message.index': 1,
-                                'event.name': 'gen_ai.assistant.message',
+                                "gen_ai.message.index": 1,
+                                "event.name": "gen_ai.assistant.message",
                             },
                             {
-                                'content': '1',
-                                'role': 'tool',
-                                'id': IsStr(),
-                                'name': 'my_ret',
-                                'gen_ai.message.index': 2,
-                                'event.name': 'gen_ai.tool.message',
+                                "content": "1",
+                                "role": "tool",
+                                "id": IsStr(),
+                                "name": "my_ret",
+                                "gen_ai.message.index": 2,
+                                "event.name": "gen_ai.tool.message",
                             },
                             {
-                                'role': 'assistant',
-                                'content': '{"my_ret":"1"}',
-                                'gen_ai.message.index': 3,
-                                'event.name': 'gen_ai.assistant.message',
+                                "role": "assistant",
+                                "content": '{"my_ret":"1"}',
+                                "gen_ai.message.index": 3,
+                                "event.name": "gen_ai.assistant.message",
                             },
                         ]
                     )
                 ),
-                'final_result': '{"my_ret":"1"}',
-                'metadata': '{"env": "test"}',
-                'logfire.json_schema': IsJson(
+                "final_result": '{"my_ret":"1"}',
+                "metadata": '{"env": "test"}',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'all_messages_events': {'type': 'array'},
-                                'metadata': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "all_messages_events": {"type": "array"},
+                                "metadata": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -355,70 +426,72 @@ def test_logfire(
             }
         )
     chat_span_attributes = next(
-        attrs for attrs in summary.attributes.values() if attrs.get('gen_ai.operation.name', None) == 'chat'
+        attrs
+        for attrs in summary.attributes.values()
+        if attrs.get("gen_ai.operation.name", None) == "chat"
     )
-    if instrument is True or instrument.event_mode == 'attributes':
-        if hasattr(capfire, 'get_collected_metrics'):  # pragma: no branch
+    if instrument is True or instrument.event_mode == "attributes":
+        if hasattr(capfire, "get_collected_metrics"):  # pragma: no branch
             assert capfire.get_collected_metrics() == snapshot(
                 [
                     {
-                        'name': 'gen_ai.client.token.usage',
-                        'description': 'Measures number of input and output tokens used',
-                        'unit': '{token}',
-                        'data': {
-                            'data_points': [
+                        "name": "gen_ai.client.token.usage",
+                        "description": "Measures number of input and output tokens used",
+                        "unit": "{token}",
+                        "data": {
+                            "data_points": [
                                 {
-                                    'attributes': {
-                                        'gen_ai.provider.name': 'test',
-                                        'gen_ai.system': 'test',
-                                        'gen_ai.operation.name': 'chat',
-                                        'gen_ai.request.model': 'test',
-                                        'gen_ai.response.model': 'test',
-                                        'gen_ai.token.type': 'input',
+                                    "attributes": {
+                                        "gen_ai.provider.name": "test",
+                                        "gen_ai.system": "test",
+                                        "gen_ai.operation.name": "chat",
+                                        "gen_ai.request.model": "test",
+                                        "gen_ai.response.model": "test",
+                                        "gen_ai.token.type": "input",
                                     },
-                                    'start_time_unix_nano': IsInt(),
-                                    'time_unix_nano': IsInt(),
-                                    'count': 2,
-                                    'sum': 103,
-                                    'scale': 12,
-                                    'zero_count': 0,
-                                    'positive': {
-                                        'offset': 23234,
-                                        'bucket_counts': IsList(length=...),
+                                    "start_time_unix_nano": IsInt(),
+                                    "time_unix_nano": IsInt(),
+                                    "count": 2,
+                                    "sum": 103,
+                                    "scale": 12,
+                                    "zero_count": 0,
+                                    "positive": {
+                                        "offset": 23234,
+                                        "bucket_counts": IsList(length=...),
                                     },
-                                    'negative': {'offset': 0, 'bucket_counts': [0]},
-                                    'flags': 0,
-                                    'min': 51,
-                                    'max': 52,
-                                    'exemplars': IsList(length=...),
+                                    "negative": {"offset": 0, "bucket_counts": [0]},
+                                    "flags": 0,
+                                    "min": 51,
+                                    "max": 52,
+                                    "exemplars": IsList(length=...),
                                 },
                                 {
-                                    'attributes': {
-                                        'gen_ai.provider.name': 'test',
-                                        'gen_ai.system': 'test',
-                                        'gen_ai.operation.name': 'chat',
-                                        'gen_ai.request.model': 'test',
-                                        'gen_ai.response.model': 'test',
-                                        'gen_ai.token.type': 'output',
+                                    "attributes": {
+                                        "gen_ai.provider.name": "test",
+                                        "gen_ai.system": "test",
+                                        "gen_ai.operation.name": "chat",
+                                        "gen_ai.request.model": "test",
+                                        "gen_ai.response.model": "test",
+                                        "gen_ai.token.type": "output",
                                     },
-                                    'start_time_unix_nano': IsInt(),
-                                    'time_unix_nano': IsInt(),
-                                    'count': 2,
-                                    'sum': 12,
-                                    'scale': 7,
-                                    'zero_count': 0,
-                                    'positive': {
-                                        'offset': 255,
-                                        'bucket_counts': IsList(length=...),
+                                    "start_time_unix_nano": IsInt(),
+                                    "time_unix_nano": IsInt(),
+                                    "count": 2,
+                                    "sum": 12,
+                                    "scale": 7,
+                                    "zero_count": 0,
+                                    "positive": {
+                                        "offset": 255,
+                                        "bucket_counts": IsList(length=...),
                                     },
-                                    'negative': {'offset': 0, 'bucket_counts': [0]},
-                                    'flags': 0,
-                                    'min': 4,
-                                    'max': 8,
-                                    'exemplars': IsList(length=...),
+                                    "negative": {"offset": 0, "bucket_counts": [0]},
+                                    "flags": 0,
+                                    "min": 4,
+                                    "max": 8,
+                                    "exemplars": IsList(length=...),
                                 },
                             ],
-                            'aggregation_temporality': 1,
+                            "aggregation_temporality": 1,
                         },
                     }
                 ]
@@ -426,36 +499,39 @@ def test_logfire(
 
         messages_attributes = {
             k: chat_span_attributes.pop(k)
-            for k in ['events', 'gen_ai.input.messages', 'gen_ai.output.messages']
+            for k in ["events", "gen_ai.input.messages", "gen_ai.output.messages"]
             if k in chat_span_attributes
         }
-        if 'events' in messages_attributes:
+        if "events" in messages_attributes:
             assert messages_attributes == snapshot(
                 {
-                    'events': IsJson(
+                    "events": IsJson(
                         snapshot(
                             [
                                 {
-                                    'event.name': 'gen_ai.user.message',
-                                    'content': 'Hello',
-                                    'role': 'user',
-                                    'gen_ai.message.index': 0,
-                                    'gen_ai.system': 'test',
+                                    "event.name": "gen_ai.user.message",
+                                    "content": "Hello",
+                                    "role": "user",
+                                    "gen_ai.message.index": 0,
+                                    "gen_ai.system": "test",
                                 },
                                 {
-                                    'event.name': 'gen_ai.choice',
-                                    'index': 0,
-                                    'message': {
-                                        'role': 'assistant',
-                                        'tool_calls': [
+                                    "event.name": "gen_ai.choice",
+                                    "index": 0,
+                                    "message": {
+                                        "role": "assistant",
+                                        "tool_calls": [
                                             {
-                                                'id': IsStr(),
-                                                'type': 'function',
-                                                'function': {'name': 'my_ret', 'arguments': {'x': 0}},
+                                                "id": IsStr(),
+                                                "type": "function",
+                                                "function": {
+                                                    "name": "my_ret",
+                                                    "arguments": {"x": 0},
+                                                },
                                             }
                                         ],
                                     },
-                                    'gen_ai.system': 'test',
+                                    "gen_ai.system": "test",
                                 },
                             ]
                         )
@@ -465,20 +541,27 @@ def test_logfire(
         else:
             assert messages_attributes == snapshot(
                 {
-                    'gen_ai.input.messages': IsJson(
-                        snapshot([{'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]}])
-                    ),
-                    'gen_ai.output.messages': IsJson(
+                    "gen_ai.input.messages": IsJson(
                         snapshot(
                             [
                                 {
-                                    'role': 'assistant',
-                                    'parts': [
+                                    "role": "user",
+                                    "parts": [{"type": "text", "content": "Hello"}],
+                                }
+                            ]
+                        )
+                    ),
+                    "gen_ai.output.messages": IsJson(
+                        snapshot(
+                            [
+                                {
+                                    "role": "assistant",
+                                    "parts": [
                                         {
-                                            'type': 'tool_call',
-                                            'id': IsStr(),
-                                            'name': 'my_ret',
-                                            'arguments': {'x': 0},
+                                            "type": "tool_call",
+                                            "id": IsStr(),
+                                            "name": "my_ret",
+                                            "arguments": {"x": 0},
                                         }
                                     ],
                                 }
@@ -490,62 +573,66 @@ def test_logfire(
 
     assert chat_span_attributes == snapshot(
         {
-            'gen_ai.operation.name': 'chat',
-            'gen_ai.provider.name': 'test',
-            'gen_ai.system': 'test',
-            'gen_ai.request.model': 'test',
-            'model_request_parameters': IsJson(
+            "gen_ai.operation.name": "chat",
+            "gen_ai.provider.name": "test",
+            "gen_ai.system": "test",
+            "gen_ai.request.model": "test",
+            "model_request_parameters": IsJson(
                 snapshot(
                     {
-                        'function_tools': [
+                        "function_tools": [
                             {
-                                'name': 'my_ret',
-                                'description': None,
-                                'parameters_json_schema': {
-                                    'additionalProperties': False,
-                                    'properties': {'x': {'type': 'integer'}},
-                                    'required': ['x'],
-                                    'type': 'object',
+                                "name": "my_ret",
+                                "description": None,
+                                "parameters_json_schema": {
+                                    "additionalProperties": False,
+                                    "properties": {"x": {"type": "integer"}},
+                                    "required": ["x"],
+                                    "type": "object",
                                 },
-                                'outer_typed_dict_key': None,
-                                'strict': None,
-                                'sequential': False,
-                                'kind': 'function',
-                                'metadata': None,
-                                'timeout': None,
+                                "outer_typed_dict_key": None,
+                                "strict": None,
+                                "sequential": False,
+                                "kind": "function",
+                                "metadata": None,
+                                "timeout": None,
                             }
                         ],
-                        'builtin_tools': [],
-                        'output_mode': 'text',
-                        'output_tools': [],
-                        'output_object': None,
-                        'prompted_output_template': None,
-                        'allow_text_output': True,
-                        'allow_image_output': False,
+                        "builtin_tools": [],
+                        "output_mode": "text",
+                        "output_tools": [],
+                        "output_object": None,
+                        "prompted_output_template": None,
+                        "allow_text_output": True,
+                        "allow_image_output": False,
                     }
                 )
             ),
-            'gen_ai.tool.definitions': '[{"type": "function", "name": "my_ret", "parameters": {"additionalProperties": false, "properties": {"x": {"type": "integer"}}, "required": ["x"], "type": "object"}}]',
-            'logfire.json_schema': IsJson(),
-            'logfire.span_type': 'span',
-            'logfire.msg': 'chat test',
-            'gen_ai.response.model': 'test',
-            'gen_ai.usage.input_tokens': 51,
-            'gen_ai.usage.output_tokens': 4,
+            "gen_ai.tool.definitions": '[{"type": "function", "name": "my_ret", "parameters": {"additionalProperties": false, "properties": {"x": {"type": "integer"}}, "required": ["x"], "type": "object"}}]',
+            "logfire.json_schema": IsJson(),
+            "logfire.span_type": "span",
+            "logfire.msg": "chat test",
+            "gen_ai.response.model": "test",
+            "gen_ai.usage.input_tokens": 51,
+            "gen_ai.usage.output_tokens": 4,
         }
     )
 
 
 def _test_logfire_metadata_values_callable_dict(ctx: RunContext[Any]) -> dict[str, str]:
-    return {'model_name': ctx.model.model_name}
+    return {"model_name": ctx.model.model_name}
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
 @pytest.mark.parametrize(
-    ('metadata', 'expected'),
+    ("metadata", "expected"),
     [
-        pytest.param({'env': 'test'}, '{"env": "test"}', id='dict'),
-        pytest.param(_test_logfire_metadata_values_callable_dict, '{"model_name": "test"}', id='callable-dict'),
+        pytest.param({"env": "test"}, '{"env": "test"}', id="dict"),
+        pytest.param(
+            _test_logfire_metadata_values_callable_dict,
+            '{"model_name": "test"}',
+            id="callable-dict",
+        ),
     ],
 )
 def test_logfire_metadata_values(
@@ -553,97 +640,119 @@ def test_logfire_metadata_values(
     metadata: dict[str, Any] | Callable[[RunContext[Any]], dict[str, Any]],
     expected: dict[str, Any],
 ) -> None:
-    agent = Agent(model=TestModel(), instrument=InstrumentationSettings(version=2), metadata=metadata)
-    agent.run_sync('Hello')
+    agent = Agent(
+        model=TestModel(),
+        instrument=InstrumentationSettings(version=2),
+        metadata=metadata,
+    )
+    agent.run_sync("Hello")
 
     summary = get_logfire_summary()
-    assert summary.attributes[0]['metadata'] == expected
+    assert summary.attributes[0]["metadata"] == expected
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-def test_logfire_metadata_override(get_logfire_summary: Callable[[], LogfireSummary]) -> None:
-    agent = Agent(model=TestModel(), instrument=InstrumentationSettings(version=2), metadata={'env': 'base'})
-    with agent.override(metadata={'env': 'override'}):
-        agent.run_sync('Hello')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+def test_logfire_metadata_override(
+    get_logfire_summary: Callable[[], LogfireSummary],
+) -> None:
+    agent = Agent(
+        model=TestModel(),
+        instrument=InstrumentationSettings(version=2),
+        metadata={"env": "base"},
+    )
+    with agent.override(metadata={"env": "override"}):
+        agent.run_sync("Hello")
 
     summary = get_logfire_summary()
-    assert summary.attributes[0]['metadata'] == '{"env": "override"}'
+    assert summary.attributes[0]["metadata"] == '{"env": "override"}'
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
 @pytest.mark.parametrize(
-    'instrument',
-    [InstrumentationSettings(version=1), InstrumentationSettings(version=2), InstrumentationSettings(version=3)],
+    "instrument",
+    [
+        InstrumentationSettings(version=1),
+        InstrumentationSettings(version=2),
+        InstrumentationSettings(version=3),
+    ],
 )
 def test_instructions_with_structured_output(
-    get_logfire_summary: Callable[[], LogfireSummary], instrument: InstrumentationSettings
+    get_logfire_summary: Callable[[], LogfireSummary],
+    instrument: InstrumentationSettings,
 ) -> None:
     @dataclass
     class MyOutput:
         content: str
 
-    my_agent = Agent(model=TestModel(), instructions='Here are some instructions', instrument=instrument)
+    my_agent = Agent(
+        model=TestModel(),
+        instructions="Here are some instructions",
+        instrument=instrument,
+    )
 
-    result = my_agent.run_sync('Hello', output_type=MyOutput)
-    assert result.output == MyOutput(content='a')
+    result = my_agent.run_sync("Hello", output_type=MyOutput)
+    assert result.output == MyOutput(content="a")
 
     summary = get_logfire_summary()
     chat_span_attributes = summary.attributes[1]
     if instrument.version == 1:
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'gen_ai.usage.input_tokens': 51,
-                'gen_ai.usage.output_tokens': 5,
-                'all_messages_events': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "gen_ai.usage.input_tokens": 51,
+                "gen_ai.usage.output_tokens": 5,
+                "all_messages_events": IsJson(
                     snapshot(
                         [
                             {
-                                'content': 'Here are some instructions',
-                                'role': 'system',
-                                'event.name': 'gen_ai.system.message',
+                                "content": "Here are some instructions",
+                                "role": "system",
+                                "event.name": "gen_ai.system.message",
                             },
                             {
-                                'content': 'Hello',
-                                'role': 'user',
-                                'gen_ai.message.index': 0,
-                                'event.name': 'gen_ai.user.message',
+                                "content": "Hello",
+                                "role": "user",
+                                "gen_ai.message.index": 0,
+                                "event.name": "gen_ai.user.message",
                             },
                             {
-                                'role': 'assistant',
-                                'tool_calls': [
+                                "role": "assistant",
+                                "tool_calls": [
                                     {
-                                        'id': IsStr(),
-                                        'type': 'function',
-                                        'function': {'name': 'final_result', 'arguments': {'content': 'a'}},
+                                        "id": IsStr(),
+                                        "type": "function",
+                                        "function": {
+                                            "name": "final_result",
+                                            "arguments": {"content": "a"},
+                                        },
                                     }
                                 ],
-                                'gen_ai.message.index': 1,
-                                'event.name': 'gen_ai.assistant.message',
+                                "gen_ai.message.index": 1,
+                                "event.name": "gen_ai.assistant.message",
                             },
                             {
-                                'content': 'Final result processed.',
-                                'role': 'tool',
-                                'id': IsStr(),
-                                'name': 'final_result',
-                                'gen_ai.message.index': 2,
-                                'event.name': 'gen_ai.tool.message',
+                                "content": "Final result processed.",
+                                "role": "tool",
+                                "id": IsStr(),
+                                "name": "final_result",
+                                "gen_ai.message.index": 2,
+                                "event.name": "gen_ai.tool.message",
                             },
                         ]
                     )
                 ),
-                'final_result': '{"content": "a"}',
-                'logfire.json_schema': IsJson(
+                "final_result": '{"content": "a"}',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'all_messages_events': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "all_messages_events": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -651,36 +760,39 @@ def test_instructions_with_structured_output(
             }
         )
 
-        assert chat_span_attributes['events'] == IsJson(
+        assert chat_span_attributes["events"] == IsJson(
             snapshot(
                 [
                     {
-                        'content': 'Here are some instructions',
-                        'role': 'system',
-                        'gen_ai.system': 'test',
-                        'event.name': 'gen_ai.system.message',
+                        "content": "Here are some instructions",
+                        "role": "system",
+                        "gen_ai.system": "test",
+                        "event.name": "gen_ai.system.message",
                     },
                     {
-                        'event.name': 'gen_ai.user.message',
-                        'content': 'Hello',
-                        'role': 'user',
-                        'gen_ai.message.index': 0,
-                        'gen_ai.system': 'test',
+                        "event.name": "gen_ai.user.message",
+                        "content": "Hello",
+                        "role": "user",
+                        "gen_ai.message.index": 0,
+                        "gen_ai.system": "test",
                     },
                     {
-                        'event.name': 'gen_ai.choice',
-                        'index': 0,
-                        'message': {
-                            'role': 'assistant',
-                            'tool_calls': [
+                        "event.name": "gen_ai.choice",
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "tool_calls": [
                                 {
-                                    'id': IsStr(),
-                                    'type': 'function',
-                                    'function': {'name': 'final_result', 'arguments': {'content': 'a'}},
+                                    "id": IsStr(),
+                                    "type": "function",
+                                    "function": {
+                                        "name": "final_result",
+                                        "arguments": {"content": "a"},
+                                    },
                                 }
                             ],
                         },
-                        'gen_ai.system': 'test',
+                        "gen_ai.system": "test",
                     },
                 ]
             )
@@ -690,10 +802,12 @@ def test_instructions_with_structured_output(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'agent run',
-                        'message': 'my_agent run',
-                        'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+                        "id": 0,
+                        "name": "agent run",
+                        "message": "my_agent run",
+                        "children": [
+                            {"id": 1, "name": "chat test", "message": "chat test"}
+                        ],
                     }
                 ]
             )
@@ -701,62 +815,67 @@ def test_instructions_with_structured_output(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'invoke_agent my_agent',
-                        'message': 'my_agent run',
-                        'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+                        "id": 0,
+                        "name": "invoke_agent my_agent",
+                        "message": "my_agent run",
+                        "children": [
+                            {"id": 1, "name": "chat test", "message": "chat test"}
+                        ],
                     }
                 ]
             )
 
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'final_result': '{"content": "a"}',
-                'gen_ai.usage.input_tokens': 51,
-                'gen_ai.usage.output_tokens': 5,
-                'pydantic_ai.all_messages': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "final_result": '{"content": "a"}',
+                "gen_ai.usage.input_tokens": 51,
+                "gen_ai.usage.output_tokens": 5,
+                "pydantic_ai.all_messages": IsJson(
                     snapshot(
                         [
-                            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]},
                             {
-                                'role': 'assistant',
-                                'parts': [
+                                "role": "user",
+                                "parts": [{"type": "text", "content": "Hello"}],
+                            },
+                            {
+                                "role": "assistant",
+                                "parts": [
                                     {
-                                        'type': 'tool_call',
-                                        'id': IsStr(),
-                                        'name': 'final_result',
-                                        'arguments': {'content': 'a'},
+                                        "type": "tool_call",
+                                        "id": IsStr(),
+                                        "name": "final_result",
+                                        "arguments": {"content": "a"},
                                     }
                                 ],
                             },
                             {
-                                'role': 'user',
-                                'parts': [
+                                "role": "user",
+                                "parts": [
                                     {
-                                        'type': 'tool_call_response',
-                                        'id': IsStr(),
-                                        'name': 'final_result',
-                                        'result': 'Final result processed.',
+                                        "type": "tool_call_response",
+                                        "id": IsStr(),
+                                        "name": "final_result",
+                                        "result": "Final result processed.",
                                     }
                                 ],
                             },
                         ]
                     )
                 ),
-                'gen_ai.system_instructions': '[{"type": "text", "content": "Here are some instructions"}]',
-                'logfire.json_schema': IsJson(
+                "gen_ai.system_instructions": '[{"type": "text", "content": "Here are some instructions"}]',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'pydantic_ai.all_messages': {'type': 'array'},
-                                'gen_ai.system_instructions': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "pydantic_ai.all_messages": {"type": "array"},
+                                "gen_ai.system_instructions": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -764,20 +883,22 @@ def test_instructions_with_structured_output(
             }
         )
 
-        assert chat_span_attributes['gen_ai.input.messages'] == IsJson(
-            snapshot([{'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]}])
+        assert chat_span_attributes["gen_ai.input.messages"] == IsJson(
+            snapshot(
+                [{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]
+            )
         )
-        assert chat_span_attributes['gen_ai.output.messages'] == IsJson(
+        assert chat_span_attributes["gen_ai.output.messages"] == IsJson(
             snapshot(
                 [
                     {
-                        'role': 'assistant',
-                        'parts': [
+                        "role": "assistant",
+                        "parts": [
                             {
-                                'type': 'tool_call',
-                                'id': IsStr(),
-                                'name': 'final_result',
-                                'arguments': {'content': 'a'},
+                                "type": "tool_call",
+                                "id": IsStr(),
+                                "name": "final_result",
+                                "arguments": {"content": "a"},
                             }
                         ],
                     }
@@ -786,63 +907,69 @@ def test_instructions_with_structured_output(
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-def test_instructions_with_structured_output_exclude_content(get_logfire_summary: Callable[[], LogfireSummary]) -> None:
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+def test_instructions_with_structured_output_exclude_content(
+    get_logfire_summary: Callable[[], LogfireSummary],
+) -> None:
     @dataclass
     class MyOutput:
         content: str
 
     settings: InstrumentationSettings = InstrumentationSettings(include_content=False)
 
-    my_agent = Agent(model=TestModel(), instructions='Here are some instructions', instrument=settings)
+    my_agent = Agent(
+        model=TestModel(),
+        instructions="Here are some instructions",
+        instrument=settings,
+    )
 
-    result = my_agent.run_sync('Hello', output_type=MyOutput)
-    assert result.output == snapshot(MyOutput(content='a'))
+    result = my_agent.run_sync("Hello", output_type=MyOutput)
+    assert result.output == snapshot(MyOutput(content="a"))
 
     summary = get_logfire_summary()
     assert summary.attributes[0] == snapshot(
         {
-            'model_name': 'test',
-            'agent_name': 'my_agent',
-            'gen_ai.agent.name': 'my_agent',
-            'logfire.msg': 'my_agent run',
-            'logfire.span_type': 'span',
-            'gen_ai.usage.input_tokens': 51,
-            'gen_ai.usage.output_tokens': 5,
-            'pydantic_ai.all_messages': IsJson(
+            "model_name": "test",
+            "agent_name": "my_agent",
+            "gen_ai.agent.name": "my_agent",
+            "logfire.msg": "my_agent run",
+            "logfire.span_type": "span",
+            "gen_ai.usage.input_tokens": 51,
+            "gen_ai.usage.output_tokens": 5,
+            "pydantic_ai.all_messages": IsJson(
                 snapshot(
                     [
-                        {'role': 'user', 'parts': [{'type': 'text'}]},
+                        {"role": "user", "parts": [{"type": "text"}]},
                         {
-                            'role': 'assistant',
-                            'parts': [
+                            "role": "assistant",
+                            "parts": [
                                 {
-                                    'type': 'tool_call',
-                                    'id': IsStr(),
-                                    'name': 'final_result',
+                                    "type": "tool_call",
+                                    "id": IsStr(),
+                                    "name": "final_result",
                                 }
                             ],
                         },
                         {
-                            'role': 'user',
-                            'parts': [
+                            "role": "user",
+                            "parts": [
                                 {
-                                    'type': 'tool_call_response',
-                                    'id': IsStr(),
-                                    'name': 'final_result',
+                                    "type": "tool_call_response",
+                                    "id": IsStr(),
+                                    "name": "final_result",
                                 }
                             ],
                         },
                     ]
                 )
             ),
-            'logfire.json_schema': IsJson(
+            "logfire.json_schema": IsJson(
                 snapshot(
                     {
-                        'type': 'object',
-                        'properties': {
-                            'pydantic_ai.all_messages': {'type': 'array'},
-                            'final_result': {'type': 'object'},
+                        "type": "object",
+                        "properties": {
+                            "pydantic_ai.all_messages": {"type": "array"},
+                            "final_result": {"type": "object"},
                         },
                     }
                 )
@@ -850,23 +977,23 @@ def test_instructions_with_structured_output_exclude_content(get_logfire_summary
         }
     )
     chat_span_attributes = summary.attributes[1]
-    assert chat_span_attributes['gen_ai.input.messages'] == IsJson(
+    assert chat_span_attributes["gen_ai.input.messages"] == IsJson(
         snapshot(
             [
-                {'role': 'user', 'parts': [{'type': 'text'}]},
+                {"role": "user", "parts": [{"type": "text"}]},
             ]
         )
     )
-    assert chat_span_attributes['gen_ai.output.messages'] == IsJson(
+    assert chat_span_attributes["gen_ai.output.messages"] == IsJson(
         snapshot(
             [
                 {
-                    'role': 'assistant',
-                    'parts': [
+                    "role": "assistant",
+                    "parts": [
                         {
-                            'type': 'tool_call',
-                            'id': IsStr(),
-                            'name': 'final_result',
+                            "type": "tool_call",
+                            "id": IsStr(),
+                            "name": "final_result",
                         }
                     ],
                 }
@@ -875,8 +1002,8 @@ def test_instructions_with_structured_output_exclude_content(get_logfire_summary
     )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('version', [2, 3])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("version", [2, 3])
 def test_instructions_with_structured_output_exclude_content_v2_v3(
     get_logfire_summary: Callable[[], LogfireSummary],
     version: Literal[2, 3],
@@ -885,12 +1012,18 @@ def test_instructions_with_structured_output_exclude_content_v2_v3(
     class MyOutput:
         content: str
 
-    settings: InstrumentationSettings = InstrumentationSettings(include_content=False, version=version)
+    settings: InstrumentationSettings = InstrumentationSettings(
+        include_content=False, version=version
+    )
 
-    my_agent = Agent(model=TestModel(), instructions='Here are some instructions', instrument=settings)
+    my_agent = Agent(
+        model=TestModel(),
+        instructions="Here are some instructions",
+        instrument=settings,
+    )
 
-    result = my_agent.run_sync('Hello', output_type=MyOutput)
-    assert result.output == MyOutput(content='a')
+    result = my_agent.run_sync("Hello", output_type=MyOutput)
+    assert result.output == MyOutput(content="a")
 
     summary = get_logfire_summary()
 
@@ -898,10 +1031,12 @@ def test_instructions_with_structured_output_exclude_content_v2_v3(
         assert summary.traces == snapshot(
             [
                 {
-                    'id': 0,
-                    'name': 'agent run',
-                    'message': 'my_agent run',
-                    'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+                    "id": 0,
+                    "name": "agent run",
+                    "message": "my_agent run",
+                    "children": [
+                        {"id": 1, "name": "chat test", "message": "chat test"}
+                    ],
                 }
             ]
         )
@@ -909,10 +1044,12 @@ def test_instructions_with_structured_output_exclude_content_v2_v3(
         assert summary.traces == snapshot(
             [
                 {
-                    'id': 0,
-                    'name': 'invoke_agent my_agent',
-                    'message': 'my_agent run',
-                    'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+                    "id": 0,
+                    "name": "invoke_agent my_agent",
+                    "message": "my_agent run",
+                    "children": [
+                        {"id": 1, "name": "chat test", "message": "chat test"}
+                    ],
                 }
             ]
         )
@@ -920,47 +1057,47 @@ def test_instructions_with_structured_output_exclude_content_v2_v3(
     # Version 2 and 3 have identical snapshots for this test case
     assert summary.attributes[0] == snapshot(
         {
-            'model_name': 'test',
-            'agent_name': 'my_agent',
-            'gen_ai.agent.name': 'my_agent',
-            'logfire.msg': 'my_agent run',
-            'logfire.span_type': 'span',
-            'gen_ai.usage.input_tokens': 51,
-            'gen_ai.usage.output_tokens': 5,
-            'pydantic_ai.all_messages': IsJson(
+            "model_name": "test",
+            "agent_name": "my_agent",
+            "gen_ai.agent.name": "my_agent",
+            "logfire.msg": "my_agent run",
+            "logfire.span_type": "span",
+            "gen_ai.usage.input_tokens": 51,
+            "gen_ai.usage.output_tokens": 5,
+            "pydantic_ai.all_messages": IsJson(
                 snapshot(
                     [
-                        {'role': 'user', 'parts': [{'type': 'text'}]},
+                        {"role": "user", "parts": [{"type": "text"}]},
                         {
-                            'role': 'assistant',
-                            'parts': [
+                            "role": "assistant",
+                            "parts": [
                                 {
-                                    'type': 'tool_call',
-                                    'id': IsStr(),
-                                    'name': 'final_result',
+                                    "type": "tool_call",
+                                    "id": IsStr(),
+                                    "name": "final_result",
                                 }
                             ],
                         },
                         {
-                            'role': 'user',
-                            'parts': [
+                            "role": "user",
+                            "parts": [
                                 {
-                                    'type': 'tool_call_response',
-                                    'id': IsStr(),
-                                    'name': 'final_result',
+                                    "type": "tool_call_response",
+                                    "id": IsStr(),
+                                    "name": "final_result",
                                 }
                             ],
                         },
                     ]
                 )
             ),
-            'logfire.json_schema': IsJson(
+            "logfire.json_schema": IsJson(
                 snapshot(
                     {
-                        'type': 'object',
-                        'properties': {
-                            'pydantic_ai.all_messages': {'type': 'array'},
-                            'final_result': {'type': 'object'},
+                        "type": "object",
+                        "properties": {
+                            "pydantic_ai.all_messages": {"type": "array"},
+                            "final_result": {"type": "object"},
                         },
                     }
                 )
@@ -970,76 +1107,78 @@ def test_instructions_with_structured_output_exclude_content_v2_v3(
     chat_span_attributes = summary.attributes[1]
     assert chat_span_attributes == snapshot(
         {
-            'gen_ai.operation.name': 'chat',
-            'gen_ai.provider.name': 'test',
-            'gen_ai.system': 'test',
-            'gen_ai.request.model': 'test',
-            'model_request_parameters': IsJson(
+            "gen_ai.operation.name": "chat",
+            "gen_ai.provider.name": "test",
+            "gen_ai.system": "test",
+            "gen_ai.request.model": "test",
+            "model_request_parameters": IsJson(
                 snapshot(
                     {
-                        'function_tools': [],
-                        'builtin_tools': [],
-                        'output_mode': 'tool',
-                        'output_object': None,
-                        'output_tools': [
+                        "function_tools": [],
+                        "builtin_tools": [],
+                        "output_mode": "tool",
+                        "output_object": None,
+                        "output_tools": [
                             {
-                                'name': 'final_result',
-                                'parameters_json_schema': {
-                                    'properties': {'content': {'type': 'string'}},
-                                    'required': ['content'],
-                                    'title': 'MyOutput',
-                                    'type': 'object',
+                                "name": "final_result",
+                                "parameters_json_schema": {
+                                    "properties": {"content": {"type": "string"}},
+                                    "required": ["content"],
+                                    "title": "MyOutput",
+                                    "type": "object",
                                 },
-                                'description': 'The final response which ends this conversation',
-                                'outer_typed_dict_key': None,
-                                'strict': None,
-                                'sequential': False,
-                                'kind': 'output',
-                                'metadata': None,
-                                'timeout': None,
+                                "description": "The final response which ends this conversation",
+                                "outer_typed_dict_key": None,
+                                "strict": None,
+                                "sequential": False,
+                                "kind": "output",
+                                "metadata": None,
+                                "timeout": None,
                             }
                         ],
-                        'prompted_output_template': None,
-                        'allow_text_output': False,
-                        'allow_image_output': False,
+                        "prompted_output_template": None,
+                        "allow_text_output": False,
+                        "allow_image_output": False,
                     }
                 )
             ),
-            'gen_ai.tool.definitions': '[{"type": "function", "name": "final_result", "description": "The final response which ends this conversation", "parameters": {"properties": {"content": {"type": "string"}}, "required": ["content"], "title": "MyOutput", "type": "object"}}]',
-            'logfire.span_type': 'span',
-            'logfire.msg': 'chat test',
-            'gen_ai.input.messages': IsJson(snapshot([{'role': 'user', 'parts': [{'type': 'text'}]}])),
-            'gen_ai.output.messages': IsJson(
+            "gen_ai.tool.definitions": '[{"type": "function", "name": "final_result", "description": "The final response which ends this conversation", "parameters": {"properties": {"content": {"type": "string"}}, "required": ["content"], "title": "MyOutput", "type": "object"}}]',
+            "logfire.span_type": "span",
+            "logfire.msg": "chat test",
+            "gen_ai.input.messages": IsJson(
+                snapshot([{"role": "user", "parts": [{"type": "text"}]}])
+            ),
+            "gen_ai.output.messages": IsJson(
                 snapshot(
                     [
                         {
-                            'role': 'assistant',
-                            'parts': [
+                            "role": "assistant",
+                            "parts": [
                                 {
-                                    'type': 'tool_call',
-                                    'id': IsStr(),
-                                    'name': 'final_result',
+                                    "type": "tool_call",
+                                    "id": IsStr(),
+                                    "name": "final_result",
                                 }
                             ],
                         }
                     ]
                 )
             ),
-            'logfire.json_schema': IsJson(
+            "logfire.json_schema": IsJson(
                 snapshot(
                     {
-                        'type': 'object',
-                        'properties': {
-                            'gen_ai.input.messages': {'type': 'array'},
-                            'gen_ai.output.messages': {'type': 'array'},
-                            'model_request_parameters': {'type': 'object'},
+                        "type": "object",
+                        "properties": {
+                            "gen_ai.input.messages": {"type": "array"},
+                            "gen_ai.output.messages": {"type": "array"},
+                            "model_request_parameters": {"type": "object"},
                         },
                     }
                 )
             ),
-            'gen_ai.usage.input_tokens': 51,
-            'gen_ai.usage.output_tokens': 5,
-            'gen_ai.response.model': 'test',
+            "gen_ai.usage.input_tokens": 51,
+            "gen_ai.usage.output_tokens": 5,
+            "gen_ai.response.model": "test",
         }
     )
 
@@ -1060,7 +1199,7 @@ def test_instrument_all():
     assert m.wrapped is model
     assert m.instrumentation_settings.event_mode == InstrumentationSettings().event_mode
 
-    options = InstrumentationSettings(version=1, event_mode='logs')
+    options = InstrumentationSettings(version=1, event_mode="logs")
     Agent.instrument_all(options)
     m = get_model()
     assert isinstance(m, InstrumentedModel)
@@ -1071,182 +1210,203 @@ def test_instrument_all():
     assert get_model() is model
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
 @pytest.mark.anyio
 async def test_aggregated_usage_attribute_names(capfire: CaptureLogfire) -> None:
     """Test that use_aggregated_usage_attribute_names changes attribute names on agent run spans."""
 
-    def model_function(messages: list[ModelRequest | ModelResponse], info: AgentInfo) -> ModelResponse:
+    def model_function(
+        messages: list[ModelRequest | ModelResponse], info: AgentInfo
+    ) -> ModelResponse:
         # Return a response with usage that includes extra details (cache tokens)
         # to test that all gen_ai.usage.* attributes are translated
         return ModelResponse(
-            parts=[TextPart('Hello!')],
+            parts=[TextPart("Hello!")],
             usage=RequestUsage(input_tokens=10, output_tokens=5, cache_read_tokens=2),
         )
 
     settings = InstrumentationSettings(use_aggregated_usage_attribute_names=True)
     agent = Agent(model=FunctionModel(model_function), instrument=settings)
 
-    await agent.run('Hello')
+    await agent.run("Hello")
 
     spans = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)
 
     # Verify that agent run span uses aggregated_usage attribute names
-    agent_run_span = next(s for s in spans if s['name'] == 'agent run')
-    assert agent_run_span['attributes'] == snapshot(
+    agent_run_span = next(s for s in spans if s["name"] == "agent run")
+    assert agent_run_span["attributes"] == snapshot(
         {
-            'model_name': 'function:model_function:',
-            'agent_name': 'agent',
-            'gen_ai.agent.name': 'agent',
-            'logfire.msg': 'agent run',
-            'logfire.span_type': 'span',
-            'final_result': 'Hello!',
-            'gen_ai.aggregated_usage.input_tokens': 10,
-            'gen_ai.aggregated_usage.output_tokens': 5,
-            'gen_ai.aggregated_usage.details.cache_read_tokens': 2,
-            'pydantic_ai.all_messages': [
-                {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]},
-                {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'Hello!'}]},
+            "model_name": "function:model_function:",
+            "agent_name": "agent",
+            "gen_ai.agent.name": "agent",
+            "logfire.msg": "agent run",
+            "logfire.span_type": "span",
+            "final_result": "Hello!",
+            "gen_ai.aggregated_usage.input_tokens": 10,
+            "gen_ai.aggregated_usage.output_tokens": 5,
+            "gen_ai.aggregated_usage.details.cache_read_tokens": 2,
+            "pydantic_ai.all_messages": [
+                {"role": "user", "parts": [{"type": "text", "content": "Hello"}]},
+                {"role": "assistant", "parts": [{"type": "text", "content": "Hello!"}]},
             ],
-            'logfire.json_schema': {
-                'type': 'object',
-                'properties': {'pydantic_ai.all_messages': {'type': 'array'}, 'final_result': {'type': 'object'}},
+            "logfire.json_schema": {
+                "type": "object",
+                "properties": {
+                    "pydantic_ai.all_messages": {"type": "array"},
+                    "final_result": {"type": "object"},
+                },
             },
         }
     )
 
     # Verify that model/chat span still uses standard attribute names
-    chat_span = next(s for s in spans if 'chat' in s['name'])
-    assert chat_span['attributes']['gen_ai.usage.input_tokens'] == 10
-    assert chat_span['attributes']['gen_ai.usage.output_tokens'] == 5
+    chat_span = next(s for s in spans if "chat" in s["name"])
+    assert chat_span["attributes"]["gen_ai.usage.input_tokens"] == 10
+    assert chat_span["attributes"]["gen_ai.usage.output_tokens"] == 5
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
 @pytest.mark.anyio
 async def test_feedback(capfire: CaptureLogfire) -> None:
     from logfire.experimental.annotations import record_feedback
 
     my_agent = Agent(model=TestModel(), instrument=True)
 
-    async with my_agent.iter('Hello') as agent_run:
+    async with my_agent.iter("Hello") as agent_run:
         async for _ in agent_run:
             pass
         result = agent_run.result
         assert result
         traceparent = get_traceparent(result)
         assert traceparent == get_traceparent(agent_run)
-    assert traceparent == snapshot('00-00000000000000000000000000000001-0000000000000001-01')
-    record_feedback(traceparent, 'factuality', 0.1, comment='the agent lied', extra={'foo': 'bar'})
+    assert traceparent == snapshot(
+        "00-00000000000000000000000000000001-0000000000000001-01"
+    )
+    record_feedback(
+        traceparent, "factuality", 0.1, comment="the agent lied", extra={"foo": "bar"}
+    )
 
-    assert capfire.exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
+    assert capfire.exporter.exported_spans_as_dict(
+        parse_json_attributes=True
+    ) == snapshot(
         [
             {
-                'name': 'chat test',
-                'context': {'trace_id': 1, 'span_id': 3, 'is_remote': False},
-                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
-                'start_time': 2000000000,
-                'end_time': 3000000000,
-                'attributes': {
-                    'gen_ai.operation.name': 'chat',
-                    'gen_ai.provider.name': 'test',
-                    'gen_ai.system': 'test',
-                    'gen_ai.request.model': 'test',
-                    'model_request_parameters': {
-                        'function_tools': [],
-                        'builtin_tools': [],
-                        'output_mode': 'text',
-                        'output_object': None,
-                        'output_tools': [],
-                        'prompted_output_template': None,
-                        'allow_text_output': True,
-                        'allow_image_output': False,
+                "name": "chat test",
+                "context": {"trace_id": 1, "span_id": 3, "is_remote": False},
+                "parent": {"trace_id": 1, "span_id": 1, "is_remote": False},
+                "start_time": 2000000000,
+                "end_time": 3000000000,
+                "attributes": {
+                    "gen_ai.operation.name": "chat",
+                    "gen_ai.provider.name": "test",
+                    "gen_ai.system": "test",
+                    "gen_ai.request.model": "test",
+                    "model_request_parameters": {
+                        "function_tools": [],
+                        "builtin_tools": [],
+                        "output_mode": "text",
+                        "output_object": None,
+                        "output_tools": [],
+                        "prompted_output_template": None,
+                        "allow_text_output": True,
+                        "allow_image_output": False,
                     },
-                    'logfire.span_type': 'span',
-                    'logfire.msg': 'chat test',
-                    'gen_ai.usage.input_tokens': 51,
-                    'gen_ai.usage.output_tokens': 4,
-                    'gen_ai.response.model': 'test',
-                    'gen_ai.input.messages': [
+                    "logfire.span_type": "span",
+                    "logfire.msg": "chat test",
+                    "gen_ai.usage.input_tokens": 51,
+                    "gen_ai.usage.output_tokens": 4,
+                    "gen_ai.response.model": "test",
+                    "gen_ai.input.messages": [
                         {
-                            'parts': [
+                            "parts": [
                                 {
-                                    'type': 'text',
-                                    'content': 'Hello',
+                                    "type": "text",
+                                    "content": "Hello",
                                 },
                             ],
-                            'role': 'user',
+                            "role": "user",
                         },
                     ],
-                    'gen_ai.output.messages': [
+                    "gen_ai.output.messages": [
                         {
-                            'role': 'assistant',
-                            'parts': [{'type': 'text', 'content': 'success (no tool calls)'}],
+                            "role": "assistant",
+                            "parts": [
+                                {"type": "text", "content": "success (no tool calls)"}
+                            ],
                         }
                     ],
-                    'logfire.json_schema': {
-                        'type': 'object',
-                        'properties': {
-                            'gen_ai.input.messages': {'type': 'array'},
-                            'gen_ai.output.messages': {'type': 'array'},
-                            'model_request_parameters': {'type': 'object'},
+                    "logfire.json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "gen_ai.input.messages": {"type": "array"},
+                            "gen_ai.output.messages": {"type": "array"},
+                            "model_request_parameters": {"type": "object"},
                         },
                     },
                 },
             },
             {
-                'name': 'agent run',
-                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
-                'parent': None,
-                'start_time': 1000000000,
-                'end_time': 4000000000,
-                'attributes': {
-                    'model_name': 'test',
-                    'agent_name': 'agent',
-                    'gen_ai.agent.name': 'agent',
-                    'logfire.msg': 'agent run',
-                    'logfire.span_type': 'span',
-                    'gen_ai.usage.input_tokens': 51,
-                    'gen_ai.usage.output_tokens': 4,
-                    'pydantic_ai.all_messages': [
-                        {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]},
-                        {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'success (no tool calls)'}]},
+                "name": "agent run",
+                "context": {"trace_id": 1, "span_id": 1, "is_remote": False},
+                "parent": None,
+                "start_time": 1000000000,
+                "end_time": 4000000000,
+                "attributes": {
+                    "model_name": "test",
+                    "agent_name": "agent",
+                    "gen_ai.agent.name": "agent",
+                    "logfire.msg": "agent run",
+                    "logfire.span_type": "span",
+                    "gen_ai.usage.input_tokens": 51,
+                    "gen_ai.usage.output_tokens": 4,
+                    "pydantic_ai.all_messages": [
+                        {
+                            "role": "user",
+                            "parts": [{"type": "text", "content": "Hello"}],
+                        },
+                        {
+                            "role": "assistant",
+                            "parts": [
+                                {"type": "text", "content": "success (no tool calls)"}
+                            ],
+                        },
                     ],
-                    'final_result': 'success (no tool calls)',
-                    'logfire.json_schema': {
-                        'type': 'object',
-                        'properties': {
-                            'pydantic_ai.all_messages': {'type': 'array'},
-                            'final_result': {'type': 'object'},
+                    "final_result": "success (no tool calls)",
+                    "logfire.json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "pydantic_ai.all_messages": {"type": "array"},
+                            "final_result": {"type": "object"},
                         },
                     },
                 },
             },
             {
-                'name': 'feedback: factuality',
-                'context': {'trace_id': 1, 'span_id': 5, 'is_remote': False},
-                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': True},
-                'start_time': 5000000000,
-                'end_time': 5000000000,
-                'attributes': {
-                    'logfire.span_type': 'annotation',
-                    'logfire.level_num': 9,
-                    'logfire.msg_template': 'feedback: factuality',
-                    'logfire.msg': 'feedback: factuality = 0.1',
-                    'code.filepath': 'test_logfire.py',
-                    'code.function': 'test_feedback',
-                    'code.lineno': 123,
-                    'logfire.feedback.name': 'factuality',
-                    'factuality': 0.1,
-                    'foo': 'bar',
-                    'logfire.feedback.comment': 'the agent lied',
-                    'logfire.json_schema': {
-                        'type': 'object',
-                        'properties': {
-                            'logfire.feedback.name': {},
-                            'factuality': {},
-                            'foo': {},
-                            'logfire.feedback.comment': {},
-                            'logfire.span_type': {},
+                "name": "feedback: factuality",
+                "context": {"trace_id": 1, "span_id": 5, "is_remote": False},
+                "parent": {"trace_id": 1, "span_id": 1, "is_remote": True},
+                "start_time": 5000000000,
+                "end_time": 5000000000,
+                "attributes": {
+                    "logfire.span_type": "annotation",
+                    "logfire.level_num": 9,
+                    "logfire.msg_template": "feedback: factuality",
+                    "logfire.msg": "feedback: factuality = 0.1",
+                    "code.filepath": "test_logfire.py",
+                    "code.function": "test_feedback",
+                    "code.lineno": 123,
+                    "logfire.feedback.name": "factuality",
+                    "factuality": 0.1,
+                    "foo": "bar",
+                    "logfire.feedback.comment": "the agent lied",
+                    "logfire.json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "logfire.feedback.name": {},
+                            "factuality": {},
+                            "foo": {},
+                            "logfire.feedback.comment": {},
+                            "logfire.span_type": {},
                         },
                     },
                 },
@@ -1255,8 +1415,11 @@ async def test_feedback(capfire: CaptureLogfire) -> None:
     )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content,tool_error', [(True, False), (True, True), (False, False), (False, True)])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize(
+    "include_content,tool_error",
+    [(True, False), (True, True), (False, False), (False, True)],
+)
 def test_include_tool_args_span_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
@@ -1272,11 +1435,11 @@ def test_include_tool_args_span_attributes(
     async def add_numbers(x: int, y: int) -> int:
         """Add two numbers together."""
         if tool_error:
-            raise ModelRetry('Tool error')
+            raise ModelRetry("Tool error")
         return x + y
 
     try:
-        result = my_agent.run_sync('Add 42 and 42')
+        result = my_agent.run_sync("Add 42 and 42")
         assert result.output == snapshot('{"add_numbers":84}')
     except UnexpectedModelBehavior:
         if not tool_error:
@@ -1285,103 +1448,105 @@ def test_include_tool_args_span_attributes(
     summary = get_logfire_summary()
 
     tool_attributes = next(
-        attributes for attributes in summary.attributes.values() if attributes.get('gen_ai.tool.name') == 'add_numbers'
+        attributes
+        for attributes in summary.attributes.values()
+        if attributes.get("gen_ai.tool.name") == "add_numbers"
     )
 
     if include_content:
         if tool_error:
             assert tool_attributes == snapshot(
                 {
-                    'gen_ai.tool.name': 'add_numbers',
-                    'gen_ai.tool.call.id': IsStr(),
-                    'tool_arguments': '{"x":42,"y":42}',
-                    'logfire.msg': 'running tool: add_numbers',
-                    'logfire.json_schema': IsJson(
+                    "gen_ai.tool.name": "add_numbers",
+                    "gen_ai.tool.call.id": IsStr(),
+                    "tool_arguments": '{"x":42,"y":42}',
+                    "logfire.msg": "running tool: add_numbers",
+                    "logfire.json_schema": IsJson(
                         snapshot(
                             {
-                                'type': 'object',
-                                'properties': {
-                                    'tool_arguments': {'type': 'object'},
-                                    'tool_response': {'type': 'object'},
-                                    'gen_ai.tool.name': {},
-                                    'gen_ai.tool.call.id': {},
+                                "type": "object",
+                                "properties": {
+                                    "tool_arguments": {"type": "object"},
+                                    "tool_response": {"type": "object"},
+                                    "gen_ai.tool.name": {},
+                                    "gen_ai.tool.call.id": {},
                                 },
                             }
                         )
                     ),
-                    'logfire.span_type': 'span',
-                    'tool_response': """\
+                    "logfire.span_type": "span",
+                    "tool_response": """\
 Tool error
 
 Fix the errors and try again.\
 """,
-                    'logfire.level_num': 17,
+                    "logfire.level_num": 17,
                 }
             )
         else:
             assert tool_attributes == snapshot(
                 {
-                    'gen_ai.tool.name': 'add_numbers',
-                    'gen_ai.tool.call.id': IsStr(),
-                    'tool_arguments': '{"x":42,"y":42}',
-                    'tool_response': '84',
-                    'logfire.msg': 'running tool: add_numbers',
-                    'logfire.json_schema': IsJson(
+                    "gen_ai.tool.name": "add_numbers",
+                    "gen_ai.tool.call.id": IsStr(),
+                    "tool_arguments": '{"x":42,"y":42}',
+                    "tool_response": "84",
+                    "logfire.msg": "running tool: add_numbers",
+                    "logfire.json_schema": IsJson(
                         snapshot(
                             {
-                                'type': 'object',
-                                'properties': {
-                                    'tool_arguments': {'type': 'object'},
-                                    'tool_response': {'type': 'object'},
-                                    'gen_ai.tool.name': {},
-                                    'gen_ai.tool.call.id': {},
+                                "type": "object",
+                                "properties": {
+                                    "tool_arguments": {"type": "object"},
+                                    "tool_response": {"type": "object"},
+                                    "gen_ai.tool.name": {},
+                                    "gen_ai.tool.call.id": {},
                                 },
                             }
                         )
                     ),
-                    'logfire.span_type': 'span',
+                    "logfire.span_type": "span",
                 }
             )
     else:
         if tool_error:
             assert tool_attributes == snapshot(
                 {
-                    'gen_ai.tool.name': 'add_numbers',
-                    'gen_ai.tool.call.id': IsStr(),
-                    'logfire.msg': 'running tool: add_numbers',
-                    'logfire.json_schema': IsJson(
+                    "gen_ai.tool.name": "add_numbers",
+                    "gen_ai.tool.call.id": IsStr(),
+                    "logfire.msg": "running tool: add_numbers",
+                    "logfire.json_schema": IsJson(
                         snapshot(
                             {
-                                'type': 'object',
-                                'properties': {
-                                    'gen_ai.tool.name': {},
-                                    'gen_ai.tool.call.id': {},
+                                "type": "object",
+                                "properties": {
+                                    "gen_ai.tool.name": {},
+                                    "gen_ai.tool.call.id": {},
                                 },
                             }
                         )
                     ),
-                    'logfire.span_type': 'span',
-                    'logfire.level_num': 17,
+                    "logfire.span_type": "span",
+                    "logfire.level_num": 17,
                 }
             )
         else:
             assert tool_attributes == snapshot(
                 {
-                    'gen_ai.tool.name': 'add_numbers',
-                    'gen_ai.tool.call.id': IsStr(),
-                    'logfire.msg': 'running tool: add_numbers',
-                    'logfire.json_schema': IsJson(
+                    "gen_ai.tool.name": "add_numbers",
+                    "gen_ai.tool.call.id": IsStr(),
+                    "logfire.msg": "running tool: add_numbers",
+                    "logfire.json_schema": IsJson(
                         snapshot(
                             {
-                                'type': 'object',
-                                'properties': {
-                                    'gen_ai.tool.name': {},
-                                    'gen_ai.tool.call.id': {},
+                                "type": "object",
+                                "properties": {
+                                    "gen_ai.tool.name": {},
+                                    "gen_ai.tool.call.id": {},
                                 },
                             }
                         )
                     ),
-                    'logfire.span_type': 'span',
+                    "logfire.span_type": "span",
                 }
             )
 
@@ -1392,12 +1557,12 @@ class WeatherInfo(BaseModel):
 
 
 def get_weather_info(city: str) -> WeatherInfo:
-    return WeatherInfo(temperature=28.7, description='sunny')
+    return WeatherInfo(temperature=28.7, description="sunny")
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
 @pytest.mark.parametrize(
-    'instrument',
+    "instrument",
     [
         True,
         False,
@@ -1415,29 +1580,37 @@ def test_logfire_output_function_v2_v3(
         return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, args_json)])
 
     my_agent = Agent(model=FunctionModel(call_tool), instrument=instrument)
-    result = my_agent.run_sync('Mexico City', output_type=get_weather_info)
-    assert result.output == WeatherInfo(temperature=28.7, description='sunny')
+    result = my_agent.run_sync("Mexico City", output_type=get_weather_info)
+    assert result.output == WeatherInfo(temperature=28.7, description="sunny")
 
     summary = get_logfire_summary()
 
-    if instrument is True or isinstance(instrument, InstrumentationSettings) and instrument.version == 2:
+    if (
+        instrument is True
+        or isinstance(instrument, InstrumentationSettings)
+        and instrument.version == 2
+    ):
         [output_function_attributes] = [
             attributes
             for attributes in summary.attributes.values()
-            if attributes.get('gen_ai.tool.name') == 'final_result'
+            if attributes.get("gen_ai.tool.name") == "final_result"
         ]
         assert summary.traces == snapshot(
             [
                 {
-                    'id': 0,
-                    'name': 'agent run',
-                    'message': 'my_agent run',
-                    'children': [
-                        {'id': 1, 'name': 'chat function:call_tool:', 'message': 'chat function:call_tool:'},
+                    "id": 0,
+                    "name": "agent run",
+                    "message": "my_agent run",
+                    "children": [
                         {
-                            'id': 2,
-                            'name': 'running output function',
-                            'message': 'running output function: final_result',
+                            "id": 1,
+                            "name": "chat function:call_tool:",
+                            "message": "chat function:call_tool:",
+                        },
+                        {
+                            "id": 2,
+                            "name": "running output function",
+                            "message": "running output function: final_result",
                         },
                     ],
                 }
@@ -1445,25 +1618,25 @@ def test_logfire_output_function_v2_v3(
         )
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'logfire.msg': 'running output function: final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'tool_arguments': '{"city":"Mexico City"}',
-                'logfire.json_schema': IsJson(
+                "gen_ai.tool.name": "final_result",
+                "logfire.msg": "running output function: final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "tool_arguments": '{"city":"Mexico City"}',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'tool_arguments': {'type': 'object'},
-                                'tool_response': {'type': 'object'},
-                                'gen_ai.tool.name': {},
-                                'gen_ai.tool.call.id': {},
+                            "type": "object",
+                            "properties": {
+                                "tool_arguments": {"type": "object"},
+                                "tool_response": {"type": "object"},
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
                             },
                         }
                     )
                 ),
-                'logfire.span_type': 'span',
-                'tool_response': '{"temperature": 28.7, "description": "sunny"}',
+                "logfire.span_type": "span",
+                "tool_response": '{"temperature": 28.7, "description": "sunny"}',
             }
         )
 
@@ -1471,20 +1644,24 @@ def test_logfire_output_function_v2_v3(
         [output_function_attributes] = [
             attributes
             for attributes in summary.attributes.values()
-            if attributes.get('gen_ai.tool.name') == 'final_result'
+            if attributes.get("gen_ai.tool.name") == "final_result"
         ]
         assert summary.traces == snapshot(
             [
                 {
-                    'id': 0,
-                    'name': 'invoke_agent my_agent',
-                    'message': 'my_agent run',
-                    'children': [
-                        {'id': 1, 'name': 'chat function:call_tool:', 'message': 'chat function:call_tool:'},
+                    "id": 0,
+                    "name": "invoke_agent my_agent",
+                    "message": "my_agent run",
+                    "children": [
                         {
-                            'id': 2,
-                            'name': 'execute_tool final_result',
-                            'message': 'running output function: final_result',
+                            "id": 1,
+                            "name": "chat function:call_tool:",
+                            "message": "chat function:call_tool:",
+                        },
+                        {
+                            "id": 2,
+                            "name": "execute_tool final_result",
+                            "message": "running output function: final_result",
                         },
                     ],
                 }
@@ -1492,25 +1669,25 @@ def test_logfire_output_function_v2_v3(
         )
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'logfire.msg': 'running output function: final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'gen_ai.tool.call.arguments': '{"city":"Mexico City"}',
-                'logfire.json_schema': IsJson(
+                "gen_ai.tool.name": "final_result",
+                "logfire.msg": "running output function: final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "gen_ai.tool.call.arguments": '{"city":"Mexico City"}',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'gen_ai.tool.call.arguments': {'type': 'object'},
-                                'gen_ai.tool.call.result': {'type': 'object'},
-                                'gen_ai.tool.name': {},
-                                'gen_ai.tool.call.id': {},
+                            "type": "object",
+                            "properties": {
+                                "gen_ai.tool.call.arguments": {"type": "object"},
+                                "gen_ai.tool.call.result": {"type": "object"},
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
                             },
                         }
                     )
                 ),
-                'logfire.span_type': 'span',
-                'gen_ai.tool.call.result': '{"temperature": 28.7, "description": "sunny"}',
+                "logfire.span_type": "span",
+                "gen_ai.tool.call.result": '{"temperature": 28.7, "description": "sunny"}',
             }
         )
     else:
@@ -1518,8 +1695,8 @@ def test_logfire_output_function_v2_v3(
         assert summary.attributes == snapshot({})
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content', [True, False])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("include_content", [True, False])
 def test_output_type_function_logfire_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
@@ -1530,63 +1707,67 @@ def test_output_type_function_logfire_attributes(
         return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, args_json)])
 
     instrumentation_settings = InstrumentationSettings(include_content=include_content)
-    my_agent = Agent(model=FunctionModel(call_tool), instrument=instrumentation_settings)
+    my_agent = Agent(
+        model=FunctionModel(call_tool), instrument=instrumentation_settings
+    )
 
-    result = my_agent.run_sync('Mexico City', output_type=get_weather_info)
-    assert result.output == WeatherInfo(temperature=28.7, description='sunny')
+    result = my_agent.run_sync("Mexico City", output_type=get_weather_info)
+    assert result.output == WeatherInfo(temperature=28.7, description="sunny")
 
     summary = get_logfire_summary()
 
     # Find the output function span attributes
     [output_function_attributes] = [
-        attributes for attributes in summary.attributes.values() if attributes.get('gen_ai.tool.name') == 'final_result'
+        attributes
+        for attributes in summary.attributes.values()
+        if attributes.get("gen_ai.tool.name") == "final_result"
     ]
 
     if include_content:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'tool_arguments': '{"city":"Mexico City"}',
-                'logfire.msg': 'running output function: final_result',
-                'logfire.json_schema': IsJson(
+                "gen_ai.tool.name": "final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "tool_arguments": '{"city":"Mexico City"}',
+                "logfire.msg": "running output function: final_result",
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'tool_arguments': {'type': 'object'},
-                                'tool_response': {'type': 'object'},
-                                'gen_ai.tool.name': {},
-                                'gen_ai.tool.call.id': {},
+                            "type": "object",
+                            "properties": {
+                                "tool_arguments": {"type": "object"},
+                                "tool_response": {"type": "object"},
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
                             },
                         }
                     )
                 ),
-                'logfire.span_type': 'span',
-                'tool_response': '{"temperature": 28.7, "description": "sunny"}',
+                "logfire.span_type": "span",
+                "tool_response": '{"temperature": 28.7, "description": "sunny"}',
             }
         )
     else:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'logfire.msg': 'running output function: final_result',
-                'logfire.json_schema': '{"type": "object", "properties": {"gen_ai.tool.name": {}, "gen_ai.tool.call.id": {}}}',
-                'logfire.span_type': 'span',
+                "gen_ai.tool.name": "final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "logfire.msg": "running output function: final_result",
+                "logfire.json_schema": '{"type": "object", "properties": {"gen_ai.tool.name": {}, "gen_ai.tool.call.id": {}}}',
+                "logfire.span_type": "span",
             }
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content', [True, False])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("include_content", [True, False])
 def test_output_type_function_with_run_context_logfire_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
 ) -> None:
     def get_weather_with_ctx(ctx: RunContext[None], city: str) -> WeatherInfo:
         assert ctx is not None
-        return WeatherInfo(temperature=28.7, description='sunny')
+        return WeatherInfo(temperature=28.7, description="sunny")
 
     def call_tool(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.output_tools is not None
@@ -1594,66 +1775,70 @@ def test_output_type_function_with_run_context_logfire_attributes(
         return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, args_json)])
 
     instrumentation_settings = InstrumentationSettings(include_content=include_content)
-    my_agent = Agent(model=FunctionModel(call_tool), instrument=instrumentation_settings)
+    my_agent = Agent(
+        model=FunctionModel(call_tool), instrument=instrumentation_settings
+    )
 
-    result = my_agent.run_sync('Mexico City', output_type=get_weather_with_ctx)
-    assert result.output == WeatherInfo(temperature=28.7, description='sunny')
+    result = my_agent.run_sync("Mexico City", output_type=get_weather_with_ctx)
+    assert result.output == WeatherInfo(temperature=28.7, description="sunny")
 
     summary = get_logfire_summary()
 
     # Find the output function span attributes
     [output_function_attributes] = [
-        attributes for attributes in summary.attributes.values() if attributes.get('gen_ai.tool.name') == 'final_result'
+        attributes
+        for attributes in summary.attributes.values()
+        if attributes.get("gen_ai.tool.name") == "final_result"
     ]
 
     if include_content:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'tool_arguments': '{"city":"Mexico City"}',
-                'logfire.msg': 'running output function: final_result',
-                'logfire.json_schema': IsJson(
+                "gen_ai.tool.name": "final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "tool_arguments": '{"city":"Mexico City"}',
+                "logfire.msg": "running output function: final_result",
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'tool_arguments': {'type': 'object'},
-                                'tool_response': {'type': 'object'},
-                                'gen_ai.tool.name': {},
-                                'gen_ai.tool.call.id': {},
+                            "type": "object",
+                            "properties": {
+                                "tool_arguments": {"type": "object"},
+                                "tool_response": {"type": "object"},
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
                             },
                         }
                     )
                 ),
-                'logfire.span_type': 'span',
-                'tool_response': '{"temperature": 28.7, "description": "sunny"}',
+                "logfire.span_type": "span",
+                "tool_response": '{"temperature": 28.7, "description": "sunny"}',
             }
         )
     else:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'logfire.msg': 'running output function: final_result',
-                'logfire.json_schema': '{"type": "object", "properties": {"gen_ai.tool.name": {}, "gen_ai.tool.call.id": {}}}',
-                'logfire.span_type': 'span',
+                "gen_ai.tool.name": "final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "logfire.msg": "running output function: final_result",
+                "logfire.json_schema": '{"type": "object", "properties": {"gen_ai.tool.name": {}, "gen_ai.tool.call.id": {}}}',
+                "logfire.span_type": "span",
             }
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content', [True, False])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("include_content", [True, False])
 def test_output_type_function_with_retry_logfire_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
 ) -> None:
     def get_weather_with_retry(city: str) -> WeatherInfo:
-        if city != 'Mexico City':
+        if city != "Mexico City":
             from pydantic_ai import ModelRetry
 
-            raise ModelRetry('City not found, I only know Mexico City')
-        return WeatherInfo(temperature=28.7, description='sunny')
+            raise ModelRetry("City not found, I only know Mexico City")
+        return WeatherInfo(temperature=28.7, description="sunny")
 
     def call_tool(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.output_tools is not None
@@ -1666,61 +1851,65 @@ def test_output_type_function_with_retry_logfire_attributes(
         return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, args_json)])
 
     instrumentation_settings = InstrumentationSettings(include_content=include_content)
-    my_agent = Agent(model=FunctionModel(call_tool), instrument=instrumentation_settings)
+    my_agent = Agent(
+        model=FunctionModel(call_tool), instrument=instrumentation_settings
+    )
 
-    result = my_agent.run_sync('New York City', output_type=get_weather_with_retry)
-    assert result.output == WeatherInfo(temperature=28.7, description='sunny')
+    result = my_agent.run_sync("New York City", output_type=get_weather_with_retry)
+    assert result.output == WeatherInfo(temperature=28.7, description="sunny")
 
     summary = get_logfire_summary()
 
     output_function_attributes = [
-        attributes for attributes in summary.attributes.values() if attributes.get('gen_ai.tool.name') == 'final_result'
+        attributes
+        for attributes in summary.attributes.values()
+        if attributes.get("gen_ai.tool.name") == "final_result"
     ]
 
     if include_content:
         assert output_function_attributes == snapshot(
             [
                 {
-                    'gen_ai.tool.name': 'final_result',
-                    'logfire.msg': 'running output function: final_result',
-                    'gen_ai.tool.call.id': IsStr(),
-                    'tool_arguments': '{"city":"New York City"}',
-                    'logfire.json_schema': IsJson(
+                    "gen_ai.tool.name": "final_result",
+                    "logfire.msg": "running output function: final_result",
+                    "gen_ai.tool.call.id": IsStr(),
+                    "tool_arguments": '{"city":"New York City"}',
+                    "logfire.json_schema": IsJson(
                         snapshot(
                             {
-                                'type': 'object',
-                                'properties': {
-                                    'tool_arguments': {'type': 'object'},
-                                    'tool_response': {'type': 'object'},
-                                    'gen_ai.tool.name': {},
-                                    'gen_ai.tool.call.id': {},
+                                "type": "object",
+                                "properties": {
+                                    "tool_arguments": {"type": "object"},
+                                    "tool_response": {"type": "object"},
+                                    "gen_ai.tool.name": {},
+                                    "gen_ai.tool.call.id": {},
                                 },
                             }
                         )
                     ),
-                    'logfire.span_type': 'span',
-                    'logfire.level_num': 17,
+                    "logfire.span_type": "span",
+                    "logfire.level_num": 17,
                 },
                 {
-                    'gen_ai.tool.name': 'final_result',
-                    'logfire.msg': 'running output function: final_result',
-                    'gen_ai.tool.call.id': IsStr(),
-                    'tool_arguments': '{"city":"Mexico City"}',
-                    'logfire.json_schema': IsJson(
+                    "gen_ai.tool.name": "final_result",
+                    "logfire.msg": "running output function: final_result",
+                    "gen_ai.tool.call.id": IsStr(),
+                    "tool_arguments": '{"city":"Mexico City"}',
+                    "logfire.json_schema": IsJson(
                         snapshot(
                             {
-                                'type': 'object',
-                                'properties': {
-                                    'tool_arguments': {'type': 'object'},
-                                    'tool_response': {'type': 'object'},
-                                    'gen_ai.tool.name': {},
-                                    'gen_ai.tool.call.id': {},
+                                "type": "object",
+                                "properties": {
+                                    "tool_arguments": {"type": "object"},
+                                    "tool_response": {"type": "object"},
+                                    "gen_ai.tool.name": {},
+                                    "gen_ai.tool.call.id": {},
                                 },
                             }
                         )
                     ),
-                    'logfire.span_type': 'span',
-                    'tool_response': '{"temperature": 28.7, "description": "sunny"}',
+                    "logfire.span_type": "span",
+                    "tool_response": '{"temperature": 28.7, "description": "sunny"}',
                 },
             ]
         )
@@ -1728,30 +1917,46 @@ def test_output_type_function_with_retry_logfire_attributes(
         assert output_function_attributes == snapshot(
             [
                 {
-                    'gen_ai.tool.name': 'final_result',
-                    'logfire.msg': 'running output function: final_result',
-                    'gen_ai.tool.call.id': IsStr(),
-                    'logfire.json_schema': IsJson(
-                        snapshot({'type': 'object', 'properties': {'gen_ai.tool.name': {}, 'gen_ai.tool.call.id': {}}})
+                    "gen_ai.tool.name": "final_result",
+                    "logfire.msg": "running output function: final_result",
+                    "gen_ai.tool.call.id": IsStr(),
+                    "logfire.json_schema": IsJson(
+                        snapshot(
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "gen_ai.tool.name": {},
+                                    "gen_ai.tool.call.id": {},
+                                },
+                            }
+                        )
                     ),
-                    'logfire.span_type': 'span',
-                    'logfire.level_num': 17,
+                    "logfire.span_type": "span",
+                    "logfire.level_num": 17,
                 },
                 {
-                    'gen_ai.tool.name': 'final_result',
-                    'logfire.msg': 'running output function: final_result',
-                    'gen_ai.tool.call.id': IsStr(),
-                    'logfire.json_schema': IsJson(
-                        snapshot({'type': 'object', 'properties': {'gen_ai.tool.name': {}, 'gen_ai.tool.call.id': {}}})
+                    "gen_ai.tool.name": "final_result",
+                    "logfire.msg": "running output function: final_result",
+                    "gen_ai.tool.call.id": IsStr(),
+                    "logfire.json_schema": IsJson(
+                        snapshot(
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "gen_ai.tool.name": {},
+                                    "gen_ai.tool.call.id": {},
+                                },
+                            }
+                        )
                     ),
-                    'logfire.span_type': 'span',
+                    "logfire.span_type": "span",
                 },
             ]
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content', [True, False])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("include_content", [True, False])
 def test_output_type_function_with_custom_tool_name_logfire_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
@@ -1764,58 +1969,72 @@ def test_output_type_function_with_custom_tool_name_logfire_attributes(
     from pydantic_ai.output import ToolOutput
 
     instrumentation_settings = InstrumentationSettings(include_content=include_content)
-    my_agent = Agent(model=FunctionModel(call_tool), instrument=instrumentation_settings)
+    my_agent = Agent(
+        model=FunctionModel(call_tool), instrument=instrumentation_settings
+    )
 
-    result = my_agent.run_sync('Mexico City', output_type=ToolOutput(get_weather_info, name='get_weather'))
-    assert result.output == WeatherInfo(temperature=28.7, description='sunny')
+    result = my_agent.run_sync(
+        "Mexico City", output_type=ToolOutput(get_weather_info, name="get_weather")
+    )
+    assert result.output == WeatherInfo(temperature=28.7, description="sunny")
 
     summary = get_logfire_summary()
 
     # Find the output function span attributes with custom tool name
     [output_function_attributes] = [
-        attributes for attributes in summary.attributes.values() if attributes.get('gen_ai.tool.name') == 'get_weather'
+        attributes
+        for attributes in summary.attributes.values()
+        if attributes.get("gen_ai.tool.name") == "get_weather"
     ]
 
     if include_content:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'get_weather',
-                'gen_ai.tool.call.id': IsStr(),
-                'tool_arguments': '{"city":"Mexico City"}',
-                'logfire.msg': 'running output function: get_weather',
-                'logfire.json_schema': IsJson(
+                "gen_ai.tool.name": "get_weather",
+                "gen_ai.tool.call.id": IsStr(),
+                "tool_arguments": '{"city":"Mexico City"}',
+                "logfire.msg": "running output function: get_weather",
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'tool_arguments': {'type': 'object'},
-                                'tool_response': {'type': 'object'},
-                                'gen_ai.tool.name': {},
-                                'gen_ai.tool.call.id': {},
+                            "type": "object",
+                            "properties": {
+                                "tool_arguments": {"type": "object"},
+                                "tool_response": {"type": "object"},
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
                             },
                         }
                     )
                 ),
-                'logfire.span_type': 'span',
-                'tool_response': '{"temperature": 28.7, "description": "sunny"}',
+                "logfire.span_type": "span",
+                "tool_response": '{"temperature": 28.7, "description": "sunny"}',
             }
         )
     else:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'get_weather',
-                'gen_ai.tool.call.id': IsStr(),
-                'logfire.msg': 'running output function: get_weather',
-                'logfire.json_schema': IsJson(
-                    snapshot({'type': 'object', 'properties': {'gen_ai.tool.name': {}, 'gen_ai.tool.call.id': {}}})
+                "gen_ai.tool.name": "get_weather",
+                "gen_ai.tool.call.id": IsStr(),
+                "logfire.msg": "running output function: get_weather",
+                "logfire.json_schema": IsJson(
+                    snapshot(
+                        {
+                            "type": "object",
+                            "properties": {
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
+                            },
+                        }
+                    )
                 ),
-                'logfire.span_type': 'span',
+                "logfire.span_type": "span",
             }
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content', [True, False])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("include_content", [True, False])
 def test_output_type_bound_instance_method_logfire_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
@@ -1827,7 +2046,7 @@ def test_output_type_bound_instance_method_logfire_attributes(
         def get_weather(self, city: str):
             return self
 
-    weather = Weather(temperature=28.7, description='sunny')
+    weather = Weather(temperature=28.7, description="sunny")
 
     def call_tool(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.output_tools is not None
@@ -1835,58 +2054,70 @@ def test_output_type_bound_instance_method_logfire_attributes(
         return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, args_json)])
 
     instrumentation_settings = InstrumentationSettings(include_content=include_content)
-    my_agent = Agent(model=FunctionModel(call_tool), instrument=instrumentation_settings)
+    my_agent = Agent(
+        model=FunctionModel(call_tool), instrument=instrumentation_settings
+    )
 
-    result = my_agent.run_sync('Mexico City', output_type=weather.get_weather)
-    assert result.output == Weather(temperature=28.7, description='sunny')
+    result = my_agent.run_sync("Mexico City", output_type=weather.get_weather)
+    assert result.output == Weather(temperature=28.7, description="sunny")
 
     summary = get_logfire_summary()
 
     # Find the output function span attributes
     [output_function_attributes] = [
-        attributes for attributes in summary.attributes.values() if attributes.get('gen_ai.tool.name') == 'final_result'
+        attributes
+        for attributes in summary.attributes.values()
+        if attributes.get("gen_ai.tool.name") == "final_result"
     ]
 
     if include_content:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'tool_arguments': '{"city":"Mexico City"}',
-                'logfire.msg': 'running output function: final_result',
-                'logfire.json_schema': IsJson(
+                "gen_ai.tool.name": "final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "tool_arguments": '{"city":"Mexico City"}',
+                "logfire.msg": "running output function: final_result",
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'tool_arguments': {'type': 'object'},
-                                'tool_response': {'type': 'object'},
-                                'gen_ai.tool.name': {},
-                                'gen_ai.tool.call.id': {},
+                            "type": "object",
+                            "properties": {
+                                "tool_arguments": {"type": "object"},
+                                "tool_response": {"type": "object"},
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
                             },
                         }
                     )
                 ),
-                'logfire.span_type': 'span',
-                'tool_response': '{"temperature": 28.7, "description": "sunny"}',
+                "logfire.span_type": "span",
+                "tool_response": '{"temperature": 28.7, "description": "sunny"}',
             }
         )
     else:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'logfire.msg': 'running output function: final_result',
-                'logfire.json_schema': IsJson(
-                    snapshot({'type': 'object', 'properties': {'gen_ai.tool.name': {}, 'gen_ai.tool.call.id': {}}})
+                "gen_ai.tool.name": "final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "logfire.msg": "running output function: final_result",
+                "logfire.json_schema": IsJson(
+                    snapshot(
+                        {
+                            "type": "object",
+                            "properties": {
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
+                            },
+                        }
+                    )
                 ),
-                'logfire.span_type': 'span',
+                "logfire.span_type": "span",
             }
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content', [True, False])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("include_content", [True, False])
 def test_output_type_bound_instance_method_with_run_context_logfire_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
@@ -1899,7 +2130,7 @@ def test_output_type_bound_instance_method_with_run_context_logfire_attributes(
             assert ctx is not None
             return self
 
-    weather = Weather(temperature=28.7, description='sunny')
+    weather = Weather(temperature=28.7, description="sunny")
 
     def call_tool(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.output_tools is not None
@@ -1907,58 +2138,70 @@ def test_output_type_bound_instance_method_with_run_context_logfire_attributes(
         return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, args_json)])
 
     instrumentation_settings = InstrumentationSettings(include_content=include_content)
-    my_agent = Agent(model=FunctionModel(call_tool), instrument=instrumentation_settings)
+    my_agent = Agent(
+        model=FunctionModel(call_tool), instrument=instrumentation_settings
+    )
 
-    result = my_agent.run_sync('Mexico City', output_type=weather.get_weather)
-    assert result.output == Weather(temperature=28.7, description='sunny')
+    result = my_agent.run_sync("Mexico City", output_type=weather.get_weather)
+    assert result.output == Weather(temperature=28.7, description="sunny")
 
     summary = get_logfire_summary()
 
     # Find the output function span attributes
     [output_function_attributes] = [
-        attributes for attributes in summary.attributes.values() if attributes.get('gen_ai.tool.name') == 'final_result'
+        attributes
+        for attributes in summary.attributes.values()
+        if attributes.get("gen_ai.tool.name") == "final_result"
     ]
 
     if include_content:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'tool_arguments': '{"city":"Mexico City"}',
-                'logfire.msg': 'running output function: final_result',
-                'logfire.json_schema': IsJson(
+                "gen_ai.tool.name": "final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "tool_arguments": '{"city":"Mexico City"}',
+                "logfire.msg": "running output function: final_result",
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'tool_arguments': {'type': 'object'},
-                                'tool_response': {'type': 'object'},
-                                'gen_ai.tool.name': {},
-                                'gen_ai.tool.call.id': {},
+                            "type": "object",
+                            "properties": {
+                                "tool_arguments": {"type": "object"},
+                                "tool_response": {"type": "object"},
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
                             },
                         }
                     )
                 ),
-                'logfire.span_type': 'span',
-                'tool_response': '{"temperature": 28.7, "description": "sunny"}',
+                "logfire.span_type": "span",
+                "tool_response": '{"temperature": 28.7, "description": "sunny"}',
             }
         )
     else:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'logfire.msg': 'running output function: final_result',
-                'logfire.json_schema': IsJson(
-                    snapshot({'type': 'object', 'properties': {'gen_ai.tool.name': {}, 'gen_ai.tool.call.id': {}}})
+                "gen_ai.tool.name": "final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "logfire.msg": "running output function: final_result",
+                "logfire.json_schema": IsJson(
+                    snapshot(
+                        {
+                            "type": "object",
+                            "properties": {
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
+                            },
+                        }
+                    )
                 ),
-                'logfire.span_type': 'span',
+                "logfire.span_type": "span",
             }
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content', [True, False])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("include_content", [True, False])
 def test_output_type_async_function_logfire_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
@@ -1966,7 +2209,7 @@ def test_output_type_async_function_logfire_attributes(
     """Test logfire attributes for async output function types."""
 
     async def get_weather_async(city: str) -> WeatherInfo:
-        return WeatherInfo(temperature=28.7, description='sunny')
+        return WeatherInfo(temperature=28.7, description="sunny")
 
     def call_tool(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.output_tools is not None
@@ -1974,52 +2217,64 @@ def test_output_type_async_function_logfire_attributes(
         return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, args_json)])
 
     instrumentation_settings = InstrumentationSettings(include_content=include_content)
-    my_agent = Agent(model=FunctionModel(call_tool), instrument=instrumentation_settings)
+    my_agent = Agent(
+        model=FunctionModel(call_tool), instrument=instrumentation_settings
+    )
 
-    result = my_agent.run_sync('Mexico City', output_type=get_weather_async)
-    assert result.output == WeatherInfo(temperature=28.7, description='sunny')
+    result = my_agent.run_sync("Mexico City", output_type=get_weather_async)
+    assert result.output == WeatherInfo(temperature=28.7, description="sunny")
 
     summary = get_logfire_summary()
 
     # Find the output function span attributes
     [output_function_attributes] = [
-        attributes for attributes in summary.attributes.values() if attributes.get('gen_ai.tool.name') == 'final_result'
+        attributes
+        for attributes in summary.attributes.values()
+        if attributes.get("gen_ai.tool.name") == "final_result"
     ]
 
     if include_content:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'tool_arguments': '{"city":"Mexico City"}',
-                'logfire.msg': 'running output function: final_result',
-                'logfire.json_schema': IsJson(
+                "gen_ai.tool.name": "final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "tool_arguments": '{"city":"Mexico City"}',
+                "logfire.msg": "running output function: final_result",
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'tool_arguments': {'type': 'object'},
-                                'tool_response': {'type': 'object'},
-                                'gen_ai.tool.name': {},
-                                'gen_ai.tool.call.id': {},
+                            "type": "object",
+                            "properties": {
+                                "tool_arguments": {"type": "object"},
+                                "tool_response": {"type": "object"},
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
                             },
                         }
                     )
                 ),
-                'logfire.span_type': 'span',
-                'tool_response': '{"temperature": 28.7, "description": "sunny"}',
+                "logfire.span_type": "span",
+                "tool_response": '{"temperature": 28.7, "description": "sunny"}',
             }
         )
     else:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'final_result',
-                'gen_ai.tool.call.id': IsStr(),
-                'logfire.msg': 'running output function: final_result',
-                'logfire.json_schema': IsJson(
-                    snapshot({'type': 'object', 'properties': {'gen_ai.tool.name': {}, 'gen_ai.tool.call.id': {}}})
+                "gen_ai.tool.name": "final_result",
+                "gen_ai.tool.call.id": IsStr(),
+                "logfire.msg": "running output function: final_result",
+                "logfire.json_schema": IsJson(
+                    snapshot(
+                        {
+                            "type": "object",
+                            "properties": {
+                                "gen_ai.tool.name": {},
+                                "gen_ai.tool.call.id": {},
+                            },
+                        }
+                    )
                 ),
-                'logfire.span_type': 'span',
+                "logfire.span_type": "span",
             }
         )
 
@@ -2029,8 +2284,8 @@ def upcase_text(text: str) -> str:
     return text.upper()
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content', [True, False])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("include_content", [True, False])
 def test_text_output_function_logfire_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
@@ -2041,13 +2296,15 @@ def test_text_output_function_logfire_attributes(
         # Return a plain text response (not a tool call)
         from pydantic_ai import TextPart
 
-        return ModelResponse(parts=[TextPart(content='hello world')])
+        return ModelResponse(parts=[TextPart(content="hello world")])
 
     instrumentation_settings = InstrumentationSettings(include_content=include_content)
-    my_agent = Agent(model=FunctionModel(call_text_response), instrument=instrumentation_settings)
+    my_agent = Agent(
+        model=FunctionModel(call_text_response), instrument=instrumentation_settings
+    )
 
-    result = my_agent.run_sync('Say hello', output_type=TextOutput(upcase_text))
-    assert result.output == 'HELLO WORLD'
+    result = my_agent.run_sync("Say hello", output_type=TextOutput(upcase_text))
+    assert result.output == "HELLO WORLD"
 
     summary = get_logfire_summary()
 
@@ -2055,44 +2312,46 @@ def test_text_output_function_logfire_attributes(
     [text_function_attributes] = [
         attributes
         for attributes in summary.attributes.values()
-        if 'running output function: upcase_text' in attributes.get('logfire.msg', '')
+        if "running output function: upcase_text" in attributes.get("logfire.msg", "")
     ]
 
     if include_content:
         assert text_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'upcase_text',
-                'tool_arguments': '{"text":"hello world"}',
-                'logfire.msg': 'running output function: upcase_text',
-                'logfire.json_schema': IsJson(
+                "gen_ai.tool.name": "upcase_text",
+                "tool_arguments": '{"text":"hello world"}',
+                "logfire.msg": "running output function: upcase_text",
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'tool_arguments': {'type': 'object'},
-                                'tool_response': {'type': 'object'},
-                                'gen_ai.tool.name': {},
+                            "type": "object",
+                            "properties": {
+                                "tool_arguments": {"type": "object"},
+                                "tool_response": {"type": "object"},
+                                "gen_ai.tool.name": {},
                             },
                         }
                     )
                 ),
-                'logfire.span_type': 'span',
-                'tool_response': 'HELLO WORLD',
+                "logfire.span_type": "span",
+                "tool_response": "HELLO WORLD",
             }
         )
     else:
         assert text_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'upcase_text',
-                'logfire.msg': 'running output function: upcase_text',
-                'logfire.json_schema': IsJson(snapshot({'type': 'object', 'properties': {'gen_ai.tool.name': {}}})),
-                'logfire.span_type': 'span',
+                "gen_ai.tool.name": "upcase_text",
+                "logfire.msg": "running output function: upcase_text",
+                "logfire.json_schema": IsJson(
+                    snapshot({"type": "object", "properties": {"gen_ai.tool.name": {}}})
+                ),
+                "logfire.span_type": "span",
             }
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content', [True, False])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("include_content", [True, False])
 def test_prompted_output_function_logfire_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
@@ -2112,13 +2371,15 @@ def test_prompted_output_function_logfire_attributes(
 
     instrumentation_settings = InstrumentationSettings(include_content=include_content)
     agent = Agent(
-        model=FunctionModel(call_tool), instrument=instrumentation_settings, output_type=PromptedOutput(upcase_text)
+        model=FunctionModel(call_tool),
+        instrument=instrumentation_settings,
+        output_type=PromptedOutput(upcase_text),
     )
 
-    result = agent.run_sync('test')
+    result = agent.run_sync("test")
 
     # Check that the function was called and returned the expected result
-    assert result.output == 'HELLO WORLD'
+    assert result.output == "HELLO WORLD"
     assert call_count == 1
 
     summary = get_logfire_summary()
@@ -2127,120 +2388,129 @@ def test_prompted_output_function_logfire_attributes(
     [output_function_attributes] = [
         attributes
         for attributes in summary.attributes.values()
-        if attributes.get('logfire.msg', '').startswith('running output function: upcase_text')
+        if attributes.get("logfire.msg", "").startswith(
+            "running output function: upcase_text"
+        )
     ]
 
     if include_content:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'upcase_text',
-                'tool_arguments': '{"text":"hello world"}',
-                'logfire.msg': 'running output function: upcase_text',
-                'logfire.json_schema': IsJson(
+                "gen_ai.tool.name": "upcase_text",
+                "tool_arguments": '{"text":"hello world"}',
+                "logfire.msg": "running output function: upcase_text",
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'tool_arguments': {'type': 'object'},
-                                'tool_response': {'type': 'object'},
-                                'gen_ai.tool.name': {},
+                            "type": "object",
+                            "properties": {
+                                "tool_arguments": {"type": "object"},
+                                "tool_response": {"type": "object"},
+                                "gen_ai.tool.name": {},
                             },
                         }
                     )
                 ),
-                'logfire.span_type': 'span',
-                'tool_response': 'HELLO WORLD',
+                "logfire.span_type": "span",
+                "tool_response": "HELLO WORLD",
             }
         )
     else:
         assert output_function_attributes == snapshot(
             {
-                'gen_ai.tool.name': 'upcase_text',
-                'logfire.msg': 'running output function: upcase_text',
-                'logfire.json_schema': IsJson(snapshot({'type': 'object', 'properties': {'gen_ai.tool.name': {}}})),
-                'logfire.span_type': 'span',
+                "gen_ai.tool.name": "upcase_text",
+                "logfire.msg": "running output function: upcase_text",
+                "logfire.json_schema": IsJson(
+                    snapshot({"type": "object", "properties": {"gen_ai.tool.name": {}}})
+                ),
+                "logfire.span_type": "span",
             }
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-@pytest.mark.parametrize('include_content', [True, False])
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+@pytest.mark.parametrize("include_content", [True, False])
 def test_output_type_text_output_function_with_retry_logfire_attributes(
     get_logfire_summary: Callable[[], LogfireSummary],
     include_content: bool,
 ) -> None:
     def get_weather_with_retry(ctx: RunContext[None], city: str) -> WeatherInfo:
         assert ctx is not None
-        if city != 'Mexico City':
+        if city != "Mexico City":
             from pydantic_ai import ModelRetry
 
-            raise ModelRetry('City not found, I only know Mexico City')
-        return WeatherInfo(temperature=28.7, description='sunny')
+            raise ModelRetry("City not found, I only know Mexico City")
+        return WeatherInfo(temperature=28.7, description="sunny")
 
     def call_tool(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         assert info.output_tools is not None
 
         if len(messages) == 1:
-            city = 'New York City'
+            city = "New York City"
         else:
-            city = 'Mexico City'
+            city = "Mexico City"
 
         return ModelResponse(parts=[TextPart(content=city)])
 
     instrumentation_settings = InstrumentationSettings(include_content=include_content)
-    my_agent = Agent(model=FunctionModel(call_tool), instrument=instrumentation_settings)
+    my_agent = Agent(
+        model=FunctionModel(call_tool), instrument=instrumentation_settings
+    )
 
-    result = my_agent.run_sync('New York City', output_type=TextOutput(get_weather_with_retry))
-    assert result.output == WeatherInfo(temperature=28.7, description='sunny')
+    result = my_agent.run_sync(
+        "New York City", output_type=TextOutput(get_weather_with_retry)
+    )
+    assert result.output == WeatherInfo(temperature=28.7, description="sunny")
 
     summary = get_logfire_summary()
 
     text_function_attributes = [
         attributes
         for attributes in summary.attributes.values()
-        if 'running output function: get_weather_with_retry' in attributes.get('logfire.msg', '')
+        if "running output function: get_weather_with_retry"
+        in attributes.get("logfire.msg", "")
     ]
 
     if include_content:
         assert text_function_attributes == snapshot(
             [
                 {
-                    'gen_ai.tool.name': 'get_weather_with_retry',
-                    'tool_arguments': '{"city":"New York City"}',
-                    'logfire.msg': 'running output function: get_weather_with_retry',
-                    'logfire.json_schema': IsJson(
+                    "gen_ai.tool.name": "get_weather_with_retry",
+                    "tool_arguments": '{"city":"New York City"}',
+                    "logfire.msg": "running output function: get_weather_with_retry",
+                    "logfire.json_schema": IsJson(
                         snapshot(
                             {
-                                'type': 'object',
-                                'properties': {
-                                    'tool_arguments': {'type': 'object'},
-                                    'tool_response': {'type': 'object'},
-                                    'gen_ai.tool.name': {},
+                                "type": "object",
+                                "properties": {
+                                    "tool_arguments": {"type": "object"},
+                                    "tool_response": {"type": "object"},
+                                    "gen_ai.tool.name": {},
                                 },
                             }
                         )
                     ),
-                    'logfire.span_type': 'span',
-                    'logfire.level_num': 17,
+                    "logfire.span_type": "span",
+                    "logfire.level_num": 17,
                 },
                 {
-                    'gen_ai.tool.name': 'get_weather_with_retry',
-                    'tool_arguments': '{"city":"Mexico City"}',
-                    'logfire.msg': 'running output function: get_weather_with_retry',
-                    'logfire.json_schema': IsJson(
+                    "gen_ai.tool.name": "get_weather_with_retry",
+                    "tool_arguments": '{"city":"Mexico City"}',
+                    "logfire.msg": "running output function: get_weather_with_retry",
+                    "logfire.json_schema": IsJson(
                         snapshot(
                             {
-                                'type': 'object',
-                                'properties': {
-                                    'tool_arguments': {'type': 'object'},
-                                    'tool_response': {'type': 'object'},
-                                    'gen_ai.tool.name': {},
+                                "type": "object",
+                                "properties": {
+                                    "tool_arguments": {"type": "object"},
+                                    "tool_response": {"type": "object"},
+                                    "gen_ai.tool.name": {},
                                 },
                             }
                         )
                     ),
-                    'logfire.span_type': 'span',
-                    'tool_response': '{"temperature": 28.7, "description": "sunny"}',
+                    "logfire.span_type": "span",
+                    "tool_response": '{"temperature": 28.7, "description": "sunny"}',
                 },
             ]
         )
@@ -2248,29 +2518,42 @@ def test_output_type_text_output_function_with_retry_logfire_attributes(
         assert text_function_attributes == snapshot(
             [
                 {
-                    'gen_ai.tool.name': 'get_weather_with_retry',
-                    'logfire.msg': 'running output function: get_weather_with_retry',
-                    'logfire.json_schema': IsJson(snapshot({'type': 'object', 'properties': {'gen_ai.tool.name': {}}})),
-                    'logfire.span_type': 'span',
-                    'logfire.level_num': 17,
+                    "gen_ai.tool.name": "get_weather_with_retry",
+                    "logfire.msg": "running output function: get_weather_with_retry",
+                    "logfire.json_schema": IsJson(
+                        snapshot(
+                            {"type": "object", "properties": {"gen_ai.tool.name": {}}}
+                        )
+                    ),
+                    "logfire.span_type": "span",
+                    "logfire.level_num": 17,
                 },
                 {
-                    'gen_ai.tool.name': 'get_weather_with_retry',
-                    'logfire.msg': 'running output function: get_weather_with_retry',
-                    'logfire.json_schema': IsJson(snapshot({'type': 'object', 'properties': {'gen_ai.tool.name': {}}})),
-                    'logfire.span_type': 'span',
+                    "gen_ai.tool.name": "get_weather_with_retry",
+                    "logfire.msg": "running output function: get_weather_with_retry",
+                    "logfire.json_schema": IsJson(
+                        snapshot(
+                            {"type": "object", "properties": {"gen_ai.tool.name": {}}}
+                        )
+                    ),
+                    "logfire.span_type": "span",
                 },
             ]
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
 @pytest.mark.parametrize(
-    'instrument',
-    [InstrumentationSettings(version=1), InstrumentationSettings(version=2), InstrumentationSettings(version=3)],
+    "instrument",
+    [
+        InstrumentationSettings(version=1),
+        InstrumentationSettings(version=2),
+        InstrumentationSettings(version=3),
+    ],
 )
 def test_static_function_instructions_in_agent_run_span(
-    get_logfire_summary: Callable[[], LogfireSummary], instrument: InstrumentationSettings
+    get_logfire_summary: Callable[[], LogfireSummary],
+    instrument: InstrumentationSettings,
 ) -> None:
     @dataclass
     class MyOutput:
@@ -2280,68 +2563,71 @@ def test_static_function_instructions_in_agent_run_span(
 
     @my_agent.instructions
     def instructions():
-        return 'Here are some instructions'
+        return "Here are some instructions"
 
-    result = my_agent.run_sync('Hello', output_type=MyOutput)
-    assert result.output == MyOutput(content='a')
+    result = my_agent.run_sync("Hello", output_type=MyOutput)
+    assert result.output == MyOutput(content="a")
 
     summary = get_logfire_summary()
     chat_span_attributes = summary.attributes[1]
     if instrument.version == 1:
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'gen_ai.usage.input_tokens': 51,
-                'gen_ai.usage.output_tokens': 5,
-                'all_messages_events': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "gen_ai.usage.input_tokens": 51,
+                "gen_ai.usage.output_tokens": 5,
+                "all_messages_events": IsJson(
                     snapshot(
                         [
                             {
-                                'content': 'Here are some instructions',
-                                'role': 'system',
-                                'event.name': 'gen_ai.system.message',
+                                "content": "Here are some instructions",
+                                "role": "system",
+                                "event.name": "gen_ai.system.message",
                             },
                             {
-                                'content': 'Hello',
-                                'role': 'user',
-                                'gen_ai.message.index': 0,
-                                'event.name': 'gen_ai.user.message',
+                                "content": "Hello",
+                                "role": "user",
+                                "gen_ai.message.index": 0,
+                                "event.name": "gen_ai.user.message",
                             },
                             {
-                                'role': 'assistant',
-                                'tool_calls': [
+                                "role": "assistant",
+                                "tool_calls": [
                                     {
-                                        'id': IsStr(),
-                                        'type': 'function',
-                                        'function': {'name': 'final_result', 'arguments': {'content': 'a'}},
+                                        "id": IsStr(),
+                                        "type": "function",
+                                        "function": {
+                                            "name": "final_result",
+                                            "arguments": {"content": "a"},
+                                        },
                                     }
                                 ],
-                                'gen_ai.message.index': 1,
-                                'event.name': 'gen_ai.assistant.message',
+                                "gen_ai.message.index": 1,
+                                "event.name": "gen_ai.assistant.message",
                             },
                             {
-                                'content': 'Final result processed.',
-                                'role': 'tool',
-                                'id': IsStr(),
-                                'name': 'final_result',
-                                'gen_ai.message.index': 2,
-                                'event.name': 'gen_ai.tool.message',
+                                "content": "Final result processed.",
+                                "role": "tool",
+                                "id": IsStr(),
+                                "name": "final_result",
+                                "gen_ai.message.index": 2,
+                                "event.name": "gen_ai.tool.message",
                             },
                         ]
                     )
                 ),
-                'final_result': '{"content": "a"}',
-                'logfire.json_schema': IsJson(
+                "final_result": '{"content": "a"}',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'all_messages_events': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "all_messages_events": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -2349,36 +2635,39 @@ def test_static_function_instructions_in_agent_run_span(
             }
         )
 
-        assert chat_span_attributes['events'] == IsJson(
+        assert chat_span_attributes["events"] == IsJson(
             snapshot(
                 [
                     {
-                        'content': 'Here are some instructions',
-                        'role': 'system',
-                        'gen_ai.system': 'test',
-                        'event.name': 'gen_ai.system.message',
+                        "content": "Here are some instructions",
+                        "role": "system",
+                        "gen_ai.system": "test",
+                        "event.name": "gen_ai.system.message",
                     },
                     {
-                        'event.name': 'gen_ai.user.message',
-                        'content': 'Hello',
-                        'role': 'user',
-                        'gen_ai.message.index': 0,
-                        'gen_ai.system': 'test',
+                        "event.name": "gen_ai.user.message",
+                        "content": "Hello",
+                        "role": "user",
+                        "gen_ai.message.index": 0,
+                        "gen_ai.system": "test",
                     },
                     {
-                        'event.name': 'gen_ai.choice',
-                        'index': 0,
-                        'message': {
-                            'role': 'assistant',
-                            'tool_calls': [
+                        "event.name": "gen_ai.choice",
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "tool_calls": [
                                 {
-                                    'id': IsStr(),
-                                    'type': 'function',
-                                    'function': {'name': 'final_result', 'arguments': {'content': 'a'}},
+                                    "id": IsStr(),
+                                    "type": "function",
+                                    "function": {
+                                        "name": "final_result",
+                                        "arguments": {"content": "a"},
+                                    },
                                 }
                             ],
                         },
-                        'gen_ai.system': 'test',
+                        "gen_ai.system": "test",
                     },
                 ]
             )
@@ -2388,10 +2677,12 @@ def test_static_function_instructions_in_agent_run_span(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'agent run',
-                        'message': 'my_agent run',
-                        'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+                        "id": 0,
+                        "name": "agent run",
+                        "message": "my_agent run",
+                        "children": [
+                            {"id": 1, "name": "chat test", "message": "chat test"}
+                        ],
                     }
                 ]
             )
@@ -2399,62 +2690,67 @@ def test_static_function_instructions_in_agent_run_span(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'invoke_agent my_agent',
-                        'message': 'my_agent run',
-                        'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+                        "id": 0,
+                        "name": "invoke_agent my_agent",
+                        "message": "my_agent run",
+                        "children": [
+                            {"id": 1, "name": "chat test", "message": "chat test"}
+                        ],
                     }
                 ]
             )
 
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'final_result': '{"content": "a"}',
-                'gen_ai.usage.input_tokens': 51,
-                'gen_ai.usage.output_tokens': 5,
-                'pydantic_ai.all_messages': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "final_result": '{"content": "a"}',
+                "gen_ai.usage.input_tokens": 51,
+                "gen_ai.usage.output_tokens": 5,
+                "pydantic_ai.all_messages": IsJson(
                     snapshot(
                         [
-                            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]},
                             {
-                                'role': 'assistant',
-                                'parts': [
+                                "role": "user",
+                                "parts": [{"type": "text", "content": "Hello"}],
+                            },
+                            {
+                                "role": "assistant",
+                                "parts": [
                                     {
-                                        'type': 'tool_call',
-                                        'id': IsStr(),
-                                        'name': 'final_result',
-                                        'arguments': {'content': 'a'},
+                                        "type": "tool_call",
+                                        "id": IsStr(),
+                                        "name": "final_result",
+                                        "arguments": {"content": "a"},
                                     }
                                 ],
                             },
                             {
-                                'role': 'user',
-                                'parts': [
+                                "role": "user",
+                                "parts": [
                                     {
-                                        'type': 'tool_call_response',
-                                        'id': IsStr(),
-                                        'name': 'final_result',
-                                        'result': 'Final result processed.',
+                                        "type": "tool_call_response",
+                                        "id": IsStr(),
+                                        "name": "final_result",
+                                        "result": "Final result processed.",
                                     }
                                 ],
                             },
                         ]
                     )
                 ),
-                'gen_ai.system_instructions': '[{"type": "text", "content": "Here are some instructions"}]',
-                'logfire.json_schema': IsJson(
+                "gen_ai.system_instructions": '[{"type": "text", "content": "Here are some instructions"}]',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'pydantic_ai.all_messages': {'type': 'array'},
-                                'gen_ai.system_instructions': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "pydantic_ai.all_messages": {"type": "array"},
+                                "gen_ai.system_instructions": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -2462,20 +2758,22 @@ def test_static_function_instructions_in_agent_run_span(
             }
         )
 
-        assert chat_span_attributes['gen_ai.input.messages'] == IsJson(
-            snapshot([{'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]}])
+        assert chat_span_attributes["gen_ai.input.messages"] == IsJson(
+            snapshot(
+                [{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]
+            )
         )
-        assert chat_span_attributes['gen_ai.output.messages'] == IsJson(
+        assert chat_span_attributes["gen_ai.output.messages"] == IsJson(
             snapshot(
                 [
                     {
-                        'role': 'assistant',
-                        'parts': [
+                        "role": "assistant",
+                        "parts": [
                             {
-                                'type': 'tool_call',
-                                'id': IsStr(),
-                                'name': 'final_result',
-                                'arguments': {'content': 'a'},
+                                "type": "tool_call",
+                                "id": IsStr(),
+                                "name": "final_result",
+                                "arguments": {"content": "a"},
                             }
                         ],
                     }
@@ -2484,13 +2782,18 @@ def test_static_function_instructions_in_agent_run_span(
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
 @pytest.mark.parametrize(
-    'instrument',
-    [InstrumentationSettings(version=1), InstrumentationSettings(version=2), InstrumentationSettings(version=3)],
+    "instrument",
+    [
+        InstrumentationSettings(version=1),
+        InstrumentationSettings(version=2),
+        InstrumentationSettings(version=3),
+    ],
 )
 def test_dynamic_function_instructions_in_agent_run_span(
-    get_logfire_summary: Callable[[], LogfireSummary], instrument: InstrumentationSettings
+    get_logfire_summary: Callable[[], LogfireSummary],
+    instrument: InstrumentationSettings,
 ) -> None:
     @dataclass
     class MyOutput:
@@ -2500,92 +2803,98 @@ def test_dynamic_function_instructions_in_agent_run_span(
 
     @my_agent.instructions
     def instructions(ctx: RunContext[None]):
-        return f'This is step {ctx.run_step + 1}'
+        return f"This is step {ctx.run_step + 1}"
 
     @my_agent.tool_plain
     def my_tool() -> str:
-        return 'This is a tool call'
+        return "This is a tool call"
 
-    result = my_agent.run_sync('Hello', output_type=MyOutput)
-    assert result.output == MyOutput(content='a')
+    result = my_agent.run_sync("Hello", output_type=MyOutput)
+    assert result.output == MyOutput(content="a")
 
     summary = get_logfire_summary()
     chat_span_attributes = summary.attributes[1]
     if instrument.version == 1:
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'gen_ai.usage.input_tokens': 107,
-                'gen_ai.usage.output_tokens': 9,
-                'all_messages_events': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "gen_ai.usage.input_tokens": 107,
+                "gen_ai.usage.output_tokens": 9,
+                "all_messages_events": IsJson(
                     snapshot(
                         [
                             {
-                                'content': 'This is step 2',
-                                'role': 'system',
-                                'event.name': 'gen_ai.system.message',
+                                "content": "This is step 2",
+                                "role": "system",
+                                "event.name": "gen_ai.system.message",
                             },
                             {
-                                'content': 'Hello',
-                                'role': 'user',
-                                'gen_ai.message.index': 0,
-                                'event.name': 'gen_ai.user.message',
+                                "content": "Hello",
+                                "role": "user",
+                                "gen_ai.message.index": 0,
+                                "event.name": "gen_ai.user.message",
                             },
                             {
-                                'role': 'assistant',
-                                'tool_calls': [
+                                "role": "assistant",
+                                "tool_calls": [
                                     {
-                                        'id': 'pyd_ai_tool_call_id__my_tool',
-                                        'type': 'function',
-                                        'function': {'name': 'my_tool', 'arguments': {}},
+                                        "id": "pyd_ai_tool_call_id__my_tool",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "my_tool",
+                                            "arguments": {},
+                                        },
                                     }
                                 ],
-                                'gen_ai.message.index': 1,
-                                'event.name': 'gen_ai.assistant.message',
+                                "gen_ai.message.index": 1,
+                                "event.name": "gen_ai.assistant.message",
                             },
                             {
-                                'content': 'This is a tool call',
-                                'role': 'tool',
-                                'id': 'pyd_ai_tool_call_id__my_tool',
-                                'name': 'my_tool',
-                                'gen_ai.message.index': 2,
-                                'event.name': 'gen_ai.tool.message',
+                                "content": "This is a tool call",
+                                "role": "tool",
+                                "id": "pyd_ai_tool_call_id__my_tool",
+                                "name": "my_tool",
+                                "gen_ai.message.index": 2,
+                                "event.name": "gen_ai.tool.message",
                             },
                             {
-                                'role': 'assistant',
-                                'tool_calls': [
+                                "role": "assistant",
+                                "tool_calls": [
                                     {
-                                        'id': 'pyd_ai_tool_call_id__final_result',
-                                        'type': 'function',
-                                        'function': {'name': 'final_result', 'arguments': {'content': 'a'}},
+                                        "id": "pyd_ai_tool_call_id__final_result",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "final_result",
+                                            "arguments": {"content": "a"},
+                                        },
                                     }
                                 ],
-                                'gen_ai.message.index': 3,
-                                'event.name': 'gen_ai.assistant.message',
+                                "gen_ai.message.index": 3,
+                                "event.name": "gen_ai.assistant.message",
                             },
                             {
-                                'content': 'Final result processed.',
-                                'role': 'tool',
-                                'id': 'pyd_ai_tool_call_id__final_result',
-                                'name': 'final_result',
-                                'gen_ai.message.index': 4,
-                                'event.name': 'gen_ai.tool.message',
+                                "content": "Final result processed.",
+                                "role": "tool",
+                                "id": "pyd_ai_tool_call_id__final_result",
+                                "name": "final_result",
+                                "gen_ai.message.index": 4,
+                                "event.name": "gen_ai.tool.message",
                             },
                         ]
                     )
                 ),
-                'final_result': '{"content": "a"}',
-                'logfire.json_schema': IsJson(
+                "final_result": '{"content": "a"}',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'all_messages_events': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "all_messages_events": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -2593,36 +2902,36 @@ def test_dynamic_function_instructions_in_agent_run_span(
             }
         )
 
-        assert chat_span_attributes['events'] == IsJson(
+        assert chat_span_attributes["events"] == IsJson(
             snapshot(
                 [
                     {
-                        'content': 'This is step 1',
-                        'role': 'system',
-                        'gen_ai.system': 'test',
-                        'event.name': 'gen_ai.system.message',
+                        "content": "This is step 1",
+                        "role": "system",
+                        "gen_ai.system": "test",
+                        "event.name": "gen_ai.system.message",
                     },
                     {
-                        'event.name': 'gen_ai.user.message',
-                        'content': 'Hello',
-                        'role': 'user',
-                        'gen_ai.message.index': 0,
-                        'gen_ai.system': 'test',
+                        "event.name": "gen_ai.user.message",
+                        "content": "Hello",
+                        "role": "user",
+                        "gen_ai.message.index": 0,
+                        "gen_ai.system": "test",
                     },
                     {
-                        'event.name': 'gen_ai.choice',
-                        'index': 0,
-                        'message': {
-                            'role': 'assistant',
-                            'tool_calls': [
+                        "event.name": "gen_ai.choice",
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "tool_calls": [
                                 {
-                                    'id': IsStr(),
-                                    'type': 'function',
-                                    'function': {'name': 'my_tool', 'arguments': {}},
+                                    "id": IsStr(),
+                                    "type": "function",
+                                    "function": {"name": "my_tool", "arguments": {}},
                                 }
                             ],
                         },
-                        'gen_ai.system': 'test',
+                        "gen_ai.system": "test",
                     },
                 ]
             )
@@ -2632,13 +2941,17 @@ def test_dynamic_function_instructions_in_agent_run_span(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'agent run',
-                        'message': 'my_agent run',
-                        'children': [
-                            {'id': 1, 'name': 'chat test', 'message': 'chat test'},
-                            {'id': 2, 'name': 'running tool', 'message': 'running tool: my_tool'},
-                            {'id': 3, 'name': 'chat test', 'message': 'chat test'},
+                        "id": 0,
+                        "name": "agent run",
+                        "message": "my_agent run",
+                        "children": [
+                            {"id": 1, "name": "chat test", "message": "chat test"},
+                            {
+                                "id": 2,
+                                "name": "running tool",
+                                "message": "running tool: my_tool",
+                            },
+                            {"id": 3, "name": "chat test", "message": "chat test"},
                         ],
                     }
                 ]
@@ -2647,13 +2960,17 @@ def test_dynamic_function_instructions_in_agent_run_span(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'invoke_agent my_agent',
-                        'message': 'my_agent run',
-                        'children': [
-                            {'id': 1, 'name': 'chat test', 'message': 'chat test'},
-                            {'id': 2, 'name': 'execute_tool my_tool', 'message': 'running tool: my_tool'},
-                            {'id': 3, 'name': 'chat test', 'message': 'chat test'},
+                        "id": 0,
+                        "name": "invoke_agent my_agent",
+                        "message": "my_agent run",
+                        "children": [
+                            {"id": 1, "name": "chat test", "message": "chat test"},
+                            {
+                                "id": 2,
+                                "name": "execute_tool my_tool",
+                                "message": "running tool: my_tool",
+                            },
+                            {"id": 3, "name": "chat test", "message": "chat test"},
                         ],
                     }
                 ]
@@ -2661,76 +2978,79 @@ def test_dynamic_function_instructions_in_agent_run_span(
 
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'final_result': '{"content": "a"}',
-                'gen_ai.usage.input_tokens': 107,
-                'gen_ai.usage.output_tokens': 9,
-                'pydantic_ai.all_messages': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "final_result": '{"content": "a"}',
+                "gen_ai.usage.input_tokens": 107,
+                "gen_ai.usage.output_tokens": 9,
+                "pydantic_ai.all_messages": IsJson(
                     snapshot(
                         [
-                            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]},
                             {
-                                'role': 'assistant',
-                                'parts': [
+                                "role": "user",
+                                "parts": [{"type": "text", "content": "Hello"}],
+                            },
+                            {
+                                "role": "assistant",
+                                "parts": [
                                     {
-                                        'type': 'tool_call',
-                                        'id': 'pyd_ai_tool_call_id__my_tool',
-                                        'name': 'my_tool',
-                                        'arguments': {},
+                                        "type": "tool_call",
+                                        "id": "pyd_ai_tool_call_id__my_tool",
+                                        "name": "my_tool",
+                                        "arguments": {},
                                     }
                                 ],
                             },
                             {
-                                'role': 'user',
-                                'parts': [
+                                "role": "user",
+                                "parts": [
                                     {
-                                        'type': 'tool_call_response',
-                                        'id': 'pyd_ai_tool_call_id__my_tool',
-                                        'name': 'my_tool',
-                                        'result': 'This is a tool call',
+                                        "type": "tool_call_response",
+                                        "id": "pyd_ai_tool_call_id__my_tool",
+                                        "name": "my_tool",
+                                        "result": "This is a tool call",
                                     }
                                 ],
                             },
                             {
-                                'role': 'assistant',
-                                'parts': [
+                                "role": "assistant",
+                                "parts": [
                                     {
-                                        'type': 'tool_call',
-                                        'id': IsStr(),
-                                        'name': 'final_result',
-                                        'arguments': {'content': 'a'},
+                                        "type": "tool_call",
+                                        "id": IsStr(),
+                                        "name": "final_result",
+                                        "arguments": {"content": "a"},
                                     }
                                 ],
                             },
                             {
-                                'role': 'user',
-                                'parts': [
+                                "role": "user",
+                                "parts": [
                                     {
-                                        'type': 'tool_call_response',
-                                        'id': IsStr(),
-                                        'name': 'final_result',
-                                        'result': 'Final result processed.',
+                                        "type": "tool_call_response",
+                                        "id": IsStr(),
+                                        "name": "final_result",
+                                        "result": "Final result processed.",
                                     }
                                 ],
                             },
                         ]
                     )
                 ),
-                'gen_ai.system_instructions': '[{"type": "text", "content": "This is step 2"}]',
-                'pydantic_ai.variable_instructions': True,
-                'logfire.json_schema': IsJson(
+                "gen_ai.system_instructions": '[{"type": "text", "content": "This is step 2"}]',
+                "pydantic_ai.variable_instructions": True,
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'pydantic_ai.all_messages': {'type': 'array'},
-                                'gen_ai.system_instructions': {'type': 'array'},
-                                'pydantic_ai.variable_instructions': {},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "pydantic_ai.all_messages": {"type": "array"},
+                                "gen_ai.system_instructions": {"type": "array"},
+                                "pydantic_ai.variable_instructions": {},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -2738,20 +3058,22 @@ def test_dynamic_function_instructions_in_agent_run_span(
             }
         )
 
-        assert chat_span_attributes['gen_ai.input.messages'] == IsJson(
-            snapshot([{'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]}])
+        assert chat_span_attributes["gen_ai.input.messages"] == IsJson(
+            snapshot(
+                [{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]
+            )
         )
-        assert chat_span_attributes['gen_ai.output.messages'] == IsJson(
+        assert chat_span_attributes["gen_ai.output.messages"] == IsJson(
             snapshot(
                 [
                     {
-                        'role': 'assistant',
-                        'parts': [
+                        "role": "assistant",
+                        "parts": [
                             {
-                                'type': 'tool_call',
-                                'id': IsStr(),
-                                'name': 'my_tool',
-                                'arguments': {},
+                                "type": "tool_call",
+                                "id": IsStr(),
+                                "name": "my_tool",
+                                "arguments": {},
                             }
                         ],
                     }
@@ -2760,13 +3082,18 @@ def test_dynamic_function_instructions_in_agent_run_span(
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
 @pytest.mark.parametrize(
-    'instrument',
-    [InstrumentationSettings(version=1), InstrumentationSettings(version=2), InstrumentationSettings(version=3)],
+    "instrument",
+    [
+        InstrumentationSettings(version=1),
+        InstrumentationSettings(version=2),
+        InstrumentationSettings(version=3),
+    ],
 )
 def test_function_instructions_with_history_in_agent_run_span(
-    get_logfire_summary: Callable[[], LogfireSummary], instrument: InstrumentationSettings
+    get_logfire_summary: Callable[[], LogfireSummary],
+    instrument: InstrumentationSettings,
 ) -> None:
     @dataclass
     class MyOutput:
@@ -2776,91 +3103,94 @@ def test_function_instructions_with_history_in_agent_run_span(
 
     @my_agent.instructions
     def instructions(ctx: RunContext[None]):
-        return 'Instructions for the current agent run'
+        return "Instructions for the current agent run"
 
     result = my_agent.run_sync(
-        'Hello',
+        "Hello",
         message_history=[
             ModelRequest(
-                parts=[UserPromptPart(content='Hi')],
-                instructions='Instructions from a previous agent run',
+                parts=[UserPromptPart(content="Hi")],
+                instructions="Instructions from a previous agent run",
                 timestamp=IsDatetime(),
             ),
-            ModelResponse(parts=[TextPart(content='Hello')]),
+            ModelResponse(parts=[TextPart(content="Hello")]),
         ],
         output_type=MyOutput,
     )
-    assert result.output == MyOutput(content='a')
+    assert result.output == MyOutput(content="a")
 
     summary = get_logfire_summary()
     chat_span_attributes = summary.attributes[1]
     if instrument.version == 1:
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'gen_ai.usage.input_tokens': 52,
-                'gen_ai.usage.output_tokens': 6,
-                'all_messages_events': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "gen_ai.usage.input_tokens": 52,
+                "gen_ai.usage.output_tokens": 6,
+                "all_messages_events": IsJson(
                     snapshot(
                         [
                             {
-                                'content': 'Instructions for the current agent run',
-                                'role': 'system',
-                                'event.name': 'gen_ai.system.message',
+                                "content": "Instructions for the current agent run",
+                                "role": "system",
+                                "event.name": "gen_ai.system.message",
                             },
                             {
-                                'content': 'Hi',
-                                'role': 'user',
-                                'gen_ai.message.index': 0,
-                                'event.name': 'gen_ai.user.message',
+                                "content": "Hi",
+                                "role": "user",
+                                "gen_ai.message.index": 0,
+                                "event.name": "gen_ai.user.message",
                             },
                             {
-                                'role': 'assistant',
-                                'content': 'Hello',
-                                'gen_ai.message.index': 1,
-                                'event.name': 'gen_ai.assistant.message',
+                                "role": "assistant",
+                                "content": "Hello",
+                                "gen_ai.message.index": 1,
+                                "event.name": "gen_ai.assistant.message",
                             },
                             {
-                                'content': 'Hello',
-                                'role': 'user',
-                                'gen_ai.message.index': 2,
-                                'event.name': 'gen_ai.user.message',
+                                "content": "Hello",
+                                "role": "user",
+                                "gen_ai.message.index": 2,
+                                "event.name": "gen_ai.user.message",
                             },
                             {
-                                'role': 'assistant',
-                                'tool_calls': [
+                                "role": "assistant",
+                                "tool_calls": [
                                     {
-                                        'id': 'pyd_ai_tool_call_id__final_result',
-                                        'type': 'function',
-                                        'function': {'name': 'final_result', 'arguments': {'content': 'a'}},
+                                        "id": "pyd_ai_tool_call_id__final_result",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "final_result",
+                                            "arguments": {"content": "a"},
+                                        },
                                     }
                                 ],
-                                'gen_ai.message.index': 3,
-                                'event.name': 'gen_ai.assistant.message',
+                                "gen_ai.message.index": 3,
+                                "event.name": "gen_ai.assistant.message",
                             },
                             {
-                                'content': 'Final result processed.',
-                                'role': 'tool',
-                                'id': 'pyd_ai_tool_call_id__final_result',
-                                'name': 'final_result',
-                                'gen_ai.message.index': 4,
-                                'event.name': 'gen_ai.tool.message',
+                                "content": "Final result processed.",
+                                "role": "tool",
+                                "id": "pyd_ai_tool_call_id__final_result",
+                                "name": "final_result",
+                                "gen_ai.message.index": 4,
+                                "event.name": "gen_ai.tool.message",
                             },
                         ]
                     )
                 ),
-                'final_result': '{"content": "a"}',
-                'logfire.json_schema': IsJson(
+                "final_result": '{"content": "a"}',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'all_messages_events': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "all_messages_events": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -2868,50 +3198,53 @@ def test_function_instructions_with_history_in_agent_run_span(
             }
         )
 
-        assert chat_span_attributes['events'] == IsJson(
+        assert chat_span_attributes["events"] == IsJson(
             snapshot(
                 [
                     {
-                        'content': 'Instructions for the current agent run',
-                        'role': 'system',
-                        'gen_ai.system': 'test',
-                        'event.name': 'gen_ai.system.message',
+                        "content": "Instructions for the current agent run",
+                        "role": "system",
+                        "gen_ai.system": "test",
+                        "event.name": "gen_ai.system.message",
                     },
                     {
-                        'content': 'Hi',
-                        'role': 'user',
-                        'gen_ai.system': 'test',
-                        'gen_ai.message.index': 0,
-                        'event.name': 'gen_ai.user.message',
+                        "content": "Hi",
+                        "role": "user",
+                        "gen_ai.system": "test",
+                        "gen_ai.message.index": 0,
+                        "event.name": "gen_ai.user.message",
                     },
                     {
-                        'role': 'assistant',
-                        'content': 'Hello',
-                        'gen_ai.system': 'test',
-                        'gen_ai.message.index': 1,
-                        'event.name': 'gen_ai.assistant.message',
+                        "role": "assistant",
+                        "content": "Hello",
+                        "gen_ai.system": "test",
+                        "gen_ai.message.index": 1,
+                        "event.name": "gen_ai.assistant.message",
                     },
                     {
-                        'content': 'Hello',
-                        'role': 'user',
-                        'gen_ai.system': 'test',
-                        'gen_ai.message.index': 2,
-                        'event.name': 'gen_ai.user.message',
+                        "content": "Hello",
+                        "role": "user",
+                        "gen_ai.system": "test",
+                        "gen_ai.message.index": 2,
+                        "event.name": "gen_ai.user.message",
                     },
                     {
-                        'event.name': 'gen_ai.choice',
-                        'index': 0,
-                        'message': {
-                            'role': 'assistant',
-                            'tool_calls': [
+                        "event.name": "gen_ai.choice",
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "tool_calls": [
                                 {
-                                    'id': IsStr(),
-                                    'type': 'function',
-                                    'function': {'name': 'final_result', 'arguments': {'content': 'a'}},
+                                    "id": IsStr(),
+                                    "type": "function",
+                                    "function": {
+                                        "name": "final_result",
+                                        "arguments": {"content": "a"},
+                                    },
                                 }
                             ],
                         },
-                        'gen_ai.system': 'test',
+                        "gen_ai.system": "test",
                     },
                 ]
             )
@@ -2921,10 +3254,12 @@ def test_function_instructions_with_history_in_agent_run_span(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'agent run',
-                        'message': 'my_agent run',
-                        'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+                        "id": 0,
+                        "name": "agent run",
+                        "message": "my_agent run",
+                        "children": [
+                            {"id": 1, "name": "chat test", "message": "chat test"}
+                        ],
                     }
                 ]
             )
@@ -2932,66 +3267,77 @@ def test_function_instructions_with_history_in_agent_run_span(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'invoke_agent my_agent',
-                        'message': 'my_agent run',
-                        'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+                        "id": 0,
+                        "name": "invoke_agent my_agent",
+                        "message": "my_agent run",
+                        "children": [
+                            {"id": 1, "name": "chat test", "message": "chat test"}
+                        ],
                     }
                 ]
             )
 
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'final_result': '{"content": "a"}',
-                'gen_ai.usage.input_tokens': 52,
-                'gen_ai.usage.output_tokens': 6,
-                'pydantic_ai.all_messages': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "final_result": '{"content": "a"}',
+                "gen_ai.usage.input_tokens": 52,
+                "gen_ai.usage.output_tokens": 6,
+                "pydantic_ai.all_messages": IsJson(
                     snapshot(
                         [
-                            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hi'}]},
-                            {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'Hello'}]},
-                            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]},
                             {
-                                'role': 'assistant',
-                                'parts': [
+                                "role": "user",
+                                "parts": [{"type": "text", "content": "Hi"}],
+                            },
+                            {
+                                "role": "assistant",
+                                "parts": [{"type": "text", "content": "Hello"}],
+                            },
+                            {
+                                "role": "user",
+                                "parts": [{"type": "text", "content": "Hello"}],
+                            },
+                            {
+                                "role": "assistant",
+                                "parts": [
                                     {
-                                        'type': 'tool_call',
-                                        'id': IsStr(),
-                                        'name': 'final_result',
-                                        'arguments': {'content': 'a'},
+                                        "type": "tool_call",
+                                        "id": IsStr(),
+                                        "name": "final_result",
+                                        "arguments": {"content": "a"},
                                     }
                                 ],
                             },
                             {
-                                'role': 'user',
-                                'parts': [
+                                "role": "user",
+                                "parts": [
                                     {
-                                        'type': 'tool_call_response',
-                                        'id': IsStr(),
-                                        'name': 'final_result',
-                                        'result': 'Final result processed.',
+                                        "type": "tool_call_response",
+                                        "id": IsStr(),
+                                        "name": "final_result",
+                                        "result": "Final result processed.",
                                     }
                                 ],
                             },
                         ]
                     )
                 ),
-                'pydantic_ai.new_message_index': 2,
-                'gen_ai.system_instructions': '[{"type": "text", "content": "Instructions for the current agent run"}]',
-                'logfire.json_schema': IsJson(
+                "pydantic_ai.new_message_index": 2,
+                "gen_ai.system_instructions": '[{"type": "text", "content": "Instructions for the current agent run"}]',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'pydantic_ai.all_messages': {'type': 'array'},
-                                'pydantic_ai.new_message_index': {},
-                                'gen_ai.system_instructions': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "pydantic_ai.all_messages": {"type": "array"},
+                                "pydantic_ai.new_message_index": {},
+                                "gen_ai.system_instructions": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -2999,26 +3345,29 @@ def test_function_instructions_with_history_in_agent_run_span(
             }
         )
 
-        assert chat_span_attributes['gen_ai.input.messages'] == IsJson(
+        assert chat_span_attributes["gen_ai.input.messages"] == IsJson(
             snapshot(
                 [
-                    {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hi'}]},
-                    {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'Hello'}]},
-                    {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]},
+                    {"role": "user", "parts": [{"type": "text", "content": "Hi"}]},
+                    {
+                        "role": "assistant",
+                        "parts": [{"type": "text", "content": "Hello"}],
+                    },
+                    {"role": "user", "parts": [{"type": "text", "content": "Hello"}]},
                 ]
             )
         )
-        assert chat_span_attributes['gen_ai.output.messages'] == IsJson(
+        assert chat_span_attributes["gen_ai.output.messages"] == IsJson(
             snapshot(
                 [
                     {
-                        'role': 'assistant',
-                        'parts': [
+                        "role": "assistant",
+                        "parts": [
                             {
-                                'type': 'tool_call',
-                                'id': IsStr(),
-                                'name': 'final_result',
-                                'arguments': {'content': 'a'},
+                                "type": "tool_call",
+                                "id": IsStr(),
+                                "name": "final_result",
+                                "arguments": {"content": "a"},
                             }
                         ],
                     }
@@ -3027,21 +3376,26 @@ def test_function_instructions_with_history_in_agent_run_span(
         )
 
 
-@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
 @pytest.mark.parametrize(
-    'instrument',
-    [InstrumentationSettings(version=1), InstrumentationSettings(version=2), InstrumentationSettings(version=3)],
+    "instrument",
+    [
+        InstrumentationSettings(version=1),
+        InstrumentationSettings(version=2),
+        InstrumentationSettings(version=3),
+    ],
 )
 async def test_run_stream(
-    get_logfire_summary: Callable[[], LogfireSummary], instrument: InstrumentationSettings
+    get_logfire_summary: Callable[[], LogfireSummary],
+    instrument: InstrumentationSettings,
 ) -> None:
     my_agent = Agent(model=TestModel(), instrument=instrument)
 
     @my_agent.instructions
     def instructions(ctx: RunContext[None]):
-        return 'Instructions for the current agent run'
+        return "Instructions for the current agent run"
 
-    async with my_agent.run_stream('Hello') as stream:
+    async with my_agent.run_stream("Hello") as stream:
         async for _ in stream.stream_output():
             pass
 
@@ -3050,44 +3404,44 @@ async def test_run_stream(
     if instrument.version == 1:
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'final_result': 'success (no tool calls)',
-                'gen_ai.usage.input_tokens': 51,
-                'gen_ai.usage.output_tokens': 4,
-                'all_messages_events': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "final_result": "success (no tool calls)",
+                "gen_ai.usage.input_tokens": 51,
+                "gen_ai.usage.output_tokens": 4,
+                "all_messages_events": IsJson(
                     snapshot(
                         [
                             {
-                                'content': 'Instructions for the current agent run',
-                                'role': 'system',
-                                'event.name': 'gen_ai.system.message',
+                                "content": "Instructions for the current agent run",
+                                "role": "system",
+                                "event.name": "gen_ai.system.message",
                             },
                             {
-                                'content': 'Hello',
-                                'role': 'user',
-                                'gen_ai.message.index': 0,
-                                'event.name': 'gen_ai.user.message',
+                                "content": "Hello",
+                                "role": "user",
+                                "gen_ai.message.index": 0,
+                                "event.name": "gen_ai.user.message",
                             },
                             {
-                                'role': 'assistant',
-                                'content': 'success (no tool calls)',
-                                'gen_ai.message.index': 1,
-                                'event.name': 'gen_ai.assistant.message',
+                                "role": "assistant",
+                                "content": "success (no tool calls)",
+                                "gen_ai.message.index": 1,
+                                "event.name": "gen_ai.assistant.message",
                             },
                         ]
                     )
                 ),
-                'logfire.json_schema': IsJson(
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'all_messages_events': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "all_messages_events": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -3095,27 +3449,30 @@ async def test_run_stream(
             }
         )
 
-        assert chat_span_attributes['events'] == IsJson(
+        assert chat_span_attributes["events"] == IsJson(
             snapshot(
                 [
                     {
-                        'content': 'Instructions for the current agent run',
-                        'role': 'system',
-                        'gen_ai.system': 'test',
-                        'event.name': 'gen_ai.system.message',
+                        "content": "Instructions for the current agent run",
+                        "role": "system",
+                        "gen_ai.system": "test",
+                        "event.name": "gen_ai.system.message",
                     },
                     {
-                        'content': 'Hello',
-                        'role': 'user',
-                        'gen_ai.system': 'test',
-                        'gen_ai.message.index': 0,
-                        'event.name': 'gen_ai.user.message',
+                        "content": "Hello",
+                        "role": "user",
+                        "gen_ai.system": "test",
+                        "gen_ai.message.index": 0,
+                        "event.name": "gen_ai.user.message",
                     },
                     {
-                        'index': 0,
-                        'message': {'role': 'assistant', 'content': 'success (no tool calls)'},
-                        'gen_ai.system': 'test',
-                        'event.name': 'gen_ai.choice',
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "success (no tool calls)",
+                        },
+                        "gen_ai.system": "test",
+                        "event.name": "gen_ai.choice",
                     },
                 ]
             )
@@ -3125,10 +3482,12 @@ async def test_run_stream(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'agent run',
-                        'message': 'my_agent run',
-                        'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+                        "id": 0,
+                        "name": "agent run",
+                        "message": "my_agent run",
+                        "children": [
+                            {"id": 1, "name": "chat test", "message": "chat test"}
+                        ],
                     }
                 ]
             )
@@ -3136,41 +3495,54 @@ async def test_run_stream(
             assert summary.traces == snapshot(
                 [
                     {
-                        'id': 0,
-                        'name': 'invoke_agent my_agent',
-                        'message': 'my_agent run',
-                        'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+                        "id": 0,
+                        "name": "invoke_agent my_agent",
+                        "message": "my_agent run",
+                        "children": [
+                            {"id": 1, "name": "chat test", "message": "chat test"}
+                        ],
                     }
                 ]
             )
 
         assert summary.attributes[0] == snapshot(
             {
-                'model_name': 'test',
-                'agent_name': 'my_agent',
-                'gen_ai.agent.name': 'my_agent',
-                'logfire.msg': 'my_agent run',
-                'logfire.span_type': 'span',
-                'final_result': 'success (no tool calls)',
-                'gen_ai.usage.input_tokens': 51,
-                'gen_ai.usage.output_tokens': 4,
-                'pydantic_ai.all_messages': IsJson(
+                "model_name": "test",
+                "agent_name": "my_agent",
+                "gen_ai.agent.name": "my_agent",
+                "logfire.msg": "my_agent run",
+                "logfire.span_type": "span",
+                "final_result": "success (no tool calls)",
+                "gen_ai.usage.input_tokens": 51,
+                "gen_ai.usage.output_tokens": 4,
+                "pydantic_ai.all_messages": IsJson(
                     snapshot(
                         [
-                            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]},
-                            {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'success (no tool calls)'}]},
+                            {
+                                "role": "user",
+                                "parts": [{"type": "text", "content": "Hello"}],
+                            },
+                            {
+                                "role": "assistant",
+                                "parts": [
+                                    {
+                                        "type": "text",
+                                        "content": "success (no tool calls)",
+                                    }
+                                ],
+                            },
                         ]
                     )
                 ),
-                'gen_ai.system_instructions': '[{"type": "text", "content": "Instructions for the current agent run"}]',
-                'logfire.json_schema': IsJson(
+                "gen_ai.system_instructions": '[{"type": "text", "content": "Instructions for the current agent run"}]',
+                "logfire.json_schema": IsJson(
                     snapshot(
                         {
-                            'type': 'object',
-                            'properties': {
-                                'pydantic_ai.all_messages': {'type': 'array'},
-                                'gen_ai.system_instructions': {'type': 'array'},
-                                'final_result': {'type': 'object'},
+                            "type": "object",
+                            "properties": {
+                                "pydantic_ai.all_messages": {"type": "array"},
+                                "gen_ai.system_instructions": {"type": "array"},
+                                "final_result": {"type": "object"},
                             },
                         }
                     )
@@ -3178,16 +3550,80 @@ async def test_run_stream(
             }
         )
 
-        assert chat_span_attributes['gen_ai.input.messages'] == IsJson(
-            snapshot([{'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]}])
+        assert chat_span_attributes["gen_ai.input.messages"] == IsJson(
+            snapshot(
+                [{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]
+            )
         )
-        assert chat_span_attributes['gen_ai.output.messages'] == IsJson(
+        assert chat_span_attributes["gen_ai.output.messages"] == IsJson(
             snapshot(
                 [
                     {
-                        'role': 'assistant',
-                        'parts': [{'type': 'text', 'content': 'success (no tool calls)'}],
+                        "role": "assistant",
+                        "parts": [
+                            {"type": "text", "content": "success (no tool calls)"}
+                        ],
                     }
                 ]
             )
         )
+
+
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+def test_call_deferred_not_recorded_as_error(
+    get_logfire_summary: Callable[[], LogfireSummary],
+) -> None:
+    """CallDeferred is a control flow mechanism and must not appear as an error in tool spans."""
+    agent = Agent(TestModel(), output_type=[str, DeferredToolRequests], instrument=True)
+
+    @agent.tool_plain
+    def my_tool(x: int) -> int:
+        raise CallDeferred
+
+    result = agent.run_sync("Hello")
+    assert isinstance(result.output, DeferredToolRequests)
+
+    summary = get_logfire_summary()
+
+    # Find the tool span
+    tool_attributes = next(
+        attrs
+        for attrs in summary.attributes.values()
+        if attrs.get("gen_ai.tool.name") == "my_tool"
+    )
+
+    # The span must NOT have an error level — CallDeferred is control flow, not an error
+    assert "logfire.level_num" not in tool_attributes
+
+    # The span must carry the deferred attribute so backends can identify deferred calls
+    assert tool_attributes.get("pydantic_ai.call_deferred") is True
+
+
+@pytest.mark.skipif(not logfire_installed, reason="logfire not installed")
+def test_approval_required_not_recorded_as_error(
+    get_logfire_summary: Callable[[], LogfireSummary],
+) -> None:
+    """ApprovalRequired is a control flow mechanism and must not appear as an error in tool spans."""
+    agent = Agent(TestModel(), output_type=[str, DeferredToolRequests], instrument=True)
+
+    @agent.tool_plain
+    def my_tool(x: int) -> int:
+        raise ApprovalRequired
+
+    result = agent.run_sync("Hello")
+    assert isinstance(result.output, DeferredToolRequests)
+
+    summary = get_logfire_summary()
+
+    # Find the tool span
+    tool_attributes = next(
+        attrs
+        for attrs in summary.attributes.values()
+        if attrs.get("gen_ai.tool.name") == "my_tool"
+    )
+
+    # The span must NOT have an error level — ApprovalRequired is control flow, not an error
+    assert "logfire.level_num" not in tool_attributes
+
+    # The span must carry the approval_required attribute so backends can identify unapproved calls
+    assert tool_attributes.get("pydantic_ai.approval_required") is True


### PR DESCRIPTION
## Summary

Control flow exceptions like `CallDeferred` and `ApprovalRequired` were being automatically caught and recorded as errors/exceptions by `tracer.start_as_current_span`. These are not real errors — they are control flow mechanisms for deferred tool execution and human-in-the-loop approval. They show up as red in Logfire UI and other OTel backends, creating false error signals.

### Changes

- **`pydantic_ai_slim/pydantic_ai/_tool_manager.py`**: Catch `CallDeferred` and `ApprovalRequired` in the tool execution span, record them as regular span attributes (`pydantic_ai.deferred` / `pydantic_ai.approval_required`) instead of span exceptions, and re-raise for normal control flow
- **`tests/test_logfire.py`**: Updated test snapshots to reflect the new span attribute behavior

### Before
```
Tool span → status: ERROR, exception: CallDeferred
```

### After
```
Tool span → status: OK, attribute: pydantic_ai.deferred=true
```

## Test plan
- [x] Control flow exceptions no longer recorded as span errors
- [x] Regular tool exceptions still recorded as errors
- [x] Exceptions are re-raised for proper control flow
- [x] Test snapshots updated
- [ ] Manual verification in Logfire UI

Fixes #4530