### PR TITLE
fix(ag-ui): drop TOOL_CALL_ARGS deltas that arrive after TOOL_CALL_END (fixes #4733)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_event_stream.py
@@ -76,6 +76,7 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
 
     _thinking_text: bool = False
     _builtin_tool_call_ids: dict[str, str] = field(default_factory=dict[str, str])
+    _ended_tool_call_ids: set[str] = field(default_factory=set)
     _error: bool = False
 
     @property
@@ -203,16 +204,22 @@ class AGUIEventStream(UIEventStream[RunAgentInput, BaseEvent, AgentDepsT, Output
         assert tool_call_id, '`ToolCallPartDelta.tool_call_id` must be set'
         if tool_call_id in self._builtin_tool_call_ids:
             tool_call_id = self._builtin_tool_call_ids[tool_call_id]
+        # Drop stray deltas that arrive after TOOL_CALL_END for the same id (#4733).
+        if tool_call_id in self._ended_tool_call_ids:
+            return
         yield ToolCallArgsEvent(
             tool_call_id=tool_call_id,
             delta=delta.args_delta if isinstance(delta.args_delta, str) else json.dumps(delta.args_delta),
         )
 
     async def handle_tool_call_end(self, part: ToolCallPart) -> AsyncIterator[BaseEvent]:
+        self._ended_tool_call_ids.add(part.tool_call_id)
         yield ToolCallEndEvent(tool_call_id=part.tool_call_id)
 
     async def handle_builtin_tool_call_end(self, part: BuiltinToolCallPart) -> AsyncIterator[BaseEvent]:
-        yield ToolCallEndEvent(tool_call_id=self._builtin_tool_call_ids[part.tool_call_id])
+        tool_call_id = self._builtin_tool_call_ids[part.tool_call_id]
+        self._ended_tool_call_ids.add(tool_call_id)
+        yield ToolCallEndEvent(tool_call_id=tool_call_id)
 
     async def handle_builtin_tool_return(self, part: BuiltinToolReturnPart) -> AsyncIterator[BaseEvent]:
         tool_call_id = self._builtin_tool_call_ids[part.tool_call_id]


### PR DESCRIPTION
## Summary

Fixes #4733.

`AGUIEventStream` had no memory of which tool calls had been ended. A `ToolCallPartDelta` arriving after `handle_builtin_tool_call_end()` (e.g. from the OpenAI Responses API with `MCPServerTool` in streaming mode) caused a `TOOL_CALL_ARGS` SSE event to be emitted **after** `TOOL_CALL_END` for the same `tool_call_id`, violating the AG-UI protocol ordering invariant and crashing the `@ag-ui/client` verifier.

**Observed (broken) stream:**
```
TOOL_CALL_START  (id: mcp_22b...)
TOOL_CALL_ARGS   (id: mcp_22b..., delta: '{"action":"call_tool",...}')
TOOL_CALL_END    (id: mcp_22b...)
TOOL_CALL_ARGS   (id: mcp_22b..., delta: '}')   ← stray delta
```

**Fix** — three-line change in `_event_stream.py`:

1. Add `_ended_tool_call_ids: set[str]` field to track closed tool call IDs.
2. Record the ID as ended inside `handle_tool_call_end` and `handle_builtin_tool_call_end` (after translating builtin IDs via `_builtin_tool_call_ids`) before yielding `ToolCallEndEvent`.
3. Early-return in `handle_tool_call_delta` when the resolved `tool_call_id` is already in the ended set.

```python
# handle_tool_call_delta
if tool_call_id in self._ended_tool_call_ids:
    return   # drop stray post-end delta

# handle_tool_call_end / handle_builtin_tool_call_end
self._ended_tool_call_ids.add(tool_call_id)
yield ToolCallEndEvent(tool_call_id=tool_call_id)
```

## Test plan

- [ ] Unit test: emit `TOOL_CALL_START` → `TOOL_CALL_ARGS` → `TOOL_CALL_END` → stray `ToolCallPartDelta`; assert the stray delta produces no `ToolCallArgsEvent`
- [ ] Verify existing `tests/ui/ag_ui/` tests still pass
- [ ] Manual smoke-test with `MCPServerTool` + OpenAI Responses API streaming