### PR TITLE
feat: add count_tokens for OpenAIResponsesModel

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1874,6 +1874,92 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             response, cast(OpenAIResponsesModelSettings, model_settings or {}), model_request_parameters
         )
 
+    async def count_tokens(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> usage.RequestUsage:
+        """Count input tokens using the OpenAI Responses API `input_tokens` endpoint.
+
+        This uses the `POST /responses/input_tokens` endpoint which returns an accurate
+        token count without running inference. See:
+        https://platform.openai.com/docs/api-reference/responses/input-tokens
+        """
+        check_allow_model_requests()
+        model_settings, model_request_parameters = self.prepare_request(
+            model_settings,
+            model_request_parameters,
+        )
+        model_settings = cast(OpenAIResponsesModelSettings, model_settings or {})
+
+        tools = (
+            self._get_builtin_tools(model_request_parameters)
+            + list(model_settings.get('openai_builtin_tools', []))
+            + self._get_tools(model_request_parameters)
+        )
+        profile = OpenAIModelProfile.from_profile(self.profile)
+        if not tools:
+            tool_choice: Literal['none', 'required', 'auto'] | None = None
+        elif not model_request_parameters.allow_text_output and profile.openai_supports_tool_choice_required:
+            tool_choice = 'required'
+        else:
+            tool_choice = 'auto'
+
+        previous_response_id = model_settings.get('openai_previous_response_id')
+        if previous_response_id == 'auto':
+            previous_response_id, messages = self._get_previous_response_id_and_new_messages(messages)
+
+        instructions, openai_messages = await self._map_messages(messages, model_settings, model_request_parameters)
+        reasoning = self._translate_thinking(model_settings, model_request_parameters)
+
+        text: responses.ResponseTextConfigParam | None = None
+        if model_request_parameters.output_mode == 'native':
+            output_object = model_request_parameters.output_object
+            assert output_object is not None
+            text = {'format': self._map_json_schema(output_object)}
+        elif (
+            model_request_parameters.output_mode == 'prompted' and self.profile.supports_json_object_output
+        ):  # pragma: no branch
+            text = {'format': {'type': 'json_object'}}
+            assert isinstance(instructions, str)
+            system_prompt_count = next(
+                (i for i, m in enumerate(openai_messages) if m.get('role') != 'system'), len(openai_messages)
+            )
+            openai_messages.insert(
+                system_prompt_count, responses.EasyInputMessageParam(role='system', content=instructions)
+            )
+            instructions = OMIT
+
+        # When there are no input messages and we're not reusing a previous response,
+        # the OpenAI API will reject a request without any input,
+        # even if there are instructions.
+        if not openai_messages and not previous_response_id:
+            openai_messages.append(
+                responses.EasyInputMessageParam(
+                    role='user',
+                    content='',
+                )
+            )
+
+        with _map_api_errors(self.model_name):
+            extra_headers = model_settings.get('extra_headers', {})
+            extra_headers.setdefault('User-Agent', get_user_agent())
+            response = await self.client.responses.input_tokens.count(
+                input=openai_messages,
+                model=self.model_name,
+                instructions=instructions,
+                parallel_tool_calls=model_settings.get('parallel_tool_calls', OMIT) if tools else OMIT,
+                tools=tools or OMIT,
+                tool_choice=tool_choice or OMIT,
+                truncation=model_settings.get('openai_truncation', OMIT),
+                previous_response_id=previous_response_id or OMIT,
+                reasoning=reasoning,
+                text=text or OMIT,
+                extra_headers=extra_headers,
+            )
+        return usage.RequestUsage(input_tokens=response.input_tokens)
+
     @asynccontextmanager
     async def request_stream(
         self,

--- a/tests/models/mock_openai.py
+++ b/tests/models/mock_openai.py
@@ -14,6 +14,7 @@ with try_import() as imports_successful:
     from openai.types.chat.chat_completion import Choice, ChoiceLogprobs
     from openai.types.chat.chat_completion_message import ChatCompletionMessage
     from openai.types.completion_usage import CompletionUsage
+    from openai.types.responses.input_token_count_response import InputTokenCountResponse
     from openai.types.responses.response import ResponseUsage
     from openai.types.responses.response_output_item import ResponseOutputItem
 
@@ -99,13 +100,21 @@ def completion_message(
 class MockOpenAIResponses:
     response: MockResponse | Sequence[MockResponse] | None = None
     stream: Sequence[MockResponseStreamEvent] | Sequence[Sequence[MockResponseStreamEvent]] | None = None
+    input_token_count: int | None = None
     index: int = 0
     response_kwargs: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
+    input_token_count_kwargs: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
     base_url: str = 'https://api.openai.com/v1'
 
     @cached_property
     def responses(self) -> Any:
-        return type('Responses', (), {'create': self.responses_create})
+        input_tokens = type('InputTokens', (), {'count': self.input_tokens_count})
+        return type('Responses', (), {'create': self.responses_create, 'input_tokens': input_tokens})
+
+    async def input_tokens_count(self, *_args: Any, **kwargs: Any) -> InputTokenCountResponse:
+        self.input_token_count_kwargs.append({k: v for k, v in kwargs.items() if v not in (NOT_GIVEN, OMIT)})
+        token_count = self.input_token_count if self.input_token_count is not None else 0
+        return InputTokenCountResponse(input_tokens=token_count, object='response.input_tokens')
 
     @classmethod
     def create_mock(cls, responses: MockResponse | Sequence[MockResponse]) -> AsyncOpenAI:
@@ -117,6 +126,14 @@ class MockOpenAIResponses:
         stream: Sequence[MockResponseStreamEvent] | Sequence[Sequence[MockResponseStreamEvent]],
     ) -> AsyncOpenAI:
         return cast(AsyncOpenAI, cls(stream=stream))  # pragma: lax no cover
+
+    @classmethod
+    def create_mock_with_token_count(
+        cls,
+        responses: MockResponse | Sequence[MockResponse],
+        input_token_count: int,
+    ) -> AsyncOpenAI:
+        return cast(AsyncOpenAI, cls(response=responses, input_token_count=input_token_count))
 
     async def responses_create(  # pragma: lax no cover
         self, *_args: Any, stream: bool = False, **kwargs: Any
@@ -144,6 +161,13 @@ class MockOpenAIResponses:
 def get_mock_responses_kwargs(async_open_ai: AsyncOpenAI) -> list[dict[str, Any]]:
     if isinstance(async_open_ai, MockOpenAIResponses):  # pragma: lax no cover
         return async_open_ai.response_kwargs
+    else:  # pragma: no cover
+        raise RuntimeError('Not a MockOpenAIResponses instance')
+
+
+def get_mock_input_token_count_kwargs(async_open_ai: AsyncOpenAI) -> list[dict[str, Any]]:
+    if isinstance(async_open_ai, MockOpenAIResponses):
+        return async_open_ai.input_token_count_kwargs
     else:  # pragma: no cover
         raise RuntimeError('Not a MockOpenAIResponses instance')
 

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -59,7 +59,12 @@ from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimitExceeded, UsageL
 
 from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsFloat, IsInstance, IsInt, IsNow, IsStr, TestEnv, try_import
-from .mock_openai import MockOpenAIResponses, get_mock_input_token_count_kwargs, get_mock_responses_kwargs, response_message
+from .mock_openai import (
+    MockOpenAIResponses,
+    get_mock_input_token_count_kwargs,
+    get_mock_responses_kwargs,
+    response_message,
+)
 
 with try_import() as imports_successful:
     from openai import AsyncOpenAI
@@ -12314,9 +12319,7 @@ async def test_openai_responses_count_tokens_different_models(allow_model_reques
             [
                 ResponseOutputMessage(
                     id='output-1',
-                    content=cast(
-                        list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]
-                    ),
+                    content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
                     role='assistant',
                     status='completed',
                     type='message',

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -55,11 +55,11 @@ from pydantic_ai.native_tools import CodeExecutionTool, FileSearchTool, ImageAsp
 from pydantic_ai.output import NativeOutput, PromptedOutput, TextOutput, ToolOutput
 from pydantic_ai.profiles.openai import OpenAIModelProfile, OpenAISystemPromptRole, openai_model_profile
 from pydantic_ai.tools import ToolDefinition
-from pydantic_ai.usage import RequestUsage, RunUsage
+from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimitExceeded, UsageLimits
 
 from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsFloat, IsInstance, IsInt, IsNow, IsStr, TestEnv, try_import
-from .mock_openai import MockOpenAIResponses, get_mock_responses_kwargs, response_message
+from .mock_openai import MockOpenAIResponses, get_mock_input_token_count_kwargs, get_mock_responses_kwargs, response_message
 
 with try_import() as imports_successful:
     from openai import AsyncOpenAI
@@ -11973,3 +11973,463 @@ def test_openai_responses_phase_profile_flag():
     assert cast(Any, openai_model_profile('gpt-5.2')).openai_supports_phase is False
     assert cast(Any, openai_model_profile('gpt-5')).openai_supports_phase is False
     assert cast(Any, openai_model_profile('gpt-4o')).openai_supports_phase is False
+# ============================
+# count_tokens tests
+# ============================
+
+
+async def test_openai_responses_count_tokens_basic(allow_model_requests: None):
+    """Test basic count_tokens call returns the correct token count."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='Hello!', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=42)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    result = await agent.run(
+        'Hello, world!',
+        usage_limits=UsageLimits(input_tokens_limit=100, count_tokens_before_request=True),
+    )
+    assert result.output == 'Hello!'
+
+
+async def test_openai_responses_count_tokens_exceeded(allow_model_requests: None):
+    """Test that count_tokens raises UsageLimitExceeded when token count exceeds limit."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='Hello!', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=50)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    with pytest.raises(
+        UsageLimitExceeded,
+        match='The next request would exceed the input_tokens_limit of 10 \\(input_tokens=50\\)',
+    ):
+        await agent.run(
+            'Hello, world!',
+            usage_limits=UsageLimits(input_tokens_limit=10, count_tokens_before_request=True),
+        )
+
+
+async def test_openai_responses_count_tokens_exact_limit(allow_model_requests: None):
+    """Test that count_tokens passes when token count equals the limit exactly."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='OK', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=10)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    # Exact match should not raise
+    result = await agent.run(
+        'Test',
+        usage_limits=UsageLimits(input_tokens_limit=10, count_tokens_before_request=True),
+    )
+    assert result.output == 'OK'
+
+
+async def test_openai_responses_count_tokens_returns_request_usage(allow_model_requests: None):
+    """Test that count_tokens returns a proper RequestUsage object."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=25)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    from pydantic_ai.models import ModelRequestParameters
+
+    result = await model.count_tokens(
+        messages=[ModelRequest(parts=[UserPromptPart(content='Hello')])],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[],
+            output_tools=[],
+            builtin_tools=[],
+        ),
+    )
+    assert result == RequestUsage(input_tokens=25)
+
+
+async def test_openai_responses_count_tokens_kwargs_passed(allow_model_requests: None):
+    """Test that count_tokens passes correct kwargs to the API."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=15)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    from pydantic_ai.models import ModelRequestParameters
+
+    await model.count_tokens(
+        messages=[ModelRequest(parts=[UserPromptPart(content='Test message')])],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[],
+            output_tools=[],
+            builtin_tools=[],
+        ),
+    )
+    kwargs_list = get_mock_input_token_count_kwargs(mock_client)
+    assert len(kwargs_list) == 1
+    kwargs = kwargs_list[0]
+    assert kwargs['model'] == 'gpt-4o'
+    assert 'input' in kwargs
+
+
+async def test_openai_responses_count_tokens_with_system_prompt(allow_model_requests: None):
+    """Test count_tokens with system prompt (instructions)."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=30)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model, instructions='You are a helpful assistant.')
+
+    result = await agent.run(
+        'Hello',
+        usage_limits=UsageLimits(input_tokens_limit=50, count_tokens_before_request=True),
+    )
+    assert result.output == 'done'
+    kwargs_list = get_mock_input_token_count_kwargs(mock_client)
+    assert len(kwargs_list) == 1
+    assert kwargs_list[0].get('instructions') == 'You are a helpful assistant.'
+
+
+async def test_openai_responses_count_tokens_with_tools(allow_model_requests: None):
+    """Test count_tokens with function tools."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=40)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    from pydantic_ai.models import ModelRequestParameters
+
+    tool_def = ToolDefinition(
+        name='get_weather',
+        description='Get the weather',
+        parameters_json_schema={'type': 'object', 'properties': {'city': {'type': 'string'}}, 'required': ['city']},
+    )
+
+    await model.count_tokens(
+        messages=[ModelRequest(parts=[UserPromptPart(content='What is the weather?')])],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[tool_def],
+            output_tools=[],
+            builtin_tools=[],
+        ),
+    )
+    kwargs_list = get_mock_input_token_count_kwargs(mock_client)
+    assert len(kwargs_list) == 1
+    assert 'tools' in kwargs_list[0]
+
+
+async def test_openai_responses_count_tokens_zero(allow_model_requests: None):
+    """Test count_tokens with zero tokens returned."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='ok', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=0)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    from pydantic_ai.models import ModelRequestParameters
+
+    result = await model.count_tokens(
+        messages=[ModelRequest(parts=[UserPromptPart(content='')])],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[],
+            output_tools=[],
+            builtin_tools=[],
+        ),
+    )
+    assert result == RequestUsage(input_tokens=0)
+
+
+async def test_openai_responses_count_tokens_large_count(allow_model_requests: None):
+    """Test count_tokens with a large token count."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='ok', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=128000)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    from pydantic_ai.models import ModelRequestParameters
+
+    result = await model.count_tokens(
+        messages=[ModelRequest(parts=[UserPromptPart(content='A very long prompt...')])],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[],
+            output_tools=[],
+            builtin_tools=[],
+        ),
+    )
+    assert result == RequestUsage(input_tokens=128000)
+
+
+async def test_openai_responses_count_tokens_total_limit_exceeded(allow_model_requests: None):
+    """Test count_tokens with total_tokens_limit exceeded."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=50)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    with pytest.raises(
+        UsageLimitExceeded,
+        match='The next request would exceed the total_tokens_limit of 10 \\(total_tokens=50\\)',
+    ):
+        await agent.run(
+            'Hello',
+            usage_limits=UsageLimits(total_tokens_limit=10, count_tokens_before_request=True),
+        )
+
+
+async def test_openai_responses_count_tokens_multiple_messages(allow_model_requests: None):
+    """Test count_tokens with multiple messages in history."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=35)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    from pydantic_ai.models import ModelRequestParameters
+
+    messages = [
+        ModelRequest(parts=[SystemPromptPart(content='Be helpful')]),
+        ModelRequest(parts=[UserPromptPart(content='First question')]),
+        ModelResponse(parts=[TextPart(content='First answer')]),
+        ModelRequest(parts=[UserPromptPart(content='Second question')]),
+    ]
+
+    result = await model.count_tokens(
+        messages=messages,
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[],
+            output_tools=[],
+            builtin_tools=[],
+        ),
+    )
+    assert result == RequestUsage(input_tokens=35)
+
+
+async def test_openai_responses_count_tokens_different_models(allow_model_requests: None):
+    """Test count_tokens works with different model names."""
+    for model_name in ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini']:
+        c = response_message(
+            [
+                ResponseOutputMessage(
+                    id='output-1',
+                    content=cast(
+                        list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]
+                    ),
+                    role='assistant',
+                    status='completed',
+                    type='message',
+                )
+            ]
+        )
+        mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=20)
+        model = OpenAIResponsesModel(model_name, provider=OpenAIProvider(openai_client=mock_client))
+
+        from pydantic_ai.models import ModelRequestParameters
+
+        result = await model.count_tokens(
+            messages=[ModelRequest(parts=[UserPromptPart(content='Hello')])],
+            model_settings=None,
+            model_request_parameters=ModelRequestParameters(
+                function_tools=[],
+                output_tools=[],
+                builtin_tools=[],
+            ),
+        )
+        assert result == RequestUsage(input_tokens=20)
+        kwargs_list = get_mock_input_token_count_kwargs(mock_client)
+        assert kwargs_list[0]['model'] == model_name
+
+
+async def test_openai_responses_count_tokens_with_model_settings(allow_model_requests: None):
+    """Test count_tokens passes relevant model settings."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=20)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    from pydantic_ai.models import ModelRequestParameters
+
+    settings: OpenAIResponsesModelSettings = {'openai_truncation': 'auto'}
+
+    await model.count_tokens(
+        messages=[ModelRequest(parts=[UserPromptPart(content='Hello')])],
+        model_settings=settings,
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[],
+            output_tools=[],
+            builtin_tools=[],
+        ),
+    )
+    kwargs_list = get_mock_input_token_count_kwargs(mock_client)
+    assert kwargs_list[0].get('truncation') == 'auto'
+
+
+async def test_openai_responses_count_tokens_without_flag(allow_model_requests: None):
+    """Test that count_tokens is not called when count_tokens_before_request is False."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=999)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    # Without count_tokens_before_request=True, count_tokens should not be called
+    result = await agent.run('Hello')
+    assert result.output == 'done'
+    kwargs_list = get_mock_input_token_count_kwargs(mock_client)
+    assert len(kwargs_list) == 0
+
+
+async def test_openai_responses_count_tokens_empty_messages(allow_model_requests: None):
+    """Test count_tokens with empty messages list adds an empty user message."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock_with_token_count(c, input_token_count=5)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    from pydantic_ai.models import ModelRequestParameters
+
+    result = await model.count_tokens(
+        messages=[],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[],
+            output_tools=[],
+            builtin_tools=[],
+        ),
+    )
+    assert result == RequestUsage(input_tokens=5)
+    # Should have added an empty user message
+    kwargs_list = get_mock_input_token_count_kwargs(mock_client)
+    input_items = kwargs_list[0]['input']
+    assert len(input_items) == 1
+    assert input_items[0]['role'] == 'user'
+    assert input_items[0]['content'] == ''


### PR DESCRIPTION
## Summary

- Implements `count_tokens` for `OpenAIResponsesModel` using the [Responses API `input_tokens` endpoint](https://platform.openai.com/docs/api-reference/responses/input-tokens)
- Returns accurate token counts without running inference, at no cost
- Enables `UsageLimits(count_tokens_before_request=True)` for OpenAI Responses models
- Mirrors the same parameter preparation logic as `_responses_create` (tools, instructions, reasoning, truncation, etc.)

Fixes #3430

## Implementation

The `count_tokens` method on `OpenAIResponsesModel` calls `client.responses.input_tokens.count(...)` with the same message/tool/instruction preparation as `_responses_create`. This follows the approach suggested by @DouweM in the [issue discussion](https://github.com/pydantic/pydantic-ai/issues/3430#issuecomment-2866651085):

> The Responses API has an endpoint for this: https://platform.openai.com/docs/api-reference/responses/input-tokens
> I'd love to see a much smaller PR that adds support using that API endpoint rather than tiktoken.

**Files changed:**
- `pydantic_ai_slim/pydantic_ai/models/openai.py` — Added `count_tokens` method to `OpenAIResponsesModel`
- `tests/models/mock_openai.py` — Extended `MockOpenAIResponses` to support `input_tokens.count` mocking
- `tests/models/test_openai_responses.py` — Added 15 test cases covering basic usage, limits, tools, settings, edge cases

## Test plan

- [x] 15 new unit tests all passing
- [x] All 109 existing `test_openai_responses.py` tests still pass
- [ ] Verify with a real OpenAI API key that `input_tokens.count` returns expected results

🤖 Generated with [Claude Code](https://claude.com/claude-code)