### PR TITLE
fix: ignore null streamed choices chunks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -598,10 +598,9 @@ class GroqStreamedResponse(StreamedResponse):
                     if chunk.id:  # pragma: no branch
                         self.provider_response_id = chunk.id
 
-                    try:
-                        choice = chunk.choices[0]
-                    except IndexError:
+                    if not chunk.choices:
                         continue
+                    choice = chunk.choices[0]
 
                     if raw_finish_reason := choice.finish_reason:
                         self.provider_details = {**(self.provider_details or {}), 'finish_reason': raw_finish_reason}

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -497,10 +497,9 @@ class HuggingFaceStreamedResponse(StreamedResponse):
                 if chunk.id:  # pragma: no branch
                     self.provider_response_id = chunk.id
 
-                try:
-                    choice = chunk.choices[0]
-                except IndexError:
+                if not chunk.choices:
                     continue
+                choice = chunk.choices[0]
 
                 if raw_finish_reason := choice.finish_reason:
                     self.provider_details = {**(self.provider_details or {}), 'finish_reason': raw_finish_reason}

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -676,10 +676,9 @@ class MistralStreamedResponse(StreamedResponse):
                 if chunk.data.id:  # pragma: no branch
                     self.provider_response_id = chunk.data.id
 
-                try:
-                    choice = chunk.data.choices[0]
-                except IndexError:
+                if not chunk.data.choices:
                     continue
+                choice = chunk.data.choices[0]
 
                 if raw_finish_reason := choice.finish_reason:
                     self.provider_details = {**(self.provider_details or {}), 'finish_reason': raw_finish_reason}

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2641,10 +2641,9 @@ class OpenAIStreamedResponse(StreamedResponse):
                 if chunk.model:
                     self._model_name = chunk.model
 
-                try:
-                    choice = chunk.choices[0]
-                except IndexError:
+                if not chunk.choices:
                     continue
+                choice = chunk.choices[0]
 
                 # When using Azure OpenAI and an async content filter is enabled, the openai SDK can return None deltas.
                 if choice.delta is None:  # pyright: ignore[reportUnnecessaryComparison]

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -484,6 +484,21 @@ async def test_stream_text_finish_reason(allow_model_requests: None):
         assert result.is_complete
 
 
+async def test_stream_text_ignores_null_choices_chunk(allow_model_requests: None):
+    malformed_chunk = chunk([])
+    malformed_chunk.choices = None  # type: ignore[assignment]
+    stream = (text_chunk('hello '), malformed_chunk, text_chunk('world'), chunk([]))
+    mock_client = MockGroq.create_mock_stream(stream)
+    m = GroqModel('llama-3.3-70b-versatile', provider=GroqProvider(groq_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('') as result:
+        assert [c async for c in result.stream_output(debounce_by=None)] == snapshot(
+            ['hello ', 'hello world', 'hello world']
+        )
+        assert result.is_complete
+
+
 def struc_chunk(
     tool_name: str | None, tool_arguments: str | None, finish_reason: FinishReason | None = None
 ) -> chat.ChatCompletionChunk:

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -524,6 +524,19 @@ async def test_stream_text_finish_reason(allow_model_requests: None):
         assert result.is_complete
 
 
+async def test_stream_text_ignores_null_choices_chunk(allow_model_requests: None):
+    malformed_chunk = chunk([])
+    malformed_chunk.choices = None  # type: ignore[assignment]
+    stream = [text_chunk('hello '), malformed_chunk, text_chunk('world'), chunk([])]
+    mock_client = MockHuggingFace.create_stream_mock(stream)
+    m = HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=mock_client, api_key='x'))
+    agent = Agent(m)
+
+    async with agent.run_stream('') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(['hello ', 'hello world'])
+        assert result.is_complete
+
+
 def struc_chunk(
     tool_name: str | None, tool_arguments: str | None, finish_reason: FinishReason | None = None
 ) -> ChatCompletionStreamOutput:

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -414,6 +414,19 @@ async def test_stream_text_finish_reason(allow_model_requests: None):
         assert result.is_complete
 
 
+async def test_stream_text_ignores_null_choices_chunk(allow_model_requests: None):
+    malformed_chunk = chunk([])
+    malformed_chunk.data.choices = None  # type: ignore[assignment]
+    stream = [text_chunk('hello '), malformed_chunk, text_chunkk('world'), chunk([])]
+    mock_client = MockMistralAI.create_stream_mock(stream)
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
+    agent = Agent(model=model)
+
+    async with agent.run_stream('') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(['hello ', 'hello world'])
+        assert result.is_complete
+
+
 async def test_no_delta(allow_model_requests: None):
     stream = [
         chunk([], with_created=False),

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -607,6 +607,19 @@ async def test_stream_text_finish_reason(allow_model_requests: None):
                 )
 
 
+async def test_stream_text_ignores_null_choices_chunk(allow_model_requests: None):
+    malformed_chunk = chunk([])
+    malformed_chunk.choices = None  # type: ignore[assignment]
+    stream = [text_chunk('hello '), malformed_chunk, text_chunk('world'), chunk([])]
+    mock_client = MockOpenAI.create_mock_stream(stream)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(['hello ', 'hello world'])
+        assert result.is_complete
+
+
 def struc_chunk(
     tool_name: str | None, tool_arguments: str | None, finish_reason: FinishReason | None = None
 ) -> chat.ChatCompletionChunk:


### PR DESCRIPTION
- Closes #5165

### Pre-Review Checklist

- [x] No breaking changes in accordance with the version policy.
- [x] Linting and type checking pass per `make format` and `make typecheck`.
- [x] PR title is fit for the release changelog.

### Pre-Merge Checklist

- [x] New tests for the fix, maintaining coverage for the changed paths.
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

### Summary

Guard streamed chat chunks whose `choices` payload is `None` or empty before indexing into the first choice.

This applies the same fix across the four sibling streaming parsers that currently assume `choices[0]` is always present:
- OpenAI
- Groq
- Hugging Face
- Mistral

That keeps OpenAI-compatible providers from crashing mid-stream when they emit usage-only or otherwise malformed chunks with `choices: null`.

### Test plan

- `uv run pytest tests/models/test_openai.py -k 'ignores_null_choices_chunk' tests/models/test_groq.py -k 'ignores_null_choices_chunk' tests/models/test_huggingface.py -k 'ignores_null_choices_chunk' tests/models/test_mistral.py -k 'ignores_null_choices_chunk'`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/models/groq.py pydantic_ai_slim/pydantic_ai/models/huggingface.py pydantic_ai_slim/pydantic_ai/models/mistral.py tests/models/test_openai.py tests/models/test_groq.py tests/models/test_huggingface.py tests/models/test_mistral.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/models/groq.py pydantic_ai_slim/pydantic_ai/models/huggingface.py pydantic_ai_slim/pydantic_ai/models/mistral.py tests/models/test_openai.py tests/models/test_groq.py tests/models/test_huggingface.py tests/models/test_mistral.py`
- `uv run pyright pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/models/groq.py pydantic_ai_slim/pydantic_ai/models/huggingface.py pydantic_ai_slim/pydantic_ai/models/mistral.py tests/models/test_openai.py tests/models/test_groq.py tests/models/test_huggingface.py tests/models/test_mistral.py`
