### PR TITLE
fix: use max_retries parameter in ToolOutput

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -887,6 +887,7 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
         default_strict = strict
 
         multiple = len(outputs) > 1
+        max_retries: int | None = None
         for output in outputs:
             name = None
             description = None
@@ -896,6 +897,9 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
                 name = output.name
                 description = output.description
                 strict = output.strict
+                # Extract max_retries from the first ToolOutput that has it set
+                if max_retries is None and output.max_retries is not None:
+                    max_retries = output.max_retries
 
                 output = output.output  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
 
@@ -936,7 +940,7 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
             processors[name] = processor
             tool_defs.append(tool_def)
 
-        return cls(processors=processors, tool_defs=tool_defs)
+        return cls(processors=processors, tool_defs=tool_defs, max_retries=max_retries or 1)
 
     def __init__(
         self,


### PR DESCRIPTION
- Closes #4678

### Description

The `ToolOutput` class has a `max_retries` parameter that was defined but never actually used in the retry logic. This fix extracts the `max_retries` value from `ToolOutput` instances in `OutputToolset.build()` and passes it to the constructor.

### Changes

- Extract `max_retries` from `ToolOutput` in `OutputToolset.build()`
- Pass `max_retries` to `OutputToolset` constructor  
- Default to 1 if no `ToolOutput` has `max_retries` set

### Checklist

- [x] No breaking changes
- [x] Type checking passes
- [x] Existing tests pass