### PR TITLE
fix: propagate ToolOutput(max_retries=...) to OutputToolset

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -864,6 +864,8 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
     processors: dict[str, ObjectOutputProcessor[Any]]
     """The processors for the output tools in this toolset."""
     max_retries: int
+    _tool_max_retries: dict[str, int]
+    """Per-tool max_retries overrides from ToolOutput(max_retries=...)."""
     output_validators: list[OutputValidator[AgentDepsT, Any]]
 
     @classmethod
@@ -879,6 +881,7 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
 
         processors: dict[str, ObjectOutputProcessor[Any]] = {}
         tool_defs: list[ToolDefinition] = []
+        tool_max_retries: dict[str, int] = {}
 
         default_name = name or DEFAULT_OUTPUT_TOOL_NAME
         default_description = description
@@ -889,11 +892,13 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
             name = None
             description = None
             strict = None
+            max_retries: int | None = None
             if isinstance(output, ToolOutput):
                 # do we need to error on conflicts here? (DavidM): If this is internal maybe doesn't matter, if public, use overloads
                 name = output.name
                 description = output.description
                 strict = output.strict
+                max_retries = output.max_retries
 
                 output = output.output  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
 
@@ -933,8 +938,10 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
             )
             processors[name] = processor
             tool_defs.append(tool_def)
+            if max_retries is not None:
+                tool_max_retries[name] = max_retries
 
-        return cls(processors=processors, tool_defs=tool_defs)
+        return cls(processors=processors, tool_defs=tool_defs, tool_max_retries=tool_max_retries)
 
     def __init__(
         self,
@@ -942,10 +949,12 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
         processors: dict[str, ObjectOutputProcessor[Any]],
         max_retries: int = 1,
         output_validators: list[OutputValidator[AgentDepsT, Any]] | None = None,
+        tool_max_retries: dict[str, int] | None = None,
     ):
         self.processors = processors
         self._tool_defs = tool_defs
         self.max_retries = max_retries
+        self._tool_max_retries = tool_max_retries or {}
         self.output_validators = output_validators or []
 
     @property
@@ -961,7 +970,7 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
             tool_def.name: ToolsetTool(
                 toolset=self,
                 tool_def=tool_def,
-                max_retries=self.max_retries,
+                max_retries=self._tool_max_retries.get(tool_def.name, self.max_retries),
                 args_validator=self.processors[tool_def.name].validator,
             )
             for tool_def in self._tool_defs

--- a/tests/test_agent_output_schemas.py
+++ b/tests/test_agent_output_schemas.py
@@ -702,3 +702,38 @@ async def test_output_type_description(output_type: type, expected_schema: dict[
 async def test_nested_output_type_description(output_type: type, expected_schema: dict[str, object]):
     agent: Agent[None, str] = Agent('test', output_type=output_type)
     assert agent.output_json_schema() == expected_schema
+
+
+async def test_tool_output_max_retries_single():
+    """Test that ToolOutput(max_retries=N) is propagated to the output toolset."""
+    agent = Agent('test', output_type=ToolOutput(Foo, max_retries=3))
+    toolset = agent._output_toolset
+    assert toolset is not None
+    # The per-tool override should be stored
+    assert toolset._tool_max_retries == {'final_result': 3}
+
+
+async def test_tool_output_max_retries_multiple():
+    """Test per-tool max_retries with multiple ToolOutput types."""
+    agent = Agent(
+        'test',
+        output_type=[
+            ToolOutput(Bar, max_retries=5),
+            ToolOutput(Foo, max_retries=2),
+        ],
+    )
+    toolset = agent._output_toolset
+    assert toolset is not None
+    assert toolset._tool_max_retries == {
+        'final_result_Bar': 5,
+        'final_result_Foo': 2,
+    }
+
+
+async def test_tool_output_max_retries_default_fallback():
+    """Test that tools without explicit max_retries fall back to the toolset default."""
+    agent = Agent('test', output_type=ToolOutput(Foo))
+    toolset = agent._output_toolset
+    assert toolset is not None
+    # No per-tool override should be stored when max_retries is not specified
+    assert toolset._tool_max_retries == {}


### PR DESCRIPTION
## Summary

Fixes #4678

- `ToolOutput(max_retries=N)` was accepted but silently ignored because `OutputToolset.build()` never extracted or forwarded the value to the toolset constructor.
- Store per-tool `max_retries` overrides in `OutputToolset._tool_max_retries` and use them in `get_tools()`, falling back to the toolset-level default when no per-tool override is set.
- This preserves the existing behavior where `Agent(retries=...)` / `Agent(output_retries=...)` sets the toolset-wide default, while allowing individual `ToolOutput(max_retries=N)` to override it per output tool.

## Test plan

- [x] Added `test_tool_output_max_retries_single` -- single `ToolOutput` with `max_retries=3` propagates correctly
- [x] Added `test_tool_output_max_retries_multiple` -- multiple `ToolOutput` types each with different `max_retries`
- [x] Added `test_tool_output_max_retries_default_fallback` -- `ToolOutput` without `max_retries` leaves no per-tool override
- [x] All 17 existing tests in `test_agent_output_schemas.py` still pass