### PR TITLE
Fix search_tools greedy matching for deferred toolsets

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py
@@ -163,8 +163,16 @@ class ToolSearchToolset(WrapperToolset[AgentDepsT]):
 
         matches: list[dict[str, str | None]] = []
         for entry in search_tool.search_index:
-            searchable = entry.name_lower + (' ' + entry.description_lower if entry.description_lower else '')
-            if any(term in searchable for term in terms):
+            # Split tool name by underscores for word-level matching to avoid
+            # false positives like "me" matching "comment" or "github" matching
+            # every github_* tool via substring.
+            name_words = set(entry.name_lower.split('_'))
+            desc_text = entry.description_lower or ''
+
+            if all(
+                term in name_words or term in desc_text
+                for term in terms
+            ):
                 matches.append({'name': entry.name, 'description': entry.description})
                 if len(matches) >= _MAX_SEARCH_RESULTS:
                     break


### PR DESCRIPTION
## Summary

Fixes #4994

Two issues with the previous matching logic in `search_tools`:

1. **Substring matching on tool names** caused false positives (e.g. `me` matching `github_add_comment_to_pending_review` because `me` is a substring of `comment`)
2. **OR logic** (`any()`) meant searching `github profile` matched every `github_*` tool because `github` alone was sufficient

## Fix

- Split tool names by underscores for **word-level exact matching** (no more substring false positives)
- Keep substring matching for descriptions (more flexible for natural language)
- Change from OR (`any`) to AND (`all`) logic — all search terms must match at least one field

## Examples

| Query | Before | After |
|-------|--------|-------|
| `github profile` | Matches ALL `github_*` tools (prefix substring) | Only tools with both `github` AND `profile` in name/description |
| `get me` | Matches `github_add_com[me]nt_to_pending_review` | Only matches tools with `get` AND `me` as words (e.g. `github_get_me`) |

## Changes

- `pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py`: 10 lines added, 2 removed