### PR TITLE
fix(ag-ui): suppress stray TOOL_CALL_ARGS after TOOL_CALL_END

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
@@ -76,6 +76,7 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
 
     _thinking_text: bool = False
     _builtin_tool_call_ids: dict[str, str] = field(default_factory=dict[str, str])
+    _ended_tool_call_ids: set[str] = field(default_factory=set[str])
     _error: bool = False
 
     @property
@@ -203,16 +204,21 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
         assert tool_call_id, '`ToolCallPartDelta.tool_call_id` must be set'
         if tool_call_id in self._builtin_tool_call_ids:
             tool_call_id = self._builtin_tool_call_ids[tool_call_id]
+        if tool_call_id in self._ended_tool_call_ids:
+            return
         yield ToolCallArgsEvent(
             tool_call_id=tool_call_id,
             delta=delta.args_delta if isinstance(delta.args_delta, str) else json.dumps(delta.args_delta),
         )
 
     async def handle_tool_call_end(self, part: ToolCallPart) -> AsyncIterator[BaseEvent]:
+        self._ended_tool_call_ids.add(part.tool_call_id)
         yield ToolCallEndEvent(tool_call_id=part.tool_call_id)
 
     async def handle_builtin_tool_call_end(self, part: BuiltinToolCallPart) -> AsyncIterator[BaseEvent]:
-        yield ToolCallEndEvent(tool_call_id=self._builtin_tool_call_ids[part.tool_call_id])
+        ag_ui_id = self._builtin_tool_call_ids[part.tool_call_id]
+        self._ended_tool_call_ids.add(ag_ui_id)
+        yield ToolCallEndEvent(tool_call_id=ag_ui_id)
 
     async def handle_builtin_tool_return(self, part: BuiltinToolReturnPart) -> AsyncIterator[BaseEvent]:
         tool_call_id = self._builtin_tool_call_ids[part.tool_call_id]

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -2624,3 +2624,131 @@ async def test_tool_return_with_files():
             },
         ]
     )
+
+
+async def test_builtin_tool_call_stray_delta_after_end() -> None:
+    """Stray TOOL_CALL_ARGS deltas arriving after TOOL_CALL_END should be suppressed.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/4733:
+    When using builtin tools (e.g. web search) with streaming, a ToolCallPartDelta
+    can arrive after BuiltinToolCallPart end has already been emitted.  This violates
+    the AG-UI protocol which requires no TOOL_CALL_ARGS after TOOL_CALL_END for the
+    same tool_call_id.
+    """
+
+    async def stream_function(
+        messages: list[ModelMessage], agent_info: AgentInfo
+    ) -> AsyncIterator[BuiltinToolCallsReturns | DeltaToolCalls | str]:
+        # Start a builtin tool call with partial args
+        yield {
+            0: BuiltinToolCallPart(
+                tool_name=WebSearchTool.kind,
+                args='{"query":',
+                tool_call_id='search_1',
+                provider_name='function',
+            )
+        }
+        # Stream more args
+        yield {
+            0: DeltaToolCall(
+                json_args='"test query"}',
+                tool_call_id='search_1',
+            )
+        }
+        # Return the result (which triggers end)
+        yield {
+            1: BuiltinToolReturnPart(
+                tool_name=WebSearchTool.kind,
+                content={'results': [{'title': 'Test', 'url': 'https://example.com'}]},
+                tool_call_id='search_1',
+                provider_name='function',
+            )
+        }
+        # Stray delta arriving AFTER the tool call has ended
+        yield {
+            0: DeltaToolCall(
+                json_args='}',
+                tool_call_id='search_1',
+            )
+        }
+        yield 'The answer is 42.'
+
+    agent = Agent(
+        model=FunctionModel(stream_function=stream_function),
+    )
+
+    run_input = create_input(
+        UserMessage(
+            id='msg_1',
+            content='Search for something',
+        ),
+    )
+    events = await run_and_collect_events(agent, run_input)
+
+    # Verify no TOOL_CALL_ARGS appears after TOOL_CALL_END for the same tool_call_id
+    tool_call_ended = set[str]()
+    for event in events:
+        if event.get('type') == 'TOOL_CALL_END':
+            tool_call_ended.add(event['toolCallId'])
+        elif event.get('type') == 'TOOL_CALL_ARGS':
+            assert event['toolCallId'] not in tool_call_ended, (
+                f"TOOL_CALL_ARGS emitted after TOOL_CALL_END for {event['toolCallId']}"
+            )
+
+    assert events == snapshot(
+        [
+            {
+                'type': 'RUN_STARTED',
+                'timestamp': IsInt(),
+                'threadId': (thread_id := IsSameStr()),
+                'runId': (run_id := IsSameStr()),
+            },
+            {
+                'type': 'TOOL_CALL_START',
+                'timestamp': IsInt(),
+                'toolCallId': 'pyd_ai_builtin|function|search_1',
+                'toolCallName': 'web_search',
+                'parentMessageId': IsSameStr(),
+            },
+            {
+                'type': 'TOOL_CALL_ARGS',
+                'timestamp': IsInt(),
+                'toolCallId': 'pyd_ai_builtin|function|search_1',
+                'delta': '{"query":',
+            },
+            {
+                'type': 'TOOL_CALL_ARGS',
+                'timestamp': IsInt(),
+                'toolCallId': 'pyd_ai_builtin|function|search_1',
+                'delta': '"test query"}',
+            },
+            {'type': 'TOOL_CALL_END', 'timestamp': IsInt(), 'toolCallId': 'pyd_ai_builtin|function|search_1'},
+            {
+                'type': 'TOOL_CALL_RESULT',
+                'timestamp': IsInt(),
+                'messageId': IsStr(),
+                'toolCallId': 'pyd_ai_builtin|function|search_1',
+                'content': '{"results":[{"title":"Test","url":"https://example.com"}]}',
+                'role': 'tool',
+            },
+            {
+                'type': 'TEXT_MESSAGE_START',
+                'timestamp': IsInt(),
+                'messageId': (message_id := IsSameStr()),
+                'role': 'assistant',
+            },
+            {
+                'type': 'TEXT_MESSAGE_CONTENT',
+                'timestamp': IsInt(),
+                'messageId': message_id,
+                'delta': 'The answer is 42.',
+            },
+            {'type': 'TEXT_MESSAGE_END', 'timestamp': IsInt(), 'messageId': message_id},
+            {
+                'type': 'RUN_FINISHED',
+                'timestamp': IsInt(),
+                'threadId': thread_id,
+                'runId': run_id,
+            },
+        ]
+    )


### PR DESCRIPTION
## Summary
- Track ended tool call IDs in `AGUIEventStream` via a `_ended_tool_call_ids` set
- Skip `ToolCallArgsEvent` emission in `handle_tool_call_delta` when the tool call has already ended
- Prevents AG-UI protocol violations where a stray delta causes `TOOL_CALL_ARGS` after `TOOL_CALL_END` for the same `tool_call_id`

Fixes #4733

## Test plan
- [x] Added regression test `test_builtin_tool_call_stray_delta_after_end` that simulates a stray delta after tool call end
- [x] All 35 existing AG-UI tests pass
- [x] Ruff lint passes