### PR TITLE
docs: add FuturMix.ai to OpenAI-compatible providers

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -620,8 +620,6 @@ agent = Agent(model)
 
 To use [FuturMix.ai](https://futurmix.ai), go to [futurmix.ai](https://futurmix.ai) and create an API key.
 
-FuturMix is a unified AI gateway providing access to 22+ models (Claude, GPT, Gemini) through a single OpenAI-compatible API with 99.99% SLA.
-
 You can use [`OpenAIProvider`][pydantic_ai.providers.openai.OpenAIProvider] with a custom base URL:
 
 ```python

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -616,6 +616,32 @@ agent = Agent(model)
 ...
 ```
 
+### FuturMix
+
+To use [FuturMix.ai](https://futurmix.ai), go to [futurmix.ai](https://futurmix.ai) and create an API key.
+
+FuturMix is a unified AI gateway providing access to 22+ models (Claude, GPT, Gemini) through a single OpenAI-compatible API with 99.99% SLA.
+
+You can use [`OpenAIProvider`][pydantic_ai.providers.openai.OpenAIProvider] with a custom base URL:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+model = OpenAIChatModel(
+    'claude-sonnet-4-20250514',
+    provider=OpenAIProvider(
+        base_url='https://futurmix.ai/v1',
+        api_key='your-futurmix-api-key',
+    ),
+)
+agent = Agent(model)
+...
+```
+
+For a complete list of available models, visit [futurmix.ai](https://futurmix.ai).
+
 ### Together AI
 
 Go to [Together.ai](https://www.together.ai/) and create an API key in your account settings.

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -23,6 +23,7 @@ In addition, many providers are compatible with the OpenAI API, and can be used 
 - [Azure AI Foundry](openai.md#azure-ai-foundry)
 - [DeepSeek](openai.md#deepseek)
 - [Fireworks AI](openai.md#fireworks-ai)
+- [FuturMix](openai.md#futurmix)
 - [GitHub Models](openai.md#github-models)
 - [Heroku](openai.md#heroku-ai)
 - [LiteLLM](openai.md#litellm)


### PR DESCRIPTION
## Summary

Add FuturMix.ai to the OpenAI-compatible providers documentation.

- Add FuturMix section to `docs/models/openai.md` (between Fireworks AI and Together AI)
- Add FuturMix to the provider list in `docs/models/overview.md`

[FuturMix.ai](https://futurmix.ai) is an enterprise AI agent platform providing access to 22+ models (Claude, GPT, Gemini) at (see [futurmix.ai](https://futurmix.ai)).

Since FuturMix provides standard API access, it works with the existing `OpenAIProvider` by setting the `base_url` parameter — no new provider class needed.