### PR TITLE
Document provider failover via routing groups in gateway docs

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -25,6 +25,7 @@ To help you get started with Pydantic AI Gateway, some code examples on the Pyda
 - **Cost Limits**: Set spending limits at project, user, and API key levels with daily, weekly, and monthly caps.
 - **BYOK and managed providers:** Bring your own API keys (BYOK) from LLM providers, or pay for inference directly through the platform.
 - **Multi-provider support:** Access models from OpenAI, Anthropic, Google Vertex, Groq, and AWS Bedrock. _More providers coming soon_.
+- **Provider failover:** Configure [routing groups](#provider-failover) so the Gateway can automatically fall back to another provider serving the same model when the primary is unavailable.
 - **Backend observability:** Log every request through [Pydantic Logfire](https://pydantic.dev/logfire) or any OpenTelemetry backend (_coming soon_).
 - **Zero translation**: Unlike traditional AI gateways that translate everything to one common schema, **Pydantic AI Gateway** allows requests to flow through directly in each provider's native format. This gives you immediate access to new model features as soon as they are released.
 - **Enterprise ready**: Inherits Logfire's enterprise features — including SSO, custom roles and permissions.
@@ -365,6 +366,49 @@ The [Vercel AI SDK](https://ai-sdk.dev/) can route through the Gateway by pointi
       process.exit(1);
     });
     ```
+
+## Provider failover
+
+Pydantic AI Gateway can automatically fail over between providers serving the same model through **routing groups**. A routing group is a named collection of providers with a priority and weight assigned to each member; the Gateway tries higher-priority members first, and load-balances across members that share the same priority using their weights.
+
+This is useful when the same model is available through more than one provider (for example Anthropic models served through both the Anthropic API and Google Vertex) and you want the Gateway to transparently retry another provider when the primary is unavailable or rate-limited.
+
+### Creating a routing group
+
+Routing groups are managed from your organization's Gateway settings in Logfire:
+
+1. Open **Gateway -> Admin -> Routing Groups** and click **Add Routing Group**.
+2. Give the group a slug (e.g. `anthropic-fallback`) and an optional description.
+3. Open the group's **Members** page and add one or more providers. For each member set:
+    - **Priority** - higher values are tried first.
+    - **Weight** - load-balancing weight used between members that share the same priority.
+    - **Active** - inactive members are skipped during routing.
+
+### Using a routing group
+
+Point the Gateway provider at the group via the `route` parameter (the group's slug):
+
+```python {title="fallback_routing.py"}
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.providers.gateway import gateway_provider
+
+provider = gateway_provider(
+    'anthropic',
+    api_key='pylf_v...',
+    route='anthropic-fallback',
+)
+model = AnthropicModel('claude-sonnet-4-6', provider=provider)
+agent = Agent(model)
+
+result = agent.run_sync('Where does "hello world" come from?')
+print(result.output)
+"""
+The first known use of "hello, world" was in a 1974 textbook about the C programming language.
+"""
+```
+
+Requests sent to this group will be dispatched to the highest-priority active member first, with the remaining members used as fallbacks in priority order. Members at the same priority split traffic according to their configured weights.
 
 ## Troubleshooting
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -371,8 +371,8 @@ The [Vercel AI SDK](https://ai-sdk.dev/) can route through the Gateway by pointi
 
 A **routing group** is a named collection of providers that all serve the same model. Each member has a **priority**, a **weight**, and an **active** flag, and those three values together let a single group express two different routing strategies:
 
-- **Failover / fallback** - Assign members different priorities. The Gateway always tries the highest-priority active member first, and only falls through to a lower-priority member when the higher one is unavailable (for example if it is down, rate-limited, or returns an error).
-- **Load balancing** - Assign two or more members the same priority and give each a weight. The Gateway splits traffic across those members in proportion to their weights.
+- **Failover / fallback**: Assign members different priorities. The Gateway always tries the highest-priority active member first, and only falls through to a lower-priority member when the higher one is unavailable (for example if it is down, rate-limited, or returns an error).
+- **Load balancing**: Assign two or more members the same priority and give each a weight. The Gateway splits traffic across those members in proportion to their weights.
 
 The two strategies compose: you can have, for example, a top priority tier with two providers load-balanced 70/30, and a second priority tier that only receives traffic when both top-tier providers fail.
 
@@ -380,7 +380,7 @@ The two strategies compose: you can have, for example, a top priority tier with 
 
 Routing groups are managed from your organization's Gateway settings in Logfire:
 
-1. Open **Gateway -> Admin -> Routing Groups** and click **Add Routing Group**.
+1. Open **Gateway -> Routing Groups** and click **Add Routing Group**.
 2. Give the group a slug (e.g. `anthropic-routing`) and an optional description.
 3. Open the group's **Members** page and add one or more providers. For each member set:
     - **Priority** - higher values are tried first. Use different priorities across members for failover.
@@ -399,7 +399,7 @@ from pydantic_ai.providers.gateway import gateway_provider
 provider = gateway_provider(
     'anthropic',
     api_key='pylf_v...',
-    route='anthropic-routing',
+    route='anthropic-routing',  # (1)!
 )
 model = AnthropicModel('claude-sonnet-4-6', provider=provider)
 agent = Agent(model)
@@ -410,6 +410,8 @@ print(result.output)
 The first known use of "hello, world" was in a 1974 textbook about the C programming language.
 """
 ```
+
+1. The slug of the routing group you created in Logfire.
 
 ## Troubleshooting
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -25,7 +25,7 @@ To help you get started with Pydantic AI Gateway, some code examples on the Pyda
 - **Cost Limits**: Set spending limits at project, user, and API key levels with daily, weekly, and monthly caps.
 - **BYOK and managed providers:** Bring your own API keys (BYOK) from LLM providers, or pay for inference directly through the platform.
 - **Multi-provider support:** Access models from OpenAI, Anthropic, Google Vertex, Groq, and AWS Bedrock. _More providers coming soon_.
-- **Provider failover:** Configure [routing groups](#provider-failover) so the Gateway can automatically fall back to another provider serving the same model when the primary is unavailable.
+- **Routing groups:** Configure [routing groups](#routing-groups) to fail over between providers serving the same model, or load-balance traffic across them by weight.
 - **Backend observability:** Log every request through [Pydantic Logfire](https://pydantic.dev/logfire) or any OpenTelemetry backend (_coming soon_).
 - **Zero translation**: Unlike traditional AI gateways that translate everything to one common schema, **Pydantic AI Gateway** allows requests to flow through directly in each provider's native format. This gives you immediate access to new model features as soon as they are released.
 - **Enterprise ready**: Inherits Logfire's enterprise features — including SSO, custom roles and permissions.
@@ -367,20 +367,23 @@ The [Vercel AI SDK](https://ai-sdk.dev/) can route through the Gateway by pointi
     });
     ```
 
-## Provider failover
+## Routing groups
 
-Pydantic AI Gateway can automatically fail over between providers serving the same model through **routing groups**. A routing group is a named collection of providers with a priority and weight assigned to each member; the Gateway tries higher-priority members first, and load-balances across members that share the same priority using their weights.
+A **routing group** is a named collection of providers that all serve the same model. Each member has a **priority**, a **weight**, and an **active** flag, and those three values together let a single group express two different routing strategies:
 
-This is useful when the same model is available through more than one provider (for example Anthropic models served through both the Anthropic API and Google Vertex) and you want the Gateway to transparently retry another provider when the primary is unavailable or rate-limited.
+- **Failover / fallback** - Assign members different priorities. The Gateway always tries the highest-priority active member first, and only falls through to a lower-priority member when the higher one is unavailable (for example if it is down, rate-limited, or returns an error).
+- **Load balancing** - Assign two or more members the same priority and give each a weight. The Gateway splits traffic across those members in proportion to their weights.
+
+The two strategies compose: you can have, for example, a top priority tier with two providers load-balanced 70/30, and a second priority tier that only receives traffic when both top-tier providers fail.
 
 ### Creating a routing group
 
 Routing groups are managed from your organization's Gateway settings in Logfire:
 
 1. Open **Gateway -> Admin -> Routing Groups** and click **Add Routing Group**.
-2. Give the group a slug (e.g. `anthropic-fallback`) and an optional description.
+2. Give the group a slug (e.g. `anthropic-routing`) and an optional description.
 3. Open the group's **Members** page and add one or more providers. For each member set:
-    - **Priority** - higher values are tried first.
+    - **Priority** - higher values are tried first. Use different priorities across members for failover.
     - **Weight** - load-balancing weight used between members that share the same priority.
     - **Active** - inactive members are skipped during routing.
 
@@ -388,7 +391,7 @@ Routing groups are managed from your organization's Gateway settings in Logfire:
 
 Point the Gateway provider at the group via the `route` parameter (the group's slug):
 
-```python {title="fallback_routing.py"}
+```python {title="routing_group.py"}
 from pydantic_ai import Agent
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.providers.gateway import gateway_provider
@@ -396,7 +399,7 @@ from pydantic_ai.providers.gateway import gateway_provider
 provider = gateway_provider(
     'anthropic',
     api_key='pylf_v...',
-    route='anthropic-fallback',
+    route='anthropic-routing',
 )
 model = AnthropicModel('claude-sonnet-4-6', provider=provider)
 agent = Agent(model)
@@ -407,8 +410,6 @@ print(result.output)
 The first known use of "hello, world" was in a 1974 textbook about the C programming language.
 """
 ```
-
-Requests sent to this group will be dispatched to the highest-priority active member first, with the remaining members used as fallbacks in priority order. Members at the same priority split traffic according to their configured weights.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### Summary

Documents the Gateway's provider failover capability in `docs/gateway.md`:

- Adds a **Provider failover** bullet to the Key features list.
- Adds a **Provider failover** section covering routing groups: how to create them in Logfire (Gateway -> Admin -> Routing Groups), what Priority/Weight/Active mean per member, and how to target a group from a client via the `route` parameter on `gateway_provider`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).