### PR TITLE
fix: preserve validation error `input` on tool-call retries

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1352,10 +1352,15 @@ class RetryPromptPart:
             else:
                 description = self.content
         else:
-            # Strip input from top-level errors where it duplicates the entire generated output
-            exclude = {
-                i: {'ctx', 'input'} if len(e.get('loc', ())) <= 1 else {'ctx'} for i, e in enumerate(self.content)
-            }
+            # For NativeOutput retries (no `tool_name`) the generated JSON is already in the model's
+            # context, so top-level errors' `input` just duplicates it. Tool-call retries keep `input`
+            # so the model sees what arguments it sent alongside the error.
+            if self.tool_name is None:
+                exclude = {
+                    i: {'ctx', 'input'} if len(e.get('loc', ())) <= 1 else {'ctx'} for i, e in enumerate(self.content)
+                }
+            else:
+                exclude = {'__all__': {'ctx'}}
             json_errors = error_details_ta.dump_json(self.content, exclude=exclude, indent=2)
             plural = isinstance(self.content, list) and len(self.content) != 1
             description = (

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -324,7 +324,7 @@ def test_result_pydantic_model_retry():
             ),
             ModelResponse(
                 parts=[ToolCallPart(tool_name='final_result', args='{"a": 42, "b": "foo"}', tool_call_id=IsStr())],
-                usage=RequestUsage(input_tokens=87, output_tokens=14),
+                usage=RequestUsage(input_tokens=89, output_tokens=14),
                 model_name='function:return_model:',
                 timestamp=IsNow(tz=timezone.utc),
                 run_id=IsStr(),
@@ -394,12 +394,14 @@ def test_result_pydantic_model_validation_error():
     "loc": [
       "b"
     ],
-    "msg": "Value error, must not be foo"
+    "msg": "Value error, must not be foo",
+    "input": "foo"
   }
 ]
 ```
 
-Fix the errors and try again.""")
+Fix the errors and try again.\
+""")
 
 
 def test_output_validator():

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1531,3 +1531,34 @@ def test_retry_prompt_strips_input_from_top_level_type_errors():
     response = part.model_response()
     assert '"input"' not in response
     assert '"age"' in response
+
+
+def test_retry_prompt_tool_call_keeps_input_at_top_level():
+    """Tool-call retries (`tool_name` set) must preserve `input` so the model sees what args it sent."""
+    part = RetryPromptPart(
+        tool_name='evaluate_content',
+        content=[
+            {'type': 'missing', 'loc': ('content',), 'msg': 'Field required', 'input': {}},
+        ],
+    )
+    response = part.model_response()
+    assert '"input": {}' in response
+    assert '"content"' in response
+
+
+def test_retry_prompt_tool_call_keeps_input_for_nested_errors():
+    """Tool-call retries preserve `input` for nested errors too, matching the existing NativeOutput nested behavior."""
+    part = RetryPromptPart(
+        tool_name='evaluate_content',
+        content=[
+            {
+                'type': 'string_type',
+                'loc': ('items', 0, 'name'),
+                'msg': 'Input should be a valid string',
+                'input': 42,
+            },
+        ],
+    )
+    response = part.model_response()
+    assert '"input": 42' in response
+    assert '"name"' in response


### PR DESCRIPTION
- Closes #5178

### Summary

#4947 stripped `input` from top-level validation errors in `RetryPromptPart.model_response()` to reduce token bloat for `NativeOutput` retries (where `input` duplicates the entire generated JSON across every error, per #4919).

That strip also applied to tool-call retries. For tool calls, the validation error is the model's most direct signal of what arguments it sent — without `input`, models like Claude Sonnet 4 can't reliably self-correct and repeat the same malformed call until `max_retries` is exhausted (~0.5% permanent failure rate reported in #5178).

### Fix

Scope the strip to `tool_name is None` (the NativeOutput path). All tool-call retry construction sites (`tool_manager.py:181`, `_output.py:140,202`) set `tool_name`, so `input` is preserved there.

Credit to @truffle-dev for the analysis and minimal patch in https://github.com/pydantic/pydantic-ai/issues/5178#issuecomment-4306739061.

### Tests

- New regression tests in `test_messages.py` for the tool-call paths (top-level and nested).
- Existing `NativeOutput`-path tests continue to assert the strip behavior.
- Two snapshots in `test_agent.py` updated to reflect `input` now surfacing in output-tool retries (expected behavior change).

### Follow-up (not in this PR)

The NativeOutput strip itself may be over-aggressive — it assumes the model reliably cross-references errors against its own prior text output. Worth revisiting separately (dedupe-per-unique-payload likely cleaner than unconditional strip).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).