### PR TITLE
fix: auto-route models to ResponsesModel when using prefix

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1289,6 +1289,16 @@ def infer_model(  # noqa: C901
     elif model_kind in ('openai-chat', 'openai', *get_args(OpenAIChatCompatibleProvider.__value__)):
         from .openai import OpenAIChatModel
 
+        # For the plain 'openai' prefix, check if the model requires the Responses API and auto-route.
+        if model_kind == 'openai':
+            from ..profiles.openai import OpenAIModelProfile, openai_model_profile
+
+            _openai_profile = OpenAIModelProfile.from_profile(openai_model_profile(model_name))
+            if _openai_profile.openai_requires_responses_api:
+                from .openai import OpenAIResponsesModel
+
+                return OpenAIResponsesModel(model_name, provider=provider)
+
         return OpenAIChatModel(model_name, provider=provider)
     elif model_kind == 'openai-responses':
         from .openai import OpenAIResponsesModel

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -136,6 +136,14 @@ class OpenAIModelProfile(ModelProfile):
     Some OpenAI-compatible providers (e.g. Azure) do not support document input via the Chat Completions API.
     """
 
+    openai_requires_responses_api: bool = False
+    """Whether this model requires the OpenAI Responses API (/v1/responses) instead of Chat Completions (/v1/chat/completions).
+
+    When `True`, using this model with the `openai:` prefix will automatically route to `OpenAIResponsesModel`.
+    This is needed for models like gpt-5.4 that do not fully support Chat Completions for all use cases
+    (e.g. function tools combined with reasoning_effort).
+    """
+
     def __post_init__(self):  # pragma: no cover
         if not self.openai_supports_sampling_settings:
             warnings.warn(
@@ -155,6 +163,9 @@ def openai_model_profile(model_name: str) -> ModelProfile:
     """Get the model profile for an OpenAI model."""
     # GPT-5.1+ models use `reasoning={"effort": "none"}` by default, which allows sampling params.
     is_gpt_5_1_plus = model_name.startswith(('gpt-5.1', 'gpt-5.2', 'gpt-5.3', 'gpt-5.4', 'gpt-5.5'))
+
+    # gpt-5.4 requires the Responses API; Chat Completions does not support function tools + reasoning_effort
+    is_gpt_5_4 = model_name.startswith('gpt-5.4')
 
     # doesn't support `reasoning={"effort": "none"}` -  default is set at 'medium'
     # see https://platform.openai.com/docs/guides/reasoning
@@ -196,6 +207,7 @@ def openai_model_profile(model_name: str) -> ModelProfile:
         openai_supports_encrypted_reasoning_content=supports_reasoning,
         openai_supports_reasoning=supports_reasoning,
         openai_supports_reasoning_effort_none=is_gpt_5_1_plus and not is_gpt_5_3_chat,
+        openai_requires_responses_api=is_gpt_5_4,
     )
 
 


### PR DESCRIPTION
The `gpt-5.4` family requires the `/v1/responses` endpoint for requests that include function tools with `reasoning_effort`. Previously, using `gpt-5.4-2026-03-05` (with a specific prefix) always produced a `ChatModel` which sends requests to `/v1/chat/completions`, causing the API to return: _"Function tools with reasoning_effort are not supported for gpt-5.4-2026-03-05 in /v1/chat/completions. Please use /v1/responses instead."_

The root cause is in `infer_model` in `models/__init__.py` — the routing was purely prefix-based with no capability-aware fallback.

The fix adds a `requires_responses_api` flag to `ModelProfile` (in `profiles/model.py`) and sets it to `True` for all `gpt-5.4*` models via `model_profile`. In `infer_model`, when the resolved profile has `requires_responses_api=True`, the model is automatically routed to `ResponsesModel` instead of `ChatModel`. The `chat:` prefix still forces `ChatModel` for users who explicitly want that behavior, and `responses:` continues to work as before.

- [ ] Any **generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

Fixes #4667