### PR TITLE
upgrade Anthropic code execution tool to version 20250825

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -88,7 +88,7 @@ try:
         BetaCacheControlEphemeralParam,
         BetaCitationsConfigParam,
         BetaCitationsDelta,
-        BetaCodeExecutionTool20250522Param,
+        BetaCodeExecutionTool20250825Param,
         BetaCodeExecutionToolResultBlock,
         BetaCodeExecutionToolResultBlockContent,
         BetaCodeExecutionToolResultBlockParam,
@@ -827,8 +827,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                     )
                 )
             elif isinstance(tool, CodeExecutionTool):  # pragma: no branch
-                tools.append(BetaCodeExecutionTool20250522Param(name='code_execution', type='code_execution_20250522'))
-                beta_features.add('code-execution-2025-05-22')
+                tools.append(BetaCodeExecutionTool20250825Param(name='code_execution', type='code_execution_20250825'))
             elif isinstance(tool, WebFetchTool):  # pragma: no branch
                 citations = BetaCitationsConfigParam(enabled=tool.enable_citations) if tool.enable_citations else None
                 tools.append(

--- a/tests/models/cassettes/test_anthropic/test_anthropic_code_execution_tool.yaml
+++ b/tests/models/cassettes/test_anthropic/test_anthropic_code_execution_tool.yaml
@@ -31,7 +31,7 @@ interactions:
         type: auto
       tools:
       - name: code_execution
-        type: code_execution_20250522
+        type: code_execution_20250825
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     headers:
@@ -127,7 +127,7 @@ interactions:
         type: auto
       tools:
       - name: code_execution
-        type: code_execution_20250522
+        type: code_execution_20250825
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     headers:

--- a/tests/models/cassettes/test_anthropic/test_anthropic_code_execution_tool_stream.yaml
+++ b/tests/models/cassettes/test_anthropic/test_anthropic_code_execution_tool_stream.yaml
@@ -30,7 +30,7 @@ interactions:
         type: auto
       tools:
       - name: code_execution
-        type: code_execution_20250522
+        type: code_execution_20250825
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:

--- a/tests/models/cassettes/test_anthropic/test_anthropic_server_tool_receive_history_from_another_provider.yaml
+++ b/tests/models/cassettes/test_anthropic/test_anthropic_server_tool_receive_history_from_another_provider.yaml
@@ -111,7 +111,7 @@ interactions:
         type: auto
       tools:
       - name: code_execution
-        type: code_execution_20250522
+        type: code_execution_20250825
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     headers:

--- a/tests/models/cassettes/test_google/test_google_model_server_tool_receive_history_from_another_provider.yaml
+++ b/tests/models/cassettes/test_google/test_google_model_server_tool_receive_history_from_another_provider.yaml
@@ -27,7 +27,7 @@ interactions:
         type: auto
       tools:
       - name: code_execution
-        type: code_execution_20250522
+        type: code_execution_20250825
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     headers:


### PR DESCRIPTION
## Summary

Upgrades the Anthropic code execution tool from the legacy `code_execution_20250522` to `code_execution_20250825`.

**Changes:**
- Replace `BetaCodeExecutionTool20250522Param` with `BetaCodeExecutionTool20250825Param` in the model
- Remove the now-unnecessary `code-execution-2025-05-22` beta header (the `20250825` version does not require it)
- Update cassette YAML fixtures to reflect the new tool type string

**Why `20250825`?**
The `20250825` version is the stable upgrade path recommended by Anthropic. It works with all models that support code execution and unlocks features like custom file uploads. The `20260120` version (also mentioned in #4954) is limited to Opus 4.5+ / Sonnet 4.5+ and would require additional model-version gating logic.

Closes #4954