### PR TITLE
fix(google): remove unsupported id field from function_call and function_response

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -696,7 +696,7 @@ class GoogleModel(Model):
                                     'function_response': {
                                         'name': part.tool_name,
                                         'response': {'error': part.model_response()},
-                                        'id': part.tool_call_id,
+                                        
                                     }
                                 }
                             )
@@ -774,7 +774,6 @@ class GoogleModel(Model):
         function_response_dict: FunctionResponseDict = {
             'name': part.tool_name,
             'response': response,
-            'id': part.tool_call_id,
         }
         if function_response_parts:
             function_response_dict['parts'] = function_response_parts
@@ -1167,7 +1166,7 @@ def _content_model_response(m: ModelResponse, provider_name: str) -> ContentDict
         thinking_part_signature = None
 
         if isinstance(item, ToolCallPart):
-            function_call = FunctionCallDict(name=item.tool_name, args=item.args_as_dict(), id=item.tool_call_id)
+            function_call = FunctionCallDict(name=item.tool_name, args=item.args_as_dict())
             part['function_call'] = function_call
             if function_call_requires_signature and not part.get('thought_signature'):
                 # Per https://ai.google.dev/gemini-api/docs/thought-signatures#faqs:


### PR DESCRIPTION
## Summary

Removes the unsupported `id` field from `function_call` and `function_response` objects sent to the Gemini API. The Gemini API does not accept this field and returns 400 errors when it is present.

## Changes

- **FunctionCallDict** (line ~1170): Remove `id=item.tool_call_id` parameter
- **ToolReturnPart** (line ~777): Remove `'id': part.tool_call_id` from `_map_tool_return`
- **RetryPromptPart** (line ~699): Remove `'id': part.tool_call_id` from function_response dict

## Root Cause

The Gemini API schema does not include an `id` field for `function_call` and `function_response` objects. Sending this field causes:
`"Invalid JSON payload received. Unknown name \"id\" at 'contents[1].parts[0].function_call': Cannot find field."`

Fixes #4645

Made with [Cursor](https://cursor.com)