### PR TITLE
Disable native output on Ollama OpenAI-compatible API

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import os
+from dataclasses import replace
 
 import httpx
 from openai import AsyncOpenAI
@@ -61,14 +62,14 @@ class OllamaProvider(Provider[AsyncOpenAI]):
             if model_name.startswith(prefix):
                 profile = profile_func(model_name)
 
-        # As OllamaProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
-        # we need to maintain that behavior unless json_schema_transformer is set explicitly
-        return OpenAIModelProfile(
+        # Ollama's OpenAI-compatible `/v1` API does not document JSON-schema enforcement via `response_format`,
+        # so the provider must not advertise native structured output even if the underlying model family supports it.
+        openai_profile = OpenAIModelProfile(
             json_schema_transformer=OpenAIJsonSchemaTransformer,
             openai_chat_thinking_field='reasoning',
-            supports_json_schema_output=True,
             supports_json_object_output=True,
         ).update(profile)
+        return replace(openai_profile, supports_json_schema_output=False)
 
     def __init__(
         self,

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -84,35 +84,39 @@ def test_ollama_provider_model_profile(mocker: MockerFixture):
     meta_model_profile_mock.assert_called_with('llama3.2')
     assert meta_profile is not None
     assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.supports_json_schema_output is False
 
     google_profile = provider.model_profile('gemma3')
     google_model_profile_mock.assert_called_with('gemma3')
     assert google_profile is not None
     assert google_profile.json_schema_transformer == GoogleJsonSchemaTransformer
+    assert google_profile.supports_json_schema_output is False
 
     deepseek_profile = provider.model_profile('deepseek-r1')
     deepseek_model_profile_mock.assert_called_with('deepseek-r1')
     assert deepseek_profile is not None
     assert deepseek_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert deepseek_profile.supports_json_schema_output is False
 
     mistral_profile = provider.model_profile('mistral-small')
     mistral_model_profile_mock.assert_called_with('mistral-small')
     assert mistral_profile is not None
     assert mistral_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert mistral_profile.supports_json_schema_output is False
 
     qwen_profile = provider.model_profile('qwen3')
     qwen_model_profile_mock.assert_called_with('qwen3')
     assert qwen_profile is not None
     assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
     assert qwen_profile.ignore_streamed_leading_whitespace is True
-    assert qwen_profile.supports_json_schema_output is True
+    assert qwen_profile.supports_json_schema_output is False
 
     qwen_profile = provider.model_profile('qwen3.5')
     qwen_model_profile_mock.assert_called_with('qwen3.5')
     assert qwen_profile is not None
     assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
     assert qwen_profile.ignore_streamed_leading_whitespace is True
-    assert qwen_profile.supports_json_schema_output is True
+    assert qwen_profile.supports_json_schema_output is False
     assert qwen_profile.supports_json_object_output is True
 
     qwen_profile = provider.model_profile('qwen3.5:35b')
@@ -120,7 +124,7 @@ def test_ollama_provider_model_profile(mocker: MockerFixture):
     assert qwen_profile is not None
     assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
     assert qwen_profile.ignore_streamed_leading_whitespace is True
-    assert qwen_profile.supports_json_schema_output is True
+    assert qwen_profile.supports_json_schema_output is False
     assert qwen_profile.supports_json_object_output is True
 
     qwen_profile = provider.model_profile('qwq')
@@ -128,20 +132,23 @@ def test_ollama_provider_model_profile(mocker: MockerFixture):
     assert qwen_profile is not None
     assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
     assert qwen_profile.ignore_streamed_leading_whitespace is True
+    assert qwen_profile.supports_json_schema_output is False
 
     cohere_profile = provider.model_profile('command-r')
     cohere_model_profile_mock.assert_called_with('command-r')
     assert cohere_profile is not None
     assert cohere_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert cohere_profile.supports_json_schema_output is False
 
     harmony_profile = provider.model_profile('gpt-oss')
     harmony_model_profile_mock.assert_called_with('gpt-oss')
     assert harmony_profile is not None
     assert harmony_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
     assert harmony_profile.ignore_streamed_leading_whitespace is True
+    assert harmony_profile.supports_json_schema_output is False
 
     unknown_profile = provider.model_profile('unknown-model')
     assert unknown_profile is not None
     assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
-    assert unknown_profile.supports_json_schema_output is True
+    assert unknown_profile.supports_json_schema_output is False
     assert unknown_profile.supports_json_object_output is True


### PR DESCRIPTION
- Closes #4917

### Pre-Review Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

This stops `OllamaProvider` from advertising native JSON-schema output on its OpenAI-compatible `/v1` API.

Ollama documents structured output through its native `format` field rather than OpenAI-style `response_format={"type": "json_schema"}`. Because of that mismatch, `NativeOutput(..., strict=True)` could look supported, fall back to post-hoc validation, and loop through invalid retries instead of getting schema-enforced output.

This patch keeps the existing Ollama-specific JSON schema transformers and JSON-object support, but forces `supports_json_schema_output=False` at the provider layer so provider capabilities do not overstate what the `/v1` API can guarantee.

Validation run:
- `uv run pytest tests/providers/test_ollama.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/providers/ollama.py tests/providers/test_ollama.py`

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.
