### PR TITLE
fix: detect empty items: {} as strict-incompatible in OpenAIJsonSchemaTransformer

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -290,6 +290,14 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
             else:
                 self.is_strict_compatible = False
 
+        if schema_type == 'array':
+            items = schema.get('items')
+            if isinstance(items, dict) and (not items or 'type' not in items):
+                # OpenAI strict mode requires items schema to have a 'type' key.
+                # Bare list (e.g. items: list) produces items: {} which is invalid.
+                if self.strict is not False:
+                    self.is_strict_compatible = False
+
         if schema_type == 'object':
             # Always ensure 'properties' key exists - OpenAI drops objects without it
             if 'properties' not in schema:

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -14,7 +14,7 @@ import pytest
 from ..conftest import try_import
 
 with try_import() as imports_successful:
-    from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
+    from pydantic_ai.profiles.openai import OpenAIModelProfile, OpenAIJsonSchemaTransformer, openai_model_profile
 
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='openai not installed'),
@@ -67,6 +67,32 @@ def test_sampling_params_support(case: SamplingParamsCase):
     assert isinstance(profile, OpenAIModelProfile)
     assert profile.openai_supports_reasoning is case.supports_reasoning
     assert profile.openai_supports_reasoning_effort_none is case.supports_reasoning_effort_none
+
+
+
+
+def test_bare_list_items_sets_strict_incompatible():
+    """Array with empty items (bare list) is not strict-compatible.
+
+    OpenAI strict mode requires items schema to have a 'type' key.
+    Bare list (e.g. def foo(items: list)) produces items: {} which is invalid.
+    See https://github.com/pydantic/pydantic-ai/issues/4425
+    """
+    schema = {
+        'properties': {
+            'items': {
+                'items': {},
+                'title': 'Items',
+                'type': 'array',
+            },
+        },
+        'required': ['items'],
+        'title': 'Test',
+        'type': 'object',
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    transformer.walk()
+    assert transformer.is_strict_compatible is False
 
 
 class TestEncryptedReasoningContent:


### PR DESCRIPTION
## Summary
OpenAI strict mode requires array items schema to have a `type` key. When using a bare `list` parameter (e.g. `def foo(items: list)`), pydantic-ai sends `items: {}` which causes 400 `invalid_function_parameters` from the API.

## Fix
`OpenAIJsonSchemaTransformer` now detects when `items` is empty or lacks a `type` key and sets `is_strict_compatible=False`, allowing the schema to be sent in lenient mode instead of failing.

## Changes
- `pydantic_ai_slim/pydantic_ai/profiles/openai.py`: Add array items check in `transform()`
- `tests/profiles/test_openai.py`: Add `test_bare_list_items_sets_strict_incompatible`

Fixes #4425

Made with [Cursor](https://cursor.com)