### PR TITLE
docs: add semantix semantic output validation integration

### DIFF
--- a/docs/third-party-tools.md
+++ b/docs/third-party-tools.md
@@ -102,7 +102,7 @@ agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 
 ## Semantix — Semantic Output Validation {#semantix}
 
-[Semantix](https://github.com/labrat-akhona/semantix-ai) adds semantic validation to Pydantic AI agents — validating that outputs match a **natural language intent**, not just a structural schema. It uses local NLI (Natural Language Inference) models for fast, offline evaluation and integrates with Pydantic AI's output validator and `ModelRetry` mechanism.
+[Semantix](https://github.com/labrat-akhona/semantix-ai) adds semantic validation to Pydantic AI agents — validating that outputs match a **natural language intent**, not just a structural schema. It uses local NLI (Natural Language Inference) models for fast, offline evaluation and integrates with Pydantic AI's [`output_validator`][pydantic_ai.agent.Agent.output_validator] and [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] mechanism.
 
 Install with:
 
@@ -110,7 +110,7 @@ Install with:
 pip install 'semantix-ai[pydantic-ai]'
 ```
 
-Define an intent (what the output should *mean*) and attach it as an output validator:
+Define an intent (what the output should *mean*) and attach it as an [output validator](output.md#output-validator-functions):
 
 ```python {test="skip"}
 from pydantic_ai import Agent
@@ -127,7 +127,7 @@ async def validate_polite(ctx, output):
     return await semantix_validator(Polite)(ctx, output)
 ```
 
-When the output fails semantic validation, the adapter raises `ModelRetry` with a detailed explanation, which Pydantic AI feeds back to the model for self-correction. The NLI judge runs locally (~15ms per evaluation), so no additional API calls are needed for validation.
+When the output fails semantic validation, the adapter raises [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] with a detailed explanation, which Pydantic AI feeds back to the model for self-correction. The NLI judge runs locally (~15ms per evaluation), so no additional API calls are needed for validation.
 
 Semantix also supports composite intents (`AllOf`, `AnyOf`), custom score thresholds, and pluggable judge backends (NLI, LLM, embedding-based).
 

--- a/docs/third-party-tools.md
+++ b/docs/third-party-tools.md
@@ -100,6 +100,37 @@ toolset = ACIToolset(
 agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 ```
 
+## Semantix — Semantic Output Validation {#semantix}
+
+[Semantix](https://github.com/labrat-akhona/semantix-ai) adds semantic validation to Pydantic AI agents — validating that outputs match a **natural language intent**, not just a structural schema. It uses local NLI (Natural Language Inference) models for fast, offline evaluation and integrates with Pydantic AI's output validator and `ModelRetry` mechanism.
+
+Install with:
+
+```bash
+pip install 'semantix-ai[pydantic-ai]'
+```
+
+Define an intent (what the output should *mean*) and attach it as an output validator:
+
+```python {test="skip"}
+from pydantic_ai import Agent
+from semantix import Intent
+from semantix.integrations.pydantic_ai import semantix_validator
+
+class Polite(Intent):
+    """The text must be polite, professional, and free of aggressive language."""
+
+agent = Agent('openai:gpt-4o', output_type=str)
+
+@agent.output_validator
+async def validate_polite(ctx, output):
+    return await semantix_validator(Polite)(ctx, output)
+```
+
+When the output fails semantic validation, the adapter raises `ModelRetry` with a detailed explanation, which Pydantic AI feeds back to the model for self-correction. The NLI judge runs locally (~15ms per evaluation), so no additional API calls are needed for validation.
+
+Semantix also supports composite intents (`AllOf`, `AnyOf`), custom score thresholds, and pluggable judge backends (NLI, LLM, embedding-based).
+
 ## See Also
 
 - [Function Tools](tools.md) - Basic tool concepts and registration


### PR DESCRIPTION
## Summary

- Adds a "Semantix — Semantic Output Validation" section to `docs/third-party-tools.md`
- [semantix-ai](https://pypi.org/project/semantix-ai/) validates that agent outputs match natural language intents using local NLI models
- Integrates with Pydantic AI's `output_validator` and `ModelRetry` mechanism for self-correcting agents
- Runs locally (~15ms per evaluation) with no additional API calls

## Context

semantix adds a semantic layer on top of Pydantic AI's structural validation. While Pydantic validates that output matches a schema, semantix validates that the output *means* what it should — e.g., "must be polite and professional" or "must decline without being rude." On failure, it raises `ModelRetry` with a detailed explanation so the model can self-correct.

**PyPI:** [pypi.org/project/semantix-ai](https://pypi.org/project/semantix-ai/)
**Repository:** [github.com/labrat-akhona/semantix-ai](https://github.com/labrat-akhona/semantix-ai)