### PR TITLE
fix: make `mcp` optional for DBOS module import

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/__init__.py
@@ -1,6 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from ._agent import DBOSAgent, DBOSParallelExecutionMode
-from ._mcp_server import DBOSMCPServer
 from ._model import DBOSModel
 from ._utils import StepConfig
 
+if TYPE_CHECKING:
+    from ._mcp_server import DBOSMCPServer
+
 __all__ = ['DBOSAgent', 'DBOSModel', 'DBOSMCPServer', 'DBOSParallelExecutionMode', 'StepConfig']
+
+
+def __getattr__(name: str) -> object:
+    if name == 'DBOSMCPServer':
+        from ._mcp_server import DBOSMCPServer
+
+        return DBOSMCPServer
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')


### PR DESCRIPTION
- Closes #<!-- no specific issue -->

## Summary

- Use `__getattr__` + `TYPE_CHECKING` pattern in `pydantic_ai/durable_exec/dbos/__init__.py` so that importing `DBOSAgent` no longer unconditionally requires the `mcp` package
- `DBOSMCPServer` is now lazily imported only when accessed, matching the pattern already used by the Temporal module
- This allows downstream packages to use `pydantic-ai-slim[dbos]` without also needing `pydantic-ai-slim[mcp]`

## Test plan

- [x] Verified `from pydantic_ai.durable_exec.dbos import DBOSAgent` works without `mcp` installed
- [x] Verified `from pydantic_ai.durable_exec.dbos import DBOSMCPServer` works when `mcp` IS installed
- [x] Pyright typecheck passes with 0 errors
- [x] All 37 DBOS tests pass

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)