### PR TITLE
test: add negative case coverage for v5 deferral span fix

### DIFF
--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3666,12 +3666,12 @@ def test_deferral_unexpected_exception_still_errors_v5(capfire: CaptureLogfire) 
     def my_tool(x: int) -> str:
         raise ValueError('something went wrong')
 
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(ValueError, match='something went wrong'):
         agent.run_sync('Hello')
 
     tool_span = _get_tool_span(capfire)
 
-    # BaseException path should still record error regardless of instrumentation version
+    # ValueError path should still record error regardless of instrumentation version
     assert tool_span['attributes'].get('logfire.level_num') == 17
     # No deferral attributes should be set
     assert 'pydantic_ai.tool.deferral.name' not in tool_span['attributes']


### PR DESCRIPTION
Closes #4530

Adds two negative-case tests verifying that the v5 OTel deferral fix does not affect general exception handling:

1. `test_deferral_model_retry_still_errors_v5` -- `ModelRetry` raised inside a tool should still record the span with ERROR status on v5, not UNSET status
2. `test_deferral_unexpected_exception_still_errors_v5` -- Unexpected `ValueError` raised inside a tool should still record ERROR status on v5

The second test previously used `pytest.raises(Exception)` (flagged by B017). Updated to `pytest.raises(ValueError, match=...)` to match the specific exception raised by the tool.

Both tests pass.