### PR TITLE
Add OpenAI Responses input token counting

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1493,6 +1493,99 @@ class OpenAIResponsesModel(Model):
                 response, cast(OpenAIResponsesModelSettings, model_settings or {}), model_request_parameters
             )
 
+    async def count_tokens(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> usage.RequestUsage:
+        check_allow_model_requests()
+        model_settings, model_request_parameters = self.prepare_request(
+            model_settings,
+            model_request_parameters,
+        )
+        model_settings = cast(OpenAIResponsesModelSettings, model_settings or {})
+
+        tools: list[responses.ToolParam] = (
+            self._get_builtin_tools(model_request_parameters)
+            + list(model_settings.get('openai_builtin_tools', []))
+            + self._get_tools(model_request_parameters)
+        )
+        profile = OpenAIModelProfile.from_profile(self.profile)
+        if not tools:
+            tool_choice: Literal['none', 'required', 'auto'] | None = None
+        elif not model_request_parameters.allow_text_output and profile.openai_supports_tool_choice_required:
+            tool_choice = 'required'
+        else:
+            tool_choice = 'auto'
+
+        previous_response_id = model_settings.get('openai_previous_response_id')
+        if previous_response_id == 'auto':
+            previous_response_id, messages = self._get_previous_response_id_and_new_messages(messages)
+
+        instructions, openai_messages = await self._map_messages(messages, model_settings, model_request_parameters)
+
+        text: responses.ResponseTextConfigParam | None = None
+        if model_request_parameters.output_mode == 'native':
+            output_object = model_request_parameters.output_object
+            assert output_object is not None
+            text = {'format': self._map_json_schema(output_object)}
+        elif (
+            model_request_parameters.output_mode == 'prompted' and self.profile.supports_json_object_output
+        ):  # pragma: no branch
+            text = {'format': {'type': 'json_object'}}
+            assert isinstance(instructions, str)
+            system_prompt_count = sum(1 for m in openai_messages if m.get('role') == 'system')
+            openai_messages.insert(
+                system_prompt_count, responses.EasyInputMessageParam(role='system', content=instructions)
+            )
+            instructions = OMIT
+
+        if verbosity := model_settings.get('openai_text_verbosity'):
+            text = text or {}
+            text['verbosity'] = verbosity
+
+        # When there are no input messages and we're not reusing a previous response,
+        # the OpenAI API will reject a request without any input,
+        # even if there are instructions.
+        # To avoid this provide an explicit empty user message.
+        if not openai_messages and not previous_response_id:
+            openai_messages.append(
+                responses.EasyInputMessageParam(
+                    role='user',
+                    content='',
+                )
+            )
+
+        reasoning = self._translate_thinking(model_settings, model_request_parameters)
+
+        extra_headers = dict(model_settings.get('extra_headers', {}))
+        extra_headers.setdefault('User-Agent', get_user_agent())
+        try:
+            response = await self.client.responses.input_tokens.count(
+                input=openai_messages,
+                model=self.model_name,
+                instructions=instructions,
+                parallel_tool_calls=model_settings.get('parallel_tool_calls', OMIT),
+                tools=tools or OMIT,
+                tool_choice=tool_choice or OMIT,
+                text=text or OMIT,
+                truncation=model_settings.get('openai_truncation', OMIT),
+                previous_response_id=previous_response_id or OMIT,
+                reasoning=reasoning,
+                timeout=model_settings.get('timeout', NOT_GIVEN),
+                extra_headers=extra_headers,
+                extra_body=model_settings.get('extra_body'),
+            )
+        except APIStatusError as e:
+            if (status_code := e.status_code) >= 400:
+                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
+            raise  # pragma: lax no cover
+        except APIConnectionError as e:
+            raise ModelAPIError(model_name=self.model_name, message=e.message) from e
+
+        return usage.RequestUsage(input_tokens=response.input_tokens)
+
     def _process_response(  # noqa: C901
         self,
         response: responses.Response,

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -286,8 +286,7 @@ class UsageLimits:
     - Anthropic
     - Google
     - Bedrock Converse
-
-    Support for OpenAI is in development: https://github.com/pydantic/pydantic-ai/issues/3430
+    - OpenAI Responses
     """
 
     @property

--- a/tests/models/cassettes/test_openai_responses/test_openai_responses_usage_limit_exceeded.yaml
+++ b/tests/models/cassettes/test_openai_responses/test_openai_responses_usage_limit_exceeded.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      input:
+      - content: The quick brown fox jumps over the lazy dog.
+        role: user
+      model: gpt-4o
+    uri: https://api.openai.com/v1/responses/input_tokens
+  response:
+    headers:
+      content-type:
+      - application/json
+    parsed_body:
+      input_tokens: 12
+      object: response.input_tokens
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_openai_responses/test_openai_responses_usage_limit_not_exceeded.yaml
+++ b/tests/models/cassettes/test_openai_responses/test_openai_responses_usage_limit_not_exceeded.yaml
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      input:
+      - content: The quick brown fox jumps over the lazy dog.
+        role: user
+      model: gpt-4o
+    uri: https://api.openai.com/v1/responses/input_tokens
+  response:
+    headers:
+      content-type:
+      - application/json
+    parsed_body:
+      input_tokens: 12
+      object: response.input_tokens
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      input:
+      - content: The quick brown fox jumps over the lazy dog.
+        role: user
+      model: gpt-4o
+      stream: false
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      content-type:
+      - application/json
+    parsed_body:
+      background: false
+      created_at: 1757604033
+      error: null
+      id: resp_count_tokens_test_001
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-4o-2024-08-06
+      object: response
+      output:
+      - content:
+        - annotations: []
+          text: That is a well-known pangram!
+          type: output_text
+        id: msg_test_001
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      reasoning: null
+      service_tier: default
+      status: completed
+      temperature: 1.0
+      text:
+        format:
+          type: text
+      tool_choice: auto
+      tools: []
+      top_p: 1.0
+      truncation: disabled
+      usage:
+        input_tokens: 12
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 8
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 20
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -50,7 +50,7 @@ from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.output import NativeOutput, PromptedOutput, TextOutput, ToolOutput
 from pydantic_ai.profiles.openai import openai_model_profile
 from pydantic_ai.tools import ToolDefinition
-from pydantic_ai.usage import RequestUsage, RunUsage
+from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimitExceeded, UsageLimits
 
 from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsFloat, IsInstance, IsInt, IsNow, IsStr, TestEnv, try_import
@@ -10159,3 +10159,28 @@ async def test_openai_responses_text_content_input(allow_model_requests: None, o
     assert m == snapshot(
         {'role': 'user', 'content': [{'text': 'test', 'type': 'input_text'}, {'text': 'test2', 'type': 'input_text'}]}
     )
+
+
+async def test_openai_responses_usage_limit_exceeded(allow_model_requests: None, openai_api_key: str):
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(api_key=openai_api_key))
+    agent = Agent(model=model)
+
+    with pytest.raises(
+        UsageLimitExceeded,
+        match='The next request would exceed the input_tokens_limit of 9 \\(input_tokens=12\\)',
+    ):
+        await agent.run(
+            'The quick brown fox jumps over the lazy dog.',
+            usage_limits=UsageLimits(input_tokens_limit=9, count_tokens_before_request=True),
+        )
+
+
+async def test_openai_responses_usage_limit_not_exceeded(allow_model_requests: None, openai_api_key: str):
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(api_key=openai_api_key))
+    agent = Agent(model=model)
+
+    result = await agent.run(
+        'The quick brown fox jumps over the lazy dog.',
+        usage_limits=UsageLimits(input_tokens_limit=15, count_tokens_before_request=True),
+    )
+    assert result.output == snapshot('That is a well-known pangram!')


### PR DESCRIPTION
- Closes #3430

## Summary

Implements `count_tokens` on `OpenAIResponsesModel` using the [`/responses/input_tokens`](https://platform.openai.com/docs/api-reference/responses/input-tokens) endpoint, enabling `UsageLimits(count_tokens_before_request=True)`.

- Mirrors the request-building logic in `_responses_create` (tools, tool_choice, instructions, text format, previous_response_id, reasoning, truncation, empty-message guard) to ensure token counts match actual requests
- Uses the OpenAI SDK's typed `client.responses.input_tokens.count()` method and `InputTokenCountResponse` model — no raw dict parsing
- Copies `extra_headers` before mutation (unlike `_responses_create` which mutates in place) per Devin's review feedback on #3951
- Handles `APIStatusError` and `APIConnectionError` consistently with `_responses_create`
- Updates the `UsageLimits.count_tokens_before_request` docstring to list OpenAI Responses as supported

### Pre-Review Checklist
- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist
- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.

### Note on shared logic

The `count_tokens` method intentionally mirrors the request-building sequence from `_responses_create` rather than extracting a shared helper, to keep this PR minimal and focused. If the maintainers prefer deduplication (as discussed in #3951), I'm happy to extract the shared logic in a follow-up or amend this PR.