### PR TITLE
fix(openrouter): normalize Anthropic model names with dots in version numbers

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -91,6 +91,24 @@ def _openrouter_google_model_profile(model_name: str) -> ModelProfile | None:
     return replace(profile, json_schema_transformer=_OpenRouterGoogleJsonSchemaTransformer)
 
 
+def _openrouter_anthropic_model_profile(model_name: str) -> ModelProfile | None:
+    """Get the model profile for an Anthropic model accessed via OpenRouter.
+
+    OpenRouter uses dots in model version numbers (e.g., 'claude-sonnet-4.5'),
+    but anthropic_model_profile() expects hyphenated names (e.g., 'claude-sonnet-4-5').
+    This function normalizes the model name before delegation by converting dots
+    to hyphens in the version suffix pattern (e.g., '-4.5' -> '-4-5').
+
+    See: https://github.com/pydantic/pydantic-ai/issues/4689
+    """
+    # Normalize model name: replace version pattern like '-4.5' with '-4-5'
+    # to match Anthropic's naming convention for structured output support
+    import re
+
+    normalized_name = re.sub(r'-(\d)\.(\d)$', r'-\1-\2', model_name)
+    return anthropic_model_profile(normalized_name)
+
+
 class OpenRouterProvider(Provider[AsyncOpenAI]):
     """Provider for OpenRouter API."""
 
@@ -111,7 +129,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
         provider_to_profile = {
             'google': _openrouter_google_model_profile,
             'openai': openai_model_profile,
-            'anthropic': anthropic_model_profile,
+            'anthropic': _openrouter_anthropic_model_profile,
             'mistralai': mistral_model_profile,
             'qwen': qwen_model_profile,
             'x-ai': grok_model_profile,

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -129,6 +129,18 @@ def test_openrouter_provider_model_profile(mocker: MockerFixture):
     assert anthropic_profile is not None
     assert anthropic_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
 
+    # Test Anthropic model name normalization for version numbers with dots (issue #4689)
+    # OpenRouter uses dots (e.g., 'claude-sonnet-4.5') but Anthropic expects hyphens (e.g., 'claude-sonnet-4-5')
+    anthropic_profile = provider.model_profile('anthropic/claude-sonnet-4.5')
+    anthropic_model_profile_mock.assert_called_with('claude-sonnet-4-5')
+    assert anthropic_profile is not None
+    assert anthropic_profile.supports_json_schema_output is True
+
+    anthropic_profile = provider.model_profile('anthropic/claude-opus-4.6')
+    anthropic_model_profile_mock.assert_called_with('claude-opus-4-6')
+    assert anthropic_profile is not None
+    assert anthropic_profile.supports_json_schema_output is True
+
     mistral_profile = provider.model_profile('mistralai/mistral-large-2407')
     mistral_model_profile_mock.assert_called_with('mistral-large-2407')
     assert mistral_profile is not None


### PR DESCRIPTION
OpenRouter uses dots in Anthropic model version numbers (e.g., 'claude-sonnet-4.5'), but `anthropic_model_profile()` expects hyphenated names (e.g., 'claude-sonnet-4-5'). This caused `supports_json_schema_output` to be incorrectly set to `False` for these models, preventing native structured output from working.

Added `_openrouter_anthropic_model_profile()` to normalize model names by converting dots to hyphens in version suffixes before delegation to `anthropic_model_profile()`.

Fixes #4689