### PR TITLE
fix(ci): add checkout step to category-label job in bots workflow

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -114,6 +114,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Checkout repository
+        if: steps.check-label.outputs.has_label == 'false'
+        uses: actions/checkout@v6
+
       - name: Determine category label with Claude Code
         if: steps.check-label.outputs.has_label == 'false'
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary

- The `category-label` job in the PR Bots workflow uses `claude-code-action@v1`, which internally runs `git fetch origin main --depth=1` to restore config files from `origin/main`
- The job was missing a `actions/checkout` step, so there was no git repository in the working directory
- This caused the action to fail with `fatal: not a git repository (or any of the parent directories): .git`
- The fix adds a checkout step before the `claude-code-action` step, matching the pattern already used by the `review` job

## Test plan

- [x] Verify the `category-label` job succeeds on subsequent PRs (the fix is in CI config, so it's tested by running it)