### PR TITLE
fix: add missing OpenRouter reasoning effort levels (xhigh, minimal, none)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -197,7 +197,7 @@ class OpenRouterReasoning(TypedDict, total=False):
     token limits, but not both simultaneously.
     """
 
-    effort: Literal['high', 'medium', 'low']
+    effort: Literal['xhigh', 'high', 'medium', 'low', 'minimal', 'none']
     """OpenAI-style reasoning effort level. Cannot be used with max_tokens."""
 
     max_tokens: int


### PR DESCRIPTION
Fixes #4708

## Summary
- Added missing effort levels `xhigh`, `minimal`, and `none` to `OpenRouterReasoning.effort` Literal type
- The OpenRouter API supports six effort values: `xhigh`, `high`, `medium`, `low`, `minimal`, `none`
- The previous type only included `high`, `medium`, `low`

## Test plan
- [ ] Verify `OpenRouterModelSettings(openrouter_reasoning={'effort': 'xhigh'})` no longer raises a type error
- [ ] Verify `OpenRouterModelSettings(openrouter_reasoning={'effort': 'minimal'})` no longer raises a type error
- [ ] Verify `OpenRouterModelSettings(openrouter_reasoning={'effort': 'none'})` no longer raises a type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)