### PR TITLE
fix: remove `structured-outputs-2025-11-13` beta header (now GA)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -560,11 +560,6 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
 
         betas: set[str] = set()
 
-        has_strict_tools = any(tool.get('strict') for tool in tools)
-
-        if has_strict_tools or model_request_parameters.output_mode == 'native':
-            betas.add('structured-outputs-2025-11-13')
-
         if model_settings.get('anthropic_context_management'):
             betas.add('compact-2026-01-12')
 

--- a/tests/models/anthropic/test_output.py
+++ b/tests/models/anthropic/test_output.py
@@ -175,7 +175,7 @@ def test_native_output_supported_model(
     mock_sonnet_4_5: tuple[AnthropicModel, AsyncAnthropic],
     city_location_schema: type[BaseModel],
 ):
-    """sonnet-4-5: NativeOutput → strict=True + beta header + output_config."""
+    """sonnet-4-5: NativeOutput → strict=True + output_config (no beta header, structured outputs is GA)."""
     model, mock_client = mock_sonnet_4_5
     agent = Agent(model, output_type=NativeOutput(city_location_schema))
 
@@ -187,7 +187,7 @@ def test_native_output_supported_model(
 
     assert output_config['format']['type'] == 'json_schema'
     assert output_config['format']['schema']['type'] == 'object'
-    assert betas == snapshot(['structured-outputs-2025-11-13'])
+    assert betas is OMIT
 
 
 # =============================================================================
@@ -209,7 +209,8 @@ def create_header_verification_hook(expect_beta: bool, test_name: str):
     NOTE: the vcr config doesn't record anthropic-beta headers.
     This hook allows us to verify them in live API tests.
 
-    TODO: remove when structured outputs is generally available and no longer a beta feature.
+    Structured outputs is now GA — all callers should pass expect_beta=False.
+    This helper can be fully removed in a follow-up cleanup.
     """
     errors: list[str] = []
 
@@ -280,9 +281,9 @@ def test_no_tools_native_output_strict_true(
     allow_model_requests: None,
     anthropic_model: ANTHROPIC_MODEL_FIXTURE,
 ) -> None:
-    """Agent with NativeOutput(strict=True) → beta header + output_format."""
+    """Agent with NativeOutput(strict=True) → output_format, no beta header (structured outputs is GA)."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_no_tools_native_output_strict_true')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_no_tools_native_output_strict_true')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo, strict=True))
@@ -298,9 +299,9 @@ def test_no_tools_native_output_strict_none(
     allow_model_requests: None,
     anthropic_model: ANTHROPIC_MODEL_FIXTURE,
 ) -> None:
-    """Agent with NativeOutput(strict=None) → forces strict=True, beta header + output_format."""
+    """Agent with NativeOutput(strict=None) → forces strict=True, output_format, no beta header (structured outputs is GA)."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_no_tools_native_output_strict_none')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_no_tools_native_output_strict_none')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -332,9 +333,9 @@ def test_strict_true_tool_no_output(
     allow_model_requests: None,
     anthropic_model: ANTHROPIC_MODEL_FIXTURE,
 ) -> None:
-    """Tool with strict=True, no output_type → beta header, tool has strict field."""
+    """Tool with strict=True, no output_type → tool has strict field, no beta header (structured outputs is GA)."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_true_tool_no_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_true_tool_no_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model)
@@ -354,9 +355,9 @@ def test_strict_true_tool_basemodel_output(
     allow_model_requests: None,
     anthropic_model: ANTHROPIC_MODEL_FIXTURE,
 ) -> None:
-    """Tool with strict=True, BaseModel output_type → beta header, tool has strict field."""
+    """Tool with strict=True, BaseModel output_type → tool has strict field, no beta header (structured outputs is GA)."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_true_tool_basemodel_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_true_tool_basemodel_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=CityInfo)
@@ -376,9 +377,9 @@ def test_strict_true_tool_native_output(
     allow_model_requests: None,
     anthropic_model: ANTHROPIC_MODEL_FIXTURE,
 ) -> None:
-    """Tool with strict=True, NativeOutput → beta header, tool has strict field + output_format."""
+    """Tool with strict=True, NativeOutput → tool has strict field + output_format, no beta header (structured outputs is GA)."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_true_tool_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_true_tool_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -443,9 +444,9 @@ def test_strict_none_tool_native_output(
     allow_model_requests: None,
     anthropic_model: ANTHROPIC_MODEL_FIXTURE,
 ) -> None:
-    """Tool with strict=None, NativeOutput → beta from native only, tool has no strict field + output_format."""
+    """Tool with strict=None, NativeOutput → tool has no strict field + output_format, no beta header."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_none_tool_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_none_tool_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -488,9 +489,9 @@ def test_strict_false_tool_native_output(
     allow_model_requests: None,
     anthropic_model: ANTHROPIC_MODEL_FIXTURE,
 ) -> None:
-    """Tool with strict=False, NativeOutput → beta from native only + output_format."""
+    """Tool with strict=False, NativeOutput → output_format, no beta header."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_false_tool_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_false_tool_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -511,9 +512,9 @@ def test_mixed_tools_no_output(
     allow_model_requests: None,
     anthropic_model: ANTHROPIC_MODEL_FIXTURE,
 ) -> None:
-    """Mixed tools (one strict=True, one strict=None), no output_type → beta, only strict=True has strict field."""
+    """Mixed tools (one strict=True, one strict=None), no output_type → only strict=True has strict field, no beta header."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_mixed_tools_no_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_mixed_tools_no_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model)
@@ -537,9 +538,9 @@ def test_mixed_tools_basemodel_output(
     allow_model_requests: None,
     anthropic_model: ANTHROPIC_MODEL_FIXTURE,
 ) -> None:
-    """Mixed tools (one strict=True, one strict=None), BaseModel output_type → beta, only strict=True has strict field."""
+    """Mixed tools (one strict=True, one strict=None), BaseModel output_type → only strict=True has strict field, no beta header."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_mixed_tools_basemodel_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_mixed_tools_basemodel_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=CityInfo)
@@ -563,9 +564,9 @@ def test_mixed_tools_native_output(
     allow_model_requests: None,
     anthropic_model: ANTHROPIC_MODEL_FIXTURE,
 ) -> None:
-    """Mixed tools (one strict=True, one strict=None), NativeOutput → beta, only strict=True has strict field + output_format."""
+    """Mixed tools (one strict=True, one strict=None), NativeOutput → only strict=True has strict field + output_format, no beta header."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_mixed_tools_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_mixed_tools_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -999,7 +999,6 @@ async def test_beta_header_merge_builtin_tools_and_native_output(allow_model_req
             'context-management-2025-06-27',
             'custom-feature-1',
             'custom-feature-2',
-            'structured-outputs-2025-11-13',
         ]
     )
 
@@ -1099,7 +1098,6 @@ async def test_anthropic_betas_merge_with_other_sources(allow_model_requests: No
     betas = completion_kwargs['betas']
     assert 'interleaved-thinking-2025-05-14' in betas
     assert 'custom-feature-1' in betas
-    assert 'structured-outputs-2025-11-13' in betas
 
 
 async def test_anthropic_mixed_strict_tool_run(allow_model_requests: None, anthropic_api_key: str):


### PR DESCRIPTION
## Summary

Anthropic structured outputs (JSON output via `output_config.format` and strict tool use via `strict: true`) are now generally available on the Claude API. The `structured-outputs-2025-11-13` beta header is no longer required.

This PR removes the automatic injection of the beta header when using strict tools or native output mode. The `output_config` parameter (already using the GA field name) continues to work as before.

**Changes:**
- Remove `structured-outputs-2025-11-13` beta addition from `_get_betas_and_extra_headers()` in the Anthropic model
- Update test assertions that expected this beta header to be present
- Update test docstrings to reflect GA status
- Mark `create_header_verification_hook` as ready for follow-up removal (per its existing TODO)

Closes #4988

## Test plan

- [x] All 160 Anthropic model tests pass (`tests/models/test_anthropic.py` + `tests/models/anthropic/`)
- [x] Verified `output_config` continues to be set correctly for NativeOutput
- [x] Verified other beta headers (compact, custom, builtin-tool) are unaffected
- [x] Header verification hooks updated to expect no structured-outputs beta