### PR TITLE
Add default request metadata to `MCPToolset`

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -228,6 +228,21 @@ async def main():
     print(result.output)
 ```
 
+## Default request metadata
+
+Use `request_meta` to attach the same MCP `_meta` values to the tool, prompt, and resource requests made by a toolset. This includes discovery requests, such as listing tools, so servers can use metadata for routing, tracing, or choosing which capabilities to expose.
+
+```python {test="skip"}
+from pydantic_ai.mcp import MCPToolset
+
+toolset = MCPToolset(
+    'http://localhost:8000/mcp',
+    request_meta={'tenant': 'acme'},
+)
+```
+
+Metadata passed to an individual tool call by `process_tool_call` is merged with these defaults and takes precedence for duplicate keys.
+
 ## Tool call customization
 
 `MCPToolset` accepts a `process_tool_call` callback that lets you customize tool call requests and their responses. A common use case is to inject metadata that the server-side handler needs to read:

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -372,6 +372,16 @@ class MCPServer(AbstractToolset[Any], ABC):
     [`IncludeToolReturnSchemas`][pydantic_ai.capabilities.IncludeToolReturnSchemas] capability is used.
     """
 
+    request_meta: dict[str, Any] | None
+    """Custom metadata fields to include in the `_meta` of every outgoing MCP request.
+
+    These fields are merged into the `_meta` of all MCP requests
+    (`tools/list`, `tools/call`, `resources/list`, `resources/read`,
+    `resources/templates/list`). Per-request metadata (e.g., from
+    [`process_tool_call`][pydantic_ai.mcp.MCPServer.process_tool_call]) takes
+    precedence over `request_meta` fields when keys overlap.
+    """
+
     _id: str | None
 
     _enter_lock: Lock = field(compare=False)
@@ -408,6 +418,7 @@ class MCPServer(AbstractToolset[Any], ABC):
         include_return_schema: bool | None = None,
         id: str | None = None,
         client_info: mcp_types.Implementation | None = None,
+        request_meta: dict[str, Any] | None = None,
     ):
         self.tool_prefix = tool_prefix
         self.log_level = log_level
@@ -424,6 +435,7 @@ class MCPServer(AbstractToolset[Any], ABC):
         self.include_instructions = include_instructions
         self.include_return_schema = include_return_schema
         self.client_info = client_info
+        self.request_meta = request_meta
 
         self._id = id or tool_prefix
 
@@ -435,6 +447,17 @@ class MCPServer(AbstractToolset[Any], ABC):
         self._exit_stack = None
         self._cached_tools = None
         self._cached_resources = None
+
+    def _build_meta(self, extra: dict[str, Any] | None = None) -> mcp_types.RequestParams.Meta | None:
+        """Build a `RequestParams.Meta` combining `request_meta` with optional per-request overrides.
+
+        Args:
+            extra: Per-request metadata that takes precedence over `request_meta`.
+        """
+        if not self.request_meta and not extra:
+            return None
+        merged = {**(self.request_meta or {}), **(extra or {})}
+        return mcp_types.RequestParams.Meta(**merged) if merged else None
 
     @abstractmethod
     @asynccontextmanager
@@ -534,7 +557,9 @@ class MCPServer(AbstractToolset[Any], ABC):
             return self._cached_tools
 
         async with self:
-            result = await self._client.list_tools()
+            meta = self._build_meta()
+            params = mcp_types.PaginatedRequestParams(_meta=meta) if meta else None
+            result = await self._client.list_tools(params=params)
             if self.cache_tools:
                 self._cached_tools = result.tools
             return result.tools
@@ -567,7 +592,7 @@ class MCPServer(AbstractToolset[Any], ABC):
                             params=mcp_types.CallToolRequestParams(
                                 name=name,
                                 arguments=args,
-                                _meta=mcp_types.RequestParams.Meta(**metadata) if metadata else None,
+                                _meta=self._build_meta(metadata),
                             ),
                         )
                     ),
@@ -661,7 +686,9 @@ class MCPServer(AbstractToolset[Any], ABC):
             if not self.capabilities.resources:
                 return []
             try:
-                result = await self._client.list_resources()
+                meta = self._build_meta()
+                params = mcp_types.PaginatedRequestParams(_meta=meta) if meta else None
+                result = await self._client.list_resources(params=params)
                 resources = [Resource.from_mcp_sdk(r) for r in result.resources]
                 if self.cache_resources:
                     self._cached_resources = resources
@@ -679,7 +706,9 @@ class MCPServer(AbstractToolset[Any], ABC):
             if not self.capabilities.resources:
                 return []
             try:
-                result = await self._client.list_resource_templates()
+                meta = self._build_meta()
+                params = mcp_types.PaginatedRequestParams(_meta=meta) if meta else None
+                result = await self._client.list_resource_templates(params=params)
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
         return [ResourceTemplate.from_mcp_sdk(t) for t in result.resourceTemplates]
@@ -710,7 +739,18 @@ class MCPServer(AbstractToolset[Any], ABC):
         resource_uri = uri if isinstance(uri, str) else uri.uri
         async with self:  # Ensure server is running
             try:
-                result = await self._client.read_resource(AnyUrl(resource_uri))
+                result = await self._client.send_request(
+                    mcp_types.ClientRequest(
+                        mcp_types.ReadResourceRequest(
+                            method='resources/read',
+                            params=mcp_types.ReadResourceRequestParams(
+                                uri=AnyUrl(resource_uri),
+                                _meta=self._build_meta(),
+                            ),
+                        )
+                    ),
+                    mcp_types.ReadResourceResult,
+                )
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
 
@@ -934,6 +974,7 @@ class MCPServerStdio(MCPServer):
         include_return_schema: bool | None = None,
         id: str | None = None,
         client_info: mcp_types.Implementation | None = None,
+        request_meta: dict[str, Any] | None = None,
     ):
         """Build a new MCP server.
 
@@ -962,6 +1003,8 @@ class MCPServerStdio(MCPServer):
                 See [`MCPServer.include_return_schema`][pydantic_ai.mcp.MCPServer.include_return_schema].
             id: An optional unique ID for the MCP server. An MCP server needs to have an ID in order to be used in a durable execution environment like Temporal, in which case the ID will be used to identify the server's activities within the workflow.
             client_info: Information describing the MCP client implementation.
+            request_meta: Custom metadata fields to include in the `_meta` of every outgoing MCP request.
+                See [`MCPServer.request_meta`][pydantic_ai.mcp.MCPServer.request_meta].
         """
         self.command = command
         self.args = args
@@ -985,6 +1028,7 @@ class MCPServerStdio(MCPServer):
             include_instructions=include_instructions,
             include_return_schema=include_return_schema,
             client_info=client_info,
+            request_meta=request_meta,
         )
 
     @classmethod
@@ -997,6 +1041,12 @@ class MCPServerStdio(MCPServer):
                     'args': core_schema.typed_dict_field(core_schema.list_schema(core_schema.str_schema())),
                     'env': core_schema.typed_dict_field(
                         core_schema.dict_schema(core_schema.str_schema(), core_schema.str_schema()),
+                        required=False,
+                    ),
+                    'request_meta': core_schema.typed_dict_field(
+                        core_schema.nullable_schema(
+                            core_schema.dict_schema(core_schema.str_schema(), core_schema.any_schema())
+                        ),
                         required=False,
                     ),
                 }
@@ -1109,6 +1159,7 @@ class _MCPServerHTTP(MCPServer):
         include_instructions: bool = False,
         include_return_schema: bool | None = None,
         client_info: mcp_types.Implementation | None = None,
+        request_meta: dict[str, Any] | None = None,
         **_deprecated_kwargs: Any,
     ):
         """Build a new MCP server.
@@ -1137,6 +1188,8 @@ class _MCPServerHTTP(MCPServer):
             include_return_schema: Whether to include return schemas in tool definitions.
                 See [`MCPServer.include_return_schema`][pydantic_ai.mcp.MCPServer.include_return_schema].
             client_info: Information describing the MCP client implementation.
+            request_meta: Custom metadata fields to include in the `_meta` of every outgoing MCP request.
+                See [`MCPServer.request_meta`][pydantic_ai.mcp.MCPServer.request_meta].
         """
         if 'sse_read_timeout' in _deprecated_kwargs:
             if read_timeout is not None:
@@ -1173,6 +1226,7 @@ class _MCPServerHTTP(MCPServer):
             include_return_schema=include_return_schema,
             id=id,
             client_info=client_info,
+            request_meta=request_meta,
         )
 
     def __repr__(self) -> str:  # pragma: no cover
@@ -1213,6 +1267,12 @@ class MCPServerSSE(_MCPServerHTTP):
                     'url': core_schema.typed_dict_field(core_schema.str_schema()),
                     'headers': core_schema.typed_dict_field(
                         core_schema.dict_schema(core_schema.str_schema(), core_schema.str_schema()), required=False
+                    ),
+                    'request_meta': core_schema.typed_dict_field(
+                        core_schema.nullable_schema(
+                            core_schema.dict_schema(core_schema.str_schema(), core_schema.any_schema())
+                        ),
+                        required=False,
                     ),
                 }
             ),
@@ -1315,6 +1375,12 @@ class MCPServerStreamableHTTP(_MCPServerHTTP):
                     'url': core_schema.typed_dict_field(core_schema.str_schema()),
                     'headers': core_schema.typed_dict_field(
                         core_schema.dict_schema(core_schema.str_schema(), core_schema.str_schema()), required=False
+                    ),
+                    'request_meta': core_schema.typed_dict_field(
+                        core_schema.nullable_schema(
+                            core_schema.dict_schema(core_schema.str_schema(), core_schema.any_schema())
+                        ),
+                        required=False,
                     ),
                 }
             ),

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -142,6 +142,10 @@ class MCPError(RuntimeError):
         return f'{self.message} (code: {self.code})'
 
 
+_MCPListKind = Literal['tools', 'prompts', 'resources', 'resource_templates']
+_MCPListItem: TypeAlias = mcp_types.Tool | mcp_types.Prompt | mcp_types.Resource | mcp_types.ResourceTemplate
+
+
 @dataclass(repr=False, kw_only=True)
 class ResourceAnnotations:
     """Additional properties describing MCP entities.
@@ -784,6 +788,13 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
     or telemetry. See [`ProcessToolCallback`][pydantic_ai.mcp.ProcessToolCallback].
     """
 
+    request_meta: dict[str, Any] | None
+    """Default metadata included with tool, prompt, and resource requests.
+
+    Per-call metadata supplied through [`process_tool_call`][pydantic_ai.mcp.MCPToolset.process_tool_call]
+    takes precedence when keys overlap.
+    """
+
     sampling_model: models.Model | None
     """A Pydantic AI model that the server may sample from via the MCP `sampling/createMessage` flow.
 
@@ -825,6 +836,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         max_retries: int | None = None,
         tool_error_behavior: Literal['retry', 'error', 'failed'] = 'retry',
         process_tool_call: ProcessToolCallback | None = None,
+        request_meta: dict[str, Any] | None = None,
         prefer_tasks: bool = True,
         cache_tools: bool = True,
         cache_resources: bool = True,
@@ -865,6 +877,8 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 [`ToolFailed`][pydantic_ai.exceptions.ToolFailed] so the model can see the error.
             process_tool_call: Hook to wrap tool calls. See
                 [`ProcessToolCallback`][pydantic_ai.mcp.ProcessToolCallback].
+            request_meta: Default metadata included with tool, prompt, and resource requests.
+                Per-call tool metadata takes precedence when keys overlap.
             prefer_tasks: Whether to prefer task-augmented execution (SEP-1686) for tools that
                 support it optionally. Tools that require task-augmented execution always use it,
                 while tools that forbid it never do.
@@ -989,6 +1003,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         self.max_retries = max_retries
         self.tool_error_behavior = tool_error_behavior
         self.process_tool_call = process_tool_call
+        self.request_meta = request_meta
         self.prefer_tasks = prefer_tasks
         self.cache_tools = cache_tools
         self.cache_resources = cache_resources
@@ -1006,6 +1021,70 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         self._cached_prompts = None
         self._running_count = 0
         self._exit_stack = None
+
+    def _request_meta(self, metadata: dict[str, Any] | None = None) -> dict[str, Any] | None:
+        if self.request_meta is None:
+            return metadata
+        return {**self.request_meta, **(metadata or {})}
+
+    @overload
+    async def _list_with_request_meta(self, kind: Literal['tools']) -> Sequence[mcp_types.Tool]: ...
+
+    @overload
+    async def _list_with_request_meta(self, kind: Literal['prompts']) -> Sequence[mcp_types.Prompt]: ...
+
+    @overload
+    async def _list_with_request_meta(self, kind: Literal['resources']) -> Sequence[mcp_types.Resource]: ...
+
+    @overload
+    async def _list_with_request_meta(
+        self, kind: Literal['resource_templates']
+    ) -> Sequence[mcp_types.ResourceTemplate]: ...
+
+    async def _list_with_request_meta(self, kind: _MCPListKind) -> Sequence[_MCPListItem]:
+        """Run a paginated MCP discovery request with the configured default metadata."""
+        items: list[_MCPListItem] = []
+        cursor: str | None = None
+        seen_cursors: set[str] = set()
+
+        for _ in range(250):
+            params = mcp_types.PaginatedRequestParams.model_validate({'cursor': cursor, '_meta': self.request_meta})
+            # Discovery metadata requires the lower MCP session API. Retain FastMCP's session-task
+            # monitor so transport failures propagate instead of leaving this request waiting forever.
+            if kind == 'tools':
+                tools_result = await self.client._await_with_session_monitoring(  # pyright: ignore[reportPrivateUsage]
+                    self.client.session.list_tools(params=params)
+                )
+                page: Sequence[_MCPListItem] = tools_result.tools
+                next_cursor = tools_result.nextCursor
+            elif kind == 'prompts':
+                prompts_result = await self.client._await_with_session_monitoring(  # pyright: ignore[reportPrivateUsage]
+                    self.client.session.list_prompts(params=params)
+                )
+                page = prompts_result.prompts
+                next_cursor = prompts_result.nextCursor
+            elif kind == 'resources':
+                resources_result = await self.client._await_with_session_monitoring(  # pyright: ignore[reportPrivateUsage]
+                    self.client.session.list_resources(params=params)
+                )
+                page = resources_result.resources
+                next_cursor = resources_result.nextCursor
+            else:
+                templates_result = await self.client._await_with_session_monitoring(  # pyright: ignore[reportPrivateUsage]
+                    self.client.session.list_resource_templates(params=params)
+                )
+                page = templates_result.resourceTemplates
+                next_cursor = templates_result.nextCursor
+
+            items.extend(page)
+            if not next_cursor:
+                return items
+            if next_cursor in seen_cursors:
+                return items
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
+        raise RuntimeError(f'Reached the 250-page limit while listing MCP {kind.replace("_", " ")}.')
 
     @property
     def id(self) -> str | None:
@@ -1143,7 +1222,10 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         if self.cache_tools and self._cached_tools is not None:
             return self._cached_tools
         async with self:
-            tools = await self.client.list_tools()
+            if self.request_meta is None:
+                tools = await self.client.list_tools()
+            else:
+                tools = list(await self._list_with_request_meta('tools'))
             if self.cache_tools:
                 self._cached_tools = tools
             return tools
@@ -1216,7 +1298,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                         name=name,
                         arguments=args,
                         task=True,
-                        meta=metadata,
+                        meta=self._request_meta(metadata),
                         raise_on_error=self.tool_error_behavior == 'error',
                     )
                     result: CallToolResult = await tool_task.result()
@@ -1224,7 +1306,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                     result = await self.client.call_tool(
                         name=name,
                         arguments=args,
-                        meta=metadata,
+                        meta=self._request_meta(metadata),
                         raise_on_error=self.tool_error_behavior == 'error',
                     )
             except ToolError as e:
@@ -1317,7 +1399,10 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             if not self.capabilities.prompts:
                 return []
             try:
-                mcp_prompts = await self.client.list_prompts()
+                if self.request_meta is None:
+                    mcp_prompts = await self.client.list_prompts()
+                else:
+                    mcp_prompts = list(await self._list_with_request_meta('prompts'))
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
             prompts = [Prompt.from_mcp_sdk(p) for p in mcp_prompts]
@@ -1343,7 +1428,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                     code=-32601,
                 )
             try:
-                result = await self.client.get_prompt(name, arguments)
+                result = await self.client.get_prompt(name, arguments, meta=self._request_meta())
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
             return PromptResult(
@@ -1372,7 +1457,10 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             if not self.capabilities.resources:
                 return []
             try:
-                mcp_resources = await self.client.list_resources()
+                if self.request_meta is None:
+                    mcp_resources = await self.client.list_resources()
+                else:
+                    mcp_resources = list(await self._list_with_request_meta('resources'))
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
             resources = [Resource.from_mcp_sdk(r) for r in mcp_resources]
@@ -1392,7 +1480,10 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             if not self.capabilities.resources:
                 return []
             try:
-                mcp_templates = await self.client.list_resource_templates()
+                if self.request_meta is None:
+                    mcp_templates = await self.client.list_resource_templates()
+                else:
+                    mcp_templates = list(await self._list_with_request_meta('resource_templates'))
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
         return [ResourceTemplate.from_mcp_sdk(t) for t in mcp_templates]
@@ -1424,7 +1515,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         resource_uri = uri if isinstance(uri, str) else uri.uri
         async with self:
             try:
-                contents = await self.client.read_resource(AnyUrl(resource_uri))
+                contents = await self.client.read_resource(AnyUrl(resource_uri), meta=self._request_meta())
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
 

--- a/tests/mcp_server.py
+++ b/tests/mcp_server.py
@@ -203,6 +203,23 @@ async def echo_deps(ctx: Context[ServerSession, None]) -> dict[str, Any]:
 
 
 @mcp.tool()
+async def echo_request_meta(ctx: Context[ServerSession, None]) -> dict[str, Any]:
+    """Echo the request metadata.
+
+    Args:
+        ctx: Context object containing request and session information.
+
+    Returns:
+        Dictionary with the request metadata fields.
+    """
+    meta = ctx.request_context.meta
+    if meta is None:
+        return {}
+    # Return all extra fields from _meta (excludes progressToken)
+    return {k: v for k, v in meta.model_dump().items() if k != 'progressToken' and v is not None}
+
+
+@mcp.tool()
 async def use_sampling(ctx: Context[ServerSession, None], foo: str) -> CreateMessageResult:
     """Use sampling callback."""
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -103,7 +103,7 @@ async def test_stdio_server(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
     async with server:
         tools = [tool.tool_def for tool in (await server.get_tools(run_context)).values()]
-        assert len(tools) == snapshot(20)
+        assert len(tools) == snapshot(21)
         assert tools[0].name == 'celsius_to_fahrenheit'
         assert isinstance(tools[0].description, str)
         assert tools[0].description.startswith('Convert Celsius to Fahrenheit.')
@@ -207,7 +207,7 @@ async def test_stdio_server_with_cwd(run_context: RunContext[int]):
     server = MCPServerStdio('python', ['mcp_server.py'], cwd=test_dir)
     async with server:
         tools = await server.get_tools(run_context)
-        assert len(tools) == snapshot(20)
+        assert len(tools) == snapshot(21)
 
 
 async def test_process_tool_call(run_context: RunContext[int]) -> int:
@@ -230,6 +230,48 @@ async def test_process_tool_call(run_context: RunContext[int]) -> int:
         result = await agent.run('Echo with deps set to 42', deps=42)
         assert result.output == snapshot('{"echo_deps":{"echo":"This is an echo message","deps":42}}')
         assert called, 'process_tool_call should have been called'
+
+
+async def test_request_meta_in_tool_call(run_context: RunContext[int]):
+    server = MCPServerStdio(
+        'python',
+        ['-m', 'tests.mcp_server'],
+        request_meta={'io.modelcontextprotocol/server-variant': 'compact', 'custom_key': 'custom_val'},
+    )
+    async with server:
+        result = await server.direct_call_tool('echo_request_meta', {})
+        assert result == snapshot(
+            {
+                'io.modelcontextprotocol/server-variant': 'compact',
+                'custom_key': 'custom_val',
+            }
+        )
+
+
+async def test_request_meta_merges_with_per_call_metadata(run_context: RunContext[int]):
+    server = MCPServerStdio(
+        'python',
+        ['-m', 'tests.mcp_server'],
+        request_meta={'base_key': 'base_val', 'shared_key': 'from_request_meta'},
+    )
+    async with server:
+        result = await server.direct_call_tool(
+            'echo_request_meta', {}, metadata={'call_key': 'call_val', 'shared_key': 'from_per_call'}
+        )
+        assert result == snapshot(
+            {
+                'base_key': 'base_val',
+                'call_key': 'call_val',
+                'shared_key': 'from_per_call',
+            }
+        )
+
+
+async def test_request_meta_none_by_default(run_context: RunContext[int]):
+    server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
+    async with server:
+        result = await server.direct_call_tool('echo_request_meta', {})
+        assert result == snapshot({})
 
 
 async def test_server_instructions_disabled_by_default(run_context: RunContext[int]):
@@ -1921,7 +1963,7 @@ async def test_read_resource_error(mcp_server: MCPServerStdio) -> None:
     async with mcp_server:
         with patch.object(
             mcp_server._client,  # pyright: ignore[reportPrivateUsage]
-            'read_resource',
+            'send_request',
             new=AsyncMock(side_effect=mcp_error),
         ):
             with pytest.raises(MCPError, match='Failed to read resource') as exc_info:
@@ -1943,7 +1985,7 @@ async def test_read_resource_empty_contents(mcp_server: MCPServerStdio) -> None:
     async with mcp_server:
         with patch.object(
             mcp_server._client,  # pyright: ignore[reportPrivateUsage]
-            'read_resource',
+            'send_request',
             new=AsyncMock(return_value=empty_result),
         ):
             result = await mcp_server.read_resource('resource://empty')
@@ -2239,6 +2281,19 @@ def test_load_mcp_servers_with_mixed_syntax(tmp_path: Path, monkeypatch: pytest.
     assert isinstance(server, MCPServerStdio)
     assert server.command == 'required_value'
     assert server.args == ['default_arg']
+
+
+def test_load_mcp_servers_with_request_meta(tmp_path: Path):
+    config = tmp_path / 'mcp.json'
+
+    config.write_text(
+        '{"mcpServers": {"potato": {"command": "python", "args": ["-m", "tests.mcp_server"], '
+        '"request_meta": {"io.modelcontextprotocol/server-variant": "compact"}}}}',
+        encoding='utf-8',
+    )
+    server = load_mcp_servers(config)[0]
+    assert isinstance(server, MCPServerStdio)
+    assert server.request_meta == {'io.modelcontextprotocol/server-variant': 'compact'}
 
 
 async def test_server_info(mcp_server: MCPServerStdio) -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -270,6 +270,20 @@ async def fastmcp_server() -> FastMCP[None]:
         return {'sum': a + b}
 
     @server.tool()
+    async def echo_request_meta(ctx: Context) -> dict[str, Any]:
+        """Return the metadata attached to this tool call."""
+        request_context = ctx.request_context
+        assert request_context is not None
+        meta = request_context.meta
+        return (
+            {}
+            if meta is None
+            else {
+                key: value for key, value in meta.model_dump().items() if key != 'progressToken' and value is not None
+            }
+        )
+
+    @server.tool()
     async def boom() -> str:
         """A tool that always raises an error — used to test error handling."""
         raise ValueError('boom')
@@ -468,6 +482,128 @@ class TestMCPToolsetIntegration:
             tools = await toolset.get_tools(run_context)
             result = await toolset.call_tool('echo', {'message': 'hi'}, run_context, tools['echo'])
         assert result == 'Echo: hi'
+
+    async def test_request_meta_is_merged_with_per_call_metadata(self, fastmcp_server: FastMCP[None]):
+        toolset = MCPToolset(
+            fastmcp_server,
+            request_meta={'tenant': 'acme', 'trace_id': 'default'},
+        )
+
+        async with toolset:
+            result = await toolset.direct_call_tool(
+                'echo_request_meta',
+                {},
+                metadata={'trace_id': 'call', 'request_id': '123'},
+            )
+
+        assert result == {
+            'tenant': 'acme',
+            'trace_id': 'call',
+            'request_id': '123',
+        }
+
+    async def test_request_meta_is_forwarded_to_resource_and_prompt_requests(self, fastmcp_server: FastMCP[None]):
+        toolset = MCPToolset(fastmcp_server, request_meta={'tenant': 'acme'})
+
+        async with toolset:
+            original_read_resource = toolset.client.read_resource
+            original_get_prompt = toolset.client.get_prompt
+            toolset.client.read_resource = AsyncMock(side_effect=original_read_resource)
+            toolset.client.get_prompt = AsyncMock(side_effect=original_get_prompt)
+
+            await toolset.read_resource('resource://greeting.txt')
+            await toolset.get_prompt('simple_prompt')
+
+        read_resource_args = toolset.client.read_resource.await_args
+        get_prompt_args = toolset.client.get_prompt.await_args
+        assert read_resource_args is not None
+        assert get_prompt_args is not None
+        assert read_resource_args.kwargs['meta'] == {'tenant': 'acme'}
+        assert get_prompt_args.kwargs['meta'] == {'tenant': 'acme'}
+
+    async def test_request_meta_is_forwarded_to_discovery_requests(self, fastmcp_server: FastMCP[None]):
+        toolset = MCPToolset(fastmcp_server, request_meta={'tenant': 'acme'})
+
+        async with toolset:
+            session = toolset.client.session
+            monitor = AsyncMock(side_effect=toolset.client._await_with_session_monitoring)  # pyright: ignore[reportPrivateUsage]
+            toolset.client._await_with_session_monitoring = monitor  # pyright: ignore[reportPrivateUsage]
+            list_tools = AsyncMock(side_effect=session.list_tools)
+            list_prompts = AsyncMock(side_effect=session.list_prompts)
+            list_resources = AsyncMock(side_effect=session.list_resources)
+            list_resource_templates = AsyncMock(side_effect=session.list_resource_templates)
+            session.list_tools = list_tools
+            session.list_prompts = list_prompts
+            session.list_resources = list_resources
+            session.list_resource_templates = list_resource_templates
+
+            await toolset.list_tools()
+            await toolset.list_prompts()
+            await toolset.list_resources()
+            await toolset.list_resource_templates()
+
+        assert monitor.await_count == 4
+        for request in (list_tools, list_prompts, list_resources, list_resource_templates):
+            assert request.await_args is not None
+            params = request.await_args.kwargs['params']
+            assert params.meta is not None
+            assert params.meta.model_dump(exclude_none=True) == {'tenant': 'acme'}
+
+    async def test_request_meta_discovery_preserves_pagination(self, fastmcp_server: FastMCP[None]):
+        toolset = MCPToolset(fastmcp_server, request_meta={'tenant': 'acme'})
+        first = mcp_types.Tool(name='first', inputSchema={})
+        second = mcp_types.Tool(name='second', inputSchema={})
+
+        async with toolset:
+            list_tools = AsyncMock(
+                side_effect=[
+                    mcp_types.ListToolsResult(tools=[first], nextCursor='next'),
+                    mcp_types.ListToolsResult(tools=[second]),
+                ]
+            )
+            toolset.client.session.list_tools = list_tools
+            tools = await toolset.list_tools()
+
+        assert tools == [first, second]
+        first_params = list_tools.await_args_list[0].kwargs['params']
+        second_params = list_tools.await_args_list[1].kwargs['params']
+        assert first_params.cursor is None
+        assert second_params.cursor == 'next'
+        assert second_params.meta is not None
+        assert second_params.meta.model_dump(exclude_none=True) == {'tenant': 'acme'}
+
+    async def test_request_meta_discovery_stops_on_duplicate_cursor(self, fastmcp_server: FastMCP[None]):
+        toolset = MCPToolset(fastmcp_server, request_meta={'tenant': 'acme'})
+        tool = mcp_types.Tool(name='tool', inputSchema={})
+
+        async with toolset:
+            list_tools = AsyncMock(
+                side_effect=[
+                    mcp_types.ListToolsResult(tools=[tool], nextCursor='duplicate'),
+                    mcp_types.ListToolsResult(tools=[tool], nextCursor='duplicate'),
+                ]
+            )
+            toolset.client.session.list_tools = list_tools
+            tools = await toolset.list_tools()
+
+        assert tools == [tool, tool]
+        assert list_tools.await_count == 2
+
+    async def test_request_meta_discovery_limits_pages(self, fastmcp_server: FastMCP[None]):
+        toolset = MCPToolset(fastmcp_server, request_meta={'tenant': 'acme'})
+
+        async def list_tools(
+            cursor: str | None = None, *, params: mcp_types.PaginatedRequestParams | None = None
+        ) -> mcp_types.ListToolsResult:
+            assert cursor is None
+            assert params is not None
+            next_cursor = str(int(params.cursor or '0') + 1)
+            return mcp_types.ListToolsResult(tools=[], nextCursor=next_cursor)
+
+        async with toolset:
+            toolset.client.session.list_tools = list_tools
+            with pytest.raises(RuntimeError, match='Reached the 250-page limit while listing MCP tools'):
+                await toolset.list_tools()
 
     async def test_tool_error_raises_model_retry(self, fastmcp_server: FastMCP[None], run_context: RunContext):
         toolset = MCPToolset(fastmcp_server)


### PR DESCRIPTION
## Summary

- Add `request_meta` to `MCPToolset` for default MCP `_meta` values.
- Apply the defaults to tool, prompt, and resource discovery and operation requests after initialization.
- Preserve pagination and let per-call tool metadata override duplicate default keys.
- Document the public behavior without depending on a draft MCP extension.

## Test plan

- [x] Default and per-call metadata merging
- [x] Tool call, prompt, and resource forwarding
- [x] Tool, prompt, resource, and resource-template discovery forwarding
- [x] Multi-page, duplicate-cursor, and page-limit behavior
- [x] Focused MCP integration tests, formatting, lint, and type checking

Closes #5100

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).