### PR TITLE
fix: omit content key for tool-call-only assistant messages

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1132,7 +1132,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     message_param[field_name] = '\n\n'.join(contents)
             if self.texts:
                 message_param['content'] = '\n\n'.join(self.texts)
-            else:
+            elif not self.tool_calls:
                 message_param['content'] = None
             if self.tool_calls:
                 message_param['tool_calls'] = self.tool_calls

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4748,6 +4748,33 @@ async def test_openai_chat_instructions_fallback_with_tool_return(allow_model_re
     assert openai_messages[0] == snapshot({'content': 'Be helpful.', 'role': 'system'})
 
 
+async def test_openai_chat_tool_call_only_omits_content(allow_model_requests: None):
+    """Tool-call-only ModelResponse must not set content=None in assistant message.
+
+    Ollama's OpenAI-compatible API rejects content=null with
+    'invalid message content type: <nil>'. Omitting the key entirely is
+    valid per the OpenAI API spec and accepted by both providers.
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/5206.
+    """
+    mock_client = MockOpenAI.create_mock(completion_message(ChatCompletionMessage(content='ok', role='assistant')))
+    model = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    messages: list[ModelRequest | ModelResponse] = [
+        ModelRequest(parts=[UserPromptPart(content='Hello')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='my_tool', args='{"x": 1}', tool_call_id='call_1')]),
+        ModelRequest(parts=[ToolReturnPart(tool_name='my_tool', content='result', tool_call_id='call_1')]),
+    ]
+
+    openai_messages = await model._map_messages(messages, ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
+
+    # Find the assistant message (the one with tool_calls)
+    assistant_msgs = [m for m in openai_messages if m.get('role') == 'assistant']
+    assert len(assistant_msgs) == 1
+    assistant_msg = assistant_msgs[0]
+    assert 'tool_calls' in assistant_msg
+    assert 'content' not in assistant_msg  # must NOT be set to None
+
+
 def test_openai_chat_audio_default_base64(allow_model_requests: None):
     c = completion_message(ChatCompletionMessage(content='success', role='assistant'))
     mock_client = MockOpenAI.create_mock(c)


### PR DESCRIPTION
Fixes #5206

### Root Cause

In `_MapModelResponseContext._into_message_param()`, `content` is unconditionally set to `None` when there are no text parts — even when `tool_calls` is present. OpenAI accepts `content: null` alongside `tool_calls`, but Ollama's OpenAI-compatible API rejects it with:

```
invalid message content type: <nil>
```

This breaks multi-tool chaining with Ollama models, since intermediate assistant messages (after the first tool result) have `content: None`.

### Fix

Only set `content = None` when there are **no tool_calls** either. When the response is tool-calls-only, omit the `content` key entirely — this is valid per the OpenAI API spec and accepted by both OpenAI and Ollama.

```python
# Before
else:
    message_param['content'] = None

# After
elif not self.tool_calls:
    message_param['content'] = None
```