### PR TITLE
docs: expand embeddings guide with model selection and reranker recipe

### DIFF
--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -77,6 +77,22 @@ async def main():
 
 _(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
 
+## Choosing a model
+
+The best embedding model depends on your constraints. Here's a starting-point cheat sheet; consult each provider's docs and the [MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard) before committing to a model for a large index.
+
+| If you want…                         | For example                                                                                                                                                                                                                                      |
+|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| A managed API                        | `openai:text-embedding-3-small` (cheap default), `openai:text-embedding-3-large`, `voyageai:voyage-3.5`, or `cohere:embed-v4.0`                                                                                                                  |
+| No API key, private, free            | `sentence-transformers:google/embeddinggemma-300m`, `sentence-transformers:lightonai/DenseOn`, `sentence-transformers:Qwen/Qwen3-Embedding-0.6B`, or any other [Hugging Face model](https://huggingface.co/models?library=sentence-transformers) |
+| Multilingual                         | `cohere:embed-multilingual-v3.0`, `sentence-transformers:jinaai/jina-embeddings-v5-text-small-retrieval`, or `sentence-transformers:Snowflake/snowflake-arctic-embed-l-v2.0`                                                                     |
+| Specialized domain                   | `voyageai:voyage-code-3`, `voyageai:voyage-law-2`, `voyageai:voyage-finance-2`, `sentence-transformers:nomic-ai/CodeRankEmbed`, or `sentence-transformers:TechWolf/JobBERT-v3`                                                                   |
+| To run on AWS infra you already have | `bedrock:amazon.titan-embed-text-v2:0` or `bedrock:cohere.embed-v4:0`                                                                                                                                                                            |
+| To reduce index size                 | Any model with dimension control (see [Settings](#settings))                                                                                                                                                                                     |
+
+!!! tip "Switching models later"
+    Swapping a model changes the output dimension and the similarity distribution, so you'll need to re-embed (and re-index) your documents. Pick a model you're happy to stick with, or one that supports [dimension control](#settings) so you can tune the index size without changing models.
+
 ## Providers
 
 ### OpenAI
@@ -595,11 +611,12 @@ embedder = Embedder(model)
 
 ### Sentence Transformers (Local)
 
-[`SentenceTransformerEmbeddingModel`][pydantic_ai.embeddings.sentence_transformers.SentenceTransformerEmbeddingModel] runs embeddings locally using the [sentence-transformers](https://www.sbert.net/) library. This is ideal for:
+[`SentenceTransformerEmbeddingModel`][pydantic_ai.embeddings.sentence_transformers.SentenceTransformerEmbeddingModel] runs embeddings locally using the [sentence-transformers](https://www.sbert.net/) library, giving you access to the thousands of [embedding models on Hugging Face](https://huggingface.co/models?library=sentence-transformers) without any API calls. This is ideal for:
 
 - **Privacy** — Data never leaves your infrastructure
 - **Cost** — No API charges for high-volume workloads
 - **Offline use** — No internet connection required after model download
+- **Specialized domains or languages** - Pick models trained for code, multilingual, biomedical, legal, etc. from the [MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard)
 
 #### Install
 
@@ -615,18 +632,18 @@ pip/uv-add "pydantic-ai-slim[sentence-transformers]"
 from pydantic_ai import Embedder
 
 # Model is downloaded from Hugging Face on first use
-embedder = Embedder('sentence-transformers:all-MiniLM-L6-v2')
+embedder = Embedder('sentence-transformers:lightonai/DenseOn')
 
 
 async def main():
     result = await embedder.embed_query('Hello world')
     print(len(result.embeddings[0]))
-    #> 384
+    #> 768
 ```
 
 _(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
 
-See the [Sentence-Transformers pretrained models](https://www.sbert.net/docs/sentence_transformer/pretrained_models.html) documentation for available models.
+[`lightonai/DenseOn`](https://huggingface.co/lightonai/DenseOn) is a strong recent 149M-parameter general-purpose model that encodes queries and documents asymmetrically: [`embed_query()`][pydantic_ai.embeddings.Embedder.embed_query] and [`embed_documents()`][pydantic_ai.embeddings.Embedder.embed_documents] automatically apply the model's `query:` / `document:` prompts. See the [Sentence Transformers pretrained models](https://www.sbert.net/docs/sentence_transformer/pretrained_models.html) documentation and the [MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard) for more options; see also [Choosing a model](#choosing-a-model) above.
 
 #### Device Selection
 
@@ -639,7 +656,7 @@ from pydantic_ai.embeddings.sentence_transformers import (
 )
 
 embedder = Embedder(
-    'sentence-transformers:all-MiniLM-L6-v2',
+    'sentence-transformers:sentence-transformers/all-MiniLM-L6-v2',
     settings=SentenceTransformersEmbeddingSettings(
         sentence_transformers_device='cuda',  # Use GPU
         sentence_transformers_normalize_embeddings=True,  # L2 normalize
@@ -660,7 +677,7 @@ from pydantic_ai.embeddings.sentence_transformers import (
 )
 
 # Create and configure the model yourself
-st_model = SentenceTransformer('all-MiniLM-L6-v2', device='cpu')
+st_model = SentenceTransformer('microsoft/harrier-oss-v1-270m', device='cpu')
 
 # Wrap it for use with Pydantic AI
 model = SentenceTransformerEmbeddingModel(st_model)
@@ -767,6 +784,40 @@ Embedder.instrument_all()
 ```
 
 See the [Debugging and Monitoring guide](logfire.md) for more details on using Logfire with Pydantic AI.
+
+## Two-stage retrieval with rerankers
+
+For high-quality retrieval, a common pattern is **two-stage**: first use an embedding model to pull a broad shortlist of candidates cheaply, then use a **cross-encoder reranker** to score each candidate against the query more precisely. The cross-encoder reads the query and document *together*, so it's slower than an embedding lookup but dramatically more accurate, making it ideal for narrowing a top-100 recall list down to the top-5 results you actually hand to the LLM.
+
+Pydantic AI does not ship a reranker provider class, so you bring your own. The most common local option is a `CrossEncoder` from `sentence-transformers`:
+
+```python {title="rerank.py" max_py="3.13"}
+import asyncio
+from functools import cache
+
+from sentence_transformers import CrossEncoder
+
+
+@cache
+def get_reranker() -> CrossEncoder:
+    # Loaded lazily on first call, then reused.
+    return CrossEncoder('cross-encoder/ms-marco-MiniLM-L6-v2')
+
+
+async def rerank(query: str, candidates: list[str], top_k: int = 3) -> list[str]:
+    """Rerank retrieval candidates by relevance to `query`."""
+    reranker = get_reranker()
+    # CrossEncoder.rank is blocking, so run it off the event loop.
+    ranked = await asyncio.to_thread(
+        reranker.rank, query, candidates, top_k=top_k, return_documents=True
+    )
+    return [item['text'] for item in ranked]
+```
+
+Call `rerank()` on the candidates returned by your vector search (for example, in the `retrieve` tool of the [RAG example](examples/rag.md)) before handing the results to the LLM.
+
+!!! tip "Managed reranker alternatives"
+    If you'd rather not run a reranker locally, several providers offer hosted rerankers, including [Cohere Rerank](https://docs.cohere.com/docs/rerank-overview), [VoyageAI Rerank](https://docs.voyageai.com/docs/reranker), and [Jina Rerank](https://jina.ai/reranker). Call their HTTP clients or SDKs from a helper function with the same shape as `rerank()` above.
 
 ## Building Custom Embedding Models
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -51,6 +51,8 @@ pip/uv-add "pydantic-ai-slim[openai]"
 * `cohere` - installs [Cohere Model](models/cohere.md) dependency `cohere` [PyPI ↗](https://pypi.org/project/cohere){:target="_blank"}
 * `bedrock` - installs [Bedrock Model](models/bedrock.md) dependency `boto3` [PyPI ↗](https://pypi.org/project/boto3){:target="_blank"}
 * `huggingface` - installs [Hugging Face Model](models/huggingface.md) dependency `huggingface-hub` [PyPI ↗](https://pypi.org/project/huggingface-hub){:target="_blank"}
+* `sentence-transformers` - installs [Sentence Transformers Embedding Model](embeddings.md#sentence-transformers-local) dependency `sentence-transformers` [PyPI ↗](https://pypi.org/project/sentence-transformers){:target="_blank"}
+* `voyageai` - installs [VoyageAI Embedding Model](embeddings.md#voyageai) dependency `voyageai` [PyPI ↗](https://pypi.org/project/voyageai){:target="_blank"}
 * `outlines-transformers` - installs [Outlines Model](models/outlines.md) dependency `outlines[transformers]` [PyPI ↗](https://pypi.org/project/outlines){:target="_blank"}
 * `outlines-llamacpp` - installs [Outlines Model](models/outlines.md) dependency `outlines[llamacpp]` [PyPI ↗](https://pypi.org/project/outlines){:target="_blank"}
 * `outlines-mlxlm` - installs [Outlines Model](models/outlines.md) dependency `outlines[mlxlm]` [PyPI ↗](https://pypi.org/project/outlines){:target="_blank"}

--- a/docs/models/huggingface.md
+++ b/docs/models/huggingface.md
@@ -2,6 +2,9 @@
 
 [Hugging Face](https://huggingface.co/) is an AI platform with all major open source models, datasets, MCPs, and demos. You can use [Inference Providers](https://huggingface.co/docs/inference-providers) to run open source models like DeepSeek R1 on scalable serverless infrastructure.
 
+!!! tip "Local embeddings via Sentence Transformers"
+    This page covers chat completions via Hugging Face Inference Providers. To run Hugging Face **embedding** models locally (no API key, no network calls), see the [Sentence Transformers embedding model](../embeddings.md#sentence-transformers-local), which works with any model in the [sentence-transformers library](https://www.sbert.net/docs/sentence_transformer/pretrained_models.html).
+
 ## Install
 
 To use `HuggingFaceModel`, you need to either install `pydantic-ai`, or install `pydantic-ai-slim` with the `huggingface` optional group:

--- a/pydantic_ai_slim/pydantic_ai/embeddings/sentence_transformers.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/sentence_transformers.py
@@ -74,10 +74,10 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel):
     )
 
     # Using a model name (downloads from Hugging Face)
-    model = SentenceTransformerEmbeddingModel('all-MiniLM-L6-v2')
+    model = SentenceTransformerEmbeddingModel('sentence-transformers/all-MiniLM-L6-v2')
 
     # Using an existing SentenceTransformer instance
-    st_model = SentenceTransformer('all-MiniLM-L6-v2')
+    st_model = SentenceTransformer('Qwen/Qwen3-Embedding-0.6B')
     model = SentenceTransformerEmbeddingModel(st_model)
     ```
     """
@@ -91,7 +91,7 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel):
         Args:
             model: The model to use. Can be:
 
-                - A model name from Hugging Face (e.g., `'all-MiniLM-L6-v2'`)
+                - A model name from Hugging Face (e.g., `'sentence-transformers/all-MiniLM-L6-v2'`)
                 - A local path to a saved model
                 - An existing `SentenceTransformer` instance
             settings: Model-specific

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1104,6 +1104,7 @@ def mock_infer_embedding_model(model: EmbeddingModel | str) -> EmbeddingModel:
         'embed-v4.0': 1024,
         'voyage-3.5': 1024,
         'all-MiniLM-L6-v2': 384,
+        'lightonai/DenseOn': 768,
         'gemini-embedding-001': 3072,
         'gemini-embedding-2-preview': 3072,
     }


### PR DESCRIPTION
Hello!

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

## Pull Request overview

* Add a "Choosing a model" cheat sheet to the embeddings docs
* Add a "Two-stage retrieval with rerankers" section (local cross-encoder recipe + pointers to managed rerankers)
* Showcase recent non-canonical Sentence Transformers models (DenseOn, EmbeddingGemma, Qwen3-Embedding, jina-v5, arctic-embed, CodeRankEmbed, JobBERT) in both the table and the main ST example
* Small gap fixes: `sentence-transformers` / `voyageai` in install.md, and a cross-link from the Hugging Face page to the local embeddings section

## Details
I'm the maintainer of `sentence-transformers`. I wanted to contribute a few things to the embeddings docs. For context: the prose and code changes here were drafted with AI assistance and then critically edited by me before opening the PR. The recommendations are based on my own experience with the local retrieval ecosystem, MTEB, etc. For example, the DenseOn model that released yesterday. I'm pitching a few changes here:

The "Choosing a model" cheat sheet sits between "Embedding Result" and "Providers" and helps users pick a starting model by constraint (managed vs local, multilingual, specialized domain, AWS infra, dim reduction).

The "Two-stage retrieval with rerankers" section shows the common embed-then-rerank pattern with a small `rerank()` helper built on `sentence_transformers.CrossEncoder.rank()`. It's framed as bring-your-own with a tip pointing to managed alternatives (Cohere Rerank, VoyageAI Rerank, Jina Rerank).

For models: the existing Sentence Transformers example used `all-MiniLM-L6-v2`, a 2021 symmetric model. The page's "Queries vs Documents" admonition didn't actually apply to it. I switched it to https://huggingface.co/lightonai/DenseOn (768-dim, defines `query:` / `document:` prompts so `embed_query` / `embed_documents` behave asymmetrically as intended). I also wanted to highlight several other Sentence Transformers models throughout the "Choosing a model" table where relevant.

I also found a small issue: `docs/install.md` was missing `sentence-transformers` and `voyageai` from the optional-groups table even though both exist in `pydantic-ai-slim`'s `pyproject.toml`, and I also added a small cross-link tip from `docs/models/huggingface.md` (which covers API chat completions) to the local embeddings section.

`mkdocs build --no-strict` produces no new warnings, and the new runnable snippets pass end-to-end against the doc test mocks.

I'm open to any suggestions/changes that you see fit, just let me know.

- Tom Aarsen