### PR TITLE
feat: add prompt and completions cost fields to OpenRouter

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -438,10 +438,9 @@ class _OpenRouterChoice(chat_completion.Choice):
 class _OpenRouterCostDetails:
     """OpenRouter specific cost details."""
 
+    upstream_inference_prompt_cost: float | None = None
+    upstream_inference_completions_cost: float | None = None
     upstream_inference_cost: float | None = None
-
-    # TODO rework fields, tests/models/cassettes/test_openrouter/test_openrouter_google_nested_schema.yaml
-    # shows an `upstream_inference_completions_cost` field as well
 
 
 class _OpenRouterPromptTokenDetails(completion_usage.PromptTokensDetails):
@@ -525,6 +524,8 @@ def _map_openrouter_provider_details(
             provider_details['cost'] = cost
 
         if cost_details := usage.cost_details:
+            provider_details['upstream_inference_prompt_cost'] = cost_details.upstream_inference_prompt_cost
+            provider_details['upstream_inference_completions_cost'] = cost_details.upstream_inference_completions_cost
             provider_details['upstream_inference_cost'] = cost_details.upstream_inference_cost
 
         if (is_byok := usage.is_byok) is not None:

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -495,7 +495,7 @@ async def test_openrouter_usage(allow_model_requests: None, openrouter_api_key: 
 
     assert isinstance(last_message, ModelResponse)
     assert last_message.provider_details is not None
-    for key in ['cost', 'upstream_inference_cost', 'is_byok']:
+    for key in ['cost', 'upstream_inference_cost', 'upstream_inference_prompt_cost', 'upstream_inference_completions_cost', 'is_byok']:
         assert key in last_message.provider_details
 
 


### PR DESCRIPTION
### Description

This PR adds detailed cost tracking for the **OpenRouter** model provider by including breakdown fields for prompt and completion costs.

Previously, only the total `upstream_inference_cost` was captured. This change exposes `upstream_inference_prompt_cost` and `upstream_inference_completions_cost`, which are provided by the OpenRouter API.

### Changes
- **Model Implementation**: Updated `_OpenRouterCostDetails` and `_OpenRouterUsage` in `pydantic_ai/models/openrouter.py` to include the new breakdown fields.
- **Provider Mapping**: Updated `_map_openrouter_provider_details` to ensure these fields are correctly extracted from the model response and made available in the `provider_details` of the agent results.
- **Testing**: Updated the assertion in `test_openrouter_usage` within `tests/models/test_openrouter.py` to verify that all cost breakdown fields are present in the output.

### Verification
- Verified against existing VCR cassettes (e.g., `test_openrouter_google_nested_schema.yaml`) which already contain these fields in the recorded API responses.
- Confirmed that the new fields are correctly populated in `result.usage()` through the `provider_details` dictionary.

Fixes #4898
