### PR TITLE
docs: remove stray comma in README tools example comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ class SupportOutput(BaseModel):
 support_agent = Agent(
     'openai:gpt-5.2',
     deps_type=SupportDependencies,
-    # The response from the agent will, be guaranteed to be a SupportOutput,
+    # The response from the agent will be guaranteed to be a SupportOutput,
     # if validation fails the agent is prompted to try again.
     output_type=SupportOutput,
     instructions=(


### PR DESCRIPTION
### What

In the README's "Tools & Dependency Injection Example" code block, the inline comment above `output_type=SupportOutput` read:

```python
# The response from the agent will, be guaranteed to be a SupportOutput,
```

Remove the stray comma after `will` so the comment reads as intended:

```python
# The response from the agent will be guaranteed to be a SupportOutput,
```

### Why

Small README polish — the comma-splice made a landing-page code comment slightly awkward to read. The equivalent prose in `docs/index.md` already uses "will be guaranteed", so this aligns the README with the docs.

No code, behavior, or public API changes. One line in `README.md`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

---
_Part of open-source blockchain work from [kcolbchain.com](https://kcolbchain.com) — maintained by [Abhishek Krishna](https://abhishekkrishna.com). PR opened via [kcolbchain contrib-bot](https://github.com/kcolbchain/kcolbchain.github.io/blob/master/deploy/contrib-bot/README.md)._