### PR TITLE
feat(openai): add CachePoint and prompt caching support for OpenAI-compatible proxies

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -680,6 +680,7 @@ class CachePoint:
 
     - Anthropic
     - Amazon Bedrock (Converse API)
+    - OpenAI-compatible proxies (e.g. LiteLLM) routing to caching-capable providers
     """
 
     kind: Literal['cache-point'] = 'cache-point'

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -448,6 +448,39 @@ class OpenAIChatModelSettings(ModelSettings, total=False):
     See [OpenAI's streaming documentation](https://platform.openai.com/docs/api-reference/chat/create#stream_options) for more information.
     """
 
+    openai_cache_instructions: bool | Literal['5m', '1h']
+    """Whether to add `cache_control` to the last system prompt message.
+
+    When using an OpenAI-compatible proxy (e.g. LiteLLM) that routes to a provider supporting
+    prompt caching (e.g. Anthropic), this enables caching of system instructions to reduce costs.
+    If `True`, uses TTL='5m'. You can also specify '5m' or '1h' directly.
+
+    Note: This has no effect when calling native OpenAI endpoints — use `openai_prompt_cache_key`
+    and `openai_prompt_cache_retention` for native OpenAI prompt caching instead.
+    """
+
+    openai_cache_messages: bool | Literal['5m', '1h']
+    """Whether to add `cache_control` to the last user message.
+
+    When using an OpenAI-compatible proxy (e.g. LiteLLM) that routes to a provider supporting
+    prompt caching (e.g. Anthropic), this enables caching of conversation history to reduce costs
+    in multi-turn conversations.
+    If `True`, uses TTL='5m'. You can also specify '5m' or '1h' directly.
+
+    Note: This has no effect when calling native OpenAI endpoints — use `openai_prompt_cache_key`
+    and `openai_prompt_cache_retention` for native OpenAI prompt caching instead.
+    """
+
+    openai_cache_tool_definitions: bool | Literal['5m', '1h']
+    """Whether to add `cache_control` to the last tool definition.
+
+    When using an OpenAI-compatible proxy (e.g. LiteLLM) that routes to a provider supporting
+    prompt caching (e.g. Anthropic), this enables caching of tool definitions to reduce costs.
+    If `True`, uses TTL='5m'. You can also specify '5m' or '1h' directly.
+
+    Note: This has no effect when calling native OpenAI endpoints.
+    """
+
 
 @deprecated('Use `OpenAIChatModelSettings` instead.')
 class OpenAIModelSettings(OpenAIChatModelSettings, total=False):
@@ -777,6 +810,9 @@ class OpenAIChatModel(Model):
             tool_choice = 'auto'
 
         openai_messages = await self._map_messages(messages, model_request_parameters)
+
+        # Apply cache_control settings for proxies routing to caching-capable providers
+        self._apply_cache_control(openai_messages, tools or [], model_settings)
 
         response_format: chat.completion_create_params.ResponseFormat | None = None
         if model_request_parameters.output_mode == 'native':
@@ -1416,10 +1452,72 @@ class OpenAIChatModel(Model):
         else:
             content = []
             for item in part.content:
+                if isinstance(item, CachePoint):
+                    # Add cache_control to the preceding content block.
+                    # Proxies like LiteLLM pass this through to providers that
+                    # support prompt caching (e.g. Anthropic).
+                    if content:
+                        last = cast(dict[str, Any], content[-1])
+                        last['cache_control'] = {'type': 'ephemeral', 'ttl': item.ttl}
+                    continue
                 mapped_item = await self._map_content_item(item)
                 if mapped_item is not None:
                     content.append(mapped_item)
         return chat.ChatCompletionUserMessageParam(role='user', content=content)
+
+    @staticmethod
+    def _apply_cache_control(
+        openai_messages: list[chat.ChatCompletionMessageParam],
+        tools: list[chat.ChatCompletionToolParam],
+        model_settings: OpenAIChatModelSettings,
+    ) -> None:
+        """Apply cache_control markers to messages and tools based on model settings.
+
+        This enables prompt caching when using OpenAI-compatible proxies (e.g. LiteLLM)
+        that route to providers supporting prompt caching (e.g. Anthropic, Google).
+        Has no effect on native OpenAI endpoints which ignore unknown fields.
+
+        Args:
+            openai_messages: The mapped OpenAI messages (modified in-place).
+            tools: The mapped tool definitions (modified in-place).
+            model_settings: Settings that may contain cache control flags.
+        """
+        # Cache system/developer instructions
+        if cache_instructions := model_settings.get('openai_cache_instructions'):
+            ttl: Literal['5m', '1h'] = '5m' if cache_instructions is True else cache_instructions
+            # Find the last system/developer message
+            for msg in reversed(openai_messages):
+                if msg.get('role') in ('system', 'developer'):
+                    content = msg.get('content')
+                    if isinstance(content, str):
+                        msg['content'] = [  # type: ignore[typeddict-unknown-key]
+                            {'type': 'text', 'text': content, 'cache_control': {'type': 'ephemeral', 'ttl': ttl}}
+                        ]
+                    elif isinstance(content, list):
+                        last_block = cast(dict[str, Any], content[-1])
+                        last_block['cache_control'] = {'type': 'ephemeral', 'ttl': ttl}
+                    break
+
+        # Cache tool definitions
+        if cache_tools := model_settings.get('openai_cache_tool_definitions'):
+            ttl = '5m' if cache_tools is True else cache_tools
+            if tools:
+                cast(dict[str, Any], tools[-1])['cache_control'] = {'type': 'ephemeral', 'ttl': ttl}
+
+        # Cache the last user message
+        if cache_messages := model_settings.get('openai_cache_messages'):
+            ttl = '5m' if cache_messages is True else cache_messages
+            for msg in reversed(openai_messages):
+                if msg.get('role') == 'user':
+                    content = msg.get('content')
+                    if isinstance(content, str):
+                        msg['content'] = [  # type: ignore[typeddict-unknown-key]
+                            {'type': 'text', 'text': content, 'cache_control': {'type': 'ephemeral', 'ttl': ttl}}
+                        ]
+                    elif isinstance(content, list):
+                        last_block = cast(dict[str, Any], content[-1])
+                        last_block['cache_control'] = {'type': 'ephemeral', 'ttl': ttl}
+                    break
 
     @staticmethod
     def _inline_text_file_part(text: str, *, media_type: str, identifier: str) -> ChatCompletionContentPartTextParam:

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -3733,20 +3733,101 @@ def test_deprecated_openai_model(openai_api_key: str):
         OpenAIModel('gpt-4o', provider=provider)  # type: ignore[reportDeprecated]
 
 
-async def test_cache_point_filtering(allow_model_requests: None):
-    """Test that CachePoint is filtered out in OpenAI Chat Completions requests."""
+async def test_cache_point_adds_cache_control(allow_model_requests: None):
+    """Test that CachePoint adds cache_control to the preceding content block."""
     c = completion_message(ChatCompletionMessage(content='response', role='assistant'))
     mock_client = MockOpenAI.create_mock(c)
     m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
 
-    # Test the instance method directly to trigger line 864
     msg = await m._map_user_prompt(UserPromptPart(content=['text before', CachePoint(), 'text after']))  # pyright: ignore[reportPrivateUsage]
 
-    # CachePoint should be filtered out, only text content should remain
+    # CachePoint should add cache_control to 'text before', then 'text after' follows normally
     assert msg['role'] == 'user'
     assert len(msg['content']) == 2  # type: ignore[reportUnknownArgumentType]
     assert msg['content'][0]['text'] == 'text before'  # type: ignore[reportUnknownArgumentType]
+    assert msg['content'][0]['cache_control'] == {'type': 'ephemeral', 'ttl': '5m'}  # type: ignore[reportUnknownArgumentType]
     assert msg['content'][1]['text'] == 'text after'  # type: ignore[reportUnknownArgumentType]
+    assert 'cache_control' not in msg['content'][1]  # type: ignore[reportUnknownArgumentType]
+
+
+async def test_cache_point_with_custom_ttl(allow_model_requests: None):
+    """Test that CachePoint respects the ttl parameter."""
+    c = completion_message(ChatCompletionMessage(content='response', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    msg = await m._map_user_prompt(UserPromptPart(content=['text', CachePoint(ttl='1h')]))  # pyright: ignore[reportPrivateUsage]
+
+    assert msg['content'][0]['cache_control'] == {'type': 'ephemeral', 'ttl': '1h'}  # type: ignore[reportUnknownArgumentType]
+
+
+async def test_cache_point_at_start_is_ignored(allow_model_requests: None):
+    """Test that CachePoint at the start (no preceding content) is silently skipped."""
+    c = completion_message(ChatCompletionMessage(content='response', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    msg = await m._map_user_prompt(UserPromptPart(content=[CachePoint(), 'text after']))  # pyright: ignore[reportPrivateUsage]
+
+    # CachePoint at start has nothing to attach to — ignored
+    assert len(msg['content']) == 1  # type: ignore[reportUnknownArgumentType]
+    assert msg['content'][0]['text'] == 'text after'  # type: ignore[reportUnknownArgumentType]
+    assert 'cache_control' not in msg['content'][0]  # type: ignore[reportUnknownArgumentType]
+
+
+async def test_cache_instructions_setting(allow_model_requests: None):
+    """Test openai_cache_instructions adds cache_control to system message."""
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='test'))
+
+    messages: list[dict[str, Any]] = [
+        {'role': 'system', 'content': 'You are helpful.'},
+        {'role': 'user', 'content': 'Hello'},
+    ]
+    tools: list[dict[str, Any]] = []
+    settings: OpenAIChatModelSettings = {'openai_cache_instructions': True}
+
+    m._apply_cache_control(messages, tools, settings)  # pyright: ignore[reportPrivateUsage]
+
+    # System message content should be converted to content block array with cache_control
+    assert isinstance(messages[0]['content'], list)
+    assert messages[0]['content'][0]['text'] == 'You are helpful.'
+    assert messages[0]['content'][0]['cache_control'] == {'type': 'ephemeral', 'ttl': '5m'}
+
+
+async def test_cache_messages_setting(allow_model_requests: None):
+    """Test openai_cache_messages adds cache_control to last user message."""
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='test'))
+
+    messages: list[dict[str, Any]] = [
+        {'role': 'system', 'content': 'System prompt'},
+        {'role': 'user', 'content': 'First message'},
+        {'role': 'assistant', 'content': 'Response'},
+        {'role': 'user', 'content': 'Second message'},
+    ]
+    settings: OpenAIChatModelSettings = {'openai_cache_messages': '1h'}
+
+    m._apply_cache_control(messages, [], settings)  # pyright: ignore[reportPrivateUsage]
+
+    # Only the LAST user message should get cache_control
+    assert isinstance(messages[1]['content'], str)  # first user message unchanged
+    assert isinstance(messages[3]['content'], list)  # last user message converted
+    assert messages[3]['content'][0]['cache_control'] == {'type': 'ephemeral', 'ttl': '1h'}
+
+
+async def test_cache_tool_definitions_setting(allow_model_requests: None):
+    """Test openai_cache_tool_definitions adds cache_control to last tool."""
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='test'))
+
+    tools: list[dict[str, Any]] = [
+        {'type': 'function', 'function': {'name': 'tool1'}},
+        {'type': 'function', 'function': {'name': 'tool2'}},
+    ]
+    settings: OpenAIChatModelSettings = {'openai_cache_tool_definitions': True}
+
+    m._apply_cache_control([], tools, settings)  # pyright: ignore[reportPrivateUsage]
+
+    assert 'cache_control' not in tools[0]
+    assert tools[1]['cache_control'] == {'type': 'ephemeral', 'ttl': '5m'}
 
 
 async def test_cache_point_filtering_responses_model():


### PR DESCRIPTION
## Summary

  Adds prompt caching support for `OpenAIChatModel`, enabling `cache_control` passthrough when using OpenAI-compatible
  proxies (e.g. LiteLLM) that route to providers supporting prompt caching (e.g. Anthropic Claude).

  ### Motivation

  Many users route requests through LiteLLM or similar proxies to Anthropic Claude models using `OpenAIChatModel`.
  Currently, `CachePoint` markers are silently filtered out in the OpenAI model path, making prompt caching unavailable.
  This is a significant cost issue for multi-turn agent conversations where the system prompt and conversation history
  are re-sent on every turn.

  ### Changes

  - **`CachePoint` handling in `_map_user_prompt`**: Instead of filtering out `CachePoint` markers, adds `cache_control`
  to the preceding content block. Proxies like LiteLLM pass this through to the downstream provider.
  - **New settings** (mirroring `AnthropicModelSettings`):
    - `openai_cache_instructions`: Cache the last system prompt message
    - `openai_cache_messages`: Cache the last user message
    - `openai_cache_tool_definitions`: Cache the last tool definition
  - **`_apply_cache_control` method**: Applies the settings after message mapping in `_completions_create`.
  - **Updated `CachePoint` docstring** to mention proxy support.

  ### Design decisions

  - **Mirrors Anthropic's API**: The three `openai_cache_*` settings follow the same pattern as `anthropic_cache_*`,
  making it easy for users to switch between direct and proxied access.
  - **No effect on native OpenAI**: Native OpenAI endpoints ignore unknown fields in content blocks. Native caching uses
  `openai_prompt_cache_key`/`openai_prompt_cache_retention` instead.
  - **TTL passthrough**: The `ttl` from `CachePoint` is passed through in the `cache_control` dict.

  ### Related

  - #4392 — CachePoint for OpenRouter (same need, different model class)
  - #4604 — OpenRouter CachePoint PR (similar implementation pattern)
  - #4840 — Anthropic automatic caching

  ### Verified

  Tested end-to-end with LiteLLM gateway routing to Anthropic Claude on AWS Bedrock. Confirmed cache writes on first
  call, cache reads on subsequent calls, with correct `cache_read_tokens` in usage response.

  - Closes #4392 (partially — covers OpenAI model path)

  ### Pre-Review Checklist

  - [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
  - [x] No **breaking changes** in accordance with the version policy.
  - [ ] **Linting and type checking** pass per `make format` and `make typecheck`.
  - [x] **PR title** is fit for the release changelog.

  ### Pre-Merge Checklist

  - [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
  - [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.