### PR TITLE
Feat(embeddings): types and limits for gemini-embedding-2-preview

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/__init__.py
@@ -37,7 +37,9 @@ KnownEmbeddingModelName = TypeAliasType(
     'KnownEmbeddingModelName',
     Literal[
         'google-gla:gemini-embedding-001',
+        'google-gla:gemini-embedding-2-preview',
         'google-vertex:gemini-embedding-001',
+        'google-vertex:gemini-embedding-2-preview',
         'google-vertex:text-embedding-005',
         'google-vertex:text-multilingual-embedding-002',
         'openai:text-embedding-ada-002',

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -20,7 +20,7 @@ except ImportError as _import_error:
     ) from _import_error
 
 
-LatestGoogleGLAEmbeddingModelNames = Literal['gemini-embedding-001']
+LatestGoogleGLAEmbeddingModelNames = Literal['gemini-embedding-001', 'gemini-embedding-2-preview']
 """Latest Google Gemini API (GLA) embedding models.
 
 See the [Google Embeddings documentation](https://ai.google.dev/gemini-api/docs/embeddings)
@@ -29,6 +29,7 @@ for available models and their capabilities.
 
 LatestGoogleVertexEmbeddingModelNames = Literal[
     'gemini-embedding-001',
+    'gemini-embedding-2-preview',
     'text-embedding-005',
     'text-multilingual-embedding-002',
 ]
@@ -47,6 +48,7 @@ GoogleEmbeddingModelName = str | LatestGoogleEmbeddingModelNames
 
 _MAX_INPUT_TOKENS: dict[GoogleEmbeddingModelName, int] = {
     'gemini-embedding-001': 2048,
+    'gemini-embedding-2-preview': 8192,
     'text-embedding-005': 2048,
     'text-multilingual-embedding-002': 2048,
 }

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1087,6 +1087,7 @@ def mock_infer_embedding_model(model: EmbeddingModel | str) -> EmbeddingModel:
         'voyage-3.5': 1024,
         'all-MiniLM-L6-v2': 384,
         'gemini-embedding-001': 3072,
+        'gemini-embedding-2-preview': 3072,
     }
     dimensions = dimensions_map.get(model_name, 8)
     return TestEmbeddingModel(model_name, provider_name=provider_name, dimensions=dimensions)


### PR DESCRIPTION
This commit  adds types and limits for gemini-embedding-2-preview. This is a multimodal embeddings model, but this only implements text support for now.

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

<!--- Closes #<issue> -->

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
