### PR TITLE
fix: add missing OpenRouter reasoning effort levels

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -197,7 +197,7 @@ class OpenRouterReasoning(TypedDict, total=False):
     token limits, but not both simultaneously.
     """
 
-    effort: Literal['high', 'medium', 'low']
+    effort: Literal['xhigh', 'high', 'medium', 'low', 'minimal', 'none']
     """OpenAI-style reasoning effort level. Cannot be used with max_tokens."""
 
     max_tokens: int


### PR DESCRIPTION
## Summary

- Adds missing `xhigh`, `minimal`, and `none` values to `OpenRouterReasoning.effort` Literal type
- Aligns the type with the [OpenRouter API docs](https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request#request.body.reasoning) which support six effort levels: `xhigh`, `high`, `medium`, `low`, `minimal`, `none`

Closes #4708

## Test plan

- [ ] Verify type checkers (pyright/mypy) accept all six effort values without errors
- [ ] Confirm existing `high`, `medium`, `low` values still work as before
- [ ] No runtime behavior change — this is a type-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)