### PR TITLE
meta: Adds AI Policy to deal with AI generated content in the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -10,6 +10,8 @@ body:
 
         Please provide as much information as possible to help us reproduce and fix your issue quickly.
 
+        Please describe the bug in your own words — see our [AI Policy](https://github.com/pydantic/pydantic-ai/blob/main/AI_POLICY.md).
+
   - type: checkboxes
     id: checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -5,7 +5,10 @@ labels: ["feature"]
 body:
   - type: markdown
     attributes:
-      value: Thank you for contributing to Pydantic AI! ✊
+      value: |
+        Thank you for contributing to Pydantic AI! ✊
+
+        Please describe the feature and your use case in your own words — see our [AI Policy](https://github.com/pydantic/pydantic-ai/blob/main/AI_POLICY.md).
 
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -11,6 +11,8 @@ body:
         The quickest way to get help or suggestions from our community or team is via our [Slack community](https://logfire.pydantic.dev/docs/join-slack/),
         but if you have a little more patience or a lot of context or code to share, GitHub is a great place too.
 
+        Please ask your question in your own words — see our [AI Policy](https://github.com/pydantic/pydantic-ai/blob/main/AI_POLICY.md).
+
   - type: textarea
     id: question
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,10 +9,13 @@
 <!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
 <!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->
 
+<!-- Please write the description and review replies in your own words. -->
+<!-- See: https://github.com/pydantic/pydantic-ai/blob/main/AI_POLICY.md -->
+
 - Closes #<issue>
 
 ### Checklist
 
-- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
+- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it. See the [AI Policy](https://github.com/pydantic/pydantic-ai/blob/main/AI_POLICY.md).
 - [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
 - [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,31 @@
+# AI Policy
+
+We support using AI (LLMs, coding assistants, agents) as tools for the work that goes into Pydantic AI — we use them ourselves. But Pydantic AI is foundational infrastructure for a lot of people, and we hold a high bar for every contribution. This page sets expectations for where AI fits and where it doesn't.
+
+## You are responsible for what you submit
+
+Whatever tools you used to produce it, **you** are the author of every issue, PR, and comment under your account. You stand by it, you understand it, and you can answer questions about it. We are responsible for anything we merge and release.
+
+The PR checklist already requires that any AI-generated code has been reviewed line-by-line by the human PR author — that same standard applies to everything else you submit, not just code.
+
+## Write to us in your own words
+
+**Do not use AI to generate issues, PR descriptions, or replies to maintainer questions.**
+
+This isn't about style — it's about the signal we need to do our jobs. We may hide or close contributions we believe were AI-generated at this layer, even if the underlying code or idea is sound.
+
+- **Issues**: we need to understand the problem *you* have — what you're building, what broke, what you tried. A generic LLM summary of a problem space is not the same thing, and doesn't help us prioritize.
+- **PR descriptions**: we need to know what *you* decided and why. Your PR body and review replies are how we calibrate whether you're the right [champion](CONTRIBUTING.md#champions) for the change — a champion who can't explain their own PR in their own words isn't one.
+- **Review replies**: we need your judgment, not the model's. Copying AI responses back into a review thread means we have to re-ask to find out what you actually think.
+
+If you want to include context from an AI interaction, put it in a quote block (`>`), disclose it, keep it short, and add your own commentary explaining the relevance. Long pasted AI snippets will be ignored.
+
+## No autonomous-agent contributions
+
+**Do not open issues or PRs that an agent produced end-to-end without a human reading and standing by the full submission.**
+
+The distinction isn't "did you use Claude Code to write some of this" — it's whether a human is in the loop who understands the submission and can answer for it. We will close issues and PRs we believe were created autonomously.
+
+## Translation is fine
+
+If English isn't your first language, it's completely OK to use AI to translate or polish your comments. Take the time to make sure the result reflects *your* voice and ideas. If you'd rather, write in your native language and include the AI translation in a quote block — either works.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,31 +1,15 @@
 # AI Policy
 
-We support using AI (LLMs, coding assistants, agents) as tools for the work that goes into Pydantic AI — we use them ourselves. But Pydantic AI is foundational infrastructure for a lot of people, and we hold a high bar for every contribution. This page sets expectations for where AI fits and where it doesn't.
+We use LLMs, coding assistants, and agents on Pydantic AI ourselves, and we're glad when our contributors do too. However, you remain responsible for any code or text you submit, and we are responsible for anything we merge and release. We hold a high bar for every contribution.
 
-## You are responsible for what you submit
+**AI should not be used to generate issues, pull request descriptions, or replies to maintainer questions.** We expect this communication to be written by humans, and we may hide or close contributions we believe are AI-generated.
 
-Whatever tools you used to produce it, **you** are the author of every issue, PR, and comment under your account. You stand by it, you understand it, and you can answer questions about it. We are responsible for anything we merge and release.
+If you are opening an issue, describe the problem in your own words: what you're building, what broke, and what you tried.
 
-The PR checklist already requires that any AI-generated code has been reviewed line-by-line by the human PR author — that same standard applies to everything else you submit, not just code.
+If you are opening a pull request, you should be able to explain the proposed changes in your own words. This includes the pull request body and replies to review questions. **Do not copy AI responses when replying to maintainers.**
 
-## Write to us in your own words
+Due to the foundational nature of Pydantic AI, we require a human in the loop who understands the work produced by AI. **We do not allow autonomous agents to contribute to the project.** We will close any issues or pull requests we believe were created autonomously.
 
-**Do not use AI to generate issues, PR descriptions, or replies to maintainer questions.**
+If you want to include context from an AI interaction in a comment, it must be in a quote block (using `>`), disclosed as such, and accompanied by your own commentary explaining why it matters. Do not share long snippets.
 
-This isn't about style — it's about the signal we need to do our jobs. We may hide or close contributions we believe were AI-generated at this layer, even if the underlying code or idea is sound.
-
-- **Issues**: we need to understand the problem *you* have — what you're building, what broke, what you tried. A generic LLM summary of a problem space is not the same thing, and doesn't help us prioritize.
-- **PR descriptions**: we need to know what *you* decided and why. Your PR body and review replies are how we calibrate whether you're the right [champion](CONTRIBUTING.md#champions) for the change — a champion who can't explain their own PR in their own words isn't one.
-- **Review replies**: we need your judgment, not the model's. Copying AI responses back into a review thread means we have to re-ask to find out what you actually think.
-
-If you want to include context from an AI interaction, put it in a quote block (`>`), disclose it, keep it short, and add your own commentary explaining the relevance. Long pasted AI snippets will be ignored.
-
-## No autonomous-agent contributions
-
-**Do not open issues or PRs that an agent produced end-to-end without a human reading and standing by the full submission.**
-
-The distinction isn't "did you use Claude Code to write some of this" — it's whether a human is in the loop who understands the submission and can answer for it. We will close issues and PRs we believe were created autonomously.
-
-## Translation is fine
-
-If English isn't your first language, it's completely OK to use AI to translate or polish your comments. Take the time to make sure the result reflects *your* voice and ideas. If you'd rather, write in your native language and include the AI translation in a quote block — either works.
+We understand that AI is useful when communicating as a non-native English speaker. If you use AI to edit your comments, please make sure the result reflects your own voice and ideas. For translation, we recommend writing in your native language and including the AI translation in a quote block.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,6 +8,7 @@ Pydantic AI is maintained by a small team. We set our own priorities based on wh
 - **Want a feature or API change?** Open an issue describing the problem you're solving. Do not start with code.
 - **Want to help build a feature?** Comment on the issue explaining why you need it and what context you bring. We call this being a "champion" — more on that below.
 - **Have a fix or code to share?** Make sure a maintainer has agreed to the approach on the issue and assigned you. Then open a PR.
+- **Using AI tools?** Read our [AI Policy](https://github.com/pydantic/pydantic-ai/blob/main/AI_POLICY.md) first. The short version: issues, PR descriptions, and replies to maintainers should be written in your own words.
 
 The rest of this page explains why we work this way and what to expect.
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
