### PR TITLE
Update stream error test snapshots for pending tool close

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -534,6 +534,7 @@ async def test_run_stream_response_error():
             '</response>',
             '<request>',
             "<function-tool-call name='unknown_tool'>None</function-tool-call>",
+            "<function-tool-result name='unknown_tool'>Tool execution was interrupted by an error.</function-tool-result>",
             "<error type='UnexpectedModelBehavior'>Tool 'unknown_tool' exceeded max retries count of 1</error>",
             '</request>',
             '</stream>',

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -2262,6 +2262,11 @@ Fix the errors and try again.\
                 'toolName': 'unknown_tool',
             },
             {'type': 'tool-input-available', 'toolCallId': IsStr(), 'toolName': 'unknown_tool', 'input': {}},
+            {
+                'type': 'tool-output-error',
+                'toolCallId': IsStr(),
+                'errorText': 'Tool execution was interrupted by an error.',
+            },
             {'type': 'error', 'errorText': "Tool 'unknown_tool' exceeded max retries count of 1"},
             {'type': 'finish-step'},
             {'type': 'finish', 'finishReason': 'error'},


### PR DESCRIPTION
Follow-up to #4963. Two tests named `test_run_stream_response_error` (in `tests/test_ui.py` and `tests/test_vercel_ai.py`) were missing the new `tool-output-error` / `function-tool-result` event that #4963 introduced when pending tool calls are closed on stream error, causing snapshot mismatches on `main`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).