### PR TITLE
fix: don't record CallDeferred/ApprovalRequired as span errors

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_manager.py
@@ -544,6 +544,18 @@ class ToolManager(Generic[AgentDepsT]):
         ) as span:
             try:
                 tool_result = await self._execute_tool_call_impl(validated, usage=usage)
+            except (CallDeferred, ApprovalRequired) as e:
+                # Control flow exceptions — record as span attributes, not errors.
+                # Without this catch, OpenTelemetry auto-records them as exceptions
+                # (red in Logfire UI), but they're intentional control flow.
+                if span.is_recording():
+                    span.set_attribute('pydantic-ai.tool.control_flow', type(e).__name__)
+                    if e.metadata:
+                        span.set_attribute(
+                            'pydantic-ai.tool.control_flow_metadata',
+                            json.dumps(e.metadata),
+                        )
+                raise
             except ToolRetryError as e:
                 part = e.tool_retry
                 if include_content and span.is_recording():


### PR DESCRIPTION
## Summary

Fixes #4530

Control flow exceptions (`CallDeferred`, `ApprovalRequired`) were being auto-recorded as errors by OpenTelemetry's `tracer.start_as_current_span` context manager. This made them show up as red/error in Logfire UI and other OTel backends, even though they're intentional control flow -- not actual errors.

## Changes

In `_tool_manager.py`, added a catch for `CallDeferred` and `ApprovalRequired` inside the tool execution span's try block (before `ToolRetryError`). When caught:

1. Records the exception type as a regular span attribute (`pydantic-ai.tool.control_flow`)
2. Records metadata (if present) as `pydantic-ai.tool.control_flow_metadata`
3. Re-raises the exception to preserve control flow semantics

This prevents OpenTelemetry from auto-recording these as span exceptions while still making the information available for querying via standard span attributes.

## Notes for Maintainers

The issue mentions this should be "changed in a new InstrumentationSettings version" for backward compatibility. The current fix is minimal and unconditional -- happy to gate it behind a version check if preferred. Please advise on:

1. Whether this should be gated behind `InstrumentationSettings.version >= N`
2. Whether the attribute names (`pydantic-ai.tool.control_flow`) follow the project's naming conventions
3. Whether additional test coverage is needed (I can add tests matching the patterns in `tests/models/test_instrumented.py`)

- [x] AI generated code