### PR TITLE
examples: add SRI integrity hash to chat_app CDN script

### DIFF
--- a/examples/pydantic_ai_examples/chat_app.html
+++ b/examples/pydantic_ai_examples/chat_app.html
@@ -58,7 +58,7 @@
   </main>
 </body>
 </html>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/typescript/5.6.3/typescript.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/typescript/5.6.3/typescript.min.js" integrity="sha512-TvPkf1JgpB7FBf8dpYVD+2FXCy+Wn4sHIIWyTQijjOOt8Z20BAbwm0Si991w2k++oXFHp5NlOfWYud/R1sJUNA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script type="module">
   // to let me write TypeScript, without adding the burden of npm we do a dirty, non-production-ready hack
   // and transpile the TypeScript code in the browser


### PR DESCRIPTION
Pins the cdnjs-loaded `typescript.min.js` in the chat app example to a specific SHA-512 hash so a CDN compromise can't inject arbitrary JavaScript into the demo. The hash matches the published value from [cdnjs's SRI API](https://api.cdnjs.com/libraries/typescript/5.6.3?fields=sri) for `typescript@5.6.3`.

Resolves CodeQL `js/functionality-from-untrusted-source`.

- Closes #<none — CodeQL alert #4>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).