### PR TITLE
fix: narrow LLMJudge evaluate return type

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, Literal, cast
@@ -13,7 +14,7 @@ from pydantic_ai.settings import ModelSettings
 
 from ..otel.span_tree import SpanQuery
 from .context import EvaluatorContext
-from .evaluator import EvaluationReason, EvaluationScalar, Evaluator, EvaluatorOutput
+from .evaluator import EvaluationReason, EvaluationScalar, Evaluator
 
 __all__ = (
     'Equals',
@@ -214,7 +215,7 @@ class LLMJudge(Evaluator[object, object, object]):
     async def evaluate(
         self,
         ctx: EvaluatorContext[object, object, object],
-    ) -> EvaluatorOutput:
+    ) -> Mapping[str, EvaluationScalar | EvaluationReason]:
         if self.include_input:
             if self.include_expected_output:
                 from .llm_as_a_judge import judge_input_output_expected

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -1,5 +1,8 @@
 from __future__ import annotations as _annotations
 
+from collections.abc import Mapping
+from typing import get_type_hints
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -8,6 +11,7 @@ from ..conftest import BinaryContent, try_import
 
 with try_import() as imports_successful:
     from pydantic_ai.settings import ModelSettings
+    from pydantic_evals.evaluators import EvaluationReason, EvaluatorContext, LLMJudge
     from pydantic_evals.evaluators.llm_as_a_judge import (
         GradingOutput,
         _stringify,  # pyright: ignore[reportPrivateUsage]
@@ -67,6 +71,37 @@ def test_stringify():
 
     obj = NonSerializable()
     assert _stringify(obj) == 'NonSerializable()'
+
+
+def test_llmjudge_evaluate_return_type_is_mapping() -> None:
+    return_type = get_type_hints(LLMJudge.evaluate)['return']
+
+    assert return_type == Mapping[str, bool | int | float | str | EvaluationReason]
+
+
+@pytest.mark.anyio
+async def test_llmjudge_evaluate_returns_mapping(mocker: MockerFixture) -> None:
+    mock_result = mocker.MagicMock()
+    mock_result.output = GradingOutput(reason='Looks good', pass_=True, score=1.0)
+    mocker.patch('pydantic_ai.agent.AbstractAgent.run', return_value=mock_result)
+
+    judge = LLMJudge(rubric='Output is correct', score={'include_reason': False})
+    result = await judge.evaluate(
+        EvaluatorContext(
+            name='case-1',
+            inputs='input',
+            metadata=None,
+            expected_output=None,
+            output='output',
+            duration=0.1,
+            _span_tree=mocker.MagicMock(),
+            attributes={},
+            metrics={},
+        )
+    )
+
+    assert isinstance(result, dict)
+    assert result == {'LLMJudge_score': 1.0, 'LLMJudge_pass': EvaluationReason(value=True, reason='Looks good')}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- narrow `LLMJudge.evaluate()` to the mapping return type it actually produces instead of the broader `EvaluatorOutput`
- add tests that lock the public return annotation and verify `LLMJudge.evaluate()` returns a mapping at runtime

## Verification
- `uv run pytest tests/evals/test_llm_as_a_judge.py`
- `uv run pytest tests/evals/test_llm_as_a_judge.py -k llmjudge`
- `uv run ruff check pydantic_evals/pydantic_evals/evaluators/common.py tests/evals/test_llm_as_a_judge.py`

Closes #4552.