### PR TITLE
fix: distinguish 'package not installed' from 'name not found' in ImportError handling

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -728,3 +728,43 @@ def is_text_like_media_type(media_type: str) -> bool:
         or media_type.endswith('+xml')
         or media_type in ('application/x-yaml', 'application/yaml')
     )
+
+
+def check_package_installed(package_name: str, *, install_group: str | None = None, install_label: str | None = None) -> None:
+    """Check if a Python package is installed using importlib.util.find_spec.
+
+    This should be called inside an ``except ImportError`` block to distinguish
+    between "package not installed" and "package installed but a specific name
+    cannot be imported" (e.g. due to an incompatible SDK version).
+
+    If the package cannot be found, raises an ``ImportError`` with a clear
+    installation instruction.  If the package *is* found, the function returns
+    without doing anything, allowing the original ``ImportError`` (which
+    contains the real diagnostic, such as ``cannot import name 'X'``) to be
+    raised by the caller.
+
+    Args:
+        package_name: The top-level package name to look up (e.g. ``"mistralai"``).
+        install_group: The pip extra group name, defaults to *package_name*
+            (e.g. ``"mistral"``).
+        install_label: Human-readable label used in the error message, defaults
+            to *install_group* (e.g. ``"Mistral"``).
+    """
+    import importlib.util
+
+    if install_group is None:
+        install_group = package_name
+    if install_label is None:
+        install_label = install_group
+
+    try:
+        spec = importlib.util.find_spec(package_name)
+    except (ModuleNotFoundError, ValueError):
+        spec = None
+
+    if spec is None:
+        raise ImportError(
+            f'Please install `{install_group}` to use the {install_label} model, '
+            f'you can use the `{install_group}` optional group — '
+            f'`pip install "pydantic-ai-slim[{install_group}]"`'
+        )

--- a/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/bedrock.py
@@ -23,10 +23,10 @@ from .settings import EmbeddingSettings
 try:
     from botocore.exceptions import ClientError
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `boto3` to use Bedrock embedding models, '
-        'you can use the `bedrock` optional group — `pip install "pydantic-ai-slim[bedrock]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('botocore', install_group='bedrock', install_label='Bedrock embeddings')
+    raise
 
 if TYPE_CHECKING:
     from botocore.client import BaseClient

--- a/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/cohere.py
@@ -20,10 +20,10 @@ try:
 
     from pydantic_ai.providers.cohere import CohereProvider
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `cohere` to use the Cohere embeddings model, '
-        'you can use the `cohere` optional group — `pip install "pydantic-ai-slim[cohere]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('cohere', install_group='cohere', install_label='Cohere embeddings')
+    raise
 
 LatestCohereEmbeddingModelNames = Literal[
     'embed-v4.0',

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -14,10 +14,10 @@ try:
     from google.genai import Client, errors
     from google.genai.types import Content, ContentListUnion, EmbedContentConfig, EmbedContentResponse, Part
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `google-genai` to use the Google embeddings model, '
-        'you can use the `google` optional group — `pip install "pydantic-ai-slim[google]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('google.genai', install_group='google', install_label='Google embeddings')
+    raise
 
 
 LatestGoogleGLAEmbeddingModelNames = Literal['gemini-embedding-001', 'gemini-embedding-2-preview']

--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -20,10 +20,10 @@ try:
 
     from pydantic_ai.models.openai import OMIT
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `openai` to use the OpenAI embeddings model, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='OpenAI embeddings')
+    raise
 
 OpenAIEmbeddingModelName = str | LatestOpenAIEmbeddingModelNames
 """Possible OpenAI embeddings model names.

--- a/pydantic_ai_slim/pydantic_ai/embeddings/sentence_transformers.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/sentence_transformers.py
@@ -17,11 +17,10 @@ try:
     import torch
     from sentence_transformers import SentenceTransformer
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `sentence-transformers` to use the Sentence-Transformers embeddings model, '
-        'you can use the `sentence-transformers` optional group — '
-        'pip install "pydantic-ai-slim[sentence-transformers]"'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('sentence_transformers', install_group='sentence-transformers', install_label='Sentence-Transformers embeddings')
+    raise
 
 
 class SentenceTransformersEmbeddingSettings(EmbeddingSettings, total=False):

--- a/pydantic_ai_slim/pydantic_ai/embeddings/voyageai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/voyageai.py
@@ -16,10 +16,10 @@ try:
     from voyageai.client_async import AsyncClient
     from voyageai.error import VoyageError
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `voyageai` to use the VoyageAI embeddings model, '
-        'you can use the `voyageai` optional group — `pip install "pydantic-ai-slim[voyageai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('voyageai', install_group='voyageai', install_label='VoyageAI embeddings')
+    raise
 
 LatestVoyageAIEmbeddingModelNames = Literal[
     'voyage-4-large',

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -158,10 +158,8 @@ try:
     from anthropic.types.model_param import ModelParam
 
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `anthropic` to use the Anthropic model, '
-        'you can use the `anthropic` optional group — `pip install "pydantic-ai-slim[anthropic]"`'
-    ) from _import_error
+    _utils.check_package_installed('anthropic', install_label='Anthropic')
+    raise
 
 
 @contextmanager

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -17,10 +17,10 @@ try:
     from botocore.client import BaseClient
     from botocore.exceptions import ClientError
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `boto3` to use the Bedrock model, '
-        'you can use the `bedrock` optional group — `pip install "pydantic-ai-slim[bedrock]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('botocore', install_group='bedrock', install_label='Bedrock')
+    raise
 
 from pydantic_ai import (
     AudioUrl,

--- a/pydantic_ai_slim/pydantic_ai/models/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cerebras.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, cast
 
 from typing_extensions import override
 
+from .. import _utils
 from ..profiles import ModelProfileSpec
 from ..providers import Provider
 from ..settings import ModelSettings
@@ -17,10 +18,8 @@ try:
 
     from .openai import OpenAIChatModel, OpenAIChatModelSettings
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install the `openai` package to use the Cerebras model, '
-        'you can use the `cerebras` optional group — `pip install "pydantic-ai-slim[cerebras]"'
-    ) from _import_error
+    _utils.check_package_installed('openai', install_group='cerebras', install_label='Cerebras')
+    raise
 
 __all__ = ('CerebrasModel', 'CerebrasModelName', 'CerebrasModelSettings')
 

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -8,7 +8,7 @@ from typing_extensions import assert_never
 
 from pydantic_ai.exceptions import ModelAPIError
 
-from .. import ModelHTTPError, usage
+from .. import ModelHTTPError, _utils, usage
 from .._utils import generate_tool_call_id as _generate_tool_call_id, guard_tool_call_id as _guard_tool_call_id
 from ..messages import (
     BuiltinToolCallPart,
@@ -58,10 +58,8 @@ try:
     from cohere.core.api_error import ApiError
     from cohere.v2.client import OMIT
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `cohere` to use the Cohere model, '
-        'you can use the `cohere` optional group — `pip install "pydantic-ai-slim[cohere]"`'
-    ) from _import_error
+    _utils.check_package_installed('cohere', install_label='Cohere')
+    raise
 
 LatestCohereModelNames = Literal[
     'c4ai-aya-expanse-32b',

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -106,10 +106,8 @@ try:
         VideoMetadataDict,
     )
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `google-genai` to use the Google model, '
-        'you can use the `google` optional group — `pip install "pydantic-ai-slim[google]"`'
-    ) from _import_error
+    _utils.check_package_installed('google.genai', install_group='google', install_label='Google')
+    raise
 
 
 _FILE_SEARCH_QUERY_PATTERN = re.compile(r'file_search\.query\(query=(["\'])((?:\\.|(?!\1).)*?)\1\)')

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -65,10 +65,8 @@ try:
     from groq.types.chat.chat_completion_content_part_image_param import ImageURL
     from groq.types.chat.chat_completion_message import ExecutedTool
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `groq` to use the Groq model, '
-        'you can use the `groq` optional group — `pip install "pydantic-ai-slim[groq]"`'
-    ) from _import_error
+    _utils.check_package_installed('groq', install_label='Groq')
+    raise
 
 
 @contextmanager

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -66,10 +66,8 @@ try:
     from huggingface_hub.errors import HfHubHTTPError
 
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `huggingface_hub` to use Hugging Face Inference Providers, '
-        'you can use the `huggingface` optional group — `pip install "pydantic-ai-slim[huggingface]"`'
-    ) from _import_error
+    _utils.check_package_installed('huggingface_hub', install_group='huggingface', install_label='Hugging Face')
+    raise
 
 
 @contextmanager

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -90,10 +90,8 @@ try:
     from mistralai.client.types.basemodel import Unset as MistralUnset
     from mistralai.client.utils.eventstreaming import EventStreamAsync as MistralEventStreamAsync
 except ImportError as e:  # pragma: lax no cover
-    raise ImportError(
-        'Please install `mistral` to use the Mistral model, '
-        'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
-    ) from e
+    _utils.check_package_installed('mistralai', install_group='mistral', install_label='Mistral')
+    raise
 
 
 @contextmanager

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -133,10 +133,8 @@ try:
 
     OMIT = omit
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `openai` to use the OpenAI model, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    _utils.check_package_installed('openai', install_label='OpenAI')
+    raise
 
 
 @contextmanager

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any, Literal, TypeAlias, cast
 from pydantic import BaseModel, Discriminator, ValidationError, field_validator
 from typing_extensions import TypedDict, assert_never, override
 
+from .. import _utils
 from ..builtin_tools import AbstractBuiltinTool, WebSearchTool
 from ..exceptions import ModelHTTPError
 from ..messages import BinaryContent, FinishReason, ModelResponseStreamEvent, ThinkingPart, VideoUrl
@@ -33,10 +34,8 @@ try:
         _ChatCompletionChunk,  # pyright: ignore[reportPrivateUsage]
     )
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `openai` to use the OpenRouter model, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    _utils.check_package_installed('openai', install_group='openai', install_label='OpenRouter')
+    raise
 
 _CHAT_FINISH_REASON_MAP: dict[Literal['stop', 'length', 'tool_calls', 'content_filter', 'error'], FinishReason] = {
     'stop': 'stop',

--- a/pydantic_ai_slim/pydantic_ai/models/outlines.py
+++ b/pydantic_ai_slim/pydantic_ai/models/outlines.py
@@ -68,10 +68,8 @@ try:
     from outlines.types.dsl import JsonSchema
     from PIL import Image as PILImage
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `outlines` to use the Outlines model, '
-        'you can use the `outlines` optional group — `pip install "pydantic-ai-slim[outlines]"`'
-    ) from _import_error
+    _utils.check_package_installed('outlines', install_label='Outlines')
+    raise
 
 if TYPE_CHECKING:
     import llama_cpp  # pyright: ignore[reportMissingImports]
@@ -204,10 +202,8 @@ class OutlinesModel(Model):
         try:
             from openai import AsyncOpenAI
         except ImportError as _import_error:
-            raise ImportError(
-                'Please install `openai` to use the Outlines SGLang model, '
-                'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-            ) from _import_error
+            _utils.check_package_installed('openai', install_label='Outlines SGLang')
+            raise
 
         openai_client = AsyncOpenAI(base_url=base_url, api_key=api_key)
         outlines_model: OutlinesBaseModel | OutlinesAsyncBaseModel = from_sglang(openai_client, model_name)

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -76,10 +76,8 @@ try:
     from xai_sdk.tools import code_execution, get_tool_call_type, mcp, web_search  # x_search not yet supported
     from xai_sdk.types.model import ChatModel
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install `xai-sdk` to use the xAI model, '
-        'you can use the `xai` optional group — `pip install "pydantic-ai-slim[xai]"`'
-    ) from _import_error
+    _utils.check_package_installed('xai_sdk', install_group='xai', install_label='xAI')
+    raise
 
 
 @contextmanager

--- a/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
@@ -16,10 +16,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the Alibaba provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='Alibaba')
+    raise
 
 
 class AlibabaProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
@@ -17,10 +17,10 @@ from .._json_schema import JsonSchema, JsonSchemaTransformer
 try:
     from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, AsyncAnthropicFoundry, AsyncAnthropicVertex
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install the `anthropic` package to use the Anthropic provider, '
-        'you can use the `anthropic` optional group — `pip install "pydantic-ai-slim[anthropic]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('anthropic', install_group='anthropic', install_label='Anthropic')
+    raise
 
 
 AsyncAnthropicClient: TypeAlias = AsyncAnthropic | AsyncAnthropicBedrock | AsyncAnthropicFoundry | AsyncAnthropicVertex

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -20,10 +20,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncAzureOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the Azure provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='Azure')
+    raise
 
 
 class AzureProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -25,10 +25,10 @@ try:
     from botocore.session import Session
     from botocore.tokens import FrozenAuthToken
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install the `boto3` package to use the Bedrock provider, '
-        'you can use the `bedrock` optional group — `pip install "pydantic-ai-slim[bedrock]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('botocore', install_group='bedrock', install_label='Bedrock')
+    raise
 
 
 @dataclass(kw_only=True)

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -18,10 +18,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the Cerebras provider, '
-        'you can use the `cerebras` optional group — `pip install "pydantic-ai-slim[cerebras]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='cerebras', install_label='Cerebras')
+    raise
 
 
 class CerebrasProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cohere.py
@@ -13,10 +13,10 @@ from pydantic_ai.providers import Provider
 try:
     from cohere import AsyncClient, AsyncClientV2
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install the `cohere` package to use the Cohere provider, '
-        'you can use the `cohere` optional group — `pip install "pydantic-ai-slim[cohere]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('cohere', install_group='cohere', install_label='Cohere')
+    raise
 
 
 class CohereProvider(Provider[AsyncClientV2]):

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -16,10 +16,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the DeepSeek provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='DeepSeek')
+    raise
 
 
 DeepSeekModelName = Literal['deepseek-chat', 'deepseek-reasoner']

--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -20,10 +20,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the Fireworks AI provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='Fireworks AI')
+    raise
 
 
 class FireworksProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/github.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/github.py
@@ -19,10 +19,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the GitHub Models provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='GitHub Models')
+    raise
 
 
 class GitHubProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -16,10 +16,10 @@ try:
     from google.genai.client import Client
     from google.genai.types import HttpOptions
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install the `google-genai` package to use the Google provider, '
-        'you can use the `google` optional group — `pip install "pydantic-ai-slim[google]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('google.genai', install_group='google', install_label='Google')
+    raise
 
 
 class GoogleProvider(Provider[Client]):

--- a/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
@@ -22,10 +22,10 @@ try:
     from google.auth.transport.requests import Request
     from google.oauth2.service_account import Credentials as ServiceAccountCredentials
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install the `google-auth` package to use the Google Vertex AI provider, '
-        'you can use the `vertexai` optional group — `pip install "pydantic-ai-slim[vertexai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('google.auth', install_group='vertexai', install_label='Google Vertex AI')
+    raise
 
 
 __all__ = ('GoogleVertexProvider',)

--- a/pydantic_ai_slim/pydantic_ai/providers/grok.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/grok.py
@@ -17,10 +17,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the Grok provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='Grok')
+    raise
 
 # https://docs.x.ai/docs/models
 GrokModelName = Literal[

--- a/pydantic_ai_slim/pydantic_ai/providers/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/groq.py
@@ -21,10 +21,10 @@ from pydantic_ai.providers import Provider
 try:
     from groq import AsyncGroq
 except ImportError as _import_error:
-    raise ImportError(
-        'Please install the `groq` package to use the Groq provider, '
-        'you can use the `groq` optional group — `pip install "pydantic-ai-slim[groq]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('groq', install_group='groq', install_label='Groq')
+    raise
 
 
 def groq_moonshotai_model_profile(model_name: str) -> ModelProfile | None:

--- a/pydantic_ai_slim/pydantic_ai/providers/heroku.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/heroku.py
@@ -15,10 +15,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the Heroku provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='Heroku')
+    raise
 
 
 class HerokuProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/huggingface.py
@@ -18,10 +18,10 @@ try:
     from huggingface_hub import AsyncInferenceClient
     from huggingface_hub.constants import INFERENCE_PROXY_TEMPLATE
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `huggingface_hub` package to use the HuggingFace provider, '
-        "you can use the `huggingface` optional group — `pip install 'pydantic-ai-slim[huggingface]'`"
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('huggingface_hub', install_group='huggingface', install_label='HuggingFace')
+    raise
 
 from . import Provider
 

--- a/pydantic_ai_slim/pydantic_ai/providers/litellm.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/litellm.py
@@ -24,10 +24,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the LiteLLM provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='LiteLLM')
+    raise
 
 
 class LiteLLMProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -14,10 +14,10 @@ from pydantic_ai.providers import Provider
 try:
     from mistralai.client import Mistral
 except ImportError as e:
-    raise ImportError(
-        'Please install the `mistral` package to use the Mistral provider, '
-        'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
-    ) from e
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('mistralai', install_group='mistral', install_label='Mistral')
+    raise
 
 
 class MistralProvider(Provider[Mistral]):

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -21,10 +21,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the Nebius provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='Nebius')
+    raise
 
 
 class NebiusProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -21,10 +21,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the Ollama provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='Ollama')
+    raise
 
 
 class OllamaProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -13,10 +13,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the OpenAI provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='OpenAI')
+    raise
 
 
 class OpenAIProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -27,10 +27,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the OpenRouter provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='OpenRouter')
+    raise
 
 
 class _OpenRouterGoogleJsonSchemaTransformer(JsonSchemaTransformer):

--- a/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
@@ -19,10 +19,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use OVHcloud AI Endpoints provider.'
-        'You can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='OVHcloud')
+    raise
 
 
 class OVHcloudProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
@@ -18,10 +18,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the SambaNova provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='SambaNova')
+    raise
 
 __all__ = ['SambaNovaProvider']
 

--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -20,10 +20,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the Together AI provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='Together AI')
+    raise
 
 
 class TogetherProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/vercel.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/vercel.py
@@ -21,10 +21,10 @@ from pydantic_ai.providers import Provider
 try:
     from openai import AsyncOpenAI
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `openai` package to use the Vercel provider, '
-        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('openai', install_group='openai', install_label='Vercel')
+    raise
 
 
 class VercelProvider(Provider[AsyncOpenAI]):

--- a/pydantic_ai_slim/pydantic_ai/providers/voyageai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/voyageai.py
@@ -9,10 +9,10 @@ from pydantic_ai.providers import Provider
 try:
     from voyageai.client_async import AsyncClient
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `voyageai` package to use the VoyageAI provider, '
-        'you can use the `voyageai` optional group — `pip install "pydantic-ai-slim[voyageai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('voyageai', install_group='voyageai', install_label='VoyageAI')
+    raise
 
 
 class VoyageAIProvider(Provider[AsyncClient]):

--- a/pydantic_ai_slim/pydantic_ai/providers/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/xai.py
@@ -12,10 +12,10 @@ from pydantic_ai.providers import Provider
 try:
     from xai_sdk import AsyncClient
 except ImportError as _import_error:  # pragma: no cover
-    raise ImportError(
-        'Please install the `xai-sdk` package to use the xAI provider, '
-        'you can use the `xai` optional group — `pip install "pydantic-ai-slim[xai]"`'
-    ) from _import_error
+    from pydantic_ai._utils import check_package_installed
+
+    check_package_installed('xai_sdk', install_group='xai', install_label='xAI')
+    raise
 
 
 class _LazyAsyncClient:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ from pydantic_ai._utils import (
     UNSET,
     PeekableAsyncStream,
     check_object_json_schema,
+    check_package_installed,
     group_by_temporal,
     is_async_callable,
     merge_json_schema_defs,
@@ -833,3 +834,80 @@ def test_validate_empty_kwargs_preserves_order():
     assert '`first`' in error_msg
     assert '`second`' in error_msg
     assert '`third`' in error_msg
+
+
+class TestCheckPackageInstalled:
+    """Tests for check_package_installed — distinguishes 'not installed' from 'name not found'."""
+
+    def test_raises_import_error_when_package_not_installed(self):
+        """When the package is genuinely missing, check_package_installed raises a
+        helpful ImportError with install instructions."""
+        with pytest.raises(ImportError, match=r'Please install.*nonexistent_pkg.*pip install'):
+            check_package_installed('nonexistent_pkg_that_does_not_exist', install_group='nonexistent_pkg')
+
+    def test_returns_none_when_package_is_installed(self):
+        """When the package IS installed, the function returns without raising,
+        so the caller can re-raise the original (more specific) ImportError."""
+        # 'os' is always available
+        result = check_package_installed('os')
+        assert result is None
+
+    def test_install_group_appears_in_message(self):
+        with pytest.raises(ImportError, match=r'pip install "pydantic-ai-slim\[my-group\]"'):
+            check_package_installed(
+                'nonexistent_pkg_xyz', install_group='my-group', install_label='MyGroup'
+            )
+
+    def test_install_label_appears_in_message(self):
+        with pytest.raises(ImportError, match=r'use the MyLabel model'):
+            check_package_installed(
+                'nonexistent_pkg_xyz', install_group='my-group', install_label='MyLabel'
+            )
+
+    def test_defaults_install_group_to_package_name(self):
+        with pytest.raises(ImportError, match=r'pip install "pydantic-ai-slim\[some_missing_pkg\]"'):
+            check_package_installed('some_missing_pkg')
+
+    def test_does_not_mask_name_import_error(self):
+        """Simulate the real-world scenario: the package is installed but a
+        specific name cannot be imported.  check_package_installed should NOT
+        raise (allowing the caller to re-raise the original error)."""
+        # pytest is installed, so this should silently return
+        check_package_installed('pytest')
+
+    def test_integration_with_try_except_pattern(self):
+        """End-to-end test of the recommended usage pattern:
+        try:
+            from some_installed_pkg import NonExistentName
+        except ImportError:
+            check_package_installed(...)
+            raise
+        The original ImportError (with the real diagnostic) should propagate."""
+        with pytest.raises(ImportError, match=r'cannot import name'):
+            try:
+                from os import this_name_does_not_exist_in_os  # type: ignore  # noqa: F401
+            except ImportError:
+                check_package_installed('os')
+                raise
+
+    def test_integration_package_missing_raises_install_hint(self):
+        """When the package is truly missing, the user gets the install hint
+        rather than a confusing internal error."""
+        with pytest.raises(ImportError, match=r'Please install.*mistral'):
+            try:
+                import nonexistent_mistralai_pkg  # type: ignore  # noqa: F401
+            except ImportError:
+                check_package_installed(
+                    'nonexistent_mistralai_pkg',
+                    install_group='mistral',
+                    install_label='Mistral',
+                )
+                raise  # should not reach here
+
+    def test_subpackage_detection(self):
+        """find_spec works with dotted package names like 'google.genai'."""
+        # os.path exists as a module
+        check_package_installed('os.path')
+        # non-existent sub-package should raise
+        with pytest.raises(ImportError, match=r'Please install'):
+            check_package_installed('os.nonexistent_subpackage_xyz', install_group='test')


### PR DESCRIPTION
## Summary
- Adds `check_package_installed()` utility using `importlib.util.find_spec` to differentiate between "package not installed" and "name not found within an installed package"
- Updates all model, provider, and embedding files (47 files) to use the new pattern: when a package IS installed but a specific name cannot be imported (e.g. due to SDK version mismatch), the original `ImportError` with its real diagnostic now propagates instead of being masked by a generic "please install X" message
- Adds 9 comprehensive tests covering the utility function and the integration pattern

## Motivation
Fixes #4927 — When `mistralai` is installed but has breaking API changes (e.g. `UNSET` was removed), users get a misleading error saying "Please install `mistral`..." instead of the actual `ImportError: cannot import name 'UNSET' from 'mistralai'`. This affects all provider integrations that use the same `try/except ImportError` pattern.

## How it works
```python
# Before (masks real errors):
try:
    from mistralai.client.types import UNSET
except ImportError as e:
    raise ImportError('Please install `mistral`...') from e

# After (preserves real errors):
try:
    from mistralai.client.types import UNSET
except ImportError:
    check_package_installed('mistralai', install_group='mistral', install_label='Mistral')
    raise  # only reached if package IS installed — re-raises original error
```

## Test plan
- [x] 9 new unit tests for `check_package_installed` covering:
  - Package not installed → raises install hint
  - Package installed → returns None (allows re-raise)
  - Custom `install_group` and `install_label` in error messages
  - Integration with try/except pattern (both scenarios)
  - Dotted subpackage names (e.g. `google.genai`)
- [x] All 35 existing `test_utils.py` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)