### PR TITLE
feat(bedrock): support native structured output and strict tool calls

### DIFF
--- a/docs/models/bedrock.md
+++ b/docs/models/bedrock.md
@@ -74,6 +74,33 @@ model = BedrockConverseModel(model_name='us.amazon.nova-pro-v1:0')
 agent = Agent(model=model, model_settings=bedrock_model_settings)
 ```
 
+## Structured Output
+
+Bedrock supports [native structured output](../output.md#native-output) via the Converse API for [supported models](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html), including Anthropic Claude 4.5+, Mistral, and DeepSeek models.
+
+```python {test="skip"}
+from pydantic import BaseModel
+
+from pydantic_ai import Agent, NativeOutput
+
+
+class CityLocation(BaseModel):
+    city: str
+    country: str
+
+
+agent = Agent(
+    'bedrock:us.anthropic.claude-sonnet-4-6',
+    output_type=NativeOutput(CityLocation),
+)
+
+result = agent.run_sync('Where were the 2024 Olympics held?')
+print(result.output)
+#> city='Paris' country='France'
+```
+
+Strict tool calling is also supported: when `strict=True` is set on a tool definition, the Converse API enforces that tool inputs match the schema exactly.
+
 ## Prompt Caching
 
 Bedrock supports [prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) on Anthropic models so you can reuse expensive context across requests. Pydantic AI provides four ways to use prompt caching:

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import json
 import typing
 from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
 from contextlib import asynccontextmanager
@@ -69,7 +70,9 @@ if TYPE_CHECKING:
         DocumentSourceTypeDef,
         GuardrailConfigurationTypeDef,
         InferenceConfigurationTypeDef,
+        JsonSchemaDefinitionTypeDef,
         MessageUnionTypeDef,
+        OutputConfigTypeDef,
         PerformanceConfigurationTypeDef,
         PromptVariableValuesTypeDef,
         ReasoningContentBlockOutputTypeDef,
@@ -403,12 +406,13 @@ class BedrockConverseModel(Model):
     def _get_tools(self, model_request_parameters: ModelRequestParameters) -> list[ToolTypeDef]:
         return [self._map_tool_definition(r) for r in model_request_parameters.tool_defs.values()]
 
-    @staticmethod
-    def _map_tool_definition(f: ToolDefinition) -> ToolTypeDef:
+    def _map_tool_definition(self, f: ToolDefinition) -> ToolTypeDef:
         tool_spec: ToolSpecificationTypeDef = {'name': f.name, 'inputSchema': {'json': f.parameters_json_schema}}
 
         if f.description:  # pragma: no branch
             tool_spec['description'] = f.description
+        if f.strict and self.profile.supports_json_schema_output:
+            tool_spec['strict'] = f.strict
 
         return {'toolSpec': tool_spec}
 
@@ -605,6 +609,10 @@ class BedrockConverseModel(Model):
         if tool_config:
             params['toolConfig'] = tool_config
 
+        output_config = self._build_output_config(model_request_parameters)
+        if output_config:
+            params['outputConfig'] = output_config
+
         tools: list[ToolTypeDef] = list(tool_config['tools']) if tool_config else []
         self._limit_cache_points(system_prompt, bedrock_messages, tools)
 
@@ -695,6 +703,32 @@ class BedrockConverseModel(Model):
             tool_config['toolChoice'] = tool_choice
 
         return tool_config
+
+    @staticmethod
+    def _build_output_config(model_request_parameters: ModelRequestParameters) -> OutputConfigTypeDef | None:
+        if model_request_parameters.output_mode != 'native':
+            return None
+
+        assert model_request_parameters.output_object is not None
+        output_object = model_request_parameters.output_object
+
+        json_schema: JsonSchemaDefinitionTypeDef = {
+            'schema': json.dumps(output_object.json_schema),
+        }
+        if output_object.name:
+            json_schema['name'] = output_object.name
+        if output_object.description:
+            json_schema['description'] = output_object.description
+
+        output_config: OutputConfigTypeDef = {
+            'textFormat': {
+                'type': 'json_schema',
+                'structure': {
+                    'jsonSchema': json_schema,
+                },
+            }
+        }
+        return output_config
 
     async def _map_messages(  # noqa: C901
         self,

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 from typing import Any, Literal, overload
 
 from pydantic_ai import ModelProfile
+from pydantic_ai._json_schema import JsonSchema, JsonSchemaTransformer
 from pydantic_ai.builtin_tools import CodeExecutionTool
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.profiles.amazon import amazon_model_profile
@@ -29,6 +30,31 @@ except ImportError as _import_error:
         'Please install the `boto3` package to use the Bedrock provider, '
         'you can use the `bedrock` optional group — `pip install "pydantic-ai-slim[bedrock]"`'
     ) from _import_error
+
+
+@dataclass(init=False)
+class BedrockJsonSchemaTransformer(JsonSchemaTransformer):
+    """Transforms schemas for the Bedrock Converse API's structured output feature.
+
+    The Converse API requires `additionalProperties: false` on all objects.
+    Other constraints (like `minLength`, `pattern`, `$ref`) are accepted.
+    """
+
+    def walk(self) -> JsonSchema:
+        schema = super().walk()
+        # Don't default tools to strict=True — only enable when explicitly requested.
+        # Same approach as AnthropicJsonSchemaTransformer.
+        self.is_strict_compatible = self.strict is True
+        return schema
+
+    def transform(self, schema: JsonSchema) -> JsonSchema:
+        schema.pop('title', None)
+        schema.pop('$schema', None)
+
+        if schema.get('type') == 'object':
+            schema['additionalProperties'] = False
+
+        return schema
 
 
 @dataclass(kw_only=True)
@@ -93,6 +119,19 @@ def _without_builtin_tools(profile: ModelProfile | None) -> ModelProfile:
     return replace(profile or BedrockModelProfile(), supported_builtin_tools=frozenset())
 
 
+def _with_bedrock_json_schema_transformer(profile: ModelProfile) -> ModelProfile:
+    """Set the Bedrock Converse API JSON schema transformer on a model profile.
+
+    This does NOT unconditionally enable native structured output — the underlying
+    model profile (e.g. from `anthropic_model_profile`) is responsible for setting
+    `supports_json_schema_output` based on the specific model.
+    """
+    return replace(
+        profile,
+        json_schema_transformer=BedrockJsonSchemaTransformer,
+    )
+
+
 class BedrockProvider(Provider[BaseClient]):
     """Provider for AWS Bedrock."""
 
@@ -111,25 +150,26 @@ class BedrockProvider(Provider[BaseClient]):
     @staticmethod
     def model_profile(model_name: str) -> ModelProfile | None:
         provider_to_profile: dict[str, Callable[[str], ModelProfile | None]] = {
-            'anthropic': lambda model_name: replace(
+            'anthropic': lambda model_name: _with_bedrock_json_schema_transformer(
                 BedrockModelProfile(
                     bedrock_supports_tool_choice=True,
                     bedrock_send_back_thinking_parts=True,
                     bedrock_supports_prompt_caching=True,
                     bedrock_supports_tool_caching=True,
                     bedrock_supported_media_kinds_in_tool_returns=frozenset({'image', 'document'}),
-                ).update(_without_builtin_tools(anthropic_model_profile(model_name))),
-                # We don't currently support native structured output with Bedrock.
-                # See https://github.com/pydantic/pydantic-ai/issues/4209.
-                supports_json_schema_output=False,
+                ).update(_without_builtin_tools(anthropic_model_profile(model_name)))
             ),
-            'mistral': lambda model_name: BedrockModelProfile(bedrock_tool_result_format='json').update(
-                _without_builtin_tools(mistral_model_profile(model_name))
+            'mistral': lambda model_name: _with_bedrock_json_schema_transformer(
+                BedrockModelProfile(bedrock_tool_result_format='json').update(
+                    _without_builtin_tools(mistral_model_profile(model_name))
+                )
             ),
             'cohere': lambda model_name: _without_builtin_tools(cohere_model_profile(model_name)),
             'amazon': bedrock_amazon_model_profile,
             'meta': lambda model_name: _without_builtin_tools(meta_model_profile(model_name)),
-            'deepseek': lambda model_name: _without_builtin_tools(bedrock_deepseek_model_profile(model_name)),
+            'deepseek': lambda model_name: _with_bedrock_json_schema_transformer(
+                _without_builtin_tools(bedrock_deepseek_model_profile(model_name))
+            ),
         }
 
         # Split the model name into parts

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -77,7 +77,7 @@ xai = ["xai-sdk>=1.5.0"]
 groq = ["groq>=0.25.0"]
 openrouter = ["openai>=2.8.0"]
 mistral = ["mistralai>=1.9.11"]
-bedrock = ["boto3>=1.42.14"]
+bedrock = ["boto3>=1.42.72"]
 huggingface = ["huggingface-hub>=1.3.4,<2.0.0"]
 sentence-transformers = ["sentence-transformers>=5.2.0; python_version < '3.14'"]
 # 3.14 pin removable once voyageai 0.3.8 drops: https://pypi.org/project/voyageai/#history

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,8 @@ dev = [
     "pytest-pretty>=1.3.0",
     "pytest-recording>=0.13.2",
     "diff-cover>=9.2.0",
-    "boto3-stubs[bedrock-runtime]>=1.42.13",
+    "boto3-stubs[bedrock-runtime]>=1.42.72",
+    "mypy-boto3-bedrock-runtime>=1.42.42",
     "strict-no-cover @ git+https://github.com/pydantic/strict-no-cover.git@7fc59da2c4dff919db2095a0f0e47101b657131d",
     "pytest-xdist>=3.6.1",
     # Needed for PyCharm users

--- a/tests/models/cassettes/test_bedrock/test_bedrock_native_structured_output.yaml
+++ b/tests/models/cassettes/test_bedrock/test_bedrock_native_structured_output.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Where were the 2024 Olympics held?"}]}], "system": [], "inferenceConfig":
+      {}, "outputConfig": {"textFormat": {"type": "json_schema", "structure": {"jsonSchema": {"schema": "{\"properties\":
+      {\"city\": {\"type\": \"string\"}, \"country\": {\"type\": \"string\"}}, \"required\": [\"city\", \"country\"], \"type\":
+      \"object\", \"additionalProperties\": false}", "name": "CityLocation"}}}}}'
+    headers:
+      amz-sdk-invocation-id:
+      - !!binary |
+        MzRhODIzNjQtYTIzMi00OTZhLTlhOTMtYTQ5M2QyM2IxODUx
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      content-length:
+      - '439'
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/converse
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '385'
+      content-type:
+      - application/json
+    parsed_body:
+      metrics:
+        latencyMs: 941
+      output:
+        message:
+          content:
+          - text: '{"city":"Paris","country":"France"}'
+          role: assistant
+      stopReason: end_turn
+      usage:
+        cacheReadInputTokenCount: 0
+        cacheReadInputTokens: 0
+        cacheWriteInputTokenCount: 0
+        cacheWriteInputTokens: 0
+        inputTokens: 180
+        outputTokens: 12
+        serverToolUsage: {}
+        totalTokens: 192
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_bedrock/test_bedrock_native_structured_output_stream.yaml
+++ b/tests/models/cassettes/test_bedrock/test_bedrock_native_structured_output_stream.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Where were the 2024 Olympics held?"}]}], "system": [], "inferenceConfig":
+      {}, "outputConfig": {"textFormat": {"type": "json_schema", "structure": {"jsonSchema": {"schema": "{\"properties\":
+      {\"city\": {\"type\": \"string\"}, \"country\": {\"type\": \"string\"}}, \"required\": [\"city\", \"country\"], \"type\":
+      \"object\", \"additionalProperties\": false}", "name": "CityLocation"}}}}}'
+    headers:
+      amz-sdk-invocation-id:
+      - !!binary |
+        MjVmNDk5MmUtMTkxYi00NGI2LTk5ODMtM2RmNmUxZTM3NDZk
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      content-length:
+      - '439'
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/converse-stream
+  response:
+    body:
+      string: !!binary |
+        AAAAqAAAAFKgEDvmCzpldmVudC10eXBlBwAMbWVzc2FnZVN0YXJ0DTpjb250ZW50LXR5cGUHABBh
+        cHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsicCI6ImFiY2RlZmdoaWprbG1u
+        b3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFEiLCJyb2xlIjoiYXNzaXN0YW50In189ig4AAAA
+        zgAAAFfGCE2ECzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcA
+        EGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRl
+        eCI6MCwiZGVsdGEiOnsidGV4dCI6IntcIiJ9LCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4
+        eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1gifbI/wEsAAAClAAAAVyjqC9gLOmV2ZW50LXR5cGUH
+        ABFjb250ZW50QmxvY2tEZWx0YQ06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVz
+        c2FnZS10eXBlBwAFZXZlbnR7ImNvbnRlbnRCbG9ja0luZGV4IjowLCJkZWx0YSI6eyJ0ZXh0Ijoi
+        Y2l0eVwiOlwiIn0sInAiOiJhYmMifTmElDEAAAC3AAAAVzLKzzoLOmV2ZW50LXR5cGUHABFjb250
+        ZW50QmxvY2tEZWx0YQ06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10
+        eXBlBwAFZXZlbnR7ImNvbnRlbnRCbG9ja0luZGV4IjowLCJkZWx0YSI6eyJ0ZXh0IjoiUGFyaXMi
+        fSwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHkifdpItlIAAADjAAAAV/9ZpjELOmV2ZW50
+        LXR5cGUHABFjb250ZW50QmxvY2tEZWx0YQ06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNv
+        bg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImNvbnRlbnRCbG9ja0luZGV4IjowLCJkZWx0YSI6eyJ0
+        ZXh0IjoiXCIsXCJjb3VudHJ5XCI6XCJGcmFuY2VcIn0ifSwicCI6ImFiY2RlZmdoaWprbG1ub3Bx
+        cnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVViJ9v8NoAQAAALEAAABWyo0KDAs6ZXZlbnQt
+        dHlwZQcAEGNvbnRlbnRCbG9ja1N0b3ANOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24N
+        Om1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwicCI6ImFiY2RlZmdo
+        aWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSUyJ9Q8x0/wAAAKYAAABRhinUPQs6
+        ZXZlbnQtdHlwZQcAC21lc3NhZ2VTdG9wDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29u
+        DTptZXNzYWdlLXR5cGUHAAVldmVudHsicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJD
+        REVGR0hJSksiLCJzdG9wUmVhc29uIjoiZW5kX3R1cm4ifV0HHjkAAAEFAAAATvf67ysLOmV2ZW50
+        LXR5cGUHAAhtZXRhZGF0YQ06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2Fn
+        ZS10eXBlBwAFZXZlbnR7Im1ldHJpY3MiOnsibGF0ZW5jeU1zIjoxMDQ2fSwicCI6ImFiY2RlZmdo
+        aWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSUyIsInVzYWdlIjp7ImlucHV0VG9r
+        ZW5zIjoxODAsIm91dHB1dFRva2VucyI6MTIsInNlcnZlclRvb2xVc2FnZSI6e30sInRvdGFsVG9r
+        ZW5zIjoxOTJ9fc8Uz1U=
+    headers:
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.amazon.eventstream
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_bedrock/test_bedrock_native_structured_output_with_tools.yaml
+++ b/tests/models/cassettes/test_bedrock/test_bedrock_native_structured_output_with_tools.yaml
@@ -1,0 +1,111 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Where were the 2024 Olympics held? Use the tool to find out."}]}],
+      "system": [], "inferenceConfig": {}, "toolConfig": {"tools": [{"toolSpec": {"name": "get_olympics_host", "inputSchema":
+      {"json": {"additionalProperties": false, "properties": {"year": {"type": "integer"}}, "required": ["year"], "type":
+      "object"}}, "description": "Get the host city for a given Olympics year."}}], "toolChoice": {"auto": {}}}, "outputConfig":
+      {"textFormat": {"type": "json_schema", "structure": {"jsonSchema": {"schema": "{\"properties\": {\"city\": {\"type\":
+      \"string\"}, \"country\": {\"type\": \"string\"}}, \"required\": [\"city\", \"country\"], \"type\": \"object\", \"additionalProperties\":
+      false}", "name": "CityLocation"}}}}}'
+    headers:
+      amz-sdk-invocation-id:
+      - !!binary |
+        MjI4YmI4ODUtMThmMy00MTI1LTg1MjctZDNiYmVhMjNmZmVk
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      content-length:
+      - '771'
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/converse
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '466'
+      content-type:
+      - application/json
+    parsed_body:
+      metrics:
+        latencyMs: 12218
+      output:
+        message:
+          content:
+          - toolUse:
+              input:
+                year: 2024
+              name: get_olympics_host
+              toolUseId: tooluse_lYKOXHgZwE67ZIbFINPr6d
+              type: tool_use
+          role: assistant
+      stopReason: tool_use
+      usage:
+        cacheReadInputTokenCount: 0
+        cacheReadInputTokens: 0
+        cacheWriteInputTokenCount: 0
+        cacheWriteInputTokens: 0
+        inputTokens: 750
+        outputTokens: 57
+        serverToolUsage: {}
+        totalTokens: 807
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Where were the 2024 Olympics held? Use the tool to find out."}]},
+      {"role": "assistant", "content": [{"toolUse": {"toolUseId": "tooluse_lYKOXHgZwE67ZIbFINPr6d", "name": "get_olympics_host",
+      "input": {"year": 2024}}}]}, {"role": "user", "content": [{"toolResult": {"toolUseId": "tooluse_lYKOXHgZwE67ZIbFINPr6d",
+      "content": [{"text": "Paris, France"}], "status": "success"}}]}], "system": [], "inferenceConfig": {}, "toolConfig":
+      {"tools": [{"toolSpec": {"name": "get_olympics_host", "inputSchema": {"json": {"additionalProperties": false, "properties":
+      {"year": {"type": "integer"}}, "required": ["year"], "type": "object"}}, "description": "Get the host city for a given
+      Olympics year."}}], "toolChoice": {"auto": {}}}, "outputConfig": {"textFormat": {"type": "json_schema", "structure":
+      {"jsonSchema": {"schema": "{\"properties\": {\"city\": {\"type\": \"string\"}, \"country\": {\"type\": \"string\"}},
+      \"required\": [\"city\", \"country\"], \"type\": \"object\", \"additionalProperties\": false}", "name": "CityLocation"}}}}}'
+    headers:
+      amz-sdk-invocation-id:
+      - !!binary |
+        ODk0ZDhiYjQtYzA4NS00YjljLWJmMjMtZjllNDAzY2M4ODNk
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      content-length:
+      - '1080'
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/converse
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '389'
+      content-type:
+      - application/json
+    parsed_body:
+      metrics:
+        latencyMs: 1212
+      output:
+        message:
+          content:
+          - text: '{"city": "Paris", "country": "France"}'
+          role: assistant
+      stopReason: end_turn
+      usage:
+        cacheReadInputTokenCount: 0
+        cacheReadInputTokens: 0
+        cacheWriteInputTokenCount: 0
+        cacheWriteInputTokens: 0
+        inputTokens: 822
+        outputTokens: 15
+        serverToolUsage: {}
+        totalTokens: 837
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from pydantic_ai import (
@@ -46,6 +47,7 @@ from pydantic_ai.messages import (
     UploadedFile,
 )
 from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.output import NativeOutput
 from pydantic_ai.profiles import DEFAULT_PROFILE
 from pydantic_ai.providers import Provider
 from pydantic_ai.run import AgentRunResult, AgentRunResultEvent
@@ -478,6 +480,163 @@ The temperature in London on 1st January 2022 was 30°C.\
                     )
                 ],
                 timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+            ),
+        ]
+    )
+
+
+async def test_bedrock_native_structured_output(allow_model_requests: None, bedrock_provider: BedrockProvider):
+    class CityLocation(BaseModel):
+        city: str
+        country: str
+
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-6', provider=bedrock_provider)
+    agent: Agent[None, CityLocation] = Agent(
+        model=model,
+        output_type=NativeOutput(CityLocation),
+    )
+
+    result = await agent.run('Where were the 2024 Olympics held?')
+    assert result.output == snapshot(CityLocation(city='Paris', country='France'))
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content='Where were the 2024 Olympics held?',
+                        timestamp=IsNow(tz=timezone.utc),
+                    )
+                ],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content=IsStr())],
+                usage=IsInstance(RequestUsage),
+                model_name='us.anthropic.claude-sonnet-4-6',
+                timestamp=IsNow(tz=timezone.utc),
+                provider_name='bedrock',
+                provider_url=IsStr(),
+                provider_details={'finish_reason': 'end_turn'},
+                finish_reason='stop',
+                run_id=IsStr(),
+            ),
+        ]
+    )
+
+
+async def test_bedrock_native_structured_output_stream(allow_model_requests: None, bedrock_provider: BedrockProvider):
+    class CityLocation(BaseModel):
+        city: str
+        country: str
+
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-6', provider=bedrock_provider)
+    agent: Agent[None, CityLocation] = Agent(
+        model=model,
+        output_type=NativeOutput(CityLocation),
+    )
+
+    async with agent.run_stream('Where were the 2024 Olympics held?') as result:
+        output = await result.get_output()
+    assert output == snapshot(CityLocation(city='Paris', country='France'))
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content='Where were the 2024 Olympics held?',
+                        timestamp=IsNow(tz=timezone.utc),
+                    )
+                ],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content=IsStr())],
+                usage=IsInstance(RequestUsage),
+                model_name='us.anthropic.claude-sonnet-4-6',
+                timestamp=IsNow(tz=timezone.utc),
+                provider_name='bedrock',
+                provider_url=IsStr(),
+                provider_details={'finish_reason': 'end_turn'},
+                finish_reason='stop',
+                run_id=IsStr(),
+            ),
+        ]
+    )
+
+
+async def test_bedrock_native_structured_output_with_tools(
+    allow_model_requests: None, bedrock_provider: BedrockProvider
+):
+    class CityLocation(BaseModel):
+        city: str
+        country: str
+
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-6', provider=bedrock_provider)
+    agent: Agent[None, CityLocation] = Agent(
+        model=model,
+        output_type=NativeOutput(CityLocation),
+    )
+
+    @agent.tool_plain
+    async def get_olympics_host(year: int) -> str:
+        """Get the host city for a given Olympics year."""
+        return 'Paris, France'
+
+    result = await agent.run('Where were the 2024 Olympics held? Use the tool to find out.')
+    assert result.output == snapshot(CityLocation(city='Paris', country='France'))
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content='Where were the 2024 Olympics held? Use the tool to find out.',
+                        timestamp=IsNow(tz=timezone.utc),
+                    )
+                ],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='get_olympics_host',
+                        args=IsInstance(dict),
+                        tool_call_id=IsStr(),
+                    )
+                ],
+                usage=IsInstance(RequestUsage),
+                model_name='us.anthropic.claude-sonnet-4-6',
+                timestamp=IsNow(tz=timezone.utc),
+                provider_name='bedrock',
+                provider_url=IsStr(),
+                provider_details={'finish_reason': 'tool_use'},
+                finish_reason='tool_call',
+                run_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='get_olympics_host',
+                        content='Paris, France',
+                        tool_call_id=IsStr(),
+                        timestamp=IsNow(tz=timezone.utc),
+                    )
+                ],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content=IsStr())],
+                usage=IsInstance(RequestUsage),
+                model_name='us.anthropic.claude-sonnet-4-6',
+                timestamp=IsNow(tz=timezone.utc),
+                provider_name='bedrock',
+                provider_url=IsStr(),
+                provider_details={'finish_reason': 'end_turn'},
+                finish_reason='stop',
                 run_id=IsStr(),
             ),
         ]
@@ -3656,3 +3815,41 @@ async def test_uploaded_file_audio_not_supported(allow_model_requests: None, bed
                 UploadedFile(file_id='s3://bucket/audio.wav', provider_name='bedrock', media_type='audio/wav'),
             ]
         )
+
+
+def test_bedrock_strict_tool_definition(bedrock_provider: BedrockProvider):
+    """Strict flag is passed through to tool spec only when supported."""
+    tool_def = ToolDefinition(
+        name='test_tool',
+        description='A test tool',
+        parameters_json_schema={
+            'type': 'object',
+            'properties': {'x': {'type': 'string'}},
+            'additionalProperties': False,
+        },
+        strict=True,
+    )
+
+    # Model that supports structured output: strict is passed through
+    supported_model = BedrockConverseModel('us.anthropic.claude-sonnet-4-6', provider=bedrock_provider)
+    tool = supported_model._map_tool_definition(tool_def)  # type: ignore[reportPrivateUsage]
+    assert tool['toolSpec'].get('strict') is True
+
+    # Model that does not support structured output: strict is silently skipped
+    unsupported_model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    tool = unsupported_model._map_tool_definition(tool_def)  # type: ignore[reportPrivateUsage]
+    assert 'strict' not in tool['toolSpec']
+
+    # strict=None/False: never passed through regardless of model
+    non_strict_def = ToolDefinition(
+        name='test_tool',
+        description='A test tool',
+        parameters_json_schema={
+            'type': 'object',
+            'properties': {'x': {'type': 'string'}},
+            'additionalProperties': False,
+        },
+        strict=None,
+    )
+    tool = supported_model._map_tool_definition(non_strict_def)  # type: ignore[reportPrivateUsage]
+    assert 'strict' not in tool['toolSpec']

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -20,6 +20,7 @@ with try_import() as imports_successful:
     from pydantic_ai.models.bedrock import LatestBedrockModelNames
     from pydantic_ai.providers.bedrock import (
         BEDROCK_GEO_PREFIXES,
+        BedrockJsonSchemaTransformer,
         BedrockModelProfile,
         BedrockProvider,
         remove_bedrock_geo_prefix,
@@ -81,9 +82,9 @@ def test_bedrock_provider_model_profile(env: TestEnv, mocker: MockerFixture):
     anthropic_model_profile_mock.assert_called_with('claude-3-5-sonnet-20240620')
     assert isinstance(anthropic_profile, BedrockModelProfile)
     assert anthropic_profile.bedrock_supports_tool_choice is True
-    # Bedrock does not support native structured output, even for models that support it via direct Anthropic API
+    # claude-3-5-sonnet doesn't support native structured output
     assert anthropic_profile.supports_json_schema_output is False
-    assert anthropic_profile.json_schema_transformer is None
+    assert anthropic_profile.json_schema_transformer is BedrockJsonSchemaTransformer
     assert anthropic_profile.supported_builtin_tools == frozenset()
 
     anthropic_profile = provider.model_profile('anthropic.claude-instant-v1')
@@ -91,20 +92,20 @@ def test_bedrock_provider_model_profile(env: TestEnv, mocker: MockerFixture):
     assert isinstance(anthropic_profile, BedrockModelProfile)
     assert anthropic_profile.bedrock_supports_tool_choice is True
     assert anthropic_profile.supports_json_schema_output is False
-    assert anthropic_profile.json_schema_transformer is None
+    assert anthropic_profile.json_schema_transformer is BedrockJsonSchemaTransformer
     assert anthropic_profile.supported_builtin_tools == frozenset()
 
     anthropic_profile = provider.model_profile('us.anthropic.claude-sonnet-4-5-20250929-v1:0')
     anthropic_model_profile_mock.assert_called_with('claude-sonnet-4-5-20250929')
     assert isinstance(anthropic_profile, BedrockModelProfile)
-    # Anthropic's direct API supports native structured output for this family,
-    # but Bedrock support is not implemented yet and must stay disabled.
-    assert anthropic_profile.supports_json_schema_output is False
+    # claude-sonnet-4-5 supports native structured output
+    assert anthropic_profile.supports_json_schema_output is True
 
     mistral_profile = provider.model_profile('mistral.mistral-large-2407-v1:0')
     mistral_model_profile_mock.assert_called_with('mistral-large-2407')
     assert isinstance(mistral_profile, BedrockModelProfile)
     assert mistral_profile.bedrock_tool_result_format == 'json'
+    assert mistral_profile.json_schema_transformer is BedrockJsonSchemaTransformer
     assert mistral_profile.supported_builtin_tools == frozenset()
 
     meta_profile = provider.model_profile('meta.llama3-8b-instruct-v1:0')

--- a/uv.lock
+++ b/uv.lock
@@ -760,30 +760,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.14"
+version = "1.42.72"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/72/e236ca627bc0461710685f5b7438f759ef3b4106e0e08dda08513a6539ab/boto3-1.42.14.tar.gz", hash = "sha256:a5d005667b480c844ed3f814a59f199ce249d0f5669532a17d06200c0a93119c", size = 112825, upload-time = "2025-12-19T20:27:15.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/78/daf8d8950341f4596b2ffa8e69750569a6f567bcae8f2be0a8095a15fc71/boto3-1.42.72.tar.gz", hash = "sha256:932f023ea3b54fd85df453dcfff7d8c5a0f8be144c0ad57568943505c72c1e6a", size = 112782, upload-time = "2026-03-19T21:03:35.786Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/ba/c657ea6f6d63563cc46748202fccd097b51755d17add00ebe4ea27580d06/boto3-1.42.14-py3-none-any.whl", hash = "sha256:bfcc665227bb4432a235cb4adb47719438d6472e5ccbf7f09512046c3f749670", size = 140571, upload-time = "2025-12-19T20:27:13.316Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c7/ac1e8d49b0cb5631410796dd439c621d50d9b241f98a79e38e8d466b8d00/boto3-1.42.72-py3-none-any.whl", hash = "sha256:2b5fdac4f202b2ccb9ed21f8b84229463b15573ea16941c2b1b8db1c69e08b63", size = 140555, upload-time = "2026-03-19T21:03:34.165Z" },
 ]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.42.14"
+version = "1.42.72"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
     { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-16-pydantic-ai-slim-huggingface' and extra == 'extra-16-pydantic-ai-slim-outlines-vllm-offline')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/42/2a73afec394eec6350d59c4deb4bda2639f7fc0ca8dfb2a41dcc4115f07e/boto3_stubs-1.42.14.tar.gz", hash = "sha256:b06c4be79348573fa03fc7fbe4bd82ebbc7e1e27cf208c8f5ab7bfcb75f55c05", size = 101097, upload-time = "2025-12-19T20:41:44.497Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/09/90a781644ed2d66f07dafcd2aef7927e9b186e460a4c0340b87466889238/boto3_stubs-1.42.72.tar.gz", hash = "sha256:41fc40b5eebd42acc449764931aae6cbd4543efd3817b1b4fa60b41f5449d4b6", size = 101379, upload-time = "2026-03-19T21:30:40.793Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/6a/f325a61d06e664ab1cd904a1813c10f0a29b64a63bf521c574ff840d191d/boto3_stubs-1.42.14-py3-none-any.whl", hash = "sha256:87bbad7f8e3dbd50e11c47f6850084d598934cd5b7ef85af13539a50b54d1202", size = 69888, upload-time = "2025-12-19T20:41:41.611Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fe/49b866b925e1199bcad3df91ed8c59f1965ffa48150221f93bdbef4564b5/boto3_stubs-1.42.72-py3-none-any.whl", hash = "sha256:c244887967a5cef751ca23a2adeeca9ead6ad85edd79513bce088bb89a33b373", size = 70009, upload-time = "2026-03-19T21:30:32.461Z" },
 ]
 
 [package.optional-dependencies]
@@ -793,16 +793,16 @@ bedrock-runtime = [
 
 [[package]]
 name = "botocore"
-version = "1.42.14"
+version = "1.42.72"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/3f/50c56f093c2c6ce6de1f579726598db1cf9a9cccd3bf8693f73b1cf5e319/botocore-1.42.14.tar.gz", hash = "sha256:cf5bebb580803c6cfd9886902ca24834b42ecaa808da14fb8cd35ad523c9f621", size = 14910547, upload-time = "2025-12-19T20:27:04.431Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ff/36bfa472894648ded83cfe7bb09faabd0db113551dbe920589cfc9cadad7/botocore-1.42.72.tar.gz", hash = "sha256:491b75eb41d46cf99cf8d6cab89f2e2c3602ce8e90d738a1da217a5fb6b2b7ef", size = 15004562, upload-time = "2026-03-19T21:03:24.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/94/67a78a8d08359e779894d4b1672658a3c7fcce216b48f06dfbe1de45521d/botocore-1.42.14-py3-none-any.whl", hash = "sha256:efe89adfafa00101390ec2c371d453b3359d5f9690261bc3bd70131e0d453e8e", size = 14583247, upload-time = "2025-12-19T20:27:00.54Z" },
+    { url = "https://files.pythonhosted.org/packages/66/50/3297ba278a0d6644396011cc592ee88f628206599fc6cff25f5c83b629e7/botocore-1.42.72-py3-none-any.whl", hash = "sha256:038f34553da68df2ce70edc729f170cc198678daaad43f98649727c59f6404d4", size = 14678727, upload-time = "2026-03-19T21:03:20.575Z" },
 ]
 
 [[package]]
@@ -4708,14 +4708,14 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-bedrock-runtime"
-version = "1.42.3"
+version = "1.42.42"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-16-pydantic-ai-slim-huggingface' and extra == 'extra-16-pydantic-ai-slim-outlines-vllm-offline')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/95/cb46d84a7a1408e14cac8a8dbbb24a612e438dd10b5f284fb5e01deece3a/mypy_boto3_bedrock_runtime-1.42.3.tar.gz", hash = "sha256:15686cf925719f14bc0d6c85530808736005fb431f007e37d40e10daff4032cc", size = 29476, upload-time = "2025-12-04T20:56:45.423Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/bb/65dc1b2c5796a6ab5f60bdb57343bd6c3ecb82251c580eca415c8548333e/mypy_boto3_bedrock_runtime-1.42.42.tar.gz", hash = "sha256:3a4088218478b6fbbc26055c03c95bee4fc04624a801090b3cce3037e8275c8d", size = 29840, upload-time = "2026-02-04T20:53:05.999Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/19/f8a855cb1ff098afb6d05e2caa681ee34e1a7e4eb51b273ceb1e9c434a4e/mypy_boto3_bedrock_runtime-1.42.3-py3-none-any.whl", hash = "sha256:e28650aaa64ed4ff84ea75aac681c3a0fab0d2c4dd7dc22c00726949dadf87ea", size = 35631, upload-time = "2025-12-04T20:56:43.487Z" },
+    { url = "https://files.pythonhosted.org/packages/00/43/7ea062f2228f47b5779dcfa14dab48d6e29f979b35d1a5102b0ba80b9c1b/mypy_boto3_bedrock_runtime-1.42.42-py3-none-any.whl", hash = "sha256:b2d16eae22607d0685f90796b3a0afc78c0b09d45872e00eafd634a31dd9358f", size = 36077, upload-time = "2026-02-04T20:53:01.768Z" },
 ]
 
 [[package]]
@@ -6670,6 +6670,7 @@ dev = [
     { name = "exa-py" },
     { name = "genai-prices" },
     { name = "inline-snapshot" },
+    { name = "mypy-boto3-bedrock-runtime" },
     { name = "pip" },
     { name = "pytest" },
     { name = "pytest-examples" },
@@ -6723,7 +6724,7 @@ provides-extras = ["a2a", "dbos", "examples", "outlines-llamacpp", "outlines-mlx
 dev = [
     { name = "anyio", specifier = ">=4.5.0" },
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
-    { name = "boto3-stubs", extras = ["bedrock-runtime"], specifier = ">=1.42.13" },
+    { name = "boto3-stubs", extras = ["bedrock-runtime"], specifier = ">=1.42.72" },
     { name = "brotli", specifier = ">=1.2.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.10.7" },
     { name = "devtools", specifier = ">=0.12.2" },
@@ -6733,6 +6734,7 @@ dev = [
     { name = "exa-py", specifier = ">=2.0.0" },
     { name = "genai-prices", specifier = ">=0.0.28" },
     { name = "inline-snapshot", specifier = ">=0.19.3" },
+    { name = "mypy-boto3-bedrock-runtime", specifier = ">=1.42.42" },
     { name = "pip", specifier = ">=26.0" },
     { name = "pytest", specifier = ">=9.0.0" },
     { name = "pytest-examples", specifier = ">=0.0.18" },
@@ -6943,7 +6945,7 @@ requires-dist = [
     { name = "ag-ui-protocol", marker = "extra == 'ag-ui'", specifier = ">=0.1.10" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.80.0" },
     { name = "argcomplete", marker = "extra == 'cli'", specifier = ">=3.5.0" },
-    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.14" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.72" },
     { name = "cohere", marker = "sys_platform != 'emscripten' and extra == 'cohere'", specifier = ">=5.20.6" },
     { name = "dbos", marker = "extra == 'dbos'", specifier = ">=2.10.0" },
     { name = "ddgs", marker = "extra == 'duckduckgo'", specifier = ">=9.0.0" },


### PR DESCRIPTION
- Closes #4209

### Pre-Review Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.

## Summary

- Add `BedrockJsonSchemaTransformer` enforcing the Converse API's `additionalProperties: false` requirement on all objects, with `is_strict_compatible` defaulting to `False` (matching the Anthropic transformer's approach)
- Add `_build_output_config()` mapping output schemas to the Converse API's `outputConfig.textFormat` format (JSON-stringified schema with optional name/description)
- Pass `strict` through on tool definitions when `profile.supports_json_schema_output` is `True`
- Apply the transformer to Anthropic, Mistral, and DeepSeek model families; native output is gated per-model by the underlying profile's `supports_json_schema_output` flag (not unconditionally enabled)
- Bump `boto3>=1.42.72` and `mypy-boto3-bedrock-runtime>=1.42.42` for `OutputConfigTypeDef` support

## Test plan

- [x] VCR integration test: native structured output (non-streaming) with `NativeOutput(CityLocation)`
- [x] VCR integration test: native structured output (streaming) with `run_stream()`
- [x] VCR integration test: native structured output combined with function tools
- [x] Unit test: strict tool definition pass-through (supported vs unsupported model, `strict=None`)
- [x] Provider profile tests: transformer set on Anthropic/Mistral/DeepSeek, `supports_json_schema_output` controlled by model family profile
- [x] All 121 Bedrock tests pass, pyright 0 errors