### PR TITLE
fix: propagate original error when CallToolsNode stream fails

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -605,14 +605,21 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
     _next_node: ModelRequestNode[DepsT, NodeRunEndT] | End[result.FinalResult[NodeRunEndT]] | None = field(
         default=None, init=False, repr=False
     )
+    _stream_error: BaseException | None = field(default=None, init=False, repr=False)
 
     async def run(
         self, ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]]
     ) -> ModelRequestNode[DepsT, NodeRunEndT] | End[result.FinalResult[NodeRunEndT]]:
         async with self.stream(ctx):
             pass
-        assert self._next_node is not None, 'the stream should set `self._next_node` before it ends'
-        return self._next_node
+        if self._next_node is not None:
+            return self._next_node
+        # If the stream raised an error that was caught by an external consumer
+        # (e.g. UIEventStream.transform_stream), _next_node will not have been set.
+        # Re-raise the original error instead of a confusing assertion.
+        if self._stream_error is not None:
+            raise self._stream_error.with_traceback(self._stream_error.__traceback__)
+        raise exceptions.AgentRunError('the stream should set `self._next_node` before it ends')  # pragma: no cover
 
     @asynccontextmanager
     async def stream(
@@ -769,8 +776,12 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
 
             self._events_iterator = _run_stream()
 
-        async for event in self._events_iterator:
-            yield event
+        try:
+            async for event in self._events_iterator:
+                yield event
+        except BaseException as e:
+            self._stream_error = e
+            raise
 
     async def _handle_tool_calls(
         self,

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3062,6 +3062,36 @@ async def test_run_event_stream_handler():
     )
 
 
+async def test_event_stream_handler_propagates_tool_error():
+    """When a tool raises during streaming with event_stream_handler and the error
+    is suppressed by the handler, the _stream_error re-raise path in run() should
+    propagate the original error — not an internal AssertionError about _next_node."""
+
+    m = TestModel()
+    test_agent = Agent(m)
+
+    @test_agent.tool_plain
+    async def failing_tool(x: str) -> str:
+        raise RuntimeError('tool execution failed')
+
+    events: list[AgentStreamEvent] = []
+
+    async def handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]):
+        # Suppress the error to simulate UIEventStream.transform_stream behavior,
+        # which catches exceptions and doesn't re-raise them.
+        try:
+            async for event in stream:
+                events.append(event)
+        except RuntimeError:
+            pass
+
+    with pytest.raises(RuntimeError, match='tool execution failed'):
+        await test_agent.run('Hello', event_stream_handler=handler)
+
+    # Events up to the tool call should still have been emitted
+    assert any(isinstance(e, FunctionToolCallEvent) for e in events)
+
+
 def test_run_sync_event_stream_handler():
     m = TestModel()
 


### PR DESCRIPTION
When `event_stream_handler` is used and `_run_stream()` raises during tool execution, `UIEventStream.transform_stream()` catches the error. This leaves `_next_node` unset. The graph's task runner then re-executes the same node via `run()`, hitting:

  AssertionError: the stream should set `self._next_node` before it ends

Fix: capture stream errors on the node and re-raise them in `run()` instead of asserting, so the agent run fails with the original error.

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #4796

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
