### PR TITLE
docs: fix indentation and typo in beta graph API warning admonition

### DIFF
--- a/docs/graph/beta/index.md
+++ b/docs/graph/beta/index.md
@@ -2,7 +2,7 @@
 
 !!! warning "Beta API"
     This is the new beta graph API. It provides enhanced capabilities for parallel execution, conditional branching, and complex workflows.
-The original graph API is still available (and compatible of interop with the new beta API) and is documented in the [main graph documentation](../../graph.md).
+    The original graph API is still available (and compatible with the new beta API) and is documented in the [main graph documentation](../../graph.md).
 
 ## Overview
 


### PR DESCRIPTION
Fixes #5185

## Problem

In `docs/graph/beta/index.md`, the warning admonition for the Beta API had two issues:

1. **Missing indentation**: The second sentence of the warning was not indented with 4 spaces, so it rendered as regular body text outside the warning box instead of inside it.
2. **Typo**: The phrase "compatible of interop with" should be "compatible with".

## Solution

- Added the required 4-space indent to put the sentence inside the `!!! warning` admonition block.
- Fixed the typo: "compatible of interop with" → "compatible with".

## Testing

The change is a pure documentation fix (indentation + typo) with no code changes. Verified by reading the rendered markdown structure.