### PR TITLE
chore: follow-up tweaks to #4421

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -19,7 +19,7 @@ from types import TracebackType
 from typing import Any, Generic, Literal, TypeVar, cast, get_args, overload
 
 import httpx
-from typing_extensions import Self, TypeAliasType, TypedDict
+from typing_extensions import Self, TypeAliasType, TypedDict, deprecated
 
 from .. import _utils
 from .._json_schema import JsonSchemaTransformer
@@ -1326,16 +1326,11 @@ def create_async_http_client(*, timeout: int = DEFAULT_HTTP_TIMEOUT, connect: in
     )
 
 
+@deprecated('`cached_async_http_client` is deprecated, use `create_async_http_client` instead.')
 def cached_async_http_client(
     *, provider: str | None = None, timeout: int = DEFAULT_HTTP_TIMEOUT, connect: int = 5
 ) -> httpx.AsyncClient:
-    """Deprecated. Use [`create_async_http_client`][pydantic_ai.models.create_async_http_client] instead."""
-    warnings.warn(
-        'cached_async_http_client is deprecated, use create_async_http_client instead. '
-        'Note: the new function creates a new client per call instead of returning a cached one.',
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    """Use [`create_async_http_client`][pydantic_ai.models.create_async_http_client] instead."""
     return create_async_http_client(timeout=timeout, connect=connect)
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, cast, overload
 from urllib.parse import parse_qs, urlparse
 
 import anyio.to_thread
-from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 from typing_extensions import ParamSpec, assert_never
 
@@ -51,7 +50,7 @@ from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse, 
 from pydantic_ai.profiles.anthropic import ANTHROPIC_THINKING_BUDGET_MAP
 from pydantic_ai.profiles.openai import OPENAI_REASONING_EFFORT_MAP
 from pydantic_ai.providers import Provider, infer_provider
-from pydantic_ai.providers.bedrock import BedrockModelProfile, remove_bedrock_geo_prefix
+from pydantic_ai.providers.bedrock import BaseClient, BedrockModelProfile, remove_bedrock_geo_prefix
 from pydantic_ai.settings import ModelSettings, ThinkingLevel
 from pydantic_ai.tools import ToolDefinition
 

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -11,8 +11,16 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, cast, overload
 from urllib.parse import parse_qs, urlparse
 
 import anyio.to_thread
-from botocore.exceptions import ClientError
 from typing_extensions import ParamSpec, assert_never
+
+try:
+    from botocore.client import BaseClient
+    from botocore.exceptions import ClientError
+except ImportError as _import_error:
+    raise ImportError(
+        'Please install `boto3` to use the Bedrock model, '
+        'you can use the `bedrock` optional group — `pip install "pydantic-ai-slim[bedrock]"`'
+    ) from _import_error
 
 from pydantic_ai import (
     AudioUrl,
@@ -50,7 +58,7 @@ from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse, 
 from pydantic_ai.profiles.anthropic import ANTHROPIC_THINKING_BUDGET_MAP
 from pydantic_ai.profiles.openai import OPENAI_REASONING_EFFORT_MAP
 from pydantic_ai.providers import Provider, infer_provider
-from pydantic_ai.providers.bedrock import BaseClient, BedrockModelProfile, remove_bedrock_geo_prefix
+from pydantic_ai.providers.bedrock import BedrockModelProfile, remove_bedrock_geo_prefix
 from pydantic_ai.settings import ModelSettings, ThinkingLevel
 from pydantic_ai.tools import ToolDefinition
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -6354,10 +6354,10 @@ async def test_agent_context_manager_no_model():
 
 
 def test_cached_async_http_client_deprecated():
-    from pydantic_ai.models import cached_async_http_client
+    from pydantic_ai.models import cached_async_http_client  # pyright: ignore[reportDeprecated]
 
-    with pytest.warns(DeprecationWarning, match='cached_async_http_client is deprecated'):
-        cached_async_http_client()
+    with pytest.warns(DeprecationWarning, match='cached_async_http_client.*is deprecated'):
+        cached_async_http_client()  # pyright: ignore[reportDeprecated]
 
 
 @requires_openai


### PR DESCRIPTION
## Summary

Follow-up to #4421 based on post-merge review comments from @Kludex:

- Use `@deprecated` decorator on `cached_async_http_client` instead of manual `warnings.warn`, remove redundant "Deprecated" from docstring
- Move `BaseClient` import in bedrock model to re-use provider's `try/except` import guard for friendly install message

Closes #4421 (post-merge feedback)

## Test plan

- [x] Pre-commit hooks pass (format, lint, typecheck)
- [x] Existing `test_cached_async_http_client_deprecated` updated with pyright ignore for `reportDeprecated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)