### PR TITLE
fix: detect empty/missing array items as strict-incompatible

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -290,6 +290,13 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
             else:
                 self.is_strict_compatible = False
 
+        if schema_type == 'array':
+            items = schema.get('items')
+            if not items:
+                # bare `list` without type params produces `items: {}` or no `items` at all,
+                # which OpenAI strict mode rejects
+                self.is_strict_compatible = False
+
         if schema_type == 'object':
             # Always ensure 'properties' key exists - OpenAI drops objects without it
             if 'properties' not in schema:

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4350,6 +4350,30 @@ def test_transformer_adds_properties_to_object_schemas():
     assert result['properties'] == {}
 
 
+def test_transformer_bare_list_not_strict_compatible():
+    """Array schema with empty `items: {}` (from bare `list`) is not strict-compatible."""
+    schema = {'type': 'array', 'items': {}}
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    transformer.walk()
+    assert transformer.is_strict_compatible is False
+
+
+def test_transformer_array_missing_items_not_strict_compatible():
+    """Array schema with no `items` key at all is not strict-compatible."""
+    schema = {'type': 'array'}
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    transformer.walk()
+    assert transformer.is_strict_compatible is False
+
+
+def test_transformer_typed_list_stays_strict_compatible():
+    """Array schema with a proper `items` type remains strict-compatible."""
+    schema = {'type': 'array', 'items': {'type': 'string'}}
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    transformer.walk()
+    assert transformer.is_strict_compatible is True
+
+
 def chunk_with_usage(
     delta: list[ChoiceDelta],
     finish_reason: FinishReason | None = None,


### PR DESCRIPTION
- Closes #4425

### Pre-Review Checklist

- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

---

When a bare `list` (no type params) is used in a tool function, pydantic generates `{"type": "array", "items": {}}`. OpenAI strict mode rejects this because `items` must have a `type` key. The transformer didn't check for this case, so it sent the schema with `strict=True` and got a 400 back.

Added a check in `OpenAIJsonSchemaTransformer.transform()`: if `schema_type == 'array'` and `items` is missing or empty, mark `is_strict_compatible = False`. This also covers the case where `items` is absent entirely (as noted in the review on #4427).

Three tests: empty items, missing items, and typed list (positive case).