### PR TITLE
refactor: move tool search wrapping into auto-injected `ToolSearch` capability

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -77,7 +77,6 @@ from ..toolsets._dynamic import (
     DynamicToolset,
     ToolsetFunc,
 )
-from ..toolsets._tool_search import ToolSearchToolset
 from ..toolsets.combined import CombinedToolset
 from ..toolsets.function import FunctionToolset
 from ..toolsets.prepared import PreparedToolset
@@ -402,6 +401,14 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             capabilities.append(HistoryProcessorCap(history_processor))
         for builtin_tool in builtin_tools:
             capabilities.append(BuiltinToolCap(builtin_tool))
+
+        # Auto-inject _ToolSearch if not already present. Always injected
+        # because deferred tools can be dynamic (from get_tools at runtime).
+        # Prepended for natural outermost-tier positioning via index tiebreak.
+        from ..capabilities._tool_search import ToolSearch
+
+        if not any(isinstance(leaf, ToolSearch) for leaf in _collect_capability_leaves(capabilities)):
+            capabilities.insert(0, ToolSearch())
 
         self._root_capability = CombinedCapability(capabilities)
 
@@ -2386,14 +2393,13 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         if self._prepare_tools:
             toolset = PreparedToolset(toolset, self._prepare_tools)
 
+        # Capability wrapper toolsets (including _ToolSearch and CodeMode) are
+        # applied here via get_wrapper_toolset. _ToolSearch is auto-injected
+        # into capabilities, replacing the previous hardcoded ToolSearchToolset wrap.
         if run_capability is not None:
             wrapper = run_capability.get_wrapper_toolset(toolset)
             if wrapper is not None:
                 toolset = wrapper
-
-        # Always wraps; short-circuits when no deferred tools.
-        # Wraps outside PreparedToolset and capability wrappers so search_tools is always available.
-        toolset = ToolSearchToolset(wrapped=toolset)
 
         output_toolset = output_toolset if _utils.is_set(output_toolset) else self._output_toolset
         if output_toolset is not None:
@@ -2614,6 +2620,18 @@ _UNSUPPORTED_SPEC_FIELDS: tuple[str, ...] = (
     'deps_schema',
 )
 """AgentSpec fields that are not supported at run/override time."""
+
+
+def _collect_capability_leaves(
+    capabilities: Sequence[AbstractCapability[Any]],
+) -> list[AbstractCapability[Any]]:
+    """Collect all leaf capabilities from a flat list, expanding CombinedCapability nodes."""
+    from ..capabilities._ordering import collect_leaves
+
+    leaves: list[AbstractCapability[Any]] = []
+    for cap in capabilities:
+        leaves.extend(collect_leaves(cap))
+    return leaves
 
 
 def _validate_spec(

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -404,11 +404,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         for builtin_tool in builtin_tools:
             capabilities.append(BuiltinToolCap(builtin_tool))
 
-        # Auto-inject ToolSearch if not already present. Always injected
-        # because deferred tools can be dynamic (from get_tools at runtime).
-        # Prepended for natural outermost-tier positioning via index tiebreak.
-        if not has_capability_type(capabilities, ToolSearchCap):
-            capabilities.insert(0, ToolSearchCap())
+        _inject_auto_capabilities(capabilities)
 
         self._root_capability = CombinedCapability(capabilities)
 
@@ -1613,10 +1609,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         validated_spec, template_context = _validate_spec(spec, self._deps_type)
 
         capabilities = list(_capabilities_from_spec(validated_spec, custom_capability_types, template_context))
-        # Auto-inject ToolSearch into spec capabilities too, so override(spec=...)
-        # doesn't lose deferred tool discovery when replacing the root capability.
-        if capabilities and not has_capability_type(capabilities, ToolSearchCap):
-            capabilities.insert(0, ToolSearchCap())
+        if capabilities:
+            _inject_auto_capabilities(capabilities)
         combined = CombinedCapability(capabilities) if capabilities else None
 
         # Warn for unsupported fields with non-default values
@@ -2401,9 +2395,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         # applied here via get_wrapper_toolset. ToolSearch is auto-injected
         # into capabilities, replacing the previous hardcoded ToolSearchToolset wrap.
         if run_capability is not None:
-            wrapper = run_capability.get_wrapper_toolset(toolset)
-            if wrapper is not None:
-                toolset = wrapper
+            toolset = run_capability.get_wrapper_toolset(toolset) or toolset
 
         output_toolset = output_toolset if _utils.is_set(output_toolset) else self._output_toolset
         if output_toolset is not None:
@@ -2629,6 +2621,20 @@ _UNSUPPORTED_SPEC_FIELDS: tuple[str, ...] = (
     'deps_schema',
 )
 """AgentSpec fields that are not supported at run/override time."""
+
+_AUTO_INJECT_CAPABILITY_TYPES: tuple[type[AbstractCapability[Any]], ...] = (ToolSearchCap,)
+"""Infrastructure capabilities auto-injected when not already present."""
+
+
+def _inject_auto_capabilities(capabilities: list[AbstractCapability[Any]]) -> None:
+    """Ensure all auto-injected infrastructure capabilities are present.
+
+    Each capability's own ``CapabilityOrdering`` (e.g. ``position='outermost'``)
+    determines its final placement, so insertion order here doesn't matter.
+    """
+    for cap_type in _AUTO_INJECT_CAPABILITY_TYPES:
+        if not has_capability_type(capabilities, cap_type):
+            capabilities.append(cap_type())
 
 
 def _validate_spec(

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1609,8 +1609,6 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         validated_spec, template_context = _validate_spec(spec, self._deps_type)
 
         capabilities = list(_capabilities_from_spec(validated_spec, custom_capability_types, template_context))
-        if capabilities:
-            _inject_auto_capabilities(capabilities)
         combined = CombinedCapability(capabilities) if capabilities else None
 
         # Warn for unsupported fields with non-default values
@@ -1729,9 +1727,14 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         else:
             model_settings_token = None
 
-        # Set capability from spec, replacing the agent's existing root capability
+        # Set capability from spec, replacing the agent's existing root capability.
+        # Auto-inject infrastructure capabilities since the override replaces
+        # (not merges with) the agent's root capability.
         if resolved is not None and resolved.capability is not None:
-            cap_token = self._override_root_capability.set(_utils.Some(resolved.capability))
+            override_caps = list(resolved.capability.capabilities)
+            _inject_auto_capabilities(override_caps)
+            override_capability = CombinedCapability(override_caps)
+            cap_token = self._override_root_capability.set(_utils.Some(override_capability))
         else:
             cap_token = None
 

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -48,6 +48,8 @@ from .._output import OutputToolset
 from .._template import TemplateStr, validate_from_spec_args
 from ..builtin_tools import AbstractBuiltinTool
 from ..capabilities import AbstractCapability, CombinedCapability
+from ..capabilities._ordering import has_capability_type
+from ..capabilities._tool_search import ToolSearch as ToolSearchCap
 from ..capabilities.builtin_tool import BuiltinTool as BuiltinToolCap
 from ..capabilities.history_processor import HistoryProcessor as HistoryProcessorCap
 from ..models.instrumented import InstrumentationSettings, InstrumentedModel, instrument_model
@@ -402,13 +404,11 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         for builtin_tool in builtin_tools:
             capabilities.append(BuiltinToolCap(builtin_tool))
 
-        # Auto-inject _ToolSearch if not already present. Always injected
+        # Auto-inject ToolSearch if not already present. Always injected
         # because deferred tools can be dynamic (from get_tools at runtime).
         # Prepended for natural outermost-tier positioning via index tiebreak.
-        from ..capabilities._tool_search import ToolSearch
-
-        if not any(isinstance(leaf, ToolSearch) for leaf in _collect_capability_leaves(capabilities)):
-            capabilities.insert(0, ToolSearch())
+        if not has_capability_type(capabilities, ToolSearchCap):
+            capabilities.insert(0, ToolSearchCap())
 
         self._root_capability = CombinedCapability(capabilities)
 
@@ -1612,7 +1612,11 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
         validated_spec, template_context = _validate_spec(spec, self._deps_type)
 
-        capabilities = _capabilities_from_spec(validated_spec, custom_capability_types, template_context)
+        capabilities = list(_capabilities_from_spec(validated_spec, custom_capability_types, template_context))
+        # Auto-inject ToolSearch into spec capabilities too, so override(spec=...)
+        # doesn't lose deferred tool discovery when replacing the root capability.
+        if capabilities and not has_capability_type(capabilities, ToolSearchCap):
+            capabilities.insert(0, ToolSearchCap())
         combined = CombinedCapability(capabilities) if capabilities else None
 
         # Warn for unsupported fields with non-default values
@@ -2393,8 +2397,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         if self._prepare_tools:
             toolset = PreparedToolset(toolset, self._prepare_tools)
 
-        # Capability wrapper toolsets (including _ToolSearch and CodeMode) are
-        # applied here via get_wrapper_toolset. _ToolSearch is auto-injected
+        # Capability wrapper toolsets (including ToolSearch and CodeMode) are
+        # applied here via get_wrapper_toolset. ToolSearch is auto-injected
         # into capabilities, replacing the previous hardcoded ToolSearchToolset wrap.
         if run_capability is not None:
             wrapper = run_capability.get_wrapper_toolset(toolset)
@@ -2408,6 +2412,11 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             toolset = CombinedToolset([output_toolset, toolset])
 
         return toolset
+
+    @property
+    def root_capability(self) -> CombinedCapability[AgentDepsT]:
+        """The root capability of the agent, containing all registered capabilities."""
+        return self._root_capability
 
     @property
     def toolsets(self) -> Sequence[AbstractToolset[AgentDepsT]]:
@@ -2620,18 +2629,6 @@ _UNSUPPORTED_SPEC_FIELDS: tuple[str, ...] = (
     'deps_schema',
 )
 """AgentSpec fields that are not supported at run/override time."""
-
-
-def _collect_capability_leaves(
-    capabilities: Sequence[AbstractCapability[Any]],
-) -> list[AbstractCapability[Any]]:
-    """Collect all leaf capabilities from a flat list, expanding CombinedCapability nodes."""
-    from ..capabilities._ordering import collect_leaves
-
-    leaves: list[AbstractCapability[Any]] = []
-    for cap in capabilities:
-        leaves.extend(collect_leaves(cap))
-    return leaves
 
 
 def _validate_spec(

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_ordering.py
@@ -167,5 +167,13 @@ def collect_leaves(cap: AbstractCapability[Any]) -> list[AbstractCapability[Any]
     return leaves
 
 
+def has_capability_type(
+    capabilities: Sequence[AbstractCapability[Any]],
+    cap_type: type[AbstractCapability[Any]],
+) -> bool:
+    """Check whether any leaf in a capability list/tree is an instance of the given type."""
+    return any(isinstance(leaf, cap_type) for cap in capabilities for leaf in collect_leaves(cap))
+
+
 def _collect_leaf_types(cap: AbstractCapability[Any]) -> set[type]:
     return {type(leaf) for leaf in collect_leaves(cap)}

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_tool_search.py
@@ -1,0 +1,34 @@
+"""Internal ToolSearch capability that wraps tools with ToolSearchToolset."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .._run_context import AgentDepsT
+from ..toolsets import AbstractToolset
+from ..toolsets._tool_search import ToolSearchToolset
+from .abstract import AbstractCapability, CapabilityOrdering
+
+
+@dataclass
+class ToolSearch(AbstractCapability[AgentDepsT]):
+    """Internal capability that wraps tools with ToolSearchToolset for deferred tool discovery.
+
+    Auto-injected when not explicitly provided by the user. Short-circuits
+    when no deferred tools exist, so there is zero overhead for agents
+    without deferred loading.
+
+    Internal for now — will be exported publicly once we add
+    user-facing configuration options.
+    """
+
+    @classmethod
+    def get_ordering(cls) -> CapabilityOrdering:
+        return CapabilityOrdering(position='outermost')
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        return None  # not spec-constructible (internal)
+
+    def get_wrapper_toolset(self, toolset: AbstractToolset[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
+        return ToolSearchToolset(wrapped=toolset)

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -20,6 +20,8 @@ from typing_extensions import TypedDict
 
 from pydantic_ai import Agent, FunctionToolset, ToolCallPart
 from pydantic_ai._run_context import RunContext
+from pydantic_ai.capabilities._ordering import collect_leaves
+from pydantic_ai.capabilities._tool_search import ToolSearch
 from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior, UserError
 from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, ToolReturn, ToolReturnPart
 from pydantic_ai.models.test import TestModel
@@ -610,9 +612,6 @@ async def test_tool_search_toolset_no_deferred_tools_returns_all():
 
 async def test_agent_auto_injects_tool_search_capability():
     """Test that agent auto-injects ToolSearch capability, with and without deferred tools."""
-    from pydantic_ai.capabilities._ordering import collect_leaves
-    from pydantic_ai.capabilities._tool_search import ToolSearch
-
     agent_no_deferred = Agent('test')
 
     @agent_no_deferred.tool_plain
@@ -620,7 +619,7 @@ async def test_agent_auto_injects_tool_search_capability():
         """Get the current weather for a city."""
         return f'Weather in {city}'
 
-    leaves = collect_leaves(agent_no_deferred._root_capability)  # pyright: ignore[reportPrivateUsage]
+    leaves = collect_leaves(agent_no_deferred.root_capability)
     assert any(isinstance(leaf, ToolSearch) for leaf in leaves)
 
     agent_with_deferred = Agent('test')
@@ -635,7 +634,7 @@ async def test_agent_auto_injects_tool_search_capability():
         """Calculate mortgage payment."""
         return 'Calculated'
 
-    leaves = collect_leaves(agent_with_deferred._root_capability)  # pyright: ignore[reportPrivateUsage]
+    leaves = collect_leaves(agent_with_deferred.root_capability)
     assert any(isinstance(leaf, ToolSearch) for leaf in leaves)
 
 

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -608,8 +608,11 @@ async def test_tool_search_toolset_no_deferred_tools_returns_all():
     assert tool_names == snapshot(['get_weather', 'get_time'])
 
 
-async def test_agent_always_wraps_in_tool_search_toolset():
-    """Test that agent always wraps toolset in ToolSearchToolset, with and without deferred tools."""
+async def test_agent_auto_injects_tool_search_capability():
+    """Test that agent auto-injects ToolSearch capability, with and without deferred tools."""
+    from pydantic_ai.capabilities._ordering import collect_leaves
+    from pydantic_ai.capabilities._tool_search import ToolSearch
+
     agent_no_deferred = Agent('test')
 
     @agent_no_deferred.tool_plain
@@ -617,7 +620,8 @@ async def test_agent_always_wraps_in_tool_search_toolset():
         """Get the current weather for a city."""
         return f'Weather in {city}'
 
-    assert isinstance(agent_no_deferred._get_toolset(), ToolSearchToolset)  # pyright: ignore[reportPrivateUsage]
+    leaves = collect_leaves(agent_no_deferred._root_capability)  # pyright: ignore[reportPrivateUsage]
+    assert any(isinstance(leaf, ToolSearch) for leaf in leaves)
 
     agent_with_deferred = Agent('test')
 
@@ -631,7 +635,8 @@ async def test_agent_always_wraps_in_tool_search_toolset():
         """Calculate mortgage payment."""
         return 'Calculated'
 
-    assert isinstance(agent_with_deferred._get_toolset(), ToolSearchToolset)  # pyright: ignore[reportPrivateUsage]
+    leaves = collect_leaves(agent_with_deferred._root_capability)  # pyright: ignore[reportPrivateUsage]
+    assert any(isinstance(leaf, ToolSearch) for leaf in leaves)
 
 
 async def test_tool_manager_with_tool_search_toolset():

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -638,6 +638,28 @@ async def test_agent_auto_injects_tool_search_capability():
     assert any(isinstance(leaf, ToolSearch) for leaf in leaves)
 
 
+async def test_explicit_tool_search_not_duplicated():
+    """Passing ToolSearch explicitly doesn't result in a second auto-injected one."""
+    agent = Agent('test', capabilities=[ToolSearch()])
+
+    @agent.tool_plain
+    def get_weather(city: str) -> str:  # pragma: no cover
+        """Get the current weather for a city."""
+        return f'Weather in {city}'
+
+    leaves = collect_leaves(agent.root_capability)
+    tool_search_count = sum(1 for leaf in leaves if isinstance(leaf, ToolSearch))
+    assert tool_search_count == 1
+
+
+def test_tool_search_excluded_from_capability_registry():
+    """ToolSearch is internal and should not appear in the serializable capability registry."""
+    from pydantic_ai.capabilities import CAPABILITY_TYPES
+
+    assert ToolSearch.get_serialization_name() is None
+    assert not any(cls is ToolSearch for cls in CAPABILITY_TYPES.values())
+
+
 async def test_tool_manager_with_tool_search_toolset():
     """Test that ToolManager works correctly with ToolSearchToolset."""
     toolset = _create_function_toolset()


### PR DESCRIPTION
## Summary

- Introduces a `ToolSearch` capability in `pydantic_ai/capabilities/_tool_search.py` that wraps tools with `ToolSearchToolset` via `get_wrapper_toolset`
- Auto-injects `ToolSearch` into the capability tree when not already present, replacing the previous hardcoded `ToolSearchToolset` wrapping in `Agent._get_toolset`
- Declares `CapabilityOrdering(position='outermost')` so other outermost capabilities (like CodeMode in pydantic-harness) can declare `wraps=[ToolSearch]` and compose correctly

This follows the same auto-inject pattern being established for `Instrumentation` in #4967, and is a stepping stone toward the global capability registration discussed in #4971.

### Pre-Review Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.

## Test plan

- [x] Existing `test_agent_auto_injects_tool_search_capability` updated to verify `ToolSearch` is present in capability leaves (with and without deferred tools)
- [x] All existing tool search tests pass unchanged (behavior is identical)
- [x] Pre-commit hooks pass (format, lint, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)