### PR TITLE
fix: handle empty thinking tags in responses

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -61,6 +61,8 @@ class ModelResponsePartsManager:
     """A list of parts (text or tool calls) that make up the current state of the model's response."""
     _vendor_id_to_part_index: dict[VendorId, int] = field(default_factory=dict[VendorId, int], init=False)
     """Maps a vendor's "part" ID (if provided) to the index in `_parts` where that part resides."""
+    _empty_start_thinking_closed_without_vendor_id: bool = field(default=False, init=False)
+    """Tracks whether empty-start-tag thinking has been closed for `vendor_part_id=None`."""
 
     def get_parts(self) -> list[ModelResponsePart]:
         """Return only model response parts that are complete (i.e., not ToolCallPartDelta's).
@@ -152,8 +154,18 @@ class ModelResponsePartsManager:
                 else:
                     raise UnexpectedModelBehavior(f'Cannot apply a text delta to {existing_part=}')
 
-        if thinking_tags and not start_tag and end_tag:
-            if vendor_part_id is None or not self._parts or vendor_part_id in self._vendor_id_to_part_index:
+        if thinking_tags and not start_tag and end_tag and existing_text_part_and_index is None:
+            if vendor_part_id is None:
+                if not self._empty_start_thinking_closed_without_vendor_id:
+                    yield from self._handle_empty_start_tag(
+                        vendor_part_id=vendor_part_id,
+                        content=content,
+                        end_tag=end_tag,
+                        provider_name=provider_name,
+                        provider_details=provider_details,
+                    )
+                    return
+            elif not self._parts or vendor_part_id in self._vendor_id_to_part_index:
                 yield from self._handle_empty_start_tag(
                     vendor_part_id=vendor_part_id,
                     content=content,
@@ -516,16 +528,22 @@ class ModelResponsePartsManager:
             if existing_thinking_part_and_index is not None:
                 existing_thinking_part, part_index = existing_thinking_part_and_index
                 if content == end_tag:
+                    self._empty_start_thinking_closed_without_vendor_id = True
                     self._handle_embedded_thinking_end(vendor_part_id)
                     return
+                self._empty_start_thinking_closed_without_vendor_id = False
                 yield from self._handle_embedded_thinking_content(
                     existing_thinking_part, part_index, content, provider_name, provider_details
                 )
                 return
         if content == end_tag:
+            if vendor_part_id is None:
+                self._empty_start_thinking_closed_without_vendor_id = True
             yield from self._handle_embedded_thinking_start(vendor_part_id, provider_name, provider_details)
             self._handle_embedded_thinking_end(vendor_part_id)
             return
+        if vendor_part_id is None:
+            self._empty_start_thinking_closed_without_vendor_id = False
         yield from self._handle_embedded_thinking_start(vendor_part_id, provider_name, provider_details)
         latest_thinking_part_and_index = self._latest_part_if_of_type(ThinkingPart)
         if latest_thinking_part_and_index is not None:

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -120,6 +120,13 @@ class ModelResponsePartsManager:
             UnexpectedModelBehavior: If attempting to apply text content to a part that is not a TextPart.
         """
         existing_text_part_and_index: tuple[TextPart, int] | None = None
+        start_tag: str | None = None
+        end_tag: str | None = None
+
+        if thinking_tags:
+            start_tag, end_tag = thinking_tags
+            if not start_tag and not end_tag:
+                thinking_tags = None
 
         if vendor_part_id is None:
             # If the vendor_part_id is None, check if the latest part is a TextPart to update
@@ -132,7 +139,7 @@ class ModelResponsePartsManager:
 
                 if thinking_tags and isinstance(existing_part, ThinkingPart):
                     # We may be building a thinking part instead of a text part if we had previously seen a thinking tag
-                    if content == thinking_tags[1]:
+                    if end_tag and content == end_tag:
                         # When we see the thinking end tag, we're done with the thinking part and the next text delta will need a new part
                         self._handle_embedded_thinking_end(vendor_part_id)
                         return
@@ -145,7 +152,17 @@ class ModelResponsePartsManager:
                 else:
                     raise UnexpectedModelBehavior(f'Cannot apply a text delta to {existing_part=}')
 
-        if thinking_tags and content == thinking_tags[0]:
+        if thinking_tags and not start_tag and end_tag:
+            yield from self._handle_empty_start_tag(
+                vendor_part_id=vendor_part_id,
+                content=content,
+                end_tag=end_tag,
+                provider_name=provider_name,
+                provider_details=provider_details,
+            )
+            return
+
+        if thinking_tags and start_tag and content == start_tag:
             # When we see a thinking start tag (which is a single token), we'll build a new thinking part instead
             yield from self._handle_embedded_thinking_start(vendor_part_id, provider_name, provider_details)
             return
@@ -482,6 +499,39 @@ class ModelResponsePartsManager:
     def _handle_embedded_thinking_end(self, vendor_part_id: VendorId) -> None:
         """Handle </think> tag - stop tracking so next delta creates new part."""
         self._stop_tracking_vendor_id(vendor_part_id)
+
+    def _handle_empty_start_tag(
+        self,
+        *,
+        vendor_part_id: VendorId | None,
+        content: str,
+        end_tag: str,
+        provider_name: str | None,
+        provider_details: dict[str, Any] | None,
+    ) -> Iterator[ModelResponseStreamEvent]:
+        """Handle thinking when the start tag is empty and end tag is present."""
+        if vendor_part_id is None:
+            existing_thinking_part_and_index = self._latest_part_if_of_type(ThinkingPart)
+            if existing_thinking_part_and_index is not None:
+                existing_thinking_part, part_index = existing_thinking_part_and_index
+                if content == end_tag:
+                    self._handle_embedded_thinking_end(vendor_part_id)
+                    return
+                yield from self._handle_embedded_thinking_content(
+                    existing_thinking_part, part_index, content, provider_name, provider_details
+                )
+                return
+        if content == end_tag:
+            yield from self._handle_embedded_thinking_start(vendor_part_id, provider_name, provider_details)
+            self._handle_embedded_thinking_end(vendor_part_id)
+            return
+        yield from self._handle_embedded_thinking_start(vendor_part_id, provider_name, provider_details)
+        latest_thinking_part_and_index = self._latest_part_if_of_type(ThinkingPart)
+        if latest_thinking_part_and_index is not None:
+            existing_thinking_part, part_index = latest_thinking_part_and_index
+            yield from self._handle_embedded_thinking_content(
+                existing_thinking_part, part_index, content, provider_name, provider_details
+            )
 
     def _resolve_provider_name(
         self, existing_part: ModelResponsePart | ToolCallPartDelta, provider_name: str | None

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -546,11 +546,11 @@ class ModelResponsePartsManager:
             self._empty_start_thinking_closed_without_vendor_id = False
         yield from self._handle_embedded_thinking_start(vendor_part_id, provider_name, provider_details)
         latest_thinking_part_and_index = self._latest_part_if_of_type(ThinkingPart)
-        if latest_thinking_part_and_index is not None:
-            existing_thinking_part, part_index = latest_thinking_part_and_index
-            yield from self._handle_embedded_thinking_content(
-                existing_thinking_part, part_index, content, provider_name, provider_details
-            )
+        assert latest_thinking_part_and_index is not None
+        existing_thinking_part, part_index = latest_thinking_part_and_index
+        yield from self._handle_embedded_thinking_content(
+            existing_thinking_part, part_index, content, provider_name, provider_details
+        )
 
     def _resolve_provider_name(
         self, existing_part: ModelResponsePart | ToolCallPartDelta, provider_name: str | None

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -153,14 +153,15 @@ class ModelResponsePartsManager:
                     raise UnexpectedModelBehavior(f'Cannot apply a text delta to {existing_part=}')
 
         if thinking_tags and not start_tag and end_tag:
-            yield from self._handle_empty_start_tag(
-                vendor_part_id=vendor_part_id,
-                content=content,
-                end_tag=end_tag,
-                provider_name=provider_name,
-                provider_details=provider_details,
-            )
-            return
+            if vendor_part_id is None or not self._parts or vendor_part_id in self._vendor_id_to_part_index:
+                yield from self._handle_empty_start_tag(
+                    vendor_part_id=vendor_part_id,
+                    content=content,
+                    end_tag=end_tag,
+                    provider_name=provider_name,
+                    provider_details=provider_details,
+                )
+                return
 
         if thinking_tags and start_tag and content == start_tag:
             # When we see a thinking start tag (which is a single token), we'll build a new thinking part instead

--- a/pydantic_ai_slim/pydantic_ai/_thinking_part.py
+++ b/pydantic_ai_slim/pydantic_ai/_thinking_part.py
@@ -12,6 +12,33 @@ def split_content_into_text_and_thinking(content: str, thinking_tags: tuple[str,
     start_tag, end_tag = thinking_tags
     parts: list[ThinkingPart | TextPart] = []
 
+    if not start_tag and not end_tag:
+        if content:
+            parts.append(TextPart(content=content))
+        return parts
+
+    if not start_tag:
+        end_index = content.find(end_tag)
+        if end_index >= 0:
+            think_content, content = content[:end_index], content[end_index + len(end_tag) :]
+            parts.append(ThinkingPart(content=think_content))
+            if content:
+                parts.append(TextPart(content=content))
+        elif content:
+            parts.append(TextPart(content=content))
+        return parts
+
+    if not end_tag:
+        start_index = content.find(start_tag)
+        if start_index >= 0:
+            before_think, think_content = content[:start_index], content[start_index + len(start_tag) :]
+            if before_think:
+                parts.append(TextPart(content=before_think))
+            parts.append(ThinkingPart(content=think_content))
+        elif content:
+            parts.append(TextPart(content=content))
+        return parts
+
     start_index = content.find(start_tag)
     while start_index >= 0:
         before_think, content = content[:start_index], content[start_index + len(start_tag) :]

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -249,6 +249,66 @@ def test_empty_start_think_tag_streaming_matches_non_stream_split():
     assert manager.get_parts() == snapshot(expected_parts)
 
 
+def test_empty_start_think_tag_without_vendor_id_multiple_thinking_chunks():
+    manager = ModelResponsePartsManager()
+    thinking_tags = ('', '</think>')
+
+    events = list(manager.handle_text_delta(vendor_part_id=None, content='think-1', thinking_tags=thinking_tags))
+    assert events == snapshot(
+        [
+            PartStartEvent(index=0, part=ThinkingPart(content='', part_kind='thinking'), event_kind='part_start'),
+            PartDeltaEvent(
+                index=0,
+                delta=ThinkingPartDelta(content_delta='think-1', part_delta_kind='thinking'),
+                event_kind='part_delta',
+            ),
+        ]
+    )
+
+    events = list(manager.handle_text_delta(vendor_part_id=None, content=' think-2', thinking_tags=thinking_tags))
+    assert events == snapshot(
+        [
+            PartDeltaEvent(
+                index=0,
+                delta=ThinkingPartDelta(content_delta=' think-2', part_delta_kind='thinking'),
+                event_kind='part_delta',
+            )
+        ]
+    )
+
+    events = list(manager.handle_text_delta(vendor_part_id=None, content='</think>', thinking_tags=thinking_tags))
+    assert events == []
+    assert manager.get_parts() == snapshot([ThinkingPart(content='think-1 think-2', part_kind='thinking')])
+
+
+def test_empty_start_think_tag_without_vendor_id_can_start_closed():
+    manager = ModelResponsePartsManager()
+    thinking_tags = ('', '</think>')
+
+    events = list(manager.handle_text_delta(vendor_part_id=None, content='</think>', thinking_tags=thinking_tags))
+    assert events == snapshot(
+        [PartStartEvent(index=0, part=ThinkingPart(content='', part_kind='thinking'), event_kind='part_start')]
+    )
+
+    event = next(manager.handle_text_delta(vendor_part_id=None, content='visible', thinking_tags=thinking_tags))
+    assert event == snapshot(
+        PartStartEvent(index=1, part=TextPart(content='visible', part_kind='text'), event_kind='part_start')
+    )
+    assert manager.get_parts() == snapshot(
+        [ThinkingPart(content='', part_kind='thinking'), TextPart(content='visible', part_kind='text')]
+    )
+
+
+def test_handle_text_delta_ignores_empty_thinking_tags():
+    manager = ModelResponsePartsManager()
+
+    event = next(manager.handle_text_delta(vendor_part_id='content', content='plain text', thinking_tags=('', '')))
+    assert event == snapshot(
+        PartStartEvent(index=0, part=TextPart(content='plain text', part_kind='text'), event_kind='part_start')
+    )
+    assert manager.get_parts() == snapshot([TextPart(content='plain text', part_kind='text')])
+
+
 def test_handle_tool_call_deltas():
     manager = ModelResponsePartsManager()
 

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -162,6 +162,35 @@ def test_handle_text_deltas_with_think_tags():
     )
 
 
+def test_handle_text_deltas_with_empty_start_think_tag():
+    manager = ModelResponsePartsManager()
+    thinking_tags = ('', '</think>')
+
+    events = list(manager.handle_text_delta(vendor_part_id='content', content='thinking', thinking_tags=thinking_tags))
+    assert events == snapshot(
+        [
+            PartStartEvent(index=0, part=ThinkingPart(content='', part_kind='thinking'), event_kind='part_start'),
+            PartDeltaEvent(
+                index=0,
+                delta=ThinkingPartDelta(content_delta='thinking', part_delta_kind='thinking'),
+                event_kind='part_delta',
+            ),
+        ]
+    )
+    assert manager.get_parts() == snapshot([ThinkingPart(content='thinking', part_kind='thinking')])
+
+    events = list(manager.handle_text_delta(vendor_part_id='content', content='</think>', thinking_tags=thinking_tags))
+    assert events == []
+
+    event = next(manager.handle_text_delta(vendor_part_id='content', content='after', thinking_tags=thinking_tags))
+    assert event == snapshot(
+        PartStartEvent(index=1, part=TextPart(content='after', part_kind='text'), event_kind='part_start')
+    )
+    assert manager.get_parts() == snapshot(
+        [ThinkingPart(content='thinking', part_kind='thinking'), TextPart(content='after', part_kind='text')]
+    )
+
+
 def test_handle_tool_call_deltas():
     manager = ModelResponsePartsManager()
 

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -18,6 +18,7 @@ from pydantic_ai import (
     UnexpectedModelBehavior,
 )
 from pydantic_ai._parts_manager import ModelResponsePartsManager
+from pydantic_ai._thinking_part import split_content_into_text_and_thinking
 
 from ._inline_snapshot import snapshot
 from .conftest import IsStr
@@ -189,6 +190,63 @@ def test_handle_text_deltas_with_empty_start_think_tag():
     assert manager.get_parts() == snapshot(
         [ThinkingPart(content='thinking', part_kind='thinking'), TextPart(content='after', part_kind='text')]
     )
+
+    event = next(manager.handle_text_delta(vendor_part_id='content', content=' more', thinking_tags=thinking_tags))
+    assert event == snapshot(
+        PartDeltaEvent(
+            index=1, delta=TextPartDelta(content_delta=' more', part_delta_kind='text'), event_kind='part_delta'
+        )
+    )
+    assert manager.get_parts() == snapshot(
+        [ThinkingPart(content='thinking', part_kind='thinking'), TextPart(content='after more', part_kind='text')]
+    )
+
+
+def test_handle_text_deltas_with_empty_start_think_tag_without_vendor_id():
+    manager = ModelResponsePartsManager()
+    thinking_tags = ('', '</think>')
+
+    events = list(manager.handle_text_delta(vendor_part_id=None, content='thinking', thinking_tags=thinking_tags))
+    assert events == snapshot(
+        [
+            PartStartEvent(index=0, part=ThinkingPart(content='', part_kind='thinking'), event_kind='part_start'),
+            PartDeltaEvent(
+                index=0,
+                delta=ThinkingPartDelta(content_delta='thinking', part_delta_kind='thinking'),
+                event_kind='part_delta',
+            ),
+        ]
+    )
+
+    events = list(manager.handle_text_delta(vendor_part_id=None, content='</think>', thinking_tags=thinking_tags))
+    assert events == []
+
+    event = next(manager.handle_text_delta(vendor_part_id=None, content='after', thinking_tags=thinking_tags))
+    assert event == snapshot(
+        PartStartEvent(index=1, part=TextPart(content='after', part_kind='text'), event_kind='part_start')
+    )
+
+    event = next(manager.handle_text_delta(vendor_part_id=None, content=' more', thinking_tags=thinking_tags))
+    assert event == snapshot(
+        PartDeltaEvent(
+            index=1, delta=TextPartDelta(content_delta=' more', part_delta_kind='text'), event_kind='part_delta'
+        )
+    )
+    assert manager.get_parts() == snapshot(
+        [ThinkingPart(content='thinking', part_kind='thinking'), TextPart(content='after more', part_kind='text')]
+    )
+
+
+def test_empty_start_think_tag_streaming_matches_non_stream_split():
+    manager = ModelResponsePartsManager()
+    thinking_tags = ('', '</think>')
+    chunks = ['thinking', '</think>', 'after', ' more']
+
+    for chunk in chunks:
+        list(manager.handle_text_delta(vendor_part_id='content', content=chunk, thinking_tags=thinking_tags))
+
+    expected_parts = split_content_into_text_and_thinking(''.join(chunks), thinking_tags)
+    assert manager.get_parts() == snapshot(expected_parts)
 
 
 def test_handle_tool_call_deltas():

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -299,6 +299,24 @@ def test_empty_start_think_tag_without_vendor_id_can_start_closed():
     )
 
 
+def test_empty_start_think_tag_with_vendor_id_can_start_closed():
+    manager = ModelResponsePartsManager()
+    thinking_tags = ('', '</think>')
+
+    events = list(manager.handle_text_delta(vendor_part_id='content', content='</think>', thinking_tags=thinking_tags))
+    assert events == snapshot(
+        [PartStartEvent(index=0, part=ThinkingPart(content='', part_kind='thinking'), event_kind='part_start')]
+    )
+
+    event = next(manager.handle_text_delta(vendor_part_id='content', content='visible', thinking_tags=thinking_tags))
+    assert event == snapshot(
+        PartStartEvent(index=1, part=TextPart(content='visible', part_kind='text'), event_kind='part_start')
+    )
+    assert manager.get_parts() == snapshot(
+        [ThinkingPart(content='', part_kind='thinking'), TextPart(content='visible', part_kind='text')]
+    )
+
+
 def test_handle_text_delta_ignores_empty_thinking_tags():
     manager = ModelResponsePartsManager()
 

--- a/tests/test_thinking_part.py
+++ b/tests/test_thinking_part.py
@@ -99,6 +99,31 @@ from ._inline_snapshot import snapshot
             'no thinking tags',
             [TextPart(content='no thinking tags')],
         ),
+        (
+            ('', ''),
+            '',
+            [],
+        ),
+        (
+            ('', '</think>'),
+            'thinking</think>',
+            [ThinkingPart(content='thinking')],
+        ),
+        (
+            ('', '</think>'),
+            '',
+            [],
+        ),
+        (
+            ('<think>', ''),
+            '<think>thinking',
+            [ThinkingPart(content='thinking')],
+        ),
+        (
+            ('<think>', ''),
+            'text only',
+            [TextPart(content='text only')],
+        ),
     ],
 )
 def test_split_content(thinking_tags: tuple[str, str], content: str, parts: list[ModelResponsePart]):

--- a/tests/test_thinking_part.py
+++ b/tests/test_thinking_part.py
@@ -71,6 +71,34 @@ from ._inline_snapshot import snapshot
             'foo bar<think>thinking</think>baz',
             [TextPart(content='foo bar<think>thinking</think>baz')],
         ),
+        # empty start tag cases
+        (
+            ('', '</think>'),
+            'thinking</think>after',
+            [ThinkingPart(content='thinking'), TextPart(content='after')],
+        ),
+        (
+            ('', '</think>'),
+            'text only',
+            [TextPart(content='text only')],
+        ),
+        # empty end tag cases
+        (
+            ('<think>', ''),
+            'before<think>thinking',
+            [TextPart(content='before'), ThinkingPart(content='thinking')],
+        ),
+        (
+            ('<think>', ''),
+            'before<think>',
+            [TextPart(content='before'), ThinkingPart(content='')],
+        ),
+        # both tags empty
+        (
+            ('', ''),
+            'no thinking tags',
+            [TextPart(content='no thinking tags')],
+        ),
     ],
 )
 def test_split_content(thinking_tags: tuple[str, str], content: str, parts: list[ModelResponsePart]):

--- a/tests/test_thinking_part.py
+++ b/tests/test_thinking_part.py
@@ -93,6 +93,11 @@ from ._inline_snapshot import snapshot
             'before<think>',
             [TextPart(content='before'), ThinkingPart(content='')],
         ),
+        (
+            ('<think>', ''),
+            '',
+            [],
+        ),
         # both tags empty
         (
             ('', ''),


### PR DESCRIPTION
## Summary
- support empty thinking tags so models that only emit an end tag split thinking from user-visible text
- align streamed parsing with non-streamed splitting when tags omit start or end markers

## Rationale
- `nvidia/Nemotron-120B-A12B` emits thinking at the start and only closes with `</think>`, so profiles need to allow an empty start tag
- empty start tags previously caused the splitter to loop indefinitely
- expected behavior is to treat content from the beginning to `</think>` as `ThinkingPart` and return the remainder as `TextPart`
- Using the default thinking separators just places the thinking part in the text part

## Testing
- `make test`

## Baseline tests
- `make test`
  - existing failures in `tests/models/test_outlines.py` from `llama_cpp`/`huggingface_hub` deprecation warnings
  - existing failures in `tests/providers/test_provider_names.py` due to missing Google/Vertex credentials

## Post-change tests
- `make test`
  - same failures as baseline in `tests/models/test_outlines.py`
  - same failures as baseline in `tests/providers/test_provider_names.py`

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #4740

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
