### PR TITLE
fix: add missing space in provider `UserError` messages

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
@@ -85,7 +85,7 @@ class AnthropicProvider(Provider[AsyncAnthropicClient]):
             if not api_key:
                 raise UserError(
                     'Set the `ANTHROPIC_API_KEY` environment variable or pass it via `AnthropicProvider(api_key=...)`'
-                    'to use the Anthropic provider.'
+                    ' to use the Anthropic provider.'
                 )
             if http_client is not None:
                 self._client = AsyncAnthropic(api_key=api_key, base_url=base_url, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -109,7 +109,7 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
         if not api_key and openai_client is None:
             raise UserError(
                 'Set the `CEREBRAS_API_KEY` environment variable or pass it via `CerebrasProvider(api_key=...)` '
-                ' to use the Cerebras provider.'
+                'to use the Cerebras provider.'
             )
 
         default_headers = {'X-Cerebras-3rd-Party-Integration': 'pydantic-ai'}

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -109,7 +109,7 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
         if not api_key and openai_client is None:
             raise UserError(
                 'Set the `CEREBRAS_API_KEY` environment variable or pass it via `CerebrasProvider(api_key=...)` '
-                'to use the Cerebras provider.'
+                ' to use the Cerebras provider.'
             )
 
         default_headers = {'X-Cerebras-3rd-Party-Integration': 'pydantic-ai'}

--- a/pydantic_ai_slim/pydantic_ai/providers/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cohere.py
@@ -70,7 +70,7 @@ class CohereProvider(Provider[AsyncClientV2]):
             if not api_key:
                 raise UserError(
                     'Set the `CO_API_KEY` environment variable or pass it via `CohereProvider(api_key=...)`'
-                    'to use the Cohere provider.'
+                    ' to use the Cohere provider.'
                 )
 
             base_url = os.getenv('CO_BASE_URL')

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -81,7 +81,7 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
         if not api_key and openai_client is None:
             raise UserError(
                 'Set the `DEEPSEEK_API_KEY` environment variable or pass it via `DeepSeekProvider(api_key=...)`'
-                'to use the DeepSeek provider.'
+                ' to use the DeepSeek provider.'
             )
 
         if openai_client is not None:

--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -88,7 +88,7 @@ class FireworksProvider(Provider[AsyncOpenAI]):
         if not api_key and openai_client is None:
             raise UserError(
                 'Set the `FIREWORKS_API_KEY` environment variable or pass it via `FireworksProvider(api_key=...)`'
-                'to use the Fireworks AI provider.'
+                ' to use the Fireworks AI provider.'
             )
 
         if openai_client is not None:

--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -128,7 +128,7 @@ class GoogleProvider(Provider[Client]):
                 if api_key is None:
                     raise UserError(
                         'Set the `GOOGLE_API_KEY` environment variable or pass it via `GoogleProvider(api_key=...)`'
-                        'to use the Google Generative Language API.'
+                        ' to use the Google Generative Language API.'
                     )
                 self._client = Client(vertexai=False, api_key=api_key, http_options=http_options)
             else:

--- a/pydantic_ai_slim/pydantic_ai/providers/google_gla.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_gla.py
@@ -44,7 +44,7 @@ class GoogleGLAProvider(Provider[httpx.AsyncClient]):
         if not api_key:
             raise UserError(
                 'Set the `GEMINI_API_KEY` environment variable or pass it via `GoogleGLAProvider(api_key=...)`'
-                'to use the Google GLA provider.'
+                ' to use the Google GLA provider.'
             )
 
         self._client = http_client or cached_async_http_client(provider='google-gla')

--- a/pydantic_ai_slim/pydantic_ai/providers/grok.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/grok.py
@@ -96,7 +96,7 @@ class GrokProvider(Provider[AsyncOpenAI]):
         if not api_key and openai_client is None:
             raise UserError(
                 'Set the `GROK_API_KEY` environment variable or pass it via `GrokProvider(api_key=...)`'
-                'to use the Grok provider.'
+                ' to use the Grok provider.'
             )
 
         if openai_client is not None:

--- a/pydantic_ai_slim/pydantic_ai/providers/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/groq.py
@@ -122,7 +122,7 @@ class GroqProvider(Provider[AsyncGroq]):
             if not api_key:
                 raise UserError(
                     'Set the `GROQ_API_KEY` environment variable or pass it via `GroqProvider(api_key=...)`'
-                    'to use the Groq provider.'
+                    ' to use the Groq provider.'
                 )
             elif http_client is not None:
                 self._client = AsyncGroq(base_url=base_url, api_key=api_key, http_client=http_client)

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -70,7 +70,7 @@ class HerokuProvider(Provider[AsyncOpenAI]):
             if not api_key:
                 raise UserError(
                     'Set the `HEROKU_INFERENCE_KEY` environment variable or pass it via `HerokuProvider(api_key=...)`'
-                    'to use the Heroku provider.'
+                    ' to use the Heroku provider.'
                 )
 
             base_url = base_url or os.getenv('HEROKU_INFERENCE_URL', 'https://us.inference.heroku.com')

--- a/pydantic_ai_slim/pydantic_ai/providers/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/huggingface.py
@@ -109,7 +109,7 @@ class HuggingFaceProvider(Provider[AsyncInferenceClient]):
         if api_key is None:
             raise UserError(
                 'Set the `HF_TOKEN` environment variable or pass it via `HuggingFaceProvider(api_key=...)`'
-                'to use the HuggingFace provider.'
+                ' to use the HuggingFace provider.'
             )
 
         if http_client is not None:

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -73,7 +73,7 @@ class MistralProvider(Provider[Mistral]):
             if not api_key:
                 raise UserError(
                     'Set the `MISTRAL_API_KEY` environment variable or pass it via `MistralProvider(api_key=...)`'
-                    'to use the Mistral provider.'
+                    ' to use the Mistral provider.'
                 )
             elif http_client is not None:
                 self._client = Mistral(api_key=api_key, async_client=http_client, server_url=base_url)

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -99,7 +99,7 @@ class OllamaProvider(Provider[AsyncOpenAI]):
             if not base_url:
                 raise UserError(
                     'Set the `OLLAMA_BASE_URL` environment variable or pass it via `OllamaProvider(base_url=...)`'
-                    'to use the Ollama provider.'
+                    ' to use the Ollama provider.'
                 )
 
             # This is a workaround for the OpenAI client requiring an API key, whilst locally served,

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -186,7 +186,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
         if not api_key and openai_client is None:
             raise UserError(
                 'Set the `OPENROUTER_API_KEY` environment variable or pass it via `OpenRouterProvider(api_key=...)`'
-                'to use the OpenRouter provider.'
+                ' to use the OpenRouter provider.'
             )
 
         attribution_headers: dict[str, str] = {}

--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -85,7 +85,7 @@ class TogetherProvider(Provider[AsyncOpenAI]):
         if not api_key and openai_client is None:
             raise UserError(
                 'Set the `TOGETHER_API_KEY` environment variable or pass it via `TogetherProvider(api_key=...)`'
-                'to use the Together AI provider.'
+                ' to use the Together AI provider.'
             )
 
         if openai_client is not None:

--- a/pydantic_ai_slim/pydantic_ai/providers/voyageai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/voyageai.py
@@ -59,7 +59,7 @@ class VoyageAIProvider(Provider[AsyncClient]):
             if not api_key:
                 raise UserError(
                     'Set the `VOYAGE_API_KEY` environment variable or pass it via `VoyageAIProvider(api_key=...)` '
-                    'to use the VoyageAI provider.'
+                    ' to use the VoyageAI provider.'
                 )
 
             self._client = AsyncClient(api_key=api_key)

--- a/pydantic_ai_slim/pydantic_ai/providers/voyageai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/voyageai.py
@@ -59,7 +59,7 @@ class VoyageAIProvider(Provider[AsyncClient]):
             if not api_key:
                 raise UserError(
                     'Set the `VOYAGE_API_KEY` environment variable or pass it via `VoyageAIProvider(api_key=...)` '
-                    ' to use the VoyageAI provider.'
+                    'to use the VoyageAI provider.'
                 )
 
             self._client = AsyncClient(api_key=api_key)

--- a/pydantic_ai_slim/pydantic_ai/providers/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/xai.py
@@ -98,7 +98,7 @@ class XaiProvider(Provider[AsyncClient]):
             if not api_key:
                 raise UserError(
                     'Set the `XAI_API_KEY` environment variable or pass it via `XaiProvider(api_key=...)`'
-                    'to use the xAI provider.'
+                    ' to use the xAI provider.'
                 )
             self._lazy_client = _LazyAsyncClient(api_key=api_key)
             self._client = None  # type: ignore[assignment]

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -31,7 +31,7 @@ def test_deep_seek_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `DEEPSEEK_API_KEY` environment variable or pass it via `DeepSeekProvider(api_key=...)`'
-            'to use the DeepSeek provider.'
+            ' to use the DeepSeek provider.'
         ),
     ):
         DeepSeekProvider()

--- a/tests/providers/test_fireworks.py
+++ b/tests/providers/test_fireworks.py
@@ -42,7 +42,7 @@ def test_fireworks_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `FIREWORKS_API_KEY` environment variable or pass it via `FireworksProvider(api_key=...)`'
-            'to use the Fireworks AI provider.'
+            ' to use the Fireworks AI provider.'
         ),
     ):
         FireworksProvider()

--- a/tests/providers/test_grok.py
+++ b/tests/providers/test_grok.py
@@ -38,7 +38,7 @@ def test_grok_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `GROK_API_KEY` environment variable or pass it via `GrokProvider(api_key=...)`'
-            'to use the Grok provider.'
+            ' to use the Grok provider.'
         ),
     ):
         GrokProvider()

--- a/tests/providers/test_groq.py
+++ b/tests/providers/test_groq.py
@@ -42,7 +42,7 @@ def test_groq_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `GROQ_API_KEY` environment variable or pass it via `GroqProvider(api_key=...)`'
-            'to use the Groq provider.'
+            ' to use the Groq provider.'
         ),
     ):
         GroqProvider()

--- a/tests/providers/test_heroku.py
+++ b/tests/providers/test_heroku.py
@@ -37,7 +37,7 @@ def test_heroku_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `HEROKU_INFERENCE_KEY` environment variable or pass it via `HerokuProvider(api_key=...)`'
-            'to use the Heroku provider.'
+            ' to use the Heroku provider.'
         ),
     ):
         HerokuProvider()

--- a/tests/providers/test_huggingface.py
+++ b/tests/providers/test_huggingface.py
@@ -40,7 +40,7 @@ def test_huggingface_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `HF_TOKEN` environment variable or pass it via `HuggingFaceProvider(api_key=...)`'
-            'to use the HuggingFace provider.'
+            ' to use the HuggingFace provider.'
         ),
     ):
         HuggingFaceProvider()

--- a/tests/providers/test_mistral.py
+++ b/tests/providers/test_mistral.py
@@ -32,7 +32,7 @@ def test_mistral_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `MISTRAL_API_KEY` environment variable or pass it via `MistralProvider(api_key=...)`'
-            'to use the Mistral provider.'
+            ' to use the Mistral provider.'
         ),
     ):
         MistralProvider()

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -43,7 +43,7 @@ def test_ollama_provider_need_base_url(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `OLLAMA_BASE_URL` environment variable or pass it via `OllamaProvider(base_url=...)`'
-            'to use the Ollama provider.'
+            ' to use the Ollama provider.'
         ),
     ):
         OllamaProvider()

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -63,7 +63,7 @@ def test_openrouter_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `OPENROUTER_API_KEY` environment variable or pass it via `OpenRouterProvider(api_key=...)`'
-            'to use the OpenRouter provider.'
+            ' to use the OpenRouter provider.'
         ),
     ):
         OpenRouterProvider()

--- a/tests/providers/test_together.py
+++ b/tests/providers/test_together.py
@@ -42,7 +42,7 @@ def test_together_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `TOGETHER_API_KEY` environment variable or pass it via `TogetherProvider(api_key=...)`'
-            'to use the Together AI provider.'
+            ' to use the Together AI provider.'
         ),
     ):
         TogetherProvider()

--- a/tests/providers/test_xai.py
+++ b/tests/providers/test_xai.py
@@ -28,7 +28,7 @@ def test_xai_provider_need_api_key(env: TestEnv) -> None:
         UserError,
         match=re.escape(
             'Set the `XAI_API_KEY` environment variable or pass it via `XaiProvider(api_key=...)`'
-            'to use the xAI provider.'
+            ' to use the xAI provider.'
         ),
     ):
         XaiProvider()


### PR DESCRIPTION
- Closes #4975

All provider modules use implicit string concatenation for the "missing API key" `UserError`, but the first string literal doesn't end with a space. This produces malformed output:

```
Set the `GOOGLE_API_KEY` environment variable or pass it via `GoogleProvider(api_key=...)`to use the Google Generative Language API.
```

The fix adds a leading space to the second string literal across all 17 affected provider files.

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.