### PR TITLE
fix(vercel_ai): skip stale `approval-responded` when tool already executed (#5154)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_utils.py
@@ -135,17 +135,46 @@ _APPROVAL_RESPONDED_TYPES = (
 )
 
 
+_TERMINAL_TOOL_OUTPUT_TYPES = (
+    ToolOutputAvailablePart,
+    ToolOutputErrorPart,
+    ToolOutputDeniedPart,
+    DynamicToolOutputAvailablePart,
+    DynamicToolOutputErrorPart,
+    DynamicToolOutputDeniedPart,
+)
+
+
 def iter_tool_approval_responses(
     messages: list[UIMessage],
 ) -> Iterator[tuple[str, ToolApprovalResponded]]:
-    """Yield `(tool_call_id, approval)` for each responded tool approval in assistant messages.
+    """Yield `(tool_call_id, approval)` for each *pending* tool-approval response in assistant messages.
 
-    Only `approval-responded` parts are matched. `output-denied` parts have
-    already been materialized into the message history by `load_messages()` and
-    must not be re-processed as deferred results.
+    An `approval-responded` part is only yielded if its tool has not yet been
+    executed. A tool counts as already-executed if any assistant message in
+    the history carries a terminal output part for the same `tool_call_id` —
+    that is, `output-available`, `output-error`, or `output-denied` (or their
+    Dynamic variants). `load_messages()` has already materialized those
+    terminal parts as `ToolCallPart` + `ToolReturnPart` in the run history,
+    so re-yielding a sibling `approval-responded` would feed the approval-
+    resolution logic a stale entry that no longer matches any
+    `DeferredToolRequests` in the current round (see #5154).
     """
+    executed_tool_call_ids: set[str] = set()
     for msg in messages:
-        if msg.role == 'assistant':
-            for part in msg.parts:
-                if isinstance(part, _APPROVAL_RESPONDED_TYPES) and isinstance(part.approval, ToolApprovalResponded):
-                    yield part.tool_call_id, part.approval
+        if msg.role != 'assistant':
+            continue
+        for part in msg.parts:
+            if isinstance(part, _TERMINAL_TOOL_OUTPUT_TYPES):
+                executed_tool_call_ids.add(part.tool_call_id)
+
+    for msg in messages:
+        if msg.role != 'assistant':
+            continue
+        for part in msg.parts:
+            if (
+                isinstance(part, _APPROVAL_RESPONDED_TYPES)
+                and isinstance(part.approval, ToolApprovalResponded)
+                and part.tool_call_id not in executed_tool_call_ids
+            ):
+                yield part.tool_call_id, part.approval

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3061,11 +3061,13 @@ async def test_tool_approval_skipped_when_output_error_sibling_exists():
                 DynamicToolApprovalRespondedPart(
                     tool_name='delete_file',
                     tool_call_id='call_err',
+                    input={'path': 'x.txt'},
                     approval=ToolApprovalResponded(id='call_err', approved=True),
                 ),
                 DynamicToolOutputErrorPart(
                     tool_name='delete_file',
                     tool_call_id='call_err',
+                    input={'path': 'x.txt'},
                     error_text='disk full',
                 ),
             ],
@@ -3089,6 +3091,7 @@ async def test_tool_approval_skipped_when_output_denied_sibling_exists_same_id()
                 DynamicToolApprovalRespondedPart(
                     tool_name='delete_file',
                     tool_call_id='call_denied',
+                    input={'path': 'x.txt'},
                     approval=ToolApprovalResponded(id='call_denied', approved=False),
                 ),
                 DynamicToolOutputDeniedPart(

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -78,6 +78,7 @@ with try_import() as starlette_import_successful:
         DynamicToolInputStreamingPart,
         DynamicToolOutputAvailablePart,
         DynamicToolOutputDeniedPart,
+        DynamicToolOutputErrorPart,
         FileUIPart,
         ReasoningUIPart,
         RegenerateMessage,
@@ -85,6 +86,7 @@ with try_import() as starlette_import_successful:
         TextUIPart,
         ToolApprovalRequested,
         ToolApprovalResponded,
+        ToolApprovalRespondedPart,
         ToolInputAvailablePart,
         ToolInputStreamingPart,
         ToolOutputAvailablePart,
@@ -3009,6 +3011,169 @@ async def test_tool_approval_ignores_output_denied_parts():
 
     results = dict(iter_tool_approval_responses(messages))
     assert results == {'tool_B': ToolApprovalResponded(id='deny-B', approved=False)}
+
+
+async def test_tool_approval_skipped_when_output_available_sibling_exists():
+    """Regression for #5154 — stale `approval-responded` must not be yielded.
+
+    When a tool is approved AND executed in the same continuation round, the
+    Vercel AI SDK v6 leaves the original `approval-responded` part alongside
+    the new `output-available` part for the same `tool_call_id`. Both parts
+    end up on the same assistant message. On the *next* continuation,
+    `iter_tool_approval_responses` used to yield that stale approval,
+    which `deferred_tool_results` then fed into the approval-resolution
+    logic as if pending — mismatching the (now empty) `DeferredToolRequests`
+    set for the current round. Skip any `approval-responded` whose
+    `tool_call_id` already has a terminal output sibling.
+    """
+    messages = [
+        UIMessage(
+            id='assistant-1',
+            role='assistant',
+            parts=[
+                ToolApprovalRespondedPart(
+                    type='tool-my_tool',
+                    tool_call_id='call_abc',
+                    approval=ToolApprovalResponded(id='call_abc', approved=True),
+                ),
+                ToolOutputAvailablePart(
+                    type='tool-my_tool',
+                    tool_call_id='call_abc',
+                    output='done',
+                ),
+            ],
+        )
+    ]
+
+    assert dict(iter_tool_approval_responses(messages)) == {}
+
+
+async def test_tool_approval_skipped_when_output_error_sibling_exists():
+    """Same as #5154 but the terminal sibling is `output-error` (tool was
+    approved, ran, and raised). The stale `approval-responded` must not
+    re-surface on the next round.
+    """
+    messages = [
+        UIMessage(
+            id='assistant-1',
+            role='assistant',
+            parts=[
+                DynamicToolApprovalRespondedPart(
+                    tool_name='delete_file',
+                    tool_call_id='call_err',
+                    approval=ToolApprovalResponded(id='call_err', approved=True),
+                ),
+                DynamicToolOutputErrorPart(
+                    tool_name='delete_file',
+                    tool_call_id='call_err',
+                    error_text='disk full',
+                ),
+            ],
+        )
+    ]
+
+    assert dict(iter_tool_approval_responses(messages)) == {}
+
+
+async def test_tool_approval_skipped_when_output_denied_sibling_exists_same_id():
+    """If a denied tool is re-submitted in the same assistant message (same
+    `tool_call_id` carries both `approval-responded(approved=False)` and
+    `output-denied`), the approval is already materialized by
+    `load_messages()` and must not be re-yielded as pending.
+    """
+    messages = [
+        UIMessage(
+            id='assistant-1',
+            role='assistant',
+            parts=[
+                DynamicToolApprovalRespondedPart(
+                    tool_name='delete_file',
+                    tool_call_id='call_denied',
+                    approval=ToolApprovalResponded(id='call_denied', approved=False),
+                ),
+                DynamicToolOutputDeniedPart(
+                    tool_name='delete_file',
+                    tool_call_id='call_denied',
+                    input={'path': 'x.txt'},
+                    approval=ToolApprovalResponded(id='call_denied', approved=False),
+                ),
+            ],
+        )
+    ]
+
+    assert dict(iter_tool_approval_responses(messages)) == {}
+
+
+async def test_tool_approval_mixed_executed_and_pending():
+    """With two tool calls in history — one already executed, one still
+    pending — only the pending one should be yielded.
+    """
+    messages = [
+        UIMessage(
+            id='assistant-1',
+            role='assistant',
+            parts=[
+                ToolApprovalRespondedPart(
+                    type='tool-do_a',
+                    tool_call_id='call_executed',
+                    approval=ToolApprovalResponded(id='call_executed', approved=True),
+                ),
+                ToolOutputAvailablePart(
+                    type='tool-do_a',
+                    tool_call_id='call_executed',
+                    output='done',
+                ),
+                ToolApprovalRespondedPart(
+                    type='tool-do_b',
+                    tool_call_id='call_pending',
+                    approval=ToolApprovalResponded(id='call_pending', approved=True),
+                ),
+            ],
+        )
+    ]
+
+    assert dict(iter_tool_approval_responses(messages)) == {
+        'call_pending': ToolApprovalResponded(id='call_pending', approved=True),
+    }
+
+
+async def test_tool_approval_terminal_sibling_on_different_message():
+    """The terminal output may live on an *earlier* assistant message than
+    the stale `approval-responded` (multi-round continuation where the
+    client re-sends the whole assembled history). The tool_call_id match
+    is history-wide, not per-message.
+    """
+    messages = [
+        UIMessage(
+            id='assistant-round-1',
+            role='assistant',
+            parts=[
+                ToolOutputAvailablePart(
+                    type='tool-ran_already',
+                    tool_call_id='call_xyz',
+                    output='first-round-result',
+                ),
+            ],
+        ),
+        UIMessage(
+            id='user-1',
+            role='user',
+            parts=[TextUIPart(text='follow-up')],
+        ),
+        UIMessage(
+            id='assistant-round-2',
+            role='assistant',
+            parts=[
+                ToolApprovalRespondedPart(
+                    type='tool-ran_already',
+                    tool_call_id='call_xyz',
+                    approval=ToolApprovalResponded(id='call_xyz', approved=True),
+                ),
+            ],
+        ),
+    ]
+
+    assert dict(iter_tool_approval_responses(messages)) == {}
 
 
 async def test_run_stream_with_deferred_tool_results_no_model_response():


### PR DESCRIPTION
Closes #5154.

## The bug

`iter_tool_approval_responses` used to yield every `approval-responded` part on any assistant message, including ones whose `tool_call_id` had already been materialized as a terminal output (`output-available`, `output-error`, or `output-denied`) by `load_messages()`. On the *next* continuation, `VercelAIAdapter.deferred_tool_results` fed that stale approval into pydantic-ai's approval-resolution logic as if pending — mismatching the (now empty) `DeferredToolRequests` set for the current round.

Pure server-side repro from #5154 (against `pydantic-ai-slim==1.84.1`):

```python
from pydantic_ai.ui.vercel_ai._utils import iter_tool_approval_responses
from pydantic_ai.ui.vercel_ai.request_types import (
    UIMessage, ToolApprovalRespondedPart, ToolApprovalResponded, ToolOutputAvailablePart,
)

approval = ToolApprovalRespondedPart(
    type='tool-my_tool',
    tool_call_id='call_abc',
    approval=ToolApprovalResponded(id='call_abc', approved=True),
)
output = ToolOutputAvailablePart(type='tool-my_tool', tool_call_id='call_abc', output='done')
msg = UIMessage(id='m1', role='assistant', parts=[approval, output])

list(iter_tool_approval_responses([msg]))
# before: [('call_abc', ToolApprovalResponded(..., approved=True))]  # ghost entry
# after:  []
```

## Fix

In `pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_utils.py`:

1. Walk all assistant messages once to collect the set of `tool_call_id`s that have a terminal output part:
   - `ToolOutputAvailablePart` / `DynamicToolOutputAvailablePart`
   - `ToolOutputErrorPart` / `DynamicToolOutputErrorPart`
   - `ToolOutputDeniedPart` / `DynamicToolOutputDeniedPart`
2. Walk them again to yield only `approval-responded` parts whose `tool_call_id` is **not** in that set.

The docstring was updated to describe the new rule. Net: +47 / -9 in `_utils.py`. No API change.

Direction confirmed by @DouweM on the issue (2026-04-21): *"not against hardening our integration to better support slightly out of spec frontends."* The specific rule — *"treat `approval-responded` as pending only if there is no terminal tool result for that `toolCallId` anywhere in the assistant history"* — was articulated by @pandego in-thread and matches the docstring's pre-existing rationale for why `output-denied` was already supposed to be excluded.

## Tests

5 new tests in `tests/test_vercel_ai.py`, following the style of the existing `test_tool_approval_ignores_output_denied_parts`:

1. `test_tool_approval_skipped_when_output_available_sibling_exists` — the exact #5154 repro.
2. `test_tool_approval_skipped_when_output_error_sibling_exists` — same rule for `output-error`.
3. `test_tool_approval_skipped_when_output_denied_sibling_exists_same_id` — same rule for `output-denied` on the same `tool_call_id`.
4. `test_tool_approval_mixed_executed_and_pending` — only the pending `tool_call_id` yields when the history has both.
5. `test_tool_approval_terminal_sibling_on_different_message` — match is history-wide, not per-message (covers multi-round continuation where the client re-sends assembled history).

The existing `test_tool_approval_ignores_output_denied_parts` still passes because it uses different `tool_call_id`s across its `output-denied` and `approval-responded` parts.

## Verification

I could not install `pydantic-ai-slim`'s dev deps in the session sandbox to run pytest on this PR locally. Did instead:

- AST-parse check on both modified files (clean).
- Self-contained algorithm check against 7 cases, including a backwards-compat check for the existing `test_tool_approval_ignores_output_denied_parts` behavior. All pass.

CI on this PR will be the authoritative test run; happy to react quickly if anything surfaces.

## Scope / alternatives considered

- **Terminal-set build only from the *same* assistant message** — rejected because real-world reproductions (see the issue thread on 2026-04-23) include cases where the terminal part lives on a prior assistant message and the client re-sends accumulated history. History-wide match is the right scope.
- **Fix at the Vercel client level (option (b) in the issue)** — maintainer noted Vercel's own client transitions parts in-place, but explicitly welcomed hardening the server side regardless. The bug repros purely server-side with the repro script above, so the server-side fix is correct even if out-of-spec clients go away tomorrow.
- **Stripping the stale parts from raw request JSON (the issue author's workaround)** — fixes the symptom but leaves other consumers of `iter_tool_approval_responses` on the wrong semantics.

## Credits

Repro, root-cause analysis, and workaround by @ritwickdsouza in #5154. Fix rule articulated by @pandego in-thread. Direction green-lit by @DouweM.

— [kcolbchain](https://kcolbchain.com) / [Abhishek Krishna](https://abhishekkrishna.com)