### PR TITLE
chore: gitignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ node_modules/
 .coverage*
 /test_tmp/
 .mcp.json
+CLAUDE.local.md
 .agents/*
 !.agents/skills/
 .agents/skills/*


### PR DESCRIPTION
### Summary

Adds `CLAUDE.local.md` to `.gitignore` so contributors can keep per-worktree, uncommitted Claude instructions at the repo root without risk of accidental commits. Mirrors the convention already in use for `.claude/*` and friends (trivial fix, no issue).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).