### PR TITLE
fix: preserve ToolReturn metadata through Temporal serialization

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
@@ -12,7 +12,7 @@ from typing_extensions import Self, assert_never
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool, WrapperToolset
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry
-from pydantic_ai.messages import ToolReturnContent
+from pydantic_ai.messages import ToolReturn, ToolReturnContent
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
@@ -55,6 +55,8 @@ class _ModelRetry:
 @dataclass
 class _ToolReturn:
     result: ToolReturnContent
+    content: str | list[Any] | None = None
+    metadata: Any = None
     kind: Literal['tool_return'] = 'tool_return'
 
 
@@ -95,6 +97,14 @@ class TemporalWrapperToolset(WrapperToolset[AgentDepsT], ABC):
     async def _wrap_call_tool_result(self, coro: Awaitable[Any]) -> CallToolResult:
         try:
             result = await coro
+            if isinstance(result, ToolReturn):
+                # Decompose ToolReturn so metadata/content survive Temporal
+                # serialization round-trip. See #4676.
+                return _ToolReturn(
+                    result=result.return_value,
+                    content=result.content,
+                    metadata=result.metadata,
+                )
             return _ToolReturn(result=result)
         except ApprovalRequired as e:
             return _ApprovalRequired(metadata=e.metadata)
@@ -105,6 +115,14 @@ class TemporalWrapperToolset(WrapperToolset[AgentDepsT], ABC):
 
     def _unwrap_call_tool_result(self, result: CallToolResult) -> Any:
         if isinstance(result, _ToolReturn):
+            # Reconstruct ToolReturn if metadata or content was preserved.
+            # See #4676.
+            if result.metadata is not None or result.content is not None:
+                return ToolReturn(
+                    return_value=result.result,
+                    content=result.content,
+                    metadata=result.metadata,
+                )
             return result.result
         elif isinstance(result, _ApprovalRequired):
             raise ApprovalRequired(metadata=result.metadata)


### PR DESCRIPTION
## Problem

When a tool returns a `ToolReturn` with `metadata` or `content`, these fields are **silently dropped** after Temporal activity serialization. `ToolReturnPart.metadata` is always `None` in `TemporalAgent` runs, while it works correctly in non-Temporal runs.

## Root Cause

1. `_ToolReturn` dataclass only captures the raw result, not `metadata` or `content`
2. When `ToolReturn` is serialized/deserialized through Temporal, it becomes a plain dict
3. `isinstance(tool_result, ToolReturn)` returns `False` for the deserialized dict
4. The else branch constructs a generic `ToolReturnPart` **without metadata**

## Fix

1. Add `content` and `metadata` fields to `_ToolReturn` dataclass
2. In `_wrap_call_tool_result`: decompose `ToolReturn` into fields so they survive serialization
3. In `_unwrap_call_tool_result`: reconstruct `ToolReturn` when metadata or content is present

The fix ensures that `ToolReturn.metadata` and `ToolReturn.content` survive the Temporal serialization round-trip, matching the behavior of non-Temporal agent runs.
