### PR TITLE
Remove PyAI Conf announcement banner

### DIFF
--- a/docs/.overrides/main.html
+++ b/docs/.overrides/main.html
@@ -1,8 +1,0 @@
-{% extends "base.html" %}
-
-{% block announce %}
-    <strong>
-        Join us at the inaugural PyAI Conf in San Francisco on March 10th!
-        <a href="https://pyai.events/?utm_source=pydantic-ai" target="_blank">Learn More</a>
-    </strong>
-{% endblock %}


### PR DESCRIPTION
## Summary

- Remove `docs/.overrides/main.html` which contained the PyAI Conf announcement banner (March 10th event has passed)

## Test plan

- [x] Verify `docs/.overrides/` still has `.icons/` and `partials/` intact
- [ ] `make docs-serve` renders without the banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)