### PR TITLE
Fix(embeddings): Wrap each separate input in a Content+Part to fix batching

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -12,7 +12,7 @@ from .settings import EmbeddingSettings
 
 try:
     from google.genai import Client, errors
-    from google.genai.types import ContentListUnion, EmbedContentConfig, EmbedContentResponse
+    from google.genai.types import Content, ContentListUnion, EmbedContentConfig, EmbedContentResponse, Part
 except ImportError as _import_error:
     raise ImportError(
         'Please install `google-genai` to use the Google embeddings model, '
@@ -163,10 +163,12 @@ class GoogleEmbeddingModel(EmbeddingModel):
             title=settings.get('google_title'),
         )
 
+        contents: ContentListUnion = [Content(parts=[Part(text=text)]) for text in inputs]
+
         try:
             response = await self._client.aio.models.embed_content(
                 model=self._model_name,
-                contents=cast(ContentListUnion, inputs),
+                contents=contents,
                 config=config,
             )
         except errors.APIError as e:


### PR DESCRIPTION
gemini-embedding-2-preview was interpreting an array as a single multi-part embedding request, causing only one embedding to be returned.

This commit wraps each separate input in a Content+Part object to fix that issue.

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #4872

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
