### PR TITLE
ci: pin workflow checkouts to PR head SHA

### DIFF
--- a/.github/workflows/at-claude.yml
+++ b/.github/workflows/at-claude.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       is_fork: ${{ steps.pr-info.outputs.is_fork }}
       pr_head_repo: ${{ steps.pr-info.outputs.pr_head_repo }}
-      pr_head_ref: ${{ steps.pr-info.outputs.pr_head_ref }}
+      pr_head_sha: ${{ steps.pr-info.outputs.pr_head_sha }}
     steps:
       - name: Get PR info
         if: github.event.issue.pull_request || github.event.pull_request
@@ -43,7 +43,7 @@ jobs:
           PR_NUMBER=${{ github.event.pull_request.number || github.event.issue.number }}
           PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${PR_NUMBER})
           echo "pr_head_repo=$(echo "$PR_DATA" | jq -r '.head.repo.full_name')" >> $GITHUB_OUTPUT
-          echo "pr_head_ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> $GITHUB_OUTPUT
+          echo "pr_head_sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
           echo "is_fork=$(echo "$PR_DATA" | jq -r '.head.repo.fork')" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ needs.get-pr-info.outputs.pr_head_repo }}
-          ref: ${{ needs.get-pr-info.outputs.pr_head_ref }}
+          ref: ${{ needs.get-pr-info.outputs.pr_head_sha }}
           fetch-depth: 1
           persist-credentials: false
 

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -221,7 +221,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
 


### PR DESCRIPTION
Resolves CodeQL alerts on `.github/workflows/{at-claude,bots}.yml` by checking out the immutable head SHA captured in the triggering event instead of a mutable branch name (`head.ref`).

## What this fixes

**bots.yml `review` job** — closes the TOCTOU window between label-application and runner start, where a fork contributor could force-push malicious code to the same branch between the maintainer applying `auto-review` and the runner beginning checkout. Canonical fix per CodeQL's `actions/improper-access-control` rule.

**at-claude.yml fork job** — same TOCTOU pattern: pins the checkout to the SHA at comment time so a race-swap between `@claude` comment and runner start can't redirect the workflow to a different commit. Closes `actions/untrusted-checkout-toctou`.

## What this does NOT fix

This is a narrow TOCTOU race fix, not a prompt-injection mitigation. The real defenses against untrusted-code execution in these workflows remain:

- `author_association` gate restricting `@claude` to `OWNER`/`MEMBER`/`COLLABORATOR`
- Stripped-down Claude tool allowlist on fork jobs (no `uv run`/`make`/`git push`/`gh pr create`)
- `AGENTS.md`/`CLAUDE.md`/`.claude/` modification guard
- `bubblewrap` sandboxing of claude-code-action subprocesses (#5037)
- `category-classify`/`category-apply` split preventing prompt-injection label writes (#4849)
- Pinned action SHAs and `persist-credentials: false` (#4853)

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).