### PR TITLE
fix(vercel-ai): strip retry suffix from UI `errorText` and preserve LLM cache

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1303,20 +1303,25 @@ class RetryPromptPart:
     part_kind: Literal['retry-prompt'] = 'retry-prompt'
     """Part type identifier, this is available on all parts as a discriminator."""
 
-    def model_response(self) -> str:
-        """Return a string message describing why the retry is requested."""
+    def error_description(self) -> str:
+        """Return the error description without the retry instruction suffix.
+
+        This is suitable for UI display where the LLM-facing "Fix the errors and try again."
+        instruction is not appropriate. For the full model-facing text, use [`model_response()`][pydantic_ai.messages.RetryPromptPart.model_response].
+        """
         if isinstance(self.content, str):
             if self.tool_name is None:
-                description = f'Validation feedback:\n{self.content}'
+                return f'Validation feedback:\n{self.content}'
             else:
-                description = self.content
+                return self.content
         else:
             json_errors = error_details_ta.dump_json(self.content, exclude={'__all__': {'ctx'}}, indent=2)
             plural = isinstance(self.content, list) and len(self.content) != 1
-            description = (
-                f'{len(self.content)} validation error{"s" if plural else ""}:\n```json\n{json_errors.decode()}\n```'
-            )
-        return f'{description}\n\nFix the errors and try again.'
+            return f'{len(self.content)} validation error{"s" if plural else ""}:\n```json\n{json_errors.decode()}\n```'
+
+    def model_response(self) -> str:
+        """Return a string message describing why the retry is requested."""
+        return f'{self.error_description()}\n\nFix the errors and try again.'
 
     def otel_event(self, settings: InstrumentationSettings) -> LogRecord:
         if self.tool_name is None:

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -391,11 +391,14 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                                     ToolReturnPart(tool_name=tool_name, tool_call_id=tool_call_id, content=part.output)
                                 )
                             elif part.state == 'output-error':
+                                # Prefer model_response from metadata (preserves LLM-facing
+                                # retry suffix for cache fidelity), fall back to error_text.
+                                error_content = provider_meta.get('model_response') or part.error_text
                                 builder.add(
                                     ToolReturnPart(
                                         tool_name=tool_name,
                                         tool_call_id=tool_call_id,
-                                        content=part.error_text,
+                                        content=error_content,
                                         outcome='failed',
                                     )
                                 )
@@ -649,14 +652,20 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
             # Check for Vercel AI chunks returned by tool calls via metadata.
             ui_parts.extend(_extract_metadata_ui_parts(tool_result))
         elif isinstance(tool_result, RetryPromptPart):
+            # error_description() returns the error text without the LLM-facing
+            # "Fix the errors and try again." suffix — suitable for UI display.
+            # The full model_response() is preserved in metadata so load_messages()
+            # can restore it for LLM cache fidelity.
+            error_meta = call_provider_metadata or {}
+            error_meta.setdefault('pydantic_ai', {})['model_response'] = tool_result.model_response()
             ui_parts.append(
                 ToolOutputErrorPart(
                     type=tool_type,
                     tool_call_id=part.tool_call_id,
                     input=part.args_as_dict(),
-                    error_text=tool_result.model_response(),
+                    error_text=tool_result.error_description(),
                     provider_executed=False,
-                    call_provider_metadata=call_provider_metadata,
+                    call_provider_metadata=error_meta,
                 )
             )
         else:

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
@@ -278,7 +278,7 @@ class VercelAIEventStream(UIEventStream[RequestData, BaseChunk, AgentDepsT, Outp
         if self.sdk_version >= 6 and isinstance(part, ToolReturnPart) and part.outcome == 'denied':
             yield ToolOutputDeniedChunk(tool_call_id=tool_call_id)
         elif isinstance(part, RetryPromptPart):
-            yield ToolOutputErrorChunk(tool_call_id=tool_call_id, error_text=part.model_response())
+            yield ToolOutputErrorChunk(tool_call_id=tool_call_id, error_text=part.error_description())
         elif isinstance(part, ToolReturnPart) and part.outcome == 'failed':
             yield ToolOutputErrorChunk(tool_call_id=tool_call_id, error_text=part.model_response_str())
         else:

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -2245,11 +2245,7 @@ async def test_run_stream_response_error():
             {
                 'type': 'tool-output-error',
                 'toolCallId': IsStr(),
-                'errorText': """\
-Unknown tool name: 'unknown_tool'. No tools available.
-
-Fix the errors and try again.\
-""",
+                'errorText': "Unknown tool name: 'unknown_tool'. No tools available.",
             },
             {'type': 'finish-step'},
             {'type': 'start-step'},
@@ -4136,12 +4132,12 @@ async def test_adapter_dump_messages_with_retry():
                         'raw_input': None,
                         'input': {'arg': 'value'},
                         'provider_executed': False,
-                        'error_text': """\
-Tool failed with error
-
-Fix the errors and try again.\
-""",
-                        'call_provider_metadata': None,
+                        'error_text': 'Tool failed with error',
+                        'call_provider_metadata': {
+                            'pydantic_ai': {
+                                'model_response': 'Tool failed with error\n\nFix the errors and try again.',
+                            }
+                        },
                         'approval': None,
                     }
                 ],
@@ -4149,8 +4145,7 @@ Fix the errors and try again.\
         ]
     )
 
-    # Verify roundtrip — load_messages now produces ToolReturnPart(outcome='failed')
-    # instead of RetryPromptPart for tool errors from the Vercel AI format
+    # Verify roundtrip — load_messages uses model_response from metadata for cache fidelity
     reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
     tool_error_part = reloaded_messages[2].parts[0]
     assert isinstance(tool_error_part, ToolReturnPart)
@@ -5691,16 +5686,13 @@ async def test_adapter_dump_messages_tool_error_with_provider_metadata():
                         'raw_input': None,
                         'input': {'x': 1},
                         'provider_executed': False,
-                        'error_text': """\
-Tool execution failed
-
-Fix the errors and try again.\
-""",
+                        'error_text': 'Tool execution failed',
                         'call_provider_metadata': {
                             'pydantic_ai': {
                                 'id': 'call_fail_id',
                                 'provider_name': 'google',
                                 'provider_details': {'attempt': 1},
+                                'model_response': 'Tool execution failed\n\nFix the errors and try again.',
                             }
                         },
                         'approval': None,
@@ -5710,7 +5702,7 @@ Fix the errors and try again.\
         ]
     )
 
-    # Verify roundtrip — load_messages now produces ToolReturnPart(outcome='failed')
+    # Verify roundtrip — uses model_response from metadata for cache fidelity
     reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
     tool_error_part = reloaded_messages[2].parts[0]
     assert isinstance(tool_error_part, ToolReturnPart)


### PR DESCRIPTION
## Summary

`RetryPromptPart.model_response()` appends `"\n\nFix the errors and try again."` — an instruction meant for the LLM, not for end users. This suffix was leaking into Vercel AI `errorText` in both the streaming and dump paths, breaking frontend logic that checks `errorText` values (e.g. `errorText === "Cancelled"` to distinguish cancelled vs failed state).

**Core change:** Add `RetryPromptPart.error_description()` — returns the error text without the retry suffix. `model_response()` now delegates to it, so all existing callers are unaffected.

**Vercel AI adapter:**
- **Dump path:** Uses `error_description()` for UI-facing `error_text`; stores the full `model_response()` in `call_provider_metadata.pydantic_ai.model_response` for round-trip cache fidelity
- **Load path:** Prefers `provider_meta['model_response']` for `ToolReturnPart.content`, falls back to `error_text` — LLM prompt cache is preserved after dump → load
- **Streaming path:** Uses `error_description()` directly

This ensures the LLM sees identical text before and after a dump/load round-trip (no cache break), while the UI gets clean error text without the retry instruction.

## Test plan

- [x] All 106 `test_vercel_ai.py` tests pass
- [x] Snapshot tests updated for new metadata field and round-trip content
- [x] `ruff check` / `ruff format` / `pyright` clean on changed files
- [ ] Verify errorText in Vercel AI frontend no longer contains suffix
- [ ] Verify dump → load → next LLM turn produces identical prompt (cache hit)