### PR TITLE
fix(ag-ui): drop stray tool call deltas after TOOL_CALL_END

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
@@ -76,6 +76,7 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
 
     _thinking_text: bool = False
     _builtin_tool_call_ids: dict[str, str] = field(default_factory=dict[str, str])
+    _ended_tool_call_ids: set[str] = field(default_factory=set[str])
     _error: bool = False
 
     @property
@@ -203,16 +204,23 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
         assert tool_call_id, '`ToolCallPartDelta.tool_call_id` must be set'
         if tool_call_id in self._builtin_tool_call_ids:
             tool_call_id = self._builtin_tool_call_ids[tool_call_id]
+        # Silently drop stray deltas that arrive after TOOL_CALL_END for the
+        # same tool_call_id — emitting them would violate the AG-UI protocol.
+        if tool_call_id in self._ended_tool_call_ids:
+            return
         yield ToolCallArgsEvent(
             tool_call_id=tool_call_id,
             delta=delta.args_delta if isinstance(delta.args_delta, str) else json.dumps(delta.args_delta),
         )
 
     async def handle_tool_call_end(self, part: ToolCallPart) -> AsyncIterator[BaseEvent]:
+        self._ended_tool_call_ids.add(part.tool_call_id)
         yield ToolCallEndEvent(tool_call_id=part.tool_call_id)
 
     async def handle_builtin_tool_call_end(self, part: BuiltinToolCallPart) -> AsyncIterator[BaseEvent]:
-        yield ToolCallEndEvent(tool_call_id=self._builtin_tool_call_ids[part.tool_call_id])
+        agui_id = self._builtin_tool_call_ids[part.tool_call_id]
+        self._ended_tool_call_ids.add(agui_id)
+        yield ToolCallEndEvent(tool_call_id=agui_id)
 
     async def handle_builtin_tool_return(self, part: BuiltinToolReturnPart) -> AsyncIterator[BaseEvent]:
         tool_call_id = self._builtin_tool_call_ids[part.tool_call_id]

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -2624,3 +2624,34 @@ async def test_tool_return_with_files():
             },
         ]
     )
+
+
+async def test_stray_delta_after_tool_call_end_is_dropped():
+    """Stray TOOL_CALL_ARGS deltas after TOOL_CALL_END should be silently dropped.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/4733
+    """
+    from pydantic_ai._parts_manager import ToolCallPartDelta
+    from pydantic_ai.messages import ToolCallPart
+
+    run_input = create_input(UserMessage(id='msg_1', content='test'))
+    event_stream = AGUIEventStream(run_input=run_input)
+
+    part = ToolCallPart(tool_name='my_tool', args='{"action":"run"}', tool_call_id='call_1')
+
+    # Start the tool call
+    events_start = [e async for e in event_stream._handle_tool_call_start(part)]
+    assert len(events_start) >= 1
+
+    # End the tool call
+    events_end = [e async for e in event_stream.handle_tool_call_end(part)]
+    assert len(events_end) == 1
+
+    # Stray delta after end — should produce NO events
+    stray_events = [
+        e
+        async for e in event_stream.handle_tool_call_delta(
+            ToolCallPartDelta(tool_call_id='call_1', args_delta='}')
+        )
+    ]
+    assert stray_events == [], f'Stray delta after TOOL_CALL_END should be dropped, got {stray_events}'


### PR DESCRIPTION
## Bug

`AGUIEventStream.handle_tool_call_delta` unconditionally emits `TOOL_CALL_ARGS` events without checking whether `TOOL_CALL_END` has already been sent for the same `tool_call_id`. This violates the AG-UI protocol spec and crashes the `@ag-ui/client` verifier.

Fixes #4733

## Fix

Track ended tool call IDs in `_ended_tool_call_ids: set[str]`. When a delta arrives for an already-ended tool call, silently return instead of yielding.

## Test

`test_stray_delta_after_tool_call_end_is_dropped` — starts a tool call, ends it, then sends a stray delta and verifies no events are emitted.

_Replaces #4743 (had lint issues from mixed branch)._