### PR TITLE
fix(vercel-adapter): make `message_id` optional in `RegenerateMessage`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
@@ -387,7 +387,7 @@ class RegenerateMessage(CamelBaseModel, extra='allow'):
     trigger: Literal['regenerate-message']
     id: str
     messages: list[UIMessage]
-    message_id: str
+    message_id: str | None = None
 
 
 RequestData = Annotated[SubmitMessage | RegenerateMessage, Discriminator('trigger')]


### PR DESCRIPTION
The Problem
The RegenerateMessage request schema in the Vercel AI adapter currently requires message_id as a non-nullable field. However, according to the Vercel AI SDK protocol, this field is optional. When omitted by the client (e.g., when using @ai-sdk/react's regenerate()), the backend responds with a 422 Unprocessable Entity error.

The Fix
This PR modifies the RegenerateMessage class in request_types.py to make message_id optional:

Changed message_id: str to message_id: str | None = None.

This allows the schema to validate successfully when the client triggers a regeneration without an explicit message ID, defaulting to the last assistant message as intended by the protocol.

Validation
Fixes #5093

Verified that the RegenerateMessage schema now accepts payloads missing the message_id field.
