### PR TITLE
fix(mistral): distinguish ModuleNotFoundError from ImportError for clearer diagnostics

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -89,13 +89,11 @@ try:
     from mistralai.client.types import UNSET, OptionalNullable as MistralOptionalNullable
     from mistralai.client.types.basemodel import Unset as MistralUnset
     from mistralai.client.utils.eventstreaming import EventStreamAsync as MistralEventStreamAsync
-except ModuleNotFoundError as e:  # pragma: lax no cover
+except ImportError as _import_error:  # pragma: lax no cover
     raise ImportError(
         'Please install `mistral` to use the Mistral model, '
         'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
-    ) from e
-except ImportError:  # pragma: lax no cover
-    raise
+    ) from _import_error
 
 
 @contextmanager

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -89,11 +89,13 @@ try:
     from mistralai.client.types import UNSET, OptionalNullable as MistralOptionalNullable
     from mistralai.client.types.basemodel import Unset as MistralUnset
     from mistralai.client.utils.eventstreaming import EventStreamAsync as MistralEventStreamAsync
-except ImportError as e:  # pragma: lax no cover
+except ModuleNotFoundError as e:  # pragma: lax no cover
     raise ImportError(
         'Please install `mistral` to use the Mistral model, '
         'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
     ) from e
+except ImportError:  # pragma: lax no cover
+    raise
 
 
 @contextmanager

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -13,11 +13,13 @@ from pydantic_ai.providers import Provider
 
 try:
     from mistralai.client import Mistral
-except ImportError as e:
+except ModuleNotFoundError as e:
     raise ImportError(
         'Please install the `mistral` package to use the Mistral provider, '
         'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
     ) from e
+except ImportError:  # pragma: no cover
+    raise
 
 
 class MistralProvider(Provider[Mistral]):

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -13,13 +13,11 @@ from pydantic_ai.providers import Provider
 
 try:
     from mistralai.client import Mistral
-except ModuleNotFoundError as e:
+except ImportError as _import_error:  # pragma: no cover
     raise ImportError(
         'Please install the `mistral` package to use the Mistral provider, '
         'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
-    ) from e
-except ImportError:  # pragma: no cover
-    raise
+    ) from _import_error
 
 
 class MistralProvider(Provider[Mistral]):


### PR DESCRIPTION
Closes #4927

In `pydantic_ai/models/mistral.py` and `pydantic_ai/providers/mistral.py`, a single `except ImportError` block catches both "package not installed" errors (`ModuleNotFoundError`) and "name not found in installed package" errors (plain `ImportError`). This means a real import failure—like `cannot import name 'UNSET' from 'mistralai'`—gets swallowed and replaced with a misleading "please install mistral" message, hiding the true root cause.

The fix replaces the single `except ImportError` with two separate handlers: `except ModuleNotFoundError` raises the helpful install hint, while a bare `except ImportError: raise` lets genuine import-name errors propagate with their original message and traceback intact.

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
