### PR TITLE
Add Vercel AI SDK example to gateway docs

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -313,7 +313,6 @@ The [Vercel AI SDK](https://ai-sdk.dev/) can route through the Gateway by pointi
 === "US"
 
     ```typescript
-    import { createAnthropic } from "@ai-sdk/anthropic";
     import { createOpenAI } from "@ai-sdk/openai";
     import { generateText } from "ai";
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -326,7 +326,7 @@ The [Vercel AI SDK](https://ai-sdk.dev/) can route through the Gateway by pointi
 
     async function main() {
       const openaiResult = await generateText({
-        model: openai("gpt-4.1"),
+        model: openai("gpt-5.2"),
         prompt: "what color is the sky? reply concisely",
       });
       console.log("openai:", openaiResult.text);
@@ -354,7 +354,7 @@ The [Vercel AI SDK](https://ai-sdk.dev/) can route through the Gateway by pointi
 
     async function main() {
       const openaiResult = await generateText({
-        model: openai("gpt-4.1"),
+        model: openai("gpt-5.2"),
         prompt: "what color is the sky? reply concisely",
       });
       console.log("openai:", openaiResult.text);

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -306,6 +306,68 @@ Use the base URL that matches your Logfire region (`gateway-us` or `gateway-eu`)
     #> Hello user
     ```
 
+#### Vercel AI SDK
+
+The [Vercel AI SDK](https://ai-sdk.dev/) can route through the Gateway by pointing each provider's `baseURL` at the matching proxy path (e.g. `/proxy/openai` or `/proxy/anthropic`). Use the base URL that matches your Logfire region (`gateway-us` or `gateway-eu`).
+
+=== "US"
+
+    ```typescript
+    import { createAnthropic } from "@ai-sdk/anthropic";
+    import { createOpenAI } from "@ai-sdk/openai";
+    import { generateText } from "ai";
+
+    const apiKey = process.env.PYDANTIC_AI_GATEWAY_API_KEY;
+    if (!apiKey) throw new Error("set PYDANTIC_AI_GATEWAY_API_KEY");
+
+    const openai = createOpenAI({
+      apiKey,
+      baseURL: "https://gateway-us.pydantic.dev/proxy/openai",
+    });
+
+    async function main() {
+      const openaiResult = await generateText({
+        model: openai("gpt-4.1"),
+        prompt: "what color is the sky? reply concisely",
+      });
+      console.log("openai:", openaiResult.text);
+    }
+
+    main().catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+    ```
+
+=== "EU"
+
+    ```typescript
+    import { createAnthropic } from "@ai-sdk/anthropic";
+    import { createOpenAI } from "@ai-sdk/openai";
+    import { generateText } from "ai";
+
+    const apiKey = process.env.PYDANTIC_AI_GATEWAY_API_KEY;
+    if (!apiKey) throw new Error("set PYDANTIC_AI_GATEWAY_API_KEY");
+
+    const openai = createOpenAI({
+      apiKey,
+      baseURL: "https://gateway-eu.pydantic.dev/proxy/openai",
+    });
+
+    async function main() {
+      const openaiResult = await generateText({
+        model: openai("gpt-4.1"),
+        prompt: "what color is the sky? reply concisely",
+      });
+      console.log("openai:", openaiResult.text);
+    }
+
+    main().catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+    ```
+
 ## Troubleshooting
 
 ### Unable to calculate spend

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -341,7 +341,6 @@ The [Vercel AI SDK](https://ai-sdk.dev/) can route through the Gateway by pointi
 === "EU"
 
     ```typescript
-    import { createAnthropic } from "@ai-sdk/anthropic";
     import { createOpenAI } from "@ai-sdk/openai";
     import { generateText } from "ai";
 


### PR DESCRIPTION
### Summary

Adds a Vercel AI SDK section to the Pydantic AI Gateway docs (`docs/gateway.md`), alongside the existing OpenAI and Anthropic SDK examples. Shows how to point the SDK's per-provider `baseURL` at the Gateway proxy path, with US and EU region tabs.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).