### PR TITLE
Implement support for Priority PayGo with VertexAI

### DIFF
--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -155,7 +155,7 @@ agent = Agent(model)
 
 #### Vertex AI service tier (`google_service_tier`)
 
-On **Vertex AI**, optional HTTP headers control how each request uses [Provisioned Throughput](https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/use-provisioned-throughput) (PT) and [Flex PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo) pricing. Set the [`google_service_tier`][pydantic_ai.models.google.GoogleModelSettings.google_service_tier] field on [`GoogleModelSettings`][pydantic_ai.models.google.GoogleModelSettings] to one of the [`GoogleServiceTier`][pydantic_ai.models.google.GoogleServiceTier] values.
+On **Vertex AI**, optional HTTP headers control how each request uses [Provisioned Throughput](https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/use-provisioned-throughput) (PT), [Flex PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo), and [Priority PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo) pricing. Set the [`google_service_tier`][pydantic_ai.models.google.GoogleModelSettings.google_service_tier] field on [`GoogleModelSettings`][pydantic_ai.models.google.GoogleModelSettings] to one of the [`GoogleServiceTier`][pydantic_ai.models.google.GoogleServiceTier] values.
 
 **Flex PayGo example**
 
@@ -175,6 +175,23 @@ result = agent.run_sync(
 ```
 
 After a Flex request, you can inspect [`ModelResponse`][pydantic_ai.messages.ModelResponse] `provider_details.get('traffic_type')` (e.g. `ON_DEMAND_FLEX` when Flex was used) if the API returns it.
+
+**Priority PayGo example**
+
+```python {test="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.models.google import GoogleModel, GoogleModelSettings
+from pydantic_ai.providers.google import GoogleProvider
+
+provider = GoogleProvider(location='global')
+model = GoogleModel('gemini-3-flash-preview', provider=provider)
+agent = Agent(model)
+
+result = agent.run_sync(
+    'Hello!',
+    model_settings=GoogleModelSettings(google_service_tier='pt_then_priority'),
+)
+```
 
 #### Model Garden
 

--- a/docs/models/google.md
+++ b/docs/models/google.md
@@ -157,7 +157,7 @@ agent = Agent(model)
 
 On **Vertex AI**, optional HTTP headers control how each request uses [Provisioned Throughput](https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/use-provisioned-throughput) (PT), [Flex PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo), and [Priority PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo) pricing. Set the [`google_service_tier`][pydantic_ai.models.google.GoogleModelSettings.google_service_tier] field on [`GoogleModelSettings`][pydantic_ai.models.google.GoogleModelSettings] to one of the [`GoogleServiceTier`][pydantic_ai.models.google.GoogleServiceTier] values.
 
-**Flex PayGo example**
+**Example**
 
 ```python {test="skip"}
 from pydantic_ai import Agent
@@ -174,24 +174,9 @@ result = agent.run_sync(
 )
 ```
 
-After a Flex request, you can inspect [`ModelResponse`][pydantic_ai.messages.ModelResponse] `provider_details.get('traffic_type')` (e.g. `ON_DEMAND_FLEX` when Flex was used) if the API returns it.
+Swap `'pt_then_flex'` for any [`GoogleServiceTier`][pydantic_ai.models.google.GoogleServiceTier] value — e.g. `'pt_then_priority'` for [Priority PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo) spillover, or `'flex_only'` / `'priority_only'` to bypass PT entirely.
 
-**Priority PayGo example**
-
-```python {test="skip"}
-from pydantic_ai import Agent
-from pydantic_ai.models.google import GoogleModel, GoogleModelSettings
-from pydantic_ai.providers.google import GoogleProvider
-
-provider = GoogleProvider(location='global')
-model = GoogleModel('gemini-3-flash-preview', provider=provider)
-agent = Agent(model)
-
-result = agent.run_sync(
-    'Hello!',
-    model_settings=GoogleModelSettings(google_service_tier='pt_then_priority'),
-)
-```
+After the request, inspect [`ModelResponse`][pydantic_ai.messages.ModelResponse] `provider_details.get('traffic_type')` to see which tier served it (e.g. `ON_DEMAND_FLEX`, `ON_DEMAND_PRIORITY`) when the API returns it.
 
 #### Model Garden
 

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -168,19 +168,29 @@ _GOOGLE_IMAGE_OUTPUT_FORMAT = Literal['png', 'jpeg', 'webp']
 _GOOGLE_IMAGE_OUTPUT_FORMATS: tuple[_GOOGLE_IMAGE_OUTPUT_FORMAT, ...] = _utils.get_args(_GOOGLE_IMAGE_OUTPUT_FORMAT)
 
 
-GoogleServiceTier = Literal['pt_then_on_demand', 'pt_only', 'pt_then_flex', 'on_demand', 'flex_only']
+GoogleServiceTier = Literal[
+    'pt_then_on_demand',
+    'pt_only',
+    'pt_then_flex',
+    'pt_then_priority',
+    'on_demand',
+    'flex_only',
+    'priority_only',
+]
 """Values for the `google_service_tier` field on [`GoogleModelSettings`][pydantic_ai.models.google.GoogleModelSettings].
 
 Controls Vertex AI HTTP headers for [Provisioned Throughput](https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/use-provisioned-throughput)
-(PT) and [Flex PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo). Only applies when using the Vertex AI API.
+(PT), [Flex PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo), and [Priority PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo). Only applies when using the Vertex AI API.
 
 **Values:**
 
 - `'pt_then_on_demand'` (**default**): PT when quota allows, then standard on-demand spillover. No headers sent.
 - `'pt_only'`: PT only (`X-Vertex-AI-LLM-Request-Type: dedicated`). No on-demand spillover; returns 429 when over quota.
 - `'pt_then_flex'`: PT when quota allows, then [Flex PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo) spillover (`X-Vertex-AI-LLM-Shared-Request-Type: flex`).
+- `'pt_then_priority'`: PT when quota allows, then [Priority PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo) spillover (`X-Vertex-AI-LLM-Shared-Request-Type: priority`).
 - `'on_demand'`: Standard on-demand only (`X-Vertex-AI-LLM-Request-Type: shared`). Bypasses PT for this request.
 - `'flex_only'`: [Flex PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo) only (`X-Vertex-AI-LLM-Request-Type: shared` and `X-Vertex-AI-LLM-Shared-Request-Type: flex`). Bypasses PT.
+- `'priority_only'`: [Priority PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo) only (`X-Vertex-AI-LLM-Request-Type: shared` and `X-Vertex-AI-LLM-Shared-Request-Type: priority`). Bypasses PT.
 
 Not every model or region supports every value; see the linked Google docs.
 
@@ -244,14 +254,14 @@ class GoogleModelSettings(ModelSettings, total=False):
     """
 
     google_service_tier: GoogleServiceTier
-    """Vertex AI routing for Provisioned Throughput and Flex PayGo. Defaults to `'pt_then_on_demand'`.
+    """Vertex AI routing for Provisioned Throughput, Flex PayGo, and Priority PayGo. Defaults to `'pt_then_on_demand'`.
 
     See [`GoogleServiceTier`][pydantic_ai.models.google.GoogleServiceTier] for all values, headers sent, and links to Google docs.
     """
 
 
 def _google_vertex_service_tier_headers(service_tier: GoogleServiceTier) -> dict[str, str]:
-    """HTTP headers for Vertex AI Provisioned Throughput and Flex PayGo routing."""
+    """HTTP headers for Vertex AI Provisioned Throughput, Flex PayGo, and Priority PayGo routing."""
     if service_tier == 'pt_then_on_demand':
         return {}
     if service_tier == 'pt_only':
@@ -260,10 +270,17 @@ def _google_vertex_service_tier_headers(service_tier: GoogleServiceTier) -> dict
         return {'X-Vertex-AI-LLM-Request-Type': 'shared'}
     if service_tier == 'pt_then_flex':
         return {'X-Vertex-AI-LLM-Shared-Request-Type': 'flex'}
+    if service_tier == 'pt_then_priority':
+        return {'X-Vertex-AI-LLM-Shared-Request-Type': 'priority'}
     if service_tier == 'flex_only':
         return {
             'X-Vertex-AI-LLM-Request-Type': 'shared',
             'X-Vertex-AI-LLM-Shared-Request-Type': 'flex',
+        }
+    if service_tier == 'priority_only':
+        return {
+            'X-Vertex-AI-LLM-Request-Type': 'shared',
+            'X-Vertex-AI-LLM-Shared-Request-Type': 'priority',
         }
     assert_never(service_tier)  # pragma: no cover
 

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -6358,12 +6358,25 @@ async def test_google_prompt_feedback_streaming(
             id='pt_then_flex',
         ),
         pytest.param(
+            'pt_then_priority',
+            {'X-Vertex-AI-LLM-Shared-Request-Type': 'priority'},
+            id='pt_then_priority',
+        ),
+        pytest.param(
             'flex_only',
             {
                 'X-Vertex-AI-LLM-Request-Type': 'shared',
                 'X-Vertex-AI-LLM-Shared-Request-Type': 'flex',
             },
             id='flex_only',
+        ),
+        pytest.param(
+            'priority_only',
+            {
+                'X-Vertex-AI-LLM-Request-Type': 'shared',
+                'X-Vertex-AI-LLM-Shared-Request-Type': 'priority',
+            },
+            id='priority_only',
         ),
     ],
 )


### PR DESCRIPTION
- Closes #5095

Follow-up to #4312 (Flex PayGo): adds [Priority PayGo](https://cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo) support to `google_service_tier`, mirroring the Flex pattern with `priority` instead of `flex`.

- `pt_then_priority` → `X-Vertex-AI-LLM-Shared-Request-Type: priority`
- `priority_only` → `X-Vertex-AI-LLM-Request-Type: shared` + `X-Vertex-AI-LLM-Shared-Request-Type: priority`

Headers per Google's [Priority PayGo docs](https://cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo#use-priority-paygo). Unit tests, docstrings and the docs page updated.

<details>
<summary>Local validation against live Vertex (click to expand)</summary>

Sweep adapted from #4312, run on `gemini-3-flash-preview` with `location='global'`:

```
--- 6. pt_then_priority (Shared-Request-Type priority; PT first) ---
Response: 'OK priority'
traffic_type: 'ON_DEMAND_PRIORITY'

--- 7. priority_only (shared + priority) ---
Response: 'OK priority_only'
traffic_type: 'ON_DEMAND_PRIORITY'
```

Vertex returns `traffic_type: 'ON_DEMAND_PRIORITY'` for both new tiers — mirroring `ON_DEMAND_FLEX` for Flex — confirming the routing headers take effect end-to-end. As in #4312, I can't prove from a single project that PT is genuinely bypassed in `priority_only` vs. `pt_then_priority`.

</details>

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).