### PR TITLE
fix: catch ModuleNotFoundError instead of ImportError in provider/model imports

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -151,7 +151,7 @@ try:
     )
     from anthropic.types.model_param import ModelParam
 
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install `anthropic` to use the Anthropic model, '
         'you can use the `anthropic` optional group — `pip install "pydantic-ai-slim[anthropic]"`'

--- a/pydantic_ai_slim/pydantic_ai/models/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cerebras.py
@@ -16,7 +16,7 @@ try:
     from openai import AsyncOpenAI
 
     from .openai import OpenAIChatModel, OpenAIChatModelSettings
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install the `openai` package to use the Cerebras model, '
         'you can use the `cerebras` optional group — `pip install "pydantic-ai-slim[cerebras]"'

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -56,7 +56,7 @@ try:
     )
     from cohere.core.api_error import ApiError
     from cohere.v2.client import OMIT
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install `cohere` to use the Cohere model, '
         'you can use the `cohere` optional group — `pip install "pydantic-ai-slim[cohere]"`'

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -104,7 +104,7 @@ try:
         UrlContextMetadata,
         VideoMetadataDict,
     )
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install `google-genai` to use the Google model, '
         'you can use the `google` optional group — `pip install "pydantic-ai-slim[google]"`'

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -63,7 +63,7 @@ try:
     from groq.types import chat
     from groq.types.chat.chat_completion_content_part_image_param import ImageURL
     from groq.types.chat.chat_completion_message import ExecutedTool
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install `groq` to use the Groq model, '
         'you can use the `groq` optional group — `pip install "pydantic-ai-slim[groq]"`'

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -64,7 +64,7 @@ try:
     )
     from huggingface_hub.errors import HfHubHTTPError
 
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install `huggingface_hub` to use Hugging Face Inference Providers, '
         'you can use the `huggingface` optional group — `pip install "pydantic-ai-slim[huggingface]"`'

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -88,7 +88,7 @@ try:
     from mistralai.client.types import UNSET, OptionalNullable as MistralOptionalNullable
     from mistralai.client.types.basemodel import Unset as MistralUnset
     from mistralai.client.utils.eventstreaming import EventStreamAsync as MistralEventStreamAsync
-except ImportError as e:  # pragma: lax no cover
+except ModuleNotFoundError as e:  # pragma: lax no cover
     raise ImportError(
         'Please install `mistral` to use the Mistral model, '
         'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -123,7 +123,7 @@ try:
     from openai.types.shared_params import Reasoning
 
     OMIT = omit
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install `openai` to use the OpenAI model, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -32,7 +32,7 @@ try:
         _ChatCompletion,  # pyright: ignore[reportPrivateUsage]
         _ChatCompletionChunk,  # pyright: ignore[reportPrivateUsage]
     )
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install `openai` to use the OpenRouter model, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/models/outlines.py
+++ b/pydantic_ai_slim/pydantic_ai/models/outlines.py
@@ -66,7 +66,7 @@ try:
     )
     from outlines.types.dsl import JsonSchema
     from PIL import Image as PILImage
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install `outlines` to use the Outlines model, '
         'you can use the `outlines` optional group — `pip install "pydantic-ai-slim[outlines]"`'
@@ -202,7 +202,7 @@ class OutlinesModel(Model):
         """
         try:
             from openai import AsyncOpenAI
-        except ImportError as _import_error:
+        except ModuleNotFoundError as _import_error:
             raise ImportError(
                 'Please install `openai` to use the Outlines SGLang model, '
                 'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -74,7 +74,7 @@ try:
     from xai_sdk.proto import chat_pb2, sample_pb2, usage_pb2
     from xai_sdk.tools import code_execution, get_tool_call_type, mcp, web_search  # x_search not yet supported
     from xai_sdk.types.model import ChatModel
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install `xai-sdk` to use the xAI model, '
         'you can use the `xai` optional group — `pip install "pydantic-ai-slim[xai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
@@ -15,7 +15,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Alibaba provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
@@ -16,7 +16,7 @@ from .._json_schema import JsonSchema, JsonSchemaTransformer
 
 try:
     from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, AsyncAnthropicFoundry, AsyncAnthropicVertex
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install the `anthropic` package to use the Anthropic provider, '
         'you can use the `anthropic` optional group — `pip install "pydantic-ai-slim[anthropic]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -19,7 +19,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncAzureOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Azure provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -24,7 +24,7 @@ try:
     from botocore.exceptions import NoRegionError
     from botocore.session import Session
     from botocore.tokens import FrozenAuthToken
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install the `boto3` package to use the Bedrock provider, '
         'you can use the `bedrock` optional group — `pip install "pydantic-ai-slim[bedrock]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -17,7 +17,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Cerebras provider, '
         'you can use the `cerebras` optional group — `pip install "pydantic-ai-slim[cerebras]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cohere.py
@@ -12,7 +12,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from cohere import AsyncClient, AsyncClientV2
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install the `cohere` package to use the Cohere provider, '
         'you can use the `cohere` optional group — `pip install "pydantic-ai-slim[cohere]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -15,7 +15,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the DeepSeek provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -19,7 +19,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Fireworks AI provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/github.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/github.py
@@ -18,7 +18,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the GitHub Models provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -15,7 +15,7 @@ try:
     from google.auth.credentials import Credentials
     from google.genai.client import Client
     from google.genai.types import HttpOptions
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install the `google-genai` package to use the Google provider, '
         'you can use the `google` optional group — `pip install "pydantic-ai-slim[google]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
@@ -21,7 +21,7 @@ try:
     from google.auth.credentials import Credentials as BaseCredentials
     from google.auth.transport.requests import Request
     from google.oauth2.service_account import Credentials as ServiceAccountCredentials
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install the `google-auth` package to use the Google Vertex AI provider, '
         'you can use the `vertexai` optional group — `pip install "pydantic-ai-slim[vertexai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/grok.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/grok.py
@@ -16,7 +16,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Grok provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/groq.py
@@ -20,7 +20,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from groq import AsyncGroq
-except ImportError as _import_error:
+except ModuleNotFoundError as _import_error:
     raise ImportError(
         'Please install the `groq` package to use the Groq provider, '
         'you can use the `groq` optional group — `pip install "pydantic-ai-slim[groq]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -14,7 +14,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Heroku provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/huggingface.py
@@ -17,7 +17,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 try:
     from huggingface_hub import AsyncInferenceClient
     from huggingface_hub.constants import INFERENCE_PROXY_TEMPLATE
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `huggingface_hub` package to use the HuggingFace provider, '
         "you can use the `huggingface` optional group — `pip install 'pydantic-ai-slim[huggingface]'`"

--- a/pydantic_ai_slim/pydantic_ai/providers/litellm.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/litellm.py
@@ -23,7 +23,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the LiteLLM provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -13,7 +13,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from mistralai.client import Mistral
-except ImportError as e:
+except ModuleNotFoundError as e:
     raise ImportError(
         'Please install the `mistral` package to use the Mistral provider, '
         'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -20,7 +20,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Nebius provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -20,7 +20,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Ollama provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -12,7 +12,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the OpenAI provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -26,7 +26,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the OpenRouter provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
@@ -18,7 +18,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use OVHcloud AI Endpoints provider.'
         'You can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
@@ -17,7 +17,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the SambaNova provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -19,7 +19,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Together AI provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/vercel.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/vercel.py
@@ -20,7 +20,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from openai import AsyncOpenAI
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `openai` package to use the Vercel provider, '
         'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/voyageai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/voyageai.py
@@ -8,7 +8,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from voyageai.client_async import AsyncClient
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `voyageai` package to use the VoyageAI provider, '
         'you can use the `voyageai` optional group — `pip install "pydantic-ai-slim[voyageai]"`'

--- a/pydantic_ai_slim/pydantic_ai/providers/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/xai.py
@@ -11,7 +11,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from xai_sdk import AsyncClient
-except ImportError as _import_error:  # pragma: no cover
+except ModuleNotFoundError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `xai-sdk` package to use the xAI provider, '
         'you can use the `xai` optional group — `pip install "pydantic-ai-slim[xai]"`'


### PR DESCRIPTION
- Closes #4927

### Pre-Review Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [ ] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

---

Per @Kludex's direction on #4927, this narrows the `except` clause in all provider and model import blocks from `ImportError` to `ModuleNotFoundError`.

**The problem:** When a provider dependency *is* installed but has an incompatible version (e.g. `mistralai` v2 dropped `UNSET` from `mistralai.client.types.basemodel`), the broad `except ImportError` catch swallows the real error and shows:

```
ImportError: Please install `mistral` to use the Mistral model, ...
```

...which is wrong -- the package *is* installed, just the wrong version.

**The fix:** `ModuleNotFoundError` (a subclass of `ImportError` since Python 3.6) is what Python's import machinery raises when a module genuinely doesn't exist. By catching only that, real `ImportError`s -- like a missing name in an installed-but-incompatible package -- now propagate with the actual traceback:

```
ImportError: cannot import name 'UNSET' from 'mistralai' (unknown location)
```

The re-raised `raise ImportError(...)` inside the except block still works correctly since it's explicitly constructed. Nothing changes for the "package not installed" path.

**Validation:** 269 provider tests pass, `ruff check` clean, `pyright` clean on affected files.
