### PR TITLE
docs: add Doubleword as an OpenAI-compatible provider

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -845,11 +845,3 @@ agent = Agent(model)
 ```
 
 For a complete list of available models, see the [Doubleword models documentation](https://docs.doubleword.ai/inference-api/models).
-
-#### Batch Pricing
-
-Doubleword offers batch pricing with up to 90% savings on inference costs. You can use the [`autobatcher`](https://pypi.org/project/autobatcher/) package to automatically batch requests:
-
-```bash
-pip install autobatcher
-```

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -845,3 +845,38 @@ agent = Agent(model)
 ```
 
 For a complete list of available models, see the [Doubleword models documentation](https://docs.doubleword.ai/inference-api/models).
+
+#### Batch and async (flex) pricing via `autobatcher`
+
+For background workloads, Doubleword exposes two off-realtime pricing tiers
+through the [`autobatcher`](https://pypi.org/project/autobatcher/) package,
+both of which are drop-in subclasses of `openai.AsyncOpenAI`:
+
+- `BatchOpenAI` — 24-hour batch tier (deepest discount, up to ~90% off realtime).
+- `AsyncOpenAI` — 1-hour flex tier (between realtime and batch on cost and latency).
+
+`OpenAIProvider` accepts an `openai_client` argument, so you can pass either
+client directly:
+
+```python
+import os
+
+from autobatcher import AsyncOpenAI  # or BatchOpenAI for the 24h tier
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+model = OpenAIChatModel(
+    'Qwen/Qwen3.5-397B-A17B-FP8',
+    provider=OpenAIProvider(
+        openai_client=AsyncOpenAI(  # 1h flex tier
+            base_url='https://api.doubleword.ai/v1',
+            api_key=os.environ['DOUBLEWORD_API_KEY'],
+        ),
+    ),
+)
+agent = Agent(model)
+```
+
+Concurrent calls fanned out from agent runs are collected into a single
+batch submission under the hood — no other code changes required.

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -819,3 +819,37 @@ model = OpenAIChatModel(
 agent = Agent(model)
 ...
 ```
+
+### Doubleword
+
+To use [Doubleword](https://doubleword.ai), create an API key from the [Doubleword dashboard](https://doubleword.ai).
+
+You can set the `DOUBLEWORD_API_KEY` environment variable and use `OpenAIProvider` with the Doubleword base URL:
+
+```python
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+model = OpenAIChatModel(
+    'Qwen/Qwen3.5-397B-A17B-FP8',
+    provider=OpenAIProvider(
+        base_url='https://api.doubleword.ai/v1',
+        api_key=os.environ['DOUBLEWORD_API_KEY'],
+    ),
+)
+agent = Agent(model)
+...
+```
+
+For a complete list of available models, see the [Doubleword models documentation](https://docs.doubleword.ai/inference-api/models).
+
+#### Batch Pricing
+
+Doubleword offers batch pricing with up to 90% savings on inference costs. You can use the [`autobatcher`](https://pypi.org/project/autobatcher/) package to automatically batch requests:
+
+```bash
+pip install autobatcher
+```

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -22,6 +22,7 @@ In addition, many providers are compatible with the OpenAI API, and can be used 
 - [Alibaba Cloud Model Studio (DashScope)](openai.md#alibaba-cloud-model-studio-dashscope)
 - [Azure AI Foundry](openai.md#azure-ai-foundry)
 - [DeepSeek](openai.md#deepseek)
+- [Doubleword](openai.md#doubleword)
 - [Fireworks AI](openai.md#fireworks-ai)
 - [GitHub Models](openai.md#github-models)
 - [Heroku](openai.md#heroku-ai)


### PR DESCRIPTION
## Summary

- Adds Doubleword to the OpenAI-compatible providers section in `docs/models/openai.md`
- Adds Doubleword to the provider list in `docs/models/overview.md`

Doubleword exposes an OpenAI-compatible API at `https://api.doubleword.ai/v1` and can be used with `OpenAIProvider` and `OpenAIChatModel`. The docs section includes a configuration example, a link to available models, and a note about batch pricing via the `autobatcher` package.

- Website: https://doubleword.ai
- Docs: https://docs.doubleword.ai

## Test plan

- [ ] Verify `mkdocs serve` builds without errors
- [ ] Check the Doubleword section renders correctly under OpenAI-compatible Models
- [ ] Confirm the overview page lists Doubleword in alphabetical order