### PR TITLE
fix: preserve prior text recovery for Agent(output_type=str | None)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1028,19 +1028,6 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
 
                         raise exceptions.ContentFilterError(message, body=body)
 
-                    # If the output type allows None, an empty response is a valid result.
-                    if is_empty and output_schema.allows_none:
-                        run_context = _build_output_run_context(ctx)
-                        try:
-                            result_data = await _run_output_validators(ctx, cast(NodeRunEndT, None), run_context)
-                            self._next_node = self._handle_final_result(ctx, result.FinalResult(result_data), [])
-                        except ToolRetryError as e:
-                            ctx.state.increment_retries(ctx.deps.max_result_retries, error=e)
-                            self._next_node = ModelRequestNode[DepsT, NodeRunEndT](
-                                _messages.ModelRequest(parts=[e.tool_retry])
-                            )
-                        return
-
                     # Try to recover text from a previous model response.
                     # This handles the case where the model returned text alongside tool calls
                     # (so the text was discarded in favor of executing the tools) and subsequently
@@ -1054,6 +1041,19 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                             except ToolRetryError:  # pragma: no cover
                                 # If the recovered text was invalid, fall through.
                                 pass
+
+                    # If the output type allows None, an empty response is a valid result.
+                    if is_empty and output_schema.allows_none:
+                        run_context = _build_output_run_context(ctx)
+                        try:
+                            result_data = await _run_output_validators(ctx, cast(NodeRunEndT, None), run_context)
+                            self._next_node = self._handle_final_result(ctx, result.FinalResult(result_data), [])
+                        except ToolRetryError as e:
+                            ctx.state.increment_retries(ctx.deps.max_result_retries, error=e)
+                            self._next_node = ModelRequestNode[DepsT, NodeRunEndT](
+                                _messages.ModelRequest(parts=[e.tool_retry])
+                            )
+                        return
 
                     if is_empty:
                         # Go back to the model request node with an empty request, which means we'll

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9328,6 +9328,34 @@ async def test_agent_allows_none_output_after_tool():
     )
 
 
+async def test_agent_allows_none_output_after_tool_recovers_prior_text():
+    """Optional text output should still recover prior assistant text after an empty follow-up response."""
+    call_count = 0
+
+    async def model_with_text_then_empty(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return ModelResponse(
+                parts=[
+                    TextPart(content='RECOVER-ME'),
+                    ToolCallPart(tool_name='noop', args={'data': 'x'}, tool_call_id='123'),
+                ]
+            )
+        return ModelResponse(parts=[])
+
+    model = FunctionModel(function=model_with_text_then_empty)
+    agent = Agent(model, output_type=str | None)
+
+    @agent.tool_plain
+    def noop(data: str) -> str:
+        return 'done'
+
+    result = await agent.run('hello')
+    assert call_count == 2
+    assert result.output == 'RECOVER-ME'
+
+
 async def test_agent_allows_none_output_validator_called():
     """Test that output validators are called when returning None on empty response."""
 


### PR DESCRIPTION
- Closes #5116

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

## Summary

- preserve backward-looking text recovery for `Agent(output_type=str | None)` when a tool-follow-up response is empty
- only return `None` for optional string output when there is no recoverable assistant text in history
- add a regression test covering `text + tool call -> empty follow-up`

## Why

Issue #3105 established that earlier assistant text should be recoverable when a model returns text alongside a tool call and then follows with an empty response.

PR #4042 correctly added support for genuinely empty runs to finish as `None` for `Agent(output_type=str | None)`, but the new `allows_none` empty-response branch now runs before `_recover_text_from_message_history(...)`.

That changes the semantics for text-capable outputs:
- before: recover prior assistant text when it already exists
- now: prefer `None` even when the library can still recover prior assistant text

This PR restores the earlier recovery precedence and keeps the optional-output behavior for truly empty runs.

## Scope

This is intentionally narrow:
- no API changes
- no docs changes
- no streaming-path changes in this PR

## Test plan

- [x] Added a regression test in `tests/test_agent.py` for `output_type=str | None` with `TextPart + ToolCallPart` followed by an empty response
- [x] Ran a focused runtime repro locally before the patch and confirmed the behavior changed from `None` to the prior text after the patch
- [x] Ran a focused runtime check that a genuinely empty `output_type=str | None` run still returns `None`
- [x] Ran `uv run ruff check pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_agent.py`
- [ ] Full pytest suite / CI
