### PR TITLE
Fix Google thought signature replay for tool calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -933,6 +933,34 @@ class GoogleModel(Model):
         return response_schema
 
 
+def _resolve_thought_signature(part: Part, pending: str | None) -> tuple[dict[str, Any] | None, str | None, bool]:
+    """Resolve the thought_signature for a Google API response part.
+
+    When Gemini streams an empty thinking part carrying only a thought_signature before a
+    function call, the signature must be forwarded to the next real part so it survives replay.
+
+    Per https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#thought-signatures:
+    - Always send the thought_signature back to the model inside its original Part.
+    - Don't merge a Part containing a signature with one that does not.
+    - Don't combine two Parts that both contain signatures.
+
+    Returns:
+        (provider_details, updated_pending, skip_part)
+    """
+    # Empty thinking part with a signature: absorb the signature, skip the part.
+    if part.text is not None and part.thought and len(part.text) == 0:
+        if part.thought_signature:
+            pending = base64.b64encode(part.thought_signature).decode('utf-8')
+        return None, pending, True
+
+    # Use the part's own signature if present, otherwise fall back to the pending one.
+    signature = base64.b64encode(part.thought_signature).decode('utf-8') if part.thought_signature else pending
+
+    if signature is not None:
+        return {'thought_signature': signature}, None, False
+    return None, None, False
+
+
 @dataclass
 class GeminiStreamedResponse(StreamedResponse):
     """Implementation of `StreamedResponse` for the Gemini model."""
@@ -946,6 +974,7 @@ class GeminiStreamedResponse(StreamedResponse):
     _file_search_tool_call_id: str | None = field(default=None, init=False)
     _code_execution_tool_call_id: str | None = field(default=None, init=False)
     _has_content_filter: bool = field(default=False, init=False)
+    _pending_thought_signature: str | None = field(default=None, init=False)
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
         if self._provider_timestamp is not None:
@@ -1019,14 +1048,11 @@ class GeminiStreamedResponse(StreamedResponse):
                     continue  # pragma: no cover
 
                 for part in parts:
-                    provider_details: dict[str, Any] | None = None
-                    if part.thought_signature:
-                        # Per https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#thought-signatures:
-                        # - Always send the thought_signature back to the model inside its original Part.
-                        # - Don't merge a Part containing a signature with one that does not. This breaks the positional context of the thought.
-                        # - Don't combine two Parts that both contain signatures, as the signature strings cannot be merged.
-                        thought_signature = base64.b64encode(part.thought_signature).decode('utf-8')
-                        provider_details = {'thought_signature': thought_signature}
+                    provider_details, self._pending_thought_signature, skip_part = _resolve_thought_signature(
+                        part, self._pending_thought_signature
+                    )
+                    if skip_part:
+                        continue
 
                     if part.text is not None:
                         if len(part.text) == 0 and not provider_details:
@@ -1093,6 +1119,7 @@ class GeminiStreamedResponse(StreamedResponse):
                 file_search_part = self._handle_file_search_grounding_metadata_streaming(candidate.grounding_metadata)
                 if file_search_part is not None:
                     yield self._parts_manager.handle_part(vendor_part_id=uuid4(), part=file_search_part)
+
         except errors.APIError as e:
             if (status_code := e.code) >= 400:
                 raise ModelHTTPError(
@@ -1258,22 +1285,16 @@ def _content_model_response(m: ModelResponse, provider_name: str) -> ContentDict
 
 
 def _process_part(
-    part: Part, code_execution_tool_call_id: str | None, provider_name: str
+    part: Part,
+    code_execution_tool_call_id: str | None,
+    provider_name: str,
+    provider_details: dict[str, Any] | None,
 ) -> tuple[ModelResponsePart | None, str | None]:
     """Process a Google Part and return the corresponding ModelResponsePart.
 
     Returns:
         A tuple of (item, code_execution_tool_call_id). Returns (None, id) if the part should be skipped.
     """
-    provider_details: dict[str, Any] | None = None
-    if part.thought_signature:
-        # Per https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#thought-signatures:
-        # - Always send the thought_signature back to the model inside its original Part.
-        # - Don't merge a Part containing a signature with one that does not. This breaks the positional context of the thought.
-        # - Don't combine two Parts that both contain signatures, as the signature strings cannot be merged.
-        thought_signature = base64.b64encode(part.thought_signature).decode('utf-8')
-        provider_details = {'thought_signature': thought_signature}
-
     if part.executable_code is not None:
         code_execution_tool_call_id = _utils.generate_tool_call_id()
         item = _map_executable_code(part.executable_code, provider_name, code_execution_tool_call_id)
@@ -1292,7 +1313,7 @@ def _process_part(
         assert part.function_call.name is not None
         item = ToolCallPart(tool_name=part.function_call.name, args=part.function_call.args)
         if part.function_call.id is not None:
-            item.tool_call_id = part.function_call.id  # pragma: no cover
+            item.tool_call_id = part.function_call.id
     elif inline_data := part.inline_data:
         data = inline_data.data
         mime_type = inline_data.mime_type
@@ -1337,10 +1358,19 @@ def _process_response_from_parts(
         items.append(web_fetch_call)
         items.append(web_fetch_return)
 
+    pending_thought_signature: str | None = None
     item: ModelResponsePart | None = None
     code_execution_tool_call_id: str | None = None
     for part in parts:
-        item, code_execution_tool_call_id = _process_part(part, code_execution_tool_call_id, provider_name)
+        provider_details, pending_thought_signature, skip_part = _resolve_thought_signature(
+            part, pending_thought_signature
+        )
+        if skip_part:
+            continue
+
+        item, code_execution_tool_call_id = _process_part(
+            part, code_execution_tool_call_id, provider_name, provider_details
+        )
         if item is not None:
             items.append(item)
 

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -83,8 +83,12 @@ from ..parts_from_messages import part_types_from_messages
 with try_import() as imports_successful:
     from google.genai import errors
     from google.genai.types import (
+        Blob,
         BlockedReason,
+        Candidate,
+        Content,
         FinishReason as GoogleFinishReason,
+        FunctionCall,
         GenerateContentResponse,
         GenerateContentResponsePromptFeedback,
         GenerateContentResponseUsageMetadata,
@@ -96,6 +100,7 @@ with try_import() as imports_successful:
         LogprobsResultTopCandidates,
         MediaModality,
         ModalityTokenCount,
+        Part,
         SafetyRating,
     )
 
@@ -105,6 +110,7 @@ with try_import() as imports_successful:
         GoogleModelSettings,
         _content_model_response,  # pyright: ignore[reportPrivateUsage]
         _metadata_as_usage,  # pyright: ignore[reportPrivateUsage]
+        _process_response_from_parts,  # pyright: ignore[reportPrivateUsage]
     )
     from pydantic_ai.models.openai import OpenAIResponsesModel, OpenAIResponsesModelSettings
     from pydantic_ai.providers.google import GoogleProvider
@@ -5570,6 +5576,311 @@ def test_google_missing_tool_call_thought_signature():
             ],
         }
     )
+
+
+def test_google_empty_thought_signature_roundtrip_on_tool_call():
+    signature = base64.b64encode(b'real-signature').decode('utf-8')
+    response = _process_response_from_parts(
+        parts=[
+            Part(text='', thought=True, thought_signature=b'real-signature'),
+            Part(function_call=FunctionCall(name='get_country', args={}, id='call_1')),
+        ],
+        grounding_metadata=None,
+        model_name='gemini-3-pro-preview',
+        provider_name='google-gla',
+        provider_url='https://generativelanguage.googleapis.com/',
+        usage=RequestUsage(),
+        vendor_id='resp_1',
+    )
+
+    assert response.parts == [
+        ToolCallPart(
+            tool_name='get_country',
+            args={},
+            tool_call_id='call_1',
+            provider_name='google-gla',
+            provider_details={'thought_signature': signature},
+        )
+    ]
+    # The replayed content must carry the *real* signature on the function_call,
+    # not the dummy 'skip_thought_signature_validator'.
+    assert _content_model_response(response, 'google-gla') == snapshot(
+        {
+            'role': 'model',
+            'parts': [
+                {
+                    'function_call': {'name': 'get_country', 'args': {}, 'id': 'call_1'},
+                    'thought_signature': b'real-signature',
+                },
+            ],
+        }
+    )
+
+
+def test_google_empty_thought_signature_is_replayed_on_text_part():
+    signature = base64.b64encode(b'real-signature').decode('utf-8')
+    response = _process_response_from_parts(
+        parts=[
+            Part(text='', thought=True, thought_signature=b'real-signature'),
+            Part(text='The capital of Mexico is Mexico City.'),
+        ],
+        grounding_metadata=None,
+        model_name='gemini-3-pro-preview',
+        provider_name='google-gla',
+        provider_url='https://generativelanguage.googleapis.com/',
+        usage=RequestUsage(),
+        vendor_id='resp_1',
+    )
+
+    assert response.parts == [
+        TextPart(
+            content='The capital of Mexico is Mexico City.',
+            provider_name='google-gla',
+            provider_details={'thought_signature': signature},
+        )
+    ]
+    assert _content_model_response(response, 'google-gla') == snapshot(
+        {
+            'role': 'model',
+            'parts': [{'thought_signature': b'real-signature', 'text': 'The capital of Mexico is Mexico City.'}],
+        }
+    )
+
+
+def test_google_empty_thought_signature_is_replayed_on_inline_data_part():
+    signature = base64.b64encode(b'real-signature').decode('utf-8')
+    response = _process_response_from_parts(
+        parts=[
+            Part(text='', thought=True, thought_signature=b'real-signature'),
+            Part(inline_data=Blob(data=b'abc', mime_type='image/png')),
+        ],
+        grounding_metadata=None,
+        model_name='gemini-3-pro-preview',
+        provider_name='google-gla',
+        provider_url='https://generativelanguage.googleapis.com/',
+        usage=RequestUsage(),
+        vendor_id='resp_1',
+    )
+
+    [file_part] = response.parts
+    assert isinstance(file_part, FilePart)
+    assert file_part.provider_name == 'google-gla'
+    assert file_part.provider_details == {'thought_signature': signature}
+    assert file_part.content.data == b'abc'
+    assert file_part.content.media_type == 'image/png'
+    assert _content_model_response(response, 'google-gla') == snapshot(
+        {
+            'role': 'model',
+            'parts': [
+                {'thought_signature': b'real-signature', 'inline_data': {'data': b'abc', 'mime_type': 'image/png'}}
+            ],
+        }
+    )
+
+
+def test_google_empty_thought_without_signature_is_skipped():
+    response = _process_response_from_parts(
+        parts=[
+            Part(text='', thought=True),
+            Part(text='The capital of Mexico is Mexico City.'),
+        ],
+        grounding_metadata=None,
+        model_name='gemini-3-pro-preview',
+        provider_name='google-gla',
+        provider_url='https://generativelanguage.googleapis.com/',
+        usage=RequestUsage(),
+        vendor_id='resp_1',
+    )
+
+    assert response.parts == [TextPart(content='The capital of Mexico is Mexico City.')]
+    assert _content_model_response(response, 'google-gla') == snapshot(
+        {'role': 'model', 'parts': [{'text': 'The capital of Mexico is Mexico City.'}]}
+    )
+
+
+def test_google_consecutive_empty_thought_signatures_use_latest_signature():
+    latest_signature = base64.b64encode(b'sig2').decode('utf-8')
+    response = _process_response_from_parts(
+        parts=[
+            Part(text='', thought=True, thought_signature=b'sig1'),
+            Part(text='', thought=True, thought_signature=b'sig2'),
+            Part(text='The capital of Mexico is Mexico City.'),
+        ],
+        grounding_metadata=None,
+        model_name='gemini-3-pro-preview',
+        provider_name='google-gla',
+        provider_url='https://generativelanguage.googleapis.com/',
+        usage=RequestUsage(),
+        vendor_id='resp_1',
+    )
+
+    assert response.parts == [
+        TextPart(
+            content='The capital of Mexico is Mexico City.',
+            provider_name='google-gla',
+            provider_details={'thought_signature': latest_signature},
+        )
+    ]
+    assert _content_model_response(response, 'google-gla') == snapshot(
+        {
+            'role': 'model',
+            'parts': [{'thought_signature': b'sig2', 'text': 'The capital of Mexico is Mexico City.'}],
+        }
+    )
+
+
+async def test_google_streaming_empty_thought_signature_is_replayed_on_tool_call(
+    allow_model_requests: None,
+    google_provider: GoogleProvider,
+    mocker: MockerFixture,
+):
+    model_name = 'gemini-3-pro-preview'
+    model = GoogleModel(model_name, provider=google_provider)
+    agent = Agent(model=model)
+
+    @agent.tool_plain
+    def get_country() -> str:
+        return 'Mexico'
+
+    def stream_part(
+        *,
+        text: str | None = None,
+        thought: bool = False,
+        thought_signature: bytes | None = None,
+        function_call: FunctionCall | None = None,
+    ) -> Part:
+        return Part(
+            text=text,
+            thought=thought,
+            thought_signature=thought_signature,
+            function_call=function_call,
+        )
+
+    def function_call() -> FunctionCall:
+        return FunctionCall(name='get_country', args={}, id='call_1')
+
+    def stream_chunk(
+        *parts: Part,
+        finish_reason: GoogleFinishReason | None = None,
+        response_id: str = 'resp_1',
+    ) -> GenerateContentResponse:
+        return GenerateContentResponse(
+            candidates=[Candidate(content=Content(parts=list(parts)), finish_reason=finish_reason)],
+            model_version=model_name,
+            usage_metadata=None,
+            create_time=datetime.datetime.now(),
+            response_id=response_id,
+        )
+
+    async def first_stream() -> AsyncIterator[GenerateContentResponse]:
+        yield stream_chunk(stream_part(text='', thought=True, thought_signature=b'real-signature'))
+        yield stream_chunk(stream_part(function_call=function_call()), finish_reason=GoogleFinishReason.STOP)
+
+    async def second_stream() -> AsyncIterator[GenerateContentResponse]:
+        yield stream_chunk(
+            stream_part(text='The capital of Mexico is Mexico City.'),
+            finish_reason=GoogleFinishReason.STOP,
+            response_id='resp_2',
+        )
+
+    mocker.patch.object(
+        model.client.aio.models, 'generate_content_stream', side_effect=[first_stream(), second_stream()]
+    )
+
+    events: list[AgentStreamEvent] = []
+    result: AgentRunResult | None = None
+    async for event in agent.run_stream_events('What is the capital of the user country? Call the tool'):
+        if isinstance(event, AgentRunResultEvent):
+            result = event.result
+        else:
+            events.append(event)
+
+    assert result is not None
+    assert result.output == 'The capital of Mexico is Mexico City.'
+    part_events = [
+        event for event in events if isinstance(event, (PartStartEvent, PartEndEvent, FunctionToolCallEvent))
+    ]
+    assert all(not isinstance(event.part, ThinkingPart) for event in part_events)
+    first_response = result.all_messages()[1]
+    assert isinstance(first_response, ModelResponse)
+    assert first_response.parts == [
+        ToolCallPart(
+            tool_name='get_country',
+            args={},
+            tool_call_id='call_1',
+            provider_name='google-gla',
+            provider_details={'thought_signature': base64.b64encode(b'real-signature').decode('utf-8')},
+        )
+    ]
+
+
+async def test_google_non_streaming_empty_thought_signature_is_replayed_on_tool_call(
+    allow_model_requests: None,
+    google_provider: GoogleProvider,
+    mocker: MockerFixture,
+):
+    model_name = 'gemini-3-pro-preview'
+    model = GoogleModel(model_name, provider=google_provider)
+    agent = Agent(model=model)
+
+    @agent.tool_plain
+    def get_country() -> str:
+        return 'Mexico'
+
+    def response_part(
+        *,
+        text: str | None = None,
+        thought: bool = False,
+        thought_signature: bytes | None = None,
+        function_call: FunctionCall | None = None,
+    ) -> Part:
+        return Part(
+            text=text,
+            thought=thought,
+            thought_signature=thought_signature,
+            function_call=function_call,
+        )
+
+    def function_call() -> FunctionCall:
+        return FunctionCall(name='get_country', args={}, id='call_1')
+
+    def response_obj(*parts: Part, response_id: str) -> GenerateContentResponse:
+        return GenerateContentResponse(
+            candidates=[Candidate(content=Content(parts=list(parts)), finish_reason=GoogleFinishReason.STOP)],
+            prompt_feedback=None,
+            response_id=response_id,
+            model_version=model_name,
+            create_time=datetime.datetime.now(),
+            usage_metadata=None,
+        )
+
+    mocker.patch.object(
+        model.client.aio.models,
+        'generate_content',
+        side_effect=[
+            response_obj(
+                response_part(text='', thought=True, thought_signature=b'real-signature'),
+                response_part(function_call=function_call()),
+                response_id='resp_1',
+            ),
+            response_obj(response_part(text='The capital of Mexico is Mexico City.'), response_id='resp_2'),
+        ],
+    )
+
+    result = await agent.run('What is the capital of the user country? Call the tool')
+
+    assert result.output == 'The capital of Mexico is Mexico City.'
+    first_response = result.all_messages()[1]
+    assert isinstance(first_response, ModelResponse)
+    assert first_response.parts == [
+        ToolCallPart(
+            tool_name='get_country',
+            args={},
+            tool_call_id='call_1',
+            provider_name='google-gla',
+            provider_details={'thought_signature': base64.b64encode(b'real-signature').decode('utf-8')},
+        )
+    ]
 
 
 async def test_google_streaming_tool_call_thought_signature(


### PR DESCRIPTION
- Closes #<issue>

Fix Google tool-call replay when Gemini/Vertex streams a `thought_signature` in an empty thinking part immediately before a function call.

Without this, the replayed tool call can be sent back without the required signature and fail with:

```text
google.genai.errors.ClientError: 400 Bad Request
Unable to submit request because function call `<tool_name>` in the 4th content block is missing a `thought_signature`.
```

This change:
- preserves the signature for the following tool call,
- applies the same handling in streaming and non-streaming paths,
- adds regression tests for both cases.

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.

