### PR TITLE
test: add tests for NativeOutput and PromptedOutput validation errors

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -485,16 +485,16 @@ class OutputSchema(ABC, Generic[OutputDataT]):
 
         if output := next((output for output in outputs if isinstance(output, NativeOutput)), None):  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
             if len(outputs) > 1:
-                raise UserError('`NativeOutput` must be the only output type.')  # pragma: no cover
+                raise UserError('`NativeOutput` must be the only output type.')
 
             flattened_outputs = _flatten_output_spec(output.outputs)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
 
             if DeferredToolRequests in flattened_outputs:
-                raise UserError(  # pragma: no cover
+                raise UserError(
                     '`NativeOutput` cannot contain `DeferredToolRequests`. Include it alongside the native output marker instead: `output_type=[NativeOutput(...), DeferredToolRequests]`'
                 )
             if _messages.BinaryImage in flattened_outputs:
-                raise UserError(  # pragma: no cover
+                raise UserError(
                     '`NativeOutput` cannot contain `BinaryImage`. Include it alongside the native output marker instead: `output_type=[NativeOutput(...), BinaryImage]`'
                 )
 
@@ -512,16 +512,16 @@ class OutputSchema(ABC, Generic[OutputDataT]):
             )
         elif output := next((output for output in outputs if isinstance(output, PromptedOutput)), None):  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
             if len(outputs) > 1:
-                raise UserError('`PromptedOutput` must be the only output type.')  # pragma: no cover
+                raise UserError('`PromptedOutput` must be the only output type.')
 
             flattened_outputs = _flatten_output_spec(output.outputs)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
 
             if DeferredToolRequests in flattened_outputs:
-                raise UserError(  # pragma: no cover
+                raise UserError(
                     '`PromptedOutput` cannot contain `DeferredToolRequests`. Include it alongside the prompted output marker instead: `output_type=[PromptedOutput(...), DeferredToolRequests]`'
                 )
             if _messages.BinaryImage in flattened_outputs:
-                raise UserError(  # pragma: no cover
+                raise UserError(
                     '`PromptedOutput` cannot contain `BinaryImage`. Include it alongside the prompted output marker instead: `output_type=[PromptedOutput(...), BinaryImage]`'
                 )
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1876,6 +1876,42 @@ def test_output_type_text_output_invalid():
         Agent('test', output_type=output_type)
 
 
+def test_output_type_native_output_must_be_only():
+    """Test that NativeOutput must be the only output type."""
+    with pytest.raises(UserError, match='`NativeOutput` must be the only output type.'):
+        Agent('test', output_type=[NativeOutput(str), str])
+
+
+def test_output_type_native_output_with_deferred_tool_requests():
+    """Test that NativeOutput cannot contain DeferredToolRequests."""
+    with pytest.raises(UserError, match='`NativeOutput` cannot contain `DeferredToolRequests`'):
+        Agent('test', output_type=NativeOutput([DeferredToolRequests]))
+
+
+def test_output_type_native_output_with_binary_image():
+    """Test that NativeOutput cannot contain BinaryImage."""
+    with pytest.raises(UserError, match='`NativeOutput` cannot contain `BinaryImage`'):
+        Agent('test', output_type=NativeOutput([BinaryImage]))
+
+
+def test_output_type_prompted_output_must_be_only():
+    """Test that PromptedOutput must be the only output type."""
+    with pytest.raises(UserError, match='`PromptedOutput` must be the only output type.'):
+        Agent('test', output_type=[PromptedOutput(str), str])
+
+
+def test_output_type_prompted_output_with_deferred_tool_requests():
+    """Test that PromptedOutput cannot contain DeferredToolRequests."""
+    with pytest.raises(UserError, match='`PromptedOutput` cannot contain `DeferredToolRequests`'):
+        Agent('test', output_type=PromptedOutput([DeferredToolRequests]))
+
+
+def test_output_type_prompted_output_with_binary_image():
+    """Test that PromptedOutput cannot contain BinaryImage."""
+    with pytest.raises(UserError, match='`PromptedOutput` cannot contain `BinaryImage`'):
+        Agent('test', output_type=PromptedOutput([BinaryImage]))
+
+
 def test_output_type_async_function():
     class Weather(BaseModel):
         temperature: float


### PR DESCRIPTION
## Summary

Add tests for error cases in `pydantic_ai_slim/pydantic_ai/_output.py` that were previously marked with `pragma: no cover`:

- `NativeOutput` must be the only output type
- `NativeOutput` cannot contain `DeferredToolRequests`
- `NativeOutput` cannot contain `BinaryImage`
- `PromptedOutput` must be the only output type
- `PromptedOutput` cannot contain `DeferredToolRequests`
- `PromptedOutput` cannot contain `BinaryImage`

These validation errors are raised when users create an `Agent` with invalid output configurations. The tests verify that the `UserError` exceptions are properly raised with appropriate error messages.

## Test plan

- [x] All 6 new tests pass
- [x] Lint checks pass
- [x] Existing tests continue to pass