### PR TITLE
fix(deepseek): add support for `deepseek-v4-flash` and `deepseek-v4-pro`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -153,6 +153,8 @@ KnownModelName = TypeAliasType(
         'cohere:command-r7b-12-2024',
         'deepseek:deepseek-chat',
         'deepseek:deepseek-reasoner',
+        'deepseek:deepseek-v4-flash',
+        'deepseek:deepseek-v4-pro',
         'gateway/anthropic:claude-3-haiku-20240307',
         'gateway/anthropic:claude-haiku-4-5-20251001',
         'gateway/anthropic:claude-mythos-preview',

--- a/pydantic_ai_slim/pydantic_ai/profiles/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/deepseek.py
@@ -6,8 +6,10 @@ from . import ModelProfile
 def deepseek_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a DeepSeek model."""
     is_r1 = 'r1' in model_name
+    # V4 supports thinking but can toggle it via reasoning_effort, unlike R1 which is always on.
+    is_v4 = model_name.startswith('deepseek-v4-')
     return ModelProfile(
         ignore_streamed_leading_whitespace=is_r1,
-        supports_thinking=is_r1,
+        supports_thinking=is_r1 or is_v4,
         thinking_always_enabled=is_r1,
     )

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -22,7 +22,12 @@ except ImportError as _import_error:  # pragma: no cover
     ) from _import_error
 
 
-DeepSeekModelName = Literal['deepseek-chat', 'deepseek-reasoner']
+DeepSeekModelName = Literal[
+    'deepseek-chat',
+    'deepseek-reasoner',
+    'deepseek-v4-flash',
+    'deepseek-v4-pro',
+]
 
 
 class DeepSeekProvider(Provider[AsyncOpenAI]):
@@ -54,8 +59,12 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
             openai_chat_thinking_field='reasoning_content',
             # Starting from DeepSeek v3.2, DeepSeek requires sending thinking parts for optimal agentic performance.
             openai_chat_send_back_thinking_parts='field',
-            # DeepSeek v3.2 reasoning mode does not support tool_choice=required yet
-            openai_supports_tool_choice_required=(model_name != 'deepseek-reasoner'),
+            # DeepSeek v3.2+ reasoning mode does not support tool_choice=required yet.
+            # V4 models default to thinking mode server-side, so they hit the same restriction.
+            openai_supports_tool_choice_required=(
+                model_name != 'deepseek-reasoner'
+                and not model_name.startswith('deepseek-v4-')
+            ),
         ).update(profile)
 
     @overload

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 
 from ..conftest import TestEnv, try_import
 
@@ -53,3 +53,33 @@ def test_deep_seek_model_profile():
     provider = DeepSeekProvider(api_key='api-key')
     model = OpenAIChatModel('deepseek-r1', provider=provider)
     assert model.profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert model.profile.supports_thinking is True
+    assert model.profile.thinking_always_enabled is True
+
+
+@pytest.mark.parametrize('model_name', ['deepseek-v4-flash', 'deepseek-v4-pro'])
+def test_deep_seek_v4_model_profile(model_name: str):
+    provider = DeepSeekProvider(api_key='api-key')
+    profile = provider.model_profile(model_name)
+    assert profile is not None
+    assert isinstance(profile, OpenAIModelProfile)
+    assert profile.supports_thinking is True
+    assert profile.thinking_always_enabled is False
+    assert profile.openai_supports_tool_choice_required is False
+
+
+def test_deep_seek_chat_model_profile():
+    provider = DeepSeekProvider(api_key='api-key')
+    profile = provider.model_profile('deepseek-chat')
+    assert profile is not None
+    assert isinstance(profile, OpenAIModelProfile)
+    assert profile.supports_thinking is False
+    assert profile.openai_supports_tool_choice_required is True
+
+
+def test_deep_seek_reasoner_model_profile():
+    provider = DeepSeekProvider(api_key='api-key')
+    profile = provider.model_profile('deepseek-reasoner')
+    assert profile is not None
+    assert isinstance(profile, OpenAIModelProfile)
+    assert profile.openai_supports_tool_choice_required is False

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -613,6 +613,8 @@ def test_model_json_schema_with_capabilities():
                         'cohere:command-r7b-12-2024',
                         'deepseek:deepseek-chat',
                         'deepseek:deepseek-reasoner',
+                        'deepseek:deepseek-v4-flash',
+                        'deepseek:deepseek-v4-pro',
                         'gateway/anthropic:claude-3-haiku-20240307',
                         'gateway/anthropic:claude-haiku-4-5-20251001',
                         'gateway/anthropic:claude-mythos-preview',


### PR DESCRIPTION
- Closes #5193
- Alternative implementation to #5195. Opened per maintainer feedback in `#pydantic-ai` Slack ("we don't need to use the same PR to drive it to completion"). Credit to @SuperMarioYL's #5195 for surfacing the `KnownModelName` registry and `tests/test_capabilities.py` snapshot updates (originally flagged by Devin AI on that PR), incorporated here.

### What

Add support for the explicit DeepSeek V4 model IDs (`deepseek-v4-flash` and `deepseek-v4-pro`) that replace the `deepseek-chat` alias on 2026-07-24 15:59 UTC.

Five files:

- `providers/deepseek.py`: extend `DeepSeekModelName` literal with both V4 IDs; replace the `deepseek-reasoner`-only exclusion in `openai_supports_tool_choice_required` with a `startswith('deepseek-v4-')` predicate so future `deepseek-v4-*` SKUs (e.g. a hypothetical `v4-mini`) inherit the right `tool_choice` behaviour automatically.
- `profiles/deepseek.py`: detect V4 via `model_name.startswith('deepseek-v4-')` (matching the convention in `profiles/openai.py`, `profiles/grok.py`, `profiles/anthropic.py`, `profiles/mistral.py`); set `supports_thinking=True` so `reasoning_content` in V4 responses is treated as a thinking part. `thinking_always_enabled` stays `False` because V4 controls thinking via `reasoning_effort` at runtime.
- `models/__init__.py`: add `'deepseek:deepseek-v4-flash'` and `'deepseek:deepseek-v4-pro'` to the `KnownModelName` literal so the gateway-style shorthand path resolves and `test_known_model_names` passes.
- `tests/test_capabilities.py`: matching snapshot lines.
- `tests/providers/test_deepseek.py`: parametrized V4 profile tests, plus regression anchors for `deepseek-chat` and `deepseek-reasoner`. Extended the existing R1 test with `supports_thinking=True` and `thinking_always_enabled=True` assertions to pin the asymmetry between R1 (always thinking) and V4 (toggleable via `reasoning_effort`).

### Why

`deepseek-v4-flash` and `deepseek-v4-pro` fall through to the `OpenAIModelProfile` defaults, which leave `openai_supports_tool_choice_required=True`. When a user passes any `output_type` to an agent, pydantic-ai sends `tool_choice=required` and DeepSeek returns a 400 with a body that points at `deepseek-reasoner` (server-side reasoner endpoint) even though the request targeted `deepseek-v4-flash`. Every pydantic-ai user migrating away from the `deepseek-chat` alias hits this on upgrade, and the alias sunsets 2026-07-24.

### Differences vs #5195

#5195 ships the same fix with two implementation details that this PR tightens:

- **Detection**: `'v4' in model_name` substring vs `startswith('deepseek-v4-')`. `deepseek_model_profile` is consumed by 16+ provider files (Azure, Bedrock, OpenRouter, Fireworks, HuggingFace, LiteLLM, etc.), so a substring match risks leaking V4 thinking semantics onto unrelated names routed through other providers.
- **Tool choice exclusion**: closed tuple `('deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro')` vs predicate `model_name != 'deepseek-reasoner' and not model_name.startswith('deepseek-v4-')`. The closed tuple won't survive future V4 SKUs.
- **R1 regression anchor**: extends the existing `test_deep_seek_model_profile` to pin `supports_thinking=True` and `thinking_always_enabled=True` for `deepseek-r1`, so the `is_r1 or is_v4` expression cannot silently lose `is_r1` in a future refactor.

The `KnownModelName` and `tests/test_capabilities.py` updates are equivalent to #5195's.

### Tests

`uv run pytest tests/providers/test_deepseek.py tests/test_capabilities.py tests/models/test_model_names.py` passes (407 tests) including:

- `test_deep_seek_v4_model_profile[deepseek-v4-flash]`
- `test_deep_seek_v4_model_profile[deepseek-v4-pro]`
- `test_deep_seek_chat_model_profile`
- `test_deep_seek_reasoner_model_profile`
- `test_deep_seek_model_profile` (extended R1 anchors)
- `test_known_model_names` (registry CI gate)
- `test_model_json_schema_with_capabilities` (inline snapshot)

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).