### PR TITLE
feat: add OpenTelemetry span for output validator functions

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -26,6 +26,9 @@ class InstrumentationNames:
     # Output Tool execution span configuration
     output_tool_span_name: str
 
+    # Output validator execution span configuration
+    output_validator_span_name: str
+
     @classmethod
     def for_version(cls, version: int) -> Self:
         """Create instrumentation configuration for a specific version.
@@ -44,6 +47,7 @@ class InstrumentationNames:
                 tool_arguments_attr='tool_arguments',
                 tool_result_attr='tool_response',
                 output_tool_span_name='running output function',
+                output_validator_span_name='running output validator',
             )
         else:
             return cls(
@@ -53,6 +57,7 @@ class InstrumentationNames:
                 tool_arguments_attr='gen_ai.tool.call.arguments',
                 tool_result_attr='gen_ai.tool.call.result',
                 output_tool_span_name='execute_tool',
+                output_validator_span_name='validate_output',
             )
 
     def get_agent_run_span_name(self, agent_name: str) -> str:
@@ -93,3 +98,16 @@ class InstrumentationNames:
         if self.output_tool_span_name == 'execute_tool':
             return f'execute_tool {tool_name}'
         return self.output_tool_span_name
+
+    def get_output_validator_span_name(self, validator_name: str) -> str:
+        """Get the formatted output validator span name.
+
+        Args:
+            validator_name: Name of the output validator function
+
+        Returns:
+            Formatted span name
+        """
+        if self.output_validator_span_name == 'validate_output':
+            return f'validate_output {validator_name}'
+        return self.output_validator_span_name

--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -172,7 +172,7 @@ class OutputValidator(Generic[AgentDepsT, OutputDataT_inv]):
         run_context: RunContext[AgentDepsT],
         wrap_validation_errors: bool = True,
     ) -> T:
-        """Validate a result but calling the function.
+        """Validate a result by calling the function within a traced span.
 
         Args:
             result: The result data after Pydantic validation the message content.
@@ -182,30 +182,62 @@ class OutputValidator(Generic[AgentDepsT, OutputDataT_inv]):
         Returns:
             Result of either the validated result data (ok) or a retry message (Err).
         """
-        if self._takes_ctx:
-            args = run_context, result
-        else:
-            args = (result,)
+        instrumentation_names = InstrumentationNames.for_version(run_context.instrumentation_version)
+        validator_name = getattr(self.function, '__name__', 'output_validator')
+        attributes = {
+            'logfire.msg': f'running output validator: {validator_name}',
+        }
+        attributes['logfire.json_schema'] = json.dumps(
+            {
+                'type': 'object',
+                'properties': {
+                    **(
+                        {instrumentation_names.tool_result_attr: {'type': 'object'}}
+                        if run_context.trace_include_content
+                        else {}
+                    ),
+                },
+            }
+        )
 
-        try:
-            if self._is_async:
-                function = cast(Callable[[Any], Awaitable[T]], self.function)
-                result_data = await function(*args)
+        with run_context.tracer.start_as_current_span(
+            instrumentation_names.get_output_validator_span_name(validator_name),
+            attributes=attributes,
+        ) as span:
+            if self._takes_ctx:
+                args = run_context, result
             else:
-                function = cast(Callable[[Any], T], self.function)
-                result_data = await _utils.run_in_executor(function, *args)
-        except ModelRetry as r:
-            if wrap_validation_errors:
-                m = _messages.RetryPromptPart(
-                    content=r.message,
-                    tool_name=run_context.tool_name,
+                args = (result,)
+
+            try:
+                if self._is_async:
+                    function = cast(Callable[[Any], Awaitable[T]], self.function)
+                    result_data = await function(*args)
+                else:
+                    function = cast(Callable[[Any], T], self.function)
+                    result_data = await _utils.run_in_executor(function, *args)
+            except ModelRetry as r:
+                if wrap_validation_errors:
+                    m = _messages.RetryPromptPart(
+                        content=r.message,
+                        tool_name=run_context.tool_name,
+                    )
+                    if run_context.tool_call_id:  # pragma: no cover
+                        m.tool_call_id = run_context.tool_call_id
+                    raise ToolRetryError(m) from r
+                else:
+                    raise r
+
+            if run_context.trace_include_content and span.is_recording():
+                from .models.instrumented import InstrumentedModel
+
+                span.set_attribute(
+                    instrumentation_names.tool_result_attr,
+                    result_data
+                    if isinstance(result_data, str)
+                    else json.dumps(InstrumentedModel.serialize_any(result_data)),
                 )
-                if run_context.tool_call_id:  # pragma: no cover
-                    m.tool_call_id = run_context.tool_call_id
-                raise ToolRetryError(m) from r
-            else:
-                raise r
-        else:
+
             return result_data
 
 

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3225,3 +3225,108 @@ async def test_agent_description_absent_when_none(capfire: CaptureLogfire) -> No
     spans = capfire.exporter.exported_spans_as_dict()
     agent_run_span = next(s for s in spans if s['name'] == 'agent run')
     assert 'gen_ai.agent.description' not in agent_run_span['attributes']
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.parametrize('include_content', [True, False])
+def test_logfire_output_validator_span(
+    get_logfire_summary: Callable[[], LogfireSummary],
+    include_content: bool,
+) -> None:
+    def return_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        assert info.output_tools is not None
+        args_json = '{"temperature": 28.7, "description": "sunny"}'
+        return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, args_json)])
+
+    instrumentation_settings = InstrumentationSettings(include_content=include_content)
+    agent = Agent(FunctionModel(return_model), output_type=WeatherInfo, instrument=instrumentation_settings)
+
+    @agent.output_validator
+    def validate_output(o: WeatherInfo) -> WeatherInfo:
+        return o
+
+    result = agent.run_sync('Hello')
+    assert result.output == WeatherInfo(temperature=28.7, description='sunny')
+
+    summary = get_logfire_summary()
+
+    # Find the output validator span
+    validator_spans = [
+        attributes
+        for attributes in summary.attributes.values()
+        if 'running output validator' in attributes.get('logfire.msg', '')
+    ]
+    assert len(validator_spans) == 1
+    [validator_attributes] = validator_spans
+
+    if include_content:
+        assert validator_attributes == snapshot(
+            {
+                'logfire.msg': 'running output validator: validate_output',
+                'logfire.json_schema': IsJson(
+                    snapshot(
+                        {
+                            'type': 'object',
+                            'properties': {
+                                'tool_response': {'type': 'object'},
+                            },
+                        }
+                    )
+                ),
+                'logfire.span_type': 'span',
+                'tool_response': IsStr(),
+            }
+        )
+    else:
+        assert validator_attributes == snapshot(
+            {
+                'logfire.msg': 'running output validator: validate_output',
+                'logfire.json_schema': IsJson(
+                    snapshot(
+                        {
+                            'type': 'object',
+                            'properties': {},
+                        }
+                    )
+                ),
+                'logfire.span_type': 'span',
+            }
+        )
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+def test_logfire_output_validator_span_with_retry(
+    get_logfire_summary: Callable[[], LogfireSummary],
+) -> None:
+    def return_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        assert info.output_tools is not None
+        if len(messages) == 1:
+            args_json = '{"temperature": 0.0, "description": "cold"}'
+        else:
+            args_json = '{"temperature": 28.7, "description": "sunny"}'
+        return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, args_json)])
+
+    agent = Agent(FunctionModel(return_model), output_type=WeatherInfo, instrument=True)
+
+    @agent.output_validator
+    def validate_output(o: WeatherInfo) -> WeatherInfo:
+        if o.temperature > 0:
+            return o
+        raise ModelRetry('temperature should be positive')
+
+    result = agent.run_sync('Hello')
+    assert result.output == WeatherInfo(temperature=28.7, description='sunny')
+
+    summary = get_logfire_summary()
+
+    # Should have two validator spans: one that retried, one that succeeded
+    validator_spans = [
+        attributes
+        for attributes in summary.attributes.values()
+        if 'running output validator' in attributes.get('logfire.msg', '')
+    ]
+    assert len(validator_spans) == 2
+    # First span should have error level (retry)
+    assert validator_spans[0].get('logfire.level_num') == snapshot(17)
+    # Second span should succeed (no error level)
+    assert 'logfire.level_num' not in validator_spans[1]


### PR DESCRIPTION
- Closes #3395

### Pre-Review Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

### Summary

Adds an OpenTelemetry span to `OutputValidator.validate()` so that output validator function execution is visible in Logfire/OTel traces. Previously, output validators ran without any tracing — validation errors were invisible in the span tree.

#### Changes

- **`_instrumentation.py`**: Added `output_validator_span_name` field and `get_output_validator_span_name()` method to `InstrumentationNames` (v1/v2: `"running output validator"`, v3: `"validate_output {name}"`)
- **`_output.py`**: Wrapped the execution inside `OutputValidator.validate()` with a traced span, following the same pattern as `execute_traced_output_function` — records the function name, captures the result when content inclusion is enabled, and marks retry spans with error level
- **`test_logfire.py`**: Added tests for the new span with content inclusion on/off and a retry scenario

This implements the output validator span from @DouweM's [guidance in the issue](https://github.com/pydantic/pydantic-ai/issues/3395#issuecomment-3688484893). The Pydantic schema validation span and output tool span mentioned there can follow in a separate PR if desired.