### PR TITLE
fix(openai): skip orphaned tool returns in Responses API message mapping

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1970,8 +1970,12 @@ class OpenAIResponsesModel(Model):
                     elif isinstance(part, ToolReturnPart):
                         call_id = _guard_tool_call_id(t=part)
                         call_id, _ = _split_combined_tool_call_id(call_id)
-                        # Skip orphaned tool returns whose matching tool call was trimmed
-                        if call_id not in known_tool_call_ids:
+                        # Skip orphaned tool returns whose matching tool call was trimmed.
+                        # The `known_tool_call_ids` guard ensures we only filter when there
+                        # are ModelResponse messages in the history — when the set is empty
+                        # (e.g. first turn or previous_response_id='auto' mode), all returns
+                        # are passed through.
+                        if known_tool_call_ids and call_id not in known_tool_call_ids:
                             continue
                         output = await self._map_tool_return_output(part)
                         item = FunctionCallOutput(
@@ -1989,7 +1993,7 @@ class OpenAIResponsesModel(Model):
                             call_id = _guard_tool_call_id(t=part)
                             call_id, _ = _split_combined_tool_call_id(call_id)
                             # Skip orphaned retry prompts whose matching tool call was trimmed
-                            if call_id not in known_tool_call_ids:
+                            if known_tool_call_ids and call_id not in known_tool_call_ids:
                                 continue
                             item = FunctionCallOutput(
                                 type='function_call_output',

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -10171,16 +10171,27 @@ async def test_openai_responses_orphaned_tool_return_skipped(allow_model_request
     agent = Agent(m)
 
     # History with an orphaned tool return — the ModelResponse containing the
-    # matching ToolCallPart has been trimmed (e.g. by a history processor).
+    # matching ToolCallPart for 'call_orphan_123' was trimmed by a history
+    # processor, but a different tool call/return pair survived.
     orphaned_history = [
         ModelRequest(
-            parts=[UserPromptPart(content='Call the tool')],
+            parts=[UserPromptPart(content='Call tools')],
         ),
-        # NOTE: no ModelResponse with ToolCallPart for 'call_orphan_123'
+        ModelResponse(
+            parts=[
+                ToolCallPart(tool_name='surviving_tool', args='{}', tool_call_id='call_surviving_456'),
+                # NOTE: no ToolCallPart for 'call_orphan_123' — it was trimmed
+            ],
+        ),
         ModelRequest(
             parts=[
                 ToolReturnPart(
-                    tool_name='some_tool',
+                    tool_name='surviving_tool',
+                    content='ok',
+                    tool_call_id='call_surviving_456',
+                ),
+                ToolReturnPart(
+                    tool_name='orphaned_tool',
                     content='result',
                     tool_call_id='call_orphan_123',
                 ),
@@ -10192,13 +10203,15 @@ async def test_openai_responses_orphaned_tool_return_skipped(allow_model_request
     result = await agent.run('Follow up', message_history=orphaned_history)
     assert result.output == 'Hello!'
 
-    # Verify the orphaned function_call_output was actually skipped from the API input
+    # Verify the orphaned function_call_output was skipped but the surviving one was kept
     kwargs = get_mock_responses_kwargs(mock_client)
-    input_items = kwargs[0]['input']
+    input_items: list[Any] = kwargs[0]['input']
     function_call_outputs = [
         item for item in input_items if isinstance(item, dict) and item.get('type') == 'function_call_output'
     ]
-    assert function_call_outputs == [], f'Expected no function_call_output items but got: {function_call_outputs}'
+    # Only the surviving tool return should be present, not the orphaned one
+    assert len(function_call_outputs) == 1, f'Expected 1 function_call_output but got: {function_call_outputs}'
+    assert function_call_outputs[0]['call_id'] == 'call_surviving_456'
 
 
 async def test_openai_responses_orphaned_retry_prompt_skipped(allow_model_requests: None, openai_api_key: str):
@@ -10225,11 +10238,21 @@ async def test_openai_responses_orphaned_retry_prompt_skipped(allow_model_reques
         ModelRequest(
             parts=[UserPromptPart(content='Call the tool')],
         ),
-        # No ModelResponse with the matching ToolCallPart
+        ModelResponse(
+            parts=[
+                ToolCallPart(tool_name='surviving_tool', args='{}', tool_call_id='call_surviving_789'),
+                # No ToolCallPart for 'call_orphan_456'
+            ],
+        ),
         ModelRequest(
             parts=[
+                ToolReturnPart(
+                    tool_name='surviving_tool',
+                    content='ok',
+                    tool_call_id='call_surviving_789',
+                ),
                 RetryPromptPart(
-                    tool_name='some_tool',
+                    tool_name='orphaned_tool',
                     content='Please try again',
                     tool_call_id='call_orphan_456',
                 ),
@@ -10242,8 +10265,10 @@ async def test_openai_responses_orphaned_retry_prompt_skipped(allow_model_reques
     assert result.output == 'Done'
 
     kwargs = get_mock_responses_kwargs(mock_client)
-    input_items = kwargs[0]['input']
+    input_items: list[Any] = kwargs[0]['input']
     function_call_outputs = [
         item for item in input_items if isinstance(item, dict) and item.get('type') == 'function_call_output'
     ]
-    assert function_call_outputs == []
+    # Only the surviving tool return should be present, not the orphaned retry
+    assert len(function_call_outputs) == 1, f'Expected 1 function_call_output but got: {function_call_outputs}'
+    assert function_call_outputs[0]['call_id'] == 'call_surviving_789'


### PR DESCRIPTION
## Summary

When using `FallbackModel` with mixed model types (e.g. `OpenAIChatModel` primary + `OpenAIResponsesModel` fallback), history processors that trim messages can create orphaned tool returns — `ToolReturnPart`s whose matching `ToolCallPart` in a `ModelResponse` was removed. The Responses API strictly requires every `function_call_output` to have a preceding `function_call`, causing 400 errors like:

> No tool call found for function call output with call_id call_00_xxx

## Fix

Added a pre-pass in `OpenAIResponsesModel._map_messages()` that collects all known tool call IDs from `ModelResponse` messages, then silently skips any `ToolReturnPart` or `RetryPromptPart` whose `call_id` is not in the set. The guard `if known_tool_call_ids and call_id not in known_tool_call_ids` ensures backward compatibility — when no tool calls exist in history (e.g. first turn), nothing is skipped.

## Test

`test_openai_responses_orphaned_tool_return_skipped`: Creates a message history with an orphaned `ToolReturnPart` (no matching `ModelResponse` with that tool call ID) and verifies the agent completes successfully without 400 errors.

Fixes #4882