### PR TITLE
feat: add `anthropic_eager_input_streaming` to `AnthropicModelSettings`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -235,6 +235,15 @@ class AnthropicModelSettings(ModelSettings, total=False):
     Set to a dict (e.g. `{'id': 'container_xxx'}`) to explicitly specify a container.
     """
 
+    anthropic_eager_input_streaming: bool
+    """Whether to enable eager input streaming on tool definitions.
+
+    When enabled, all tool definitions will have `eager_input_streaming` set to `True`,
+    allowing Anthropic to stream tool call arguments incrementally instead of buffering
+    the entire JSON before streaming. This reduces latency for tool calls with large inputs.
+    See https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming for more information.
+    """
+
     anthropic_betas: list[AnthropicBetaParam]
     """List of Anthropic beta features to enable for API requests.
 
@@ -658,7 +667,7 @@ class AnthropicModel(Model):
         self, model_request_parameters: ModelRequestParameters, model_settings: AnthropicModelSettings
     ) -> list[BetaToolUnionParam]:
         tools: list[BetaToolUnionParam] = [
-            self._map_tool_definition(r) for r in model_request_parameters.tool_defs.values()
+            self._map_tool_definition(r, model_settings) for r in model_request_parameters.tool_defs.values()
         ]
 
         # Add cache_control to the last tool if enabled
@@ -1245,7 +1254,7 @@ class AnthropicModel(Model):
                 else:
                     raise RuntimeError(f'Unsupported content type: {type(item)}')  # pragma: no cover
 
-    def _map_tool_definition(self, f: ToolDefinition) -> BetaToolParam:
+    def _map_tool_definition(self, f: ToolDefinition, model_settings: AnthropicModelSettings) -> BetaToolParam:
         """Maps a `ToolDefinition` dataclass to an Anthropic `BetaToolParam` dictionary."""
         tool_param: BetaToolParam = {
             'name': f.name,
@@ -1254,6 +1263,8 @@ class AnthropicModel(Model):
         }
         if f.strict and self.profile.supports_json_schema_output:
             tool_param['strict'] = f.strict
+        if model_settings.get('anthropic_eager_input_streaming'):
+            tool_param['eager_input_streaming'] = True
         return tool_param
 
     def _build_output_config(

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -614,6 +614,50 @@ async def test_anthropic_cache_tools(allow_model_requests: None):
     )
 
 
+async def test_anthropic_eager_input_streaming(allow_model_requests: None):
+    """Test that anthropic_eager_input_streaming sets eager_input_streaming on all tools."""
+    c = completion_message(
+        [BetaTextBlock(text='Tool result', type='text')],
+        usage=BetaUsage(input_tokens=10, output_tokens=5),
+    )
+    mock_client = MockAnthropic.create_mock(c)
+    m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+    agent = Agent(
+        m,
+        system_prompt='Test system prompt',
+        model_settings=AnthropicModelSettings(anthropic_eager_input_streaming=True),
+    )
+
+    @agent.tool_plain
+    def tool_one() -> str:  # pragma: no cover
+        return 'one'
+
+    @agent.tool_plain
+    def tool_two() -> str:  # pragma: no cover
+        return 'two'
+
+    await agent.run('test prompt')
+
+    completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    tools = completion_kwargs['tools']
+    assert tools == snapshot(
+        [
+            {
+                'name': 'tool_one',
+                'description': '',
+                'input_schema': {'additionalProperties': False, 'properties': {}, 'type': 'object'},
+                'eager_input_streaming': True,
+            },
+            {
+                'name': 'tool_two',
+                'description': '',
+                'input_schema': {'additionalProperties': False, 'properties': {}, 'type': 'object'},
+                'eager_input_streaming': True,
+            },
+        ]
+    )
+
+
 async def test_anthropic_cache_instructions(allow_model_requests: None):
     """Test that anthropic_cache_instructions adds cache_control to system prompt."""
     c = completion_message(


### PR DESCRIPTION
- Closes #4820

Adds `anthropic_eager_input_streaming: bool` to `AnthropicModelSettings`. When enabled, sets `eager_input_streaming: True` on all tool definitions, allowing Anthropic to stream tool call arguments incrementally instead of buffering the entire JSON before streaming (see https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming). 

I followed the same pattern as other `anthropic_*` settings. The setting is applied in `_map_tool_definition` during tool construction.

### Pre-Review Checklist
- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist
- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.
