### PR TITLE
ci: enable display_report on auto-review action

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -217,6 +217,7 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_API_KEY || secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
+          display_report: 'true'
           additional_permissions: |
             actions: read
           claude_args: |


### PR DESCRIPTION
## Summary

- The `display_report` input on `anthropics/claude-code-action@v1` defaults to `false`, so review summaries were not appearing on the GitHub Actions summary page
- Enable it for the review job so we can see the review summary in the Actions tab

## Test plan

- [ ] Trigger auto-review on a PR and verify the summary appears on the GitHub Actions summary page

🤖 Generated with [Claude Code](https://claude.com/claude-code)