### PR TITLE
docs: soft-deprecate `history_processors` in favor of `before_model_request` hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ All changes need to:
 
 - be thoughtful and deliberate about new abstractions, public APIs, and behaviors, as every wrong-in-retrospect choice (made in a rush or with insufficient context) makes life harder for hundreds of thousands of users (and agents), and is much more difficult to change later than to do right the first time
 - be backward compatible as laid out in the [version policy](docs/version-policy.md), so that users can upgrade with confidence
+- not entrench patterns slated for retirement in the [v2 roadmap](V2.md) — that file tracks API simplifications planned for the next major release and their preferred alternatives; new code should use the alternatives, and reviewers may reject code that adds new usage of deprecated patterns listed there
 - be fully type-safe (both internally and in public API) without unnecessary `cast`s or `Any`s, so that users don't need `isinstance` checks and can trust that code that typechecks will work at runtime
 - have comprehensive tests covering 100% of code paths, favoring integration tests and real requests (using recordings and snapshots -- see below) over unit tests and mocking
 - update/add all relevant documentation, following the existing voice and patterns

--- a/V2.md
+++ b/V2.md
@@ -1,0 +1,98 @@
+# Pydantic AI v2 roadmap
+
+> **Why this file exists**
+>
+> This file tracks non-urgent cleanups and API simplifications we'd like to land in a future v2 release, along with migration guidance for users. It exists so that:
+>
+> 1. Contributors (human and agent) can recommend modern patterns with confidence, knowing which v1 patterns are slated for removal.
+> 2. Users who hit pain points with deprecated APIs can see the long-term plan and migrate preemptively.
+> 3. Reviewers can reject new code that entrenches patterns we're trying to retire.
+>
+> Items here are **not commitments** — they're direction. Removal requires a major version bump and a deprecation cycle per the [version policy](https://ai.pydantic.dev/version-policy/).
+>
+> This file lives at the repository root (not under `docs/`) so it's visible in the GitHub UI and referenceable from code/docs, but isn't published on [ai.pydantic.dev](https://ai.pydantic.dev/) as a user-facing guide.
+
+## Retirements
+
+### `history_processors` → `before_model_request`
+
+The `history_processors` parameter on `Agent` is superseded by the `before_model_request` hook on the `Hooks` capability. New code should use hooks; `history_processors` is planned for removal in v2.
+
+Docs: [hooks › Model request hooks](https://ai.pydantic.dev/hooks/#model-request-hooks).
+
+#### Motivation
+
+- **The hook strictly supersedes history processors.** The `HistoryProcessor` capability is implemented internally as a thin wrapper around `before_model_request`, so every history-processor use case is already expressible as a hook. Hooks additionally expose the full `ModelRequestContext`, including `model_request_parameters.function_tools`, which gives users the exact tool definitions the model will see on the current step — something history processors can't access cleanly (reaching through `ctx.agent.toolsets` from a history processor returns uninitialized dynamic toolset instances, because per-run tool materialization happens later in the lifecycle).
+- **Fewer ways to do the same thing.** Two parallel APIs for intercepting pre-model-request state is unnecessary surface area. Consolidating on hooks means users have one mental model for all pre-request interception (compaction, filtering, token budgeting, tool-def inspection).
+- **Hooks compose with other lifecycle interception.** Hooks sit alongside `before_tool_validate`, `wrap_model_request`, `on_run_error`, etc. Users who need to coordinate behavior across stages get a single, consistent API.
+
+#### Migration guide
+
+**Simple filter**
+
+Before:
+
+```python
+from pydantic_ai import Agent, ModelMessage, ModelRequest
+
+
+def filter_responses(messages: list[ModelMessage]) -> list[ModelMessage]:
+    return [msg for msg in messages if isinstance(msg, ModelRequest)]
+
+
+agent = Agent('openai:gpt-5.2', history_processors=[filter_responses])
+```
+
+After:
+
+```python
+from pydantic_ai import Agent, ModelRequest, ModelRequestContext, RunContext
+from pydantic_ai.capabilities import Hooks
+
+hooks = Hooks()
+
+
+@hooks.on.before_model_request
+def filter_responses(
+    ctx: RunContext[None], request_context: ModelRequestContext
+) -> ModelRequestContext:
+    request_context.messages = [
+        msg for msg in request_context.messages if isinstance(msg, ModelRequest)
+    ]
+    return request_context
+
+
+agent = Agent('openai:gpt-5.2', capabilities=[hooks])
+```
+
+**Token-aware compaction with tool-def access**
+
+The main reason to prefer hooks: you can see the tool definitions the model will receive this step and size your context budget accordingly.
+
+```python
+from pydantic_ai import Agent, ModelRequestContext, RunContext
+from pydantic_ai.capabilities import Hooks
+
+hooks = Hooks()
+
+
+@hooks.on.before_model_request
+async def compact(
+    ctx: RunContext[None], request_context: ModelRequestContext
+) -> ModelRequestContext:
+    tool_defs = request_context.model_request_parameters.function_tools
+    # More tool schemas consume more of the context window, so keep fewer messages.
+    keep_n = max(1, 20 - len(tool_defs))
+    request_context.messages = request_context.messages[-keep_n:]
+    return request_context
+
+
+agent = Agent('openai:gpt-5.2', capabilities=[hooks])
+```
+
+#### Edge cases
+
+- **`RunContext` access:** identical — the first parameter of a `before_model_request` hook is `RunContext[DepsT]`, same as a context-aware history processor.
+- **Multiple processors:** register multiple `before_model_request` hooks; they fire in registration order, matching the history-processor sequence behavior.
+- **Sync vs async:** both are supported. Sync hooks are automatically wrapped for async execution.
+- **Mutation semantics:** assign to `request_context.messages` (as shown above). The hook returns the (same or new) `ModelRequestContext` instance, matching how history processors return a new message list.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -112,6 +112,8 @@ Model request hooks fire around each LLM call. [`ModelRequestContext`][pydantic_
 
 To skip the model call entirely, raise [`SkipModelRequest(response)`][pydantic_ai.exceptions.SkipModelRequest] from `before_model_request` or `model_request` (wrap).
 
+`before_model_request` is also the recommended way to mutate the message history before each model call (e.g. for token-aware compaction) — see [Processing Message History](message-history.md#processing-message-history). `request_context.model_request_parameters.function_tools` gives per-step access to the exact tool definitions the model will see, which `history_processors` can't expose.
+
 ### Tool validation hooks
 
 | `hooks.on.` | Constructor kwarg | `AbstractCapability` method |

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -341,7 +341,35 @@ reasons (filtering out sensitive information), to save costs on tokens, to give 
 custom processing logic.
 
 Pydantic AI provides a `history_processors` parameter on `Agent` that allows you to intercept and modify
-the message history before each model request. History processors can also be provided via the [`HistoryProcessor`][pydantic_ai.capabilities.HistoryProcessor] capability.
+the message history before each model request.
+
+!!! warning "Prefer `before_model_request` hooks"
+    Since the release of [hooks](hooks.md), the [`before_model_request`](hooks.md#model-request-hooks) hook is the recommended way to intercept and modify messages before each model call. It supersedes `history_processors` for all use cases and exposes [`ModelRequestContext`][pydantic_ai.models.ModelRequestContext], which includes `model_request_parameters.function_tools` — letting you inspect the exact tool definitions the model will see, useful for token-aware compaction.
+
+    `history_processors` may be removed in a future major version — see the [migration guide](https://github.com/pydantic/pydantic-ai/blob/main/V2.md#history_processors--before_model_request). New code should use hooks.
+
+Here's an equivalent `before_model_request` hook for message compaction:
+
+```python {title="compaction_hook.py"}
+from pydantic_ai import Agent, ModelRequestContext, RunContext
+from pydantic_ai.capabilities import Hooks
+
+hooks = Hooks()
+
+
+@hooks.on.before_model_request
+async def compact(
+    ctx: RunContext[None], request_context: ModelRequestContext
+) -> ModelRequestContext:
+    tool_defs = request_context.model_request_parameters.function_tools
+    # More tool schemas consume more of the context window, so keep fewer messages.
+    keep_n = max(1, 20 - len(tool_defs))
+    request_context.messages = request_context.messages[-keep_n:]
+    return request_context
+
+
+agent = Agent('openai:gpt-5.2', capabilities=[hooks])
+```
 
 !!! warning "History processors replace the message history"
     History processors replace the message history in the state with the processed messages, including the new user prompt part.

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -374,6 +374,13 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             history_processors: Optional list of callables to process the message history before sending it to the model.
                 Each processor takes a list of messages and returns a modified list of messages.
                 Processors can be sync or async and are applied in sequence.
+
+                !!! warning "Deprecated: prefer `before_model_request` hooks"
+                    The [`before_model_request`](../hooks.md#model-request-hooks) hook on the [`Hooks`][pydantic_ai.capabilities.Hooks]
+                    capability supersedes `history_processors` for all use cases and additionally exposes per-step
+                    tool definitions via [`ModelRequestContext`][pydantic_ai.models.ModelRequestContext]. `history_processors`
+                    may be removed in a future major version — see the
+                    [migration guide](https://github.com/pydantic/pydantic-ai/blob/main/V2.md#history_processors--before_model_request).
             event_stream_handler: Optional handler for events from the model's streaming response and the agent's execution of tools.
             tool_timeout: Default timeout in seconds for tool execution. If a tool takes longer than this,
                 the tool is considered to have failed and a retry prompt is returned to the model (counting towards the retry limit).
@@ -396,6 +403,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         self._description = description
         self.end_strategy = end_strategy
 
+        # TODO(v2): remove history_processors in favor of the before_model_request hook (see V2.md)
         self.history_processors: list[HistoryProcessor[AgentDepsT]] = list(history_processors or [])
 
         capabilities = list(capabilities or [])

--- a/pydantic_ai_slim/pydantic_ai/capabilities/history_processor.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/history_processor.py
@@ -24,7 +24,16 @@ if TYPE_CHECKING:
 
 @dataclass
 class HistoryProcessor(AbstractCapability[AgentDepsT]):
-    """A capability that processes message history before model requests."""
+    """A capability that processes message history before model requests.
+
+    !!! warning "Deprecated: prefer `before_model_request` hooks"
+        This capability is a thin wrapper around the [`before_model_request`](../hooks.md#model-request-hooks)
+        hook on the [`Hooks`][pydantic_ai.capabilities.Hooks] capability. The hook supersedes this capability
+        for all use cases and additionally exposes per-step tool definitions via
+        [`ModelRequestContext`][pydantic_ai.models.ModelRequestContext]. `HistoryProcessor` may be removed
+        in a future major version — see the
+        [migration guide](https://github.com/pydantic/pydantic-ai/blob/main/V2.md#history_processors--before_model_request).
+    """
 
     processor: HistoryProcessorFunc[AgentDepsT]
 


### PR DESCRIPTION
<!-- No linked issue: this came out of a Slack thread where a user tried to access tool definitions from inside a `history_processors` callable and hit a footgun (`ctx.agent.toolsets` returns uninitialized dynamic toolsets before the per-run lifecycle runs). Douwe clarified in-thread that `before_model_request` supersedes `history_processors` for all use cases. This PR captures that guidance in docs so future users don't hit the same dead-end. -->

## What this changes

Docs-only. No behavior change, no runtime `DeprecationWarning`. `history_processors` remains fully supported.

- **`docs/message-history.md`** — adds a `!!! warning "Prefer before_model_request hooks"` admonition on the `## Processing Message History` section, followed by an equivalent `compaction_hook.py` example that shows the real motivating use case: accessing `request_context.model_request_parameters.function_tools` to size the message budget based on how many tool schemas are already consuming the context window.
- **`docs/hooks.md`** — one-sentence cross-reference from the `### Model request hooks` section back to message-history.md, explaining that `before_model_request` is the recommended place for token-aware history compaction.
- **`pydantic_ai_slim/pydantic_ai/agent/__init__.py`** — adds a `!!! warning "Deprecated: prefer before_model_request hooks"` admonition to the `history_processors` constructor param docstring, and a `# TODO(v2): remove history_processors ...` comment on the field assignment.
- **`pydantic_ai_slim/pydantic_ai/capabilities/history_processor.py`** — adds a matching deprecation admonition to the `HistoryProcessor` class docstring. (This capability is already implemented internally as a thin `before_model_request` wrapper, so the deprecation is a pure API-surface consolidation.)
- **`V2.md`** (new, repo root, **not under `docs/`**) — introduces a \"v2 roadmap\" file tracking non-urgent retirements and their migration guides. Placed at repo root so it's visible in the GitHub UI and referenceable from code/docs, but intentionally unpublished on ai.pydantic.dev. First entry is `history_processors → before_model_request` with motivation, before/after migration code, and edge-case notes.
- **`AGENTS.md`** — one new bullet under \"Requirements of all contributions\" steering contributors (human and agent) away from entrenching patterns listed in `V2.md`.

## Why no runtime `DeprecationWarning`?

Kept out of scope deliberately. This PR is about surfacing the preferred API in docs and collecting direction in `V2.md` so contributors stop entrenching the legacy pattern. An actual runtime warning + removal cycle should be a separate, more intentional change since it touches every user who's currently using `history_processors`.

## Decisions worth flagging to reviewers

1. **Wording is intentionally hedged.** \"May be removed in a future major version\" rather than \"planned for removal\" — matches `V2.md`'s own caveat that \"items here are not commitments — they're direction.\"
2. **`V2.md` placement and link style.** Cross-references from published docs/docstrings use absolute GitHub URLs (\`https://github.com/pydantic/pydantic-ai/blob/main/V2.md#history_processors--before_model_request\`) so mkdocs strict-mode doesn't flag them and published readers still get a clickable migration path. Open to moving `V2.md` under `docs/` and using normal mkdocs cross-refs if you'd prefer to publish it — happy to follow up.
3. **Section structure in `message-history.md`.** The existing `## Processing Message History` section is kept intact (warning added on top) rather than being rewritten to lead with hooks. Strict reading of \`docs/AGENTS.md\` (\"show the recommended approach first\" / \"omit deprecated features from user-facing docs\") could argue for demoting the legacy examples below the fold. Didn't do that here because it's a bigger change and would break 5 inbound anchor references from capabilities.md, input.md, multi-agent-applications.md, thinking.md, and tools-advanced.md. Happy to restructure if you prefer.
4. **`ModelRequestContext` cross-references.** Uses the same \`[ModelRequestContext][pydantic_ai.models.ModelRequestContext]\` form as the existing (mkdocstrings-unresolvable) refs in `hooks.md` and `capabilities.md`. These don't resolve in strict mode but CI uses `--no-strict`, so this is baseline behavior — consistent with existing patterns rather than introducing a new one.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)