### PR TITLE
feat(ag-ui): support new AG-UI InputContent types (Image, Audio, Video, Document)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -16,6 +16,7 @@ from ... import ExternalToolset, ToolDefinition
 from ...messages import (
     AudioUrl,
     BinaryContent,
+    BinaryImage,
     BuiltinToolCallPart,
     BuiltinToolReturnPart,
     DocumentUrl,
@@ -36,16 +37,23 @@ try:
     from ag_ui.core import (
         ActivityMessage,
         AssistantMessage,
+        AudioInputContent,
         BaseEvent,
         BinaryInputContent,
         DeveloperMessage,
+        DocumentInputContent,
+        ImageInputContent,
+        InputContentDataSource,
+        InputContentUrlSource,
         Message,
+        ReasoningMessage,
         RunAgentInput,
         SystemMessage,
         TextInputContent,
         Tool as AGUITool,
         ToolMessage,
         UserMessage,
+        VideoInputContent,
     )
 
     from .. import MessagesBuilder, UIAdapter, UIEventStream
@@ -79,7 +87,7 @@ class _AGUIFrontendToolset(ExternalToolset[AgentDepsT]):
                 ToolDefinition(
                     name=tool.name,
                     description=tool.description,
-                    parameters_json_schema=tool.parameters,
+                    parameters_json_schema=tool.parameters or {'type': 'object', 'properties': {}},
                 )
                 for tool in tools
             ]
@@ -89,6 +97,18 @@ class _AGUIFrontendToolset(ExternalToolset[AgentDepsT]):
     def label(self) -> str:
         """Return the label for this toolset."""
         return 'the AG-UI frontend tools'  # pragma: no cover
+
+
+def _convert_media_source(
+    source: InputContentDataSource | InputContentUrlSource,
+    url_type: type[ImageUrl] | type[AudioUrl] | type[VideoUrl] | type[DocumentUrl],
+) -> ImageUrl | AudioUrl | VideoUrl | DocumentUrl | BinaryContent | BinaryImage:
+    """Convert an AG-UI InputContentSource to the corresponding Pydantic AI content type."""
+    match source:
+        case InputContentDataSource(value=value, mime_type=mime_type):
+            return BinaryContent.narrow_type(BinaryContent(data=b64decode(value), media_type=mime_type))
+        case _:
+            return url_type(url=source.value, media_type=source.mime_type)
 
 
 class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, OutputDataT]):
@@ -143,6 +163,14 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             match part:
                                 case TextInputContent(text=text):
                                     user_prompt_content.append(text)
+                                case ImageInputContent(source=source):
+                                    user_prompt_content.append(_convert_media_source(source, ImageUrl))
+                                case AudioInputContent(source=source):
+                                    user_prompt_content.append(_convert_media_source(source, AudioUrl))
+                                case VideoInputContent(source=source):
+                                    user_prompt_content.append(_convert_media_source(source, VideoUrl))
+                                case DocumentInputContent(source=source):
+                                    user_prompt_content.append(_convert_media_source(source, DocumentUrl))
                                 case BinaryInputContent():
                                     if part.url:
                                         try:
@@ -235,7 +263,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             )
                         )
 
-                case ActivityMessage():
+                case ActivityMessage() | ReasoningMessage():
                     pass
 
         return builder.messages

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -119,7 +119,7 @@ ui = ["starlette>=0.45.3"]
 # A2A
 a2a = ["fasta2a>=0.4.1"]
 # AG-UI
-ag-ui = ["ag-ui-protocol>=0.1.10", "starlette>=0.45.3"]
+ag-ui = ["ag-ui-protocol>=0.1.15", "starlette>=0.45.3"]
 # Web
 web = ["starlette>=0.45.3", "httpx>=0.27.0", "uvicorn>=0.38.0"]
 # Retries

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -63,12 +63,17 @@ with try_import() as imports_successful:
     from ag_ui.core import (
         ActivityMessage,
         AssistantMessage,
+        AudioInputContent,
         BaseEvent,
         BinaryInputContent,
         CustomEvent,
         DeveloperMessage,
+        DocumentInputContent,
         EventType,
         FunctionCall,
+        ImageInputContent,
+        InputContentDataSource,
+        InputContentUrlSource,
         Message,
         RunAgentInput,
         StateSnapshotEvent,
@@ -78,6 +83,7 @@ with try_import() as imports_successful:
         ToolCall,
         ToolMessage,
         UserMessage,
+        VideoInputContent,
     )
     from ag_ui.encoder import EventEncoder
     from starlette.requests import Request
@@ -103,6 +109,7 @@ pytestmark = [
     pytest.mark.filterwarnings(
         'ignore:`BuiltinToolResultEvent` is deprecated, look for `PartStartEvent` and `PartDeltaEvent` with `BuiltinToolReturnPart` instead.:DeprecationWarning'
     ),
+    pytest.mark.filterwarnings('ignore:BinaryInputContent is deprecated:DeprecationWarning'),
 ]
 
 
@@ -1963,6 +1970,202 @@ async def test_user_message_empty_content_list_skipped() -> None:
 
     result = AGUIAdapter.load_messages(messages)
     assert result == []
+
+
+async def test_image_input_content_url_source() -> None:
+    """ImageInputContent with a URL source produces an ImageUrl."""
+    messages: list[Message] = [
+        UserMessage(
+            id='msg_1',
+            content=[
+                ImageInputContent(
+                    source=InputContentUrlSource(value='http://example.com/photo.png', mime_type='image/png'),
+                ),
+            ],
+        ),
+    ]
+
+    result = AGUIAdapter.load_messages(messages)
+    assert result == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[
+                            ImageUrl(
+                                url='http://example.com/photo.png', _media_type='image/png', media_type='image/png'
+                            )
+                        ],
+                        timestamp=IsDatetime(),
+                    ),
+                ]
+            ),
+        ]
+    )
+
+
+async def test_audio_input_content_url_source() -> None:
+    """AudioInputContent with a URL source produces an AudioUrl."""
+    messages: list[Message] = [
+        UserMessage(
+            id='msg_1',
+            content=[
+                AudioInputContent(
+                    source=InputContentUrlSource(value='http://example.com/track.mp3', mime_type='audio/mpeg'),
+                ),
+            ],
+        ),
+    ]
+
+    result = AGUIAdapter.load_messages(messages)
+    assert result == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[
+                            AudioUrl(
+                                url='http://example.com/track.mp3', _media_type='audio/mpeg', media_type='audio/mpeg'
+                            )
+                        ],
+                        timestamp=IsDatetime(),
+                    ),
+                ]
+            ),
+        ]
+    )
+
+
+async def test_video_input_content_url_source() -> None:
+    """VideoInputContent with a URL source produces a VideoUrl."""
+    messages: list[Message] = [
+        UserMessage(
+            id='msg_1',
+            content=[
+                VideoInputContent(
+                    source=InputContentUrlSource(value='http://example.com/clip.mp4', mime_type='video/mp4'),
+                ),
+            ],
+        ),
+    ]
+
+    result = AGUIAdapter.load_messages(messages)
+    assert result == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[
+                            VideoUrl(url='http://example.com/clip.mp4', _media_type='video/mp4', media_type='video/mp4')
+                        ],
+                        timestamp=IsDatetime(),
+                    ),
+                ]
+            ),
+        ]
+    )
+
+
+async def test_document_input_content_url_source() -> None:
+    """DocumentInputContent with a URL source produces a DocumentUrl."""
+    messages: list[Message] = [
+        UserMessage(
+            id='msg_1',
+            content=[
+                DocumentInputContent(
+                    source=InputContentUrlSource(value='http://example.com/report.pdf', mime_type='application/pdf'),
+                ),
+            ],
+        ),
+    ]
+
+    result = AGUIAdapter.load_messages(messages)
+    assert result == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[
+                            DocumentUrl(
+                                url='http://example.com/report.pdf',
+                                _media_type='application/pdf',
+                                media_type='application/pdf',
+                            )
+                        ],
+                        timestamp=IsDatetime(),
+                    ),
+                ]
+            ),
+        ]
+    )
+
+
+async def test_image_input_content_data_source(image_content: BinaryContent) -> None:
+    """ImageInputContent with a data source produces a BinaryContent."""
+    messages: list[Message] = [
+        UserMessage(
+            id='msg_1',
+            content=[
+                ImageInputContent(
+                    source=InputContentDataSource(value=image_content.base64, mime_type=image_content.media_type),
+                ),
+            ],
+        ),
+    ]
+
+    result = AGUIAdapter.load_messages(messages)
+    assert result == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[image_content],
+                        timestamp=IsDatetime(),
+                    ),
+                ]
+            ),
+        ]
+    )
+
+
+async def test_mixed_new_input_content_types() -> None:
+    """Multiple new InputContent types in a single UserMessage."""
+    messages: list[Message] = [
+        UserMessage(
+            id='msg_1',
+            content=[
+                TextInputContent(text='Check these files:'),
+                ImageInputContent(
+                    source=InputContentUrlSource(value='http://example.com/photo.png', mime_type='image/png'),
+                ),
+                AudioInputContent(
+                    source=InputContentUrlSource(value='http://example.com/track.mp3', mime_type='audio/mpeg'),
+                ),
+            ],
+        ),
+    ]
+
+    result = AGUIAdapter.load_messages(messages)
+    assert result == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[
+                            'Check these files:',
+                            ImageUrl(
+                                url='http://example.com/photo.png', _media_type='image/png', media_type='image/png'
+                            ),
+                            AudioUrl(
+                                url='http://example.com/track.mp3', _media_type='audio/mpeg', media_type='audio/mpeg'
+                            ),
+                        ],
+                        timestamp=IsDatetime(),
+                    ),
+                ]
+            ),
+        ]
+    )
 
 
 async def test_builtin_tool_call() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -47,14 +47,14 @@ wheels = [
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.10"
+version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/bb/5a5ec893eea5805fb9a3db76a9888c3429710dfb6f24bbb37568f2cf7320/ag_ui_protocol-0.1.10.tar.gz", hash = "sha256:3213991c6b2eb24bb1a8c362ee270c16705a07a4c5962267a083d0959ed894f4", size = 6945, upload-time = "2025-11-06T15:17:17.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/71/96c21ae7e2fb9b610c1a90d38bd2de8b6e5b2900a63001f3882f43e519af/ag_ui_protocol-0.1.15.tar.gz", hash = "sha256:5e23c1042c7d4e364d685e68d2fb74d37c16bc83c66d270102d8eaedce56ad82", size = 6269, upload-time = "2026-04-01T15:44:33.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/78/eb55fabaab41abc53f52c0918a9a8c0f747807e5306273f51120fd695957/ag_ui_protocol-0.1.10-py3-none-any.whl", hash = "sha256:c81e6981f30aabdf97a7ee312bfd4df0cd38e718d9fc10019c7d438128b93ab5", size = 7889, upload-time = "2025-11-06T15:17:15.325Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/a73398d30bb0f9ad70cd70426151a4a19527a7296e48a3a16a50e1d5db05/ag_ui_protocol-0.1.15-py3-none-any.whl", hash = "sha256:85cde077023ccbc37b5ce2ad953537883c262d210320f201fc2ec4e85408b06a", size = 8661, upload-time = "2026-04-01T15:44:32.079Z" },
 ]
 
 [[package]]
@@ -6946,7 +6946,7 @@ xai = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag-ui-protocol", marker = "extra == 'ag-ui'", specifier = ">=0.1.10" },
+    { name = "ag-ui-protocol", marker = "extra == 'ag-ui'", specifier = ">=0.1.15" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.80.0" },
     { name = "argcomplete", marker = "extra == 'cli'", specifier = ">=3.5.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.14" },


### PR DESCRIPTION
- Bump ag-ui-protocol dependency from >=0.1.10 to >=0.1.15
- Add `_convert_media_source` helper for `InputContentDataSource`/`InputContentUrlSource`
- Add match cases for `ImageInputContent`, `AudioInputContent`, `VideoInputContent`, `DocumentInputContent` in `load_messages()`
- Handle `ReasoningMessage` (new in 0.1.15) with a no-op case to fix pyright exhaustiveness check
- Fix `Tool.parameters` nullability (now `Optional` in 0.1.15)
- Add comprehensive tests for all new input content types

### Context

ag-ui-protocol 0.1.15 introduced new typed `*InputContent` classes (`ImageInputContent`, `AudioInputContent`, `VideoInputContent`, `DocumentInputContent`) to replace the deprecated `BinaryInputContent`. The AG-UI adapter currently only handles `TextInputContent` and `BinaryInputContent`, so messages with the new types are silently dropped.

This PR adds support for converting these new types to the corresponding pydantic-ai message types (`ImageUrl`/`AudioUrl`/`VideoUrl`/`DocumentUrl` for URL sources, `BinaryContent` for data sources).

**Scope:** This PR intentionally only addresses the new user input content types. The `ReasoningMessage` type (also new in 0.1.15) is handled with a pass-through to satisfy pyright's exhaustiveness check, but full reasoning message support is out of scope — see #3971.

Closes #4946

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.