### PR TITLE
Add `PerModelCapability` for model-specific capability routing

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -758,6 +758,34 @@ When multiple capabilities are passed to an agent, they are composed into a sing
 
 This means the first capability in the list has the first and last say on the operation — it sees the original input in its `wrap_*` before handler, and it sees the final output after handler returns.
 
+### Per-model routing
+
+[`PerModelCapability`][pydantic_ai.capabilities.PerModelCapability] delegates to different capability implementations based on the model being used. This is useful when a capability needs provider-specific logic:
+
+```python {title="per_model_routing.py" test="skip" lint="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import PerModelCapability
+
+cap = PerModelCapability(
+    routes={
+        'openai': my_openai_capability,
+        'anthropic': my_anthropic_capability,
+    },
+    fallback='ignore',  # silently skip unsupported models
+)
+agent = Agent('openai:gpt-4o', capabilities=[cap])
+```
+
+Routes can map by **system string** (e.g. `'openai'`, `'anthropic'`) or by **model class** (e.g. `OpenAIModel`). Wrapper models are automatically unwrapped to find the underlying provider model.
+
+The `fallback` parameter controls what happens when no route matches:
+
+- `None` (default) — raise a `UserError`
+- `'ignore'` — silently return a no-op capability
+- A capability instance — use it as the fallback
+
+You can also subclass `PerModelCapability` and override [`get_capability_for_model`][pydantic_ai.capabilities.PerModelCapability.get_capability_for_model] for custom routing logic.
+
 ## Examples
 
 ### Guardrail (PII redaction)

--- a/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
@@ -21,6 +21,7 @@ from .image_generation import ImageGeneration
 from .mcp import MCP
 from .prefix_tools import PrefixTools
 from .prepare_tools import PrepareTools
+from .routed import PerModelCapability
 from .thinking import Thinking
 from .thread_executor import ThreadExecutor
 from .toolset import Toolset
@@ -70,6 +71,7 @@ __all__ = [
     'Toolset',
     'WebFetch',
     'WebSearch',
+    'PerModelCapability',
     'WrapperCapability',
     'CombinedCapability',
     'HookTimeoutError',

--- a/pydantic_ai_slim/pydantic_ai/capabilities/routed.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/routed.py
@@ -1,0 +1,123 @@
+"""Per-model capability routing.
+
+Provides [`PerModelCapability`][pydantic_ai.capabilities.PerModelCapability], a capability
+that delegates to different implementations based on the model being used.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.models.fallback import FallbackModel
+from pydantic_ai.tools import AgentDepsT, RunContext
+
+from .abstract import AbstractCapability
+
+if TYPE_CHECKING:
+    from pydantic_ai.models import Model
+
+
+def _unwrap_model(model: Model) -> Model:
+    """Unwrap wrapper models to find the underlying provider model."""
+    from pydantic_ai.models.wrapper import WrapperModel
+
+    while isinstance(model, WrapperModel):
+        model = model.wrapped
+    return model
+
+
+@dataclass
+class PerModelCapability(AbstractCapability[AgentDepsT]):
+    """A capability that delegates to different implementations based on the model.
+
+    Can be used directly with a `routes` mapping, or subclassed with
+    [`get_capability_for_model`][pydantic_ai.capabilities.PerModelCapability.get_capability_for_model]
+    for dynamic routing.
+
+    At runtime, `for_run` unwraps any wrapper models, rejects `FallbackModel`,
+    and delegates to the matched capability.
+
+    Example using `routes` directly::
+
+        cap = PerModelCapability(routes={
+            'openai': my_openai_capability,
+            'anthropic': my_anthropic_capability,
+        })
+
+    Example subclassing::
+
+        class MyCapability(PerModelCapability):
+            def get_capability_for_model(self, model):
+                ...  # return provider-specific capability based on model
+    """
+
+    routes: dict[type[Model] | str, AbstractCapability[AgentDepsT]] = field(default_factory=dict)  # pyright: ignore[reportUnknownVariableType]
+    """Mapping of model class or system string (e.g. `'openai'`, `'anthropic'`) to capability instance."""
+
+    fallback: AbstractCapability[AgentDepsT] | Literal['ignore'] | None = None
+    """What to do when the model doesn't match any route.
+
+    - `None`: Raise `UserError` (default, safest).
+    - `'ignore'`: Silently return a no-op capability.
+    - A capability instance: Use it as the fallback.
+    """
+
+    def get_capability_for_model(self, model: Model) -> AbstractCapability[AgentDepsT] | None:
+        """Return the provider-specific capability for the given (unwrapped) model.
+
+        Override this to define custom routing logic.
+        The default implementation looks up `routes` by model class and system string.
+
+        Returns:
+            A capability instance, or `None` to indicate the model is unmatched
+            (which will fall through to `fallback` handling).
+        """
+        # Match by model class
+        for key, cap in self.routes.items():
+            if isinstance(key, type) and isinstance(model, key):
+                return cap
+
+        # Match by system string
+        if model.system in self.routes:
+            key_str = model.system
+            return self.routes[key_str]
+
+        return None
+
+    async def for_run(self, ctx: RunContext[AgentDepsT]) -> AbstractCapability[AgentDepsT]:
+        model = _unwrap_model(ctx.model)
+
+        if isinstance(model, FallbackModel):
+            raise UserError(
+                f'{type(self).__name__} is not compatible with FallbackModel '
+                f'because it produces provider-specific data that cannot be used across providers'
+            )
+
+        cap = self.get_capability_for_model(model)
+        if cap is not None:
+            return await cap.for_run(ctx)
+
+        # No route matched — check fallback
+        if isinstance(self.fallback, AbstractCapability):
+            return await self.fallback.for_run(ctx)
+
+        if self.fallback == 'ignore':
+            return _NoOpCapability()
+
+        raise UserError(
+            f'{type(self).__name__} does not have a route for {model.model_name} '
+            f'(system={model.system!r}). Add a route, set fallback, or use fallback="ignore".'
+        )
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        return None
+
+
+@dataclass
+class _NoOpCapability(AbstractCapability[AgentDepsT]):
+    """Internal no-op capability returned when fallback='ignore'."""
+
+    pass

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -21,6 +21,7 @@ from pydantic_ai.capabilities import (
     MCP,
     BuiltinTool,
     ImageGeneration,
+    PerModelCapability,
     PrefixTools,
     Thinking,
     ThreadExecutor,
@@ -8256,6 +8257,105 @@ class TestCtxAgentInCapability:
         agent = Agent(FunctionModel(simple_model_function), name='hook_test_agent', capabilities=[AgentTrackingCap()])
         await agent.run('hello')
         assert hook_agent_names == ['hook_test_agent', 'hook_test_agent']
+
+
+class TestPerModelCapability:
+    async def test_per_model_errors_on_unmatched(self):
+        """PerModelCapability raises UserError when no route matches (default)."""
+        agent = Agent(TestModel(), capabilities=[PerModelCapability()])
+        with pytest.raises(UserError, match='does not have a route for'):
+            await agent.run('hello')
+
+    async def test_per_model_errors_on_fallback_model(self):
+        """PerModelCapability raises UserError for FallbackModel."""
+        from pydantic_ai.models.fallback import FallbackModel
+
+        model = FallbackModel(TestModel(), TestModel())
+        agent = Agent(model, capabilities=[PerModelCapability()])
+        with pytest.raises(UserError, match='not compatible with FallbackModel'):
+            await agent.run('hello')
+
+    async def test_per_model_ignore_unmatched(self):
+        """PerModelCapability with fallback='ignore' silently skips unsupported models."""
+        agent = Agent(TestModel(), capabilities=[PerModelCapability(fallback='ignore')])
+        result = await agent.run('hello')
+        assert result.output == snapshot('success (no tool calls)')
+
+    async def test_per_model_unwraps_wrapper_model(self):
+        """PerModelCapability unwraps WrapperModel to find the underlying model."""
+        from pydantic_ai.models.wrapper import WrapperModel
+
+        class CustomWrapper(WrapperModel):
+            pass
+
+        wrapped = CustomWrapper(TestModel())
+        agent = Agent(wrapped, capabilities=[PerModelCapability()])
+        with pytest.raises(UserError, match='does not have a route for'):
+            await agent.run('hello')
+
+    async def test_per_model_routes_by_system_string(self):
+        """PerModelCapability routes by system string to a matching capability."""
+        from pydantic_ai.capabilities.abstract import AbstractCapability
+
+        class TrackingCapability(AbstractCapability[None]):
+            activated = False
+
+            async def before_model_request(
+                self,
+                ctx: RunContext[None],
+                request_context: ModelRequestContext,
+            ) -> ModelRequestContext:
+                TrackingCapability.activated = True
+                return request_context
+
+        cap = PerModelCapability(routes={'test': TrackingCapability()})
+        agent = Agent(TestModel(), capabilities=[cap])
+        await agent.run('hello')
+        assert TrackingCapability.activated
+
+    async def test_per_model_routes_by_model_class(self):
+        """PerModelCapability routes by model class to a matching capability."""
+        from pydantic_ai.capabilities.abstract import AbstractCapability
+
+        class TrackingCapability(AbstractCapability[None]):
+            activated = False
+
+            async def before_model_request(
+                self,
+                ctx: RunContext[None],
+                request_context: ModelRequestContext,
+            ) -> ModelRequestContext:
+                TrackingCapability.activated = True
+                return request_context
+
+        cap = PerModelCapability(routes={TestModel: TrackingCapability()})
+        agent = Agent(TestModel(), capabilities=[cap])
+        await agent.run('hello')
+        assert TrackingCapability.activated
+
+    async def test_per_model_with_fallback_capability(self):
+        """PerModelCapability uses fallback capability when no route matches."""
+        from pydantic_ai.capabilities.abstract import AbstractCapability
+
+        class FallbackCap(AbstractCapability[None]):
+            activated = False
+
+            async def before_model_request(
+                self,
+                ctx: RunContext[None],
+                request_context: ModelRequestContext,
+            ) -> ModelRequestContext:
+                FallbackCap.activated = True
+                return request_context
+
+        cap = PerModelCapability(fallback=FallbackCap())
+        agent = Agent(TestModel(), capabilities=[cap])
+        await agent.run('hello')
+        assert FallbackCap.activated
+
+    def test_per_model_serialization_name_is_none(self):
+        """PerModelCapability itself is not serializable (routes have type keys)."""
+        assert PerModelCapability.get_serialization_name() is None
 
 
 def test_thread_executor_not_serializable() -> None:


### PR DESCRIPTION
## Summary
- Adds `PerModelCapability`, a generic capability that routes to different implementations based on the model
- Accepts a `routes` dict mapping model class or system string to capability instance
- Configurable `fallback`: `None` (error, default), `'ignore'` (no-op), or a capability instance
- Unwraps `WrapperModel`, rejects `FallbackModel`
- Calls `for_run` on matched/fallback capabilities
- Split out from #4943 (compaction support) for independent review

## Test plan
- [x] TestPerModelCapability with 8 tests covering routing, fallback, error cases
- [x] Spec/schema snapshot tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)