### PR TITLE
fix(ollama): disable supports_json_schema_output by default

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -61,13 +61,15 @@ class OllamaProvider(Provider[AsyncOpenAI]):
             if model_name.startswith(prefix):
                 profile = profile_func(model_name)
 
-        # As OllamaProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
-        # we need to maintain that behavior unless json_schema_transformer is set explicitly
+        # Ollama's OpenAI-compatible API does not reliably support the OpenAI
+        # `response_format` parameter for schema enforcement. While some models
+        # may work, there's no documented guarantee. Users should rely on
+        # model-specific profiles (qwen, llama, etc.) which indicate support.
         return OpenAIModelProfile(
             json_schema_transformer=OpenAIJsonSchemaTransformer,
             openai_chat_thinking_field='reasoning',
-            supports_json_schema_output=True,
-            supports_json_object_output=True,
+            supports_json_schema_output=False,
+            supports_json_object_output=False,
         ).update(profile)
 
     def __init__(

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -143,5 +143,7 @@ def test_ollama_provider_model_profile(mocker: MockerFixture):
     unknown_profile = provider.model_profile('unknown-model')
     assert unknown_profile is not None
     assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
-    assert unknown_profile.supports_json_schema_output is True
-    assert unknown_profile.supports_json_object_output is True
+    # Ollama's OpenAI-compatible API doesn't reliably support response_format
+    # for schema enforcement - models must provide their own profile
+    assert unknown_profile.supports_json_schema_output is False
+    assert unknown_profile.supports_json_object_output is False


### PR DESCRIPTION
## What
Disables `supports_json_schema_output` and `supports_json_object_output` by default in `OllamaProvider.model_profile()`.

## Why
Ollama OpenAI-compatible API does not reliably support the `response_format` parameter for JSON schema enforcement. This caused `output_mode="native"` with `strict=True` to silently fail — PydanticAI assumes schema enforcement works, but Ollama ignores the `response_format` field and returns unconstrained output.

See: #4917

## How
- Changed default `supports_json_schema_output` from `True` to `False`
- Changed default `supports_json_object_output` from `True` to `False`  
- Model-specific profiles (qwen, llama, deepseek, etc.) still indicate support via their own profiles which override the defaults

## Testing
- Updated test assertions for unknown models to expect `False`
- Verified qwen models still work (they have their own profile with schema support)
- `ruff check` passes

## Checklist
- [x] Tests updated
- [x] Linter passes
- [x] No breaking change for models with specific profiles

Closes #4917