### PR TITLE
Fix collapsible indentation in graph persistence example

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -647,160 +647,160 @@ In this example, an AI asks the user a question, the user provides an answer, th
 Instead of running the entire graph in a single process invocation, we run the graph by running the process repeatedly, optionally providing an answer to the question as a command line argument.
 
 ??? example "`ai_q_and_a_graph.py` — `question_graph` definition"
-```python {title="ai_q_and_a_graph.py" noqa="I001"}
-from __future__ import annotations as _annotations
+    ```python {title="ai_q_and_a_graph.py" noqa="I001"}
+    from __future__ import annotations as _annotations
 
-from typing import Annotated
-from pydantic_graph import Edge
-from dataclasses import dataclass, field
-from pydantic import BaseModel
-from pydantic_graph import (
-    BaseNode,
-    End,
-    Graph,
-    GraphRunContext,
-)
-from pydantic_ai import Agent, format_as_xml
-from pydantic_ai import ModelMessage
+    from typing import Annotated
+    from pydantic_graph import Edge
+    from dataclasses import dataclass, field
+    from pydantic import BaseModel
+    from pydantic_graph import (
+        BaseNode,
+        End,
+        Graph,
+        GraphRunContext,
+    )
+    from pydantic_ai import Agent, format_as_xml
+    from pydantic_ai import ModelMessage
 
-ask_agent = Agent('openai:gpt-5.2', output_type=str, instrument=True)
-
-
-@dataclass
-class QuestionState:
-    question: str | None = None
-    ask_agent_messages: list[ModelMessage] = field(default_factory=list)
-    evaluate_agent_messages: list[ModelMessage] = field(default_factory=list)
+    ask_agent = Agent('openai:gpt-5.2', output_type=str, instrument=True)
 
 
-@dataclass
-class Ask(BaseNode[QuestionState]):
-    """Generate question using GPT-5."""
-    docstring_notes = True
-    async def run(
-        self, ctx: GraphRunContext[QuestionState]
-    ) -> Annotated[Answer, Edge(label='Ask the question')]:
-        result = await ask_agent.run(
-            'Ask a simple question with a single correct answer.',
-            message_history=ctx.state.ask_agent_messages,
-        )
-        ctx.state.ask_agent_messages += result.new_messages()
-        ctx.state.question = result.output
-        return Answer(result.output)
+    @dataclass
+    class QuestionState:
+        question: str | None = None
+        ask_agent_messages: list[ModelMessage] = field(default_factory=list)
+        evaluate_agent_messages: list[ModelMessage] = field(default_factory=list)
 
 
-@dataclass
-class Answer(BaseNode[QuestionState]):
-    question: str
-
-    async def run(self, ctx: GraphRunContext[QuestionState]) -> Evaluate:
-        answer = input(f'{self.question}: ')
-        return Evaluate(answer)
-
-
-class EvaluationResult(BaseModel, use_attribute_docstrings=True):
-    correct: bool
-    """Whether the answer is correct."""
-    comment: str
-    """Comment on the answer, reprimand the user if the answer is wrong."""
-
-
-evaluate_agent = Agent(
-    'openai:gpt-5.2',
-    output_type=EvaluationResult,
-    instructions='Given a question and answer, evaluate if the answer is correct.',
-)
+    @dataclass
+    class Ask(BaseNode[QuestionState]):
+        """Generate question using GPT-5."""
+        docstring_notes = True
+        async def run(
+            self, ctx: GraphRunContext[QuestionState]
+        ) -> Annotated[Answer, Edge(label='Ask the question')]:
+            result = await ask_agent.run(
+                'Ask a simple question with a single correct answer.',
+                message_history=ctx.state.ask_agent_messages,
+            )
+            ctx.state.ask_agent_messages += result.new_messages()
+            ctx.state.question = result.output
+            return Answer(result.output)
 
 
-@dataclass
-class Evaluate(BaseNode[QuestionState, None, str]):
-    answer: str
+    @dataclass
+    class Answer(BaseNode[QuestionState]):
+        question: str
 
-    async def run(
-        self,
-        ctx: GraphRunContext[QuestionState],
-    ) -> Annotated[End[str], Edge(label='success')] | Reprimand:
-        assert ctx.state.question is not None
-        result = await evaluate_agent.run(
-            format_as_xml({'question': ctx.state.question, 'answer': self.answer}),
-            message_history=ctx.state.evaluate_agent_messages,
-        )
-        ctx.state.evaluate_agent_messages += result.new_messages()
-        if result.output.correct:
-            return End(result.output.comment)
+        async def run(self, ctx: GraphRunContext[QuestionState]) -> Evaluate:
+            answer = input(f'{self.question}: ')
+            return Evaluate(answer)
+
+
+    class EvaluationResult(BaseModel, use_attribute_docstrings=True):
+        correct: bool
+        """Whether the answer is correct."""
+        comment: str
+        """Comment on the answer, reprimand the user if the answer is wrong."""
+
+
+    evaluate_agent = Agent(
+        'openai:gpt-5.2',
+        output_type=EvaluationResult,
+        instructions='Given a question and answer, evaluate if the answer is correct.',
+    )
+
+
+    @dataclass
+    class Evaluate(BaseNode[QuestionState, None, str]):
+        answer: str
+
+        async def run(
+            self,
+            ctx: GraphRunContext[QuestionState],
+        ) -> Annotated[End[str], Edge(label='success')] | Reprimand:
+            assert ctx.state.question is not None
+            result = await evaluate_agent.run(
+                format_as_xml({'question': ctx.state.question, 'answer': self.answer}),
+                message_history=ctx.state.evaluate_agent_messages,
+            )
+            ctx.state.evaluate_agent_messages += result.new_messages()
+            if result.output.correct:
+                return End(result.output.comment)
+            else:
+                return Reprimand(result.output.comment)
+
+
+    @dataclass
+    class Reprimand(BaseNode[QuestionState]):
+        comment: str
+
+        async def run(self, ctx: GraphRunContext[QuestionState]) -> Ask:
+            print(f'Comment: {self.comment}')
+            ctx.state.question = None
+            return Ask()
+
+
+    question_graph = Graph(
+        nodes=(Ask, Answer, Evaluate, Reprimand), state_type=QuestionState
+    )
+    ```
+
+    _(This example is complete, it can be run "as is")_
+
+    ```python {title="ai_q_and_a_run.py" noqa="I001" requires="ai_q_and_a_graph.py"}
+    import sys
+    from pathlib import Path
+
+    from pydantic_graph import End
+    from pydantic_graph.persistence.file import FileStatePersistence
+    from pydantic_ai import ModelMessage  # noqa: F401
+
+    from ai_q_and_a_graph import Ask, question_graph, Evaluate, QuestionState, Answer
+
+
+    async def main():
+        answer: str | None = sys.argv[1] if len(sys.argv) > 1 else None  # (1)!
+        persistence = FileStatePersistence(Path('question_graph.json'))  # (2)!
+        persistence.set_graph_types(question_graph)  # (3)!
+
+        if snapshot := await persistence.load_next():  # (4)!
+            state = snapshot.state
+            assert answer is not None
+            node = Evaluate(answer)
         else:
-            return Reprimand(result.output.comment)
+            state = QuestionState()
+            node = Ask()  # (5)!
 
+        async with question_graph.iter(node, state=state, persistence=persistence) as run:
+            while True:
+                node = await run.next()  # (6)!
+                if isinstance(node, End):  # (7)!
+                    print('END:', node.data)
+                    history = await persistence.load_all()  # (8)!
+                    print([e.node for e in history])
+                    break
+                elif isinstance(node, Answer):  # (9)!
+                    print(node.question)
+                    #> What is the capital of France?
+                    break
+                # otherwise just continue
+    ```
 
-@dataclass
-class Reprimand(BaseNode[QuestionState]):
-    comment: str
+    1. Get the user's answer from the command line, if provided. See [question graph example](examples/question-graph.md) for a complete example.
+    2. Create a state persistence instance the `'question_graph.json'` file may or may not already exist.
+    3. Since we're using the [persistence interface][pydantic_graph.persistence.BaseStatePersistence] outside a graph, we need to call [`set_graph_types`][pydantic_graph.persistence.BaseStatePersistence.set_graph_types] to set the graph generic types `StateT` and `RunEndT` for the persistence instance. This is necessary to allow the persistence instance to know how to serialize and deserialize graph nodes.
+    4. If we're run the graph before, [`load_next`][pydantic_graph.persistence.BaseStatePersistence.load_next] will return a snapshot of the next node to run, here we use `state` from that snapshot, and create a new `Evaluate` node with the answer provided on the command line.
+    5. If the graph hasn't been run before, we create a new `QuestionState` and start with the `Ask` node.
+    6. Call [`GraphRun.next()`][pydantic_graph.graph.GraphRun.next] to run the node. This will return either a node or an `End` object.
+    7. If the node is an `End` object, the graph run is complete. The `data` field of the `End` object contains the comment returned by the `evaluate_agent` about the correct answer.
+    8. To demonstrate the state persistence, we call [`load_all`][pydantic_graph.persistence.BaseStatePersistence.load_all] to get all the snapshots from the persistence instance. This will return a list of [`Snapshot`][pydantic_graph.persistence.Snapshot] objects.
+    9. If the node is an `Answer` object, we print the question and break out of the loop to end the process and wait for user input.
 
-    async def run(self, ctx: GraphRunContext[QuestionState]) -> Ask:
-        print(f'Comment: {self.comment}')
-        ctx.state.question = None
-        return Ask()
+    _(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
 
-
-question_graph = Graph(
-    nodes=(Ask, Answer, Evaluate, Reprimand), state_type=QuestionState
-)
-```
-
-_(This example is complete, it can be run "as is")_
-
-```python {title="ai_q_and_a_run.py" noqa="I001" requires="ai_q_and_a_graph.py"}
-import sys
-from pathlib import Path
-
-from pydantic_graph import End
-from pydantic_graph.persistence.file import FileStatePersistence
-from pydantic_ai import ModelMessage  # noqa: F401
-
-from ai_q_and_a_graph import Ask, question_graph, Evaluate, QuestionState, Answer
-
-
-async def main():
-    answer: str | None = sys.argv[1] if len(sys.argv) > 1 else None  # (1)!
-    persistence = FileStatePersistence(Path('question_graph.json'))  # (2)!
-    persistence.set_graph_types(question_graph)  # (3)!
-
-    if snapshot := await persistence.load_next():  # (4)!
-        state = snapshot.state
-        assert answer is not None
-        node = Evaluate(answer)
-    else:
-        state = QuestionState()
-        node = Ask()  # (5)!
-
-    async with question_graph.iter(node, state=state, persistence=persistence) as run:
-        while True:
-            node = await run.next()  # (6)!
-            if isinstance(node, End):  # (7)!
-                print('END:', node.data)
-                history = await persistence.load_all()  # (8)!
-                print([e.node for e in history])
-                break
-            elif isinstance(node, Answer):  # (9)!
-                print(node.question)
-                #> What is the capital of France?
-                break
-            # otherwise just continue
-```
-
-1. Get the user's answer from the command line, if provided. See [question graph example](examples/question-graph.md) for a complete example.
-2. Create a state persistence instance the `'question_graph.json'` file may or may not already exist.
-3. Since we're using the [persistence interface][pydantic_graph.persistence.BaseStatePersistence] outside a graph, we need to call [`set_graph_types`][pydantic_graph.persistence.BaseStatePersistence.set_graph_types] to set the graph generic types `StateT` and `RunEndT` for the persistence instance. This is necessary to allow the persistence instance to know how to serialize and deserialize graph nodes.
-4. If we're run the graph before, [`load_next`][pydantic_graph.persistence.BaseStatePersistence.load_next] will return a snapshot of the next node to run, here we use `state` from that snapshot, and create a new `Evaluate` node with the answer provided on the command line.
-5. If the graph hasn't been run before, we create a new `QuestionState` and start with the `Ask` node.
-6. Call [`GraphRun.next()`][pydantic_graph.graph.GraphRun.next] to run the node. This will return either a node or an `End` object.
-7. If the node is an `End` object, the graph run is complete. The `data` field of the `End` object contains the comment returned by the `evaluate_agent` about the correct answer.
-8. To demonstrate the state persistence, we call [`load_all`][pydantic_graph.persistence.BaseStatePersistence.load_all] to get all the snapshots from the persistence instance. This will return a list of [`Snapshot`][pydantic_graph.persistence.Snapshot] objects.
-9. If the node is an `Answer` object, we print the question and break out of the loop to end the process and wait for user input.
-
-_(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
-
-For a complete example of this graph, see the [question graph example](examples/question-graph.md).
+    For a complete example of this graph, see the [question graph example](examples/question-graph.md).
 
 ## Dependency Injection
 


### PR DESCRIPTION
## Summary

- The code blocks, annotation list, and surrounding text inside the `ai_q_and_a_graph.py` collapsible example (`docs/graph.md`) were at column 0 instead of 4-space indented under the `???` marker
- MkDocs collapsible syntax requires body content to be indented by 4 spaces — without it, the content renders outside the fold
- The indentation was likely lost in commit 883e1ea2 ("update logos, favicon and brand names")

Found while building the unified docs site, where the transform that converts `???` blocks faithfully enforces the indentation requirement.