### PR TITLE
fix: remove duplicate word in toolsets documentation

### DIFF
--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -530,7 +530,7 @@ agent = Agent('openai:gpt-5.2', toolsets=[mcp.defer_loading()])
 
 [`WrapperToolset`][pydantic_ai.toolsets.WrapperToolset] wraps another toolset and delegates all responsibility to it.
 
-It is is a no-op by default, but you can subclass `WrapperToolset` to change the wrapped toolset's tool execution behavior by overriding the [`call_tool()`][pydantic_ai.toolsets.AbstractToolset.call_tool] method.
+It is a no-op by default, but you can subclass `WrapperToolset` to change the wrapped toolset's tool execution behavior by overriding the [`call_tool()`][pydantic_ai.toolsets.AbstractToolset.call_tool] method.
 
 ```python {title="logging_toolset.py" requires="function_toolset.py,combined_toolset.py,renamed_toolset.py,prepared_toolset.py"}
 import asyncio


### PR DESCRIPTION
## Summary
- Fix `It is is` → `It is` in `docs/toolsets.md`

## Test plan
- [ ] Documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)