### PR TITLE
fix: install bubblewrap for claude-code-action subprocess isolation

### DIFF
--- a/.github/workflows/at-claude.yml
+++ b/.github/workflows/at-claude.yml
@@ -75,6 +75,9 @@ jobs:
 
       - run: make install
 
+      - name: Install bubblewrap
+        run: sudo apt-get install -y bubblewrap
+
       - uses: anthropics/claude-code-action@2fb9ee77a029749082ac35126a09ecd05fe34cf0 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -113,6 +116,9 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install bubblewrap
+        run: sudo apt-get install -y bubblewrap
 
       - uses: anthropics/claude-code-action@2fb9ee77a029749082ac35126a09ecd05fe34cf0 # v1
         with:

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -128,6 +128,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install bubblewrap
+        if: steps.check-label.outputs.has_label == 'false'
+        run: sudo apt-get install -y bubblewrap
+
       - name: Classify PR with Claude Code
         if: steps.check-label.outputs.has_label == 'false'
         id: classify
@@ -265,6 +269,9 @@ jobs:
           REPO: ${{ github.repository }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Install bubblewrap
+        run: sudo apt-get install -y bubblewrap
 
       - uses: anthropics/claude-code-action@2fb9ee77a029749082ac35126a09ecd05fe34cf0 # v1
         env:


### PR DESCRIPTION
## Summary
- Install `bubblewrap` before each `claude-code-action` step in `bots.yml` and `at-claude.yml`
- Claude Code now requires bubblewrap for subprocess env scrubbing and PID-namespace isolation, without which the action errors out
- This is especially important for the auto-review and classify jobs which process untrusted PR content with `allowed_non_write_users: "*"` — env scrubbing prevents prompt injection from exfiltrating secrets via subprocess environment variables

## Test plan
- [ ] Verify the auto-review job succeeds when the `auto-review` label is applied to a PR
- [ ] Verify the category-classify job succeeds on a new PR
- [ ] Verify `@claude` works on a non-fork PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)