### PR TITLE
fix: support mistralai v2.0.x import paths

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -55,38 +55,71 @@ from . import (
 )
 
 try:
-    from mistralai import (
-        UNSET,
-        CompletionChunk as MistralCompletionChunk,
-        Content as MistralContent,
-        ContentChunk as MistralContentChunk,
-        DocumentURLChunk as MistralDocumentURLChunk,
-        FunctionCall as MistralFunctionCall,
-        ImageURL as MistralImageURL,
-        ImageURLChunk as MistralImageURLChunk,
-        Mistral,
-        OptionalNullable as MistralOptionalNullable,
-        ReferenceChunk as MistralReferenceChunk,
-        TextChunk as MistralTextChunk,
-        ThinkChunk as MistralThinkChunk,
-        ToolChoiceEnum as MistralToolChoiceEnum,
-    )
-    from mistralai.models import (
-        ChatCompletionResponse as MistralChatCompletionResponse,
-        CompletionEvent as MistralCompletionEvent,
-        FinishReason as MistralFinishReason,
-        Messages as MistralMessages,
-        SDKError,
-        Tool as MistralTool,
-        ToolCall as MistralToolCall,
-    )
-    from mistralai.models.assistantmessage import AssistantMessage as MistralAssistantMessage
-    from mistralai.models.function import Function as MistralFunction
-    from mistralai.models.systemmessage import SystemMessage as MistralSystemMessage
-    from mistralai.models.toolmessage import ToolMessage as MistralToolMessage
-    from mistralai.models.usermessage import UserMessage as MistralUserMessage
-    from mistralai.types.basemodel import Unset as MistralUnset
-    from mistralai.utils.eventstreaming import EventStreamAsync as MistralEventStreamAsync
+    try:
+        # mistralai >=2.0.0: types moved under mistralai.client.*
+        from mistralai.client import Mistral
+        from mistralai.client.types import UNSET, OptionalNullable as MistralOptionalNullable
+        from mistralai.client.types.basemodel import Unset as MistralUnset
+        from mistralai.client.models import (
+            ChatCompletionRequestMessage as MistralMessages,
+            ChatCompletionResponse as MistralChatCompletionResponse,
+            ChatCompletionChoiceFinishReason as MistralFinishReason,
+            CompletionChunk as MistralCompletionChunk,
+            CompletionEvent as MistralCompletionEvent,
+            ContentChunk as MistralContentChunk,
+            DeltaMessageContent as MistralContent,
+            DocumentURLChunk as MistralDocumentURLChunk,
+            FunctionCall as MistralFunctionCall,
+            ImageURL as MistralImageURL,
+            ImageURLChunk as MistralImageURLChunk,
+            ReferenceChunk as MistralReferenceChunk,
+            TextChunk as MistralTextChunk,
+            ThinkChunk as MistralThinkChunk,
+            Tool as MistralTool,
+            ToolCall as MistralToolCall,
+            ToolChoiceEnum as MistralToolChoiceEnum,
+        )
+        from mistralai.client.errors import SDKError
+        from mistralai.client.models.assistantmessage import AssistantMessage as MistralAssistantMessage
+        from mistralai.client.models.function import Function as MistralFunction
+        from mistralai.client.models.systemmessage import SystemMessage as MistralSystemMessage
+        from mistralai.client.models.toolmessage import ToolMessage as MistralToolMessage
+        from mistralai.client.models.usermessage import UserMessage as MistralUserMessage
+        from mistralai.client.utils.eventstreaming import EventStreamAsync as MistralEventStreamAsync
+    except ImportError:
+        # mistralai <2.0.0
+        from mistralai import (
+            UNSET,
+            CompletionChunk as MistralCompletionChunk,
+            Content as MistralContent,
+            ContentChunk as MistralContentChunk,
+            DocumentURLChunk as MistralDocumentURLChunk,
+            FunctionCall as MistralFunctionCall,
+            ImageURL as MistralImageURL,
+            ImageURLChunk as MistralImageURLChunk,
+            Mistral,
+            OptionalNullable as MistralOptionalNullable,
+            ReferenceChunk as MistralReferenceChunk,
+            TextChunk as MistralTextChunk,
+            ThinkChunk as MistralThinkChunk,
+            ToolChoiceEnum as MistralToolChoiceEnum,
+        )
+        from mistralai.models import (
+            ChatCompletionResponse as MistralChatCompletionResponse,
+            CompletionEvent as MistralCompletionEvent,
+            FinishReason as MistralFinishReason,
+            Messages as MistralMessages,
+            SDKError,
+            Tool as MistralTool,
+            ToolCall as MistralToolCall,
+        )
+        from mistralai.models.assistantmessage import AssistantMessage as MistralAssistantMessage
+        from mistralai.models.function import Function as MistralFunction
+        from mistralai.models.systemmessage import SystemMessage as MistralSystemMessage
+        from mistralai.models.toolmessage import ToolMessage as MistralToolMessage
+        from mistralai.models.usermessage import UserMessage as MistralUserMessage
+        from mistralai.types.basemodel import Unset as MistralUnset
+        from mistralai.utils.eventstreaming import EventStreamAsync as MistralEventStreamAsync
 except ImportError as e:  # pragma: lax no cover
     raise ImportError(
         'Please install `mistral` to use the Mistral model, '

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -12,7 +12,12 @@ from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.providers import Provider
 
 try:
-    from mistralai import Mistral
+    try:
+        # mistralai >=2.0.0
+        from mistralai.client import Mistral
+    except ImportError:
+        # mistralai <2.0.0
+        from mistralai import Mistral
 except ImportError as e:  # pragma: no cover
     raise ImportError(
         'Please install the `mistral` package to use the Mistral provider, '


### PR DESCRIPTION
## Summary

Fixes #4727

Mistral released v2.0.x of their Python client which reorganized all types under `mistralai.client.*`, breaking `pydantic-ai-slim[mistral]` on import with `ImportError: cannot import name 'UNSET' from 'mistralai'`.

- Add try/except fallback imports in `models/mistral.py` and `providers/mistral.py` that try v2.0.x paths first, then fall back to v1.x paths
- Key renames in v2.0.x: `FinishReason` -> `ChatCompletionChoiceFinishReason`, `Messages` -> `ChatCompletionRequestMessage`, `Content` -> `DeltaMessageContent`, `SDKError` moved from `mistralai.models` to `mistralai.client.errors`
- All other types (`CompletionChunk`, `TextChunk`, `Tool`, `ToolCall`, etc.) kept same names but moved under `mistralai.client.models`

## Test plan

- [ ] Verify import succeeds with `mistralai>=2.0.0` (requires Python >=3.10)
- [ ] Verify import still succeeds with `mistralai<2.0.0` (v1.x)
- [ ] Run existing Mistral model tests to confirm no runtime regressions