### PR TITLE
fix(openrouter): accept provider-specific service tiers in chat responses

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -474,6 +474,9 @@ class _OpenRouterChatCompletion(chat.ChatCompletion):
     provider: str
     """The downstream provider that was used by OpenRouter."""
 
+    service_tier: str | None = None  # type: ignore[reportIncompatibleVariableOverride]
+    """The provider-specific service tier returned by OpenRouter, if any."""
+
     choices: list[_OpenRouterChoice]  # type: ignore[reportIncompatibleVariableOverride]
     """A list of chat completion choices modified with OpenRouter specific attributes."""
 
@@ -739,6 +742,9 @@ class _OpenRouterChatCompletionChunk(chat.ChatCompletionChunk):
 
     provider: str
     """The downstream provider that was used by OpenRouter."""
+
+    service_tier: str | None = None  # type: ignore[reportIncompatibleVariableOverride]
+    """The provider-specific service tier returned by OpenRouter, if any."""
 
     choices: list[_OpenRouterChunkChoice]  # type: ignore[reportIncompatibleVariableOverride]
     """A list of chat completion chunk choices modified with OpenRouter specific attributes."""

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -35,8 +35,10 @@ from .._inline_snapshot import snapshot
 from ..conftest import try_import
 
 with try_import() as imports_successful:
-    from openai.types.chat import ChatCompletion
+    from openai.types.chat import ChatCompletion, ChatCompletionChunk
     from openai.types.chat.chat_completion import Choice
+    from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice, ChoiceDelta
+    from openai.types.completion_usage import CompletionUsage
 
     from pydantic_ai.models.openrouter import (
         OpenRouterModel,
@@ -44,6 +46,7 @@ with try_import() as imports_successful:
         _map_openrouter_provider_details,  # pyright: ignore[reportPrivateUsage]
         _openrouter_settings_to_openai_settings,  # pyright: ignore[reportPrivateUsage]
         _OpenRouterChatCompletion,  # pyright: ignore[reportPrivateUsage]
+        _OpenRouterChatCompletionChunk,  # pyright: ignore[reportPrivateUsage]
     )
     from pydantic_ai.providers.openrouter import OpenRouterProvider
 
@@ -528,6 +531,67 @@ async def test_openrouter_validate_error_response(openrouter_api_key: str) -> No
     assert str(exc_info.value) == snapshot(
         'status_code: 200, model_name: test, body: This response has an error attribute'
     )
+
+
+@pytest.mark.parametrize('service_tier', ['standard', 'custom-tier'])
+async def test_openrouter_accepts_provider_specific_service_tier_response(
+    openrouter_api_key: str, service_tier: str
+) -> None:
+    provider = OpenRouterProvider(api_key=openrouter_api_key)
+    model = OpenRouterModel('anthropic/claude-sonnet-4.6', provider=provider)
+
+    choice = Choice.model_construct(
+        index=0,
+        message={'role': 'assistant', 'content': 'hello'},
+        finish_reason='stop',
+        native_finish_reason='stop',
+    )
+    response = ChatCompletion.model_construct(
+        id='test',
+        choices=[choice],
+        created=1704067200,
+        object='chat.completion',
+        model='anthropic/claude-sonnet-4.6',
+        provider='Anthropic',
+        service_tier=service_tier,
+    )
+
+    result = model._process_response(response)  # type: ignore[reportPrivateUsage]
+    text_part = cast(TextPart, result.parts[0])
+
+    assert text_part.content == 'hello'
+    assert result.provider_details == snapshot(
+        {
+            'downstream_provider': 'Anthropic',
+            'finish_reason': 'stop',
+            'timestamp': datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
+        }
+    )
+
+
+@pytest.mark.parametrize('service_tier', ['standard', 'custom-tier'])
+def test_openrouter_accepts_provider_specific_service_tier_stream_chunk(service_tier: str) -> None:
+    chunk = ChatCompletionChunk.model_construct(
+        id='chunk-123',
+        choices=[
+            ChunkChoice(
+                index=0,
+                delta=ChoiceDelta(content='hello', role='assistant'),
+                finish_reason=None,
+            )
+        ],
+        created=1704067200,
+        model='anthropic/claude-sonnet-4.6',
+        object='chat.completion.chunk',
+        provider='Anthropic',
+        service_tier=service_tier,
+        usage=CompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+    )
+
+    validated_chunk = _OpenRouterChatCompletionChunk.model_validate(chunk.model_dump())
+
+    assert validated_chunk.service_tier == service_tier
+    assert validated_chunk.provider == 'Anthropic'
 
 
 async def test_openrouter_with_provider_details_but_no_parent_details(openrouter_api_key: str) -> None:


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please add the issue number that should be closed when this PR is merged. -->
<!-- If there is no issue, please create one first, even for simple bug fixes. -->

- Closes #4895

### What changed

Relax OpenRouter response validation for `service_tier` on chat completions.

In particular, Anthropic-backed OpenRouter responses can include `service_tier="standard"` in the response metadata. That is a valid response-side value, even though the OpenRouter chat completions request schema does not expose a matching `service_tier` request parameter, and Anthropic-style request values use different names.

This PR changes the OpenRouter chat response wrappers to accept any string `service_tier` value, rather than rejecting valid provider-specific metadata during response validation ([OpenRouter documentation](https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request#response.body.service_tier)).

### Tests

Added regression coverage in `tests/models/test_openrouter.py` for both:

- non-streaming responses with provider-specific `service_tier` values
- streaming chunks with provider-specific `service_tier` values

The tests cover both `standard` and an arbitrary custom tier string to make it explicit that OpenRouter response metadata is treated as provider-specific rather than constrained to OpenAI literals.

### Verification

- `uv run pytest tests/models/test_openrouter.py`
- `uv run pyright pydantic_ai_slim/pydantic_ai/models/openrouter.py tests/models/test_openrouter.py`
- `make lint`
- `make format`
- `make typecheck` (Note: this has 620 pre-existing errors on `main` (unrelated to this PR).)
- Tested with the "Minimal, Reproducible Example" shown in the issue and confirmed working correctly

### Pre-Review Checklist

<!-- These checks need to be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.
