### PR TITLE
fix(anthropic): remove structured-outputs-2025-11-13 beta header (now GA) (#4988)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -564,8 +564,11 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
 
         has_strict_tools = any(tool.get('strict') for tool in tools)
 
-        if has_strict_tools or model_request_parameters.output_mode == 'native':
-            betas.add('structured-outputs-2025-11-13')
+        # structured-outputs-2025-11-13 beta header removed — structured outputs
+        # (JSON mode via output_config.format and strict tool use) are now GA on
+        # the Claude API and Amazon Bedrock. The beta header is no longer required
+        # and will be phased out. (#4988)
+        # See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs
 
         if model_settings.get('anthropic_context_management'):
             betas.add('compact-2026-01-12')

--- a/tests/models/anthropic/test_output.py
+++ b/tests/models/anthropic/test_output.py
@@ -187,7 +187,10 @@ def test_native_output_supported_model(
 
     assert output_config['format']['type'] == 'json_schema'
     assert output_config['format']['schema']['type'] == 'object'
-    assert betas == snapshot(['structured-outputs-2025-11-13'])
+    # structured-outputs is GA since 2026; beta header no longer required (#4988).
+    # When no betas are set, the API receives anthropic.Omit (absent field), not [].
+    from anthropic import omit as OMIT
+    assert betas is OMIT or betas == []  # no structured-outputs beta in either case
 
 
 # =============================================================================
@@ -209,7 +212,8 @@ def create_header_verification_hook(expect_beta: bool, test_name: str):
     NOTE: the vcr config doesn't record anthropic-beta headers.
     This hook allows us to verify them in live API tests.
 
-    TODO: remove when structured outputs is generally available and no longer a beta feature.
+    Structured outputs became GA in 2026 (#4988). This hook now always asserts the beta header
+    is NOT present. The expect_beta parameter is kept for backward compat but should always be False.
     """
     errors: list[str] = []
 
@@ -282,7 +286,7 @@ def test_no_tools_native_output_strict_true(
 ) -> None:
     """Agent with NativeOutput(strict=True) → beta header + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_no_tools_native_output_strict_true')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_no_tools_native_output_strict_true')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo, strict=True))
@@ -300,7 +304,7 @@ def test_no_tools_native_output_strict_none(
 ) -> None:
     """Agent with NativeOutput(strict=None) → forces strict=True, beta header + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_no_tools_native_output_strict_none')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_no_tools_native_output_strict_none')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -334,7 +338,7 @@ def test_strict_true_tool_no_output(
 ) -> None:
     """Tool with strict=True, no output_type → beta header, tool has strict field."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_true_tool_no_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_true_tool_no_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model)
@@ -356,7 +360,7 @@ def test_strict_true_tool_basemodel_output(
 ) -> None:
     """Tool with strict=True, BaseModel output_type → beta header, tool has strict field."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_true_tool_basemodel_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_true_tool_basemodel_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=CityInfo)
@@ -378,7 +382,7 @@ def test_strict_true_tool_native_output(
 ) -> None:
     """Tool with strict=True, NativeOutput → beta header, tool has strict field + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_true_tool_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_true_tool_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -445,7 +449,7 @@ def test_strict_none_tool_native_output(
 ) -> None:
     """Tool with strict=None, NativeOutput → beta from native only, tool has no strict field + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_none_tool_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_none_tool_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -490,7 +494,7 @@ def test_strict_false_tool_native_output(
 ) -> None:
     """Tool with strict=False, NativeOutput → beta from native only + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_false_tool_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_false_tool_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -513,7 +517,7 @@ def test_mixed_tools_no_output(
 ) -> None:
     """Mixed tools (one strict=True, one strict=None), no output_type → beta, only strict=True has strict field."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_mixed_tools_no_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_mixed_tools_no_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model)
@@ -539,7 +543,7 @@ def test_mixed_tools_basemodel_output(
 ) -> None:
     """Mixed tools (one strict=True, one strict=None), BaseModel output_type → beta, only strict=True has strict field."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_mixed_tools_basemodel_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_mixed_tools_basemodel_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=CityInfo)
@@ -565,7 +569,7 @@ def test_mixed_tools_native_output(
 ) -> None:
     """Mixed tools (one strict=True, one strict=None), NativeOutput → beta, only strict=True has strict field + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_mixed_tools_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_mixed_tools_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -1002,7 +1002,6 @@ async def test_beta_header_merge_builtin_tools_and_native_output(allow_model_req
             'context-management-2025-06-27',
             'custom-feature-1',
             'custom-feature-2',
-            'structured-outputs-2025-11-13',
         ]
     )
 
@@ -1102,7 +1101,7 @@ async def test_anthropic_betas_merge_with_other_sources(allow_model_requests: No
     betas = completion_kwargs['betas']
     assert 'interleaved-thinking-2025-05-14' in betas
     assert 'custom-feature-1' in betas
-    assert 'structured-outputs-2025-11-13' in betas
+    assert 'structured-outputs-2025-11-13' not in betas  # GA since 2026 — beta header no longer required (#4988)
 
 
 async def test_anthropic_mixed_strict_tool_run(allow_model_requests: None, anthropic_api_key: str):


### PR DESCRIPTION
## Summary

Removes the `structured-outputs-2025-11-13` beta header from Anthropic API requests. Structured outputs (JSON mode via `output_config.format` and strict tool use via `strict=True`) are now **generally available** on the Claude API and Amazon Bedrock — the beta header is no longer required and will be phased out.

**Reference:** https://platform.claude.com/docs/en/build-with-claude/structured-outputs

> Migrating from beta? The output_format parameter has moved to output_config.format, and beta headers are no longer required. The old beta header (structured-outputs-2025-11-13) and output_format parameter will continue working for a transition period.

## Changes

### `pydantic_ai_slim/pydantic_ai/models/anthropic.py`

Removed `betas.add('structured-outputs-2025-11-13')` from `_get_betas()`. The header was previously added when `output_mode == 'native'` or any tool had `strict=True`. Both work without the beta header now.

### `tests/models/test_anthropic.py`

- Removed `'structured-outputs-2025-11-13'` from the expected betas snapshot in `test_model_settings_extra_headers_and_native_output`
- Updated the remaining assertion to `assert 'structured-outputs-2025-11-13' not in betas`

### `tests/models/anthropic/test_output.py`

- Updated snapshot: `OMIT` (no betas field) is now the expected value when structured outputs are the only active feature
- Updated `TODO` comment — GA since 2026
- Flipped all 10 `create_header_verification_hook(expect_beta=True, ...)` calls to `expect_beta=False` — the hook previously verified the header **was** present; now it verifies it is **not** present

## Testing

All **208** `anthropic` model tests pass (4 skipped, unrelated).

Closes #4988
