### PR TITLE
Fix exponential-time regex in Google `FileSearchTool` response parsing

### DIFF
--- a/docs/.hooks/main.py
+++ b/docs/.hooks/main.py
@@ -127,7 +127,7 @@ def create_gateway_toggle(markdown: str, relative_path: Path) -> str:
     # The closing fence must match the same indentation via backreference \1.
     # Annotation definitions are numbered list items like "1. Some text" that follow the code block.
     return re.sub(
-        r'^( *)```py(?:thon)?(?: *\{?([^}\n]*)\}?)?\n(.*?)\n\1```(\n\n(?:[ \t]*\d+\..+?\n)+?\n)?',
+        r'^( *)```py(?:thon)?(?: *\{?([^}\n]*)\}?)?\n(.*?)\n\1```(\n\n(?:[ \t]*\d+\.[^\n]+\n)+\n)?',
         lambda m: transform_gateway_code_block(m, relative_path),
         markdown,
         flags=re.MULTILINE | re.DOTALL,

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -112,7 +112,7 @@ except ImportError as _import_error:
     ) from _import_error
 
 
-_FILE_SEARCH_QUERY_PATTERN = re.compile(r'file_search\.query\(query=(["\'])((?:\\.|(?!\1).)*?)\1\)')
+_FILE_SEARCH_QUERY_PATTERN = re.compile(r'file_search\.query\(query=(["\'])((?:\\.|(?!\1)[^\\])*)\1\)')
 
 
 LatestGoogleModelNames = Literal[


### PR DESCRIPTION
The pattern was reachable in principle from Gemini streaming responses but could not be triggered by an attacker via real Gemini output in testing — filing as a hardening fix rather than a vulnerability advisory.