### PR TITLE
docs: link Logfire Live Evaluations UI from online-evaluation guide

### DIFF
--- a/docs/evals/online-evaluation.md
+++ b/docs/evals/online-evaluation.md
@@ -35,7 +35,7 @@ async def summarize(text: str) -> str:
     return f'Summary of: {text}'
 ```
 
-Wire up OTel export (e.g. [`logfire.configure()`](../logfire.md#using-logfire)) elsewhere in your application startup so that the emitted `gen_ai.evaluation.result` events reach your backend.
+Wire up OTel export (e.g. [`logfire.configure()`](../logfire.md#using-logfire)) elsewhere in your application startup so that the emitted `gen_ai.evaluation.result` events reach your backend. When using [Pydantic Logfire](https://pydantic.dev/docs/logfire/evaluate/live-evals/), these events surface in the **Live Evaluations** view, where you can browse results by target, drill into the originating trace, and watch scores over a time window.
 
 Each decorated call emits one `gen_ai.evaluation.result` OTel event per evaluator result, following the [OTel GenAI evaluation semconv](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#event-gen_aievaluationresult). This mirrors how offline evaluation emits OTel spans via `logfire.span`: if any OTel SDK is configured in the process (via [`logfire.configure()`](../logfire.md#using-logfire), the OTel SDK directly, or a vendor instrumentation), events flow to your backend; if not, emission is a cheap no-op.
 
@@ -990,5 +990,6 @@ The complete API for the `pydantic_evals.online` module is documented in the [AP
 
 - **[Custom Evaluators](evaluators/custom.md)** — Write evaluators for your domain
 - **[Native Evaluators](evaluators/built-in.md)** — Use ready-made evaluators
+- **[Live Evaluations in Logfire](https://pydantic.dev/docs/logfire/evaluate/live-evals/)** — Browse, filter, and trend online evaluation results in the Logfire web UI
 - **[Logfire Integration](how-to/logfire-integration.md)** — Visualize evaluation results in Logfire
 - **[Quick Start](quick-start.md)** — Offline evaluation with [`Dataset.evaluate()`][pydantic_evals.dataset.Dataset.evaluate]


### PR DESCRIPTION
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

## Summary

Follow-up to [pydantic/logfire#1870 (comment)](https://github.com/pydantic/logfire/pull/1870#discussion_r3123139966), where @alexmojaki noted we should link to the new Logfire **Live Evaluations** web-UI guide from the Pydantic AI docs after it merged.

- Adds a one-sentence link from the `online-evaluation.md` **Quick Start** section into the Logfire Live Evaluations page, right after the `logfire.configure()` wire-up, so readers who just plugged in OTel export know where the events land.
- Adds a **Next Steps** bullet to the same page linking out to the Live Evaluations guide.

No code changes; docs only.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).