### PR TITLE
fix(output): properly use ToolOutput max_retries parameter

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -885,6 +885,7 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
         default_name = name or DEFAULT_OUTPUT_TOOL_NAME
         default_description = description
         default_strict = strict
+        max_retries: int | None = None
 
         multiple = len(outputs) > 1
         for output in outputs:
@@ -896,6 +897,8 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
                 name = output.name
                 description = output.description
                 strict = output.strict
+                if max_retries is None:
+                    max_retries = output.max_retries
 
                 output = output.output  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
 
@@ -936,7 +939,7 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
             processors[name] = processor
             tool_defs.append(tool_def)
 
-        return cls(processors=processors, tool_defs=tool_defs)
+        return cls(processors=processors, tool_defs=tool_defs, max_retries=max_retries or 1)
 
     def __init__(
         self,


### PR DESCRIPTION
- Closes #4678

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the version policy.
- [x] **Linting and type checking** pass.

### Pre-Merge Checklist

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.

### Description

The max_retries parameter from ToolOutput was not being passed through to OutputToolset. This fix:

1. Extracts max_retries from ToolOutput instances during OutputToolset.build()
2. Passes the value to the OutputToolset constructor (defaulting to 1 if not set)

This ensures that when users specify ToolOutput(Foo, max_retries=3), the retry count is correctly applied to the output tool.
