### PR TITLE
fix: exclude message_history trailing ModelRequest from new_messages()

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1527,13 +1527,11 @@ def _first_new_message_index(
     if resumed_request is not None:
         for index, message in enumerate(messages):
             if message is resumed_request:
-                # Include the resumed request in new_messages only if it was
-                # mapped/created during the current run (e.g., via adapters).
-                return index if message.run_id == run_id else index + 1
+                return index + 1
 
         for index in range(len(messages) - 1, -1, -1):
             if _is_same_request(messages[index], resumed_request):
-                return index if messages[index].run_id == run_id else index + 1
+                return index + 1
     return _first_run_id_index(messages, run_id)
 
 

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1590,7 +1590,8 @@ async def test_adapter_sets_current_run_id_on_trailing_mapped_request() -> None:
     assert messages[1].run_id is None
     assert messages[2].run_id == run_result.run_id
     assert messages[3].run_id == run_result.run_id
-    assert run_result.new_messages() == messages[-2:]
+    # The mapped request is not "new" — it came from message_history, not from the run itself.
+    assert run_result.new_messages() == messages[-1:]
 
 
 async def test_callback_async() -> None:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2622,7 +2622,7 @@ def test_run_with_history_ending_on_model_request_and_no_user_prompt():
         ]
     )
 
-    assert result.new_messages() == result.all_messages()[-2:]
+    assert result.new_messages() == result.all_messages()[-1:]
 
 
 def test_run_with_history_ending_on_model_response_with_tool_calls_and_no_user_prompt():
@@ -2883,6 +2883,24 @@ def test_agent_message_history_includes_run_id() -> None:
     run_ids = [message.run_id for message in history]
     assert run_ids == snapshot([IsStr(), IsStr()])
     assert len({*run_ids}) == snapshot(1)
+
+
+def test_new_messages_excludes_history_request_without_user_prompt() -> None:
+    """Regression test for https://github.com/pydantic/pydantic-ai/issues/4669.
+
+    When agent.run() is called with message_history containing a trailing ModelRequest
+    (and no user_prompt), that request should not appear in new_messages().
+    """
+    agent = Agent(TestModel())
+
+    result = agent.run_sync(
+        message_history=[ModelRequest(parts=[UserPromptPart(content='hi')])]
+    )
+
+    new = result.new_messages()
+    # Only the model response should be new — not the request from message_history.
+    assert len(new) == 1
+    assert isinstance(new[0], ModelResponse)
 
 
 async def test_agent_run_result_metadata_available() -> None:
@@ -7910,16 +7928,6 @@ async def test_message_history():
             pass
         assert run.new_messages() == snapshot(
             [
-                ModelRequest(
-                    parts=[
-                        UserPromptPart(
-                            content='Hello',
-                            timestamp=IsDatetime(),
-                        )
-                    ],
-                    timestamp=IsDatetime(),
-                    run_id=IsStr(),
-                ),
                 ModelResponse(
                     parts=[TextPart(content='ok here is text')],
                     usage=RequestUsage(input_tokens=51, output_tokens=4),
@@ -7929,7 +7937,7 @@ async def test_message_history():
                 ),
             ]
         )
-        assert run.new_messages_json().startswith(b'[{"parts":[{"content":"Hello",')
+        assert run.new_messages_json().startswith(b'[{"parts":[{"content":"ok here is text",')
         assert run.all_messages() == snapshot(
             [
                 ModelRequest(

--- a/tests/test_history_processor.py
+++ b/tests/test_history_processor.py
@@ -1288,8 +1288,8 @@ async def test_history_processor_resuming_without_prompt(
 ):
     """
     When running without a user prompt (resuming from history), new_messages()
-    should include the resumed request when that request has the current
-    run_id.
+    should not include the resumed request — it came from message_history, not
+    from the current run.
     """
 
     def prepend_summary(messages: list[ModelMessage]) -> list[ModelMessage]:
@@ -1351,14 +1351,14 @@ async def test_history_processor_resuming_without_prompt(
             ),
         ]
     )
-    assert result.new_messages() == result.all_messages()[-2:]
+    assert result.new_messages() == result.all_messages()[-1:]
 
 
-async def test_resuming_without_prompt_with_tool_calls_includes_resumed_request_with_current_run_id():
+async def test_resuming_without_prompt_with_tool_calls_excludes_resumed_request():
     """
     When resuming without a user prompt and the model enters a tool-call loop,
-    new_messages() should include the resumed history request when it has
-    the current run_id.
+    new_messages() should not include the resumed history request — only the
+    messages generated during the current run.
     """
 
     call_count = 0
@@ -1418,7 +1418,7 @@ async def test_resuming_without_prompt_with_tool_calls_includes_resumed_request_
         ]
     )
 
-    assert result.new_messages() == result.all_messages()
+    assert result.new_messages() == result.all_messages()[1:]
 
 
 async def test_resuming_without_prompt_excludes_request_with_different_run_id(
@@ -1487,8 +1487,8 @@ async def test_history_processor_deepcopy_resuming_without_prompt(
 ):
     """
     When a history processor deep-copies messages (breaking object identity),
-    new_messages() should still include the resumed request when it has the
-    current run_id.
+    new_messages() should still exclude the resumed request — it came from
+    message_history, not from the current run.
     """
 
     def deepcopy_processor(messages: list[ModelMessage]) -> list[ModelMessage]:
@@ -1526,7 +1526,7 @@ async def test_history_processor_deepcopy_resuming_without_prompt(
         ]
     )
 
-    assert result.new_messages() == result.all_messages()
+    assert result.new_messages() == result.all_messages()[-1:]
 
 
 async def test_history_processor_rebuild_resuming_without_prompt(
@@ -1534,8 +1534,8 @@ async def test_history_processor_rebuild_resuming_without_prompt(
 ):
     """
     When a history processor rebuilds `ModelRequest` instances with equivalent
-    values, new_messages() should include the resumed request when it has the
-    current run_id.
+    values, new_messages() should still exclude the resumed request — it came
+    from message_history, not from the current run.
     """
 
     def rebuild_processor(messages: list[ModelMessage]) -> list[ModelMessage]:
@@ -1601,7 +1601,7 @@ async def test_history_processor_rebuild_resuming_without_prompt(
         ]
     )
 
-    assert result.new_messages() == result.all_messages()[-2:]
+    assert result.new_messages() == result.all_messages()[-1:]
 
 
 async def test_history_processor_replace_resumed_request_falls_through(
@@ -1609,8 +1609,9 @@ async def test_history_processor_replace_resumed_request_falls_through(
 ):
     """
     When a history processor replaces the resumed request with completely
-    different content, new_messages() falls back to run_id-based detection
-    to determine which messages belong to the current run.
+    different content (breaking both identity and value matching), new_messages()
+    falls back to run_id-based detection. The replaced request gets the current
+    run_id assigned and is included in new_messages().
     """
 
     def replace_all_requests(messages: list[ModelMessage]) -> list[ModelMessage]:
@@ -1674,6 +1675,7 @@ async def test_history_processor_replace_resumed_request_falls_through(
         ]
     )
 
-    # Falls back to run_id-based detection: the replaced request got run_id from
-    # the framework, so new_messages includes both it and the model response
+    # Falls back to run_id-based detection: identity and value matching both fail
+    # because the processor replaced the content. The replaced request got run_id
+    # assigned by the framework, so new_messages includes both it and the response.
     assert result.new_messages() == result.all_messages()[-2:]


### PR DESCRIPTION
Closes #4669

## Summary

- **Bug**: `result.new_messages()` incorrectly included a `ModelRequest` from `message_history` when calling `agent.run(message_history=[...])` without a `user_prompt` — a regression since v1.64.0
- **Root cause**: PR #4419 fixed a missing `run_id` for AG-UI adapters by (1) always assigning `run_id` to the trailing history message, and (2) changing `_first_new_message_index` to include the resumed request when `message.run_id == run_id`. Since (1) always makes (2)'s check True, the history request was always included
- **Fix**: Revert `_first_new_message_index` to always exclude the resumed request (`return index + 1`). A `ModelRequest` from `message_history` is never "new" — only messages generated during the current run are. The `run_id` assignment from #4419 is kept so AG-UI `parent_message_id` still works correctly

Edge cases verified:
- History `ModelRequest` with or without prior `run_id` → excluded
- Tool-call loop when resuming without prompt → only current-run messages included
- Deep-copy/rebuild history processors → value-match fallback still excludes history request
- Complete-replacement processor → falls through to `_first_run_id_index` (acceptable edge case, behaviour unchanged)
- Deferred tool results path → bypasses `_prepare_request` entirely, unaffected

## Test plan

- [ ] Added regression test `test_new_messages_excludes_history_request_without_user_prompt` in `test_agent.py`
- [ ] Updated `test_adapter_sets_current_run_id_on_trailing_mapped_request` in `test_ag_ui.py` — `run_id` is still set on the mapped request, but it's no longer in `new_messages()`
- [ ] Updated 5 tests in `test_history_processor.py` that encoded the now-reverted behavior from #4419
- [ ] Updated 2 existing tests in `test_agent.py` that expected the old (incorrect) behavior
- [ ] All 488 relevant tests pass; 7 pre-existing failures in `test_reporting.py` (terminal table rendering, unrelated)

> [!NOTE]
> AI generated code has been reviewed line-by-line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)