### PR TITLE
fix(toolsets): prevent `MCPServer.__aexit__` called more times than `__aenter__` in `DynamicToolset`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/toolsets/_dynamic.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/_dynamic.py
@@ -85,33 +85,29 @@ class DynamicToolset(AbstractToolset[AgentDepsT]):
         if new_toolset is self._toolset:
             return self
 
-        # Manage the transition: exit old toolset, enter new one.
-        # Use try/finally so self._toolset is updated even if __aexit__ raises.
-        try:
-            if self._toolset is not None:
-                await self._toolset.__aexit__(None, None, None)
-        finally:
-            self._toolset = new_toolset
-        if self._toolset is not None:
-            try:
-                await self._toolset.__aenter__()
-            except BaseException:
-                # If __aenter__ fails, clear _toolset so that DynamicToolset.__aexit__
-                # does not attempt to call __aexit__ on a toolset that was never entered.
-                self._toolset = None
-                raise
+        # Detach the old toolset first so that if either the exit-old or enter-new step
+        # raises, `__aexit__` does not try to exit a toolset that was never entered
+        # (or has already been exited).
+        old_toolset = self._toolset
+        self._toolset = None
+        if old_toolset is not None:
+            await old_toolset.__aexit__(None, None, None)
+        await self._enter_inner_toolset(new_toolset)
         return self
 
     async def __aenter__(self) -> Self:
-        if self._toolset is not None:
-            try:
-                await self._toolset.__aenter__()
-            except BaseException:
-                # If __aenter__ fails, clear _toolset so that DynamicToolset.__aexit__
-                # does not attempt to call __aexit__ on a toolset that was never entered.
-                self._toolset = None
-                raise
+        await self._enter_inner_toolset(self._toolset)
         return self
+
+    async def _enter_inner_toolset(self, toolset: AbstractToolset[AgentDepsT] | None) -> None:
+        # Only register `toolset` as the active inner toolset after a successful
+        # `__aenter__`, so `__aexit__` cannot be called on a toolset that was
+        # never entered.
+        self._toolset = None
+        if toolset is None:
+            return
+        await toolset.__aenter__()
+        self._toolset = toolset
 
     async def __aexit__(self, *args: Any) -> bool | None:
         try:

--- a/pydantic_ai_slim/pydantic_ai/toolsets/_dynamic.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/_dynamic.py
@@ -93,12 +93,24 @@ class DynamicToolset(AbstractToolset[AgentDepsT]):
         finally:
             self._toolset = new_toolset
         if self._toolset is not None:
-            await self._toolset.__aenter__()
+            try:
+                await self._toolset.__aenter__()
+            except BaseException:
+                # If __aenter__ fails, clear _toolset so that DynamicToolset.__aexit__
+                # does not attempt to call __aexit__ on a toolset that was never entered.
+                self._toolset = None
+                raise
         return self
 
     async def __aenter__(self) -> Self:
         if self._toolset is not None:
-            await self._toolset.__aenter__()
+            try:
+                await self._toolset.__aenter__()
+            except BaseException:
+                # If __aenter__ fails, clear _toolset so that DynamicToolset.__aexit__
+                # does not attempt to call __aexit__ on a toolset that was never entered.
+                self._toolset = None
+                raise
         return self
 
     async def __aexit__(self, *args: Any) -> bool | None:

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -946,6 +946,188 @@ async def test_dynamic_toolset():
     assert tools == {}
 
 
+async def test_dynamic_toolset_enter_failure_does_not_exit_unentered_toolset():
+    """If the inner toolset's __aenter__ raises, DynamicToolset.__aexit__ must not
+    try to exit a toolset that was never entered.
+
+    Reproduces https://github.com/pydantic/pydantic-ai/issues/3542: a per-run-step
+    factory produces a fresh toolset each step; if __aenter__ on the new one fails,
+    the old logic still stored it and the outer context manager then called
+    __aexit__ on an unentered toolset (MCPServer raised "__aexit__ called more
+    times than __aenter__").
+    """
+
+    class FlakyToolset(AbstractToolset[None]):
+        enter_count = 0
+        exit_count = 0
+        fail_on_enter = False
+
+        @property
+        def id(self) -> str | None:
+            return None  # pragma: no cover
+
+        async def __aenter__(self) -> Self:
+            if self.fail_on_enter:
+                raise RuntimeError('enter failed')
+            self.enter_count += 1
+            return self
+
+        async def __aexit__(self, *args: Any) -> bool | None:
+            self.exit_count += 1
+            return None
+
+        async def get_tools(self, ctx: RunContext[None]) -> dict[str, ToolsetTool[None]]:
+            return {}  # pragma: no cover
+
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
+        ) -> Any:
+            return None  # pragma: no cover
+
+    first = FlakyToolset()
+    second = FlakyToolset()
+    second.fail_on_enter = True
+    produced = iter([first, second])
+
+    def factory(ctx: RunContext[None]) -> AbstractToolset[None]:
+        return next(produced)
+
+    dynamic = DynamicToolset[None](toolset_func=factory)
+    run_context = build_run_context(None)
+
+    toolset = await dynamic.for_run(run_context)
+    assert isinstance(toolset, DynamicToolset)
+    async with toolset:
+        await toolset.for_run_step(run_context)
+        assert first.enter_count == 1
+        with pytest.raises(RuntimeError, match='enter failed'):
+            await toolset.for_run_step(run_context)
+        # After the failed transition, _toolset should be None so __aexit__ is a no-op.
+        assert toolset._toolset is None  # pyright: ignore[reportPrivateUsage]
+
+    # Old toolset was exited exactly once during the transition; the failed one
+    # was never entered so must never be exited.
+    assert first.exit_count == 1
+    assert second.exit_count == 0
+
+
+async def test_dynamic_toolset_aenter_failure_does_not_exit_unentered_toolset():
+    """If the initial outer __aenter__ fails, __aexit__ must not try to exit it."""
+
+    class FailingEnterToolset(AbstractToolset[None]):
+        exit_count = 0
+
+        @property
+        def id(self) -> str | None:
+            return None  # pragma: no cover
+
+        async def __aenter__(self) -> Self:
+            raise RuntimeError('enter failed')
+
+        async def __aexit__(self, *args: Any) -> bool | None:
+            self.exit_count += 1  # pragma: no cover
+            return None
+
+        async def get_tools(self, ctx: RunContext[None]) -> dict[str, ToolsetTool[None]]:
+            return {}  # pragma: no cover
+
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
+        ) -> Any:
+            return None  # pragma: no cover
+
+    inner = FailingEnterToolset()
+    dynamic = DynamicToolset[None](toolset_func=lambda ctx: inner, per_run_step=False)
+    run_context = build_run_context(None)
+
+    toolset = await dynamic.for_run(run_context)
+    assert isinstance(toolset, DynamicToolset)
+    with pytest.raises(RuntimeError, match='enter failed'):
+        async with toolset:
+            pass  # pragma: no cover
+
+    assert toolset._toolset is None  # pyright: ignore[reportPrivateUsage]
+    assert inner.exit_count == 0
+
+
+async def test_dynamic_toolset_old_aexit_failure_does_not_store_new_toolset():
+    """If the old toolset's __aexit__ raises during a per-run-step transition,
+    the new toolset must not be stored (and thus not exited) since it was never entered.
+    """
+
+    class FailingExitToolset(AbstractToolset[None]):
+        entered = False
+        exited = False
+
+        @property
+        def id(self) -> str | None:
+            return None  # pragma: no cover
+
+        async def __aenter__(self) -> Self:
+            self.entered = True
+            return self
+
+        async def __aexit__(self, *args: Any) -> bool | None:
+            self.exited = True
+            raise RuntimeError('exit failed')
+
+        async def get_tools(self, ctx: RunContext[None]) -> dict[str, ToolsetTool[None]]:
+            return {}  # pragma: no cover
+
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
+        ) -> Any:
+            return None  # pragma: no cover
+
+    class TrackedToolset(AbstractToolset[None]):
+        entered = False
+        exited = False
+
+        @property
+        def id(self) -> str | None:
+            return None  # pragma: no cover
+
+        async def __aenter__(self) -> Self:
+            self.entered = True  # pragma: no cover
+            return self
+
+        async def __aexit__(self, *args: Any) -> bool | None:
+            self.exited = True  # pragma: no cover
+            return None
+
+        async def get_tools(self, ctx: RunContext[None]) -> dict[str, ToolsetTool[None]]:
+            return {}  # pragma: no cover
+
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
+        ) -> Any:
+            return None  # pragma: no cover
+
+    first = FailingExitToolset()
+    second = TrackedToolset()
+    produced = iter([first, second])
+
+    def factory(ctx: RunContext[None]) -> AbstractToolset[None]:
+        return next(produced)
+
+    dynamic = DynamicToolset[None](toolset_func=factory)
+    run_context = build_run_context(None)
+
+    toolset = await dynamic.for_run(run_context)
+    # Suppress the transition failure so we can inspect state afterwards; the
+    # outer __aexit__ must not then try to exit the never-entered second toolset.
+    with pytest.raises(RuntimeError, match='exit failed'):
+        async with toolset:
+            await toolset.for_run_step(run_context)
+            assert first.entered
+            await toolset.for_run_step(run_context)  # raises on old.__aexit__
+            pass  # pragma: no cover
+
+    assert first.exited
+    assert not second.entered
+    assert not second.exited
+
+
 async def test_dynamic_toolset_empty():
     def no_toolset_func(ctx: RunContext[None]) -> None:
         return None  # pragma: no cover

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1024,8 +1024,8 @@ async def test_dynamic_toolset_aenter_failure_does_not_exit_unentered_toolset():
         async def __aenter__(self) -> Self:
             raise RuntimeError('enter failed')
 
-        async def __aexit__(self, *args: Any) -> bool | None:
-            self.exit_count += 1  # pragma: no cover
+        async def __aexit__(self, *args: Any) -> bool | None:  # pragma: no cover
+            self.exit_count += 1
             return None
 
         async def get_tools(self, ctx: RunContext[None]) -> dict[str, ToolsetTool[None]]:
@@ -1087,12 +1087,12 @@ async def test_dynamic_toolset_old_aexit_failure_does_not_store_new_toolset():
         def id(self) -> str | None:
             return None  # pragma: no cover
 
-        async def __aenter__(self) -> Self:
-            self.entered = True  # pragma: no cover
+        async def __aenter__(self) -> Self:  # pragma: no cover
+            self.entered = True
             return self
 
-        async def __aexit__(self, *args: Any) -> bool | None:
-            self.exited = True  # pragma: no cover
+        async def __aexit__(self, *args: Any) -> bool | None:  # pragma: no cover
+            self.exited = True
             return None
 
         async def get_tools(self, ctx: RunContext[None]) -> dict[str, ToolsetTool[None]]:


### PR DESCRIPTION
When a `DynamicToolset` factory creates a new `MCPServer` instance on each run step (the common pattern for per-user authentication), the `for_run_step` method exits the old server and then enters the new one. If `__aenter__` fails on the new server, `self._toolset` still points to it. When the outer context manager then calls `DynamicToolset.__aexit__`, it tries to exit this unentered server, triggering `ValueError: MCPServer.__aexit__ called more times than __aenter__`.

The fix in `pydantic_ai/toolsets/_dynamic.py` wraps the `__aenter__` calls in both `for_run_step` and `__aenter__` with a try/except that clears `self._toolset` to `None` on failure, ensuring `DynamicToolset.__aexit__` will not attempt to exit a context manager that was never entered.

Fixes #3542
