### PR TITLE
fix: skip tool hooks for output tools (kind='output')

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -248,7 +248,12 @@ class ToolManager(Generic[AgentDepsT]):
         *,
         allow_partial: bool,
     ) -> dict[str, Any]:
-        """Run validation with before/wrap/after tool_validate hooks."""
+        """Run validation with before/wrap/after tool_validate hooks.
+
+        Note: Hooks are skipped for output tools (kind='output') to maintain
+        consistency with the rest of the architecture where output tools are
+        handled separately from function tools.
+        """
         cap = self.root_capability
 
         async def do_validate(args: str | dict[str, Any]) -> dict[str, Any]:
@@ -256,7 +261,10 @@ class ToolManager(Generic[AgentDepsT]):
             validated = await self._validate_tool_args(call, tool, ctx, allow_partial=allow_partial, args_override=args)
             return validated
 
-        if cap is not None:
+        # Skip hooks for output tools — they are internal tools that should not
+        # trigger user-facing hooks. This is consistent with WrapperToolset and
+        # prepare_tools which also exclude output tools.
+        if cap is not None and tool.tool_def.kind != 'output':
             tool_def = tool.tool_def
 
             # before_tool_validate
@@ -286,7 +294,12 @@ class ToolManager(Generic[AgentDepsT]):
         *,
         usage: RunUsage | None = None,
     ) -> Any:
-        """Run execution with before/wrap/after tool_execute hooks."""
+        """Run execution with before/wrap/after tool_execute hooks.
+
+        Note: Hooks are skipped for output tools (kind='output') to maintain
+        consistency with the rest of the architecture where output tools are
+        handled separately from function tools.
+        """
         assert validated.tool is not None
         assert validated.validated_args is not None
 
@@ -299,7 +312,10 @@ class ToolManager(Generic[AgentDepsT]):
             modified_validated = replace(validated, validated_args=args)
             return await self._raw_execute(modified_validated, usage=usage)
 
-        if cap is not None:
+        # Skip hooks for output tools — they are internal tools that should not
+        # trigger user-facing hooks. This is consistent with WrapperToolset and
+        # prepare_tools which also exclude output tools.
+        if cap is not None and validated.tool.tool_def.kind != 'output':
             tool_def = validated.tool.tool_def
 
             try:

--- a/tests/test_output_tool_hooks.py
+++ b/tests/test_output_tool_hooks.py
@@ -1,0 +1,263 @@
+"""Tests for issue #5111: after_tool_execute hook fires for internal output tools.
+
+The bug: Unscoped `after_tool_execute` hooks fire for internal output tools (e.g. `final_result`).
+When the hook returns `ToolReturn`, the output tool code path doesn't unwrap it (unlike function
+tools at `_agent_graph.py:1759`), so `result.output` becomes a `ToolReturn` instead of the
+expected output type.
+
+The fix: Skip hooks entirely for output tools (kind='output') to maintain consistency with
+the rest of the architecture where output tools are handled separately from function tools.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities import Hooks
+from pydantic_ai.messages import ToolCallPart, ToolReturn
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import ToolDefinition
+
+
+class MyOutput(BaseModel):
+    answer: str
+
+
+pytestmark = [pytest.mark.anyio]
+
+
+async def test_after_tool_execute_does_not_fire_for_output_tools():
+    """Test that after_tool_execute hook does NOT fire for output tools.
+
+    This is the minimal reproducer from issue #5111. Before the fix,
+    result.output would be a ToolReturn instead of MyOutput.
+    """
+    hook_calls: list[str] = []
+
+    hooks: Hooks = Hooks()
+
+    @hooks.on.after_tool_execute
+    async def wrap_result(
+        ctx: RunContext[None],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: dict[str, Any],
+        result: Any,
+    ) -> ToolReturn:
+        hook_calls.append(call.tool_name)
+        return ToolReturn(return_value=result, content='Extra context for the model')
+
+    agent = Agent(
+        TestModel(),
+        output_type=MyOutput,
+        capabilities=[hooks],
+    )
+
+    result = await agent.run('Say hello')
+
+    # The output should be MyOutput, not ToolReturn
+    assert isinstance(result.output, MyOutput), (
+        f'Expected MyOutput, got {type(result.output).__name__}. '
+        f'The after_tool_execute hook incorrectly fired for output tool.'
+    )
+
+    # The hook should NOT have been called for the output tool
+    assert 'final_result' not in hook_calls, (
+        f'after_tool_execute hook was called for output tool: {hook_calls}'
+    )
+
+
+async def test_after_tool_execute_still_fires_for_function_tools():
+    """Test that after_tool_execute hook still fires for function tools."""
+    hook_calls: list[str] = []
+
+    hooks: Hooks = Hooks()
+
+    @hooks.on.after_tool_execute
+    async def wrap_result(
+        ctx: RunContext[None],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: dict[str, Any],
+        result: Any,
+    ) -> ToolReturn:
+        hook_calls.append(call.tool_name)
+        return ToolReturn(return_value=result, content='Extra context for the model')
+
+    agent = Agent(
+        TestModel(),
+        output_type=str,
+        capabilities=[hooks],
+    )
+
+    @agent.tool_plain
+    def greet(name: str) -> str:
+        """Greet someone by name."""
+        return f'Hello, {name}!'
+
+    result = await agent.run('Greet Alice')
+
+    # The hook SHOULD have been called for the function tool
+    assert 'greet' in hook_calls, (
+        f'after_tool_execute hook was NOT called for function tool: {hook_calls}'
+    )
+
+
+async def test_before_tool_execute_does_not_fire_for_output_tools():
+    """Test that before_tool_execute hook does NOT fire for output tools."""
+    hook_calls: list[str] = []
+
+    hooks: Hooks = Hooks()
+
+    @hooks.on.before_tool_execute
+    async def before_execute(
+        ctx: RunContext[None],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: dict[str, Any],
+    ) -> dict[str, Any]:
+        hook_calls.append(call.tool_name)
+        return args
+
+    agent = Agent(
+        TestModel(),
+        output_type=MyOutput,
+        capabilities=[hooks],
+    )
+
+    result = await agent.run('Say hello')
+
+    assert isinstance(result.output, MyOutput)
+
+    # The hook should NOT have been called for the output tool
+    assert 'final_result' not in hook_calls, (
+        f'before_tool_execute hook was called for output tool: {hook_calls}'
+    )
+
+
+async def test_wrap_tool_execute_does_not_fire_for_output_tools():
+    """Test that wrap_tool_execute hook does NOT fire for output tools."""
+    hook_calls: list[str] = []
+
+    hooks: Hooks = Hooks()
+
+    @hooks.on.tool_execute  # This is the wrap form of tool_execute hook
+    async def wrap_execute(
+        ctx: RunContext[None],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: dict[str, Any],
+        handler,
+    ):
+        hook_calls.append(call.tool_name)
+        return await handler(args)
+
+    agent = Agent(
+        TestModel(),
+        output_type=MyOutput,
+        capabilities=[hooks],
+    )
+
+    result = await agent.run('Say hello')
+
+    assert isinstance(result.output, MyOutput)
+
+    # The hook should NOT have been called for the output tool
+    assert 'final_result' not in hook_calls, (
+        f'wrap_tool_execute hook was called for output tool: {hook_calls}'
+    )
+
+
+async def test_validate_hooks_do_not_fire_for_output_tools():
+    """Test that tool_validate hooks do NOT fire for output tools."""
+    hook_calls: list[str] = []
+
+    hooks: Hooks = Hooks()
+
+    @hooks.on.before_tool_validate
+    async def before_validate(
+        ctx: RunContext[None],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: str | dict[str, Any],
+    ) -> str | dict[str, Any]:
+        hook_calls.append(f'before_validate:{call.tool_name}')
+        return args
+
+    @hooks.on.after_tool_validate
+    async def after_validate(
+        ctx: RunContext[None],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: dict[str, Any],
+    ) -> dict[str, Any]:
+        hook_calls.append(f'after_validate:{call.tool_name}')
+        return args
+
+    agent = Agent(
+        TestModel(),
+        output_type=MyOutput,
+        capabilities=[hooks],
+    )
+
+    result = await agent.run('Say hello')
+
+    assert isinstance(result.output, MyOutput)
+
+    # Neither validate hook should have been called for the output tool
+    output_tool_hooks = [h for h in hook_calls if 'final_result' in h]
+    assert not output_tool_hooks, (
+        f'Validate hooks were called for output tool: {output_tool_hooks}'
+    )
+
+
+async def test_hooks_fire_for_function_tools_not_output_tools():
+    """Test that hooks fire for function tools but not for output tools in the same agent."""
+    hook_calls: list[str] = []
+
+    hooks: Hooks = Hooks()
+
+    @hooks.on.after_tool_execute
+    async def after_execute(
+        ctx: RunContext[None],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: dict[str, Any],
+        result: Any,
+    ) -> Any:
+        hook_calls.append(f'after_execute:{call.tool_name}')
+        return result
+
+    agent = Agent(
+        TestModel(),
+        output_type=MyOutput,
+        capabilities=[hooks],
+    )
+
+    @agent.tool_plain
+    def get_greeting() -> str:
+        """Get a greeting message."""
+        return 'Hello!'
+
+    result = await agent.run('Get a greeting and return it')
+
+    assert isinstance(result.output, MyOutput)
+
+    # Function tool hook should have fired
+    function_hooks = [h for h in hook_calls if 'get_greeting' in h]
+    assert function_hooks, 'Hook should have fired for function tool'
+
+    # Output tool hook should NOT have fired
+    output_hooks = [h for h in hook_calls if 'final_result' in h]
+    assert not output_hooks, f'Hook should NOT have fired for output tool: {output_hooks}'


### PR DESCRIPTION
Fixes #5111

## Summary

The `after_tool_execute` hook (and other tool hooks) was incorrectly firing for internal output tools like `final_result`. When the hook returned a `ToolReturn`, the output would be wrapped incorrectly, corrupting `result.output`.

## The Bug

As reported in #5111, when using an unscoped `after_tool_execute` hook that returns `ToolReturn`, the hook fires for output tools and the result is not unwrapped correctly:

```python
@hooks.on.after_tool_execute
async def wrap_result(ctx, *, call, tool_def, args, result):
    return ToolReturn(return_value=result, content="Extra context")

result = await agent.run("Say hello")
print(type(result.output))  # ToolReturn instead of MyOutput!
```

## The Fix

This change skips all tool hooks (validate and execute) for output tools (`kind='output'`), maintaining consistency with the rest of the architecture where output tools are handled separately from function tools.

This is consistent with how:
- `WrapperToolset.get_wrapper_toolset` excludes output tools
- `prepare_tools`/`prepare_output_tools` handle them separately

## Changes

- Modified `_run_execute_hooks` to skip hooks when `tool_def.kind == 'output'`
- Modified `_run_validate_hooks` to skip hooks when `tool_def.kind == 'output'`
- Added comprehensive tests for the fix

## Tests

- `test_after_tool_execute_does_not_fire_for_output_tools` - minimal reproducer from issue
- `test_after_tool_execute_still_fires_for_function_tools` - ensure hooks still work for function tools
- `test_before_tool_execute_does_not_fire_for_output_tools`
- `test_wrap_tool_execute_does_not_fire_for_output_tools`
- `test_validate_hooks_do_not_fire_for_output_tools`
- `test_hooks_fire_for_function_tools_not_output_tools` - combination test