### PR TITLE
docs: add pydantic-ai-strale to third-party toolsets

### DIFF
--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -900,9 +900,7 @@ agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 [`pydantic-ai-strale`](https://pypi.org/project/pydantic-ai-strale/) provides access to Strale's 250+ quality-scored capabilities for AI agents — company verification, IBAN/VAT validation, sanctions screening, and more across 27 countries. Every capability is independently tested with a published Strale Quality Score (SQS).
 
 You will need to install the `pydantic-ai-strale` package and set your Strale API key in the `STRALE_API_KEY` environment variable.
-```bash
-pip install pydantic-ai-strale
-```
+
 ```python {test="skip" lint="skip"}
 import os
 from pydantic_ai import Agent

--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -903,7 +903,7 @@ You will need to install the `pydantic-ai-strale` package and set your Strale AP
 ```bash
 pip install pydantic-ai-strale
 ```
-```python {test="skip"}
+```python {test="skip" lint="skip"}
 import os
 from pydantic_ai import Agent
 from pydantic_ai_strale import StraleToolset

--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -903,6 +903,7 @@ You'll need to install `pydantic-ai-strale` and set the `STRALE_API_KEY` environ
 
 ```python {test="skip" lint="skip"}
 import os
+
 from pydantic_ai import Agent
 from pydantic_ai_strale import StraleToolset
 

--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -894,3 +894,32 @@ toolset = ACIToolset(
 
 agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 ```
+
+#### Strale
+
+[`pydantic-ai-strale`](https://pypi.org/project/pydantic-ai-strale/) provides access to Strale's 250+ quality-scored capabilities for AI agents — company verification, IBAN/VAT validation, sanctions screening, and more across 27 countries. Every capability is independently tested with a published Strale Quality Score (SQS).
+
+You will need to install the `pydantic-ai-strale` package and set your Strale API key in the `STRALE_API_KEY` environment variable.
+```bash
+pip install pydantic-ai-strale
+```
+```python
+import os
+from pydantic_ai import Agent
+from pydantic_ai_strale import StraleToolset
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    toolsets=[StraleToolset(api_key=os.environ['STRALE_API_KEY'])],
+    system_prompt=(
+        'When you need to verify businesses, validate financial identifiers '
+        '(IBAN, VAT, SWIFT), or screen for sanctions — use Strale capabilities.'
+    ),
+)
+
+result = agent.run_sync('Validate IBAN DE89370400440532013000')
+print(result.output)
+```
+
+Free tier available — validate IBANs and emails without an API key via the [Strale MCP server](https://strale.dev/docs).
+```

--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -897,9 +897,9 @@ agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 
 ### Strale
 
-[`pydantic-ai-strale`](https://pypi.org/project/pydantic-ai-strale/) provides access to Strale's 250+ quality-scored capabilities for AI agents — company verification, IBAN/VAT validation, sanctions screening, and more across 27 countries. Every capability is independently tested with a published Strale Quality Score (SQS).
+If you'd like to use [Strale](https://strale.dev) capabilities (company verification, IBAN/VAT/SWIFT validation, sanctions screening) with Pydantic AI, you can use the [`StraleToolset`](https://pypi.org/project/pydantic-ai-strale/) from the `pydantic-ai-strale` package.
 
-You will need to install the `pydantic-ai-strale` package and set your Strale API key in the `STRALE_API_KEY` environment variable.
+You'll need to install `pydantic-ai-strale` and set the `STRALE_API_KEY` environment variable.
 
 ```python {test="skip" lint="skip"}
 import os
@@ -918,5 +918,3 @@ agent = Agent(
 result = agent.run_sync('Validate IBAN DE89370400440532013000')
 print(result.output)
 ```
-
-Free tier available — validate IBANs and emails without an API key via the [Strale MCP server](https://strale.dev/docs).

--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -895,7 +895,7 @@ toolset = ACIToolset(
 agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 ```
 
-#### Strale
+### Strale
 
 [`pydantic-ai-strale`](https://pypi.org/project/pydantic-ai-strale/) provides access to Strale's 250+ quality-scored capabilities for AI agents — company verification, IBAN/VAT validation, sanctions screening, and more across 27 countries. Every capability is independently tested with a published Strale Quality Score (SQS).
 
@@ -903,7 +903,7 @@ You will need to install the `pydantic-ai-strale` package and set your Strale AP
 ```bash
 pip install pydantic-ai-strale
 ```
-```python
+```python {test="skip"}
 import os
 from pydantic_ai import Agent
 from pydantic_ai_strale import StraleToolset
@@ -922,4 +922,3 @@ print(result.output)
 ```
 
 Free tier available — validate IBANs and emails without an API key via the [Strale MCP server](https://strale.dev/docs).
-```

--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -909,7 +909,7 @@ from pydantic_ai import Agent
 from pydantic_ai_strale import StraleToolset
 
 agent = Agent(
-    'anthropic:claude-sonnet-4-6',
+    'openai:gpt-5.2',
     toolsets=[StraleToolset(api_key=os.environ['STRALE_API_KEY'])],
     system_prompt=(
         'When you need to verify businesses, validate financial identifiers '


### PR DESCRIPTION
Adds a `Strale` entry under the Third-Party Toolsets section of `docs/toolsets.md`, following the same structure as the `ACI.dev Tools` entry directly above it (one-paragraph summary + install note + working code example).

- **Package**: https://pypi.org/project/pydantic-ai-strale/
- **License**: MIT
- **Test skip**: the code example uses `{test="skip" lint="skip"}` since it depends on a live `STRALE_API_KEY`.

Only file changed: `docs/toolsets.md`.