### PR TITLE
Always return dict-shaped validated args for single-BaseModel tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_function_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_function_schema.py
@@ -12,7 +12,7 @@ from functools import partial
 from inspect import Parameter, signature
 from typing import TYPE_CHECKING, Any, Concatenate, Literal, cast, get_args, get_origin
 
-from pydantic import ConfigDict, TypeAdapter
+from pydantic import ConfigDict, TypeAdapter, ValidationError
 from pydantic._internal import _decorators, _generate_schema
 from pydantic._internal._config import ConfigWrapper
 from pydantic.errors import PydanticSchemaGenerationError, PydanticUserError
@@ -299,8 +299,13 @@ def _build_schema(
             # so the model generates its fields at the top level rather than inside a redundant wrapper.
             # The validator output is wrapped to `{name: value}` so validated args are always a dict
             # keyed by parameter name — matching the contract that hooks and `call_tool` rely on.
+            # Use a wrap validator so we also accept the already-wrapped `{name: value}` shape,
+            # which is what Temporal (and any other caller) passes when re-validating previously
+            # validated args after serialization round-trip.
             return (
-                core_schema.no_info_after_validator_function(partial(_wrap_single_arg, name=name), td_field['schema']),
+                core_schema.no_info_wrap_validator_function(
+                    partial(_validate_single_arg, name=name), td_field['schema']
+                ),
                 name,
             )
 
@@ -314,8 +319,20 @@ def _build_schema(
     return td_schema, None
 
 
-def _wrap_single_arg(value: Any, *, name: str) -> dict[str, Any]:
-    return {name: value}
+def _validate_single_arg(
+    value: Any,
+    handler: core_schema.ValidatorFunctionWrapHandler,
+    *,
+    name: str,
+) -> dict[str, Any]:
+    try:
+        return {name: handler(value)}
+    except ValidationError:
+        # Fall back to unwrapping the `{name: value}` shape produced by a previous validation pass
+        # (e.g. after Temporal serialization/deserialization of already-validated args).
+        if isinstance(value, dict) and list(cast(dict[Any, Any], value)) == [name]:
+            return {name: handler(value[name])}
+        raise
 
 
 def _extract_return_schema_type(return_annotation: Any, function: Callable[..., Any]) -> Any:

--- a/pydantic_ai_slim/pydantic_ai/_function_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_function_schema.py
@@ -72,9 +72,6 @@ class FunctionSchema:
         args_dict: dict[str, Any],
         ctx: RunContext[Any],
     ) -> tuple[list[Any], dict[str, Any]]:
-        if self.single_arg_name:
-            args_dict = {self.single_arg_name: args_dict}
-
         args = [ctx] if self.takes_ctx else []
         for positional_field in self.positional_fields:
             args.append(args_dict.pop(positional_field))  # pragma: no cover
@@ -298,7 +295,14 @@ def _build_schema(
         name = next(iter(fields))
         td_field = fields[name]
         if td_field['metadata']['is_model_like']:  # type: ignore
-            return td_field['schema'], name
+            # The JSON schema sent to the model is the model-like parameter's schema directly (unwrapped),
+            # so the model generates its fields at the top level rather than inside a redundant wrapper.
+            # The validator output is wrapped to `{name: value}` so validated args are always a dict
+            # keyed by parameter name — matching the contract that hooks and `call_tool` rely on.
+            return (
+                core_schema.no_info_after_validator_function(partial(_wrap_single_arg, name=name), td_field['schema']),
+                name,
+            )
 
     extra_behavior: Literal['allow', 'forbid'] = 'allow' if var_kwargs_schema else 'forbid'
     td_schema = core_schema.typed_dict_schema(
@@ -308,6 +312,10 @@ def _build_schema(
         extras_schema=var_kwargs_schema,
     )
     return td_schema, None
+
+
+def _wrap_single_arg(value: Any, *, name: str) -> dict[str, Any]:
+    return {name: value}
 
 
 def _extract_return_schema_type(return_annotation: Any, function: Callable[..., Any]) -> Any:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import anyio
 import pytest
+from pydantic import BaseModel
 
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._spec import CapabilitySpec, NamedSpec
@@ -2323,6 +2324,11 @@ async def tool_calling_stream_function(
     yield 'no tools available'  # pragma: no cover
 
 
+# Defined at module scope so pydantic-ai can resolve the annotation under `from __future__ import annotations`.
+class SingleBaseModelArg(BaseModel):
+    label: str = 'default'
+
+
 def tool_calling_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
     """A model that calls a tool on first request, then returns text."""
     # Check if there's already a tool return in messages (i.e., tool was called)
@@ -2996,6 +3002,52 @@ class TestToolExecuteHooks:
 
         await agent.run('call tool')
         assert cap.caught_error == 'tool failed'
+
+    async def test_hooks_receive_dict_args_for_single_base_model_tool(self):
+        """Validate and execute hooks receive dict-shaped args when the tool has a single BaseModel parameter.
+
+        The JSON schema sent to the model unwraps the BaseModel, so the model generates its fields at the
+        top level. Pydantic's validator returns a BaseModel instance directly, but the framework wraps it
+        as `{param_name: model}` so hooks and `call_tool` always see a dict.
+        """
+        captured_args: list[tuple[str, dict[str, Any]]] = []
+
+        @dataclass
+        class CapturingCap(AbstractCapability[Any]):
+            async def after_tool_validate(
+                self,
+                ctx: RunContext[Any],
+                *,
+                call: ToolCallPart,
+                tool_def: ToolDefinition,
+                args: dict[str, Any],
+            ) -> dict[str, Any]:
+                captured_args.append(('validate', args))
+                return args
+
+            async def wrap_tool_execute(
+                self,
+                ctx: RunContext[Any],
+                *,
+                call: ToolCallPart,
+                tool_def: ToolDefinition,
+                args: dict[str, Any],
+                handler: Any,
+            ) -> Any:
+                captured_args.append(('execute', args))
+                return await handler(args)
+
+        agent = Agent(FunctionModel(tool_calling_model), capabilities=[CapturingCap()])
+
+        @agent.tool_plain
+        def my_tool(payload: SingleBaseModelArg) -> str:
+            return f'got {payload.label}'
+
+        await agent.run('call the tool')
+        assert captured_args == [
+            ('validate', {'payload': SingleBaseModelArg()}),
+            ('execute', {'payload': SingleBaseModelArg()}),
+        ]
 
 
 class TestCompositionOrder:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3728,6 +3728,33 @@ def test_args_validator_not_double_called_for_approved_tools():
     assert validator_calls[0] == (0, True)  # retry=0, approved=True
 
 
+def test_args_validator_single_base_model_arg():
+    """`args_validator` works when a tool has a single BaseModel parameter.
+
+    The tool's JSON schema is the BaseModel's fields directly (unwrapped), but the validated
+    args dict remains keyed by parameter name so `args_validator_func(ctx, **args)` unpacks correctly.
+    """
+
+    class MyArgs(BaseModel):
+        x: int
+        y: int
+
+    validator_calls: list[MyArgs] = []
+
+    def my_validator(ctx: RunContext[int], argument: MyArgs) -> None:
+        validator_calls.append(argument)
+
+    agent = Agent(TestModel(), deps_type=int)
+
+    @agent.tool(args_validator=my_validator)
+    def add_numbers(ctx: RunContext[int], argument: MyArgs) -> int:
+        return argument.x + argument.y
+
+    agent.run_sync('call add_numbers', deps=42)
+    assert len(validator_calls) == 1
+    assert isinstance(validator_calls[0], MyArgs)
+
+
 def test_tool_ctx_agent():
     """ctx.agent gives tools access to the running agent's properties."""
     agent = Agent('test', name='my_agent', output_type=int)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3755,6 +3755,27 @@ def test_args_validator_single_base_model_arg():
     assert isinstance(validator_calls[0], MyArgs)
 
 
+def test_single_base_model_arg_validator_accepts_wrapped_input():
+    """The single-BaseModel-arg validator also accepts already-wrapped `{name: value}` input.
+
+    This shape arises when previously-validated args are serialized out (e.g. through Temporal's
+    activity boundary) and then re-validated with the same schema.
+    """
+
+    class Payload(BaseModel):
+        city: str
+
+    def my_tool(argument: Payload) -> str:  # pragma: no cover
+        return argument.city
+
+    tool = Tool(my_tool)
+    validator = tool.function_schema.validator
+
+    raw = validator.validate_python({'city': 'Mexico City'})
+    wrapped = validator.validate_python({'argument': {'city': 'Mexico City'}})
+    assert raw == wrapped == {'argument': Payload(city='Mexico City')}
+
+
 def test_tool_ctx_agent():
     """ctx.agent gives tools access to the running agent's properties."""
     agent = Agent('test', name='my_agent', output_type=int)


### PR DESCRIPTION
- Closes #5134

### Problem

When a tool function has exactly one "model-like" parameter (`BaseModel`, dataclass, `TypedDict`), the JSON schema sent to the model is the parameter's schema directly — so the model generates the model's fields at the top level instead of inside a redundant wrapper. However, Pydantic validation then returned the `BaseModel` instance itself rather than a `{param_name: instance}` dict. This violated the `ValidatedToolArgs = dict[str, Any]` type contract and broke every downstream consumer that relied on a dict-shaped view:

- Capability hooks: `after_tool_validate`, `wrap_tool_validate`, `before_tool_execute`, `after_tool_execute`, `wrap_tool_execute`, `on_tool_execute_error`, `on_tool_validate_error`
- `ValidatedToolCall.validated_args: dict[str, Any] | None`
- `AbstractToolset.call_tool(tool_args: dict[str, Any], ...)`
- **`args_validator_func(ctx, **args)`** — silently broken at runtime, since `**base_model_instance` isn't a valid mapping unpack

### Fix

Wrap the validator's core schema with `core_schema.no_info_after_validator_function` that produces `{single_arg_name: value}`. The JSON schema sent to the model is unchanged (pydantic's JSON schema generator delegates to the inner schema for `function-after`), so the model keeps receiving the BaseModel's fields at the top level — but the validator's output is uniformly dict-shaped, so every downstream consumer sees the same contract.

The now-redundant rewrapping inside `FunctionSchema._call_args` is removed.

### Tests

- `test_args_validator_single_base_model_arg` confirms `args_validator` now works with single-BaseModel-arg tools (was silently broken)
- `test_hooks_receive_dict_args_for_single_base_model_tool` confirms `after_tool_validate` and `wrap_tool_execute` hooks both receive dict-shaped args

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).