### PR TITLE
fix: disambiguate missing-package vs broken-import in providers

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -5,10 +5,36 @@ The providers are in charge of providing an authenticated client to the API.
 
 from __future__ import annotations as _annotations
 
+import importlib.util
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
 from ..profiles import ModelProfile
+
+
+def check_package_installed(package_name: str, install_group: str | None = None) -> None:
+    """Verify that a package is installed before attempting to import from it.
+
+    This should be called before a ``from <package> import ...`` block so that
+    a missing *package* produces a clear "please install" message, while a
+    missing *name* inside an installed package still raises the real
+    ``ImportError`` with its original traceback.
+
+    Args:
+        package_name: Top-level package to check (e.g. ``"mistralai"``).
+        install_group: Optional pip install group hint shown in the error
+            message.  Defaults to ``package_name``.
+
+    Raises:
+        ImportError: If the package cannot be found by ``importlib``.
+    """
+    if importlib.util.find_spec(package_name) is None:
+        group = install_group or package_name
+        raise ImportError(
+            f'Please install the `{package_name}` package to use this provider, '
+            f'you can use the `{group}` optional group — '
+            f'`pip install "pydantic-ai-slim[{group}]"`'
+        )
 
 InterfaceClient = TypeVar('InterfaceClient')
 

--- a/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
@@ -14,13 +14,11 @@ from pydantic_ai.providers import Provider
 
 from .._json_schema import JsonSchema, JsonSchemaTransformer
 
-try:
-    from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, AsyncAnthropicFoundry, AsyncAnthropicVertex
-except ImportError as _import_error:
-    raise ImportError(
-        'Please install the `anthropic` package to use the Anthropic provider, '
-        'you can use the `anthropic` optional group — `pip install "pydantic-ai-slim[anthropic]"`'
-    ) from _import_error
+from pydantic_ai.providers import check_package_installed
+
+check_package_installed('anthropic', install_group='anthropic')
+
+from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, AsyncAnthropicFoundry, AsyncAnthropicVertex  # noqa: E402
 
 
 AsyncAnthropicClient: TypeAlias = AsyncAnthropic | AsyncAnthropicBedrock | AsyncAnthropicFoundry | AsyncAnthropicVertex

--- a/pydantic_ai_slim/pydantic_ai/providers/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cohere.py
@@ -10,13 +10,11 @@ from pydantic_ai.models import cached_async_http_client
 from pydantic_ai.profiles.cohere import cohere_model_profile
 from pydantic_ai.providers import Provider
 
-try:
-    from cohere import AsyncClient, AsyncClientV2
-except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `cohere` package to use the Cohere provider, '
-        'you can use the `cohere` optional group — `pip install "pydantic-ai-slim[cohere]"`'
-    ) from _import_error
+from pydantic_ai.providers import check_package_installed
+
+check_package_installed('cohere', install_group='cohere')
+
+from cohere import AsyncClient, AsyncClientV2  # noqa: E402
 
 
 class CohereProvider(Provider[AsyncClientV2]):

--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -11,15 +11,13 @@ from pydantic_ai.models import DEFAULT_HTTP_TIMEOUT, cached_async_http_client, g
 from pydantic_ai.profiles.google import google_model_profile
 from pydantic_ai.providers import Provider
 
-try:
-    from google.auth.credentials import Credentials
-    from google.genai.client import Client
-    from google.genai.types import HttpOptions
-except ImportError as _import_error:
-    raise ImportError(
-        'Please install the `google-genai` package to use the Google provider, '
-        'you can use the `google` optional group — `pip install "pydantic-ai-slim[google]"`'
-    ) from _import_error
+from pydantic_ai.providers import check_package_installed
+
+check_package_installed('google.genai', install_group='google')
+
+from google.auth.credentials import Credentials  # noqa: E402
+from google.genai.client import Client  # noqa: E402
+from google.genai.types import HttpOptions  # noqa: E402
 
 
 class GoogleProvider(Provider[Client]):

--- a/pydantic_ai_slim/pydantic_ai/providers/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/groq.py
@@ -18,13 +18,11 @@ from pydantic_ai.profiles.openai import openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.providers import Provider
 
-try:
-    from groq import AsyncGroq
-except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `groq` package to use the Groq provider, '
-        'you can use the `groq` optional group — `pip install "pydantic-ai-slim[groq]"`'
-    ) from _import_error
+from pydantic_ai.providers import check_package_installed
+
+check_package_installed('groq', install_group='groq')
+
+from groq import AsyncGroq  # noqa: E402
 
 
 def groq_moonshotai_model_profile(model_name: str) -> ModelProfile | None:

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -11,13 +11,11 @@ from pydantic_ai.models import cached_async_http_client
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.providers import Provider
 
-try:
-    from mistralai.client import Mistral
-except ImportError as e:  # pragma: no cover
-    raise ImportError(
-        'Please install the `mistral` package to use the Mistral provider, '
-        'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
-    ) from e
+from pydantic_ai.providers import check_package_installed
+
+check_package_installed('mistralai', install_group='mistral')
+
+from mistralai.client import Mistral  # noqa: E402
 
 
 class MistralProvider(Provider[Mistral]):

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -10,13 +10,11 @@ from pydantic_ai.models import cached_async_http_client
 from pydantic_ai.profiles.openai import openai_model_profile
 from pydantic_ai.providers import Provider
 
-try:
-    from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the OpenAI provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+from pydantic_ai.providers import check_package_installed
+
+check_package_installed('openai', install_group='openai')
+
+from openai import AsyncOpenAI  # noqa: E402
 
 
 class OpenAIProvider(Provider[AsyncOpenAI]):

--- a/tests/providers/test_check_package_installed.py
+++ b/tests/providers/test_check_package_installed.py
@@ -1,0 +1,64 @@
+"""Tests for the check_package_installed utility function."""
+
+from __future__ import annotations
+
+import importlib.util
+from unittest.mock import patch
+
+import pytest
+
+from pydantic_ai.providers import check_package_installed
+
+
+class TestCheckPackageInstalled:
+    """Tests for check_package_installed()."""
+
+    def test_installed_package_does_not_raise(self) -> None:
+        """A package that is installed should not raise."""
+        # 'os' is always available
+        check_package_installed('os')
+
+    def test_missing_package_raises_import_error(self) -> None:
+        """A package that is not installed should raise ImportError with install hint."""
+        with pytest.raises(ImportError, match=r'Please install the `nonexistent_pkg_xyz` package'):
+            check_package_installed('nonexistent_pkg_xyz')
+
+    def test_missing_package_shows_install_group(self) -> None:
+        """The error message should include the install group."""
+        with pytest.raises(ImportError, match=r'pydantic-ai-slim\[mistral\]'):
+            check_package_installed('nonexistent_pkg_xyz', install_group='mistral')
+
+    def test_missing_package_default_install_group(self) -> None:
+        """When install_group is not specified, use package_name as the group."""
+        with pytest.raises(ImportError, match=r'pydantic-ai-slim\[nonexistent_pkg_xyz\]'):
+            check_package_installed('nonexistent_pkg_xyz')
+
+    def test_installed_but_broken_import_propagates_real_error(self) -> None:
+        """If the package is installed but a name import fails, the real ImportError should propagate.
+
+        This is the core bug from #4927: when mistralai is installed but 'UNSET'
+        cannot be imported, the user should see the real error, not "please install".
+        """
+        # Simulate: find_spec says the package exists, but importing a name fails
+        check_package_installed('os')  # passes — package exists
+        # Now the subsequent import of a nonexistent name should give the real error
+        with pytest.raises(ImportError, match="cannot import name 'nonexistent_name'"):
+            from os import nonexistent_name  # type: ignore[attr-defined]  # noqa: F401
+
+    def test_find_spec_returns_none_for_missing_package(self) -> None:
+        """Verify that find_spec returns None for a package that doesn't exist."""
+        assert importlib.util.find_spec('nonexistent_pkg_xyz_12345') is None
+
+    def test_find_spec_returns_spec_for_installed_package(self) -> None:
+        """Verify that find_spec returns a spec for an installed package."""
+        assert importlib.util.find_spec('os') is not None
+
+    def test_check_with_subpackage(self) -> None:
+        """check_package_installed should work with dotted package names."""
+        # email.mime is a valid subpackage in the stdlib
+        check_package_installed('email.mime')
+
+    def test_check_with_missing_subpackage_raises(self) -> None:
+        """A missing subpackage should raise ImportError."""
+        with pytest.raises(ImportError, match=r'Please install'):
+            check_package_installed('email.nonexistent_subpkg_xyz')


### PR DESCRIPTION
## Summary
- Added `check_package_installed()` utility to `providers/__init__.py` using `importlib.util.find_spec` to verify a package exists before importing from it
- When a package is **missing**: users get a clear "please install X" message (same as before)
- When a package is **installed but a name import fails** (e.g. `UNSET` removed from `mistralai`): the **real ImportError propagates** with its original traceback instead of being masked
- Applied to 6 providers: mistral, anthropic, openai, groq, cohere, google
- Remaining providers can be migrated incrementally in follow-up PRs

## Test plan
- [x] Added `tests/providers/test_check_package_installed.py` with 9 tests covering:
  - Installed package does not raise
  - Missing package raises with install hint
  - Custom install_group shown in error
  - Default install_group fallback
  - Installed-but-broken import propagates real error (core bug scenario)
  - find_spec behavior verification
  - Dotted subpackage support
  - Missing subpackage detection
- [x] All 9 tests pass

Fixes #4927

🤖 Generated with [Claude Code](https://claude.com/claude-code)