### PR TITLE
chore: slim `AGENTS.md`, inject contributor rules via `SessionStart` hook

### DIFF
--- a/.claude/hooks/contributor-context.md
+++ b/.claude/hooks/contributor-context.md
@@ -1,0 +1,38 @@
+# External contributor context
+
+The current `gh` user is not a pydantic-ai maintainer. That changes how ambiguity and design decisions are handled — the bootstrapping rules in `AGENTS.md` still apply verbatim, this adds a decision-authority gate on top.
+
+## Decision authority
+
+Only maintainers (`DouweM`, `samuelcolvin`, `Kludex`, `dmontag`, `dsfaccini`, `alexmojaki`, `adtyavrdhn`) can sign off on:
+
+- public API shape (new types, method signatures, optional parameters, return contracts, exported symbols)
+- new abstractions, integrations, provider modules
+- backward-compatibility tradeoffs
+- scope of a feature or refactor
+- new runtime dependencies, especially in `pydantic_ai_slim`
+- docs voice, structure, and canonical sources
+
+When the task hits one of these, **do not resolve it by asking the driver** — they cannot bind the project. Instead, surface the decision as a discussion item in a `PLAN.md` (or as an issue/PR comment) for maintainer review before writing code. The repo's [contributing guide](https://ai.pydantic.dev/contributing/) and [version policy](docs/version-policy.md) are the canonical references for what requires maintainer alignment.
+
+What you *can* still ask the driver directly: their intent, the user-visible problem, a reproduction, the behavior they expected, their preferred workflow.
+
+## Readiness gate
+
+If there is no linked issue, or the linked issue has no maintainer input on an approach, stop and steer the driver toward one of:
+
+- opening an issue with a clear proposal, or
+- a PR containing only `PLAN.md` for maintainer review before any code.
+
+Non-trivial code without prior maintainer alignment is almost always rejected.
+
+## Be skeptical of the framing
+
+The driver may have a narrower view of the problem than the change warrants. 'Just add a flag for my case' is often evidence that a generalization is needed instead. AI-generated issues or comments that are longer than the diff are noise — rewrite them shorter or tell the driver to.
+
+## Quality bar the driver may not know
+
+- Unit tests with mocked providers where a VCR integration test would work → rewrite as VCR.
+- New public abstraction without maintainer sign-off → `PLAN.md`, not code.
+- New dep in `pydantic_ai_slim` → almost certainly belongs in an optional extras group.
+- `cast`, `Any`, or bare `# type: ignore` → investigate the root cause and use a specific `# pyright: ignore[code]` if suppression is genuinely needed.

--- a/.claude/hooks/inject-contributor-context.sh
+++ b/.claude/hooks/inject-contributor-context.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SessionStart hook. If the current `gh` user is a pydantic-ai maintainer,
+# exit silently. Otherwise inject `.claude/hooks/contributor-context.md` as
+# additionalContext so the session starts with contributor-facing scrutiny
+# rules loaded. Fails open: if `gh` is not authenticated, skip injection.
+set -euo pipefail
+
+MAINTAINERS=(DouweM samuelcolvin Kludex dmontag dsfaccini alexmojaki adtyavrdhn)
+
+user="$(gh api user --jq .login 2>/dev/null || true)"
+for m in "${MAINTAINERS[@]}"; do
+  [[ "$user" == "$m" ]] && exit 0
+done
+
+ctx_file="$(dirname "$0")/contributor-context.md"
+[[ -f "$ctx_file" ]] || exit 0
+
+jq -cn --rawfile ctx "$ctx_file" '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $ctx
+  }
+}'

--- a/.claude/hooks/inject-contributor-context.sh
+++ b/.claude/hooks/inject-contributor-context.sh
@@ -1,23 +1,38 @@
 #!/usr/bin/env bash
-# SessionStart hook. If the current `gh` user is a pydantic-ai maintainer,
-# exit silently. Otherwise inject `.claude/hooks/contributor-context.md` as
-# additionalContext so the session starts with contributor-facing scrutiny
-# rules loaded. Fails open: if `gh` is not authenticated, skip injection.
+# SessionStart hook for pydantic-ai.
+#
+# Behavior:
+# - `gh` CLI not installed         -> inject setup-required.md
+# - `gh` installed but not authed  -> inject setup-required.md
+# - `gh` authed, maintainer login  -> silent exit (lean AGENTS.md only)
+# - `gh` authed, other login       -> inject contributor-context.md
 set -euo pipefail
 
 MAINTAINERS=(DouweM samuelcolvin Kludex dmontag dsfaccini alexmojaki adtyavrdhn)
 
+inject() {
+  local file="$1"
+  [[ -f "$file" ]] || exit 0
+  jq -cn --rawfile ctx "$file" '{
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: $ctx
+    }
+  }'
+  exit 0
+}
+
+hook_dir="$(dirname "$0")"
+setup_msg="$hook_dir/setup-required.md"
+contributor_msg="$hook_dir/contributor-context.md"
+
+command -v gh >/dev/null 2>&1 || inject "$setup_msg"
+
 user="$(gh api user --jq .login 2>/dev/null || true)"
+[[ -z "$user" ]] && inject "$setup_msg"
+
 for m in "${MAINTAINERS[@]}"; do
   [[ "$user" == "$m" ]] && exit 0
 done
 
-ctx_file="$(dirname "$0")/contributor-context.md"
-[[ -f "$ctx_file" ]] || exit 0
-
-jq -cn --rawfile ctx "$ctx_file" '{
-  hookSpecificOutput: {
-    hookEventName: "SessionStart",
-    additionalContext: $ctx
-  }
-}'
+inject "$contributor_msg"

--- a/.claude/hooks/reject-no-verify.sh
+++ b/.claude/hooks/reject-no-verify.sh
@@ -2,7 +2,7 @@
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // ""')
 
-if echo "$command" | grep -qE 'git\s+commit' && echo "$command" | grep -qE '\-\-no-verify'; then
+if echo "$command" | grep -qE 'git[[:space:]]+commit' && echo "$command" | grep -qE '(--no-verify|[[:space:]]-[^-[:space:]]*n)'; then
   echo "BLOCKED: Do not skip pre-commit hooks with --no-verify." >&2
   echo "Fix the hook failure instead. If pre-commit fails, investigate and fix the issue." >&2
   exit 1

--- a/.claude/hooks/reject-no-verify.sh
+++ b/.claude/hooks/reject-no-verify.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // ""')
+
+if echo "$command" | grep -qE 'git\s+commit' && echo "$command" | grep -qE '\-\-no-verify'; then
+  echo "BLOCKED: Do not skip pre-commit hooks with --no-verify." >&2
+  echo "Fix the hook failure instead. If pre-commit fails, investigate and fix the issue." >&2
+  exit 1
+fi
+
+echo "$input"
+exit 0

--- a/.claude/hooks/setup-required.md
+++ b/.claude/hooks/setup-required.md
@@ -1,0 +1,11 @@
+# `gh` CLI setup required
+
+This repo's workflow depends on an installed, authenticated `gh` CLI — hooks, the `address-feedback` skill, and the post-push review flow all use it.
+
+Before making any code changes or running non-read-only tool calls, walk the user through these three steps:
+
+1. **Install** (if missing): `brew install gh` on macOS, or see <https://github.com/cli/cli#installation> for other platforms.
+2. **Authenticate**: `gh auth login`
+3. **Verify**: `gh auth status` should print 'Logged in to github.com'.
+
+Do not proceed with the task until all three succeed.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,5 +21,29 @@
       "Bash(uv run:*)",
       "Bash(make:*)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/inject-contributor-context.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/reject-no-verify.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ node_modules/
 .claude/skills/*
 !.claude/skills/address-feedback
 !.claude/skills/pre-push-review
+!.claude/hooks/
+.claude/hooks/*
+!.claude/hooks/contributor-context.md
+!.claude/hooks/inject-contributor-context.sh
+!.claude/hooks/reject-no-verify.sh
 .github/.review-context/
 /.cursor/
 /.devcontainer/

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ node_modules/
 !.claude/hooks/contributor-context.md
 !.claude/hooks/inject-contributor-context.sh
 !.claude/hooks/reject-no-verify.sh
+!.claude/hooks/setup-required.md
 .github/.review-context/
 /.cursor/
 /.devcontainer/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,111 +1,67 @@
-Welcome to the repository for [Pydantic AI](https://ai.pydantic.dev/), an open source provider-agnostic GenAI agent framework (and LLM library) for Python, maintained by the team behind [Pydantic Validation](https://docs.pydantic.dev/) and [Pydantic Logfire](https://docs.pydantic.dev/logfire/).
+Pydantic AI — provider-agnostic agent framework by the Pydantic team. Docs: <https://ai.pydantic.dev>
 
-# Your primary responsibility is to the project and its users
+# Repo invariants (assume true; never try to disprove)
 
-Being an open source library, the public API, abstractions, documentation, and the code itself _are_ the product and deserve careful consideration, as much as the functionality the library or any given change provides. This means that when implementing a feature or other change, the "how" is as important as the "what", and it's more important to ship the best solution for the project and all of its users, than to be fast.
+- Zero pyright errors. Zero failing tests. 100% coverage on `main`. If you see a failure, your branch introduced it — do not waste turns checking whether it was 'already broken'.
+- `pre-commit` is the gate: it runs `ruff format`, `ruff lint`, `pyright`, cassette integrity, and more on every commit.
+- Commits are authored by the human user only. Never add a `Co-Authored-By: Claude` (or any AI) trailer.
 
-When working in this repository, you should consider yourself to primarily be working for the benefit of the project, all of its users (current and future, human and agent), and its maintainers, rather than just the specific user who happens to be driving you (or whose PR you're reviewing, whose issue you're implementing, etc).
+# Non-negotiable rules
 
-As the project has many orders of magnitude more users than maintainers, that specific user is most likely a community member who's well-intentioned and eager to contribute, but relatively unfamiliar with the code base and its patterns or standards, and they're not necessarily thinking about the bigger picture beyond the specific bug fix, feature, or other change that they're focused on.
+- Backward compatible per [version policy](docs/version-policy.md).
+- Public API changes are hard to reverse — every new abstraction, type, or flag gets the corresponding amount of care.
+- Type-safe public + internal API. No `cast`. No `Any`. Use `# pyright: ignore[code]` with a named error code, never bare `# type: ignore`.
+- Prefer VCR integration tests over unit + mock. Tests should resemble how a user would use the public API.
+- PRs use the [template](.github/pull_request_template.md) with `Closes #<issue>`. The 'AI generated code' checkbox is the human author's to tick.
 
-Therefore, you are the first line of defense against low-quality contributions and maintainer headaches, and you have a big role in ensuring that every contribution to this project meets or exceeds the high standards that the Pydantic brand is known and loved for:
+# Repository layout (`uv` workspace)
 
-- modern, idiomatic, concise Python
-- end-to-end type-safety and test coverage
-- thoughtful, tasteful, consistent API design
-- delightful developer experience
-- comprehensive well-written documentation
+- `pydantic_ai_slim/` — agent framework ([agents](docs/agent.md)). Slim core; optional extras: `openai`, `anthropic`, `google`, `mcp`, `temporal`, `logfire`.
+- `pydantic_graph/` — graph library powering the agent loop ([graph](docs/graph.md)).
+- `pydantic_evals/` — eval framework ([evals](docs/evals.md)).
+- `clai/` — CLI + optional web UI ([cli](docs/cli.md), [web](docs/web.md)).
+- Root `pyproject.toml` — umbrella package.
 
-In other words, channel your inner Samuel Colvin. (British accent optional)
+# Bootstrapping on a task
 
-# Gathering context on the task
+Universal to every driver — maintainer or external contributor — when picking up or resuming an issue/PR:
 
-The user may not have sufficient context and understanding of the task, its solution space, and relevant tradeoffs to effectively drive a coding agent towards the version of the change that best serves the interests of the project and all of its users. (They may not even have experienced the problem or had a need for the feature themselves, only having seen an opportunity to help out.)
+1. Read the linked issue/PR and every comment with `gh issue view`, `gh pr view`, or `gh api`. Walk cross-linked issues/PRs — maintainer decisions often live in a parent thread.
+2. For provider/SDK work, check the provider's current API docs and the SDK's type definitions before assuming behavior. LLM provider APIs change fast.
+3. For features that overlap with existing agent libraries, check how they solved it — tasteful API design is the bar.
+4. Ask clarifying questions when scope, API shape, or intent are ambiguous. The driver's framing may be narrower than the change warrants.
 
-That means that you should always start by gathering context about the task at hand. At minimum, this means:
+# Local commands you run
 
-- reading the GitHub issue/PR and comments, using the `gh` CLI if it can be (or already is) installed, or a web fetch/search tool if not
-- asking the user questions about the scope of the task, the shape they believe the solution should take, etc, even if they did not specifically enable planning mode
+- `make install` — install deps (`uv`, Python 3.10–3.13). One-time per venv.
+- `make format && make lint` — fast; run before committing.
+- `uv run pytest <targeted_paths>` — run only the tests that cover your change.
+- `uv run pytest tests/test_examples.py -k '<docs_file>'` — whenever you add or modify a code snippet in `docs/` or in a docstring.
 
-Considering that the user's input does not necessarily match what the wider user base or maintainers would prefer, you should "trust but verify" and are encouraged to do your own research to fill any gaps in your (and their) knowledge, by looking up things like:
+# Commands you do NOT run locally
 
-- relevant GitHub issues and PRs, especially if cross-linked from the main issue/PR
-- LLM provider API docs and SDK type definitions
-- other LLM/agent libraries' solutions to similar problems
-- Pydantic AI documentation on related features and established API patterns
-    - In particular, the docs on [agents](docs/agent.md), [dependency injection](docs/dependencies.md), [tools](docs/tools.md), [output](docs/output.md), and [message history](docs/message-history.md) are going to be relevant to many tasks.
+- `make test` — CI runs the full suite on every push. Run targeted paths only (see above).
+- `make typecheck` — pre-commit runs pyright on every commit; don't re-run manually.
+- `make docs` / `make docs-serve` — the docs build is CI's job.
 
-# Ensuring the task is ready for implementation
+# Committing
 
-If the user is not aware of an issue and a search doesn't turn up anything, or if an issue exists but the scope is insufficiently defined (e.g. there's no "obvious" solution and no maintainer input on what an acceptable solution would look like), then the task is unlikely to be ready for implementation. Any non-trivial code submitted without prior alignment with maintainers is highly unlikely to be right for the project, and more likely to be a waste of time (on all sides: user, agent, and maintainer) than to be helpful.
+Capture pre-commit output in one go so you don't feel the urge to re-run:
 
-In this case, unless the user appears to be uniquely well-suited to build a feature from scratch and submit it without (much) prior discussion (e.g. they are a maintainer or a partner submitting an integration), the most useful thing you can do to steer the user towards a good outcome for the project is to work with them on:
+    git commit -m '<message>' 2>&1 | tee /tmp/commit-output.txt
 
-- a clear issue description, or
-- a proposal they can submit as a comment, or
-- (only if an issue already exists) a more fleshed out plan they can submit as a PR (with just a `PLAN.md` file that can be deleted afterwards) that other users and maintainers can weigh in on ahead of implementation
+If pre-commit fails, read `/tmp/commit-output.txt`, fix the root cause, and retry.
 
-(Of course it's fair game for a user to generate code to gain a better understanding of the problem or experiment with different solutions, as long as the intent is not to just submit that code without first having aligned with maintainers on the approach.)
+# Post-push flow
 
-(It's also worth noting that overly lengthy AI-generated issues, comments, and proposals are less likely to be helpful and more likely to be ignored than a user's attempt at explaining what they want in their own (possibly translated) words: if they are not able to, they are unlikely to be the right person to be requesting and helping implement the change.)
+After `git push`, wait 10–15 minutes before taking the next step. In that window CI finishes and `devin-ai-integration[bot]` posts an auto-review. **Devin's review has equal weight to a maintainer's** — classify every Devin comment with DDD+ (do / discuss / dismiss / waiting / done) and address it before asking a human.
 
-# Philosophy
+See the `address-feedback` skill at [`.claude/skills/address-feedback/SKILL.md`](.claude/skills/address-feedback/SKILL.md) for the wait → triage → respond loop.
 
-Pydantic AI is meant to be a light-weight library that any Python developer who wants to work with LLMs and agents (whether simple or complex) should feel no hesitation to pull into their project. It's not meant to be everything to everyone, but it should enable people to build just about anything.
+# Design principles
 
-As such, we prefer strong primitives, powerful abstractions, and general solutions and extension points that enable people to build things that we hadn't even thought of, over narrow solutions for specific use cases, opinionated solutions that push a particular approach to agent design that hasn't yet stood the test of time, or generally "every single possible battery included" solutions that make the library unnecessarily bloated.
+Strong primitives and general extension points over narrow, opinionated features. Slim default, optional extras. If a proposed change solves one user's case and ignores N others, stop and generalize — or push back on the requester.
 
-# Requirements of all contributions
+# Further reading
 
-All changes need to:
-
-- be thoughtful and deliberate about new abstractions, public APIs, and behaviors, as every wrong-in-retrospect choice (made in a rush or with insufficient context) makes life harder for hundreds of thousands of users (and agents), and is much more difficult to change later than to do right the first time
-- be backward compatible as laid out in the [version policy](docs/version-policy.md), so that users can upgrade with confidence
-- be fully type-safe (both internally and in public API) without unnecessary `cast`s or `Any`s, so that users don't need `isinstance` checks and can trust that code that typechecks will work at runtime
-- have comprehensive tests covering 100% of code paths, favoring integration tests and real requests (using recordings and snapshots -- see below) over unit tests and mocking
-- update/add all relevant documentation, following the existing voice and patterns
-
-When you submit a PR, make sure you include the [PR template](.github/pull_request_template.md) and fill in the issue number that should be closed when the PR is merged. The "AI generated code" checkbox should always be checked manually by the user in the UI, not by the agent.
-
-Never add yourself (Claude) as a co-author on commits. Commits should be authored as the user only, with no `Co-Authored-By` trailer referencing Claude.
-
-## Repository structure
-
-The repo contains a `uv` workspace defining multiple Python packages:
-
-- `pydantic-ai-slim` in `pydantic_ai_slim/`: the [agent framework](docs/agent.md), including the `Agent` class and `Model` classes for each model provider/API
-    - This is a slim package with minimal dependencies and optional dependency groups for each model provider (e.g. `openai`, `anthropic`, `google`) or integration (e.g. `logfire`, `mcp`, `temporal`).
-- `pydantic-graph` in `pydantic_graph/`: the type-hint based [graph library](docs/graph.md) that powers the agent loop
-- `pydantic-evals` in `pydantic_evals/`: the [evaluation framework](docs/evals.md) for evaluating the arbitrary stochastic functions including LLMs and agents
-- `clai` in `clai/`: a [CLI](docs/cli.md) (with an optional [web UI](docs/web.md)) to chat with Pydantic AI agents
-- `pydantic-ai` defined in `pyproject.toml` at the root, bringing in the packages above as well the optional dependency groups for all model providers and select integrations.
-
-## Development workflow
-
-The project uses:
-
-- [`uv`](https://docs.astral.sh/uv/getting-started/installation/), supporting Python 3.10 through 3.13
-    - Install all dependencies with `make install`
-- `pre-commit`, can be installed with `uv tool install pre-commit`
-- `ruff` via `make lint` and `make format`
-- `pyright` via `make typecheck`
-- `pytest` in `tests/`, via `make test`, with:
-    - `inline-snapshot` for inline assertions
-    - `pytest-recording` and `vcrpy` for recording and playing back requests to model APIs
-- `mkdocs` in `docs/`, via `make docs` and `make docs-serve`, served at <https://ai.pydantic.dev>, with:
-    - `mkdocstrings-python` to generate API docs from docstrings and types
-    - `mkdocs-material` to theme the docs
-    - `tests/test_examples.py` to test all code examples in the docs (including docstrings)
-- [`logfire`](docs/logfire.md) for OTel instrumentation of Pydantic AI and `httpx`
-    - If you have access to the Logfire MCP server, you can use it to inspect agent runs, tool calls, and model requests
-
-# Coding Guidelines
-
-When generating or reviewing code anywhere in this repo, always read [agent_docs/index.md](agent_docs/index.md) and follow/enforce those guidelines. Don't forget to read the linked "topic guides" when appropriate.
-
-Additionally, always read the directory-specific instructions when working in those directories:
-
-- [docs/AGENTS.md](docs/AGENTS.md)
-- [pydantic_ai_slim/pydantic_ai/AGENTS.md](pydantic_ai_slim/pydantic_ai/AGENTS.md)
-- [pydantic_ai_slim/pydantic_ai/models/AGENTS.md](pydantic_ai_slim/pydantic_ai/models/AGENTS.md)
-- [tests/AGENTS.md](tests/AGENTS.md)
+- [`agent_docs/index.md`](agent_docs/index.md) and its topic guides ([api-design](agent_docs/api-design.md), [code-simplification](agent_docs/code-simplification.md), [documentation](agent_docs/documentation.md)) — read the relevant sections when touching those areas.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-Pydantic AI — provider-agnostic agent framework by the Pydantic team. Docs: <https://ai.pydantic.dev>
+Pydantic AI is a provider-agnostic GenAI agent framework by the team behind [Pydantic Validation](https://docs.pydantic.dev/) and [Pydantic Logfire](https://pydantic.dev/logfire), used by hundreds of thousands of Python developers. People pick it because the code is simple to read and write, the same API works across every major LLM provider, and the abstractions are flexible enough to build anything from a single-tool chatbot to a multi-agent system without locking them into a particular shape. We optimize for modern idiomatic Python, end-to-end type safety, a tasteful public API, and a developer experience that doesn't fight you. [`README.md`](README.md) has the full 'why use it' pitch; docs live at <https://ai.pydantic.dev>.
 
 # Repo invariants (assume true; never try to disprove)
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,35 +1,166 @@
-<!-- braindump: rules extracted from PR review patterns -->
+# Testing Guidelines
 
-# tests/ Guidelines
+## Test File Structure
 
-## Testing
+```python
+from __future__ import annotations
 
-<!-- rule:177 -->
-- Test through public APIs, not private methods (prefixed with `_`) or helpers — Prevents brittle tests tied to implementation details, reduces maintenance burden when refactoring internals, and validates actual user-facing behavior rather than isolated units
-<!-- rule:173 -->
-- Maintain 1:1 correspondence between test files and source modules (`test_{module}.py`) — consolidate related tests instead of splitting by feature, config, or test type — Prevents test suite fragmentation and makes tests easier to locate by matching source structure; use fixtures/markers to distinguish test types within the file
-<!-- rule:86 -->
-- Use `snapshot()` for complex structured outputs (objects, message sequences, API responses, nested dicts, span attributes) — prevents brittle field-by-field assertions and improves test maintainability — Snapshot testing catches unexpected changes in complex structures more reliably than manual assertions, and `IsStr` matchers handle variable values gracefully
-<!-- rule:318 -->
-- Use `pytest-vcr` cassettes (not mocks) in `tests/models/` — records real HTTP interactions for deterministic replay, captures both success and error cases — Ensures integration tests validate real API behavior without live calls on every run, making tests faster and preventing flakiness from network issues or rate limits
-<!-- rule:334 -->
-- Assert meaningful behavior in tests, not just code execution or type checks — validates correctness and data flow — Prevents false confidence from tests that pass without verifying actual functionality works as intended
-<!-- rule:194 -->
-- In agent/model/stream tests, assert on final output AND snapshot `result.all_messages()` — validates complete execution trace, not just end result — Catches regressions in tool calls, intermediate steps, and message flow that final output assertions miss
-<!-- rule:363 -->
-- Test through real APIs, not mocks — mock only slow/external dependencies outside your control — Improves refactoring safety, documents real usage patterns, and catches integration issues — use lightweight local infrastructure (test servers, in-memory DBs) for systems you control (provider APIs, Temporal workflows, frameworks) in files like `test_{provider}.py`; reserve mocks for third-party HTTP APIs and unreliable external services
-<!-- rule:11 -->
-- Parametrize tests across all providers that support the feature (or at minimum OpenAI, Anthropic, Google) — catches provider-specific regressions and ensures cross-provider compatibility — Prevents breaking unchanged providers when modifying shared model logic, and surfaces integration issues across different provider APIs before they reach production
-<!-- rule:385 -->
-- Ensure test assertions match test names and docstrings — prevents false confidence in test coverage and catches actual regressions — Tests without proper assertions or that verify opposite behavior create false positives and fail to catch bugs they claim to prevent.
-<!-- rule:89 -->
-- Test both positive and negative cases for optional capabilities (model features, server features, streaming) — ensures features work when supported AND fail gracefully when absent — Prevents false confidence from tests that only check unsupported cases, catching both implementation bugs and missing error handling
-<!-- rule:630 -->
-- Test MCP against real `tests.mcp_server` instance, not mocks — extend test server with helper tools to expose runtime context (instructions, client info, session state) — Verifies actual data flow and integration behavior rather than just testing mock interfaces, catching real-world issues that mocks would miss
+import pytest
+from inline_snapshot import snapshot
 
-## General
+from pydantic_ai import Agent
+from pydantic_ai.models import Model
+# ... other imports
 
-<!-- rule:463 -->
-- Remove stale test docstrings, comments, and historical provider bug notes when behavior changes — Outdated test documentation misleads developers about what's actually being tested and why
+pytestmark = [pytest.mark.anyio, pytest.mark.vcr]
 
-<!-- /braindump -->
+
+# fixtures/helpers immediately before their test
+@pytest.fixture
+def my_helper():
+    ...
+
+
+@pytest.mark.parametrize('model', ['openai', 'anthropic', 'google'], indirect=True)
+@pytest.mark.parametrize('stream', [False, True])
+async def test_feature(model: Model, stream: bool):
+    ...
+```
+
+## Parametrization with Expectations
+
+For cartesian product tests, use a dict to map parameter combinations to expected results:
+
+```python
+from vcr.cassette import Cassette
+
+from pydantic_ai.models import Model
+
+# expectation can be a dataclass, for more complex cases
+EXPECTATIONS: dict[tuple[str, bool], str] = {
+    ('openai', False): 'expected output for openai non-streaming',
+    ('openai', True): 'expected output for openai streaming',
+    ('anthropic', False): 'expected output for anthropic non-streaming',
+    ('anthropic', True): 'expected output for anthropic streaming',
+}
+
+
+@pytest.mark.parametrize('model', ['openai', 'anthropic'], indirect=True)
+@pytest.mark.parametrize('stream', [False, True])
+async def test_feature(model: Model, stream: bool, request: pytest.FixtureRequest, vcr: Cassette):
+    """What the test is asserting.
+
+    Use the `request` fixture to access test parameter values.
+
+    Use the `vcr` to make assertions about the HTTP requests if needed.
+    Another creative way of, for instance, asserting headers, is to use a patched httpx client fixture.
+    This spares us the overhead of parsing cassette fields, so it is to be preferred whenever optimal.
+    """
+    model_name = request.node.callspec.params['model']
+    expected = EXPECTATIONS[(model_name, stream)]
+
+    agent = Agent(model)
+    if stream:
+        async with agent.run_stream('hello') as result:
+            output = await result.get_output()
+    else:
+        result = await agent.run('hello')
+        output = result.output
+
+    assert output == expected
+```
+
+## VCR Workflow
+
+Record cassettes with `--record-mode=rewrite`, verify playback without the flag, and review diffs.
+
+## Key Fixtures
+
+### From `conftest.py`
+
+#### Model requests
+- `allow_model_requests` - bypasses the default `ALLOW_MODEL_REQUESTS = False`
+
+#### The `model` fixture (use with `indirect=True`)
+
+The `model` fixture takes a string param (e.g. `'openai'`, `'anthropic'`, `'google'`) and returns a configured `Model` instance, using session-scoped API key fixtures that default to `'mock-api-key'` (real keys loaded from env when recording).
+See `tests/conftest.py` for the full list of supported param values.
+
+```python
+@pytest.mark.parametrize('model', ['openai', 'anthropic'], indirect=True)
+async def test_something(model: Model):
+    ...
+```
+
+#### Environment management
+- `env` - `TestEnv` instance for temporary env var changes
+  ```python
+  def test_missing_key(env: TestEnv):
+      env.remove('OPENAI_API_KEY')
+      with pytest.raises(UserError):
+          ...
+  ```
+
+#### Binary content (session-scoped)
+- `assets_path` - `Path` to `tests/assets/`
+- `image_content` - `BinaryImage` (kiwi.jpg)
+- `audio_content` - `BinaryContent` (marcelo.mp3)
+- `video_content` - `BinaryContent` (small_video.mp4)
+- `document_content` - `BinaryContent` (dummy.pdf)
+- `text_document_content` - `BinaryContent` (dummy.txt)
+
+#### SSRF protection for URL downloads
+- `disable_ssrf_protection_for_vcr` - required for VCR tests that download URL content (`ImageUrl`, `AudioUrl`, `DocumentUrl`, `VideoUrl` with `force_download=True`)
+- An autouse guard raises a `RuntimeError` if a VCR test triggers SSRF validation without this fixture
+
+## Assertion Helpers
+
+### From `conftest.py`
+- `IsNow(tz=timezone.utc)` - datetime within 10 seconds of now
+- `IsStr()` - any string, supports `regex=r'...'`
+- `IsDatetime()` - any datetime
+- `IsBytes()` - any bytes
+- `IsInt()` - any int
+- `IsFloat()` - any float
+- `IsList()` - any list
+- `IsInstance(SomeClass)` - instance of class
+
+### Additional helpers
+- `IsSameStr()` - asserts same string value across multiple uses in one assertion
+  ```python
+  assert events == [
+      {'id': (msg_id := IsSameStr())},
+      {'id': msg_id},  # must match first
+  ]
+  ```
+
+## Best Practices
+
+- Test through public APIs, not private methods (prefixed with `_`) or helpers — validates actual user-facing behavior and prevents brittle tests tied to implementation details
+- Prefer feature-centric parametrized test files (e.g. `test_multimodal_tool_returns.py`) over appending to monolithic `test_<provider>.py` files — the legacy per-provider files are large and hard for agents to navigate; new features should get their own test file with a `Case` class and parametrized providers
+- Use `snapshot()` for complex structured outputs (objects, message sequences, API responses, nested dicts) — catches unexpected changes more reliably than field-by-field assertions; use `IsStr` and similar matchers for variable values
+- Assert the core aspect of the change being introduced — use whatever means necessary: patching clients to inspect request payloads, tapping into pydantic-ai internals, snapshot comparisons. Snapshots are valuable for catching structural drift in objects and message arrays, but only use `result.all_messages()` or output assertions when the structure demonstrates behavior you care about keeping consistent
+- Test both positive and negative cases for optional capabilities (model features, server features, streaming) — ensures features work when supported AND fail gracefully when absent
+- Ensure test assertions match test names and docstrings — tests without proper assertions or that verify opposite behavior create false positives
+- Test MCP against real `tests.mcp_server` instance, not mocks — extend test server with helper tools to expose runtime context (instructions, client info, session state)
+- Remove stale test docstrings, comments, and historical provider bug notes when behavior changes
+
+## Directory Structure
+
+```
+tests/
+├── conftest.py              # shared fixtures
+├── json_body_serializer.py  # custom VCR serializer
+├── assets/                  # binary test files
+├── cassettes/               # VCR recordings for root tests
+├── models/
+│   ├── conftest.py          # model-specific fixtures (if needed)
+│   ├── cassettes/           # VCR recordings per test file
+│   │   ├── test_openai/
+│   │   ├── test_anthropic/
+│   │   └── ...
+│   └── test_*.py
+├── providers/
+│   └── test_*.py            # provider initialization tests (unit)
+└── test_*.py                # feature tests (prefer VCR + parametrize)
+```


### PR DESCRIPTION
No linked issue — self-initiated CE cleanup.

## Summary

Root `AGENTS.md` was written as a 'first line of defense against low-quality contributions' and ~60 of its 112 lines are prose calibrated for first-time external contributors. `git shortlog` shows 8 of us now write ~95% of commits, so that prose is dead weight on every maintainer turn. This PR slims `AGENTS.md` to engineering essentials and moves the contributor-facing stuff behind a SessionStart hook that only fires when the `gh` user isn't a maintainer.

A few latent issues were worth fixing along the way:

- Claude routinely 'checks if this type error is pre-existing' — a wasted turn, because `main` holds zero pyright errors, zero failing tests, 100% coverage (otherwise CI is red and nothing merges). No canonical warning existed, so there's now an **Invariants** block at the top of `AGENTS.md`.
- The file advertised `make test`, `make typecheck`, and `make docs` as local commands. None of them should run locally: CI runs the full test suite, pre-commit runs pyright on every commit, and the docs build is CI's. They're now under an explicit **Commands you do NOT run locally** section.
- Committing had no guidance, so pre-commit failures tended to trigger a re-run. Added the tee'd `git commit … | tee /tmp/commit-output.txt` pattern so the output is captured once.
- No committed `--no-verify` blocker. Added `.claude/hooks/reject-no-verify.sh` wired as a `PreToolUse` Bash hook.
- The post-push flow was undocumented. Added a **Post-push flow** section that spells out the 10–15 minute wait for CI + Devin and calls out that **Devin's auto-review carries the same weight as a maintainer's** — classify with DDD+ before asking a human.

## The SessionStart hook

`.claude/hooks/inject-contributor-context.sh` runs on every session start. It calls `gh api user --jq .login` and, if the user isn't in the maintainer set (`DouweM`, `samuelcolvin`, `Kludex`, `dmontag`, `dsfaccini`, `alexmojaki`, `adtyavrdhn`), injects `.claude/hooks/contributor-context.md` as `additionalContext`. Maintainers see the lean `AGENTS.md` only. Fails open if `gh` isn't authenticated.

The injected block isn't a restatement of `AGENTS.md` — the bootstrapping rules (read the linked issue, walk cross-links, check provider docs, ask clarifying questions) apply universally and live in `AGENTS.md`. What the hook adds is specifically a **decision-authority gate**: non-maintainer drivers can't sign off on public API shape, new abstractions, backward-compat tradeoffs, or new deps in `pydantic_ai_slim`. When a task hits one of those, the agent should surface it in a `PLAN.md` for maintainer review instead of resolving it with the driver.

## Out of scope

Worth doing but kept for follow-up PRs so each can be discussed on its own:

- Extract the ~1900 words of inline prompts in `.github/workflows/bots.yml` into `agent_docs/pr-review.md` / `pr-categories.md` (touches a safety-sensitive workflow file).
- Lift the rest of my local toolkit's hooks (`block-cassette-rm`, `reject-type-ignore`, `redirect-uv-pip-install`, etc.).
- Teach `.claude/commands/gcap.md` the post-push wait + Devin fetch loop.
- Reword `agent_docs/index.md`'s 'always read' claim — only about half of its rules are universally relevant to every task.

## Overlap with #4211

#4211 restructures `.gitignore` around `.agents/skills/` as the canonical location with `.claude/skills` as a symlink. Assuming this PR lands first, #4211 will need a ~4-line rebase to re-add the `!.claude/hooks/*` allowlist in its new shape. Non-blocking — I've left a note on #4211 spelling out the resolution.

## Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).