### PR TITLE
fix(openai): insert instructions after leading system messages only

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1128,7 +1128,14 @@ class OpenAIChatModel(Model):
             else:
                 assert_never(message)
         if instructions := self._get_instructions(messages, model_request_parameters):
-            system_prompt_count = sum(1 for m in openai_messages if m.get('role') == 'system')
+            # Count only *leading* system messages so the instructions are inserted
+            # after any existing system preamble but before the first non-system
+            # message. Counting all system messages in the list would place the
+            # insert after a mid-history SystemPromptPart, splitting a
+            # tool_calls / tool message pair and causing an OpenAI HTTP 400.
+            system_prompt_count = sum(
+                1 for _ in itertools.takewhile(lambda m: m.get('role') == 'system', openai_messages)
+            )
             openai_messages.insert(
                 system_prompt_count, chat.ChatCompletionSystemMessageParam(content=instructions, role='system')
             )
@@ -1704,7 +1711,9 @@ class OpenAIResponsesModel(Model):
             # > Response input messages must contain the word 'json' in some form to use 'text.format' of type 'json_object'.
             # Apparently they're only checking input messages for "JSON", not instructions.
             assert isinstance(instructions, str)
-            system_prompt_count = sum(1 for m in openai_messages if m.get('role') == 'system')
+            system_prompt_count = sum(
+                1 for _ in itertools.takewhile(lambda m: m.get('role') == 'system', openai_messages)
+            )
             openai_messages.insert(
                 system_prompt_count, responses.EasyInputMessageParam(role='system', content=instructions)
             )


### PR DESCRIPTION
## Problem

When `message_history` contains a `SystemPromptPart` mid-history (e.g. an injected conversation summary) and the history starts with a `ModelResponse` that has `ToolCallPart`s, the instructions system message is inserted between the assistant `tool_calls` message and its corresponding `tool` message. OpenAI rejects this with:

```
HTTP 400: An assistant message with 'tool_calls' must be followed by tool messages
responding to each 'tool_call_id'. The following tool_call_ids did not have
response messages: call_abc123
```

**Root cause:** `system_prompt_count` counts **all** system-role messages in `openai_messages`, not just the leading ones:

```python
# current — counts mid-history system messages too
system_prompt_count = sum(1 for m in openai_messages if m.get('role') == 'system')
```

If there's a system message at index 5, `system_prompt_count = 1`, so the insert lands at position 1 — right between the `tool_calls` message (index 0) and the `tool` message (index 2).

## Fix

Use `itertools.takewhile` to count only the **contiguous leading** system messages:

```python
system_prompt_count = sum(
    1 for _ in itertools.takewhile(lambda m: m.get('role') == 'system', openai_messages)
)
```

This ensures instructions are always inserted at the head of the conversation, never mid-history. Applied to both the Chat Completions and Responses API code paths.

`itertools` is already imported in this module.

Fixes #4827

## Test plan

- [ ] Reproduce the scenario from #4827: history starts with a `ModelResponse(ToolCallPart)` followed by a `ModelRequest(ToolReturnPart)`, with a later `ModelRequest(SystemPromptPart)` — should no longer raise HTTP 400
- [ ] Existing tests for instructions/system prompt insertion should be unaffected