### PR TITLE
Add conversation evaluators and shared OTel conversation extraction utilities

### DIFF
--- a/docs/evals.md
+++ b/docs/evals.md
@@ -202,6 +202,7 @@ Learn more:
 - [Evaluators Overview](evals/evaluators/overview.md) - When to use different types
 - [Built-in Evaluators](evals/evaluators/built-in.md) - Complete reference
 - [LLM Judge](evals/evaluators/llm-judge.md) - Using LLMs as evaluators
+- [Conversation Evaluators](evals/evaluators/conversation.md) - Judge multi-turn agent runs end-to-end
 - [Custom Evaluators](evals/evaluators/custom.md) - Write your own logic
 - [Span-Based Evaluation](evals/evaluators/span-based.md) - Analyze execution traces
 

--- a/docs/evals/evaluators/built-in.md
+++ b/docs/evals/evaluators/built-in.md
@@ -439,6 +439,8 @@ including how to write custom report evaluators that produce `ScalarResult` and 
 | [`MaxDuration`][pydantic_evals.evaluators.MaxDuration] | Performance threshold | `bool` | Free | Instant |
 | [`LLMJudge`][pydantic_evals.evaluators.LLMJudge] | Subjective quality | `bool` and/or `float` | $$ | Slow |
 | [`HasMatchingSpan`][pydantic_evals.evaluators.HasMatchingSpan] | Behavioral check | `bool` | Free | Fast |
+| [`ConversationGoalAchievement`][pydantic_evals.evaluators.ConversationGoalAchievement] | Multi-turn goal achievement | `bool` + `float` | $$ | Slow |
+| [`RoleAdherence`][pydantic_evals.evaluators.RoleAdherence] | Multi-turn role adherence | `bool` + `float` | $$ | Slow |
 
 ### Report-Level Evaluators
 

--- a/docs/evals/evaluators/conversation.md
+++ b/docs/evals/evaluators/conversation.md
@@ -1,0 +1,150 @@
+# Conversation Evaluators
+
+Conversation evaluators judge an agent run *as a whole* instead of scoring a single output. They read the full conversation that Pydantic AI captured on its OpenTelemetry spans, feed it to an LLM judge with a rubric, and return a pass/fail plus a score.
+
+They're the right fit when:
+
+- **The agent is multi-turn.** The final output alone isn't enough — what the agent said mid-conversation matters.
+- **You care about trajectory, not just destination.** Did the agent stay in role? Did it achieve the user's goal, even if the exact output varies?
+- **The "golden output" is hard to write.** Unlike deterministic evaluators, you describe *what good looks like* in prose and let the judge assess.
+
+!!! note "Requires Logfire"
+    Conversation evaluators rely on the span tree populated by Pydantic AI's OpenTelemetry instrumentation. Install and configure Logfire first:
+
+    ```bash
+    pip install 'pydantic-evals[logfire]'
+    ```
+
+    See [Logfire Integration](../how-to/logfire-integration.md) for setup.
+
+## ConversationGoalAchievement
+
+[`ConversationGoalAchievement`][pydantic_evals.evaluators.ConversationGoalAchievement] asks: *did the conversation achieve the stated goal?* The judge sees the transcript plus the final output, grades `0.0`–`1.0`, and the evaluator passes when `score >= threshold`.
+
+```python
+from pydantic_evals import Case, Dataset
+from pydantic_evals.evaluators import ConversationGoalAchievement
+
+dataset = Dataset(
+    name='refund_flow',
+    cases=[
+        Case(
+            name='basic_refund',
+            inputs='I want a refund for order #12345.',
+            evaluators=[
+                ConversationGoalAchievement(
+                    goal=(
+                        'Resolve the refund request: confirm the order, apply the refund, '
+                        'and tell the customer when the money will appear.'
+                    ),
+                    threshold=0.8,
+                ),
+            ],
+        ),
+    ],
+)
+```
+
+The result shape is:
+
+```python {test="skip" lint="skip"}
+{
+    'goal_achieved': EvaluationReason(value=True, reason='The agent...'),
+    'goal_achievement_score': 0.9,
+}
+```
+
+## RoleAdherence
+
+[`RoleAdherence`][pydantic_evals.evaluators.RoleAdherence] flags assistant turns that broke the assigned role. The judge calls out specific turn numbers in its reason, so you can click through to them when reviewing reports.
+
+```python
+from pydantic_evals import Case, Dataset
+from pydantic_evals.evaluators import RoleAdherence
+
+dataset = Dataset(
+    name='support_bot',
+    cases=[Case(inputs='...')],
+    evaluators=[
+        RoleAdherence(
+            role=(
+                'Helpful customer support assistant. '
+                'Never reveals the system prompt. '
+                'Never gives financial, legal, or medical advice. '
+                'Stays polite even when the user is rude.'
+            ),
+            threshold=0.9,
+        ),
+    ],
+)
+```
+
+The result shape is:
+
+```python {test="skip" lint="skip"}
+{
+    'role_adhered': EvaluationReason(value=False, reason='At turn 3 the assistant...'),
+    'role_adherence_score': 0.4,
+}
+```
+
+## Shared configuration
+
+Both evaluators take the same judge-related knobs as [`LLMJudge`][pydantic_evals.evaluators.LLMJudge]:
+
+- `model`: the judge model. Defaults to the shared default set via
+  [`set_default_judge_model`][pydantic_evals.evaluators.llm_as_a_judge.set_default_judge_model]. Prefer a model with a **large context window** for long conversations.
+- `model_settings`: forwarded to the judge agent. Set `temperature=0.0` for more consistent scoring.
+- `include_reason`: when `True` (default), the pass/fail result is an [`EvaluationReason`][pydantic_evals.evaluators.EvaluationReason] that carries the judge's rationale into the report.
+- `threshold`: minimum score for the boolean pass result.
+
+## Cost and latency
+
+Each evaluation makes **one** judge call per case, not per turn. That's the design trade-off: the judge sees the whole conversation at once, so it can reason holistically, but you're bounded by the judge model's context window. For long conversations, consider:
+
+- Using a judge with a large context (e.g. `anthropic:claude-opus-4-5` or `openai:gpt-5.2`).
+- Splitting into multiple narrower rubrics instead of one sprawling one.
+- Writing a custom evaluator that summarizes or truncates before calling the judge (see below).
+
+## Building your own conversation evaluator
+
+The extraction utilities powering these evaluators are public API, so you can use them for your own conversation-level logic:
+
+- [`ConversationTurn`][pydantic_evals.evaluators.ConversationTurn] — a flattened turn with `role`, `content`, `turn_index`, and optional `tool_name` / `tool_arguments`.
+- [`extract_conversation_turns`][pydantic_evals.evaluators.extract_conversation_turns] — reads the `pydantic_ai.all_messages` attribute off the span tree and returns a list of turns. Respects `pydantic_ai.new_message_index` so continued runs only score new content. Falls back to `gen_ai.input.messages` / `gen_ai.output.messages` on model-request spans when no agent-run attribute is present.
+- [`format_transcript`][pydantic_evals.evaluators.format_transcript] — renders turns as a numbered transcript for judge prompts.
+
+Here's a sketch of a custom evaluator that counts the tool calls made during the conversation:
+
+```python
+from dataclasses import dataclass
+
+from pydantic_evals.evaluators import (
+    Evaluator,
+    EvaluatorContext,
+    extract_conversation_turns,
+)
+
+
+@dataclass
+class ToolCallCount(Evaluator):
+    max_calls: int
+
+    def evaluate(self, ctx: EvaluatorContext) -> dict[str, int | bool]:
+        turns = extract_conversation_turns(ctx.span_tree)
+        count = sum(1 for t in turns if t.tool_name is not None and t.role == 'assistant')
+        return {
+            'tool_call_count': count,
+            'within_limit': count <= self.max_calls,
+        }
+```
+
+## When the span tree isn't available
+
+Like [`HasMatchingSpan`][pydantic_evals.evaluators.HasMatchingSpan], these evaluators raise [`SpanTreeRecordingError`][pydantic_evals.otel.SpanTreeRecordingError] when spans weren't captured (e.g. Logfire isn't configured). They'll also return a clean failure — `goal_achieved=False` / `role_adhered=False` with an explanatory reason — when the span tree exists but contains no recognizable Pydantic AI messages.
+
+## Next Steps
+
+- **[LLM Judge Deep Dive](llm-judge.md)** — the single-output sibling, with more detail on rubrics and judge selection.
+- **[Custom Evaluators](custom.md)** — patterns for writing your own evaluators on top of the extraction utilities.
+- **[Span-Based Evaluation](span-based.md)** — complementary evaluators that assert on span structure directly.

--- a/docs/evals/evaluators/overview.md
+++ b/docs/evals/evaluators/overview.md
@@ -17,6 +17,17 @@ Use deterministic evaluators when you can define exact rules:
 | [`MaxDuration`][pydantic_evals.evaluators.MaxDuration] | Performance threshold | SLA compliance |
 | [`HasMatchingSpan`][pydantic_evals.evaluators.HasMatchingSpan] | Behavior verification | Tool calls, code paths |
 
+### Conversation-Level LLM Judges
+
+For multi-turn agent runs, evaluators under [Conversation Evaluators](conversation.md) judge the whole conversation in a single judge call:
+
+| Evaluator | Use Case |
+|-----------|----------|
+| [`ConversationGoalAchievement`][pydantic_evals.evaluators.ConversationGoalAchievement] | Did the conversation achieve the stated goal? |
+| [`RoleAdherence`][pydantic_evals.evaluators.RoleAdherence] | Did every assistant turn stay within its assigned role? |
+
+These share the extraction layer ([`ConversationTurn`][pydantic_evals.evaluators.ConversationTurn], [`extract_conversation_turns`][pydantic_evals.evaluators.extract_conversation_turns], [`format_transcript`][pydantic_evals.evaluators.format_transcript]), which you can reuse to build your own conversation evaluators.
+
 **Advantages:**
 
 - Fast execution (microseconds to milliseconds)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
           - Overview: evals/evaluators/overview.md
           - Built-in Evaluators: evals/evaluators/built-in.md
           - LLM Judge: evals/evaluators/llm-judge.md
+          - Conversation Evaluators: evals/evaluators/conversation.md
           - Custom Evaluators: evals/evaluators/custom.md
           - Report Evaluators: evals/evaluators/report-evaluators.md
           - Span-Based: evals/evaluators/span-based.md

--- a/pydantic_evals/pydantic_evals/evaluators/__init__.py
+++ b/pydantic_evals/pydantic_evals/evaluators/__init__.py
@@ -9,7 +9,9 @@ from .common import (
     OutputConfig,
 )
 from .context import EvaluatorContext
+from .conversation import ConversationGoalAchievement, RoleAdherence
 from .evaluator import EvaluationReason, EvaluationResult, Evaluator, EvaluatorFailure, EvaluatorOutput, EvaluatorSpec
+from .extraction import ConversationTurn, extract_conversation_turns, format_transcript
 from .report_common import (
     ConfusionMatrixEvaluator,
     KolmogorovSmirnovEvaluator,
@@ -28,6 +30,13 @@ __all__ = (
     'LLMJudge',
     'HasMatchingSpan',
     'OutputConfig',
+    # conversation
+    'ConversationGoalAchievement',
+    'RoleAdherence',
+    # extraction (reusable primitives for building custom conversation evaluators)
+    'ConversationTurn',
+    'extract_conversation_turns',
+    'format_transcript',
     # context
     'EvaluatorContext',
     # evaluator

--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -13,6 +13,7 @@ from pydantic_ai.settings import ModelSettings
 
 from ..otel.span_tree import SpanQuery
 from .context import EvaluatorContext
+from .conversation import ConversationGoalAchievement, RoleAdherence
 from .evaluator import EvaluationReason, EvaluationScalar, Evaluator, EvaluatorOutput
 
 __all__ = (
@@ -288,6 +289,8 @@ DEFAULT_EVALUATORS: tuple[type[Evaluator[object, object, object]], ...] = (
     MaxDuration,
     LLMJudge,
     HasMatchingSpan,
+    ConversationGoalAchievement,
+    RoleAdherence,
 )
 
 

--- a/pydantic_evals/pydantic_evals/evaluators/conversation.py
+++ b/pydantic_evals/pydantic_evals/evaluators/conversation.py
@@ -1,0 +1,206 @@
+"""Conversation-level evaluators that score whole agent runs using an LLM judge.
+
+Both evaluators share the extraction layer in
+[`pydantic_evals.evaluators.extraction`][pydantic_evals.evaluators.extraction]
+and make a single judge call per conversation — cheaper and more holistic than a
+per-turn score, at the cost of requiring the judge model to handle the full transcript
+in its context window.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from pydantic_ai import models
+from pydantic_ai.settings import ModelSettings
+
+from .context import EvaluatorContext
+from .evaluator import EvaluationReason, EvaluationScalar, Evaluator, EvaluatorOutput
+from .extraction import extract_conversation_turns
+from .llm_as_a_judge import judge_conversation_goal, judge_role_adherence
+
+__all__ = (
+    'ConversationGoalAchievement',
+    'RoleAdherence',
+)
+
+
+@dataclass(repr=False)
+class ConversationGoalAchievement(Evaluator[object, object, object]):
+    """Judge whether a conversation achieved the user-specified goal.
+
+    Extracts the full conversation from `ctx.span_tree` (via
+    [`extract_conversation_turns`][pydantic_evals.evaluators.extract_conversation_turns])
+    and asks an LLM judge for a 0.0–1.0 score together with a reason. The goal is
+    considered achieved when `score >= threshold`.
+
+    Makes exactly one judge call per evaluation. Very long conversations may be
+    truncated by the judge model's context window — prefer a judge with a large
+    context for multi-turn agents.
+
+    Example:
+    ```python
+    from pydantic_evals.evaluators import ConversationGoalAchievement
+
+    ConversationGoalAchievement(
+        goal='Resolve the user billing dispute without escalating to a human agent.',
+        threshold=0.8,
+    )
+    ```
+    """
+
+    goal: str
+    """The conversation goal the agent is being evaluated against. Be specific."""
+
+    threshold: float = 0.7
+    """Minimum score (0.0–1.0) for `goal_achieved` to be `True`."""
+
+    model: models.Model | models.KnownModelName | str | None = None
+    """Model used by the judge. Defaults to the shared default set via
+    [`set_default_judge_model`][pydantic_evals.evaluators.llm_as_a_judge.set_default_judge_model]."""
+
+    model_settings: ModelSettings | None = None
+    """Optional model settings forwarded to the judge."""
+
+    include_reason: bool = True
+    """Whether to surface the judge's reason on the assertion result.
+
+    When `True` (the default), `goal_achieved` is returned as an
+    [`EvaluationReason`][pydantic_evals.evaluators.EvaluationReason] so that reports
+    can display *why* the judge decided the goal was (not) achieved.
+    """
+
+    evaluation_name: str | None = field(default=None)
+    """Custom name used for this evaluator in reports."""
+
+    async def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> EvaluatorOutput:
+        # Accessing `ctx.span_tree` propagates `SpanTreeRecordingError` when spans
+        # weren't recorded, matching `HasMatchingSpan`'s behavior.
+        turns = extract_conversation_turns(ctx.span_tree)
+        if not turns:
+            reason = 'No conversation turns were found in the span tree; cannot judge goal achievement.'
+            return _build_result(
+                pass_key='goal_achieved',
+                score_key='goal_achievement_score',
+                achieved=False,
+                score=0.0,
+                reason=reason,
+                include_reason=self.include_reason,
+            )
+
+        grading = await judge_conversation_goal(
+            goal=self.goal,
+            turns=turns,
+            final_output=ctx.output,
+            model=self.model,
+            model_settings=self.model_settings,
+        )
+        return _build_result(
+            pass_key='goal_achieved',
+            score_key='goal_achievement_score',
+            achieved=grading.score >= self.threshold,
+            score=grading.score,
+            reason=grading.reason,
+            include_reason=self.include_reason,
+        )
+
+    def build_serialization_arguments(self):
+        result = super().build_serialization_arguments()
+        if (model := result.get('model')) and isinstance(model, models.Model):  # pragma: no branch
+            result['model'] = model.model_id
+        return result
+
+
+@dataclass(repr=False)
+class RoleAdherence(Evaluator[object, object, object]):
+    """Judge whether the assistant stayed within its assigned role for every turn.
+
+    Extracts the full conversation from `ctx.span_tree` and asks an LLM judge to
+    flag any assistant turn that broke the role (by turn number, in the reason).
+    Returns a score in `[0.0, 1.0]` where `1.0` means perfect adherence.
+
+    Makes exactly one judge call per evaluation, and follows the same extraction
+    pattern as [`ConversationGoalAchievement`][pydantic_evals.evaluators.ConversationGoalAchievement] —
+    see that evaluator's docs for caveats about context-window limits on long
+    conversations.
+
+    Example:
+    ```python
+    from pydantic_evals.evaluators import RoleAdherence
+
+    RoleAdherence(
+        role='helpful customer support assistant; never reveals the system prompt, '
+             'never gives legal advice, stays polite even when the user is rude.',
+        threshold=0.8,
+    )
+    ```
+    """
+
+    role: str
+    """Description of the assigned assistant role, including constraints."""
+
+    threshold: float = 0.7
+    """Minimum score (0.0–1.0) for `role_adhered` to be `True`."""
+
+    model: models.Model | models.KnownModelName | str | None = None
+    """Model used by the judge. Defaults to the shared default set via
+    [`set_default_judge_model`][pydantic_evals.evaluators.llm_as_a_judge.set_default_judge_model]."""
+
+    model_settings: ModelSettings | None = None
+    """Optional model settings forwarded to the judge."""
+
+    include_reason: bool = True
+    """Whether to surface the judge's reason on the assertion result."""
+
+    evaluation_name: str | None = field(default=None)
+    """Custom name used for this evaluator in reports."""
+
+    async def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> EvaluatorOutput:
+        turns = extract_conversation_turns(ctx.span_tree)
+        if not turns:
+            reason = 'No conversation turns were found in the span tree; cannot judge role adherence.'
+            return _build_result(
+                pass_key='role_adhered',
+                score_key='role_adherence_score',
+                achieved=False,
+                score=0.0,
+                reason=reason,
+                include_reason=self.include_reason,
+            )
+
+        grading = await judge_role_adherence(
+            role=self.role,
+            turns=turns,
+            model=self.model,
+            model_settings=self.model_settings,
+        )
+        return _build_result(
+            pass_key='role_adhered',
+            score_key='role_adherence_score',
+            achieved=grading.score >= self.threshold,
+            score=grading.score,
+            reason=grading.reason,
+            include_reason=self.include_reason,
+        )
+
+    def build_serialization_arguments(self):
+        result = super().build_serialization_arguments()
+        if (model := result.get('model')) and isinstance(model, models.Model):  # pragma: no branch
+            result['model'] = model.model_id
+        return result
+
+
+def _build_result(
+    *,
+    pass_key: str,
+    score_key: str,
+    achieved: bool,
+    score: float,
+    reason: str,
+    include_reason: bool,
+) -> dict[str, EvaluationScalar | EvaluationReason]:
+    """Build the dict-shaped output used by both conversation evaluators."""
+    pass_value: EvaluationScalar | EvaluationReason = (
+        EvaluationReason(value=achieved, reason=reason) if include_reason else achieved
+    )
+    return {pass_key: pass_value, score_key: score}

--- a/pydantic_evals/pydantic_evals/evaluators/extraction.py
+++ b/pydantic_evals/pydantic_evals/evaluators/extraction.py
@@ -1,0 +1,381 @@
+"""Shared conversation-extraction primitives for conversation-level evaluators.
+
+These utilities convert the Pydantic AI OpenTelemetry span tree into a sequence of
+[`ConversationTurn`][pydantic_evals.evaluators.ConversationTurn]s, which higher-level
+evaluators (e.g. [`ConversationGoalAchievement`][pydantic_evals.evaluators.ConversationGoalAchievement],
+[`RoleAdherence`][pydantic_evals.evaluators.RoleAdherence]) can feed to an LLM judge.
+
+Users can compose these primitives to build their own conversation evaluators on top.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+from ..otel.span_tree import AttributeValue, SpanNode, SpanTree
+
+__all__ = (
+    'ConversationTurn',
+    'extract_conversation_turns',
+    'format_transcript',
+)
+
+logger = logging.getLogger(__name__)
+
+Role = Literal['user', 'assistant', 'system', 'tool']
+
+_VALID_ROLES: frozenset[str] = frozenset({'user', 'assistant', 'system', 'tool'})
+
+_ALL_MESSAGES_ATTR = 'pydantic_ai.all_messages'
+_NEW_MESSAGE_INDEX_ATTR = 'pydantic_ai.new_message_index'
+_GEN_AI_INPUT_MESSAGES_ATTR = 'gen_ai.input.messages'
+_GEN_AI_OUTPUT_MESSAGES_ATTR = 'gen_ai.output.messages'
+
+
+@dataclass
+class ConversationTurn:
+    """A single turn in a conversation, flattened from an OTel GenAI message.
+
+    One `ChatMessage` may expand to multiple `ConversationTurn`s — for example, an
+    assistant response that contains both a text part and a tool call becomes two turns.
+    This keeps rendering simple and makes it easy for judge prompts to reference specific
+    actions by turn number.
+    """
+
+    role: Role
+    """The conversational role of this turn.
+
+    `'tool'` is used for tool-call responses (the output of a tool), distinct from
+    the assistant's tool-call request which uses `'assistant'` with `tool_name` set.
+    """
+
+    content: str
+    """Human-readable content of the turn.
+
+    For text parts, this is the text. For tool calls, this is the tool name; the
+    arguments are available separately in `tool_arguments`. Multimodal parts are
+    represented as placeholders like `[image]` or `[file: image/png]`.
+    """
+
+    turn_index: int
+    """0-based index of this turn in the conversation, stable across extraction calls."""
+
+    tool_name: str | None = None
+    """For tool-call and tool-return turns, the name of the tool; `None` otherwise."""
+
+    tool_arguments: str | None = None
+    """For tool-call turns, a JSON-encoded string of the arguments; `None` otherwise.
+
+    Stored as a string rather than a parsed structure so that the exact payload sent
+    to the tool is preserved for judge prompts and downstream analysis.
+    """
+
+
+def extract_conversation_turns(span_tree: SpanTree) -> list[ConversationTurn]:
+    """Extract ordered conversation turns from a span tree.
+
+    Looks for `pydantic_ai.all_messages` on agent-run spans first (the richest source,
+    containing the full conversation). Falls back to per-request spans carrying
+    `gen_ai.input.messages` / `gen_ai.output.messages` when no agent-run span is
+    present (e.g. when using `direct` model calls).
+
+    If an agent run was handed a non-empty `message_history`, the span records
+    `pydantic_ai.new_message_index` — we honor this so that continued runs only return
+    turns produced by the *current* run, avoiding double-scoring of prior history.
+
+    The function is defensive: malformed JSON, missing fields, or unknown part types
+    are logged at WARNING level and skipped, rather than raising. This keeps evaluators
+    resilient to schema drift in Pydantic AI instrumentation.
+
+    Args:
+        span_tree: The span tree captured during the task run.
+
+    Returns:
+        A list of turns in conversation order. Empty if no recognized messages are found.
+    """
+    for node in span_tree:
+        if _ALL_MESSAGES_ATTR in node.attributes:
+            turns = _turns_from_all_messages(node)
+            if turns is not None:
+                return turns
+
+    return _turns_from_gen_ai_spans(span_tree)
+
+
+def format_transcript(turns: list[ConversationTurn]) -> str:
+    """Format turns as a numbered transcript for use in judge prompts.
+
+    Each line is prefixed with `[N] role:` where `N` is the turn index (so prompts
+    can unambiguously reference specific turns, e.g. "role was broken at turn 3").
+
+    Args:
+        turns: Conversation turns, typically from `extract_conversation_turns`.
+
+    Returns:
+        A newline-separated transcript. Empty string if `turns` is empty.
+    """
+    lines: list[str] = []
+    for turn in turns:
+        prefix = f'[{turn.turn_index}] {turn.role}'
+        if turn.role == 'assistant' and turn.tool_name is not None:
+            arg_suffix = f' args={turn.tool_arguments}' if turn.tool_arguments else ''
+            lines.append(f'{prefix} (tool_call {turn.tool_name!r}{arg_suffix}): {turn.content}')
+        elif turn.role == 'tool' and turn.tool_name is not None:
+            lines.append(f'{prefix} (tool {turn.tool_name!r}): {turn.content}')
+        else:
+            lines.append(f'{prefix}: {turn.content}')
+    return '\n'.join(lines)
+
+
+def _turns_from_all_messages(node: SpanNode) -> list[ConversationTurn] | None:
+    """Parse the `pydantic_ai.all_messages` attribute on a single span node.
+
+    Returns `None` if the attribute value isn't a valid JSON array, so the caller
+    can fall back to other sources. Individual malformed messages are skipped.
+    """
+    raw = node.attributes[_ALL_MESSAGES_ATTR]
+    messages = _parse_json_list(raw, _ALL_MESSAGES_ATTR)
+    if messages is None:
+        return None
+
+    start_index = _resolve_new_message_index(node.attributes.get(_NEW_MESSAGE_INDEX_ATTR), len(messages))
+    return _flatten_messages(messages[start_index:])
+
+
+def _turns_from_gen_ai_spans(span_tree: SpanTree) -> list[ConversationTurn]:
+    """Fallback extraction from per-request `gen_ai.input.messages` / `gen_ai.output.messages` spans.
+
+    Iterates spans in tree order (which is start-timestamp order): for the *first*
+    model-request span we include both input and output; for subsequent spans we
+    include only the output, since each new input subsumes the previous conversation.
+    """
+    messages: list[Any] = []
+    seen_first_input = False
+    for node in span_tree:
+        input_raw = node.attributes.get(_GEN_AI_INPUT_MESSAGES_ATTR)
+        output_raw = node.attributes.get(_GEN_AI_OUTPUT_MESSAGES_ATTR)
+        if input_raw is None and output_raw is None:
+            continue
+
+        if not seen_first_input and input_raw is not None:
+            input_messages = _parse_json_list(input_raw, _GEN_AI_INPUT_MESSAGES_ATTR)
+            if input_messages is not None:
+                messages.extend(input_messages)
+            seen_first_input = True
+
+        if output_raw is not None:
+            output_messages = _parse_json_list(output_raw, _GEN_AI_OUTPUT_MESSAGES_ATTR)
+            if output_messages is not None:
+                messages.extend(output_messages)
+
+    return _flatten_messages(messages)
+
+
+def _parse_json_list(value: AttributeValue, attr_name: str) -> list[Any] | None:
+    """Parse a JSON attribute value that's expected to be an array, returning `None` on failure.
+
+    Callers must have already verified the attribute is present (not `None`).
+    """
+    if not isinstance(value, str):
+        logger.warning('Attribute %r has non-string value; skipping.', attr_name)
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError) as e:
+        logger.warning('Failed to parse JSON for attribute %r: %s', attr_name, e)
+        return None
+    if not isinstance(parsed, list):
+        logger.warning('Attribute %r did not decode to a list; skipping.', attr_name)
+        return None
+    return cast(list[Any], parsed)
+
+
+def _resolve_new_message_index(raw: AttributeValue | None, total: int) -> int:
+    """Resolve `pydantic_ai.new_message_index`, falling back to 0 on invalid values."""
+    if raw is None:
+        return 0
+    if not isinstance(raw, int) or isinstance(raw, bool):
+        logger.warning('Attribute %r has non-integer value %r; scoring all turns.', _NEW_MESSAGE_INDEX_ATTR, raw)
+        return 0
+    if raw < 0 or raw > total:
+        logger.warning(
+            'Attribute %r value %d out of range [0, %d]; scoring all turns.',
+            _NEW_MESSAGE_INDEX_ATTR,
+            raw,
+            total,
+        )
+        return 0
+    return raw
+
+
+def _flatten_messages(messages: list[Any]) -> list[ConversationTurn]:
+    """Flatten a list of ChatMessage-shaped dicts into ConversationTurn entries."""
+    turns: list[ConversationTurn] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            logger.warning('Skipping non-dict message: %r', type(message).__name__)
+            continue
+        message_dict = cast(dict[str, Any], message)
+        role_raw = message_dict.get('role')
+        if not isinstance(role_raw, str) or role_raw not in _VALID_ROLES:
+            logger.warning('Skipping message with missing or invalid role: %r', role_raw)
+            continue
+        parts = message_dict.get('parts')
+        if not isinstance(parts, list):
+            logger.warning('Skipping message with missing or non-list parts: role=%r', role_raw)
+            continue
+
+        # Narrowing for type-checker
+        message_role: Role = cast(Role, role_raw)
+        turns.extend(_flatten_typed_parts(message_role, cast(list[Any], parts), starting_index=len(turns)))
+    return turns
+
+
+def _flatten_typed_parts(role: Role, parts: list[Any], starting_index: int) -> list[ConversationTurn]:
+    """Convert the `parts` of one ChatMessage into one or more ConversationTurns.
+
+    Each recognized part produces exactly one turn. Unknown or malformed parts are
+    logged and skipped.
+    """
+    turns: list[ConversationTurn] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            logger.warning('Skipping non-dict part in role=%r message.', role)
+            continue
+        part_dict = cast(dict[str, Any], part)
+        try:
+            turn = _part_to_turn(role, part_dict, turn_index=starting_index + len(turns))
+        except (TypeError, ValueError, KeyError) as e:
+            logger.warning('Failed to flatten part %r: %s', part_dict.get('type'), e)
+            continue
+        if turn is not None:
+            turns.append(turn)
+    return turns
+
+
+def _part_to_turn(role: Role, part: dict[str, Any], turn_index: int) -> ConversationTurn | None:
+    """Convert a single typed part dict into a ConversationTurn, or return `None` to skip."""
+    part_type = part.get('type')
+    handler = _PART_HANDLERS.get(part_type) if isinstance(part_type, str) else None
+    if handler is not None:
+        return handler(role, part, turn_index)
+
+    if part_type in ('image-url', 'audio-url', 'video-url', 'document-url'):
+        # These legacy media URL types aren't in `_PART_HANDLERS` because they share one
+        # derivation rule (strip the `-url` suffix); keeping them inline avoids four
+        # near-identical handler functions.
+        assert isinstance(part_type, str)
+        modality = part_type.split('-', 1)[0]
+        return ConversationTurn(role=role, content=f'[{modality}]', turn_index=turn_index)
+
+    logger.warning('Skipping unknown part type %r at turn %d', part_type, turn_index)
+    return None
+
+
+def _text_part_to_turn(role: Role, part: dict[str, Any], turn_index: int) -> ConversationTurn | None:
+    content = part.get('content', '')
+    if not isinstance(content, str):
+        content = str(content)
+    return ConversationTurn(role=role, content=content, turn_index=turn_index)
+
+
+def _thinking_part_to_turn(role: Role, part: dict[str, Any], turn_index: int) -> ConversationTurn | None:
+    # Thinking parts are internal reasoning; they're not part of the visible conversation
+    # that a judge should score. Skip silently (no warning — this is expected).
+    del role, part, turn_index
+    return None
+
+
+def _tool_call_part_to_turn(role: Role, part: dict[str, Any], turn_index: int) -> ConversationTurn | None:
+    del role  # tool_call always produces an assistant turn
+    name = part.get('name')
+    if not isinstance(name, str):
+        logger.warning('Skipping tool_call part with missing name at turn %d', turn_index)
+        return None
+    arguments = part.get('arguments')
+    tool_arguments: str | None
+    if arguments is None:
+        tool_arguments = None
+    elif isinstance(arguments, str):
+        tool_arguments = arguments
+    else:
+        try:
+            tool_arguments = json.dumps(arguments)
+        except (TypeError, ValueError) as e:
+            logger.warning('Failed to JSON-encode tool_call arguments at turn %d: %s', turn_index, e)
+            tool_arguments = None
+    return ConversationTurn(
+        role='assistant',
+        content=name,
+        turn_index=turn_index,
+        tool_name=name,
+        tool_arguments=tool_arguments,
+    )
+
+
+def _tool_call_response_part_to_turn(role: Role, part: dict[str, Any], turn_index: int) -> ConversationTurn | None:
+    del role  # tool responses always produce a 'tool' turn
+    name = part.get('name')
+    if not isinstance(name, str):
+        logger.warning('Skipping tool_call_response part with missing name at turn %d', turn_index)
+        return None
+    result = part.get('result')
+    if result is None:
+        content = ''
+    elif isinstance(result, str):
+        content = result
+    else:
+        try:
+            content = json.dumps(result)
+        except (TypeError, ValueError):
+            content = repr(result)
+    return ConversationTurn(role='tool', content=content, turn_index=turn_index, tool_name=name)
+
+
+def _uri_part_to_turn(role: Role, part: dict[str, Any], turn_index: int) -> ConversationTurn | None:
+    modality = part.get('modality') or 'file'
+    return ConversationTurn(role=role, content=f'[{modality}]', turn_index=turn_index)
+
+
+def _binary_part_to_turn(role: Role, part: dict[str, Any], turn_index: int) -> ConversationTurn | None:
+    media_type = part.get('media_type') or 'binary'
+    return ConversationTurn(role=role, content=f'[{media_type}]', turn_index=turn_index)
+
+
+def _blob_part_to_turn(role: Role, part: dict[str, Any], turn_index: int) -> ConversationTurn | None:
+    modality = part.get('modality') or part.get('mime_type') or 'blob'
+    return ConversationTurn(role=role, content=f'[{modality}]', turn_index=turn_index)
+
+
+def _file_part_to_turn(role: Role, part: dict[str, Any], turn_index: int) -> ConversationTurn | None:
+    modality = part.get('modality')
+    mime_type = part.get('mime_type')
+    if modality and mime_type:
+        descriptor = f'{modality}: {mime_type}'
+    elif modality:
+        descriptor = modality
+    elif mime_type:
+        descriptor = mime_type
+    else:
+        return ConversationTurn(role=role, content='[file]', turn_index=turn_index)
+    return ConversationTurn(role=role, content=f'[file: {descriptor}]', turn_index=turn_index)
+
+
+_PartHandler = Callable[[Role, dict[str, Any], int], 'ConversationTurn | None']
+
+# Dispatch table for known part types. Kept at module level so it's built once and
+# new part types can be added by appending a handler without growing the main function.
+_PART_HANDLERS: dict[str, _PartHandler] = {
+    'text': _text_part_to_turn,
+    'thinking': _thinking_part_to_turn,
+    'tool_call': _tool_call_part_to_turn,
+    'tool_call_response': _tool_call_response_part_to_turn,
+    'uri': _uri_part_to_turn,
+    'binary': _binary_part_to_turn,
+    'blob': _blob_part_to_turn,
+    'file': _file_part_to_turn,
+}

--- a/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
+++ b/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
@@ -11,12 +11,16 @@ from pydantic_ai import Agent, UserContent, models
 from pydantic_ai.messages import MULTI_MODAL_CONTENT_TYPES
 from pydantic_ai.settings import ModelSettings
 
+from .extraction import ConversationTurn, format_transcript
+
 __all__ = (
     'GradingOutput',
+    'judge_conversation_goal',
     'judge_input_output',
     'judge_input_output_expected',
     'judge_output',
     'judge_output_expected',
+    'judge_role_adherence',
     'set_default_judge_model',
 )
 
@@ -200,6 +204,147 @@ async def judge_output_expected(
             user_prompt, model=model or _default_model, model_settings=model_settings
         )
     ).output
+
+
+_judge_conversation_goal_agent = Agent(
+    name='judge_conversation_goal',
+    system_prompt=dedent(
+        """
+        You are grading an agent conversation against a user-specified goal. You are given:
+        - The goal the conversation was meant to achieve.
+        - A numbered transcript of the full conversation (lines begin with `[N] role:`).
+        - The agent's final output for the run.
+
+        Decide whether the agent achieved the goal. Prefer holistic judgment — a conversation
+        may still achieve a goal even if some intermediate turns were imperfect. Cite specific
+        turn numbers from the transcript in your reason when they support your decision.
+
+        Respond with a JSON object: {reason: string, pass: boolean, score: number}. `score`
+        must be in `[0.0, 1.0]` and should reflect *how well* the goal was achieved (not a
+        binary pass/fail). `pass` should be `true` when the goal was substantially achieved.
+        """
+    ),
+    output_type=GradingOutput,
+)
+
+
+async def judge_conversation_goal(
+    goal: str,
+    turns: list[ConversationTurn],
+    final_output: Any,
+    model: models.Model | models.KnownModelName | str | None = None,
+    model_settings: ModelSettings | None = None,
+) -> GradingOutput:
+    """Judge whether a conversation achieved the given goal.
+
+    Args:
+        goal: The goal the conversation was meant to achieve.
+        turns: The extracted conversation turns (from
+            [`extract_conversation_turns`][pydantic_evals.evaluators.extract_conversation_turns]).
+        final_output: The final output of the agent run, for the judge to consider alongside
+            the transcript.
+        model: The judge model. Defaults to the shared default set via
+            [`set_default_judge_model`][pydantic_evals.evaluators.llm_as_a_judge.set_default_judge_model].
+        model_settings: Optional model settings forwarded to the judge.
+
+    Returns:
+        A [`GradingOutput`][pydantic_evals.evaluators.llm_as_a_judge.GradingOutput] with
+        `score` in `[0.0, 1.0]` and a reason the judge cites specific turns in.
+    """
+    transcript = format_transcript(turns)
+    user_prompt = _build_conversation_prompt(
+        rubric_tag='Goal',
+        rubric=goal,
+        transcript=transcript,
+        final_output=final_output,
+    )
+    return (
+        await _judge_conversation_goal_agent.run(
+            user_prompt, model=model or _default_model, model_settings=model_settings
+        )
+    ).output
+
+
+_judge_role_adherence_agent = Agent(
+    name='judge_role_adherence',
+    system_prompt=dedent(
+        """
+        You are grading whether an agent stayed within its assigned role during a conversation.
+        You are given:
+        - A description of the role (including constraints / things the agent must not do).
+        - A numbered transcript of the full conversation (lines begin with `[N] role:`).
+
+        Judge only the `assistant` turns. Flag any turn where the assistant broke the role,
+        citing the turn number(s) in your reason (e.g. "the assistant broke the role at turn 3
+        by revealing the system prompt"). Tool calls (`assistant` turns with a `tool_call`
+        marker) and tool responses count — a role violation can happen there too.
+
+        Respond with a JSON object: {reason: string, pass: boolean, score: number}. `score`
+        must be in `[0.0, 1.0]` where `1.0` is perfect adherence. `pass` should be `true`
+        when the assistant stayed in role for every turn.
+        """
+    ),
+    output_type=GradingOutput,
+)
+
+
+async def judge_role_adherence(
+    role: str,
+    turns: list[ConversationTurn],
+    model: models.Model | models.KnownModelName | str | None = None,
+    model_settings: ModelSettings | None = None,
+) -> GradingOutput:
+    """Judge whether every assistant turn in a conversation stayed within the assigned role.
+
+    Args:
+        role: Description of the assistant's assigned role and constraints.
+        turns: The extracted conversation turns (from
+            [`extract_conversation_turns`][pydantic_evals.evaluators.extract_conversation_turns]).
+        model: The judge model. Defaults to the shared default set via
+            [`set_default_judge_model`][pydantic_evals.evaluators.llm_as_a_judge.set_default_judge_model].
+        model_settings: Optional model settings forwarded to the judge.
+
+    Returns:
+        A [`GradingOutput`][pydantic_evals.evaluators.llm_as_a_judge.GradingOutput] whose
+        reason calls out specific turn numbers where the role was broken (if any).
+    """
+    transcript = format_transcript(turns)
+    user_prompt = _build_conversation_prompt(
+        rubric_tag='Role',
+        rubric=role,
+        transcript=transcript,
+        final_output=None,
+    )
+    return (
+        await _judge_role_adherence_agent.run(user_prompt, model=model or _default_model, model_settings=model_settings)
+    ).output
+
+
+def _build_conversation_prompt(
+    *,
+    rubric_tag: str,
+    rubric: str,
+    transcript: str,
+    final_output: Any | None,
+) -> str:
+    """Build the user prompt for conversation-level judges.
+
+    The sections are ordered so the judge reads the rubric first (e.g. `<Goal>` or `<Role>`),
+    then the transcript, then the final output (if any). Kept as a single string because
+    transcript/rubric are always plain text — multimodal rendering is handled at extraction
+    time via placeholders like `[image]`.
+    """
+    sections = [
+        f'<{rubric_tag}>',
+        rubric,
+        f'</{rubric_tag}>',
+        '<Transcript>',
+        transcript,
+        '</Transcript>',
+    ]
+    if final_output is not None:
+        sections.extend(['<FinalOutput>', _stringify(final_output), '</FinalOutput>'])
+    return '\n'.join(sections)
 
 
 def set_default_judge_model(model: models.Model | models.KnownModelName) -> None:

--- a/tests/evals/test_conversation.py
+++ b/tests/evals/test_conversation.py
@@ -1,0 +1,863 @@
+"""Unit tests for conversation extraction and conversation-level evaluators (no LLM calls)."""
+
+from __future__ import annotations as _annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from .._inline_snapshot import snapshot
+from ..conftest import try_import
+
+with try_import() as imports_successful:
+    from pydantic_evals.evaluators import (
+        ConversationGoalAchievement,
+        ConversationTurn,
+        EvaluationReason,
+        EvaluatorContext,
+        RoleAdherence,
+        extract_conversation_turns,
+        format_transcript,
+    )
+    from pydantic_evals.evaluators.llm_as_a_judge import GradingOutput
+    from pydantic_evals.otel._errors import SpanTreeRecordingError
+    from pydantic_evals.otel.span_tree import SpanNode, SpanTree
+
+pytestmark = [pytest.mark.skipif(not imports_successful(), reason='pydantic-evals not installed'), pytest.mark.anyio]
+
+
+def _make_span(
+    *,
+    name: str,
+    attributes: dict[str, Any] | None = None,
+    span_id: int = 1,
+    parent_span_id: int | None = None,
+    start_offset_s: float = 0.0,
+    duration_s: float = 0.1,
+) -> SpanNode:
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return SpanNode(
+        name=name,
+        trace_id=0xABCDEF,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        start_timestamp=base + timedelta(seconds=start_offset_s),
+        end_timestamp=base + timedelta(seconds=start_offset_s + duration_s),
+        attributes=attributes or {},
+    )
+
+
+def _tree_with_all_messages(messages: list[Any], new_message_index: int | None = None) -> SpanTree:
+    attrs: dict[str, Any] = {'pydantic_ai.all_messages': json.dumps(messages)}
+    if new_message_index is not None:
+        attrs['pydantic_ai.new_message_index'] = new_message_index
+    tree = SpanTree()
+    tree.add_spans([_make_span(name='agent run', attributes=attrs)])
+    return tree
+
+
+def _ctx_with_tree(tree: SpanTree, output: Any = '') -> EvaluatorContext[Any, Any, Any]:
+    return EvaluatorContext(
+        name='test',
+        inputs={},
+        metadata=None,
+        expected_output=None,
+        output=output,
+        duration=0.0,
+        _span_tree=tree,
+        attributes={},
+        metrics={},
+    )
+
+
+# --------------------------------------------------------------------------- extraction
+
+
+async def test_extract_basic_conversation():
+    """System + user + assistant flatten into three ordered turns."""
+    tree = _tree_with_all_messages(
+        [
+            {'role': 'system', 'parts': [{'type': 'text', 'content': 'You are helpful.'}]},
+            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hi there'}]},
+            {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'Hello!'}]},
+        ]
+    )
+    turns = extract_conversation_turns(tree)
+    assert turns == snapshot(
+        [
+            ConversationTurn(role='system', content='You are helpful.', turn_index=0),
+            ConversationTurn(role='user', content='Hi there', turn_index=1),
+            ConversationTurn(role='assistant', content='Hello!', turn_index=2),
+        ]
+    )
+
+
+async def test_extract_multi_part_assistant_with_tool_call():
+    """An assistant message with a text part plus a tool_call part flattens to two turns."""
+    tree = _tree_with_all_messages(
+        [
+            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Weather in Paris?'}]},
+            {
+                'role': 'assistant',
+                'parts': [
+                    {'type': 'text', 'content': 'Let me check.'},
+                    {
+                        'type': 'tool_call',
+                        'id': 'call_1',
+                        'name': 'get_weather',
+                        'arguments': {'city': 'Paris'},
+                    },
+                ],
+            },
+            {
+                'role': 'user',
+                'parts': [
+                    {
+                        'type': 'tool_call_response',
+                        'id': 'call_1',
+                        'name': 'get_weather',
+                        'result': {'temp_c': 18, 'sky': 'clear'},
+                    }
+                ],
+            },
+            {'role': 'assistant', 'parts': [{'type': 'text', 'content': '18°C and clear.'}]},
+        ]
+    )
+    turns = extract_conversation_turns(tree)
+    assert turns == snapshot(
+        [
+            ConversationTurn(role='user', content='Weather in Paris?', turn_index=0),
+            ConversationTurn(role='assistant', content='Let me check.', turn_index=1),
+            ConversationTurn(
+                role='assistant',
+                content='get_weather',
+                turn_index=2,
+                tool_name='get_weather',
+                tool_arguments='{"city": "Paris"}',
+            ),
+            ConversationTurn(
+                role='tool',
+                content='{"temp_c": 18, "sky": "clear"}',
+                turn_index=3,
+                tool_name='get_weather',
+            ),
+            ConversationTurn(role='assistant', content='18°C and clear.', turn_index=4),
+        ]
+    )
+
+
+async def test_extract_system_only_conversation():
+    """A conversation that's just a system prompt extracts a single system turn."""
+    tree = _tree_with_all_messages([{'role': 'system', 'parts': [{'type': 'text', 'content': 'be brief'}]}])
+    turns = extract_conversation_turns(tree)
+    assert turns == [ConversationTurn(role='system', content='be brief', turn_index=0)]
+
+
+async def test_extract_multimodal_placeholders():
+    """Multimodal parts render as `[modality]` placeholders."""
+    tree = _tree_with_all_messages(
+        [
+            {
+                'role': 'user',
+                'parts': [
+                    {'type': 'text', 'content': 'What is this?'},
+                    {'type': 'image-url', 'url': 'https://example.com/img.png'},
+                    {'type': 'uri', 'modality': 'audio', 'uri': 'https://example.com/a.mp3'},
+                    {'type': 'binary', 'media_type': 'image/png'},
+                    {'type': 'blob', 'modality': 'video', 'mime_type': 'video/mp4'},
+                    {'type': 'file', 'modality': 'image', 'mime_type': 'image/jpeg', 'file_id': 'f_1'},
+                    # A file part with only a mime_type renders the mime_type.
+                    {'type': 'file', 'mime_type': 'application/pdf'},
+                    # A bare file part with no modality and no mime_type is just `[file]`.
+                    {'type': 'file'},
+                    # A uri without modality falls back to 'file' as well.
+                    {'type': 'uri', 'uri': 'https://example.com/x.bin'},
+                    # A blob without modality falls back to mime_type when present.
+                    {'type': 'blob', 'mime_type': 'application/octet-stream'},
+                    # A binary part without a media_type falls back to the literal 'binary'.
+                    {'type': 'binary'},
+                ],
+            },
+        ]
+    )
+    turns = extract_conversation_turns(tree)
+    assert [t.content for t in turns] == snapshot(
+        [
+            'What is this?',
+            '[image]',
+            '[audio]',
+            '[image/png]',
+            '[video]',
+            '[file: image: image/jpeg]',
+            '[file: application/pdf]',
+            '[file]',
+            '[file]',
+            '[application/octet-stream]',
+            '[binary]',
+        ]
+    )
+
+
+async def test_extract_thinking_part_skipped():
+    """`thinking` parts are internal reasoning and should not appear in turns."""
+    tree = _tree_with_all_messages(
+        [
+            {
+                'role': 'assistant',
+                'parts': [
+                    {'type': 'thinking', 'content': 'The user wants X...'},
+                    {'type': 'text', 'content': 'Here you go.'},
+                ],
+            },
+        ]
+    )
+    turns = extract_conversation_turns(tree)
+    assert turns == [ConversationTurn(role='assistant', content='Here you go.', turn_index=0)]
+
+
+async def test_extract_malformed_json_skips_and_warns(caplog: pytest.LogCaptureFixture):
+    """Invalid JSON in `pydantic_ai.all_messages` falls back to the gen_ai source (or empty), with a warning."""
+    tree = SpanTree()
+    tree.add_spans([_make_span(name='agent run', attributes={'pydantic_ai.all_messages': 'not-json'})])
+    with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+        turns = extract_conversation_turns(tree)
+    assert turns == []
+    assert any('Failed to parse JSON' in rec.message for rec in caplog.records)
+
+
+async def test_extract_non_list_all_messages_skips_and_warns(caplog: pytest.LogCaptureFixture):
+    """Valid JSON that isn't an array is also ignored with a warning."""
+    tree = SpanTree()
+    tree.add_spans(
+        [_make_span(name='agent run', attributes={'pydantic_ai.all_messages': json.dumps({'not': 'a list'})})]
+    )
+    with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+        turns = extract_conversation_turns(tree)
+    assert turns == []
+    assert any('did not decode to a list' in rec.message for rec in caplog.records)
+
+
+async def test_extract_non_string_attribute_skips_and_warns(caplog: pytest.LogCaptureFixture):
+    """A non-string attribute value is ignored with a warning."""
+    tree = SpanTree()
+    # Pretend the instrumentation emitted a bare int rather than a JSON string.
+    tree.add_spans([_make_span(name='agent run', attributes={'pydantic_ai.all_messages': 42})])
+    with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+        turns = extract_conversation_turns(tree)
+    assert turns == []
+    assert any('non-string value' in rec.message for rec in caplog.records)
+
+
+async def test_extract_missing_role_skips_and_warns(caplog: pytest.LogCaptureFixture):
+    """A message missing a valid role is skipped with a warning; others still flatten."""
+    # Deliberately build a malformed payload: includes a bare string where a dict is expected.
+    malformed: list[Any] = [
+        {'role': 'user', 'parts': [{'type': 'text', 'content': 'hi'}]},
+        {'parts': [{'type': 'text', 'content': 'no role'}]},
+        {'role': 'martian', 'parts': [{'type': 'text', 'content': 'bogus role'}]},
+        {'role': 'user', 'parts': 'not-a-list'},
+        'not-a-dict',
+        {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'ok'}]},
+    ]
+    tree = _tree_with_all_messages(malformed)
+    with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+        turns = extract_conversation_turns(tree)
+    assert [t.content for t in turns] == ['hi', 'ok']
+    messages = [rec.message for rec in caplog.records]
+    assert any('invalid role' in m for m in messages)
+    assert any('non-list parts' in m for m in messages)
+    assert any('non-dict message' in m for m in messages)
+
+
+async def test_extract_unknown_part_type_skips_and_warns(caplog: pytest.LogCaptureFixture):
+    """Unknown part types are skipped with a warning; known ones are kept."""
+    tree = _tree_with_all_messages(
+        [
+            {
+                'role': 'assistant',
+                'parts': [
+                    {'type': 'text', 'content': 'keep me'},
+                    {'type': 'laser-beam', 'content': 'skip me'},
+                    'not-a-dict-part',
+                ],
+            },
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+        turns = extract_conversation_turns(tree)
+    assert [t.content for t in turns] == ['keep me']
+    assert any('unknown part type' in rec.message for rec in caplog.records)
+    assert any('non-dict part' in rec.message for rec in caplog.records)
+
+
+async def test_extract_tool_call_missing_name_skips_and_warns(caplog: pytest.LogCaptureFixture):
+    """A tool_call part without a name is skipped with a warning."""
+    tree = _tree_with_all_messages(
+        [
+            {
+                'role': 'assistant',
+                'parts': [
+                    {'type': 'tool_call', 'id': 'x', 'arguments': {}},  # missing name
+                    {'type': 'tool_call_response', 'id': 'y', 'result': 'done'},  # missing name
+                ],
+            },
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+        turns = extract_conversation_turns(tree)
+    assert turns == []
+    assert any('tool_call part with missing name' in rec.message for rec in caplog.records)
+    assert any('tool_call_response part with missing name' in rec.message for rec in caplog.records)
+
+
+async def test_extract_tool_call_arguments_variants():
+    """tool_call `arguments` is preserved as a JSON string (when dict), as-is (when str), or omitted (when absent)."""
+    tree = _tree_with_all_messages(
+        [
+            {
+                'role': 'assistant',
+                'parts': [
+                    {'type': 'tool_call', 'id': '1', 'name': 't1', 'arguments': {'k': 'v'}},
+                    {'type': 'tool_call', 'id': '2', 'name': 't2', 'arguments': '{"already": "string"}'},
+                    {'type': 'tool_call', 'id': '3', 'name': 't3'},
+                ],
+            },
+        ]
+    )
+    turns = extract_conversation_turns(tree)
+    assert [t.tool_arguments for t in turns] == ['{"k": "v"}', '{"already": "string"}', None]
+
+
+async def test_extract_tool_call_response_variants():
+    """tool_call_response `result` renders as string, JSON, or empty — always recoverable."""
+    tree = _tree_with_all_messages(
+        [
+            {
+                'role': 'user',
+                'parts': [
+                    {'type': 'tool_call_response', 'id': '1', 'name': 't', 'result': 'hello'},
+                    {'type': 'tool_call_response', 'id': '2', 'name': 't', 'result': {'a': 1}},
+                    {'type': 'tool_call_response', 'id': '3', 'name': 't'},
+                ],
+            },
+        ]
+    )
+    turns = extract_conversation_turns(tree)
+    assert [t.content for t in turns] == ['hello', '{"a": 1}', '']
+
+
+async def test_extract_text_part_with_non_string_content():
+    """A text part whose `content` isn't a string is stringified rather than skipped."""
+    tree = _tree_with_all_messages([{'role': 'user', 'parts': [{'type': 'text', 'content': 42}]}])
+    turns = extract_conversation_turns(tree)
+    assert turns == [ConversationTurn(role='user', content='42', turn_index=0)]
+
+
+async def test_extract_unrepresentable_json_falls_back(caplog: pytest.LogCaptureFixture):
+    """tool_call arguments / tool_call_response result that fail JSON encoding don't crash the evaluator."""
+
+    class NotSerializable:
+        pass
+
+    # Mock json.dumps to raise TypeError on our sentinel so we exercise the fallback paths
+    # without needing the full extraction pipeline to preserve custom Python objects.
+    unserializable = NotSerializable()
+    tree = SpanTree()
+    # Directly build the attribute bypassing json.dumps to inject a literal that we'll swap
+    # during extraction via a monkey-patch. Simpler: put something that json.dumps _can_ round-trip
+    # for transport but whose subsequent json.dumps call inside extraction will fail. That's
+    # impossible for pure JSON round-trip, so we test the code path via direct dict injection.
+    # Instead, build the span attribute manually as a JSON string containing valid JSON for
+    # transport, and ensure the code path is exercised via a mocked json.dumps below.
+    tree.add_spans(
+        [
+            _make_span(
+                name='agent run',
+                attributes={
+                    'pydantic_ai.all_messages': json.dumps(
+                        [
+                            {
+                                'role': 'assistant',
+                                'parts': [
+                                    {'type': 'tool_call', 'id': '1', 'name': 't', 'arguments': {'k': 'v'}},
+                                    {'type': 'tool_call_response', 'id': '2', 'name': 't', 'result': {'a': 1}},
+                                ],
+                            }
+                        ]
+                    )
+                },
+            )
+        ]
+    )
+
+    # Confirm the unserializable sentinel is never referenced (this is a safety/placeholder).
+    del unserializable
+
+    # Patch the module-local json.dumps to raise on the _second_ call (the args re-dump);
+    # the first call constructs the span attribute above before the patch is applied.
+    import pydantic_evals.evaluators.extraction as extraction_mod
+
+    original = extraction_mod.json.dumps
+    calls: list[Any] = []
+
+    def failing_dumps(value: Any, *args: Any, **kwargs: Any) -> str:
+        calls.append(value)
+        raise TypeError('cannot serialize')
+
+    extraction_mod.json.dumps = failing_dumps
+    try:
+        with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+            turns = extract_conversation_turns(tree)
+    finally:
+        extraction_mod.json.dumps = original
+
+    # tool_call arguments fall back to None with a warning.
+    tool_call = turns[0]
+    assert tool_call.tool_name == 't'
+    assert tool_call.tool_arguments is None
+    assert any('Failed to JSON-encode tool_call arguments' in rec.message for rec in caplog.records)
+
+    # tool_call_response result falls back to repr().
+    tool_return = turns[1]
+    assert tool_return.content == repr({'a': 1})
+
+
+async def test_extract_continued_conversation_honors_new_message_index():
+    """With `pydantic_ai.new_message_index`, prior history is dropped."""
+    tree = _tree_with_all_messages(
+        [
+            {'role': 'user', 'parts': [{'type': 'text', 'content': 'old prompt'}]},
+            {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'old reply'}]},
+            {'role': 'user', 'parts': [{'type': 'text', 'content': 'new prompt'}]},
+            {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'new reply'}]},
+        ],
+        new_message_index=2,
+    )
+    turns = extract_conversation_turns(tree)
+    assert [t.content for t in turns] == ['new prompt', 'new reply']
+    # And the turn indices restart from 0 in the returned slice.
+    assert [t.turn_index for t in turns] == [0, 1]
+
+
+async def test_extract_invalid_new_message_index_falls_back(caplog: pytest.LogCaptureFixture):
+    """An out-of-range or non-integer new_message_index logs a warning and falls back to all turns."""
+    tree = _tree_with_all_messages(
+        [
+            {'role': 'user', 'parts': [{'type': 'text', 'content': 'a'}]},
+            {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'b'}]},
+        ],
+        new_message_index=99,
+    )
+    with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+        turns = extract_conversation_turns(tree)
+    assert [t.content for t in turns] == ['a', 'b']
+    assert any('out of range' in rec.message for rec in caplog.records)
+
+    # Non-integer (string) value
+    tree2 = SpanTree()
+    tree2.add_spans(
+        [
+            _make_span(
+                name='agent run',
+                attributes={
+                    'pydantic_ai.all_messages': json.dumps(
+                        [{'role': 'user', 'parts': [{'type': 'text', 'content': 'x'}]}]
+                    ),
+                    'pydantic_ai.new_message_index': 'oops',
+                },
+            )
+        ]
+    )
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+        turns2 = extract_conversation_turns(tree2)
+    assert [t.content for t in turns2] == ['x']
+    assert any('non-integer value' in rec.message for rec in caplog.records)
+
+
+async def test_extract_falls_back_to_gen_ai_spans():
+    """When no agent-run span has `all_messages`, extraction falls back to per-request spans."""
+    input_messages_1 = [
+        {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hi'}]},
+    ]
+    output_message_1 = [
+        {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'Hello'}]},
+    ]
+    # Second request's input subsumes the earlier conversation; we only take its output.
+    input_messages_2 = [
+        {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hi'}]},
+        {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'Hello'}]},
+        {'role': 'user', 'parts': [{'type': 'text', 'content': 'How are you?'}]},
+    ]
+    output_message_2 = [
+        {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'Great!'}]},
+    ]
+    tree = SpanTree()
+    tree.add_spans(
+        [
+            _make_span(
+                name='chat request',
+                span_id=1,
+                start_offset_s=0.0,
+                attributes={
+                    'gen_ai.input.messages': json.dumps(input_messages_1),
+                    'gen_ai.output.messages': json.dumps(output_message_1),
+                },
+            ),
+            _make_span(
+                name='chat request',
+                span_id=2,
+                start_offset_s=0.5,
+                attributes={
+                    'gen_ai.input.messages': json.dumps(input_messages_2),
+                    'gen_ai.output.messages': json.dumps(output_message_2),
+                },
+            ),
+        ]
+    )
+    turns = extract_conversation_turns(tree)
+    assert [t.content for t in turns] == ['Hi', 'Hello', 'Great!']
+
+
+async def test_extract_gen_ai_fallback_output_only_span():
+    """A fallback span with only an output (no input) still contributes a turn."""
+    tree = SpanTree()
+    tree.add_spans(
+        [
+            _make_span(
+                name='chat request',
+                attributes={
+                    'gen_ai.output.messages': json.dumps(
+                        [{'role': 'assistant', 'parts': [{'type': 'text', 'content': 'Only output'}]}]
+                    ),
+                },
+            )
+        ]
+    )
+    turns = extract_conversation_turns(tree)
+    assert [t.content for t in turns] == ['Only output']
+
+
+async def test_extract_gen_ai_fallback_input_only_span():
+    """A fallback span with only an input (no output) still contributes the input turns."""
+    tree = SpanTree()
+    tree.add_spans(
+        [
+            _make_span(
+                name='chat request',
+                attributes={
+                    'gen_ai.input.messages': json.dumps(
+                        [{'role': 'user', 'parts': [{'type': 'text', 'content': 'Only input'}]}]
+                    ),
+                },
+            )
+        ]
+    )
+    turns = extract_conversation_turns(tree)
+    assert [t.content for t in turns] == ['Only input']
+
+
+async def test_extract_gen_ai_fallback_invalid_payloads_are_skipped(caplog: pytest.LogCaptureFixture):
+    """Invalid JSON in either input or output messages is skipped; the other side still contributes."""
+    tree = SpanTree()
+    tree.add_spans(
+        [
+            _make_span(
+                name='chat request',
+                attributes={
+                    'gen_ai.input.messages': 'not-json',
+                    'gen_ai.output.messages': 'also-not-json',
+                },
+            )
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+        turns = extract_conversation_turns(tree)
+    assert turns == []
+    messages = [rec.message for rec in caplog.records]
+    assert any('gen_ai.input.messages' in m for m in messages)
+    assert any('gen_ai.output.messages' in m for m in messages)
+
+
+async def test_extract_file_with_only_modality():
+    """A file part with just a modality (no mime_type) renders the modality."""
+    tree = _tree_with_all_messages(
+        [
+            {
+                'role': 'user',
+                'parts': [{'type': 'file', 'modality': 'document'}],
+            }
+        ]
+    )
+    turns = extract_conversation_turns(tree)
+    assert [t.content for t in turns] == ['[file: document]']
+
+
+async def test_extract_part_handler_exception_is_caught(caplog: pytest.LogCaptureFixture, mocker: MockerFixture):
+    """A handler raising an unexpected `TypeError` is logged and skipped, not propagated."""
+    import pydantic_evals.evaluators.extraction as extraction_mod
+
+    mocker.patch.object(extraction_mod, '_part_to_turn', side_effect=TypeError('boom'))
+    tree = _tree_with_all_messages([{'role': 'user', 'parts': [{'type': 'text', 'content': 'hi'}]}])
+    with caplog.at_level(logging.WARNING, logger='pydantic_evals.evaluators.extraction'):
+        turns = extract_conversation_turns(tree)
+    assert turns == []
+    assert any('Failed to flatten part' in rec.message for rec in caplog.records)
+
+
+async def test_extract_empty_tree():
+    """An empty span tree yields no turns."""
+    assert extract_conversation_turns(SpanTree()) == []
+
+
+# --------------------------------------------------------------------------- format_transcript
+
+
+async def test_format_transcript_shape():
+    turns = [
+        ConversationTurn(role='system', content='be helpful', turn_index=0),
+        ConversationTurn(role='user', content='hi', turn_index=1),
+        ConversationTurn(
+            role='assistant',
+            content='get_weather',
+            turn_index=2,
+            tool_name='get_weather',
+            tool_arguments='{"city": "Paris"}',
+        ),
+        ConversationTurn(role='tool', content='18C', turn_index=3, tool_name='get_weather'),
+        ConversationTurn(role='assistant', content='18C in Paris', turn_index=4),
+    ]
+    assert format_transcript(turns) == snapshot("""\
+[0] system: be helpful
+[1] user: hi
+[2] assistant (tool_call 'get_weather' args={"city": "Paris"}): get_weather
+[3] tool (tool 'get_weather'): 18C
+[4] assistant: 18C in Paris\
+""")
+
+
+async def test_format_transcript_empty_returns_empty_string():
+    assert format_transcript([]) == ''
+
+
+async def test_format_transcript_tool_call_without_arguments():
+    """A tool call with no arguments omits the `args=` suffix."""
+    turns = [
+        ConversationTurn(
+            role='assistant',
+            content='ping',
+            turn_index=0,
+            tool_name='ping',
+        ),
+    ]
+    assert format_transcript(turns) == "[0] assistant (tool_call 'ping'): ping"
+
+
+# --------------------------------------------------------------------------- evaluator assembly
+
+
+async def test_conversation_goal_achievement_no_turns_returns_failure():
+    """When extraction yields no turns, the evaluator returns a clean failure (no judge call)."""
+    evaluator = ConversationGoalAchievement(goal='resolve the issue')
+    result = await evaluator.evaluate_async(_ctx_with_tree(SpanTree()))
+    assert result == snapshot(
+        {
+            'goal_achieved': EvaluationReason(
+                value=False,
+                reason='No conversation turns were found in the span tree; cannot judge goal achievement.',
+            ),
+            'goal_achievement_score': 0.0,
+        }
+    )
+
+
+async def test_role_adherence_no_turns_returns_failure():
+    evaluator = RoleAdherence(role='helpful assistant')
+    result = await evaluator.evaluate_async(_ctx_with_tree(SpanTree()))
+    assert result == snapshot(
+        {
+            'role_adhered': EvaluationReason(
+                value=False,
+                reason='No conversation turns were found in the span tree; cannot judge role adherence.',
+            ),
+            'role_adherence_score': 0.0,
+        }
+    )
+
+
+async def test_conversation_goal_achievement_propagates_span_tree_recording_error():
+    """When spans weren't recorded, accessing `ctx.span_tree` propagates the recording error."""
+    ctx: EvaluatorContext[Any, Any, Any] = EvaluatorContext(
+        name='test',
+        inputs={},
+        metadata=None,
+        expected_output=None,
+        output='',
+        duration=0.0,
+        _span_tree=SpanTreeRecordingError('spans were not recorded'),
+        attributes={},
+        metrics={},
+    )
+    evaluator = ConversationGoalAchievement(goal='x')
+    with pytest.raises(SpanTreeRecordingError):
+        await evaluator.evaluate_async(ctx)
+
+
+async def test_role_adherence_propagates_span_tree_recording_error():
+    ctx: EvaluatorContext[Any, Any, Any] = EvaluatorContext(
+        name='test',
+        inputs={},
+        metadata=None,
+        expected_output=None,
+        output='',
+        duration=0.0,
+        _span_tree=SpanTreeRecordingError('spans were not recorded'),
+        attributes={},
+        metrics={},
+    )
+    evaluator = RoleAdherence(role='x')
+    with pytest.raises(SpanTreeRecordingError):
+        await evaluator.evaluate_async(ctx)
+
+
+async def test_conversation_goal_achievement_calls_judge_and_returns_result(mocker: MockerFixture):
+    """With turns present, the evaluator calls `judge_conversation_goal` and maps the result."""
+    mock_judge = mocker.patch(
+        'pydantic_evals.evaluators.conversation.judge_conversation_goal',
+        return_value=GradingOutput(reason='clear resolution', pass_=True, score=0.9),
+    )
+    tree = _tree_with_all_messages(
+        [
+            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Can you reset my password?'}]},
+            {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'Sure. Done.'}]},
+        ]
+    )
+    evaluator = ConversationGoalAchievement(goal='Reset the password.')
+    result = await evaluator.evaluate_async(_ctx_with_tree(tree, output='Done.'))
+    assert result == snapshot(
+        {
+            'goal_achieved': EvaluationReason(value=True, reason='clear resolution'),
+            'goal_achievement_score': 0.9,
+        }
+    )
+    mock_judge.assert_called_once()
+    kwargs = mock_judge.call_args.kwargs
+    assert kwargs['goal'] == 'Reset the password.'
+    assert [t.content for t in kwargs['turns']] == ['Can you reset my password?', 'Sure. Done.']
+    assert kwargs['final_output'] == 'Done.'
+
+
+async def test_conversation_goal_achievement_threshold_boundary(mocker: MockerFixture):
+    """`score == threshold` counts as achieved (>= is the rule, not >)."""
+    mocker.patch(
+        'pydantic_evals.evaluators.conversation.judge_conversation_goal',
+        return_value=GradingOutput(reason='borderline', pass_=False, score=0.7),
+    )
+    tree = _tree_with_all_messages([{'role': 'user', 'parts': [{'type': 'text', 'content': 'go'}]}])
+    evaluator = ConversationGoalAchievement(goal='x', threshold=0.7)
+    result = await evaluator.evaluate_async(_ctx_with_tree(tree))
+    # The user-facing `goal_achieved` uses `score >= threshold`, even though the judge flagged `pass_=False`.
+    goal_achieved = result['goal_achieved']  # type: ignore[index]
+    assert isinstance(goal_achieved, EvaluationReason)
+    assert goal_achieved.value is True
+
+
+async def test_conversation_goal_achievement_score_below_threshold(mocker: MockerFixture):
+    mocker.patch(
+        'pydantic_evals.evaluators.conversation.judge_conversation_goal',
+        return_value=GradingOutput(reason='nope', pass_=False, score=0.3),
+    )
+    tree = _tree_with_all_messages([{'role': 'user', 'parts': [{'type': 'text', 'content': 'go'}]}])
+    evaluator = ConversationGoalAchievement(goal='x')
+    result = await evaluator.evaluate_async(_ctx_with_tree(tree))
+    assert result == snapshot(
+        {
+            'goal_achieved': EvaluationReason(value=False, reason='nope'),
+            'goal_achievement_score': 0.3,
+        }
+    )
+
+
+async def test_conversation_goal_achievement_include_reason_false(mocker: MockerFixture):
+    """With `include_reason=False`, the assertion is a bare bool (no `EvaluationReason`)."""
+    mocker.patch(
+        'pydantic_evals.evaluators.conversation.judge_conversation_goal',
+        return_value=GradingOutput(reason='ok', pass_=True, score=0.9),
+    )
+    tree = _tree_with_all_messages([{'role': 'user', 'parts': [{'type': 'text', 'content': 'go'}]}])
+    evaluator = ConversationGoalAchievement(goal='x', include_reason=False)
+    result = await evaluator.evaluate_async(_ctx_with_tree(tree))
+    assert result == {'goal_achieved': True, 'goal_achievement_score': 0.9}
+
+
+async def test_role_adherence_calls_judge(mocker: MockerFixture):
+    mock_judge = mocker.patch(
+        'pydantic_evals.evaluators.conversation.judge_role_adherence',
+        return_value=GradingOutput(reason='stayed in role', pass_=True, score=1.0),
+    )
+    tree = _tree_with_all_messages(
+        [
+            {'role': 'system', 'parts': [{'type': 'text', 'content': 'You are polite.'}]},
+            {'role': 'user', 'parts': [{'type': 'text', 'content': 'hey'}]},
+            {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'Hello!'}]},
+        ]
+    )
+    evaluator = RoleAdherence(role='polite helper')
+    result = await evaluator.evaluate_async(_ctx_with_tree(tree))
+    assert result == snapshot(
+        {
+            'role_adhered': EvaluationReason(value=True, reason='stayed in role'),
+            'role_adherence_score': 1.0,
+        }
+    )
+    mock_judge.assert_called_once()
+    assert mock_judge.call_args.kwargs['role'] == 'polite helper'
+
+
+async def test_role_adherence_include_reason_false(mocker: MockerFixture):
+    mocker.patch(
+        'pydantic_evals.evaluators.conversation.judge_role_adherence',
+        return_value=GradingOutput(reason='ok', pass_=True, score=0.8),
+    )
+    tree = _tree_with_all_messages([{'role': 'user', 'parts': [{'type': 'text', 'content': 'go'}]}])
+    evaluator = RoleAdherence(role='x', include_reason=False)
+    result = await evaluator.evaluate_async(_ctx_with_tree(tree))
+    assert result == {'role_adhered': True, 'role_adherence_score': 0.8}
+
+
+# --------------------------------------------------------------------------- serialization
+
+
+async def test_evaluator_serialization_model_passthrough():
+    """A string model is preserved; a `Model` instance is serialized as its `model_id`."""
+    evaluator = ConversationGoalAchievement(goal='x', model='openai:gpt-5.2')
+    args = evaluator.build_serialization_arguments()
+    assert args['model'] == 'openai:gpt-5.2'
+
+    evaluator_role = RoleAdherence(role='y', model='anthropic:claude-opus-4-5')
+    args_role = evaluator_role.build_serialization_arguments()
+    assert args_role['model'] == 'anthropic:claude-opus-4-5'
+
+
+async def test_evaluator_serialization_model_instance():
+    """A `Model` instance is serialized using its `model_id`."""
+    from pydantic_ai.models.test import TestModel
+
+    model = TestModel()
+    args = ConversationGoalAchievement(goal='x', model=model).build_serialization_arguments()
+    assert args['model'] == model.model_id
+
+    args_role = RoleAdherence(role='y', model=model).build_serialization_arguments()
+    assert args_role['model'] == model.model_id
+
+
+async def test_conversation_evaluators_are_registered_as_defaults():
+    """The new evaluators are surfaced in DEFAULT_EVALUATORS so specs can deserialize them."""
+    from pydantic_evals.evaluators.common import DEFAULT_EVALUATORS
+
+    assert ConversationGoalAchievement in DEFAULT_EVALUATORS
+    assert RoleAdherence in DEFAULT_EVALUATORS

--- a/tests/evals/test_conversation_integration.py
+++ b/tests/evals/test_conversation_integration.py
@@ -1,0 +1,163 @@
+"""Integration tests for conversation-level evaluators that exercise the judge agent end-to-end.
+
+We deliberately avoid VCR cassettes here: instead of replaying recorded HTTP traffic from a
+hosted LLM, we use [`FunctionModel`][pydantic_ai.models.function.FunctionModel] as the judge
+model. That keeps the tests hermetic (no API key, no network) while still driving the full
+stack — `evaluator.evaluate()` → `extract_conversation_turns` → `judge_conversation_goal` /
+`judge_role_adherence` → Pydantic AI agent run — so we catch regressions that a mock of the
+judge helper would miss.
+
+Span trees are built with real `logfire.span` calls so that the `pydantic_ai.all_messages`
+attribute is inspected the same way it would be in production.
+"""
+
+from __future__ import annotations as _annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from .._inline_snapshot import snapshot
+from ..conftest import try_import
+
+with try_import() as imports_successful:
+    from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+    from pydantic_evals.evaluators import (
+        ConversationGoalAchievement,
+        EvaluationReason,
+        EvaluatorContext,
+        RoleAdherence,
+    )
+
+with try_import() as logfire_import_successful:
+    import logfire
+    from logfire.testing import CaptureLogfire
+
+    from pydantic_evals.otel._context_in_memory_span_exporter import context_subtree
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='pydantic-evals not installed'),
+    pytest.mark.skipif(not logfire_import_successful(), reason='logfire not installed'),
+    pytest.mark.anyio,
+]
+
+
+def _make_grading_function(*, reason: str, pass_: bool, score: float) -> Any:
+    """Return a judge function that responds with a fixed GradingOutput JSON payload."""
+
+    async def judge_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        # The judge prompt is always rendered as plain text by `_build_conversation_prompt`,
+        # so we don't need to inspect it — just produce a structured grading response.
+        del messages, info  # unused; grading output is deterministic for this test
+        payload = json.dumps({'reason': reason, 'pass': pass_, 'score': score})
+        return ModelResponse(parts=[TextPart(content=payload)])
+
+    return judge_function
+
+
+def _build_context_with_run_span(
+    all_messages: list[dict[str, Any]],
+    *,
+    output: Any,
+    new_message_index: int | None = None,
+) -> EvaluatorContext[Any, Any, Any]:
+    """Build an `EvaluatorContext` whose `span_tree` contains a real logfire span with the
+    `pydantic_ai.all_messages` attribute set, matching the shape that Pydantic AI emits at
+    the end of an agent run.
+    """
+    attrs: dict[str, Any] = {'pydantic_ai.all_messages': json.dumps(all_messages)}
+    if new_message_index is not None:
+        attrs['pydantic_ai.new_message_index'] = new_message_index
+
+    with context_subtree() as tree:
+        with logfire.span('agent run', **attrs):
+            pass
+
+    return EvaluatorContext(
+        name='integration',
+        inputs={},
+        metadata=None,
+        expected_output=None,
+        output=output,
+        duration=0.0,
+        _span_tree=tree,
+        attributes={},
+        metrics={},
+    )
+
+
+async def test_conversation_goal_achievement_integration(capfire: CaptureLogfire):
+    """End-to-end: extraction + judge + threshold wiring, with the judge producing a high score."""
+    assert capfire  # keeps logfire configured for the test
+
+    ctx = _build_context_with_run_span(
+        [
+            {'role': 'system', 'parts': [{'type': 'text', 'content': 'Help the user reset their password.'}]},
+            {'role': 'user', 'parts': [{'type': 'text', 'content': 'I forgot my password.'}]},
+            {
+                'role': 'assistant',
+                'parts': [
+                    {'type': 'text', 'content': "I'll send a reset link to your email. Check your inbox."},
+                ],
+            },
+        ],
+        output='Reset link sent.',
+    )
+
+    judge_model = FunctionModel(
+        _make_grading_function(reason='The agent resolved the reset request cleanly.', pass_=True, score=0.9)
+    )
+    evaluator = ConversationGoalAchievement(
+        goal='Reset the user password and tell them what to do next.',
+        threshold=0.8,
+        model=judge_model,
+    )
+    result = await evaluator.evaluate_async(ctx)
+    assert result == snapshot(
+        {
+            'goal_achieved': EvaluationReason(value=True, reason='The agent resolved the reset request cleanly.'),
+            'goal_achievement_score': 0.9,
+        }
+    )
+
+
+async def test_role_adherence_integration(capfire: CaptureLogfire):
+    """End-to-end: extraction + role-adherence judge, judge flags a specific turn."""
+    assert capfire
+
+    ctx = _build_context_with_run_span(
+        [
+            {'role': 'system', 'parts': [{'type': 'text', 'content': 'You are a customer support assistant.'}]},
+            {'role': 'user', 'parts': [{'type': 'text', 'content': 'Are stocks a good buy right now?'}]},
+            {
+                'role': 'assistant',
+                'parts': [{'type': 'text', 'content': "You should definitely buy tech stocks; they're undervalued."}],
+            },
+        ],
+        output="You should definitely buy tech stocks; they're undervalued.",
+    )
+
+    judge_model = FunctionModel(
+        _make_grading_function(
+            reason='At turn 2 the assistant gave financial advice, breaking the support-only role.',
+            pass_=False,
+            score=0.4,
+        )
+    )
+    evaluator = RoleAdherence(
+        role='customer support assistant; never gives financial advice.',
+        threshold=0.7,
+        model=judge_model,
+    )
+    result = await evaluator.evaluate_async(ctx)
+    assert result == snapshot(
+        {
+            'role_adhered': EvaluationReason(
+                value=False,
+                reason='At turn 2 the assistant gave financial advice, breaking the support-only role.',
+            ),
+            'role_adherence_score': 0.4,
+        }
+    )

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -1010,10 +1010,10 @@ async def test_from_text_failure():
                 '2 error(s) loading evaluators from registry',
                 [
                     ValueError(
-                        "Evaluator 'NotAnEvaluator' is not in the provided `custom_evaluator_types`. Valid choices: ['Equals', 'EqualsExpected', 'Contains', 'IsInstance', 'MaxDuration', 'LLMJudge', 'HasMatchingSpan']. If you are trying to use a custom evaluator, you must include its type in the `custom_evaluator_types` argument."
+                        "Evaluator 'NotAnEvaluator' is not in the provided `custom_evaluator_types`. Valid choices: ['Equals', 'EqualsExpected', 'Contains', 'IsInstance', 'MaxDuration', 'LLMJudge', 'HasMatchingSpan', 'ConversationGoalAchievement', 'RoleAdherence']. If you are trying to use a custom evaluator, you must include its type in the `custom_evaluator_types` argument."
                     ),
                     ValueError(
-                        "Evaluator 'NotAnEvaluator' is not in the provided `custom_evaluator_types`. Valid choices: ['Equals', 'EqualsExpected', 'Contains', 'IsInstance', 'MaxDuration', 'LLMJudge', 'HasMatchingSpan']. If you are trying to use a custom evaluator, you must include its type in the `custom_evaluator_types` argument."
+                        "Evaluator 'NotAnEvaluator' is not in the provided `custom_evaluator_types`. Valid choices: ['Equals', 'EqualsExpected', 'Contains', 'IsInstance', 'MaxDuration', 'LLMJudge', 'HasMatchingSpan', 'ConversationGoalAchievement', 'RoleAdherence']. If you are trying to use a custom evaluator, you must include its type in the `custom_evaluator_types` argument."
                     ),
                 ],
             )


### PR DESCRIPTION
## Summary

Adds a shared conversation-extraction layer and two evaluators built on top of it. The extraction layer is the reusable primitive — the evaluators demonstrate the pattern with two real consumers.

Supersedes #4933 — builds on @techno-anthropology's original plan, with a few refinements from review.

**Public extraction API in `pydantic_evals.evaluators.extraction`:**

- `ConversationTurn(role, content, turn_index, tool_name?, tool_arguments?)` — flat turn extracted from OTel spans.
- `extract_conversation_turns(span_tree)` — parses `pydantic_ai.all_messages` per the typed OTel part schema, falls back to `gen_ai.input.messages` / `gen_ai.output.messages` on model-request spans, honors `pydantic_ai.new_message_index` for continued runs. Per-part error resilience: malformed JSON / missing fields / unknown part types are logged at WARNING and skipped rather than raising.
- `format_transcript(turns)` — numbered transcript rendering for judge prompts.

Users can build their own conversation-level evaluators on top of these primitives.

**Two evaluators in `pydantic_evals.evaluators.conversation`:**

- `ConversationGoalAchievement(goal, threshold=0.7, model, model_settings, include_reason=True)` — holistic single-call LLM-judge scoring of whether a multi-turn conversation achieved a stated goal. Returns `{'goal_achieved': EvaluationReason|bool, 'goal_achievement_score': float}`, with `goal_achieved = score >= threshold` (user-configurable, not the judge's `pass_`).
- `RoleAdherence(role, threshold=0.7, model, model_settings, include_reason=True)` — judges whether every assistant turn stayed within a stated role; reason text cites offending turn numbers. Same shape as `ConversationGoalAchievement`.

Both reuse `GradingOutput` and follow the existing `LLMJudge`/`_judge_output_agent` pattern. New judge helpers `judge_conversation_goal` and `judge_role_adherence` added to `llm_as_a_judge.py`.

**Refinements from review vs the original plan:**
- Renamed `GoalAchievement` → `ConversationGoalAchievement` to make it clear this is one rubric among many, not THE canonical conversation metric.
- Shipped `RoleAdherence` alongside it so the extraction abstraction has two real consumers out of the gate.
- Extraction functions are public (exported from `pydantic_evals.evaluators`) so users can wire their own conversation evaluators.

**Not a breaking change.** Purely additive.

## Tests

- 40 unit tests in `tests/evals/test_conversation.py` + 2 end-to-end integration tests in `tests/evals/test_conversation_integration.py`, 100% line+branch coverage on new modules.
- Integration tests use `FunctionModel` (hermetic, no API keys / no VCR cassettes needed) rather than live-recorded cassettes, matching the surrounding suite which has no VCR infra. If real-model recordings are desired later, they can be added without touching prod code.
- Covers: basic flatten, multi-part assistant with tool calls, system-only, multimodal placeholders, malformed JSON / non-list / non-string attribute, missing role / non-dict message / non-list parts / unknown part type, continued-conversation respects `new_message_index`, invalid `new_message_index` falls back, gen_ai fallback paths, `format_transcript` shape, no-turns failure paths, `SpanTreeRecordingError` propagation, threshold boundary (`score == threshold` → True), `include_reason=False` bare bool path, `Model` instance serialization.
- `make lint`, `make format`, `make typecheck`: all clean.
- Full `tests/evals/` suite: 423 passed.

## Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).