### PR TITLE
Add Slack alerts and streaming coverage to gateway health checks

### DIFF
--- a/.github/workflows/gateway-model-health.yml
+++ b/.github/workflows/gateway-model-health.yml
@@ -39,3 +39,28 @@ jobs:
 
       - name: Run gateway model catalog checks
         run: uv run pytest tests/providers/test_gateway_catalog.py -q --run-gateway-live
+
+      - name: Notify Slack on failure
+        if: failure() && !cancelled()
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          errors: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":x: Gateway model health failed in ${{ github.repository }} on ${{ github.ref_name }}."
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":x: *Gateway model health failed*"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Repository*\n<${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
+                  - type: mrkdwn
+                    text: "*Trigger*\n${{ github.event_name }}"
+                  - type: mrkdwn
+                    text: "*Ref*\n`${{ github.ref_name }}`"
+                  - type: mrkdwn
+                    text: "*Run*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"

--- a/tests/providers/test_gateway_catalog.py
+++ b/tests/providers/test_gateway_catalog.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import os
-import warnings
 from typing import get_args
 
 import pytest
@@ -25,7 +24,7 @@ with try_import() as imports_successful:
 if not imports_successful():
     pytest.skip('gateway model checks require provider packages to be installed', allow_module_level=True)
 
-pytestmark = pytest.mark.anyio
+pytestmark = [pytest.mark.anyio, pytest.mark.filterwarnings('ignore::DeprecationWarning')]
 
 
 @pytest.fixture(scope='module')
@@ -52,15 +51,17 @@ def _gateway_supported_providers() -> set[str]:
     return {f'gateway/{provider}' for provider in get_args(GatewayModelProvider)}
 
 
-async def _run_gateway_smoke_test(model_name: str) -> str:
+async def _run_gateway_smoke_test(model_name: str) -> None:
     agent = Agent(model_name, model_settings={'max_tokens': 256}, retries=3)
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', DeprecationWarning)
-        result = await agent.run('Reply with exactly OK.')
-    output = result.output
-    assert isinstance(output, str)
-    assert output.strip()
-    return output
+    result = await agent.run('Reply with exactly OK.')
+    assert result.output.strip()
+
+    async with agent.run_stream('Reply with exactly OK.') as streamed_result:
+        chunks = [chunk async for chunk in streamed_result.stream_text(debounce_by=None)]
+        streamed_output = await streamed_result.get_output()
+    assert chunks
+    assert streamed_output.strip()
+    assert chunks[-1].strip() == streamed_output.strip()
 
 
 def test_gateway_known_model_names_only_use_supported_providers() -> None:


### PR DESCRIPTION
- Closes #4939

### Summary

- send a Slack notification when the gateway model health workflow fails
- exercise `agent.run_stream()` in the live gateway catalog smoke test
- pin the Slack GitHub Action to the `v3.0.1` commit hash

### Why

These were follow-up gaps in the gateway model health checks added in `#4939`.
The workflow should alert on failures instead of failing silently, and the smoke test should cover both the standard and streaming execution paths.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Validation

- `uv run pytest tests/providers/test_gateway_catalog.py -q`
- local commit hooks (`pre-commit`, format, lint, typecheck, check-cassettes) passed during `git commit`
