### PR TITLE
feat: add RepairToolOrphans capability for fixing broken tool pairing

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
@@ -25,6 +25,7 @@ from .include_return_schemas import IncludeToolReturnSchemas
 from .mcp import MCP
 from .prefix_tools import PrefixTools
 from .prepare_tools import PrepareTools
+from .repair_tool_orphans import RepairToolOrphans
 from .set_tool_metadata import SetToolMetadata
 from .thinking import Thinking
 from .thread_executor import ThreadExecutor
@@ -43,6 +44,7 @@ CAPABILITY_TYPES: dict[str, type[AbstractCapability[Any]]] = {
         MCP,
         PrefixTools,
         PrepareTools,
+        RepairToolOrphans,
         SetToolMetadata,
         Thinking,
         Toolset,
@@ -79,6 +81,7 @@ __all__ = [
     'MCP',
     'PrefixTools',
     'PrepareTools',
+    'RepairToolOrphans',
     'SetToolMetadata',
     'Thinking',
     'ThreadExecutor',

--- a/pydantic_ai_slim/pydantic_ai/capabilities/repair_tool_orphans.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/repair_tool_orphans.py
@@ -1,0 +1,250 @@
+"""Capability that repairs broken tool-call / tool-return pairing in message history.
+
+Multi-turn conversations with tools can accumulate structural problems:
+dangling tool calls without matching returns, or orphaned returns referencing
+calls that don't exist. Providers like Anthropic strictly enforce pairing and
+will reject malformed history with a 400 error.
+
+This capability hooks into ``before_model_request`` to transparently repair
+these issues before each model request.
+
+Usage::
+
+    from pydantic_ai import Agent
+    from pydantic_ai.capabilities import RepairToolOrphans
+
+    agent = Agent('anthropic:claude-sonnet', capabilities=[RepairToolOrphans()])
+
+See https://github.com/pydantic/pydantic-ai/issues/4728 for background.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from pydantic_ai import messages as _messages
+from pydantic_ai.tools import AgentDepsT
+
+from .abstract import AbstractCapability
+
+if TYPE_CHECKING:
+    from pydantic_ai.models import ModelRequestContext
+    from pydantic_ai.tools import RunContext
+
+__all__ = ['RepairToolOrphans']
+
+_DANGLING_TOOL_CALL_MESSAGE = 'Tool call was not completed.'
+
+
+@dataclass
+class RepairToolOrphans(AbstractCapability[AgentDepsT]):
+    """Repair broken tool-call / tool-return pairing in message history.
+
+    Fixes two classes of structural problems:
+
+    1. **Dangling tool calls** -- a ``ToolCallPart`` or ``BuiltinToolCallPart``
+       in a ``ModelResponse`` that has no matching return anywhere later in the
+       history.
+
+       - For regular ``ToolCallPart``: a synthetic ``ToolReturnPart`` is injected
+         into the next ``ModelRequest``.
+       - For ``BuiltinToolCallPart``: a synthetic ``BuiltinToolReturnPart`` is
+         injected into the *same* ``ModelResponse`` (required by Anthropic).
+
+    2. **Orphaned tool returns** -- a ``ToolReturnPart`` or ``RetryPromptPart``
+       whose ``tool_call_id`` does not match any tool call in the preceding
+       ``ModelResponse``.  These parts are removed.  If that empties the
+       ``ModelRequest``, a placeholder ``UserPromptPart`` is inserted.
+
+    Args:
+        warn: If ``True`` (the default), emit a warning when repairs are made
+              so the underlying issue can be investigated.
+    """
+
+    warn: bool = True
+
+    async def before_model_request(
+        self,
+        ctx: RunContext[AgentDepsT],
+        request_context: ModelRequestContext,
+    ) -> ModelRequestContext:
+        request_context.messages = _repair_messages(request_context.messages, warn=self.warn)
+        return request_context
+
+
+def _repair_messages(
+    messages: list[_messages.ModelMessage],
+    *,
+    warn: bool,
+) -> list[_messages.ModelMessage]:
+    """Core repair logic operating on a message list."""
+    if not messages:
+        return messages
+
+    repaired = False
+    result: list[_messages.ModelMessage] = []
+
+    for i, message in enumerate(messages):
+        if isinstance(message, _messages.ModelResponse):
+            fixed = _repair_response(message)
+            if fixed is not message:
+                repaired = True
+            result.append(fixed)
+        elif isinstance(message, _messages.ModelRequest):
+            fixed = _repair_request(message, result)
+            if fixed is not message:
+                repaired = True
+            result.append(fixed)
+        else:
+            result.append(message)
+
+    # Handle trailing ModelResponse with dangling regular tool calls
+    if result and isinstance(result[-1], _messages.ModelResponse):
+        trailing = result[-1]
+        dangling_calls = [p for p in trailing.parts if isinstance(p, _messages.ToolCallPart)]
+        if dangling_calls:
+            repaired = True
+            result.append(
+                _messages.ModelRequest(
+                    parts=[
+                        _messages.ToolReturnPart(
+                            tool_name=part.tool_name,
+                            content=_DANGLING_TOOL_CALL_MESSAGE,
+                            tool_call_id=part.tool_call_id,
+                        )
+                        for part in dangling_calls
+                    ]
+                )
+            )
+
+    if repaired and warn:
+        warnings.warn(
+            'RepairToolOrphans: repaired broken tool-call/return pairing in message history. '
+            'This usually means a previous agent run was interrupted before tool results '
+            'were recorded. Consider investigating the root cause.',
+            UserWarning,
+            stacklevel=4,
+        )
+
+    return result
+
+
+def _repair_response(response: _messages.ModelResponse) -> _messages.ModelResponse:
+    """Inject synthetic BuiltinToolReturnPart for unanswered BuiltinToolCallParts.
+
+    Builtin tool returns must live in the same ModelResponse as the call
+    (required by Anthropic).
+    """
+    builtin_call_ids: set[str] = set()
+    existing_return_ids: set[str] = set()
+
+    for part in response.parts:
+        if isinstance(part, _messages.BuiltinToolCallPart):
+            builtin_call_ids.add(part.tool_call_id)
+        elif isinstance(part, _messages.BuiltinToolReturnPart):
+            existing_return_ids.add(part.tool_call_id)
+
+    unanswered = builtin_call_ids - existing_return_ids
+    if not unanswered:
+        return response
+
+    new_parts: list[_messages.ModelResponsePart] = list(response.parts)
+    for part in response.parts:
+        if isinstance(part, _messages.BuiltinToolCallPart) and part.tool_call_id in unanswered:
+            new_parts.append(
+                _messages.BuiltinToolReturnPart(
+                    tool_name=part.tool_name,
+                    content=_DANGLING_TOOL_CALL_MESSAGE,
+                    tool_call_id=part.tool_call_id,
+                )
+            )
+
+    return _messages.ModelResponse(
+        parts=new_parts,
+        usage=response.usage,
+        model_name=response.model_name,
+        timestamp=response.timestamp,
+        provider_name=response.provider_name,
+        provider_url=response.provider_url,
+        provider_details=response.provider_details,
+        provider_response_id=response.provider_response_id,
+        finish_reason=response.finish_reason,
+        run_id=response.run_id,
+    )
+
+
+def _repair_request(
+    request: _messages.ModelRequest,
+    preceding: list[_messages.ModelMessage],
+) -> _messages.ModelRequest:
+    """Fix orphaned tool returns and inject synthetic returns for dangling calls.
+
+    1. Find the preceding ModelResponse's regular tool call IDs.
+    2. Remove ToolReturnPart / RetryPromptPart whose tool_call_id is not in
+       the preceding response.
+    3. Inject synthetic ToolReturnPart for any ToolCallPart in the preceding
+       response that has no matching return in this request.
+    4. If the request ends up empty, insert a placeholder UserPromptPart.
+    """
+    # Find preceding ModelResponse's tool call IDs
+    prev_regular_calls: dict[str, _messages.ToolCallPart] = {}
+    for prev in reversed(preceding):
+        if isinstance(prev, _messages.ModelResponse):
+            for part in prev.parts:
+                if isinstance(part, _messages.ToolCallPart):
+                    prev_regular_calls[part.tool_call_id] = part
+            break
+
+    prev_call_ids = set(prev_regular_calls.keys())
+
+    # Step 1: Filter out orphaned tool returns / retries
+    filtered_parts: list[_messages.ModelRequestPart] = []
+    answered_ids: set[str] = set()
+    changed = False
+    for part in request.parts:
+        if isinstance(part, (_messages.ToolReturnPart, _messages.RetryPromptPart)):
+            if part.tool_call_id in prev_call_ids:
+                filtered_parts.append(part)
+                answered_ids.add(part.tool_call_id)
+            else:
+                changed = True  # Dropping orphaned part
+        else:
+            filtered_parts.append(part)
+
+    # Step 2: Inject synthetic returns for unanswered regular tool calls
+    unanswered = prev_call_ids - answered_ids
+    synthetic_parts: list[_messages.ModelRequestPart] = []
+    if unanswered:
+        changed = True
+        # Preserve the order of tool calls from the response
+        for prev in reversed(preceding):
+            if isinstance(prev, _messages.ModelResponse):
+                for part in prev.parts:
+                    if isinstance(part, _messages.ToolCallPart) and part.tool_call_id in unanswered:
+                        synthetic_parts.append(
+                            _messages.ToolReturnPart(
+                                tool_name=part.tool_name,
+                                content=_DANGLING_TOOL_CALL_MESSAGE,
+                                tool_call_id=part.tool_call_id,
+                            )
+                        )
+                break
+
+    if not changed:
+        return request
+
+    all_parts = synthetic_parts + filtered_parts
+
+    # Step 3: If empty, add placeholder
+    if not all_parts:
+        all_parts = [_messages.UserPromptPart(content='...')]
+
+    return _messages.ModelRequest(
+        parts=all_parts,
+        timestamp=request.timestamp,
+        instructions=request.instructions,
+        run_id=request.run_id,
+        metadata=request.metadata,
+    )

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -71,6 +71,8 @@ from pydantic_graph import End
 from ._inline_snapshot import snapshot
 from .conftest import IsDatetime, IsInstance, IsStr
 
+from pydantic_ai.capabilities import RepairToolOrphans
+
 pytestmark = [
     pytest.mark.anyio,
 ]
@@ -84,6 +86,7 @@ def test_capability_types() -> None:
             'IncludeToolReturnSchemas': IncludeToolReturnSchemas,
             'MCP': MCP,
             'PrefixTools': PrefixTools,
+            'RepairToolOrphans': RepairToolOrphans,
             'SetToolMetadata': SetToolMetadata,
             'Thinking': Thinking,
             'WebFetch': WebFetch,

--- a/tests/test_repair_tool_orphans.py
+++ b/tests/test_repair_tool_orphans.py
@@ -1,0 +1,337 @@
+"""Tests for the RepairToolOrphans capability."""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import AsyncIterator
+
+import pytest
+
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import RepairToolOrphans
+from pydantic_ai.messages import (
+    BuiltinToolCallPart,
+    BuiltinToolReturnPart,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    RetryPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+pytestmark = [pytest.mark.anyio]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DANGLING_MSG = 'Tool call was not completed.'
+
+
+def _ids_of(parts: list, cls: type) -> set[str]:
+    """Extract tool_call_ids from parts of a given type."""
+    return {p.tool_call_id for p in parts if isinstance(p, cls)}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the repair logic
+# ---------------------------------------------------------------------------
+
+
+class TestRepairToolOrphansUnit:
+    """Unit tests that directly call the internal _repair_messages function."""
+
+    def _repair(self, messages: list[ModelMessage], *, warn: bool = False) -> list[ModelMessage]:
+        from pydantic_ai.capabilities.repair_tool_orphans import _repair_messages
+
+        return _repair_messages(messages, warn=warn)
+
+    def test_empty_history(self):
+        assert self._repair([]) == []
+
+    def test_clean_history_unchanged(self):
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hello')]),
+            ModelResponse(parts=[ToolCallPart(tool_name='t', args='{}', tool_call_id='tc1')]),
+            ModelRequest(parts=[ToolReturnPart(tool_name='t', content='ok', tool_call_id='tc1')]),
+            ModelResponse(parts=[TextPart(content='done')]),
+        ]
+        result = self._repair(messages)
+        assert len(result) == 4
+        # No synthetic parts should have been added
+        req = result[2]
+        assert isinstance(req, ModelRequest)
+        returns = [p for p in req.parts if isinstance(p, ToolReturnPart)]
+        assert len(returns) == 1
+        assert returns[0].tool_call_id == 'tc1'
+
+    def test_dangling_regular_call_with_following_request(self):
+        """ToolCallPart with no return -> synthetic ToolReturnPart injected."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(parts=[ToolCallPart(tool_name='t', args='{}', tool_call_id='tc1')]),
+            ModelRequest(parts=[UserPromptPart(content='continue')]),
+        ]
+        result = self._repair(messages)
+        assert len(result) == 3
+        req = result[2]
+        assert isinstance(req, ModelRequest)
+        synthetic = [p for p in req.parts if isinstance(p, ToolReturnPart)]
+        assert len(synthetic) == 1
+        assert synthetic[0].tool_call_id == 'tc1'
+        assert synthetic[0].content == _DANGLING_MSG
+        # Original user prompt preserved
+        assert any(isinstance(p, UserPromptPart) for p in req.parts)
+
+    def test_dangling_regular_call_trailing(self):
+        """Trailing ModelResponse with dangling call -> synthetic request appended."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(parts=[ToolCallPart(tool_name='t', args='{}', tool_call_id='tc1')]),
+        ]
+        result = self._repair(messages)
+        assert len(result) == 3
+        req = result[2]
+        assert isinstance(req, ModelRequest)
+        assert len(req.parts) == 1
+        assert isinstance(req.parts[0], ToolReturnPart)
+        assert req.parts[0].tool_call_id == 'tc1'
+
+    def test_dangling_builtin_call(self):
+        """BuiltinToolCallPart without return -> synthetic return in same response."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(
+                parts=[BuiltinToolCallPart(tool_name='web_search', args='{}', tool_call_id='btc1')]
+            ),
+            ModelRequest(parts=[UserPromptPart(content='continue')]),
+        ]
+        result = self._repair(messages)
+        resp = result[1]
+        assert isinstance(resp, ModelResponse)
+        builtin_returns = [p for p in resp.parts if isinstance(p, BuiltinToolReturnPart)]
+        assert len(builtin_returns) == 1
+        assert builtin_returns[0].tool_call_id == 'btc1'
+        assert builtin_returns[0].content == _DANGLING_MSG
+
+    def test_orphaned_tool_return_removed(self):
+        """ToolReturnPart with no matching call in preceding response -> removed."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(parts=[TextPart(content='no tools called')]),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(tool_name='t', content='stale', tool_call_id='orphan'),
+                    UserPromptPart(content='continue'),
+                ]
+            ),
+        ]
+        result = self._repair(messages)
+        req = result[2]
+        assert isinstance(req, ModelRequest)
+        # Orphaned return should be gone
+        returns = [p for p in req.parts if isinstance(p, ToolReturnPart)]
+        assert len(returns) == 0
+        # User prompt preserved
+        assert any(isinstance(p, UserPromptPart) for p in req.parts)
+
+    def test_orphaned_retry_prompt_removed(self):
+        """RetryPromptPart with no matching call -> removed."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(parts=[TextPart(content='done')]),
+            ModelRequest(
+                parts=[
+                    RetryPromptPart(content='retry orphan', tool_call_id='orphan'),
+                    UserPromptPart(content='next'),
+                ]
+            ),
+        ]
+        result = self._repair(messages)
+        req = result[2]
+        assert isinstance(req, ModelRequest)
+        retries = [p for p in req.parts if isinstance(p, RetryPromptPart)]
+        assert len(retries) == 0
+
+    def test_empty_request_gets_placeholder(self):
+        """If removing orphans empties the request, a placeholder is inserted."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(parts=[TextPart(content='done')]),
+            ModelRequest(
+                parts=[ToolReturnPart(tool_name='t', content='orphan', tool_call_id='orphan')]
+            ),
+        ]
+        result = self._repair(messages)
+        req = result[2]
+        assert isinstance(req, ModelRequest)
+        assert len(req.parts) == 1
+        assert isinstance(req.parts[0], UserPromptPart)
+        assert req.parts[0].content == '...'
+
+    def test_multiple_dangling_calls(self):
+        """Multiple tool calls without returns -> all get synthetic returns."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(tool_name='a', args='{}', tool_call_id='tc1'),
+                    ToolCallPart(tool_name='b', args='{}', tool_call_id='tc2'),
+                ]
+            ),
+            ModelRequest(parts=[UserPromptPart(content='continue')]),
+        ]
+        result = self._repair(messages)
+        req = result[2]
+        assert isinstance(req, ModelRequest)
+        returns = [p for p in req.parts if isinstance(p, ToolReturnPart)]
+        assert len(returns) == 2
+        assert _ids_of(returns, ToolReturnPart) == {'tc1', 'tc2'}
+
+    def test_partial_answer(self):
+        """One of two calls answered -> only the unanswered one gets synthetic return."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(tool_name='a', args='{}', tool_call_id='tc1'),
+                    ToolCallPart(tool_name='b', args='{}', tool_call_id='tc2'),
+                ]
+            ),
+            ModelRequest(
+                parts=[ToolReturnPart(tool_name='a', content='ok', tool_call_id='tc1')]
+            ),
+        ]
+        result = self._repair(messages)
+        req = result[2]
+        assert isinstance(req, ModelRequest)
+        returns = [p for p in req.parts if isinstance(p, ToolReturnPart)]
+        assert len(returns) == 2
+        ids = {r.tool_call_id for r in returns}
+        assert ids == {'tc1', 'tc2'}
+        # tc1 should have real content, tc2 synthetic
+        for r in returns:
+            if r.tool_call_id == 'tc1':
+                assert r.content == 'ok'
+            else:
+                assert r.content == _DANGLING_MSG
+
+    def test_metadata_preserved(self):
+        """Request metadata should survive repair."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(parts=[ToolCallPart(tool_name='t', args='{}', tool_call_id='tc1')]),
+            ModelRequest(
+                parts=[UserPromptPart(content='next')],
+                instructions='keep me',
+                metadata={'key': 'value'},
+            ),
+        ]
+        result = self._repair(messages)
+        req = result[2]
+        assert isinstance(req, ModelRequest)
+        assert req.instructions == 'keep me'
+        assert req.metadata == {'key': 'value'}
+
+    def test_warning_emitted(self):
+        """When warn=True, a UserWarning should be emitted on repair."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(parts=[ToolCallPart(tool_name='t', args='{}', tool_call_id='tc1')]),
+            ModelRequest(parts=[UserPromptPart(content='continue')]),
+        ]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self._repair(messages, warn=True)
+            assert len(w) == 1
+            assert 'RepairToolOrphans' in str(w[0].message)
+
+    def test_no_warning_when_clean(self):
+        """No warning should be emitted when no repairs are needed."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(parts=[TextPart(content='done')]),
+        ]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self._repair(messages, warn=True)
+            assert len(w) == 0
+
+    def test_no_warning_when_disabled(self):
+        """No warning when warn=False even if repairs happen."""
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hi')]),
+            ModelResponse(parts=[ToolCallPart(tool_name='t', args='{}', tool_call_id='tc1')]),
+            ModelRequest(parts=[UserPromptPart(content='continue')]),
+        ]
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            self._repair(messages, warn=False)
+            assert len(w) == 0
+
+    def test_multi_turn_poisoned_conversation(self):
+        """Multiple rounds of damage: dangling calls + orphaned returns."""
+        messages: list[ModelMessage] = [
+            # Turn 1: normal
+            ModelRequest(parts=[UserPromptPart(content='start')]),
+            ModelResponse(parts=[ToolCallPart(tool_name='a', args='{}', tool_call_id='tc1')]),
+            ModelRequest(parts=[ToolReturnPart(tool_name='a', content='ok', tool_call_id='tc1')]),
+            # Turn 2: response has dangling call, next request has orphaned return
+            ModelResponse(parts=[ToolCallPart(tool_name='b', args='{}', tool_call_id='tc2')]),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(tool_name='c', content='stale', tool_call_id='tc_orphan'),
+                    UserPromptPart(content='help'),
+                ]
+            ),
+            # Turn 3: clean
+            ModelResponse(parts=[TextPart(content='final')]),
+        ]
+        result = self._repair(messages)
+        # Turn 2 request should have: synthetic for tc2, user prompt, orphan removed
+        req = result[4]
+        assert isinstance(req, ModelRequest)
+        returns = [p for p in req.parts if isinstance(p, ToolReturnPart)]
+        assert len(returns) == 1
+        assert returns[0].tool_call_id == 'tc2'
+        assert returns[0].content == _DANGLING_MSG
+        # User prompt preserved
+        assert any(isinstance(p, UserPromptPart) and p.content == 'help' for p in req.parts)
+
+
+# ---------------------------------------------------------------------------
+# Integration test with Agent
+# ---------------------------------------------------------------------------
+
+
+class TestRepairToolOrphansIntegration:
+    """Test the capability end-to-end with a real Agent."""
+
+    async def test_agent_with_poisoned_history(self):
+        """Agent should successfully run with a poisoned message history when
+        RepairToolOrphans is enabled."""
+
+        def model_func(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            return ModelResponse(parts=[TextPart(content='recovered')])
+
+        agent = Agent(
+            FunctionModel(model_func),
+            capabilities=[RepairToolOrphans(warn=False)],
+        )
+
+        # Poisoned history: dangling tool call
+        poisoned_history: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='hello')]),
+            ModelResponse(parts=[ToolCallPart(tool_name='t', args='{}', tool_call_id='tc1')]),
+            # Missing ToolReturnPart for tc1
+            ModelRequest(parts=[UserPromptPart(content='continue')]),
+            ModelResponse(parts=[TextPart(content='partial')]),
+        ]
+
+        result = await agent.run('try again', message_history=poisoned_history)
+        assert result.output == 'recovered'


### PR DESCRIPTION
## Summary

Implements the `RepairToolOrphans` **capability** (as requested by @DouweM in #4728) to repair broken tool-call/return pairing in persisted message history.

Previous PR #5021 was closed because it was implemented as a `history_processor` instead of a capability. This PR follows the guidance correctly.

## What it does

- **Dangling tool calls**: `ToolCallPart` with no matching return → injects synthetic `ToolReturnPart` in the next request
- **Dangling builtin calls**: `BuiltinToolCallPart` without return → injects `BuiltinToolReturnPart` in the **same** `ModelResponse` (required by Anthropic)
- **Orphaned returns**: `ToolReturnPart`/`RetryPromptPart` with no matching call → removed
- **Empty requests**: If cleanup empties a `ModelRequest`, inserts placeholder `UserPromptPart`
- **Warnings**: Emits `UserWarning` when repairs are made (configurable via `warn=True/False`)

## Usage

```python
from pydantic_ai import Agent
from pydantic_ai.capabilities import RepairToolOrphans

agent = Agent('anthropic:claude-sonnet', capabilities=[RepairToolOrphans()])
```

## Files changed

- `pydantic_ai_slim/pydantic_ai/capabilities/repair_tool_orphans.py` — capability implementation (250 lines)
- `pydantic_ai_slim/pydantic_ai/capabilities/__init__.py` — register in exports and `CAPABILITY_TYPES`
- `tests/test_repair_tool_orphans.py` — 16 tests (unit + integration)
- `tests/test_capabilities.py` — snapshot update for registry

## Test plan

- [x] 15 unit tests covering: empty/clean history, dangling regular/builtin calls, trailing responses, orphaned returns/retries, empty request placeholders, partial answers, metadata preservation, warning behavior, multi-turn poisoned conversations
- [x] 1 integration test with `Agent` + `FunctionModel` using poisoned message history
- [x] All 424 existing capability tests pass (2 pre-existing failures unrelated to this change)

Closes #4728

🤖 Generated with [Claude Code](https://claude.com/claude-code)