### PR TITLE
docs(temporal): add missing package installation instructions

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -70,7 +70,19 @@ Any agent can be wrapped in a [`TemporalAgent`][pydantic_ai.durable_exec.tempora
 
 At the time of wrapping, the agent's [model](../models/overview.md) and [toolsets](../toolsets.md) (including function tools registered on the agent and MCP servers) are frozen, activities are dynamically created for each, and the original model and toolsets are wrapped to call on the worker to execute the corresponding activities instead of directly performing the actions inside the workflow. The original agent can still be used as normal outside the Temporal workflow, but any changes to its model or toolsets after wrapping will not be reflected in the durable agent.
 
-Here is a simple but complete example of wrapping an agent for durable execution, creating a Temporal workflow with durable execution logic, connecting to a Temporal server, and running the workflow from non-durable code. All it requires is a Temporal server to be [running locally](https://github.com/temporalio/temporal#download-and-start-temporal-server-locally):
+Here is a simple but complete example of wrapping an agent for durable execution, creating a Temporal workflow with durable execution logic, connecting to a Temporal server, and running the workflow from non-durable code. All it requires is to install Pydantic AI with [Temporal](https://github.com/temporalio/sdk-python):
+
+```bash
+pip/uv-add pydantic-ai[temporal]
+```
+
+Or if you're using the slim package, you can install it with the `temporal` optional group:
+
+```bash
+pip/uv-add pydantic-ai-slim[temporal]
+```
+
+You'll also need a Temporal server to be [running locally](https://github.com/temporalio/temporal#download-and-start-temporal-server-locally):
 
 ```sh
 brew install temporal

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -70,7 +70,7 @@ Any agent can be wrapped in a [`TemporalAgent`][pydantic_ai.durable_exec.tempora
 
 At the time of wrapping, the agent's [model](../models/overview.md) and [toolsets](../toolsets.md) (including function tools registered on the agent and MCP servers) are frozen, activities are dynamically created for each, and the original model and toolsets are wrapped to call on the worker to execute the corresponding activities instead of directly performing the actions inside the workflow. The original agent can still be used as normal outside the Temporal workflow, but any changes to its model or toolsets after wrapping will not be reflected in the durable agent.
 
-Here is a simple but complete example of wrapping an agent for durable execution, creating a Temporal workflow with durable execution logic, connecting to a Temporal server, and running the workflow from non-durable code. All it requires is to install Pydantic AI with [Temporal](https://github.com/temporalio/sdk-python):
+Here is a simple but complete example of wrapping an agent for durable execution, creating a Temporal workflow with durable execution logic, connecting to a Temporal server, and running the workflow from non-durable code. All it requires is to install Pydantic AI with the `temporal` optional group:
 
 ```bash
 pip/uv-add pydantic-ai[temporal]
@@ -106,7 +106,7 @@ from pydantic_ai.durable_exec.temporal import (
 agent = Agent(
     'openai:gpt-5.2',
     instructions="You're an expert in geography.",
-    name='geography',  # (10)!
+    name='geography',  # (9)!
 )
 
 temporal_agent = TemporalAgent(agent)  # (1)!


### PR DESCRIPTION
- Closes #4717

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.

### Summary

The Temporal documentation page was missing the `pydantic-ai[temporal]` / `pydantic-ai-slim[temporal]` installation instructions that the [DBOS](https://ai.pydantic.dev/durable-execution/dbos/) and [Prefect](https://ai.pydantic.dev/durable-execution/prefect/) documentation pages both include.

Added the installation instructions before the Temporal server setup section, matching the pattern used in the other durable execution docs.