### PR TITLE
fix: pass max_tokens to max_tokens parameter and add max_completion_tokens setting

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -454,6 +454,16 @@ class OpenAIChatModelSettings(ModelSettings, total=False):
     See the [OpenAI Prompt Caching documentation](https://platform.openai.com/docs/guides/prompt-caching#how-it-works) for more information.
     """
 
+    openai_max_completion_tokens: int
+    """An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.
+
+    This is the OpenAI-specific `max_completion_tokens` parameter, which is distinct from `max_tokens`.
+    Use this for OpenAI reasoning models (o-series) where `max_completion_tokens` controls the combined
+    limit of output tokens plus reasoning tokens. For most providers and models, use `max_tokens` instead.
+
+    See the [OpenAI API reference](https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens) for more details.
+    """
+
     openai_continuous_usage_stats: bool
     """When True, enables continuous usage statistics in streaming responses.
 
@@ -848,7 +858,8 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     stream=stream,
                     stream_options=self._get_stream_options(model_settings) if stream else OMIT,
                     stop=model_settings.get('stop_sequences', OMIT),
-                    max_completion_tokens=model_settings.get('max_tokens', OMIT),
+                    max_tokens=model_settings.get('max_tokens', OMIT),
+                    max_completion_tokens=model_settings.get('openai_max_completion_tokens', OMIT),
                     timeout=model_settings.get('timeout', NOT_GIVEN),
                     response_format=response_format or OMIT,
                     seed=model_settings.get('seed', OMIT),

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -859,7 +859,9 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     stream_options=self._get_stream_options(model_settings) if stream else OMIT,
                     stop=model_settings.get('stop_sequences', OMIT),
                     max_tokens=model_settings.get('max_tokens', OMIT),
-                    max_completion_tokens=model_settings.get('openai_max_completion_tokens', OMIT),
+                    max_completion_tokens=model_settings.get(
+                        'openai_max_completion_tokens', model_settings.get('max_tokens', OMIT)
+                    ),
                     timeout=model_settings.get('timeout', NOT_GIVEN),
                     response_format=response_format or OMIT,
                     seed=model_settings.get('seed', OMIT),

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -859,9 +859,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     stream_options=self._get_stream_options(model_settings) if stream else OMIT,
                     stop=model_settings.get('stop_sequences', OMIT),
                     max_tokens=model_settings.get('max_tokens', OMIT),
-                    max_completion_tokens=model_settings.get(
-                        'openai_max_completion_tokens', model_settings.get('max_tokens', OMIT)
-                    ),
+                    max_completion_tokens=model_settings.get('openai_max_completion_tokens', OMIT),
                     timeout=model_settings.get('timeout', NOT_GIVEN),
                     response_format=response_format or OMIT,
                     seed=model_settings.get('seed', OMIT),


### PR DESCRIPTION
In `pydantic_ai_slim/pydantic_ai/models/openai.py`, the `_completions_create` method was incorrectly mapping the `max_tokens` model setting to the `max_completion_tokens` API parameter. This meant the `max_tokens` parameter was never sent to the API, and all providers received `max_completion_tokens` instead — breaking any model or provider that only supports `max_tokens` (a very common case with OpenRouter and other compatible providers).

The fix maps `max_tokens` from `ModelSettings` to the `max_tokens` API parameter as intended. A new `max_completion_tokens` field has been added to `ChatModelSettings` for users who specifically need to set the `max_completion_tokens` API parameter — useful for reasoning models where this parameter controls the combined limit of output tokens and reasoning tokens.

This restores correct token limiting behavior for all providers while still allowing specific `max_completion_tokens` usage through the new explicit setting.

- [ ] Any code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

Fixes #5186