### PR TITLE
Handle dict `reasoning_content` from Gemini 2.5 models

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -996,7 +996,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             if not field_name:
                 continue
             reasoning: str | None = getattr(message, field_name, None)
-            if reasoning:  # pragma: no branch
+            if isinstance(reasoning, str) and reasoning:  # guard against non-string values (e.g. Gemini returns a dict)
                 items.append(ThinkingPart(id=field_name, content=reasoning, provider_name=self.system))
                 return items
 
@@ -2705,7 +2705,7 @@ class OpenAIStreamedResponse(StreamedResponse):
             if not field_name:
                 continue
             reasoning: str | None = getattr(choice.delta, field_name, None)
-            if reasoning:  # pragma: no branch
+            if isinstance(reasoning, str) and reasoning:  # guard against non-string values (e.g. Gemini returns a dict)
                 yield from self._parts_manager.handle_thinking_delta(
                     vendor_part_id=field_name,
                     id=field_name,

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -995,10 +995,18 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         for field_name in (custom_field, 'reasoning', 'reasoning_content'):
             if not field_name:
                 continue
-            reasoning: str | None = getattr(message, field_name, None)
-            if isinstance(reasoning, str) and reasoning:  # guard against non-string values (e.g. Gemini returns a dict)
-                items.append(ThinkingPart(id=field_name, content=reasoning, provider_name=self.system))
-                return items
+            reasoning: object = getattr(message, field_name, None)
+            if not reasoning:
+                continue
+            if not isinstance(reasoning, str):
+                warnings.warn(
+                    f'Unexpected non-string value for {field_name!r}: {type(reasoning).__name__}. '
+                    'Please open an issue at https://github.com/pydantic/pydantic-ai/issues.',
+                    UserWarning,
+                )
+                continue
+            items.append(ThinkingPart(id=field_name, content=reasoning, provider_name=self.system))
+            return items
 
         return items or None
 
@@ -2704,15 +2712,23 @@ class OpenAIStreamedResponse(StreamedResponse):
         for field_name in (custom_field, 'reasoning', 'reasoning_content'):
             if not field_name:
                 continue
-            reasoning: str | None = getattr(choice.delta, field_name, None)
-            if isinstance(reasoning, str) and reasoning:  # guard against non-string values (e.g. Gemini returns a dict)
-                yield from self._parts_manager.handle_thinking_delta(
-                    vendor_part_id=field_name,
-                    id=field_name,
-                    content=reasoning,
-                    provider_name=self.provider_name,
+            reasoning: object = getattr(choice.delta, field_name, None)
+            if not reasoning:
+                continue
+            if not isinstance(reasoning, str):
+                warnings.warn(
+                    f'Unexpected non-string value for {field_name!r}: {type(reasoning).__name__}. '
+                    'Please open an issue at https://github.com/pydantic/pydantic-ai/issues.',
+                    UserWarning,
                 )
-                break
+                continue
+            yield from self._parts_manager.handle_thinking_delta(
+                vendor_part_id=field_name,
+                id=field_name,
+                content=reasoning,
+                provider_name=self.provider_name,
+            )
+            break
 
     def _map_text_delta(self, choice: chat_completion_chunk.Choice) -> Iterable[ModelResponseStreamEvent]:
         """Hook that maps text delta content to events.

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4264,6 +4264,43 @@ async def test_openai_auto_mode_no_thinking_field_uses_default_fields(allow_mode
     assert mapped2 == snapshot({'role': 'assistant', 'reasoning_content': 'thought', 'content': 'response'})
 
 
+async def test_openai_non_string_reasoning_content_warns(allow_model_requests: None):
+    """Malformed OpenAI-compatible responses where `reasoning_content` is a dict (e.g. via a buggy gateway)
+    should not crash; they should emit a warning and be skipped."""
+    dict_reasoning = {'reasoningContent': {'reasoningText': {'text': '', 'signature': 'CoAI...'}}}
+    c = completion_message(
+        ChatCompletionMessage.model_construct(content='response', reasoning_content=dict_reasoning, role='assistant')
+    )
+    m = OpenAIChatModel('foobar', provider=OpenAIProvider(openai_client=MockOpenAI.create_mock(c)))
+    settings = ModelSettings()
+    params = ModelRequestParameters()
+
+    with pytest.warns(UserWarning, match=r"Unexpected non-string value for 'reasoning_content': dict"):
+        resp = await m.request(messages=[], model_settings=settings, model_request_parameters=params)
+
+    assert [p for p in resp.parts if isinstance(p, ThinkingPart)] == []
+
+
+async def test_openai_non_string_reasoning_content_warns_stream(allow_model_requests: None):
+    """Streaming equivalent: dict `reasoning_content` deltas should warn instead of crashing."""
+    dict_reasoning = {'reasoningContent': {'reasoningText': {'text': '', 'signature': 'CoAI...'}}}
+    stream = [
+        chunk([ChoiceDelta.model_construct(role='assistant', reasoning_content=dict_reasoning)]),
+        chunk([ChoiceDelta(content='response')]),
+        chunk([ChoiceDelta()], finish_reason='stop'),
+    ]
+    m = OpenAIChatModel('foobar', provider=OpenAIProvider(openai_client=MockOpenAI.create_mock_stream(stream)))
+    agent = Agent(m)
+
+    with pytest.warns(UserWarning, match=r"Unexpected non-string value for 'reasoning_content': dict"):
+        async with agent.run_stream('') as result:
+            await result.get_output()
+
+    messages = result.all_messages()
+    response = next(m for m in messages if isinstance(m, ModelResponse))
+    assert [p for p in response.parts if isinstance(p, ThinkingPart)] == []
+
+
 async def test_openai_auto_mode_mismatched_field_uses_tags(allow_model_requests: None):
     """Test that auto mode falls back to tags when configured field doesn't match where reasoning comes from."""
     # Configure thinking_field as 'reasoning_content', but reasoning comes in 'reasoning'


### PR DESCRIPTION
## Summary

Gemini 2.5 models (Flash and Pro) return `reasoning_content` as a **dict** in their OpenAI-compatible response, not a string. Other thinking/reasoning models via OpenAI-compatible proxies may exhibit the same behavior.

The existing truthy check (`if reasoning:`) treats a non-empty dict as valid, storing it as `ThinkingPart.content`. On the **second** API call, `_into_message_param()` calls `'\n\n'.join(contents)` which raises:

```
TypeError: sequence item 0: expected str instance, dict found
```

This crashes any multi-step / ReAct agent using Gemini 2.5 after the first tool call.

## Fix

Add an `isinstance(reasoning, str)` guard in both the non-streamed and streamed `_process_thinking` paths so non-string values are silently ignored:

```diff
- if reasoning:  # pragma: no branch
+ if isinstance(reasoning, str) and reasoning:  # guard against non-string values (e.g. Gemini 2.5 returns a dict)
```

## Reproduction

```python
import types

msg = types.SimpleNamespace(
    reasoning_content={"reasoningContent": {"reasoningText": {"text": "", "signature": "abc"}}},
    reasoning=None,
)

reasoning = getattr(msg, "reasoning_content", None)

try:
    "\n\n".join([reasoning])
except TypeError as e:
    print(f"BUG: {e}")  # sequence item 0: expected str instance, dict found

if isinstance(reasoning, str) and reasoning:
    pass
else:
    print("Fix: non-string reasoning_content ignored")
```



<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #5157

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
