### PR TITLE
fix: propagate ToolOutput max_retries to OutputToolset

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -886,6 +886,7 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
         default_description = description
         default_strict = strict
 
+        max_retries: int | None = None
         multiple = len(outputs) > 1
         for output in outputs:
             name = None
@@ -896,6 +897,8 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
                 name = output.name
                 description = output.description
                 strict = output.strict
+                if output.max_retries is not None:
+                    max_retries = max(max_retries or 0, output.max_retries)
 
                 output = output.output  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
 
@@ -936,7 +939,10 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
             processors[name] = processor
             tool_defs.append(tool_def)
 
-        return cls(processors=processors, tool_defs=tool_defs)
+        kwargs: dict[str, Any] = dict(processors=processors, tool_defs=tool_defs)
+        if max_retries is not None:
+            kwargs['max_retries'] = max_retries
+        return cls(**kwargs)
 
     def __init__(
         self,

--- a/tests/test_agent_output_schemas.py
+++ b/tests/test_agent_output_schemas.py
@@ -702,3 +702,33 @@ async def test_output_type_description(output_type: type, expected_schema: dict[
 async def test_nested_output_type_description(output_type: type, expected_schema: dict[str, object]):
     agent: Agent[None, str] = Agent('test', output_type=output_type)
     assert agent.output_json_schema() == expected_schema
+
+
+async def test_tool_output_max_retries_passed_through():
+    """Test that ToolOutput(max_retries=N) is propagated to OutputToolset.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/4678
+    """
+    from pydantic_ai._output import OutputToolset
+
+    toolset = OutputToolset.build([ToolOutput(Foo, max_retries=3)])
+    assert toolset is not None
+    assert toolset.max_retries == 3
+
+
+async def test_tool_output_max_retries_default():
+    """Test that OutputToolset uses default max_retries=1 when not specified."""
+    from pydantic_ai._output import OutputToolset
+
+    toolset = OutputToolset.build([ToolOutput(Foo)])
+    assert toolset is not None
+    assert toolset.max_retries == 1
+
+
+async def test_tool_output_max_retries_multiple_takes_max():
+    """Test that with multiple ToolOutputs, the highest max_retries wins."""
+    from pydantic_ai._output import OutputToolset
+
+    toolset = OutputToolset.build([ToolOutput(Foo, max_retries=2), ToolOutput(Bar, max_retries=5)])
+    assert toolset is not None
+    assert toolset.max_retries == 5


### PR DESCRIPTION
## Summary
- `ToolOutput(Foo, max_retries=3)` accepts a `max_retries` parameter, but `OutputToolset.build()` never extracted it — the toolset always got the default `max_retries=1`
- Extract `max_retries` from `ToolOutput` instances in `OutputToolset.build()` and pass it to the constructor
- When multiple `ToolOutput` instances specify `max_retries`, take the maximum value

Fixes #4678

## Test plan
- [x] Added `test_tool_output_max_retries_passed_through` — verifies `ToolOutput(Foo, max_retries=3)` results in `toolset.max_retries == 3`
- [x] Added `test_tool_output_max_retries_default` — verifies default remains `1` when `max_retries` is not specified
- [x] Added `test_tool_output_max_retries_multiple_takes_max` — verifies multiple `ToolOutput`s take the highest `max_retries`
- [x] All 3 new tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)