### PR TITLE
Fix: Add 'standard' to allowed service_tier values for OpenRouter responses

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -480,6 +480,13 @@ class _OpenRouterChatCompletion(chat.ChatCompletion):
     error: _OpenRouterError | None = None
     """OpenRouter specific error attribute."""
 
+    service_tier: Literal['auto', 'default', 'flex', 'scale', 'priority', 'standard'] | None = None
+    """The service tier that was used for this request.
+
+    OpenRouter can return "standard" when using Claude through the Anthropic provider,
+    which is not included in the stricter OpenAI type definition.
+    """
+
     usage: _OpenRouterUsage | None = None  # type: ignore[reportIncompatibleVariableOverride]
     """OpenRouter specific usage attribute."""
 
@@ -742,6 +749,13 @@ class _OpenRouterChatCompletionChunk(chat.ChatCompletionChunk):
 
     choices: list[_OpenRouterChunkChoice]  # type: ignore[reportIncompatibleVariableOverride]
     """A list of chat completion chunk choices modified with OpenRouter specific attributes."""
+
+    service_tier: Literal['auto', 'default', 'flex', 'scale', 'priority', 'standard'] | None = None
+    """The service tier that was used for this request.
+
+    OpenRouter can return "standard" when using Claude through the Anthropic provider,
+    which is not included in the stricter OpenAI type definition.
+    """
 
     usage: _OpenRouterUsage | None = None  # type: ignore[reportIncompatibleVariableOverride]
     """Usage statistics for the completion request."""


### PR DESCRIPTION
Closes #4895.

## Summary

OpenRouter can return `service_tier="standard"` in responses when using Claude via the Anthropic provider, but the existing Pydantic model validation only allowed the original OpenAI literal values: `'auto'`, `'default'`, `'flex'`, `'scale'`, or `'priority'`.

This caused a validation error that converted a successful model response into an `UnexpectedModelBehavior` exception.

## Fix

This change adds `"standard"` as an allowed value to both:
- `_OpenRouterChatCompletion` (non-streaming responses)
- `_OpenRouterChatCompletionChunk` (streaming responses)

## Testing

- All 33 existing OpenRouter tests pass ✓
- The fix is backward compatible - if `service_tier` is not present or has another value that's already allowed, nothing changes
- Only the specific case where OpenRouter returns `"standard"` will be fixed - this was a validation-only issue, so no behavior changes for other cases