### PR TITLE
fix(deepseek): add support for `deepseek-v4-flash` and`deepseek-v4-pro`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -153,6 +153,8 @@ KnownModelName = TypeAliasType(
         'cohere:command-r7b-12-2024',
         'deepseek:deepseek-chat',
         'deepseek:deepseek-reasoner',
+        'deepseek:deepseek-v4-flash',
+        'deepseek:deepseek-v4-pro',
         'gateway/anthropic:claude-3-haiku-20240307',
         'gateway/anthropic:claude-haiku-4-5-20251001',
         'gateway/anthropic:claude-mythos-preview',

--- a/pydantic_ai_slim/pydantic_ai/profiles/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/deepseek.py
@@ -6,8 +6,11 @@ from . import ModelProfile
 def deepseek_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a DeepSeek model."""
     is_r1 = 'r1' in model_name
+    # V4 models (deepseek-v4-flash, deepseek-v4-pro) support thinking via reasoning_effort
+    # but do not always enable it — thinking_always_enabled stays False.
+    is_v4 = 'v4' in model_name
     return ModelProfile(
         ignore_streamed_leading_whitespace=is_r1,
-        supports_thinking=is_r1,
+        supports_thinking=is_r1 or is_v4,
         thinking_always_enabled=is_r1,
     )

--- a/pydantic_ai_slim/pydantic_ai/profiles/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/deepseek.py
@@ -5,10 +5,10 @@ from . import ModelProfile
 
 def deepseek_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a DeepSeek model."""
-    is_r1 = 'r1' in model_name
-    # V4 models (deepseek-v4-flash, deepseek-v4-pro) support thinking via reasoning_effort
+    is_r1 = model_name.startswith('deepseek-r1') or model_name == 'deepseek-reasoner'
+    # V4 models (deepseek-v4-flash, deepseek-v4-pro, …) support thinking via reasoning_effort
     # but do not always enable it — thinking_always_enabled stays False.
-    is_v4 = 'v4' in model_name
+    is_v4 = model_name.startswith('deepseek-v4-')
     return ModelProfile(
         ignore_streamed_leading_whitespace=is_r1,
         supports_thinking=is_r1 or is_v4,

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -54,9 +54,10 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
             openai_chat_thinking_field='reasoning_content',
             # Starting from DeepSeek v3.2, DeepSeek requires sending thinking parts for optimal agentic performance.
             openai_chat_send_back_thinking_parts='field',
-            # DeepSeek reasoning models (deepseek-reasoner, deepseek-v4-*) do not support tool_choice=required
+            # Reasoning-capable models do not support tool_choice=required; use startswith so
+            # future deepseek-v4-* SKUs are covered automatically without listing each one.
             openai_supports_tool_choice_required=(
-                model_name not in ('deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro')
+                model_name != 'deepseek-reasoner' and not model_name.startswith('deepseek-v4-')
             ),
         ).update(profile)
 

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -22,7 +22,7 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-DeepSeekModelName = Literal['deepseek-chat', 'deepseek-reasoner']
+DeepSeekModelName = Literal['deepseek-chat', 'deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro']
 
 
 class DeepSeekProvider(Provider[AsyncOpenAI]):
@@ -54,8 +54,8 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
             openai_chat_thinking_field='reasoning_content',
             # Starting from DeepSeek v3.2, DeepSeek requires sending thinking parts for optimal agentic performance.
             openai_chat_send_back_thinking_parts='field',
-            # DeepSeek v3.2 reasoning mode does not support tool_choice=required yet
-            openai_supports_tool_choice_required=(model_name != 'deepseek-reasoner'),
+            # DeepSeek reasoning models (deepseek-reasoner, deepseek-v4-*) do not support tool_choice=required
+            openai_supports_tool_choice_required=(model_name not in ('deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro')),
         ).update(profile)
 
     @overload

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -55,7 +55,9 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
             # Starting from DeepSeek v3.2, DeepSeek requires sending thinking parts for optimal agentic performance.
             openai_chat_send_back_thinking_parts='field',
             # DeepSeek reasoning models (deepseek-reasoner, deepseek-v4-*) do not support tool_choice=required
-            openai_supports_tool_choice_required=(model_name not in ('deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro')),
+            openai_supports_tool_choice_required=(
+                model_name not in ('deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro')
+            ),
         ).update(profile)
 
     @overload

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -53,3 +53,28 @@ def test_deep_seek_model_profile():
     provider = DeepSeekProvider(api_key='api-key')
     model = OpenAIChatModel('deepseek-r1', provider=provider)
     assert model.profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+
+
+@pytest.mark.parametrize('model_name', ['deepseek-v4-flash', 'deepseek-v4-pro'])
+def test_deep_seek_v4_model_profile(model_name: str):
+    provider = DeepSeekProvider(api_key='api-key')
+    profile = provider.model_profile(model_name)
+    assert profile is not None
+    assert profile.supports_thinking is True
+    assert profile.thinking_always_enabled is False
+    assert profile.openai_supports_tool_choice_required is False
+
+
+def test_deep_seek_chat_model_profile():
+    provider = DeepSeekProvider(api_key='api-key')
+    profile = provider.model_profile('deepseek-chat')
+    assert profile is not None
+    assert profile.supports_thinking is False
+    assert profile.openai_supports_tool_choice_required is True
+
+
+def test_deep_seek_reasoner_model_profile():
+    provider = DeepSeekProvider(api_key='api-key')
+    profile = provider.model_profile('deepseek-reasoner')
+    assert profile is not None
+    assert profile.openai_supports_tool_choice_required is False

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 
 from ..conftest import TestEnv, try_import
 
@@ -60,6 +60,7 @@ def test_deep_seek_v4_model_profile(model_name: str):
     provider = DeepSeekProvider(api_key='api-key')
     profile = provider.model_profile(model_name)
     assert profile is not None
+    assert isinstance(profile, OpenAIModelProfile)
     assert profile.supports_thinking is True
     assert profile.thinking_always_enabled is False
     assert profile.openai_supports_tool_choice_required is False
@@ -69,6 +70,7 @@ def test_deep_seek_chat_model_profile():
     provider = DeepSeekProvider(api_key='api-key')
     profile = provider.model_profile('deepseek-chat')
     assert profile is not None
+    assert isinstance(profile, OpenAIModelProfile)
     assert profile.supports_thinking is False
     assert profile.openai_supports_tool_choice_required is True
 
@@ -77,4 +79,5 @@ def test_deep_seek_reasoner_model_profile():
     provider = DeepSeekProvider(api_key='api-key')
     profile = provider.model_profile('deepseek-reasoner')
     assert profile is not None
+    assert isinstance(profile, OpenAIModelProfile)
     assert profile.openai_supports_tool_choice_required is False

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -75,9 +75,30 @@ def test_deep_seek_chat_model_profile():
     assert profile.openai_supports_tool_choice_required is True
 
 
+def test_deep_seek_r1_model_profile():
+    """Regression anchor: deepseek-r1 must always have thinking enabled."""
+    provider = DeepSeekProvider(api_key='api-key')
+    profile = provider.model_profile('deepseek-r1')
+    assert profile is not None
+    assert isinstance(profile, OpenAIModelProfile)
+    assert profile.supports_thinking is True
+    assert profile.thinking_always_enabled is True
+
+
 def test_deep_seek_reasoner_model_profile():
     provider = DeepSeekProvider(api_key='api-key')
     profile = provider.model_profile('deepseek-reasoner')
+    assert profile is not None
+    assert isinstance(profile, OpenAIModelProfile)
+    assert profile.supports_thinking is True
+    assert profile.thinking_always_enabled is True
+    assert profile.openai_supports_tool_choice_required is False
+
+
+def test_deep_seek_v4_future_sku_inherits_tool_choice_restriction():
+    """Future deepseek-v4-* SKUs must inherit tool_choice=required restriction via startswith predicate."""
+    provider = DeepSeekProvider(api_key='api-key')
+    profile = provider.model_profile('deepseek-v4-turbo')
     assert profile is not None
     assert isinstance(profile, OpenAIModelProfile)
     assert profile.openai_supports_tool_choice_required is False

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -53,6 +53,8 @@ def test_deep_seek_model_profile():
     provider = DeepSeekProvider(api_key='api-key')
     model = OpenAIChatModel('deepseek-r1', provider=provider)
     assert model.profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert model.profile.supports_thinking is True
+    assert model.profile.thinking_always_enabled is True
 
 
 @pytest.mark.parametrize('model_name', ['deepseek-v4-flash', 'deepseek-v4-pro'])

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -614,6 +614,8 @@ def test_model_json_schema_with_capabilities():
                         'cohere:command-r7b-12-2024',
                         'deepseek:deepseek-chat',
                         'deepseek:deepseek-reasoner',
+                        'deepseek:deepseek-v4-flash',
+                        'deepseek:deepseek-v4-pro',
                         'gateway/anthropic:claude-3-haiku-20240307',
                         'gateway/anthropic:claude-haiku-4-5-20251001',
                         'gateway/anthropic:claude-mythos-preview',


### PR DESCRIPTION
- Closes #5193

### What

Add support for the explicit DeepSeek V4 model IDs (`deepseek-v4-flash` and `deepseek-v4-pro`) that replace the `deepseek-chat` alias on 2026-07-24.

**Three changes across two files:**

`providers/deepseek.py`:
- Extend `DeepSeekModelName` literal with `deepseek-v4-flash` and `deepseek-v4-pro` for type safety
- Set `openai_supports_tool_choice_required=False` for V4 models — V4 routes through the reasoner endpoint, which rejects `tool_choice=required` with a 400

`profiles/deepseek.py`:
- Detect V4 models and set `supports_thinking=True` so that `reasoning_content` in V4 responses is treated as a thinking part (mirrors the R1 path)
- `thinking_always_enabled` stays `False` because V4 controls thinking via `reasoning_effort` at runtime, not unconditionally

### Why

`deepseek-v4-flash` and `deepseek-v4-pro` fall through to the `OpenAIModelProfile` defaults, which leave `openai_supports_tool_choice_required=True`. When a user passes any `output_type` to an agent, pydantic-ai sends `tool_choice=required` and DeepSeek returns a 400. Every pydantic-ai user migrating away from the `deepseek-chat` alias will hit this on upgrade. The alias sunsets 2026-07-24.

### Tests

Added parametrized tests for V4 profile shape and regression guards for `deepseek-chat` and `deepseek-reasoner`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).