### PR TITLE
common_tools/exa: add integration attribution header and refresh search types

### DIFF
--- a/docs/common-tools.md
+++ b/docs/common-tools.md
@@ -231,7 +231,7 @@ pip/uv-add "pydantic-ai-slim[exa]"
 
 You can use Exa tools individually or as a toolset. The following tools are available:
 
-- [`exa_search_tool`][pydantic_ai.common_tools.exa.exa_search_tool]: Search the web with various search types (auto, keyword, neural, fast, deep)
+- [`exa_search_tool`][pydantic_ai.common_tools.exa.exa_search_tool]: Search the web with various search types (auto, neural, fast, instant, deep, deep-lite, deep-reasoning)
 - [`exa_find_similar_tool`][pydantic_ai.common_tools.exa.exa_find_similar_tool]: Find pages similar to a given URL
 - [`exa_get_contents_tool`][pydantic_ai.common_tools.exa.exa_get_contents_tool]: Get full text content from URLs
 - [`exa_answer_tool`][pydantic_ai.common_tools.exa.exa_answer_tool]: Get AI-powered answers with citations

--- a/pydantic_ai_slim/pydantic_ai/common_tools/exa.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/exa.py
@@ -29,6 +29,14 @@ __all__ = (
     'exa_answer_tool',
 )
 
+_INTEGRATION_NAME = 'pydantic-ai'
+
+
+def _build_client(api_key: str) -> AsyncExa:
+    client = AsyncExa(api_key=api_key)
+    client.headers['x-exa-integration'] = _INTEGRATION_NAME
+    return client
+
 
 class ExaSearchResult(TypedDict):
     """An Exa search result with content.
@@ -97,16 +105,17 @@ class ExaSearchTool:
     async def __call__(
         self,
         query: str,
-        search_type: Literal['auto', 'keyword', 'neural', 'fast', 'deep'] = 'auto',
+        search_type: Literal['auto', 'neural', 'fast', 'instant', 'deep', 'deep-lite', 'deep-reasoning'] = 'auto',
     ) -> list[ExaSearchResult]:
         """Searches Exa for the given query and returns the results with content.
 
         Args:
             query: The search query to execute with Exa.
             search_type: The type of search to perform. 'auto' automatically chooses
-                the best search type, 'keyword' for exact matches, 'neural' for
-                semantic search, 'fast' for speed-optimized search, 'deep' for
-                comprehensive multi-query search.
+                the best search type, 'neural' for embeddings-based semantic search,
+                'fast' for a speed-optimized version, 'instant' for the lowest latency,
+                'deep' for a light deep search, 'deep-lite' for a lightweight synthesized
+                output, and 'deep-reasoning' for the base deep search.
 
         Returns:
             The search results with text content.
@@ -282,7 +291,7 @@ def exa_search_tool(
     if client is None:
         if api_key is None:
             raise ValueError('Either api_key or client must be provided')
-        client = AsyncExa(api_key=api_key)
+        client = _build_client(api_key)
     return Tool[Any](
         ExaSearchTool(
             client=client,
@@ -329,7 +338,7 @@ def exa_find_similar_tool(
     if client is None:
         if api_key is None:
             raise ValueError('Either api_key or client must be provided')
-        client = AsyncExa(api_key=api_key)
+        client = _build_client(api_key)
     return Tool[Any](
         ExaFindSimilarTool(client=client, num_results=num_results).__call__,
         name='exa_find_similar',
@@ -362,7 +371,7 @@ def exa_get_contents_tool(
     if client is None:
         if api_key is None:
             raise ValueError('Either api_key or client must be provided')
-        client = AsyncExa(api_key=api_key)
+        client = _build_client(api_key)
     return Tool[Any](
         ExaGetContentsTool(client=client).__call__,
         name='exa_get_contents',
@@ -395,7 +404,7 @@ def exa_answer_tool(
     if client is None:
         if api_key is None:
             raise ValueError('Either api_key or client must be provided')
-        client = AsyncExa(api_key=api_key)
+        client = _build_client(api_key)
     return Tool[Any](
         ExaAnswerTool(client=client).__call__,
         name='exa_answer',
@@ -446,7 +455,7 @@ class ExaToolset(FunctionToolset):
             include_answer: Whether to include the answer tool. Defaults to True.
             id: Optional ID for the toolset, used for durable execution environments.
         """
-        client = AsyncExa(api_key=api_key)
+        client = _build_client(api_key)
         tools: list[Tool[Any]] = []
 
         if include_search:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -688,6 +688,11 @@ def tavily_api_key() -> str:
     return os.getenv('TAVILY_API_KEY', 'mock-api-key')
 
 
+@pytest.fixture(scope='session')
+def exa_api_key() -> str:
+    return os.getenv('EXA_API_KEY', 'mock-api-key')
+
+
 @pytest.fixture(scope='function')  # Needs to be function scoped to get the request node name
 def xai_provider(request: pytest.FixtureRequest) -> Iterator[XaiProvider | None]:
     """xAI provider fixture backed by protobuf cassettes.

--- a/tests/test_exa.py
+++ b/tests/test_exa.py
@@ -1,0 +1,59 @@
+"""Tests for the Exa search tools."""
+
+from __future__ import annotations
+
+from exa_py import AsyncExa
+
+from pydantic_ai.common_tools.exa import (
+    ExaAnswerTool,
+    ExaFindSimilarTool,
+    ExaGetContentsTool,
+    ExaSearchTool,
+    ExaToolset,
+    exa_answer_tool,
+    exa_find_similar_tool,
+    exa_get_contents_tool,
+    exa_search_tool,
+)
+
+
+def _get_client(tool_obj: object) -> AsyncExa:
+    """Pull the AsyncExa client out of the underlying tool dataclass captured by `Tool.function`."""
+    function = getattr(tool_obj, 'function', None)
+    if function is not None:
+        bound_self = getattr(function, '__self__', None)
+        assert isinstance(bound_self, (ExaSearchTool, ExaFindSimilarTool, ExaGetContentsTool, ExaAnswerTool))
+        return bound_self.client
+    assert isinstance(tool_obj, (ExaSearchTool, ExaFindSimilarTool, ExaGetContentsTool, ExaAnswerTool))
+    return tool_obj.client
+
+
+def test_factory_sets_integration_header(exa_api_key: str):
+    """Each factory attaches the pydantic-ai attribution header when it builds the client."""
+    for tool in (
+        exa_search_tool(exa_api_key),
+        exa_find_similar_tool(exa_api_key),
+        exa_get_contents_tool(exa_api_key),
+        exa_answer_tool(exa_api_key),
+    ):
+        client = _get_client(tool)
+        assert client.headers['x-exa-integration'] == 'pydantic-ai'
+
+
+def test_factory_preserves_user_provided_client(exa_api_key: str):
+    """A user-supplied client is used as-is; the factory does not mutate its headers."""
+    client = AsyncExa(api_key=exa_api_key)
+    assert 'x-exa-integration' not in client.headers
+
+    tool = exa_search_tool(client=client)
+    assert _get_client(tool) is client
+    assert 'x-exa-integration' not in client.headers
+
+
+def test_toolset_sets_integration_header(exa_api_key: str):
+    """The shared client inside ExaToolset is tagged with the pydantic-ai attribution header."""
+    toolset = ExaToolset(exa_api_key)
+    tools = list(toolset.tools.values())
+    assert tools, 'ExaToolset should expose at least one tool by default'
+    for tool in tools:
+        assert _get_client(tool).headers['x-exa-integration'] == 'pydantic-ai'


### PR DESCRIPTION
<!-- No issue exists for this — submitting as the Exa partner maintaining this integration. -->

### Summary

Two small, related fixes to `pydantic_ai.common_tools.exa`:

1. **Attribution header.** When the Exa tools build an `AsyncExa` client for the user (i.e. the `api_key=` path on each factory and `ExaToolset.__init__`), we now set `client.headers['x-exa-integration'] = 'pydantic-ai'`. This is how Exa attributes API traffic to integrating projects. Clients passed in via `client=` are left untouched, so users who bring their own client keep full control of its headers.

2. **Search-type `Literal` refresh.** Exa's `POST /search` no longer accepts `'keyword'` (see https://exa.ai/docs/reference/search), and it has added `'instant'`, `'deep-lite'`, and `'deep-reasoning'`. The `Literal` on `ExaSearchTool.__call__`, its docstring, and the matching line in `docs/common-tools.md` are updated to reflect the current API.

Only `common_tools/exa` and its doc section are touched; no other public API or behavior changes.

### Usage (unchanged)

```python
from pydantic_ai import Agent
from pydantic_ai.common_tools.exa import ExaToolset

agent = Agent('openai:gpt-5.2', toolsets=[ExaToolset(api_key='...')])
```

### Files changed

- `pydantic_ai_slim/pydantic_ai/common_tools/exa.py` — new `_build_client` helper that sets the attribution header; updated `search_type` `Literal` and docstring.
- `docs/common-tools.md` — search-type list matches the current API.
- `tests/conftest.py` — `exa_api_key` session fixture (mirrors `tavily_api_key`).
- `tests/test_exa.py` — new, covers the attribution-header contract for each factory, for `ExaToolset`, and verifies user-provided clients are not mutated.

### Test plan

- [x] `uv run pytest tests/test_exa.py` — 3 passed locally.
- [x] `uv run pyright pydantic_ai_slim/pydantic_ai/common_tools/exa.py tests/test_exa.py` — 0 errors.
- [x] `uv run ruff check` + `ruff format --check` on changed files — clean.
- [ ] CI on all supported Python versions.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md). Note: `'keyword'` is removed from the `Literal`, but it is also no longer accepted by the Exa API — code passing it would already fail at runtime today.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).