### PR TITLE
Fix orphan-task leak in `CombinedToolset` and `CombinedCapability`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -208,7 +208,9 @@ async def gather(*coros: Awaitable[T]) -> list[T]:
                 tg.start_soon(_run, i, coro)
     except BaseExceptionGroup as eg:
         if len(eg.exceptions) == 1:
-            raise eg.exceptions[0] from None
+            exc = eg.exceptions[0]
+            exc.__suppress_context__ = True
+            raise exc
         raise
 
     return results

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -5,6 +5,7 @@ import copy
 import functools
 import inspect
 import re
+import sys
 import time
 import uuid
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Iterable, Iterator
@@ -27,7 +28,13 @@ from typing import (
     overload,
 )
 
+import anyio
 from anyio.to_thread import run_sync
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup as BaseExceptionGroup  # pragma: lax no cover
+else:
+    BaseExceptionGroup = BaseExceptionGroup  # pragma: lax no cover
 from pydantic import BaseModel, TypeAdapter
 from pydantic._internal import _decorators, _typing_extra
 from pydantic.json_schema import JsonSchemaValue
@@ -181,6 +188,30 @@ class Some(Generic[T]):
 
 Option: TypeAlias = Some[T] | None
 """Analogous to Rust's `Option` type, usage: `Option[Thing]` is equivalent to `Some[Thing] | None`."""
+
+
+async def gather(*coros: Awaitable[T]) -> list[T]:
+    """Run awaitables concurrently via an `anyio` task group and return results in input order.
+
+    Unlike `asyncio.gather`, a failure in one coroutine cancels the rest instead of leaving them
+    as orphan background tasks. If exactly one task fails, its exception is re-raised directly to
+    match `asyncio.gather`'s shape; multi-failure cases propagate as an `ExceptionGroup`.
+    """
+    results: list[T] = [None] * len(coros)  # type: ignore[list-item]
+
+    async def _run(index: int, coro: Awaitable[T]) -> None:
+        results[index] = await coro
+
+    try:
+        async with anyio.create_task_group() as tg:
+            for i, coro in enumerate(coros):
+                tg.start_soon(_run, i, coro)
+    except BaseExceptionGroup as eg:
+        if len(eg.exceptions) == 1:
+            raise eg.exceptions[0] from None
+        raise
+
+    return results
 
 
 class Unset:

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from collections.abc import AsyncIterable, Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
@@ -9,6 +8,7 @@ from pydantic import ValidationError
 
 from pydantic_ai import _system_prompt
 from pydantic_ai._instructions import AgentInstructions, normalize_instructions
+from pydantic_ai._utils import gather
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.settings import ModelSettings, merge_model_settings
@@ -50,7 +50,7 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
         return any(c.has_wrap_run_event_stream for c in self.capabilities)
 
     async def for_run(self, ctx: RunContext[AgentDepsT]) -> AbstractCapability[AgentDepsT]:
-        new_caps = await asyncio.gather(*(c.for_run(ctx) for c in self.capabilities))
+        new_caps = await gather(*(c.for_run(ctx) for c in self.capabilities))
         if all(new is old for new, old in zip(new_caps, self.capabilities)):
             return self
         return replace(self, capabilities=list(new_caps))

--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -42,11 +42,11 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
         return f'{self.__class__.__name__}({", ".join(toolset.label for toolset in self.toolsets)})'  # pragma: no cover
 
     async def for_run(self, ctx: RunContext[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
-        new_toolsets = [await t.for_run(ctx) for t in self.toolsets]
+        new_toolsets = await gather(*(t.for_run(ctx) for t in self.toolsets))
         return replace(self, toolsets=new_toolsets)
 
     async def for_run_step(self, ctx: RunContext[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
-        new_toolsets = [await t.for_run_step(ctx) for t in self.toolsets]
+        new_toolsets = await gather(*(t.for_run_step(ctx) for t in self.toolsets))
         if all(new is old for new, old in zip(new_toolsets, self.toolsets)):
             return self
         return replace(self, toolsets=new_toolsets)

--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable, Sequence
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field, replace
@@ -9,6 +8,7 @@ from typing import Any
 from typing_extensions import Self
 
 from .._run_context import AgentDepsT, RunContext
+from .._utils import gather
 from ..exceptions import UserError
 from ..messages import InstructionPart
 from .abstract import AbstractToolset, ToolsetTool
@@ -64,7 +64,7 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
             self._exit_stack = None
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
-        toolsets_tools = await asyncio.gather(*(toolset.get_tools(ctx) for toolset in self.toolsets))
+        toolsets_tools = await gather(*(toolset.get_tools(ctx) for toolset in self.toolsets))
         all_tools: dict[str, ToolsetTool[AgentDepsT]] = {}
 
         for toolset, tools in zip(self.toolsets, toolsets_tools):
@@ -103,7 +103,7 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
         return replace(self, toolsets=[toolset.visit_and_replace(visitor) for toolset in self.toolsets])
 
     async def get_instructions(self, ctx: RunContext[AgentDepsT]) -> list[str | InstructionPart] | None:
-        results = await asyncio.gather(*(ts.get_instructions(ctx) for ts in self.toolsets))
+        results = await gather(*(ts.get_instructions(ctx) for ts in self.toolsets))
         parts: list[str | InstructionPart] = []
         for r in results:
             if r is not None:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1996,9 +1996,9 @@ async def test_combined_capability_for_run_cancels_siblings_on_failure():
     class SlowCap(AbstractCapability[None]):
         async def for_run(self, ctx: RunContext[None]) -> AbstractCapability[None]:
             nonlocal sibling_completed
-            await anyio.sleep(0.5)
-            sibling_completed = True
-            return self
+            await anyio.sleep(0.1)
+            sibling_completed = True  # pragma: no cover
+            return self  # pragma: no cover
 
     combined = CombinedCapability([FailingCap(), SlowCap()])
     ctx = _build_run_context()
@@ -2006,7 +2006,7 @@ async def test_combined_capability_for_run_cancels_siblings_on_failure():
     with pytest.raises(RuntimeError, match='boom'):
         await combined.for_run(ctx)
 
-    await anyio.sleep(0.6)
+    await anyio.sleep(0.2)
     assert sibling_completed is False
 
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import anyio
 import pytest
 
 from pydantic_ai._run_context import RunContext
@@ -1980,6 +1981,33 @@ async def test_combined_capability_for_run_returns_new_when_child_changes():
     new_per_run = result.capabilities[1]
     assert isinstance(new_per_run, PerRunCap)
     assert new_per_run.run_id == 1
+
+
+async def test_combined_capability_for_run_cancels_siblings_on_failure():
+    """When one child's for_run fails, siblings are cancelled instead of leaking as orphan tasks."""
+    sibling_completed = False
+
+    @dataclass
+    class FailingCap(AbstractCapability[None]):
+        async def for_run(self, ctx: RunContext[None]) -> AbstractCapability[None]:
+            raise RuntimeError('boom')
+
+    @dataclass
+    class SlowCap(AbstractCapability[None]):
+        async def for_run(self, ctx: RunContext[None]) -> AbstractCapability[None]:
+            nonlocal sibling_completed
+            await anyio.sleep(0.5)
+            sibling_completed = True
+            return self
+
+    combined = CombinedCapability([FailingCap(), SlowCap()])
+    ctx = _build_run_context()
+
+    with pytest.raises(RuntimeError, match='boom'):
+        await combined.for_run(ctx)
+
+    await anyio.sleep(0.6)
+    assert sibling_completed is False
 
 
 def test_apply_single_capability():

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, replace
 from typing import Any, TypeVar
 from unittest.mock import AsyncMock
 
+import anyio
 import pytest
 from typing_extensions import Self
 
@@ -1275,6 +1276,49 @@ async def test_combined_toolset_with_nested_list_instructions():
         InstructionPart(content='Instruction B.', dynamic=False),
         InstructionPart(content='Instruction C.', dynamic=False),
     ]
+
+
+async def test_combined_toolset_cancels_siblings_on_get_tools_failure():
+    """When one child's get_tools fails, siblings are cancelled instead of leaking as orphan tasks."""
+    sibling_completed = False
+
+    class FailingToolset(AbstractToolset[Any]):
+        @property
+        def id(self) -> str | None:
+            return None
+
+        async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
+            raise RuntimeError('boom')
+
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[Any], tool: ToolsetTool[Any]
+        ) -> Any:
+            return None  # pragma: no cover
+
+    class SlowToolset(AbstractToolset[Any]):
+        @property
+        def id(self) -> str | None:
+            return None
+
+        async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
+            nonlocal sibling_completed
+            await anyio.sleep(0.5)
+            sibling_completed = True
+            return {}
+
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[Any], tool: ToolsetTool[Any]
+        ) -> Any:
+            return None  # pragma: no cover
+
+    combined = CombinedToolset([FailingToolset(), SlowToolset()])
+    ctx = build_run_context(None)
+
+    with pytest.raises(RuntimeError, match='boom'):
+        await combined.get_tools(ctx)
+
+    await anyio.sleep(0.6)
+    assert sibling_completed is False
 
 
 async def test_dynamic_toolset_instructions_before_resolution():

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1310,6 +1310,24 @@ async def test_combined_toolset_cancels_siblings_on_get_tools_failure():
     assert sibling_completed is False
 
 
+async def test_combined_toolset_get_tools_preserves_exception_cause():
+    """Unwrapping the single-failure exception must preserve the original `__cause__` chain."""
+    original = ValueError('underlying')
+
+    class FailingToolset(WrapperToolset[Any]):
+        async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
+            raise RuntimeError('wrapper') from original
+
+    inner = FunctionToolset[None]()
+    combined = CombinedToolset([FailingToolset(inner)])
+    ctx = build_run_context(None)
+
+    with pytest.raises(RuntimeError, match='wrapper') as exc_info:
+        await combined.get_tools(ctx)
+
+    assert exc_info.value.__cause__ is original
+
+
 async def test_combined_toolset_get_tools_raises_group_on_multiple_failures():
     """When multiple children fail concurrently, their errors surface as an ExceptionGroup."""
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import sys
 from collections import defaultdict
 from dataclasses import dataclass, replace
 from typing import Any, TypeVar
@@ -9,6 +10,11 @@ from unittest.mock import AsyncMock
 import anyio
 import pytest
 from typing_extensions import Self
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup as BaseExceptionGroup  # pragma: lax no cover
+else:
+    BaseExceptionGroup = BaseExceptionGroup  # pragma: lax no cover
 
 from pydantic_ai import (
     AbstractToolset,
@@ -1282,43 +1288,50 @@ async def test_combined_toolset_cancels_siblings_on_get_tools_failure():
     """When one child's get_tools fails, siblings are cancelled instead of leaking as orphan tasks."""
     sibling_completed = False
 
-    class FailingToolset(AbstractToolset[Any]):
-        @property
-        def id(self) -> str | None:
-            return None
-
+    class FailingToolset(WrapperToolset[Any]):
         async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
             raise RuntimeError('boom')
 
-        async def call_tool(
-            self, name: str, tool_args: dict[str, Any], ctx: RunContext[Any], tool: ToolsetTool[Any]
-        ) -> Any:
-            return None  # pragma: no cover
-
-    class SlowToolset(AbstractToolset[Any]):
-        @property
-        def id(self) -> str | None:
-            return None
-
+    class SlowToolset(WrapperToolset[Any]):
         async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
             nonlocal sibling_completed
-            await anyio.sleep(0.5)
-            sibling_completed = True
-            return {}
+            await anyio.sleep(0.1)
+            sibling_completed = True  # pragma: no cover
+            return await self.wrapped.get_tools(ctx)  # pragma: no cover
 
-        async def call_tool(
-            self, name: str, tool_args: dict[str, Any], ctx: RunContext[Any], tool: ToolsetTool[Any]
-        ) -> Any:
-            return None  # pragma: no cover
-
-    combined = CombinedToolset([FailingToolset(), SlowToolset()])
+    inner = FunctionToolset[None]()
+    combined = CombinedToolset([FailingToolset(inner), SlowToolset(inner)])
     ctx = build_run_context(None)
 
     with pytest.raises(RuntimeError, match='boom'):
         await combined.get_tools(ctx)
 
-    await anyio.sleep(0.6)
+    await anyio.sleep(0.2)
     assert sibling_completed is False
+
+
+async def test_combined_toolset_get_tools_raises_group_on_multiple_failures():
+    """When multiple children fail concurrently, their errors surface as an ExceptionGroup."""
+
+    @dataclass
+    class RaisingToolset(WrapperToolset[Any]):
+        message: str = ''
+
+        async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
+            await anyio.sleep(0)
+            raise RuntimeError(self.message)
+
+    inner = FunctionToolset[None]()
+    combined = CombinedToolset(
+        [RaisingToolset(wrapped=inner, message='first'), RaisingToolset(wrapped=inner, message='second')]
+    )
+    ctx = build_run_context(None)
+
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        await combined.get_tools(ctx)
+
+    messages = {str(e) for e in exc_info.value.exceptions}
+    assert messages == {'first', 'second'}
 
 
 async def test_dynamic_toolset_instructions_before_resolution():


### PR DESCRIPTION
- Closes #5073

### Summary

`asyncio.gather` does not implement structured concurrency: when one coroutine raises, the exception propagates immediately while the remaining coroutines keep running as unmanaged background tasks. This leaks resources and makes failure semantics harder to reason about.

Three call sites in `CombinedToolset` and `CombinedCapability` are affected:

- `CombinedToolset.get_tools`
- `CombinedToolset.get_instructions`
- `CombinedCapability.for_run`

This PR introduces a small private `_utils.gather` helper backed by an `anyio` task group, which cancels siblings on failure, and migrates the three call sites to it. The helper unwraps single-exception `BaseExceptionGroup`s to match `asyncio.gather`'s shape, so callers continue to see a direct exception in the common case.

The other `asyncio.create_task` / `asyncio.wait(FIRST_COMPLETED)` race patterns in `_agent_graph.py` and `_utils.group_by_temporal` are deliberately out of scope — they have materially different semantics (racing, not fan-out-collect) and warrant a separate, more deliberate pass.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Test plan

- [x] New regression test in `tests/test_toolsets.py` asserting that `CombinedToolset.get_tools` cancels sibling toolsets when one child raises
- [x] New regression test in `tests/test_capabilities.py` asserting the same for `CombinedCapability.for_run`
- [x] Existing `tests/test_toolsets.py`, `tests/test_capabilities.py`, and `tests/test_utils.py` suites pass (492 tests)