### PR TITLE
fix: propagate ToolOutput(max_retries=...) to OutputToolset

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -884,6 +884,7 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
         default_description = description
         default_strict = strict
 
+        max_retries: int | None = None
         multiple = len(outputs) > 1
         for output in outputs:
             name = None
@@ -894,6 +895,8 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
                 name = output.name
                 description = output.description
                 strict = output.strict
+                if output.max_retries is not None:
+                    max_retries = output.max_retries if max_retries is None else max(max_retries, output.max_retries)
 
                 output = output.output  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
 
@@ -934,7 +937,10 @@ class OutputToolset(AbstractToolset[AgentDepsT]):
             processors[name] = processor
             tool_defs.append(tool_def)
 
-        return cls(processors=processors, tool_defs=tool_defs)
+        kwargs: dict[str, Any] = dict(processors=processors, tool_defs=tool_defs)
+        if max_retries is not None:
+            kwargs['max_retries'] = max_retries
+        return cls(**kwargs)
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -384,7 +384,12 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
         self._output_toolset = self._output_schema.toolset
         if self._output_toolset:
-            self._output_toolset.max_retries = self._max_result_retries
+            # Respect max_retries from ToolOutput(...) when neither output_retries
+            # nor retries was explicitly changed at the Agent level. Agent-level
+            # output_retries always takes priority when explicitly set.
+            toolset_has_custom_retries = self._output_toolset.max_retries != 1
+            if output_retries is not None or not toolset_has_custom_retries:
+                self._output_toolset.max_retries = self._max_result_retries
 
         self._function_toolset = _AgentFunctionToolset(
             tools,

--- a/tests/test_agent_output_schemas.py
+++ b/tests/test_agent_output_schemas.py
@@ -138,6 +138,37 @@ async def test_tool_output_json_schema():
     assert agent.output_json_schema() == snapshot({'type': 'boolean'})
 
 
+def test_tool_output_max_retries():
+    """Test that ToolOutput(max_retries=N) is propagated to the OutputToolset."""
+
+    class Foo(BaseModel):
+        bar: str
+
+    # max_retries should be passed through to the toolset
+    agent = Agent('test', output_type=[ToolOutput(Foo, max_retries=3)])
+    output_schema = agent.toolsets[0].output_schema
+    assert output_schema.toolset is not None
+    assert output_schema.toolset.max_retries == 3
+
+    # default max_retries should remain 1 when not specified
+    agent_default = Agent('test', output_type=[ToolOutput(Foo)])
+    output_schema_default = agent_default.toolsets[0].output_schema
+    assert output_schema_default.toolset is not None
+    assert output_schema_default.toolset.max_retries == 1
+
+    # with multiple outputs, the max value should be used
+    agent_multi = Agent('test', output_type=[ToolOutput(Foo, max_retries=5), ToolOutput(bool, max_retries=2)])
+    output_schema_multi = agent_multi.toolsets[0].output_schema
+    assert output_schema_multi.toolset is not None
+    assert output_schema_multi.toolset.max_retries == 5
+
+    # Agent-level output_retries should take priority over ToolOutput max_retries
+    agent_override = Agent('test', output_type=[ToolOutput(Foo, max_retries=3)], output_retries=7)
+    output_schema_override = agent_override.toolsets[0].output_schema
+    assert output_schema_override.toolset is not None
+    assert output_schema_override.toolset.max_retries == 7
+
+
 async def test_native_output_json_schema():
     agent = Agent(
         'test',


### PR DESCRIPTION
## Summary
- `OutputToolset.build()` now extracts `max_retries` from `ToolOutput` instances (taking the max when multiple outputs specify different values)
- `Agent.__init__()` now respects the `ToolOutput`-level `max_retries` instead of unconditionally overwriting it with the Agent-level default
- Agent-level `output_retries` still takes priority when explicitly set

Fixes #4678

## Test plan
- [x] Added `test_tool_output_max_retries` covering: single ToolOutput with custom max_retries, default behavior, multiple outputs (max wins), and Agent-level `output_retries` override
- [x] All 15 existing tests in `test_agent_output_schemas.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)