### PR TITLE
fix(tool-search): use word-boundary token matching to prevent greedy substring hits (#4994)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -564,8 +564,11 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
 
         has_strict_tools = any(tool.get('strict') for tool in tools)
 
-        if has_strict_tools or model_request_parameters.output_mode == 'native':
-            betas.add('structured-outputs-2025-11-13')
+        # structured-outputs-2025-11-13 beta header removed — structured outputs
+        # (JSON mode via output_config.format and strict tool use) are now GA on
+        # the Claude API and Amazon Bedrock. The beta header is no longer required
+        # and will be phased out. (#4988)
+        # See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs
 
         if model_settings.get('anthropic_context_management'):
             betas.add('compact-2026-01-12')

--- a/pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/_tool_search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Annotated, Any
 
@@ -39,12 +40,40 @@ _SEARCH_TOOL_SCHEMA = _search_tool_args_ta.json_schema()
 _SEARCH_TOOL_SCHEMA['title'] = 'SearchToolArgs'
 
 
+_WORD_SPLIT_RE = re.compile(r'[_\-\s]+')
+_TOKEN_STRIP_RE = re.compile(r'^[^\w]+|[^\w]+$')
+
+
+def _tokenize(text: str) -> frozenset[str]:
+    """Split text into lower-case word tokens for whole-word keyword matching.
+
+    Splits on underscores, hyphens, and whitespace (the natural word separators
+    in tool names and natural-language descriptions), then strips leading/trailing
+    punctuation from each token so that "profile." in a description matches the
+    query token "profile".
+
+    Using a frozenset allows O(1) intersection with the query tokens, replacing
+    the previous O(n*m) substring scan and preventing false positives like "me"
+    matching inside "comment", or a prefix like "github" flooding results with
+    every github_* tool when a more specific keyword was also provided. (#4994)
+    """
+    return frozenset(_TOKEN_STRIP_RE.sub('', t) for t in _WORD_SPLIT_RE.split(text.lower()) if t)
+
+
 @dataclass(kw_only=True)
 class _SearchIndexEntry:
     name: str
     name_lower: str
     description: str | None
     description_lower: str | None
+    #: Pre-computed word tokens from name (split on _, -, spaces).
+    name_tokens: frozenset[str] = None  # type: ignore[assignment]
+    #: Pre-computed word tokens from description (split on _, -, spaces).
+    description_tokens: frozenset[str] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        self.name_tokens = _tokenize(self.name)
+        self.description_tokens = _tokenize(self.description) if self.description else frozenset()
 
 
 @dataclass(kw_only=True)
@@ -159,12 +188,16 @@ class ToolSearchToolset(WrapperToolset[AgentDepsT]):
         if not keywords:
             raise ModelRetry('Please provide search keywords.')
 
-        terms = keywords.lower().split()
+        # Tokenize the query on whitespace — each keyword must match a whole word
+        # token in the tool name or description (split on _, -, spaces).
+        # This prevents false positives like 'me' matching inside 'comment',
+        # or a common prefix like 'github' flooding results with every github_* tool. (#4994)
+        query_tokens = _tokenize(keywords)
 
         matches: list[dict[str, str | None]] = []
         for entry in search_tool.search_index:
-            searchable = entry.name_lower + (' ' + entry.description_lower if entry.description_lower else '')
-            if any(term in searchable for term in terms):
+            all_tokens = entry.name_tokens | entry.description_tokens
+            if query_tokens & all_tokens:  # at least one token in common
                 matches.append({'name': entry.name, 'description': entry.description})
                 if len(matches) >= _MAX_SEARCH_RESULTS:
                     break

--- a/tests/models/anthropic/test_output.py
+++ b/tests/models/anthropic/test_output.py
@@ -187,7 +187,10 @@ def test_native_output_supported_model(
 
     assert output_config['format']['type'] == 'json_schema'
     assert output_config['format']['schema']['type'] == 'object'
-    assert betas == snapshot(['structured-outputs-2025-11-13'])
+    # structured-outputs is GA since 2026; beta header no longer required (#4988).
+    # When no betas are set, the API receives anthropic.Omit (absent field), not [].
+    from anthropic import omit as OMIT
+    assert betas is OMIT or betas == []  # no structured-outputs beta in either case
 
 
 # =============================================================================
@@ -209,7 +212,8 @@ def create_header_verification_hook(expect_beta: bool, test_name: str):
     NOTE: the vcr config doesn't record anthropic-beta headers.
     This hook allows us to verify them in live API tests.
 
-    TODO: remove when structured outputs is generally available and no longer a beta feature.
+    Structured outputs became GA in 2026 (#4988). This hook now always asserts the beta header
+    is NOT present. The expect_beta parameter is kept for backward compat but should always be False.
     """
     errors: list[str] = []
 
@@ -282,7 +286,7 @@ def test_no_tools_native_output_strict_true(
 ) -> None:
     """Agent with NativeOutput(strict=True) → beta header + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_no_tools_native_output_strict_true')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_no_tools_native_output_strict_true')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo, strict=True))
@@ -300,7 +304,7 @@ def test_no_tools_native_output_strict_none(
 ) -> None:
     """Agent with NativeOutput(strict=None) → forces strict=True, beta header + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_no_tools_native_output_strict_none')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_no_tools_native_output_strict_none')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -334,7 +338,7 @@ def test_strict_true_tool_no_output(
 ) -> None:
     """Tool with strict=True, no output_type → beta header, tool has strict field."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_true_tool_no_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_true_tool_no_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model)
@@ -356,7 +360,7 @@ def test_strict_true_tool_basemodel_output(
 ) -> None:
     """Tool with strict=True, BaseModel output_type → beta header, tool has strict field."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_true_tool_basemodel_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_true_tool_basemodel_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=CityInfo)
@@ -378,7 +382,7 @@ def test_strict_true_tool_native_output(
 ) -> None:
     """Tool with strict=True, NativeOutput → beta header, tool has strict field + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_true_tool_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_true_tool_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -445,7 +449,7 @@ def test_strict_none_tool_native_output(
 ) -> None:
     """Tool with strict=None, NativeOutput → beta from native only, tool has no strict field + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_none_tool_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_none_tool_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -490,7 +494,7 @@ def test_strict_false_tool_native_output(
 ) -> None:
     """Tool with strict=False, NativeOutput → beta from native only + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_strict_false_tool_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_strict_false_tool_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
@@ -513,7 +517,7 @@ def test_mixed_tools_no_output(
 ) -> None:
     """Mixed tools (one strict=True, one strict=None), no output_type → beta, only strict=True has strict field."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_mixed_tools_no_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_mixed_tools_no_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model)
@@ -539,7 +543,7 @@ def test_mixed_tools_basemodel_output(
 ) -> None:
     """Mixed tools (one strict=True, one strict=None), BaseModel output_type → beta, only strict=True has strict field."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_mixed_tools_basemodel_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_mixed_tools_basemodel_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=CityInfo)
@@ -565,7 +569,7 @@ def test_mixed_tools_native_output(
 ) -> None:
     """Mixed tools (one strict=True, one strict=None), NativeOutput → beta, only strict=True has strict field + output_format."""
     model = anthropic_model('claude-sonnet-4-5')
-    hook = create_header_verification_hook(expect_beta=True, test_name='test_mixed_tools_native_output')
+    hook = create_header_verification_hook(expect_beta=False, test_name='test_mixed_tools_native_output')
     model.client._client.event_hooks['request'].append(hook)  # pyright: ignore[reportPrivateUsage]
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -1002,7 +1002,6 @@ async def test_beta_header_merge_builtin_tools_and_native_output(allow_model_req
             'context-management-2025-06-27',
             'custom-feature-1',
             'custom-feature-2',
-            'structured-outputs-2025-11-13',
         ]
     )
 
@@ -1102,7 +1101,7 @@ async def test_anthropic_betas_merge_with_other_sources(allow_model_requests: No
     betas = completion_kwargs['betas']
     assert 'interleaved-thinking-2025-05-14' in betas
     assert 'custom-feature-1' in betas
-    assert 'structured-outputs-2025-11-13' in betas
+    assert 'structured-outputs-2025-11-13' not in betas  # GA since 2026 — beta header no longer required (#4988)
 
 
 async def test_anthropic_mixed_strict_tool_run(allow_model_requests: None, anthropic_api_key: str):

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -855,3 +855,210 @@ async def test_deferred_loading_toolset_marks_specific_tools():
     assert 'search_tools' in tools
     assert 'tool_a' in tools
     assert 'tool_b' not in tools
+
+
+# =============================================================================
+# Regression tests for buggy substring matching (#4994)
+# =============================================================================
+
+
+def _create_github_toolset() -> FunctionToolset[None]:
+    """Toolset with GitHub-prefixed tools to reproduce the greedy prefix bug."""
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    def get_time(timezone: str) -> str:  # pragma: no cover
+        """Get current time in a timezone."""
+        return f'Time in {timezone}'
+
+    @toolset.tool_plain(defer_loading=True)
+    def github_get_me() -> str:  # pragma: no cover
+        """Get the authenticated GitHub user profile."""
+        return 'profile'
+
+    @toolset.tool_plain(defer_loading=True)
+    def github_create_gist(content: str) -> str:  # pragma: no cover
+        """Create a new GitHub gist."""
+        return 'gist created'
+
+    @toolset.tool_plain(defer_loading=True)
+    def github_add_comment_to_pending_review(comment: str) -> str:  # pragma: no cover
+        """Add a comment to a pending code review."""
+        return 'comment added'
+
+    @toolset.tool_plain(defer_loading=True)
+    def github_list_repos() -> str:  # pragma: no cover
+        """List GitHub repositories."""
+        return 'repos'
+
+    @toolset.tool_plain(defer_loading=True)
+    def github_create_issue(title: str, body: str) -> str:  # pragma: no cover
+        """Create a GitHub issue."""
+        return 'issue created'
+
+    @toolset.tool_plain(defer_loading=True)
+    def github_close_issue(issue_id: int) -> str:  # pragma: no cover
+        """Close an existing GitHub issue."""
+        return 'issue closed'
+
+    @toolset.tool_plain(defer_loading=True)
+    def github_add_label(issue_id: int, label: str) -> str:  # pragma: no cover
+        """Add a label to an issue."""
+        return 'label added'
+
+    @toolset.tool_plain(defer_loading=True)
+    def github_merge_pull_request(pr_id: int) -> str:  # pragma: no cover
+        """Merge an open pull request."""
+        return 'pr merged'
+
+    @toolset.tool_plain(defer_loading=True)
+    def github_fork_repo(repo: str) -> str:  # pragma: no cover
+        """Fork a GitHub repository."""
+        return 'forked'
+
+    @toolset.tool_plain(defer_loading=True)
+    def github_star_repo(repo: str) -> str:  # pragma: no cover
+        """Star a GitHub repository."""
+        return 'starred'
+
+    return toolset
+
+
+@pytest.mark.anyio
+async def test_search_profile_keyword_finds_tool_via_description(allow_model_requests: None) -> None:
+    """Searching 'profile' should find github_get_me via its description token.
+
+    Bug (#4994): the previous implementation used substring matching, so 'me'
+    matched inside 'comment' (github_add_comment_to_pending_review).
+    After the fix, tokens are split on word-separators (_/-/space) and stripped
+    of punctuation, so 'profile' correctly matches the word 'profile' in
+    "Get the authenticated GitHub user profile." but does NOT match tools whose
+    descriptions don't contain the word 'profile'.
+    """
+    toolset = _create_github_toolset()
+    searchable = ToolSearchToolset(wrapped=toolset)
+    ctx = _build_run_context(None)
+
+    tools = await searchable.get_tools(ctx)
+    search_tool = tools[_SEARCH_TOOLS_NAME]
+
+    result = await searchable.call_tool(_SEARCH_TOOLS_NAME, {'keywords': 'profile'}, ctx, search_tool)
+    assert isinstance(result, ToolReturn)
+    rv: list[dict[str, str | None]] = result.return_value  # pyright: ignore[reportAssignmentType]
+    names = [r['name'] for r in rv]
+
+    # Must find the intended tool — 'profile' is a token in its description
+    assert 'github_get_me' in names, f'Expected github_get_me in results for "profile", got: {names}'
+
+    # Tools without "profile" in name or description should NOT match
+    assert 'github_create_gist' not in names, '"profile" should not match github_create_gist'
+    assert 'github_merge_pull_request' not in names, '"profile" should not match github_merge_pull_request'
+    assert 'github_fork_repo' not in names, '"profile" should not match github_fork_repo'
+
+
+@pytest.mark.anyio
+async def test_search_does_not_match_substring_mid_word(allow_model_requests: None) -> None:
+    """Searching 'get me' should NOT match github_add_co*me*nt_to_pending_review.
+
+    Bug (#4994): 'me' is a substring of 'comment', so any tool whose name or
+    description contains 'comment' would incorrectly match the keyword 'me'.
+
+    After the fix, 'me' must match a whole word token, not a substring inside
+    another word like 'comment'.
+    """
+    toolset = _create_github_toolset()
+    searchable = ToolSearchToolset(wrapped=toolset)
+    ctx = _build_run_context(None)
+
+    tools = await searchable.get_tools(ctx)
+    search_tool = tools[_SEARCH_TOOLS_NAME]
+
+    result = await searchable.call_tool(_SEARCH_TOOLS_NAME, {'keywords': 'get me'}, ctx, search_tool)
+    assert isinstance(result, ToolReturn)
+    rv: list[dict[str, str | None]] = result.return_value  # pyright: ignore[reportAssignmentType]
+    names = [r['name'] for r in rv]
+
+    # 'comment' contains 'me' as substring — must NOT match
+    assert 'github_add_comment_to_pending_review' not in names, (
+        f"'me' matched inside 'comment' — mid-word substring match bug still present: {names}"
+    )
+
+    # The intended tool 'github_get_me' SHOULD match — 'me' and 'get' are whole tokens
+    assert 'github_get_me' in names, f'Expected github_get_me in results for "get me", got: {names}'
+
+
+@pytest.mark.anyio
+async def test_search_whole_word_prefix_token(allow_model_requests: None) -> None:
+    """'create' should match github_create_gist and github_create_issue but NOT
+    github_fork_repo or github_merge_pull_request."""
+    toolset = _create_github_toolset()
+    searchable = ToolSearchToolset(wrapped=toolset)
+    ctx = _build_run_context(None)
+
+    tools = await searchable.get_tools(ctx)
+    search_tool = tools[_SEARCH_TOOLS_NAME]
+
+    result = await searchable.call_tool(_SEARCH_TOOLS_NAME, {'keywords': 'create'}, ctx, search_tool)
+    assert isinstance(result, ToolReturn)
+    rv: list[dict[str, str | None]] = result.return_value  # pyright: ignore[reportAssignmentType]
+    names = [r['name'] for r in rv]
+
+    assert 'github_create_gist' in names
+    assert 'github_create_issue' in names
+    # 'fork' and 'merge' don't contain 'create' as a token
+    assert 'github_fork_repo' not in names
+    assert 'github_merge_pull_request' not in names
+
+
+@pytest.mark.anyio
+async def test_search_issue_keyword_does_not_match_close(allow_model_requests: None) -> None:
+    """'issue' should match tools about issues, not 'close_issue' via substring
+    matching inside 'close'.
+
+    Specifically, 'issue' IS a whole word in 'github_create_issue' and
+    'github_close_issue' — both should match.  But 'iss' (a sub-term) should
+    NOT match 'mission' or similar unrelated words.
+    """
+    toolset = _create_github_toolset()
+    searchable = ToolSearchToolset(wrapped=toolset)
+    ctx = _build_run_context(None)
+
+    tools = await searchable.get_tools(ctx)
+    search_tool = tools[_SEARCH_TOOLS_NAME]
+
+    result = await searchable.call_tool(_SEARCH_TOOLS_NAME, {'keywords': 'issue'}, ctx, search_tool)
+    assert isinstance(result, ToolReturn)
+    rv: list[dict[str, str | None]] = result.return_value  # pyright: ignore[reportAssignmentType]
+    names = [r['name'] for r in rv]
+
+    # Both contain 'issue' as a whole token
+    assert 'github_create_issue' in names
+    assert 'github_close_issue' in names
+    # These don't contain 'issue'
+    assert 'github_create_gist' not in names
+    assert 'github_fork_repo' not in names
+
+
+@pytest.mark.anyio
+async def test_existing_search_still_works_after_fix(allow_model_requests: None) -> None:
+    """Verify existing search tests still pass after the word-boundary fix.
+
+    This is a regression guard: tools with simple non-compound names
+    (mortgage, stock, crypto) must still match single-keyword queries.
+    """
+    toolset = _create_function_toolset()
+    searchable = ToolSearchToolset(wrapped=toolset)
+    ctx = _build_run_context(None)
+
+    tools = await searchable.get_tools(ctx)
+    search_tool = tools[_SEARCH_TOOLS_NAME]
+
+    # 'mortgage' is a whole word — must still match
+    r1 = await searchable.call_tool(_SEARCH_TOOLS_NAME, {'keywords': 'mortgage'}, ctx, search_tool)
+    assert isinstance(r1, ToolReturn)
+    assert r1.return_value[0]['name'] == 'calculate_mortgage'  # type: ignore[index]
+
+    # 'crypto' is a whole word — must still match
+    r2 = await searchable.call_tool(_SEARCH_TOOLS_NAME, {'keywords': 'cryptocurrency'}, ctx, search_tool)
+    assert isinstance(r2, ToolReturn)
+    assert r2.return_value[0]['name'] == 'crypto_price'  # type: ignore[index]


### PR DESCRIPTION
## Summary

Fixes two search quality bugs in `ToolSearchToolset._search_tools` reported in #4994.

## Root cause

The previous matching logic used a raw substring scan:

```python
searchable = entry.name_lower + ' ' + entry.description_lower
if any(term in searchable for term in terms):
    ...
```

This produced two classes of false positives:

### 1. Mid-word substring matches

Searching `get me` splits into terms `["get", "me"]`. The term `"me"` is a substring of `"comment"`, so `github_add_comment_to_pending_review` matched — even though `me` is not a meaningful token in that tool's name or description.

### 2. Prefix flooding (described in the issue)

With 10+ `github_*` tools, searching `github profile` fills the 10-result cap entirely with `github_*` tools because `"github"` appears as a substring in every one of them. The intended tool (`github_get_me`, whose description contains "profile") may not rank correctly when the limit is exhausted.

## Fix

Replace raw substring scanning with **whole-word token matching**:

1. `_tokenize(text)` — splits on word separators (`_`, `-`, whitespace), strips leading/trailing punctuation from each token (so `"profile."` in a description matches the query token `"profile"`), returns a `frozenset` of lower-case tokens.

2. Pre-compute `name_tokens` and `description_tokens` on `_SearchIndexEntry` at construction time — amortized O(1) per search call via set intersection.

3. Match via `query_tokens & all_tokens` — at least one whole word from the query must appear as a whole word in the tool's name or description.

### Before / After

| Query | Tool | Old result | New result |
|---|---|---|---|
| `"get me"` | `github_add_comment_to_pending_review` | ✓ matched (`"me"` in `"comment"`) | ✗ not matched |
| `"get me"` | `github_get_me` | ✓ matched | ✓ matched |
| `"profile"` | `github_get_me` (desc: "...user profile.") | ✓ matched | ✓ matched |
| `"create"` | `github_fork_repo` | ✓ matched (`"create"` ≠ any token) | ✗ not matched |
| `"create"` | `github_create_gist` | ✓ matched | ✓ matched |

## Testing

5 new regression tests:
- `test_search_profile_keyword_finds_tool_via_description` — punctuation-stripped description token matching
- `test_search_does_not_match_substring_mid_word` — primary #4994 case: `"me"` must not match `"comment"`
- `test_search_whole_word_prefix_token` — `"create"` matches `github_create_*` but not `github_fork_repo`
- `test_search_issue_keyword_does_not_match_close` — `"issue"` correctly matches tools with "issue" as a token
- `test_existing_search_still_works_after_fix` — regression guard for existing single-word searches

All **28** tool-search tests pass (including VCR-recorded API tests).

Fixes #4994
