### PR TITLE
fix: normalize OpenRouter dot notation in Anthropic model names

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/anthropic.py
@@ -17,7 +17,11 @@ def anthropic_model_profile(model_name: str) -> ModelProfile | None:
     # TODO update when new models are released that support structured outputs
     # https://docs.claude.com/en/docs/build-with-claude/structured-outputs#example-usage
 
-    supports_json_schema_output = model_name.startswith(models_that_support_json_schema_output)
+    # OpenRouter uses dots in version numbers (e.g., claude-sonnet-4.5),
+    # but Anthropic's official naming uses hyphens (e.g., claude-sonnet-4-5).
+    # Normalize dots to hyphens so the startswith check works correctly.
+    normalized_name = model_name.replace('.', '-')
+    supports_json_schema_output = normalized_name.startswith(models_that_support_json_schema_output)
     return ModelProfile(
         thinking_tags=('<thinking>', '</thinking>'),
         supports_json_schema_output=supports_json_schema_output,

--- a/tests/profiles/test_anthropic.py
+++ b/tests/profiles/test_anthropic.py
@@ -233,3 +233,29 @@ def test_model_profile_opus():
     profile = anthropic_model_profile('claude-opus-4-1')
     assert profile is not None
     assert profile.supports_json_schema_output is True
+
+
+def test_model_profile_openrouter_dot_notation():
+    """OpenRouter uses dots in version numbers (e.g., claude-sonnet-4.5).
+    These should be normalized to hyphens and still match supported models."""
+    # Dotted version numbers (OpenRouter format)
+    profile = anthropic_model_profile('claude-sonnet-4.5')
+    assert profile is not None
+    assert profile.supports_json_schema_output is True
+
+    profile = anthropic_model_profile('claude-haiku-4.5')
+    assert profile is not None
+    assert profile.supports_json_schema_output is True
+
+    profile = anthropic_model_profile('claude-opus-4.5')
+    assert profile is not None
+    assert profile.supports_json_schema_output is True
+
+    profile = anthropic_model_profile('claude-opus-4.6')
+    assert profile is not None
+    assert profile.supports_json_schema_output is True
+
+    # Unsupported model should still return False
+    profile = anthropic_model_profile('claude-sonnet-4.0')
+    assert profile is not None
+    assert profile.supports_json_schema_output is False


### PR DESCRIPTION
## Summary

OpenRouter uses dots in version numbers (e.g., `claude-sonnet-4.5`), but the `anthropic_model_profile` function checks against hyphenated names (e.g., `claude-sonnet-4-5`). This causes `supports_json_schema_output` to be incorrectly set to `False` for models that actually support native structured output.

## Root Cause

In `pydantic_ai/profiles/anthropic.py`, the `startswith` check uses a tuple of hyphenated model names:

```python
models_that_support_json_schema_output = (
    "claude-haiku-4-5",
    "claude-sonnet-4-5",
    ...
)
supports_json_schema_output = model_name.startswith(models_that_support_json_schema_output)
```

When OpenRouter passes `claude-sonnet-4.5`, the check fails because:
- `claude-sonnet-4.5.startswith(claude-sonnet-4-5)` → `False`

## Fix

Normalize dots to hyphens in the model name before the `startswith` check:

```python
normalized_name = model_name.replace(., -)
supports_json_schema_output = normalized_name.startswith(models_that_support_json_schema_output)
```

## Test Results

Added test `test_model_profile_openrouter_dot_notation` covering:
- ✅ `claude-sonnet-4.5` → `supports_json_schema_output=True`
- ✅ `claude-haiku-4.5` → `supports_json_schema_output=True`
- ✅ `claude-opus-4.5` → `supports_json_schema_output=True`
- ✅ `claude-opus-4.6` → `supports_json_schema_output=True`
- ✅ `claude-sonnet-4.0` → `supports_json_schema_output=False` (correctly unsupported)

## Reproduction

```python
from pydantic import BaseModel
from pydantic_ai import Agent
from pydantic_ai.output import NativeOutput
from pydantic_ai.models.openrouter import OpenRouterModel
from pydantic_ai.providers.openrouter import OpenRouterProvider

class CityInfo(BaseModel):
    name: str
    population: int

provider = OpenRouterProvider(api_key="test-key")
model = OpenRouterModel("anthropic/claude-sonnet-4.5", provider=provider)
agent = Agent(model, output_type=NativeOutput(CityInfo))

# Before fix: raises UserError: Native structured output is not supported by this model.
# After fix: works correctly
```

Fixes #4689