### PR TITLE
Fix wrap_run_event_stream hooks ignored when event_stream_handler is not set

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -319,6 +319,20 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                     return await agent_run._advance_graph(n)  # pyright: ignore[reportPrivateUsage]
 
                 _stream_step = _stream_and_advance
+            else:
+
+                async def _stream_hooks_only(
+                    n: _agent_graph.AgentNode[AgentDepsT, Any],
+                ) -> _agent_graph.AgentNode[AgentDepsT, Any] | End[FinalResult[Any]]:
+                    if self.is_model_request_node(n) or self.is_call_tools_node(n):
+                        async with n.stream(agent_run.ctx) as stream:
+                            run_ctx = _agent_graph.build_run_context(agent_run.ctx)
+                            wrapped = agent_run.ctx.deps.root_capability.wrap_run_event_stream(run_ctx, stream=stream)
+                            async for _ in wrapped:
+                                pass
+                    return await agent_run._advance_graph(n)  # pyright: ignore[reportPrivateUsage]
+
+                _stream_step = _stream_hooks_only
 
             node = agent_run.next_node
             while not isinstance(node, End):


### PR DESCRIPTION
## Summary

Fixes #4986

When `Agent.run()` is called without an `event_stream_handler`, hooks registered via `@hooks.on.event` or `@hooks.wrap_run_event_stream` are never evaluated.

### Root Cause

The streaming step function (which calls `wrap_run_event_stream`) is only created inside the `if event_stream_handler is not None` block in `agent/abstract.py`. When no handler is provided, `_stream_step` stays `None` and the code takes a path that skips event streaming entirely.

### Fix

Add an `else` branch that still creates a streaming step. This step:
1. Opens the event stream for model request and call tools nodes
2. Wraps it through `wrap_run_event_stream` (so hooks fire)
3. Consumes the events without an external handler

This ensures hooks always fire regardless of whether an explicit `event_stream_handler` is provided.

### Testing

```python
from pydantic_ai import Agent, hooks

agent = Agent('test-model')

@agent.hooks.on.event
async def on_event(ctx, event):
    print(f'Event fired: {event}')

# Before fix: on_event never fires
# After fix: on_event fires correctly
result = await agent.run('Hello')
```
