### PR TITLE
fix(ollama): normalize assistant message content=None to empty string

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/models/ollama.py
@@ -12,6 +12,7 @@ from ..settings import ModelSettings
 
 try:
     from openai import AsyncOpenAI
+    from openai.types import chat
 
     from .openai import OpenAIChatModel
 except ImportError as _import_error:
@@ -93,3 +94,10 @@ class OllamaModel(OpenAIChatModel):
             profile = replace(base_profile, supports_json_schema_output=False)
 
         super().__init__(model_name, provider=provider, profile=profile, settings=settings)
+
+    class _MapModelResponseContext(OpenAIChatModel._MapModelResponseContext):  # type: ignore[reportPrivateUsage]
+        def _into_message_param(self) -> chat.ChatCompletionAssistantMessageParam:
+            message_param = super()._into_message_param()
+            if message_param.get('content') is None:
+                message_param['content'] = ''
+            return message_param

--- a/tests/models/test_ollama.py
+++ b/tests/models/test_ollama.py
@@ -22,9 +22,16 @@ from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsStr, try_import
 
 with try_import() as imports_successful:
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
+    from openai.types.chat.chat_completion_message_function_tool_call import ChatCompletionMessageFunctionToolCall
+    from openai.types.chat.chat_completion_message_tool_call import Function
+    from openai.types.completion_usage import CompletionUsage
+
     from pydantic_ai.models.ollama import OllamaModel
     from pydantic_ai.profiles.openai import OpenAIModelProfile
     from pydantic_ai.providers.ollama import OllamaProvider
+
+    from ..models.mock_openai import MockOpenAI, completion_message, get_mock_chat_completion_kwargs
 
 
 pytestmark = [
@@ -335,3 +342,51 @@ We need to provide answer in JSON format. Let's do that.\
             ),
         ]
     )
+
+
+async def test_ollama_assistant_message_content_none_becomes_empty_string(
+    allow_model_requests: None, ollama_api_key: str
+) -> None:
+    """Ollama's OpenAI-compatible API rejects `content: null` in assistant messages.
+
+    When a tool call response has no text content, OpenAI's API accepts `content: None`,
+    but Ollama requires it to be an empty string. This test verifies that `OllamaModel`
+    normalizes `None` to `''` before sending the request.
+    See https://github.com/pydantic/pydantic-ai/issues/5206
+    """
+    responses = [
+        completion_message(
+            ChatCompletionMessage(
+                content=None,
+                role='assistant',
+                tool_calls=[
+                    ChatCompletionMessageFunctionToolCall(
+                        id='1',
+                        function=Function(arguments='{"value": 42}', name='get_value'),
+                        type='function',
+                    )
+                ],
+            ),
+            usage=CompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+        ),
+        completion_message(ChatCompletionMessage(content='The value is 42', role='assistant')),
+    ]
+    mock_client = MockOpenAI.create_mock(responses)
+    provider = OllamaProvider(openai_client=mock_client)
+    m = OllamaModel('qwen3:0.6b', provider=provider)
+    agent = Agent(m)
+
+    @agent.tool_plain
+    async def get_value(value: int) -> int:
+        return value
+
+    result = await agent.run('What is the value?')
+    assert result.output == 'The value is 42'
+
+    kwargs = get_mock_chat_completion_kwargs(mock_client)
+    # Second request includes the assistant message with the tool call
+    second_request_messages = kwargs[1]['messages']
+    assistant_message = second_request_messages[1]
+    assert assistant_message['role'] == 'assistant'
+    assert assistant_message['content'] == ''
+    assert 'tool_calls' in assistant_message


### PR DESCRIPTION
- Closes #5206

### Summary

Ollama OpenAI-compatible API rejects content: null in assistant messages (e.g. during multi-tool chaining), returning a 400 error:

  invalid message content type: <nil>

OpenAI accepts content=None when tool_calls is present, but Ollama requires a string. This fix overrides _MapModelResponseContext._into_message_param in OllamaModel to replace None with empty string before sending the request.

### Changes

- Added _MapModelResponseContext override in OllamaModel that normalizes content=None to content=''
- Added unit test verifying the fix

### Testing

- New unit test: test_ollama_assistant_message_content_none_becomes_empty_string
- All existing tests/models/test_ollama.py tests pass
- ruff and pyright clean on changed files

### Checklist

- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No breaking changes in accordance with the version policy.
- [x] PR title is fit for the release changelog.