### PR TITLE
fix: count only leading system messages when inserting instructions

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1000,16 +1000,6 @@ class Model(ABC):
 
         return instructions
 
-    @staticmethod
-    def _count_leading_system_messages(messages: Sequence[Any], is_system_message: Callable[[Any], bool]) -> int:
-        """Count only the system messages at the start of a mapped message history."""
-        system_prompt_count = 0
-        for message in messages:
-            if not is_system_message(message):
-                break
-            system_prompt_count += 1
-        return system_prompt_count
-
 
 @dataclass
 class StreamedResponse(ABC):

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -268,8 +268,9 @@ class CohereModel(Model):
             else:
                 assert_never(message)
         if instructions := self._get_instructions(messages, model_request_parameters):
-            system_prompt_count = self._count_leading_system_messages(
-                cohere_messages, lambda mapped_message: isinstance(mapped_message, SystemChatMessageV2)
+            system_prompt_count = next(
+                (i for i, m in enumerate(cohere_messages) if not isinstance(m, SystemChatMessageV2)),
+                len(cohere_messages),
             )
             cohere_messages.insert(system_prompt_count, SystemChatMessageV2(role='system', content=instructions))
         return cohere_messages

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -450,8 +450,8 @@ class GroqModel(Model):
             else:
                 assert_never(message)
         if instructions := self._get_instructions(messages, model_request_parameters):
-            system_prompt_count = self._count_leading_system_messages(
-                groq_messages, lambda mapped_message: mapped_message.get('role') == 'system'
+            system_prompt_count = next(
+                (i for i, m in enumerate(groq_messages) if m.get('role') != 'system'), len(groq_messages)
             )
             groq_messages.insert(
                 system_prompt_count, chat.ChatCompletionSystemMessageParam(role='system', content=instructions)

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -359,8 +359,8 @@ class HuggingFaceModel(Model):
             else:
                 assert_never(message)
         if instructions := self._get_instructions(messages, model_request_parameters):
-            system_prompt_count = self._count_leading_system_messages(
-                hf_messages, lambda mapped_message: getattr(mapped_message, 'role', None) == 'system'
+            system_prompt_count = next(
+                (i for i, m in enumerate(hf_messages) if getattr(m, 'role', None) != 'system'), len(hf_messages)
             )
             hf_messages.insert(system_prompt_count, ChatCompletionInputMessage(content=instructions, role='system'))
         return hf_messages

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -562,8 +562,9 @@ class MistralModel(Model):
             else:
                 assert_never(message)
         if instructions := self._get_instructions(messages, model_request_parameters):
-            system_prompt_count = self._count_leading_system_messages(
-                mistral_messages, lambda mapped_message: isinstance(mapped_message, MistralSystemMessage)
+            system_prompt_count = next(
+                (i for i, m in enumerate(mistral_messages) if not isinstance(m, MistralSystemMessage)),
+                len(mistral_messages),
             )
             mistral_messages.insert(system_prompt_count, MistralSystemMessage(content=instructions))
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1128,8 +1128,8 @@ class OpenAIChatModel(Model):
             else:
                 assert_never(message)
         if instructions := self._get_instructions(messages, model_request_parameters):
-            system_prompt_count = self._count_leading_system_messages(
-                openai_messages, lambda mapped_message: mapped_message.get('role') == 'system'
+            system_prompt_count = next(
+                (i for i, m in enumerate(openai_messages) if m.get('role') != 'system'), len(openai_messages)
             )
             openai_messages.insert(
                 system_prompt_count, chat.ChatCompletionSystemMessageParam(content=instructions, role='system')
@@ -1706,8 +1706,8 @@ class OpenAIResponsesModel(Model):
             # > Response input messages must contain the word 'json' in some form to use 'text.format' of type 'json_object'.
             # Apparently they're only checking input messages for "JSON", not instructions.
             assert isinstance(instructions, str)
-            system_prompt_count = self._count_leading_system_messages(
-                openai_messages, lambda mapped_message: mapped_message.get('role') == 'system'
+            system_prompt_count = next(
+                (i for i, m in enumerate(openai_messages) if m.get('role') != 'system'), len(openai_messages)
             )
             openai_messages.insert(
                 system_prompt_count, responses.EasyInputMessageParam(role='system', content=instructions)

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -242,9 +242,9 @@ class XaiModel(Model):
 
         # Insert instructions as a system message after existing system messages if present
         if instructions := self._get_instructions(messages, model_request_parameters):
-            system_prompt_count = self._count_leading_system_messages(
-                xai_messages,
-                lambda mapped_message: mapped_message.role == chat_types.chat_pb2.MessageRole.ROLE_SYSTEM,
+            system_prompt_count = next(
+                (i for i, m in enumerate(xai_messages) if m.role != chat_types.chat_pb2.MessageRole.ROLE_SYSTEM),
+                len(xai_messages),
             )
             xai_messages.insert(system_prompt_count, system(instructions))
 

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -1,9 +1,6 @@
 import os
 import warnings
-from collections.abc import Callable, Sequence
-from dataclasses import dataclass
 from importlib import import_module
-from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -386,48 +383,3 @@ def test_custom_provider_instance_method_model_profile():
     # Instance call should still work
     profile = provider.model_profile('some-model')
     assert isinstance(profile, ModelProfile)
-
-
-def test_count_leading_system_messages_stops_before_mid_history_system_message():
-    class ModelForTest(Model):
-        @staticmethod
-        def count_leading_system_messages(messages: Sequence[Any], is_system_message: Callable[[Any], bool]) -> int:
-            return ModelForTest._count_leading_system_messages(messages, is_system_message)
-
-    messages: Sequence[Any] = [
-        {'role': 'system'},
-        {'role': 'system'},
-        {'role': 'assistant'},
-        {'role': 'system'},
-    ]
-
-    def is_system_message(message: Any) -> bool:
-        return cast(dict[str, str], message).get('role') == 'system'
-
-    count = ModelForTest.count_leading_system_messages(messages, is_system_message)
-
-    assert count == 2
-
-
-def test_count_leading_system_messages_supports_object_messages():
-    @dataclass
-    class MessageObject:
-        role: str
-
-    class ModelForTest(Model):
-        @staticmethod
-        def count_leading_system_messages(messages: Sequence[Any], is_system_message: Callable[[Any], bool]) -> int:
-            return ModelForTest._count_leading_system_messages(messages, is_system_message)
-
-    messages: Sequence[Any] = [
-        MessageObject(role='system'),
-        MessageObject(role='user'),
-        MessageObject(role='system'),
-    ]
-
-    def is_system_message(message: Any) -> bool:
-        return cast(MessageObject, message).role == 'system'
-
-    count = ModelForTest.count_leading_system_messages(messages, is_system_message)
-
-    assert count == 1


### PR DESCRIPTION
## Summary
- keep OpenAI chat instructions with the leading system prompt block instead of counting every later system message
- avoid splitting assistant tool calls from their matching tool responses when `message_history` contains a later `SystemPromptPart`
- add a regression test covering late system prompts in tool-call history

Fixes #4827

## Testing
- .venv/bin/pytest tests/models/test_openai.py -k "test_message_history_can_start_with_model_response or test_openai_chat_instructions_after_system_prompts or test_openai_chat_instructions_do_not_split_tool_call_history"
- .venv/bin/ruff check pydantic_ai_slim/pydantic_ai/models/openai.py tests/models/test_openai.py