### PR TITLE
ci: harden bots workflow against prompt injection

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -75,15 +75,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-  category-label:
-    name: Category Label
+  # Security: The classify job runs the LLM with READ-ONLY permissions and no label API access.
+  # The LLM's output is validated against an allowlist before the apply job takes any write action.
+  # This prevents prompt injection from adding arbitrary labels (e.g. 'auto-review' to trigger the review job).
+  category-classify:
+    name: Category Classify
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
+      pull-requests: read
+    outputs:
+      category: ${{ steps.extract.outputs.category }}
+      skip: ${{ steps.check-label.outputs.has_label }}
     steps:
       - name: Check for modified config files
         if: github.event.pull_request.head.repo.fork
@@ -94,7 +99,7 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Check if category label already exists
         id: check-label
@@ -118,39 +123,81 @@ jobs:
         if: steps.check-label.outputs.has_label == 'false'
         uses: actions/checkout@v6
 
-      - name: Determine category label with Claude Code
+      - name: Classify PR with Claude Code
         if: steps.check-label.outputs.has_label == 'false'
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.CLAUDE_CODE_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_API_KEY || secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
           allowed_non_write_users: "*"
           claude_args: |
-            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels:*)"
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*)"
           prompt: |
-            Classify PR #${{ github.event.pull_request.number }} in ${{ github.repository }} and add exactly one label.
+            Classify PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
             Run `gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }}` for the title and description.
             Run `gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --name-only` for the changed files.
 
             Categories:
-            - `bug`: Fixes broken behavior
-            - `feature`: New functionality
-            - `docs`: Documentation-only (no code changes)
-            - `chore`: CI, refactoring, dev dependencies, tests-only
-            - `dependency`: Production dependency updates
+            - bug: Fixes broken behavior
+            - feature: New functionality
+            - docs: Documentation-only (no code changes)
+            - chore: CI, refactoring, dev dependencies, tests-only
+            - dependency: Production dependency updates
 
             When both code and docs change, prefer `feature` or `bug` over `docs`.
-            If pyproject.toml files changed, check their diff to distinguish production deps (`dependency`) from dev-only deps in `[dependency-groups]` (`chore`).
+            If pyproject.toml files changed, run `gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}` to see the full diff and distinguish production deps (`dependency`) from dev-only deps in `[dependency-groups]` (`chore`).
 
-            Add the label:
-            gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --method POST -f "labels[]=<category>"
+            After determining the category, write ONLY the category name (one of: bug, feature, docs, chore, dependency) to /tmp/category.txt with no other text or whitespace.
+
+      - name: Extract category
+        if: steps.check-label.outputs.has_label == 'false'
+        id: extract
+        run: |
+          if [ ! -f /tmp/category.txt ]; then
+            echo "::error::Claude did not write category to /tmp/category.txt"
+            exit 1
+          fi
+          CATEGORY=$(cat /tmp/category.txt | tr -d '[:space:]')
+          # Validate before even outputting — defense in depth
+          ALLOWED="bug feature docs chore dependency"
+          if ! echo "$ALLOWED" | grep -qw "$CATEGORY"; then
+            echo "::error::Invalid category '$CATEGORY' from Claude — must be one of: $ALLOWED"
+            exit 1
+          fi
+          echo "category=$CATEGORY" >> $GITHUB_OUTPUT
+          echo "Classified as: $CATEGORY"
+
+  category-apply:
+    name: Category Apply
+    needs: category-classify
+    if: needs.category-classify.outputs.skip != 'true' && needs.category-classify.outputs.category != ''
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Validate and apply category label
+        run: |
+          CATEGORY="${{ needs.category-classify.outputs.category }}"
+          ALLOWED="bug feature docs chore dependency"
+
+          if ! echo "$ALLOWED" | grep -qw "$CATEGORY"; then
+            echo "::error::Invalid category '$CATEGORY' — must be one of: $ALLOWED"
+            exit 1
+          fi
+
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
+            --method POST -f "labels[]=$CATEGORY"
+          echo "Applied label: $CATEGORY"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   review:
     name: Review
-    needs: [size-label, category-label]
+    needs: [size-label, category-apply]
     if: >-
       !failure() && !cancelled() &&
       github.event.action == 'labeled' && github.event.label.name == 'auto-review'
@@ -222,7 +269,7 @@ jobs:
             actions: read
           claude_args: |
             --model ${{ steps.model.outputs.model }}
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh api:*),Bash(git log:*),Bash(git diff:*),Bash(git grep:*),Bash(git show:*),Bash(git status:*),Bash(jq:*),Bash(cat:*),Bash(rg:*),Bash(ls:*),Bash(tree:*),Bash(grep:*),WebSearch,WebFetch"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh api repos/${{ github.repository }}/pulls/comments/:*),Bash(git log:*),Bash(git diff:*),Bash(git grep:*),Bash(git show:*),Bash(git status:*),Bash(jq:*),Bash(cat:*),Bash(rg:*),Bash(ls:*),Bash(tree:*),Bash(grep:*),WebSearch,WebFetch"
 
           prompt: |
             REPO: ${{ github.repository }}
@@ -268,7 +315,8 @@ jobs:
             When you need code context beyond what the diffs provide, use the `Read` tool on the checked-out source files.
 
             Use the `gh` CLI only when you need additional information not already in these files (e.g. to read other referenced PRs or issues, check CI status, or read files excluded from the gathered diff).
-            When using `gh api`, prefer using the built-in `--jq` and `--template` flags for filtering/formatting since `python3` is not allowed.
+            Use specific `gh` subcommands (`gh pr view`, `gh issue view`, `gh run view`, etc.) rather than `gh api` for most queries.
+            `gh api` is only available for fetching individual review comment details: `gh api repos/${{ github.repository }}/pulls/comments/<id>`.
 
             Be careful about loading large diffs if you're unlikely to need them yet, like massive test files when there's plenty of more interesting code to comment on first, as you don't want to blow your context window too early.
             You will usually want to read all the "core implementation" and docs diffs in one go, though, so you have the full context of the PR as you identify problems, instead of going file by file.


### PR DESCRIPTION
## Summary

- Split `category-label` into `category-classify` (read-only LLM) + `category-apply` (validated write) to prevent prompt injection from adding arbitrary labels
- Replace broad `Bash(gh api:*)` in the review job with a scoped endpoint for reading review comment details only
- Add defense-in-depth allowlist validation at both the extract and apply stages

### Security issue addressed

The `category-label` job gave the LLM direct access to `gh api .../labels`, meaning a prompt injection in the PR title/body/diff could trick it into adding any label — including `auto-review`, which would chain into the review job that checks out attacker code with broad tool access and secrets.

### Changes

**Category labeling** is now two jobs:
1. `category-classify`: LLM runs with `pull-requests: read` only, no label API tool, writes classification to `/tmp/category.txt`
2. `category-apply`: deterministic shell script validates against hardcoded allowlist (`bug`, `feature`, `docs`, `chore`, `dependency`), then applies

**Review job**: `Bash(gh api:*)` (arbitrary GitHub API access) replaced with `Bash(gh api repos/.../pulls/comments/:*)` (scoped to reading review comment details). The bot retains inline comment and `gh pr comment` tools for posting feedback.

## Test plan

- [ ] Open a test PR and verify the category-classify job runs and outputs a valid category
- [ ] Verify the category-apply job picks up the output and applies the label
- [ ] Verify the review job still functions correctly with the scoped `gh api` access
- [ ] Verify that if Claude outputs an invalid category, the extract step rejects it