### PR TITLE
Skip tool hooks for internal output tools

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -123,6 +123,9 @@ To skip the model call entirely, raise [`SkipModelRequest(response)`][pydantic_a
 
 Validation hooks fire when the model's JSON arguments are parsed and validated. All tool hooks receive `call` ([`ToolCallPart`][pydantic_ai.messages.ToolCallPart]) and `tool_def` ([`ToolDefinition`][pydantic_ai.tools.ToolDefinition]) parameters.
 
+!!! note
+    Tool validation and execution hooks only fire for function tools. Internal output tools (used to deliver structured output) are not user-facing and are skipped.
+
 To skip validation, raise [`SkipToolValidation(args)`][pydantic_ai.exceptions.SkipToolValidation] from `before_tool_validate` or `tool_validate` (wrap).
 
 ### Tool execution hooks

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -256,7 +256,9 @@ class ToolManager(Generic[AgentDepsT]):
             validated = await self._validate_tool_args(call, tool, ctx, allow_partial=allow_partial, args_override=args)
             return validated
 
-        if cap is not None:
+        # Output tools are internal — they don't fire user-facing tool hooks, matching how
+        # `WrapperToolset` and `prepare_tools` exclude them.
+        if cap is not None and tool.tool_def.kind != 'output':
             tool_def = tool.tool_def
 
             # before_tool_validate
@@ -299,7 +301,9 @@ class ToolManager(Generic[AgentDepsT]):
             modified_validated = replace(validated, validated_args=args)
             return await self._raw_execute(modified_validated, usage=usage)
 
-        if cap is not None:
+        # Output tools are internal — they don't fire user-facing tool hooks, matching how
+        # `WrapperToolset` and `prepare_tools` exclude them.
+        if cap is not None and validated.tool.tool_def.kind != 'output':
             tool_def = validated.tool.tool_def
 
             try:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import anyio
 import pytest
+from pydantic import BaseModel
 
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._spec import CapabilitySpec, NamedSpec
@@ -62,6 +63,7 @@ from pydantic_ai.messages import (
     RetryPromptPart,
     TextPart,
     ToolCallPart,
+    ToolReturn,
     ToolReturnPart,
     UserPromptPart,
 )
@@ -2996,6 +2998,58 @@ class TestToolExecuteHooks:
 
         await agent.run('call tool')
         assert cap.caught_error == 'tool failed'
+
+    async def test_tool_hooks_skip_output_tools(self):
+        """Tool hooks don't fire for internal output tools (#5111).
+
+        Output tools deliver structured output to the user via `result.output`; they're not
+        user-facing tool calls. Firing hooks on them lets e.g. `after_tool_execute` return a
+        `ToolReturn` that leaks through to `result.output` instead of the typed value.
+        """
+
+        class MyOutput(BaseModel):
+            answer: str
+
+        hooks = Hooks()
+
+        @hooks.on.after_tool_execute
+        async def wrap_result(
+            ctx: RunContext[Any],
+            *,
+            call: ToolCallPart,
+            tool_def: ToolDefinition,
+            args: dict[str, Any],
+            result: Any,
+        ) -> ToolReturn:
+            return ToolReturn(return_value=result, content='extra context')
+
+        cap = LoggingCapability()
+        agent = Agent(
+            TestModel(custom_output_args={'answer': 'hi'}),
+            output_type=MyOutput,
+            capabilities=[cap, hooks],
+        )
+
+        @agent.tool_plain
+        def my_tool() -> str:
+            return 'tool result'
+
+        result = await agent.run('call tool and answer')
+
+        # Function tool still fires every tool hook.
+        assert 'before_tool_validate:my_tool' in cap.log
+        assert 'after_tool_validate:my_tool' in cap.log
+        assert 'wrap_tool_validate:my_tool:before' in cap.log
+        assert 'wrap_tool_validate:my_tool:after' in cap.log
+        assert 'before_tool_execute:my_tool' in cap.log
+        assert 'after_tool_execute:my_tool' in cap.log
+        assert 'wrap_tool_execute:my_tool:before' in cap.log
+        assert 'wrap_tool_execute:my_tool:after' in cap.log
+        # Output tool does not appear in any hook log entry.
+        assert all('final_result' not in entry for entry in cap.log)
+        # Regression for #5111: the ToolReturn from `after_tool_execute` would have corrupted
+        # `result.output` if output tool hooks still fired.
+        assert result.output == MyOutput(answer='hi')
 
 
 class TestCompositionOrder:


### PR DESCRIPTION
Tool hooks (validation and execution) were firing for internal output tools like `final_result`, leaving `after_tool_execute` free to return a `ToolReturn` that leaked through as `result.output` instead of the typed value.

Exclude `kind='output'` tools from tool hook dispatch, matching how `WrapperToolset` and `prepare_tools` already exclude them. Follow-up PR #4859 will add dedicated output hooks for cases where users do want to wrap output tool calls.

- Closes #5111

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).