### PR TITLE
fix(ag-ui): drop TOOL_CALL_ARGS deltas arriving after TOOL_CALL_END (fixes #4733)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
@@ -76,6 +76,7 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
 
     _thinking_text: bool = False
     _builtin_tool_call_ids: dict[str, str] = field(default_factory=dict[str, str])
+    _ended_tool_call_ids: set[str] = field(default_factory=set)
     _error: bool = False
 
     @property
@@ -203,16 +204,23 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
         assert tool_call_id, '`ToolCallPartDelta.tool_call_id` must be set'
         if tool_call_id in self._builtin_tool_call_ids:
             tool_call_id = self._builtin_tool_call_ids[tool_call_id]
+        # Drop stray deltas that arrive after TOOL_CALL_END has already been emitted for this ID.
+        # See https://github.com/pydantic/pydantic-ai/issues/4733
+        if tool_call_id in self._ended_tool_call_ids:
+            return
         yield ToolCallArgsEvent(
             tool_call_id=tool_call_id,
             delta=delta.args_delta if isinstance(delta.args_delta, str) else json.dumps(delta.args_delta),
         )
 
     async def handle_tool_call_end(self, part: ToolCallPart) -> AsyncIterator[BaseEvent]:
+        self._ended_tool_call_ids.add(part.tool_call_id)
         yield ToolCallEndEvent(tool_call_id=part.tool_call_id)
 
     async def handle_builtin_tool_call_end(self, part: BuiltinToolCallPart) -> AsyncIterator[BaseEvent]:
-        yield ToolCallEndEvent(tool_call_id=self._builtin_tool_call_ids[part.tool_call_id])
+        builtin_id = self._builtin_tool_call_ids[part.tool_call_id]
+        self._ended_tool_call_ids.add(builtin_id)
+        yield ToolCallEndEvent(tool_call_id=builtin_id)
 
     async def handle_builtin_tool_return(self, part: BuiltinToolReturnPart) -> AsyncIterator[BaseEvent]:
         tool_call_id = self._builtin_tool_call_ids[part.tool_call_id]


### PR DESCRIPTION
## Problem

Fixes #4733. `AGUIEventStream.handle_tool_call_delta` was unconditionally emitting `TOOL_CALL_ARGS` events even when a stray `ToolCallPartDelta` arrived **after** `TOOL_CALL_END` had already been emitted for the same `tool_call_id`. This violates the AG-UI protocol ordering invariant and crashes the `@ag-ui/client` verifier.

Observed SSE sequence before this fix:
```
TOOL_CALL_START  (id: mcp_22b...)
TOOL_CALL_ARGS   (id: mcp_22b..., delta: '{...}')
TOOL_CALL_END    (id: mcp_22b...)
TOOL_CALL_ARGS   (id: mcp_22b..., delta: '}')   ← stray delta, INVALID
```

## Fix

Added `_ended_tool_call_ids: set[str]` to `AGUIEventStream`. Both `handle_tool_call_end` and `handle_builtin_tool_call_end` now register their (mapped) `tool_call_id` in this set before yielding `ToolCallEndEvent`. `handle_tool_call_delta` silently discards any delta whose resolved `tool_call_id` is already in the set.

The guard also handles the builtin tool call case — the mapped builtin ID (not the original) is tracked, consistent with how the existing `_builtin_tool_call_ids` mapping works.

## Test Plan

- [ ] Verify that `TOOL_CALL_ARGS` is never emitted after `TOOL_CALL_END` for the same `tool_call_id`
- [ ] Existing AG-UI streaming tests still pass
- [ ] `@ag-ui/client` verifier no longer crashes for `MCPServerTool` calls in streaming mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)