### PR TITLE
fix: reverse `get_wrapper_toolset` iteration and add `CapabilityOrdering`

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -871,6 +871,35 @@ When multiple capabilities are passed to an agent, they are composed into a sing
 
 This means the first capability in the list has the first and last say on the operation — it sees the original input in its `wrap_*` before handler, and it sees the final output after handler returns.
 
+### Ordering
+
+By default, capabilities are composed in the order you list them. When a capability needs to be at a specific position regardless of where the user lists it, override [`get_ordering`][pydantic_ai.capabilities.AbstractCapability.get_ordering] to return a [`CapabilityOrdering`][pydantic_ai.capabilities.CapabilityOrdering]:
+
+```python {test="skip" lint="skip"}
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
+
+
+@dataclass
+class InstrumentationCapability(AbstractCapability[Any]):
+    """Must wrap all other capabilities to trace everything."""
+
+    @classmethod
+    def get_ordering(cls) -> CapabilityOrdering:
+        return CapabilityOrdering(position='outermost')
+```
+
+The available constraints are:
+
+* **`position`** — `'outermost'` or `'innermost'`. Places the capability in a tier before (or after) all capabilities without that position. Multiple capabilities can share a tier; original list order breaks ties within it.
+* **`wraps`** — list of capability types this one wraps around (is outside of). Use when your capability needs to see the output of another: `CapabilityOrdering(wraps=[OtherCapability])`.
+* **`wrapped_by`** — list of capability types that wrap around this one (are outside of it). The inverse of `wraps`.
+* **`requires`** — list of capability types that must be present. Raises [`UserError`][pydantic_ai.exceptions.UserError] if any are missing. Does not imply ordering.
+
+When constraints are declared, [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability] topologically sorts its children at construction time, preserving user-provided order as a tiebreaker.
+
 ## Examples
 
 ### Guardrail (PII redaction)

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -862,7 +862,7 @@ print(counter.count)
 
 ### Composition and middleware semantics
 
-When multiple capabilities are passed to an agent, they are composed into a single [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability] that follows **middleware semantics** — the same pattern used by web frameworks like Django, Express, and Ring:
+When multiple capabilities are passed to an agent, they are composed into a single [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability] that follows **middleware semantics** — the same pattern used by web frameworks like Django and Starlette:
 
 * **Configuration** is merged: instructions concatenate, model settings merge additively (later capabilities override earlier ones), toolsets combine, builtin tools collect.
 * **`before_*`** hooks fire in capability order (outermost to innermost): `cap1 → cap2 → cap3`.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -860,16 +860,17 @@ print(counter.count)
 #> 0
 ```
 
-### Composition
+### Composition and middleware semantics
 
-When multiple capabilities are passed to an agent, they are composed into a single [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability]:
+When multiple capabilities are passed to an agent, they are composed into a single [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability] that follows **middleware semantics** — the same pattern used by web frameworks like Django, Express, and Ring:
 
 * **Configuration** is merged: instructions concatenate, model settings merge additively (later capabilities override earlier ones), toolsets combine, builtin tools collect.
-* **`before_*`** hooks fire in capability order: `cap1 → cap2 → cap3`.
-* **`after_*`** hooks fire in reverse order: `cap3 → cap2 → cap1`.
-* **`wrap_*`** hooks nest as middleware: `cap1` wraps `cap2` wraps `cap3` wraps the actual operation. The first capability is the outermost layer.
+* **`before_*`** hooks fire in capability order (outermost to innermost): `cap1 → cap2 → cap3`.
+* **`after_*`** hooks fire in reverse order (innermost to outermost): `cap3 → cap2 → cap1`.
+* **`wrap_*`** hooks nest as middleware: `cap1` wraps `cap2` wraps `cap3` wraps the actual operation. The first capability is the **outermost** layer.
+* **`get_wrapper_toolset`** follows the same nesting: the first capability's wrapper is outermost.
 
-This means the first capability in the list has the first and last say on the operation — it sees the original input in its `wrap_*` before handler, and it sees the final output after handler returns.
+This means the first capability in the list has the first and last say on the operation — it sees the original input before any other capability, and it sees the final output after all inner capabilities have processed it.
 
 ### Ordering
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -879,8 +879,11 @@ By default, capabilities are composed in the order you list them. When a capabil
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
-from pydantic_ai.capabilities.combined import CombinedCapability
+from pydantic_ai.capabilities import (
+    AbstractCapability,
+    CapabilityOrdering,
+    CombinedCapability,
+)
 
 
 @dataclass

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -875,11 +875,12 @@ This means the first capability in the list has the first and last say on the op
 
 By default, capabilities are composed in the order you list them. When a capability needs to be at a specific position regardless of where the user lists it, override [`get_ordering`][pydantic_ai.capabilities.AbstractCapability.get_ordering] to return a [`CapabilityOrdering`][pydantic_ai.capabilities.CapabilityOrdering]:
 
-```python {test="skip" lint="skip"}
+```python {title="capability_ordering_example.py"}
 from dataclasses import dataclass
 from typing import Any
 
 from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
+from pydantic_ai.capabilities.combined import CombinedCapability
 
 
 @dataclass
@@ -889,6 +890,16 @@ class InstrumentationCapability(AbstractCapability[Any]):
     @classmethod
     def get_ordering(cls) -> CapabilityOrdering:
         return CapabilityOrdering(position='outermost')
+
+
+@dataclass
+class PlainCapability(AbstractCapability[Any]):
+    pass
+
+
+# InstrumentationCapability ends up first regardless of list order
+combined = CombinedCapability([PlainCapability(), InstrumentationCapability()])
+assert type(combined.capabilities[0]) is InstrumentationCapability
 ```
 
 The available constraints are:

--- a/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from ._ordering import sort_capabilities
 from .abstract import (
     AbstractCapability,
     AgentNode,
@@ -84,4 +85,5 @@ __all__ = [
     'CombinedCapability',
     'HookTimeoutError',
     'Hooks',
+    'sort_capabilities',
 ]

--- a/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
@@ -3,6 +3,8 @@ from typing import Any
 from .abstract import (
     AbstractCapability,
     AgentNode,
+    CapabilityOrdering,
+    CapabilityPosition,
     NodeResult,
     RawToolArgs,
     ValidatedToolArgs,
@@ -53,6 +55,8 @@ CAPABILITY_TYPES: dict[str, type[AbstractCapability[Any]]] = {
 __all__ = [
     'AbstractCapability',
     'AgentNode',
+    'CapabilityOrdering',
+    'CapabilityPosition',
     'NodeResult',
     'RawToolArgs',
     'ValidatedToolArgs',

--- a/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from ._ordering import sort_capabilities
 from .abstract import (
     AbstractCapability,
     AgentNode,
@@ -85,5 +84,4 @@ __all__ = [
     'CombinedCapability',
     'HookTimeoutError',
     'Hooks',
-    'sort_capabilities',
 ]

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import heapq
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic_ai.exceptions import UserError
 
-from .abstract import AbstractCapability, CapabilityOrdering, CapabilityPosition
+from .abstract import AbstractCapability, CapabilityOrdering
+
+if TYPE_CHECKING:
+    from .abstract import CapabilityPosition
 
 _AddEdge = Callable[[int, int], None]
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
@@ -1,0 +1,202 @@
+"""Topological sorting of capabilities based on ordering constraints."""
+
+from __future__ import annotations
+
+import heapq
+from collections.abc import Callable, Iterator, Sequence
+from typing import Any
+
+from pydantic_ai.exceptions import UserError
+
+from .abstract import AbstractCapability, CapabilityOrdering, CapabilityPosition
+
+_AddEdge = Callable[[int, int], None]
+
+
+def sort_capabilities(
+    capabilities: Sequence[AbstractCapability[Any]],
+) -> list[AbstractCapability[Any]]:
+    """Sort capabilities to satisfy ordering constraints.
+
+    Preserves the original order as a tiebreaker when constraints allow.
+    Raises ``UserError`` on conflicts (duplicate positions, missing requirements, cycles).
+    """
+    caps = list(capabilities)
+    n = len(caps)
+    if n <= 1:
+        return caps
+
+    orderings: list[CapabilityOrdering | None] = [_effective_ordering(cap) for cap in caps]
+    leaf_types: list[set[type]] = [_collect_leaf_types(cap) for cap in caps]
+
+    _validate_constraints(caps, orderings, leaf_types)
+
+    edges, in_degree = _build_dag(caps, orderings, leaf_types)
+
+    return _topo_sort(caps, edges, in_degree)
+
+
+def _validate_constraints(
+    caps: list[AbstractCapability[Any]],
+    orderings: list[CapabilityOrdering | None],
+    leaf_types: list[set[type]],
+) -> None:
+    """Validate position uniqueness and required dependencies."""
+    outermost = [i for i, o in enumerate(orderings) if o and o.position == 'outermost']
+    innermost = [i for i, o in enumerate(orderings) if o and o.position == 'innermost']
+
+    if len(outermost) > 1:
+        names = [type(caps[i]).__name__ for i in outermost]
+        raise UserError(f"Multiple capabilities declare position 'outermost': {', '.join(names)}")
+    if len(innermost) > 1:
+        names = [type(caps[i]).__name__ for i in innermost]
+        raise UserError(f"Multiple capabilities declare position 'innermost': {', '.join(names)}")
+
+    all_leaf_types: set[type] = set[type]().union(*leaf_types)
+    for i, ordering in enumerate(orderings):
+        if ordering and ordering.requires:
+            for req_type in ordering.requires:
+                if not any(issubclass(t, req_type) for t in all_leaf_types):
+                    raise UserError(
+                        f'`{type(caps[i]).__name__}` requires `{req_type.__name__}` '
+                        f'but it was not found among the capabilities.'
+                    )
+
+
+def _build_dag(
+    caps: list[AbstractCapability[Any]],
+    orderings: list[CapabilityOrdering | None],
+    leaf_types: list[set[type]],
+) -> tuple[dict[int, set[int]], dict[int, int]]:
+    """Build a DAG from position and wraps/wrapped_by constraints."""
+    n = len(caps)
+    edges: dict[int, set[int]] = {i: set() for i in range(n)}
+    in_degree: dict[int, int] = {i: 0 for i in range(n)}
+
+    def add_edge(outer: int, inner: int) -> None:
+        if inner not in edges[outer]:
+            edges[outer].add(inner)
+            in_degree[inner] += 1
+
+    _add_position_edges(n, orderings, add_edge)
+    _add_relative_edges(n, orderings, leaf_types, add_edge)
+
+    return edges, in_degree
+
+
+def _add_position_edges(
+    n: int,
+    orderings: list[CapabilityOrdering | None],
+    add_edge: _AddEdge,
+) -> None:
+    outermost = [i for i, o in enumerate(orderings) if o and o.position == 'outermost']
+    innermost = [i for i, o in enumerate(orderings) if o and o.position == 'innermost']
+
+    if outermost:
+        oi = outermost[0]
+        for j in range(n):
+            if j != oi:
+                add_edge(oi, j)
+    if innermost:
+        ii = innermost[0]
+        for j in range(n):
+            if j != ii:
+                add_edge(j, ii)
+
+
+def _add_relative_edges(
+    n: int,
+    orderings: list[CapabilityOrdering | None],
+    leaf_types: list[set[type]],
+    add_edge: _AddEdge,
+) -> None:
+    for i, ordering in enumerate(orderings):
+        if not ordering:
+            continue
+        # wraps=[X] → I wrap around X → edge from me (outer) to X (inner)
+        for wraps_type in ordering.wraps:
+            for j in range(n):
+                if i != j and any(issubclass(t, wraps_type) for t in leaf_types[j]):
+                    add_edge(i, j)
+        # wrapped_by=[X] → X wraps around me → edge from X (outer) to me (inner)
+        for wrapped_by_type in ordering.wrapped_by:
+            for j in range(n):
+                if i != j and any(issubclass(t, wrapped_by_type) for t in leaf_types[j]):
+                    add_edge(j, i)
+
+
+def _topo_sort(
+    caps: list[AbstractCapability[Any]],
+    edges: dict[int, set[int]],
+    in_degree: dict[int, int],
+) -> list[AbstractCapability[Any]]:
+    """Kahn's algorithm with original-index tiebreaking for stability."""
+    n = len(caps)
+    queue: list[int] = []
+    for i in range(n):
+        if in_degree[i] == 0:
+            heapq.heappush(queue, i)
+
+    result: list[AbstractCapability[Any]] = []
+    while queue:
+        i = heapq.heappop(queue)
+        result.append(caps[i])
+        for j in edges[i]:
+            in_degree[j] -= 1
+            if in_degree[j] == 0:
+                heapq.heappush(queue, j)
+
+    if len(result) != n:
+        remaining = [type(caps[i]).__name__ for i in range(n) if in_degree[i] > 0]
+        raise UserError(f'Circular ordering constraints among capabilities: {", ".join(remaining)}')
+
+    return result
+
+
+def _effective_ordering(cap: AbstractCapability[Any]) -> CapabilityOrdering | None:
+    """Get the effective ordering for a capability, merging from leaves for nested groups."""
+    from .combined import CombinedCapability
+
+    if not isinstance(cap, CombinedCapability):
+        return type(cap).get_ordering()
+
+    merged_position: CapabilityPosition | None = None
+    merged_wraps: list[type[AbstractCapability[Any]]] = []
+    merged_wrapped_by: list[type[AbstractCapability[Any]]] = []
+    merged_requires: list[type[AbstractCapability[Any]]] = []
+    has_any = False
+
+    for leaf in iter_leaves(cap):
+        ordering = type(leaf).get_ordering()
+        if ordering is None:
+            continue
+        has_any = True
+        if ordering.position is not None:
+            merged_position = ordering.position
+        merged_wraps.extend(ordering.wraps)
+        merged_wrapped_by.extend(ordering.wrapped_by)
+        merged_requires.extend(ordering.requires)
+
+    if not has_any:
+        return None
+    return CapabilityOrdering(
+        position=merged_position,
+        wraps=merged_wraps,
+        wrapped_by=merged_wrapped_by,
+        requires=merged_requires,
+    )
+
+
+def iter_leaves(cap: AbstractCapability[Any]) -> Iterator[AbstractCapability[Any]]:
+    """Recursively yield all leaf capabilities."""
+    from .combined import CombinedCapability
+
+    if isinstance(cap, CombinedCapability):
+        for child in cap.capabilities:
+            yield from iter_leaves(child)
+    else:
+        yield cap
+
+
+def _collect_leaf_types(cap: AbstractCapability[Any]) -> set[type]:
+    return {type(leaf) for leaf in iter_leaves(cap)}

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import heapq
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
+from graphlib import CycleError, TopologicalSorter
 from typing import TYPE_CHECKING, Any
 
 from pydantic_ai.exceptions import UserError
@@ -13,8 +13,6 @@ from .abstract import AbstractCapability, CapabilityOrdering
 if TYPE_CHECKING:
     from .abstract import CapabilityPosition
 
-_AddEdge = Callable[[int, int], None]
-
 
 def sort_capabilities(
     capabilities: Sequence[AbstractCapability[Any]],
@@ -22,7 +20,7 @@ def sort_capabilities(
     """Sort capabilities to satisfy ordering constraints.
 
     Preserves the original order as a tiebreaker when constraints allow.
-    Raises `UserError` on conflicts (duplicate positions, missing requirements, cycles).
+    Raises `UserError` on conflicts (missing requirements, cycles).
     """
     caps = list(capabilities)
     n = len(caps)
@@ -32,14 +30,12 @@ def sort_capabilities(
     orderings: list[CapabilityOrdering | None] = [_effective_ordering(cap) for cap in caps]
     leaf_types: list[set[type]] = [_collect_leaf_types(cap) for cap in caps]
 
-    _validate_constraints(caps, orderings, leaf_types)
+    _validate_requires(caps, orderings, leaf_types)
 
-    edges, in_degree = _build_dag(caps, orderings, leaf_types)
-
-    return _topo_sort(caps, edges, in_degree)
+    return _topo_sort(caps, orderings, leaf_types)
 
 
-def _validate_constraints(
+def _validate_requires(
     caps: list[AbstractCapability[Any]],
     orderings: list[CapabilityOrdering | None],
     leaf_types: list[set[type]],
@@ -56,97 +52,74 @@ def _validate_constraints(
                     )
 
 
-def _build_dag(
+def _topo_sort(
     caps: list[AbstractCapability[Any]],
     orderings: list[CapabilityOrdering | None],
     leaf_types: list[set[type]],
-) -> tuple[dict[int, set[int]], dict[int, int]]:
-    """Build a DAG from position and wraps/wrapped_by constraints."""
+) -> list[AbstractCapability[Any]]:
+    """Topological sort using graphlib.TopologicalSorter.
+
+    Edges go from outer (earlier) to inner (later). TopologicalSorter
+    preserves insertion order as tiebreaker for unconstrained nodes.
+    """
     n = len(caps)
-    edges: dict[int, set[int]] = {i: set() for i in range(n)}
-    in_degree: dict[int, int] = {i: 0 for i in range(n)}
+    ts: TopologicalSorter[int] = TopologicalSorter()
 
-    def add_edge(outer: int, inner: int) -> None:
-        if inner not in edges[outer]:
-            edges[outer].add(inner)
-            in_degree[inner] += 1
+    # Add all nodes in original order (establishes tiebreaker)
+    for i in range(n):
+        ts.add(i)
 
-    _add_position_edges(n, orderings, add_edge)
-    _add_relative_edges(n, orderings, leaf_types, add_edge)
+    _add_position_edges(ts, n, orderings)
+    _add_relative_edges(ts, n, orderings, leaf_types)
 
-    return edges, in_degree
+    try:
+        sorted_indices = list(ts.static_order())
+    except CycleError:
+        raise UserError('Circular ordering constraints among capabilities')
+
+    return [caps[i] for i in sorted_indices]
 
 
 def _add_position_edges(
+    ts: TopologicalSorter[int],
     n: int,
     orderings: list[CapabilityOrdering | None],
-    add_edge: _AddEdge,
 ) -> None:
     outermost = {i for i, o in enumerate(orderings) if o and o.position == 'outermost'}
     innermost = {i for i, o in enumerate(orderings) if o and o.position == 'innermost'}
 
-    # Outermost tier: each member gets edges to all non-members.
-    # No edges within the tier — wraps/wrapped_by and the min-heap
-    # tiebreaker (original list index) determine order within.
+    # Outermost tier: each member must come before all non-members.
     for oi in outermost:
         for j in range(n):
             if j != oi and j not in outermost:
-                add_edge(oi, j)
+                ts.add(j, oi)  # j depends on oi (oi comes first)
 
-    # Innermost tier: each member gets edges from all non-members.
+    # Innermost tier: each member must come after all non-members.
     for ii in innermost:
         for j in range(n):
             if j != ii and j not in innermost:
-                add_edge(j, ii)
+                ts.add(ii, j)  # ii depends on j (j comes first)
 
 
 def _add_relative_edges(
+    ts: TopologicalSorter[int],
     n: int,
     orderings: list[CapabilityOrdering | None],
     leaf_types: list[set[type]],
-    add_edge: _AddEdge,
 ) -> None:
     for i, ordering in enumerate(orderings):
         if not ordering:
             continue
-        # wraps=[X] → I wrap around X → edge from me (outer) to X (inner)
+        # wraps=[X] → I come before X
         for wraps_type in ordering.wraps:
             for j in range(n):
                 if i != j and any(issubclass(t, wraps_type) for t in leaf_types[j]):
-                    add_edge(i, j)
-        # wrapped_by=[X] → X wraps around me → edge from X (outer) to me (inner)
+                    ts.add(j, i)  # j depends on i (i comes first)
+        # wrapped_by=[X] → X comes before me
         for wrapped_by_type in ordering.wrapped_by:
             for j in range(n):
                 if i != j and any(issubclass(t, wrapped_by_type) for t in leaf_types[j]):
-                    add_edge(j, i)
-
-
-def _topo_sort(
-    caps: list[AbstractCapability[Any]],
-    edges: dict[int, set[int]],
-    in_degree: dict[int, int],
-) -> list[AbstractCapability[Any]]:
-    """Kahn's algorithm with original-index tiebreaking for stability."""
-    n = len(caps)
-    queue: list[int] = []
-    for i in range(n):
-        if in_degree[i] == 0:
-            heapq.heappush(queue, i)
-
-    result: list[AbstractCapability[Any]] = []
-    while queue:
-        i = heapq.heappop(queue)
-        result.append(caps[i])
-        for j in edges[i]:
-            in_degree[j] -= 1
-            if in_degree[j] == 0:
-                heapq.heappush(queue, j)
-
-    if len(result) != n:
-        remaining = [type(caps[i]).__name__ for i in range(n) if in_degree[i] > 0]
-        raise UserError(f'Circular ordering constraints among capabilities: {", ".join(remaining)}')
-
-    return result
+                    ts.add(i, j)  # i depends on j (j comes first)
 
 
 def _effective_ordering(cap: AbstractCapability[Any]) -> CapabilityOrdering | None:

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
@@ -41,17 +41,7 @@ def _validate_constraints(
     orderings: list[CapabilityOrdering | None],
     leaf_types: list[set[type]],
 ) -> None:
-    """Validate position uniqueness and required dependencies."""
-    outermost = [i for i, o in enumerate(orderings) if o and o.position == 'outermost']
-    innermost = [i for i, o in enumerate(orderings) if o and o.position == 'innermost']
-
-    if len(outermost) > 1:
-        names = [type(caps[i]).__name__ for i in outermost]
-        raise UserError(f"Multiple capabilities declare position 'outermost': {', '.join(names)}")
-    if len(innermost) > 1:
-        names = [type(caps[i]).__name__ for i in innermost]
-        raise UserError(f"Multiple capabilities declare position 'innermost': {', '.join(names)}")
-
+    """Validate required dependencies."""
     all_leaf_types: set[type] = set[type]().union(*leaf_types)
     for i, ordering in enumerate(orderings):
         if ordering and ordering.requires:
@@ -89,18 +79,21 @@ def _add_position_edges(
     orderings: list[CapabilityOrdering | None],
     add_edge: _AddEdge,
 ) -> None:
-    outermost = [i for i, o in enumerate(orderings) if o and o.position == 'outermost']
-    innermost = [i for i, o in enumerate(orderings) if o and o.position == 'innermost']
+    outermost = {i for i, o in enumerate(orderings) if o and o.position == 'outermost'}
+    innermost = {i for i, o in enumerate(orderings) if o and o.position == 'innermost'}
 
-    if outermost:
-        oi = outermost[0]
+    # Outermost tier: each member gets edges to all non-members.
+    # No edges within the tier — wraps/wrapped_by and the min-heap
+    # tiebreaker (original list index) determine order within.
+    for oi in outermost:
         for j in range(n):
-            if j != oi:
+            if j != oi and j not in outermost:
                 add_edge(oi, j)
-    if innermost:
-        ii = innermost[0]
+
+    # Innermost tier: each member gets edges from all non-members.
+    for ii in innermost:
         for j in range(n):
-            if j != ii:
+            if j != ii and j not in innermost:
                 add_edge(j, ii)
 
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
@@ -147,10 +147,15 @@ def _topo_sort(
 
 
 def _effective_ordering(cap: AbstractCapability[Any]) -> CapabilityOrdering | None:
-    """Get the effective ordering for a capability, merging from leaves for nested groups."""
-    from .combined import CombinedCapability
+    """Get the effective ordering for a capability, merging from leaves for nested groups.
 
-    if not isinstance(cap, CombinedCapability):
+    For plain capabilities, returns ``get_ordering()`` directly. For containers
+    (``CombinedCapability``, ``WrapperCapability``), merges constraints from all leaves.
+    """
+    from .combined import CombinedCapability
+    from .wrapper import WrapperCapability
+
+    if not isinstance(cap, (CombinedCapability, WrapperCapability)):
         return type(cap).get_ordering()
 
     merged_position: CapabilityPosition | None = None
@@ -165,6 +170,10 @@ def _effective_ordering(cap: AbstractCapability[Any]) -> CapabilityOrdering | No
             continue
         has_any = True
         if ordering.position is not None:
+            if merged_position is not None and merged_position != ordering.position:
+                raise UserError(
+                    f'Conflicting positions in nested CombinedCapability: {merged_position!r} and {ordering.position!r}'
+                )
             merged_position = ordering.position
         merged_wraps.extend(ordering.wraps)
         merged_wrapped_by.extend(ordering.wrapped_by)
@@ -181,12 +190,21 @@ def _effective_ordering(cap: AbstractCapability[Any]) -> CapabilityOrdering | No
 
 
 def iter_leaves(cap: AbstractCapability[Any]) -> Iterator[AbstractCapability[Any]]:
-    """Recursively yield all leaf capabilities."""
+    """Recursively yield all leaf capabilities.
+
+    Recurses through both [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability]
+    (which aggregates children) and [`WrapperCapability`][pydantic_ai.capabilities.WrapperCapability]
+    (which delegates to a wrapped capability), consistent with
+    [`apply`][pydantic_ai.capabilities.AbstractCapability.apply].
+    """
     from .combined import CombinedCapability
+    from .wrapper import WrapperCapability
 
     if isinstance(cap, CombinedCapability):
         for child in cap.capabilities:
             yield from iter_leaves(child)
+    elif isinstance(cap, WrapperCapability):
+        yield from iter_leaves(cap.wrapped)
     else:
         yield cap
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import heapq
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 
 from pydantic_ai.exceptions import UserError
@@ -19,7 +19,7 @@ def sort_capabilities(
     """Sort capabilities to satisfy ordering constraints.
 
     Preserves the original order as a tiebreaker when constraints allow.
-    Raises ``UserError`` on conflicts (duplicate positions, missing requirements, cycles).
+    Raises `UserError` on conflicts (duplicate positions, missing requirements, cycles).
     """
     caps = list(capabilities)
     n = len(caps)
@@ -147,24 +147,19 @@ def _topo_sort(
 
 
 def _effective_ordering(cap: AbstractCapability[Any]) -> CapabilityOrdering | None:
-    """Get the effective ordering for a capability, merging from leaves for nested groups.
+    """Get the effective ordering for a capability, merging from all leaves.
 
-    For plain capabilities, returns ``get_ordering()`` directly. For containers
-    (``CombinedCapability``, ``WrapperCapability``), merges constraints from all leaves.
+    For plain capabilities (single leaf), returns `get_ordering()` directly.
+    For containers (`CombinedCapability`, `WrapperCapability`), merges
+    constraints from all leaves via `apply`.
     """
-    from .combined import CombinedCapability
-    from .wrapper import WrapperCapability
-
-    if not isinstance(cap, (CombinedCapability, WrapperCapability)):
-        return type(cap).get_ordering()
-
     merged_position: CapabilityPosition | None = None
     merged_wraps: list[type[AbstractCapability[Any]]] = []
     merged_wrapped_by: list[type[AbstractCapability[Any]]] = []
     merged_requires: list[type[AbstractCapability[Any]]] = []
     has_any = False
 
-    for leaf in iter_leaves(cap):
+    for leaf in collect_leaves(cap):
         ordering = type(leaf).get_ordering()
         if ordering is None:
             continue
@@ -189,25 +184,12 @@ def _effective_ordering(cap: AbstractCapability[Any]) -> CapabilityOrdering | No
     )
 
 
-def iter_leaves(cap: AbstractCapability[Any]) -> Iterator[AbstractCapability[Any]]:
-    """Recursively yield all leaf capabilities.
-
-    Recurses through both [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability]
-    (which aggregates children) and [`WrapperCapability`][pydantic_ai.capabilities.WrapperCapability]
-    (which delegates to a wrapped capability), consistent with
-    [`apply`][pydantic_ai.capabilities.AbstractCapability.apply].
-    """
-    from .combined import CombinedCapability
-    from .wrapper import WrapperCapability
-
-    if isinstance(cap, CombinedCapability):
-        for child in cap.capabilities:
-            yield from iter_leaves(child)
-    elif isinstance(cap, WrapperCapability):
-        yield from iter_leaves(cap.wrapped)
-    else:
-        yield cap
+def collect_leaves(cap: AbstractCapability[Any]) -> list[AbstractCapability[Any]]:
+    """Collect all leaf capabilities using the `apply` visitor pattern."""
+    leaves: list[AbstractCapability[Any]] = []
+    cap.apply(leaves.append)
+    return leaves
 
 
 def _collect_leaf_types(cap: AbstractCapability[Any]) -> set[type]:
-    return {type(leaf) for leaf in iter_leaves(cap)}
+    return {type(leaf) for leaf in collect_leaves(cap)}

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -56,10 +56,10 @@ WrapToolExecuteHandler: TypeAlias = 'Callable[[dict[str, Any]], Awaitable[Any]]'
 CapabilityPosition = Literal['outermost', 'innermost']
 """Position tier for a capability in the middleware chain.
 
-- ``'outermost'``: in the outermost tier, before all non-outermost capabilities.
-  Multiple capabilities can declare ``'outermost'``; original list order breaks ties
-  within the tier, and ``wraps``/``wrapped_by`` edges refine order further.
-- ``'innermost'``: in the innermost tier, after all non-innermost capabilities.
+- `'outermost'`: in the outermost tier, before all non-outermost capabilities.
+  Multiple capabilities can declare `'outermost'`; original list order breaks ties
+  within the tier, and `wraps`/`wrapped_by` edges refine order further.
+- `'innermost'`: in the innermost tier, after all non-innermost capabilities.
   Same tie-breaking rules apply.
 """
 
@@ -79,7 +79,7 @@ class CapabilityOrdering:
     """
 
     position: CapabilityPosition | None = None
-    """Fixed position in the chain, or ``None`` for user-provided order."""
+    """Fixed position in the chain, or `None` for user-provided order."""
 
     wraps: Sequence[type[AbstractCapability[Any]]] = field(default_factory=tuple)
     """This capability wraps around (is outside of) these types in the middleware chain."""
@@ -154,11 +154,11 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
 
     @classmethod
     def get_ordering(cls) -> CapabilityOrdering | None:
-        """Return ordering constraints for this capability, or ``None`` for default behavior.
+        """Return ordering constraints for this capability, or `None` for default behavior.
 
-        Override to declare a fixed position (``'outermost'`` / ``'innermost'``),
-        relative ordering (``wraps`` / ``wrapped_by`` other capability types),
-        or dependency requirements (``requires``).
+        Override to declare a fixed position (`'outermost'` / `'innermost'`),
+        relative ordering (`wraps` / `wrapped_by` other capability types),
+        or dependency requirements (`requires`).
 
         [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability] uses
         these to topologically sort its children at construction time.
@@ -216,7 +216,7 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         Unlike the other `get_*` methods which are called once at agent construction,
         this is called each run (after [`for_run`][pydantic_ai.capabilities.AbstractCapability.for_run]).
         When multiple capabilities provide wrappers, they follow middleware semantics:
-        the first capability in the list wraps outermost (matching ``wrap_*`` hooks).
+        the first capability in the list wraps outermost (matching `wrap_*` hooks).
 
         Use this to apply cross-cutting toolset wrappers like
         [`PreparedToolset`][pydantic_ai.toolsets.PreparedToolset],

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import AsyncIterable, Awaitable, Callable, Sequence
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, TypeAlias
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias
 
 from pydantic import ValidationError
 
@@ -51,6 +51,41 @@ WrapToolValidateHandler: TypeAlias = 'Callable[[str | dict[str, Any]], Awaitable
 
 WrapToolExecuteHandler: TypeAlias = 'Callable[[dict[str, Any]], Awaitable[Any]]'
 """Handler type for [`wrap_tool_execute`][pydantic_ai.capabilities.AbstractCapability.wrap_tool_execute]."""
+
+
+CapabilityPosition = Literal['outermost', 'innermost']
+"""Fixed position for a capability in the middleware chain.
+
+- ``'outermost'``: first in the chain, wraps all other capabilities (e.g. instrumentation).
+- ``'innermost'``: last in the chain, closest to the handler (e.g. durable execution).
+"""
+
+
+@dataclass
+class CapabilityOrdering:
+    """Ordering constraints for a capability within a combined capability chain.
+
+    Capabilities follow middleware semantics: the first capability in the list is the
+    **outermost** layer, wrapping all others. Declare ordering constraints via
+    [`get_ordering`][pydantic_ai.capabilities.AbstractCapability.get_ordering]
+    to control a capability's position in the chain regardless of how the user lists them.
+
+    When a [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability] is
+    constructed, it topologically sorts its children to satisfy these constraints,
+    preserving user-provided order as a tiebreaker.
+    """
+
+    position: CapabilityPosition | None = None
+    """Fixed position in the chain, or ``None`` for user-provided order."""
+
+    wraps: Sequence[type[AbstractCapability[Any]]] = field(default_factory=tuple)
+    """This capability wraps around (is outside of) these types in the middleware chain."""
+
+    wrapped_by: Sequence[type[AbstractCapability[Any]]] = field(default_factory=tuple)
+    """This capability is wrapped by (is inside of) these types in the middleware chain."""
+
+    requires: Sequence[type[AbstractCapability[Any]]] = field(default_factory=tuple)
+    """These types must be present in the chain (no ordering implied)."""
 
 
 @dataclass
@@ -114,6 +149,19 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         """
         return cls(*args, **kwargs)
 
+    @classmethod
+    def get_ordering(cls) -> CapabilityOrdering | None:
+        """Return ordering constraints for this capability, or ``None`` for default behavior.
+
+        Override to declare a fixed position (``'outermost'`` / ``'innermost'``),
+        relative ordering (``wraps`` / ``wrapped_by`` other capability types),
+        or dependency requirements (``requires``).
+
+        [`CombinedCapability`][pydantic_ai.capabilities.CombinedCapability] uses
+        these to topologically sort its children at construction time.
+        """
+        return None
+
     async def for_run(self, ctx: RunContext[AgentDepsT]) -> AbstractCapability[AgentDepsT]:
         """Return the capability instance to use for this agent run.
 
@@ -164,8 +212,8 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
 
         Unlike the other `get_*` methods which are called once at agent construction,
         this is called each run (after [`for_run`][pydantic_ai.capabilities.AbstractCapability.for_run]).
-        When multiple capabilities provide wrappers, each receives the already-wrapped
-        toolset from earlier capabilities (first capability wraps innermost).
+        When multiple capabilities provide wrappers, they follow middleware semantics:
+        the first capability in the list wraps outermost (matching ``wrap_*`` hooks).
 
         Use this to apply cross-cutting toolset wrappers like
         [`PreparedToolset`][pydantic_ai.toolsets.PreparedToolset],

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -54,10 +54,13 @@ WrapToolExecuteHandler: TypeAlias = 'Callable[[dict[str, Any]], Awaitable[Any]]'
 
 
 CapabilityPosition = Literal['outermost', 'innermost']
-"""Fixed position for a capability in the middleware chain.
+"""Position tier for a capability in the middleware chain.
 
-- ``'outermost'``: first in the chain, wraps all other capabilities (e.g. instrumentation).
-- ``'innermost'``: last in the chain, closest to the handler (e.g. durable execution).
+- ``'outermost'``: in the outermost tier, before all non-outermost capabilities.
+  Multiple capabilities can declare ``'outermost'``; original list order breaks ties
+  within the tier, and ``wraps``/``wrapped_by`` edges refine order further.
+- ``'innermost'``: in the innermost tier, after all non-innermost capabilities.
+  Same tie-breaking rules apply.
 """
 
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import AsyncIterable, Awaitable, Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias
 
 from pydantic import ValidationError
@@ -81,13 +81,13 @@ class CapabilityOrdering:
     position: CapabilityPosition | None = None
     """Fixed position in the chain, or `None` for user-provided order."""
 
-    wraps: Sequence[type[AbstractCapability[Any]]] = field(default_factory=tuple)
+    wraps: Sequence[type[AbstractCapability[Any]]] = ()
     """This capability wraps around (is outside of) these types in the middleware chain."""
 
-    wrapped_by: Sequence[type[AbstractCapability[Any]]] = field(default_factory=tuple)
+    wrapped_by: Sequence[type[AbstractCapability[Any]]] = ()
     """This capability is wrapped by (is inside of) these types in the middleware chain."""
 
-    requires: Sequence[type[AbstractCapability[Any]]] = field(default_factory=tuple)
+    requires: Sequence[type[AbstractCapability[Any]]] = ()
     """These types must be present in the chain (no ordering implied)."""
 
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -16,6 +16,7 @@ from pydantic_ai.tools import AgentBuiltinTool, AgentDepsT, RunContext, ToolDefi
 from pydantic_ai.toolsets import AbstractToolset, AgentToolset, CombinedToolset
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
+from ._ordering import collect_leaves, sort_capabilities
 from .abstract import AbstractCapability
 
 if TYPE_CHECKING:
@@ -33,8 +34,6 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     capabilities: Sequence[AbstractCapability[AgentDepsT]]
 
     def __post_init__(self) -> None:
-        from ._ordering import collect_leaves, sort_capabilities
-
         if any(type(leaf).get_ordering() is not None for leaf in collect_leaves(self)):
             self.capabilities = sort_capabilities(list(self.capabilities))
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -32,6 +32,12 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
 
     capabilities: Sequence[AbstractCapability[AgentDepsT]]
 
+    def __post_init__(self) -> None:
+        from ._ordering import iter_leaves, sort_capabilities
+
+        if any(type(leaf).get_ordering() is not None for leaf in iter_leaves(self)):
+            self.capabilities = sort_capabilities(list(self.capabilities))
+
     def apply(self, visitor: Callable[[AbstractCapability[AgentDepsT]], None]) -> None:
         for cap in self.capabilities:
             cap.apply(visitor)
@@ -109,7 +115,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     def get_wrapper_toolset(self, toolset: AbstractToolset[AgentDepsT]) -> AbstractToolset[AgentDepsT] | None:
         wrapped = toolset
         any_wrapped = False
-        for capability in self.capabilities:
+        for capability in reversed(self.capabilities):
             result = capability.get_wrapper_toolset(wrapped)
             if result is not None:
                 wrapped = result

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -33,9 +33,9 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
     capabilities: Sequence[AbstractCapability[AgentDepsT]]
 
     def __post_init__(self) -> None:
-        from ._ordering import iter_leaves, sort_capabilities
+        from ._ordering import collect_leaves, sort_capabilities
 
-        if any(type(leaf).get_ordering() is not None for leaf in iter_leaves(self)):
+        if any(type(leaf).get_ordering() is not None for leaf in collect_leaves(self)):
             self.capabilities = sort_capabilities(list(self.capabilities))
 
     def apply(self, visitor: Callable[[AbstractCapability[AgentDepsT]], None]) -> None:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -20,6 +20,7 @@ from pydantic_ai.capabilities import (
     CAPABILITY_TYPES,
     MCP,
     BuiltinTool,
+    CapabilityOrdering,
     ImageGeneration,
     IncludeToolReturnSchemas,
     PrefixTools,
@@ -30,9 +31,8 @@ from pydantic_ai.capabilities import (
     WebFetch,
     WebSearch,
     WrapperCapability,
-    sort_capabilities,
 )
-from pydantic_ai.capabilities.abstract import AbstractCapability, CapabilityOrdering
+from pydantic_ai.capabilities.abstract import AbstractCapability
 from pydantic_ai.capabilities.builtin_tool import BuiltinTool as BuiltinToolCap
 from pydantic_ai.capabilities.combined import CombinedCapability
 from pydantic_ai.capabilities.hooks import Hooks, HookTimeoutError
@@ -8483,23 +8483,27 @@ class RequiresOutermostCap(AbstractCapability[Any]):
         return CapabilityOrdering(requires=[OutermostCap])
 
 
+def _cap_names(combined: CombinedCapability) -> list[str]:
+    return [type(c).__name__ for c in combined.capabilities]
+
+
 def test_ordering_outermost():
     """Capability declaring 'outermost' ends up at index 0."""
-    caps = sort_capabilities([PlainCapA(), OutermostCap(), PlainCapB()])
-    assert [type(c).__name__ for c in caps] == ['OutermostCap', 'PlainCapA', 'PlainCapB']
+    combined = CombinedCapability([PlainCapA(), OutermostCap(), PlainCapB()])
+    assert _cap_names(combined) == ['OutermostCap', 'PlainCapA', 'PlainCapB']
 
 
 def test_ordering_innermost():
     """Capability declaring 'innermost' ends up last."""
-    caps = sort_capabilities([InnermostCap(), PlainCapA(), PlainCapB()])
-    assert [type(c).__name__ for c in caps] == ['PlainCapA', 'PlainCapB', 'InnermostCap']
+    combined = CombinedCapability([InnermostCap(), PlainCapA(), PlainCapB()])
+    assert _cap_names(combined) == ['PlainCapA', 'PlainCapB', 'InnermostCap']
 
 
 def test_ordering_both_outermost_and_innermost():
     """Both outermost and innermost present."""
-    caps = sort_capabilities([PlainCapA(), InnermostCap(), OutermostCap()])
-    assert caps[0].__class__ is OutermostCap
-    assert caps[-1].__class__ is InnermostCap
+    combined = CombinedCapability([PlainCapA(), InnermostCap(), OutermostCap()])
+    assert combined.capabilities[0].__class__ is OutermostCap
+    assert combined.capabilities[-1].__class__ is InnermostCap
 
 
 def test_ordering_multiple_outermost_tier():
@@ -8511,10 +8515,9 @@ def test_ordering_multiple_outermost_tier():
         def get_ordering(cls) -> CapabilityOrdering:
             return CapabilityOrdering(position='outermost')
 
-    caps = sort_capabilities([PlainCapA(), OutermostCap2(), OutermostCap()])
-    names = [type(c).__name__ for c in caps]
+    combined = CombinedCapability([PlainCapA(), OutermostCap2(), OutermostCap()])
     # Both outermost caps before PlainCapA; original order (OutermostCap2 before OutermostCap) preserved
-    assert names == ['OutermostCap2', 'OutermostCap', 'PlainCapA']
+    assert _cap_names(combined) == ['OutermostCap2', 'OutermostCap', 'PlainCapA']
 
 
 def test_ordering_multiple_innermost_tier():
@@ -8526,10 +8529,9 @@ def test_ordering_multiple_innermost_tier():
         def get_ordering(cls) -> CapabilityOrdering:
             return CapabilityOrdering(position='innermost')
 
-    caps = sort_capabilities([InnermostCap(), InnermostCap2(), PlainCapA()])
-    names = [type(c).__name__ for c in caps]
+    combined = CombinedCapability([InnermostCap(), InnermostCap2(), PlainCapA()])
     # PlainCapA first, then both innermost in original order
-    assert names == ['PlainCapA', 'InnermostCap', 'InnermostCap2']
+    assert _cap_names(combined) == ['PlainCapA', 'InnermostCap', 'InnermostCap2']
 
 
 def test_ordering_outermost_tier_with_wraps():
@@ -8548,15 +8550,14 @@ def test_ordering_outermost_tier_with_wraps():
             return CapabilityOrdering(position='outermost', wraps=[OuterA])
 
     # OuterB listed after OuterA, but wraps=[OuterA] overrides tiebreaker
-    caps = sort_capabilities([OuterA(), PlainCapA(), OuterB()])
-    names = [type(c).__name__ for c in caps]
-    assert names == ['OuterB', 'OuterA', 'PlainCapA']
+    combined = CombinedCapability([OuterA(), PlainCapA(), OuterB()])
+    assert _cap_names(combined) == ['OuterB', 'OuterA', 'PlainCapA']
 
 
 def test_ordering_wraps():
     """Explicit 'wraps' edge is respected."""
-    caps = sort_capabilities([PlainCapA(), WrapsACap()])
-    assert [type(c).__name__ for c in caps] == ['WrapsACap', 'PlainCapA']
+    combined = CombinedCapability([PlainCapA(), WrapsACap()])
+    assert _cap_names(combined) == ['WrapsACap', 'PlainCapA']
 
 
 def test_ordering_wrapped_by():
@@ -8568,25 +8569,26 @@ def test_ordering_wrapped_by():
         def get_ordering(cls) -> CapabilityOrdering:
             return CapabilityOrdering(wrapped_by=[PlainCapA])
 
-    caps = sort_capabilities([WrappedByACap(), PlainCapA()])
-    assert [type(c).__name__ for c in caps] == ['PlainCapA', 'WrappedByACap']
+    combined = CombinedCapability([WrappedByACap(), PlainCapA()])
+    assert _cap_names(combined) == ['PlainCapA', 'WrappedByACap']
 
 
 def test_ordering_requires_present():
     """No error when required capability is present."""
-    caps = sort_capabilities([RequiresOutermostCap(), OutermostCap()])
-    assert len(caps) == 2
+    combined = CombinedCapability([RequiresOutermostCap(), OutermostCap()])
+    assert len(combined.capabilities) == 2
 
 
 def test_ordering_requires_missing():
     with pytest.raises(UserError, match='`RequiresOutermostCap` requires `OutermostCap`'):
-        sort_capabilities([RequiresOutermostCap(), PlainCapA()])
+        CombinedCapability([RequiresOutermostCap(), PlainCapA()])
 
 
 def test_ordering_preserves_user_order():
     """Capabilities without constraints keep their relative order."""
-    caps = sort_capabilities([PlainCapB(), PlainCapA()])
-    assert [type(c).__name__ for c in caps] == ['PlainCapB', 'PlainCapA']
+    a, b = PlainCapB(), PlainCapA()
+    combined = CombinedCapability([a, b])
+    assert list(combined.capabilities) == [a, b]
 
 
 def test_ordering_nested_combined():
@@ -8600,17 +8602,17 @@ def test_ordering_nested_combined():
     # The merged effective ordering for 'inner' should be position='outermost',
     # placing it before PlainCapA despite being listed second.
     inner = CombinedCapability([PlainCapB(), OutermostCap()])
-    caps = sort_capabilities([PlainCapA(), inner])
-    assert caps[0] is inner
+    combined = CombinedCapability([PlainCapA(), inner])
+    assert combined.capabilities[0] is inner
 
 
 def test_ordering_nested_combined_no_constraints():
     """A nested CombinedCapability with no ordering leaves is treated as unconstrained."""
     inner = CombinedCapability([PlainCapA(), PlainCapB()])
-    outer_caps = sort_capabilities([inner, OutermostCap()])
+    combined = CombinedCapability([inner, OutermostCap()])
     # OutermostCap first (has ordering), inner second (no constraints → unconstrained)
-    assert outer_caps[0].__class__ is OutermostCap
-    assert outer_caps[1] is inner
+    assert combined.capabilities[0].__class__ is OutermostCap
+    assert combined.capabilities[1] is inner
 
 
 def test_ordering_nested_combined_wraps_without_position():
@@ -8618,23 +8620,23 @@ def test_ordering_nested_combined_wraps_without_position():
     inner = CombinedCapability([PlainCapB(), WrapsACap()])
     # WrapsACap has wraps=[PlainCapA] but no position.
     # The nested group inherits that constraint, so it sorts before PlainCapA.
-    caps = sort_capabilities([PlainCapA(), inner])
-    assert caps[0] is inner
-    assert caps[1].__class__ is PlainCapA
+    combined = CombinedCapability([PlainCapA(), inner])
+    assert combined.capabilities[0] is inner
+    assert combined.capabilities[1].__class__ is PlainCapA
 
 
 def test_ordering_single_capability():
-    """sort_capabilities with a single capability returns it unchanged."""
+    """Single capability in CombinedCapability is unchanged."""
     cap = OutermostCap()
-    caps = sort_capabilities([cap])
-    assert caps == [cap]
+    combined = CombinedCapability([cap])
+    assert list(combined.capabilities) == [cap]
 
 
 def test_ordering_no_constraints_noop():
     """When no capability declares ordering, list is unchanged."""
     a, b = PlainCapA(), PlainCapB()
-    caps = sort_capabilities([a, b])
-    assert caps == [a, b]
+    combined = CombinedCapability([a, b])
+    assert list(combined.capabilities) == [a, b]
 
 
 def test_ordering_cycle_detection():
@@ -8651,22 +8653,14 @@ def test_ordering_cycle_detection():
             return CapabilityOrdering(wraps=[CycleA])
 
     with pytest.raises(UserError, match='Circular ordering constraints'):
-        sort_capabilities([CycleA(), CycleB()])
-
-
-def test_ordering_via_combined_capability():
-    """CombinedCapability.__post_init__ auto-sorts when constraints exist."""
-    combined = CombinedCapability([PlainCapA(), InnermostCap(), OutermostCap()])
-    names = [type(c).__name__ for c in combined.capabilities]
-    assert names[0] == 'OutermostCap'
-    assert names[-1] == 'InnermostCap'
+        CombinedCapability([CycleA(), CycleB()])
 
 
 def test_ordering_conflicting_positions_in_nested():
     """Conflicting positions in a nested CombinedCapability raise UserError."""
     inner = CombinedCapability([OutermostCap(), InnermostCap()])
     with pytest.raises(UserError, match='Conflicting positions in nested CombinedCapability'):
-        sort_capabilities([inner, PlainCapA()])
+        CombinedCapability([inner, PlainCapA()])
 
 
 def test_ordering_wrapper_capability_recurses():
@@ -8674,8 +8668,8 @@ def test_ordering_wrapper_capability_recurses():
     wrapped = WrapperCapability(wrapped=OutermostCap())
     # The WrapperCapability wraps an OutermostCap; ordering sees through via apply()
     # and picks up OutermostCap's position='outermost' constraint.
-    caps = sort_capabilities([PlainCapA(), wrapped])
-    assert caps[0] is wrapped
+    combined = CombinedCapability([PlainCapA(), wrapped])
+    assert combined.capabilities[0] is wrapped
 
 
 # --- Hook recovery tests (after_node_run End→node, ErrorMarker in next_node) ---

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -30,8 +30,8 @@ from pydantic_ai.capabilities import (
     WebFetch,
     WebSearch,
     WrapperCapability,
+    sort_capabilities,
 )
-from pydantic_ai.capabilities._ordering import sort_capabilities
 from pydantic_ai.capabilities.abstract import AbstractCapability, CapabilityOrdering
 from pydantic_ai.capabilities.builtin_tool import BuiltinTool as BuiltinToolCap
 from pydantic_ai.capabilities.combined import CombinedCapability
@@ -8660,6 +8660,22 @@ def test_ordering_via_combined_capability():
     names = [type(c).__name__ for c in combined.capabilities]
     assert names[0] == 'OutermostCap'
     assert names[-1] == 'InnermostCap'
+
+
+def test_ordering_conflicting_positions_in_nested():
+    """Conflicting positions in a nested CombinedCapability raise UserError."""
+    inner = CombinedCapability([OutermostCap(), InnermostCap()])
+    with pytest.raises(UserError, match='Conflicting positions in nested CombinedCapability'):
+        sort_capabilities([inner, PlainCapA()])
+
+
+def test_ordering_wrapper_capability_recurses():
+    """iter_leaves recurses through WrapperCapability, so ordering constraints are preserved."""
+    wrapped = WrapperCapability(wrapped=OutermostCap())
+    # The WrapperCapability wraps an OutermostCap; iter_leaves should see through
+    # and pick up OutermostCap's position='outermost' constraint.
+    caps = sort_capabilities([PlainCapA(), wrapped])
+    assert caps[0] is wrapped
 
 
 # --- Hook recovery tests (after_node_run End→node, ErrorMarker in next_node) ---

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -8670,10 +8670,10 @@ def test_ordering_conflicting_positions_in_nested():
 
 
 def test_ordering_wrapper_capability_recurses():
-    """iter_leaves recurses through WrapperCapability, so ordering constraints are preserved."""
+    """Ordering constraints on capabilities inside a WrapperCapability are preserved."""
     wrapped = WrapperCapability(wrapped=OutermostCap())
-    # The WrapperCapability wraps an OutermostCap; iter_leaves should see through
-    # and pick up OutermostCap's position='outermost' constraint.
+    # The WrapperCapability wraps an OutermostCap; ordering sees through via apply()
+    # and picks up OutermostCap's position='outermost' constraint.
     caps = sort_capabilities([PlainCapA(), wrapped])
     assert caps[0] is wrapped
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -8590,10 +8590,44 @@ def test_ordering_preserves_user_order():
 
 
 def test_ordering_nested_combined():
-    """Outermost inside a nested CombinedCapability bubbles up."""
-    inner = CombinedCapability([OutermostCap()])
+    """Ordering from leaves inside a nested CombinedCapability is respected.
+
+    When a CombinedCapability is nested inside another, its leaves' ordering
+    constraints are merged and applied to the outer sort. Leaves without
+    ordering constraints are skipped during the merge.
+    """
+    # OutermostCap declares position='outermost'; PlainCapB has no ordering.
+    # The merged effective ordering for 'inner' should be position='outermost',
+    # placing it before PlainCapA despite being listed second.
+    inner = CombinedCapability([PlainCapB(), OutermostCap()])
     caps = sort_capabilities([PlainCapA(), inner])
     assert caps[0] is inner
+
+
+def test_ordering_nested_combined_no_constraints():
+    """A nested CombinedCapability with no ordering leaves is treated as unconstrained."""
+    inner = CombinedCapability([PlainCapA(), PlainCapB()])
+    outer_caps = sort_capabilities([inner, OutermostCap()])
+    # OutermostCap first (has ordering), inner second (no constraints → unconstrained)
+    assert outer_caps[0].__class__ is OutermostCap
+    assert outer_caps[1] is inner
+
+
+def test_ordering_nested_combined_wraps_without_position():
+    """A nested CombinedCapability with wraps constraints (but no position) merges correctly."""
+    inner = CombinedCapability([PlainCapB(), WrapsACap()])
+    # WrapsACap has wraps=[PlainCapA] but no position.
+    # The nested group inherits that constraint, so it sorts before PlainCapA.
+    caps = sort_capabilities([PlainCapA(), inner])
+    assert caps[0] is inner
+    assert caps[1].__class__ is PlainCapA
+
+
+def test_ordering_single_capability():
+    """sort_capabilities with a single capability returns it unchanged."""
+    cap = OutermostCap()
+    caps = sort_capabilities([cap])
+    assert caps == [cap]
 
 
 def test_ordering_no_constraints_noop():

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -8502,26 +8502,55 @@ def test_ordering_both_outermost_and_innermost():
     assert caps[-1].__class__ is InnermostCap
 
 
-def test_ordering_conflict_two_outermost():
+def test_ordering_multiple_outermost_tier():
+    """Multiple outermost capabilities form a tier; original order breaks ties."""
+
     @dataclass
     class OutermostCap2(AbstractCapability[Any]):
         @classmethod
         def get_ordering(cls) -> CapabilityOrdering:
             return CapabilityOrdering(position='outermost')
 
-    with pytest.raises(UserError, match="Multiple capabilities declare position 'outermost'"):
-        sort_capabilities([OutermostCap(), OutermostCap2()])
+    caps = sort_capabilities([PlainCapA(), OutermostCap2(), OutermostCap()])
+    names = [type(c).__name__ for c in caps]
+    # Both outermost caps before PlainCapA; original order (OutermostCap2 before OutermostCap) preserved
+    assert names == ['OutermostCap2', 'OutermostCap', 'PlainCapA']
 
 
-def test_ordering_conflict_two_innermost():
+def test_ordering_multiple_innermost_tier():
+    """Multiple innermost capabilities form a tier; original order breaks ties."""
+
     @dataclass
     class InnermostCap2(AbstractCapability[Any]):
         @classmethod
         def get_ordering(cls) -> CapabilityOrdering:
             return CapabilityOrdering(position='innermost')
 
-    with pytest.raises(UserError, match="Multiple capabilities declare position 'innermost'"):
-        sort_capabilities([InnermostCap(), InnermostCap2()])
+    caps = sort_capabilities([InnermostCap(), InnermostCap2(), PlainCapA()])
+    names = [type(c).__name__ for c in caps]
+    # PlainCapA first, then both innermost in original order
+    assert names == ['PlainCapA', 'InnermostCap', 'InnermostCap2']
+
+
+def test_ordering_outermost_tier_with_wraps():
+    """wraps/wrapped_by refines order within the outermost tier."""
+
+    @dataclass
+    class OuterA(AbstractCapability[Any]):
+        @classmethod
+        def get_ordering(cls) -> CapabilityOrdering:
+            return CapabilityOrdering(position='outermost')
+
+    @dataclass
+    class OuterB(AbstractCapability[Any]):
+        @classmethod
+        def get_ordering(cls) -> CapabilityOrdering:
+            return CapabilityOrdering(position='outermost', wraps=[OuterA])
+
+    # OuterB listed after OuterA, but wraps=[OuterA] overrides tiebreaker
+    caps = sort_capabilities([OuterA(), PlainCapA(), OuterB()])
+    names = [type(c).__name__ for c in caps]
+    assert names == ['OuterB', 'OuterA', 'PlainCapA']
 
 
 def test_ordering_wraps():

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -31,7 +31,8 @@ from pydantic_ai.capabilities import (
     WebSearch,
     WrapperCapability,
 )
-from pydantic_ai.capabilities.abstract import AbstractCapability
+from pydantic_ai.capabilities._ordering import sort_capabilities
+from pydantic_ai.capabilities.abstract import AbstractCapability, CapabilityOrdering
 from pydantic_ai.capabilities.builtin_tool import BuiltinTool as BuiltinToolCap
 from pydantic_ai.capabilities.combined import CombinedCapability
 from pydantic_ai.capabilities.hooks import Hooks, HookTimeoutError
@@ -5062,7 +5063,7 @@ class TestGetWrapperToolsetHook:
         )
 
     async def test_wrapper_chaining_order(self):
-        """Multiple capabilities' wrappers compose by nesting: first wraps innermost."""
+        """Multiple capabilities' wrappers compose by nesting: first wraps outermost."""
         from pydantic_ai.toolsets.prefixed import PrefixedToolset
 
         @dataclass
@@ -5086,8 +5087,8 @@ class TestGetWrapperToolsetHook:
             return 'r'  # pragma: no cover
 
         result = await agent.run('hello')
-        # First cap wraps innermost (a_tool), then second wraps that (b_a_tool)
-        assert result.output == "tools: ['b_a_tool']"
+        # First cap wraps outermost (matching wrap_* hooks): a_b_tool
+        assert result.output == "tools: ['a_b_tool']"
         assert result.all_messages() == snapshot(
             [
                 ModelRequest(
@@ -5096,7 +5097,7 @@ class TestGetWrapperToolsetHook:
                     run_id=IsStr(),
                 ),
                 ModelResponse(
-                    parts=[TextPart(content="tools: ['b_a_tool']")],
+                    parts=[TextPart(content="tools: ['a_b_tool']")],
                     usage=RequestUsage(input_tokens=51, output_tokens=2),
                     model_name='function:model_fn:',
                     timestamp=IsDatetime(),
@@ -8437,3 +8438,162 @@ async def test_thread_executor_static_method() -> None:
         assert tool_threads[0].startswith('static-pool')
     finally:
         executor.shutdown(wait=True)
+
+
+# --- Capability ordering tests ---
+
+
+@dataclass
+class OutermostCap(AbstractCapability[Any]):
+    @classmethod
+    def get_ordering(cls) -> CapabilityOrdering:
+        return CapabilityOrdering(position='outermost')
+
+
+@dataclass
+class InnermostCap(AbstractCapability[Any]):
+    @classmethod
+    def get_ordering(cls) -> CapabilityOrdering:
+        return CapabilityOrdering(position='innermost')
+
+
+@dataclass
+class PlainCapA(AbstractCapability[Any]):
+    pass
+
+
+@dataclass
+class PlainCapB(AbstractCapability[Any]):
+    pass
+
+
+@dataclass
+class WrapsACap(AbstractCapability[Any]):
+    """Must wrap around PlainCapA."""
+
+    @classmethod
+    def get_ordering(cls) -> CapabilityOrdering:
+        return CapabilityOrdering(wraps=[PlainCapA])
+
+
+@dataclass
+class RequiresOutermostCap(AbstractCapability[Any]):
+    @classmethod
+    def get_ordering(cls) -> CapabilityOrdering:
+        return CapabilityOrdering(requires=[OutermostCap])
+
+
+def test_ordering_outermost():
+    """Capability declaring 'outermost' ends up at index 0."""
+    caps = sort_capabilities([PlainCapA(), OutermostCap(), PlainCapB()])
+    assert [type(c).__name__ for c in caps] == ['OutermostCap', 'PlainCapA', 'PlainCapB']
+
+
+def test_ordering_innermost():
+    """Capability declaring 'innermost' ends up last."""
+    caps = sort_capabilities([InnermostCap(), PlainCapA(), PlainCapB()])
+    assert [type(c).__name__ for c in caps] == ['PlainCapA', 'PlainCapB', 'InnermostCap']
+
+
+def test_ordering_both_outermost_and_innermost():
+    """Both outermost and innermost present."""
+    caps = sort_capabilities([PlainCapA(), InnermostCap(), OutermostCap()])
+    assert caps[0].__class__ is OutermostCap
+    assert caps[-1].__class__ is InnermostCap
+
+
+def test_ordering_conflict_two_outermost():
+    @dataclass
+    class OutermostCap2(AbstractCapability[Any]):
+        @classmethod
+        def get_ordering(cls) -> CapabilityOrdering:
+            return CapabilityOrdering(position='outermost')
+
+    with pytest.raises(UserError, match="Multiple capabilities declare position 'outermost'"):
+        sort_capabilities([OutermostCap(), OutermostCap2()])
+
+
+def test_ordering_conflict_two_innermost():
+    @dataclass
+    class InnermostCap2(AbstractCapability[Any]):
+        @classmethod
+        def get_ordering(cls) -> CapabilityOrdering:
+            return CapabilityOrdering(position='innermost')
+
+    with pytest.raises(UserError, match="Multiple capabilities declare position 'innermost'"):
+        sort_capabilities([InnermostCap(), InnermostCap2()])
+
+
+def test_ordering_wraps():
+    """Explicit 'wraps' edge is respected."""
+    caps = sort_capabilities([PlainCapA(), WrapsACap()])
+    assert [type(c).__name__ for c in caps] == ['WrapsACap', 'PlainCapA']
+
+
+def test_ordering_wrapped_by():
+    """Explicit 'wrapped_by' edge is respected."""
+
+    @dataclass
+    class WrappedByACap(AbstractCapability[Any]):
+        @classmethod
+        def get_ordering(cls) -> CapabilityOrdering:
+            return CapabilityOrdering(wrapped_by=[PlainCapA])
+
+    caps = sort_capabilities([WrappedByACap(), PlainCapA()])
+    assert [type(c).__name__ for c in caps] == ['PlainCapA', 'WrappedByACap']
+
+
+def test_ordering_requires_present():
+    """No error when required capability is present."""
+    caps = sort_capabilities([RequiresOutermostCap(), OutermostCap()])
+    assert len(caps) == 2
+
+
+def test_ordering_requires_missing():
+    with pytest.raises(UserError, match='`RequiresOutermostCap` requires `OutermostCap`'):
+        sort_capabilities([RequiresOutermostCap(), PlainCapA()])
+
+
+def test_ordering_preserves_user_order():
+    """Capabilities without constraints keep their relative order."""
+    caps = sort_capabilities([PlainCapB(), PlainCapA()])
+    assert [type(c).__name__ for c in caps] == ['PlainCapB', 'PlainCapA']
+
+
+def test_ordering_nested_combined():
+    """Outermost inside a nested CombinedCapability bubbles up."""
+    inner = CombinedCapability([OutermostCap()])
+    caps = sort_capabilities([PlainCapA(), inner])
+    assert caps[0] is inner
+
+
+def test_ordering_no_constraints_noop():
+    """When no capability declares ordering, list is unchanged."""
+    a, b = PlainCapA(), PlainCapB()
+    caps = sort_capabilities([a, b])
+    assert caps == [a, b]
+
+
+def test_ordering_cycle_detection():
+    @dataclass
+    class CycleA(AbstractCapability[Any]):
+        @classmethod
+        def get_ordering(cls) -> CapabilityOrdering:
+            return CapabilityOrdering(wraps=[CycleB])
+
+    @dataclass
+    class CycleB(AbstractCapability[Any]):
+        @classmethod
+        def get_ordering(cls) -> CapabilityOrdering:
+            return CapabilityOrdering(wraps=[CycleA])
+
+    with pytest.raises(UserError, match='Circular ordering constraints'):
+        sort_capabilities([CycleA(), CycleB()])
+
+
+def test_ordering_via_combined_capability():
+    """CombinedCapability.__post_init__ auto-sorts when constraints exist."""
+    combined = CombinedCapability([PlainCapA(), InnermostCap(), OutermostCap()])
+    names = [type(c).__name__ for c in combined.capabilities]
+    assert names[0] == 'OutermostCap'
+    assert names[-1] == 'InnermostCap'


### PR DESCRIPTION
- Closes #<!-- no issue yet -->

## Summary

- **Fix `get_wrapper_toolset` direction**: `CombinedCapability.get_wrapper_toolset` now iterates `reversed(self.capabilities)`, matching all `wrap_*` hooks. "First in list = outermost wrapper" is now consistent across all capability behaviors.
- **Add `CapabilityOrdering`**: New ordering system with `wraps`/`wrapped_by`/`position`/`requires` constraints and topological sorting (Kahn's algorithm). `CombinedCapability.__post_init__` auto-sorts when any capability declares ordering; no-op otherwise.
- **Tier-based positions**: Multiple capabilities can declare `position='outermost'` (or `'innermost'`). They form a tier that's placed before (or after) all non-tier capabilities, with original list order as tiebreaker within the tier.
- **Middleware-native naming**: Uses `wraps`/`wrapped_by` instead of `before`/`after` to directly describe the spatial middleware relationship — no mental mapping from temporal ordering to onion layers.

### The wrapper direction bug

`wrap_*` hooks iterate `reversed(self.capabilities)` → first in list = outermost. But `get_wrapper_toolset` iterated forward → first in list = **innermost**. This meant `position='outermost'` and `wraps`/`wrapped_by` constraints had opposite semantics for hooks vs toolset wrapping.

### `CapabilityOrdering` API

- `position='outermost'` / `'innermost'` — tier-based position (multiple allowed, original order tiebreaks within tier)
- `wraps=[X]` — "I wrap around X" (I'm outside X in the middleware chain)
- `wrapped_by=[X]` — "X wraps around me" (I'm inside X)
- `requires=[X]` — "X must be present" (no ordering implied)

### Target ordering for infrastructure capabilities

The ordering system is designed to support this target capability order:

```
Instrumentation  [outermost — wraps all hooks for tracing]
  └─ CodeMode    [outermost — wraps toolset around ToolSearch]
       └─ ToolSearch  [outermost — wraps toolset around base tools]
            └─ [user capabilities]
                 └─ Durable  [innermost — closest to handler]
```

Each infrastructure capability should declare `get_ordering()` as follows:

```python
# pydantic-ai: Instrumentation (auto-injected first)
# Wraps all hooks (wrap_model_request, wrap_tool_execute, etc.) for observability.
# Doesn't provide a wrapper toolset, so it's transparent for toolset wrapping.
class Instrumentation(AbstractCapability):
    @classmethod
    def get_ordering(cls) -> CapabilityOrdering:
        return CapabilityOrdering(position='outermost')

# pydantic-ai: ToolSearch (auto-injected after Instrumentation)
# Wraps toolset to hide deferred tools and expose search_tools.
# No hook overrides, so transparent for hook wrapping.
class ToolSearch(AbstractCapability):
    @classmethod
    def get_ordering(cls) -> CapabilityOrdering:
        return CapabilityOrdering(position='outermost')

# pydantic-harness: CodeMode (user-added or auto-injected)
# Wraps toolset around ToolSearch to sandbox tools into run_code.
# Must be outside ToolSearch but doesn't need to be outside Instrumentation.
class CodeMode(AbstractCapability):
    @classmethod
    def get_ordering(cls) -> CapabilityOrdering:
        return CapabilityOrdering(position='outermost', wraps=[ToolSearch])

# pydantic-ai: Durable execution (user-added or auto-injected)
# Must be innermost to checkpoint at the handler boundary.
class Durable(AbstractCapability):
    @classmethod
    def get_ordering(cls) -> CapabilityOrdering:
        return CapabilityOrdering(position='innermost')
```

**Why this works**: All three outer capabilities declare `position='outermost'`, forming a tier that's placed before all user capabilities. Auto-injection places Instrumentation before ToolSearch in the list, so the min-heap tiebreaker preserves that order. CodeMode's `wraps=[ToolSearch]` edge ensures it's placed between Instrumentation and ToolSearch regardless of where the user lists it. Capabilities that don't provide wrapper toolsets (Instrumentation) or don't override hooks (ToolSearch) are transparent in those dimensions — the linear order serves both hooks and toolset wrapping correctly.

## Test plan

- [x] Updated `test_wrapper_chaining_order` to expect reversed nesting (`a_b_tool` not `b_a_tool`)
- [x] 19 ordering tests: outermost, innermost, both, multiple outermost/innermost tiers, tier with wraps refinement, wraps, wrapped_by, requires present/missing, order preservation, nested combined (with/without constraints, wraps without position), single capability, no-constraints noop, cycle detection, combined auto-sort
- [x] All 356 capability tests pass
- [x] Coverage 100.00%
- [x] Pre-commit hooks pass (format, lint, typecheck, cassettes)
- [x] Docs: added "Ordering" section to capabilities page

🤖 Generated with [Claude Code](https://claude.com/claude-code)