### PR TITLE
fix: restore system prompts when resuming UI runs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -275,6 +275,8 @@ class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
 
         if next_message:
             await self._reevaluate_dynamic_prompts([next_message], run_context)
+            if not messages and not any(isinstance(part, _messages.SystemPromptPart) for part in next_message.parts):
+                next_message.parts = [*await self._sys_parts(run_context), *next_message.parts]
         else:
             parts: list[_messages.ModelRequestPart] = []
             if not messages:

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -2405,6 +2405,40 @@ async def test_adapter_sets_current_run_id_on_trailing_mapped_request() -> None:
     assert run_result.new_messages() == messages[-2:]
 
 
+async def test_adapter_includes_system_prompt_for_frontend_only_user_message() -> None:
+    captured_results: list[AgentRunResult[Any]] = []
+
+    def sync_callback(run_result: AgentRunResult[Any]) -> None:
+        captured_results.append(run_result)
+
+    agent = Agent(TestModel(), system_prompt='Be fun!')
+    run_input = create_input(UserMessage(id='msg1', content='Hello!'))
+
+    await run_and_collect_events(agent, run_input, on_complete=sync_callback)
+
+    assert len(captured_results) == 1
+    assert captured_results[0].all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    SystemPromptPart(content='Be fun!', timestamp=IsDatetime()),
+                    UserPromptPart(content='Hello!', timestamp=IsDatetime()),
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='success (no tool calls)')],
+                usage=RequestUsage(input_tokens=IsInt(), output_tokens=IsInt()),
+                model_name='test',
+                timestamp=IsDatetime(),
+                provider_name='test',
+                run_id=IsStr(),
+            ),
+        ]
+    )
+
+
 async def test_callback_async() -> None:
     """Test that async callbacks work correctly."""
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3236,6 +3236,32 @@ def test_run_with_history_ending_on_model_response_without_tool_calls_or_user_pr
     assert result.new_messages() == snapshot([])
 
 
+def test_run_with_history_ending_on_user_prompt_includes_system_prompt():
+    agent = Agent(TestModel(), system_prompt='Be fun!')
+
+    result = agent.run_sync(message_history=[ModelRequest(parts=[UserPromptPart(content='Hello')])])
+
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    SystemPromptPart(content='Be fun!', timestamp=IsNow(tz=timezone.utc)),
+                    UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc)),
+                ],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='success (no tool calls)')],
+                usage=RequestUsage(input_tokens=53, output_tokens=4),
+                model_name='test',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+        ]
+    )
+
+
 async def test_message_history_ending_on_model_response_with_instructions():
     model = TestModel(custom_output_text='James likes cars in general, especially the Fiat 126p that his parents had.')
     summarize_agent = Agent(

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -2514,6 +2514,54 @@ async def test_run_stream_on_complete():
     )
 
 
+async def test_run_stream_on_complete_includes_system_prompt_for_frontend_only_user_message():
+    agent = Agent(model=TestModel(), system_prompt='Be fun!')
+
+    request = SubmitMessage(
+        id='foo',
+        messages=[
+            UIMessage(
+                id='bar',
+                role='user',
+                parts=[TextUIPart(text='Hello')],
+            ),
+        ],
+    )
+
+    adapter = VercelAIAdapter(agent, request)
+
+    result: AgentRunResult[Any] | None = None
+
+    def capture_result(r: AgentRunResult[Any]) -> None:
+        nonlocal result
+        result = r
+
+    async for _event in adapter.encode_stream(adapter.run_stream(on_complete=capture_result)):
+        pass
+
+    assert result is not None
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    SystemPromptPart(content='Be fun!', timestamp=IsDatetime()),
+                    UserPromptPart(content='Hello', timestamp=IsDatetime()),
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='success (no tool calls)')],
+                usage=RequestUsage(input_tokens=53, output_tokens=4),
+                model_name='test',
+                timestamp=IsDatetime(),
+                provider_name='test',
+                run_id=IsStr(),
+            ),
+        ]
+    )
+
+
 async def test_data_chunk_with_id_and_transient():
     """Test DataChunk supports optional id and transient fields for AI SDK compatibility."""
     agent = Agent(model=TestModel())


### PR DESCRIPTION
## Summary
- restore system prompts when a UI run resumes from frontend-provided user messages
- ensure the resumed request prepends the computed system prompt before the user prompt
- add regression coverage for the generic agent path, AG UI adapter, and Vercel AI adapter

## Why
When a run resumed from a frontend-only user message, the next request could omit the system prompt entirely. That changes agent behavior and makes resumed runs inconsistent with fresh runs.

## Validation
- `uv run pytest tests/test_ag_ui.py -k frontend_only_user_message tests/test_vercel_ai.py -k frontend_only_user_message`
- `uv run pytest tests/test_agent.py -k ending_on_user_prompt_includes_system_prompt`
