### PR TITLE
feat(google): unblock `NativeOutput` + function tools on Gemini 3+

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -621,9 +621,13 @@ class GoogleModel(Model[Client]):
         response_mime_type = None
         response_schema = None
         if model_request_parameters.output_mode == 'native':
-            if model_request_parameters.function_tools:
+            if (
+                model_request_parameters.function_tools
+                and not GoogleModelProfile.from_profile(self.profile).google_supports_tool_combination
+            ):
                 raise UserError(
-                    'Google does not support `NativeOutput` and function tools at the same time. Use `output_type=ToolOutput(...)` instead.'
+                    'This model does not support `NativeOutput` and function tools at the same time. '
+                    'Use `output_type=ToolOutput(...)` instead.'
                 )
             response_mime_type = 'application/json'
             output_object = model_request_parameters.output_object

--- a/pydantic_ai_slim/pydantic_ai/profiles/google.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/google.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import warnings
 from dataclasses import dataclass
 
 from .._json_schema import JsonSchema, JsonSchemaTransformer
@@ -23,9 +24,17 @@ class GoogleModelProfile(ModelProfile):
     ALL FIELDS MUST BE `google_` PREFIXED SO YOU CAN MERGE THEM WITH OTHER MODELS.
     """
 
-    google_supports_native_output_with_builtin_tools: bool = False
-    """Whether the model supports native output with builtin tools.
-    See https://ai.google.dev/gemini-api/docs/structured-output?example=recipe#structured_outputs_with_tools"""
+    google_supports_tool_combination: bool = False
+    """Whether the model supports combining function declarations with builtin tools and `response_schema`.
+
+    Gemini 3+ lifts the historical restriction that prevented combining `function_declarations` with
+    builtin tools or with `response_schema` (`NativeOutput`) in the same request.
+    See https://ai.google.dev/gemini-api/docs/tool-combination
+    """
+
+    # TODO(v2): remove `google_supports_native_output_with_builtin_tools`
+    google_supports_native_output_with_builtin_tools: bool | None = None
+    """Deprecated: use `google_supports_tool_combination` instead."""
 
     google_supported_mime_types_in_tool_returns: tuple[str, ...] = ()
     """MIME types supported in native FunctionResponseDict.parts.
@@ -36,6 +45,16 @@ class GoogleModelProfile(ModelProfile):
 
     Gemini 3+ models use `thinking_level`; Gemini 2.5 uses `thinking_budget`.
     """
+
+    def __post_init__(self):
+        if self.google_supports_native_output_with_builtin_tools is not None:
+            warnings.warn(
+                '`google_supports_native_output_with_builtin_tools` is deprecated, '
+                'use `google_supports_tool_combination` instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.google_supports_tool_combination = self.google_supports_native_output_with_builtin_tools
 
 
 def google_model_profile(model_name: str) -> ModelProfile | None:
@@ -55,7 +74,7 @@ def google_model_profile(model_name: str) -> ModelProfile | None:
         supports_tool_return_schema=not is_image_model,
         supports_thinking=is_thinking_model,
         thinking_always_enabled=thinking_always_enabled,
-        google_supports_native_output_with_builtin_tools=is_3_or_newer,
+        google_supports_tool_combination=is_3_or_newer,
         google_supported_mime_types_in_tool_returns=_GOOGLE_NATIVE_TOOL_RETURN_MIME_TYPES if is_3_or_newer else (),
         google_supports_thinking_level=is_3_or_newer,
     )

--- a/tests/models/cassettes/test_google_structured_output/test_native_output_with_function_tools.yaml
+++ b/tests/models/cassettes/test_google_structured_output/test_native_output_with_function_tools.yaml
@@ -1,0 +1,184 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '554'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: What is the largest city in the user country?
+        role: user
+      generationConfig:
+        responseJsonSchema:
+          properties:
+            city:
+              type: string
+            country:
+              type: string
+          required:
+          - city
+          - country
+          title: CityLocation
+          type: object
+        responseMimeType: application/json
+        responseModalities:
+        - TEXT
+      tools:
+      - functionDeclarations:
+        - description: ''
+          name: get_user_country
+          parameters_json_schema:
+            additionalProperties: false
+            properties: {}
+            type: object
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '956'
+      content-type:
+      - application/json; charset=UTF-8
+      server-timing:
+      - gfet4t7; dur=1975
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    parsed_body:
+      candidates:
+      - content:
+          parts:
+          - functionCall:
+              args: {}
+              id: 433twugp
+              name: get_user_country
+            thoughtSignature: EsICCr8CAb4+9vu3iLbkgBv3NM8MTZ8AY0qigLMvQw2c4zaPLTBVOjJIoxDi+HxhqumFkQACTbeY79Gdx577m9h8SHhP5ixCoHGc0Um8Dnhv2W4abbuVP/OSYelZzRXDWEX4O9JvHzC1V1gxx/OQYhwY5zipl3DLHFI/2yYlRxMsia2aeaqsc/3nafJ9LmItk54EyX2XYPhF0BDSE96auSJV9DCnDvHdXNZeXuSM96dNLi4hUFQfPAAainjD96vZcWtv9nNJBxnNR2u754x9Z5jh120fBm53l9Zu7PT9Jzwe9szpUUn9PTyzs2iqrgpC5DrkxBZkWQu/10LBIpK6iYGVTMtkiUfkRe9GDAACObOL+qI+THW2HsAhgIVs7+PjI2IkaTJf6MYSnbBl+Ya/6D4NttH3GUGN724uF9LwjPhnUOf+Mw==
+          role: model
+        finishMessage: Model generated function call(s).
+        finishReason: STOP
+        index: 0
+      modelVersion: gemini-3-flash-preview
+      responseId: 1MnFaZLAD6Ky1MkP8Nrx4QQ
+      usageMetadata:
+        candidatesTokenCount: 12
+        promptTokenCount: 29
+        promptTokensDetails:
+        - modality: TEXT
+          tokenCount: 29
+        thoughtsTokenCount: 64
+        totalTokenCount: 105
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1261'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: What is the largest city in the user country?
+        role: user
+      - parts:
+        - functionCall:
+            args: {}
+            id: 433twugp
+            name: get_user_country
+          thoughtSignature: EsICCr8CAb4-9vu3iLbkgBv3NM8MTZ8AY0qigLMvQw2c4zaPLTBVOjJIoxDi-HxhqumFkQACTbeY79Gdx577m9h8SHhP5ixCoHGc0Um8Dnhv2W4abbuVP_OSYelZzRXDWEX4O9JvHzC1V1gxx_OQYhwY5zipl3DLHFI_2yYlRxMsia2aeaqsc_3nafJ9LmItk54EyX2XYPhF0BDSE96auSJV9DCnDvHdXNZeXuSM96dNLi4hUFQfPAAainjD96vZcWtv9nNJBxnNR2u754x9Z5jh120fBm53l9Zu7PT9Jzwe9szpUUn9PTyzs2iqrgpC5DrkxBZkWQu_10LBIpK6iYGVTMtkiUfkRe9GDAACObOL-qI-THW2HsAhgIVs7-PjI2IkaTJf6MYSnbBl-Ya_6D4NttH3GUGN724uF9LwjPhnUOf-Mw==
+        role: model
+      - parts:
+        - functionResponse:
+            id: 433twugp
+            name: get_user_country
+            response:
+              return_value: Mexico
+        role: user
+      generationConfig:
+        responseJsonSchema:
+          properties:
+            city:
+              type: string
+            country:
+              type: string
+          required:
+          - city
+          - country
+          title: CityLocation
+          type: object
+        responseMimeType: application/json
+        responseModalities:
+        - TEXT
+      tools:
+      - functionDeclarations:
+        - description: ''
+          name: get_user_country
+          parameters_json_schema:
+            additionalProperties: false
+            properties: {}
+            type: object
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '734'
+      content-type:
+      - application/json; charset=UTF-8
+      server-timing:
+      - gfet4t7; dur=912
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    parsed_body:
+      candidates:
+      - content:
+          parts:
+          - text: "{\n  \"city\": \"Mexico City\",\n  \"country\": \"Mexico\"\n} "
+            thoughtSignature: EsQBCsEBAb4+9vv+qq+pJIPjFrHh/p/G6JuOaDnnTsQnBqtCTMrral46e73Jd8X1nJfxxtexSiy9Jvz+hF5n51mXGWnyUrNfo4LEsH6opvfJjVMzcWg/qhdkNhkW1fc0U+EYNtbMPbFf1VrS/Tc57vOk6J8X3HoxuOq1H1v8SisuAYN+w69cIboxwvcETfGjhNdT+OKQ06Viy01GPPUUKLIZY6fwL4Idrvei8iq4GVnRh/4LlJvEka+GBcDIoDVIzamBqFjOfA==
+          role: model
+        finishReason: STOP
+        index: 0
+      modelVersion: gemini-3-flash-preview
+      responseId: 1cnFaY76C47TjMcPkM6k0Qg
+      usageMetadata:
+        candidatesTokenCount: 21
+        promptTokenCount: 123
+        promptTokensDetails:
+        - modality: TEXT
+          tokenCount: 123
+        thoughtsTokenCount: 31
+        totalTokenCount: 175
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_google_structured_output/test_native_output_with_function_tools_stream.yaml
+++ b/tests/models/cassettes/test_google_structured_output/test_native_output_with_function_tools_stream.yaml
@@ -1,0 +1,164 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '554'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: What is the largest city in the user country?
+        role: user
+      generationConfig:
+        responseJsonSchema:
+          properties:
+            city:
+              type: string
+            country:
+              type: string
+          required:
+          - city
+          - country
+          title: CityLocation
+          type: object
+        responseMimeType: application/json
+        responseModalities:
+        - TEXT
+      tools:
+      - functionDeclarations:
+        - description: ''
+          name: get_user_country
+          parameters_json_schema:
+            additionalProperties: false
+            properties: {}
+            type: object
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:streamGenerateContent?alt=sse
+  response:
+    body:
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\": {\"name\": \"get_user_country\",\"args\":
+        {},\"id\": \"zeq8pw5c\"},\"thoughtSignature\": \"EswECskEAb4+9vszSOSJFcX7HcWj42UcDRpqzTKd69hrO2bufTCQdKZs6Shy65Z1ZKRZyOuhOmbRhEkOq23rpA2p0sw2mKwvcUcLEIvHBr4Bta7awDi1kvohNCC/2L7vcN+ikJmChE/SwT7nved+3HZ2ekMHBSN7mlZexdS2OheIip8NjeCaypgl+guvGG9gfgyR3Sau6DUC+UhJKvZ+b5bhuNNTIjIwsECdYQVMjlyyRep6bP89FdCSR/C0q3y7Zyeo/4oS1i0GZLJu3EvasByNYzbcgoOZUon4GQdiUkyTfuTb0/N6q/S0bMZAN5CMByGhuYgZu4DQpLlcInBOLAZ0w0a72A0LuLgftzK4gkjA0AhzmYxw3uBSlgvclH3iFbb1+hmLg85gQ7M4be4eeFGA/KAtLru4UOhMpAKTRK1LMUiM18nGSI68D7AtQki8p3OMdI8dOewzgitVAFTxDvkeC7RJdMJBdZmQuRP3fimjZu+vr8vCe+szncc/vRtOLYmIqKsz8eH1T2/UFLX3srDfbbQqwTIQvFgZ0xGD8AbNz/iZswzha0cgl4XypyDpCl2q51NdOHTVuSU/QS4tDdnPj37/q03q/s5TNoLKrRUHjcZra1CIZGwVFi0fwU1uee80K1Oyss1chvB0k9JNi2UQagAZ13n3YpD3aNIzD/cT10MY2/PmwWQnOK+yMc0R4uG9JlhRKwHlAbfFI7K5hJV6IvUA6f4pBeuzLOfbkSs8+9cfMY9e3tdGUTsP3uB9TxHkNMSMCxpVFF9QNhtv\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 29,\"candidatesTokenCount\": 12,\"totalTokenCount\":
+        156,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 29}],\"thoughtsTokenCount\": 115},\"modelVersion\":
+        \"gemini-3-flash-preview\",\"responseId\": \"1snFaaeXKbjD-sAPtam9qQY\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
+        {\"parts\": [{\"text\": \"\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        29,\"candidatesTokenCount\": 12,\"totalTokenCount\": 156,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        29}],\"thoughtsTokenCount\": 115},\"modelVersion\": \"gemini-3-flash-preview\",\"responseId\": \"1snFaaeXKbjD-sAPtam9qQY\"}\r\n\r\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-disposition:
+      - attachment
+      content-type:
+      - text/event-stream
+      server-timing:
+      - gfet4t7; dur=1366
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1613'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: What is the largest city in the user country?
+        role: user
+      - parts:
+        - functionCall:
+            args: {}
+            id: zeq8pw5c
+            name: get_user_country
+          thoughtSignature: EswECskEAb4-9vszSOSJFcX7HcWj42UcDRpqzTKd69hrO2bufTCQdKZs6Shy65Z1ZKRZyOuhOmbRhEkOq23rpA2p0sw2mKwvcUcLEIvHBr4Bta7awDi1kvohNCC_2L7vcN-ikJmChE_SwT7nved-3HZ2ekMHBSN7mlZexdS2OheIip8NjeCaypgl-guvGG9gfgyR3Sau6DUC-UhJKvZ-b5bhuNNTIjIwsECdYQVMjlyyRep6bP89FdCSR_C0q3y7Zyeo_4oS1i0GZLJu3EvasByNYzbcgoOZUon4GQdiUkyTfuTb0_N6q_S0bMZAN5CMByGhuYgZu4DQpLlcInBOLAZ0w0a72A0LuLgftzK4gkjA0AhzmYxw3uBSlgvclH3iFbb1-hmLg85gQ7M4be4eeFGA_KAtLru4UOhMpAKTRK1LMUiM18nGSI68D7AtQki8p3OMdI8dOewzgitVAFTxDvkeC7RJdMJBdZmQuRP3fimjZu-vr8vCe-szncc_vRtOLYmIqKsz8eH1T2_UFLX3srDfbbQqwTIQvFgZ0xGD8AbNz_iZswzha0cgl4XypyDpCl2q51NdOHTVuSU_QS4tDdnPj37_q03q_s5TNoLKrRUHjcZra1CIZGwVFi0fwU1uee80K1Oyss1chvB0k9JNi2UQagAZ13n3YpD3aNIzD_cT10MY2_PmwWQnOK-yMc0R4uG9JlhRKwHlAbfFI7K5hJV6IvUA6f4pBeuzLOfbkSs8-9cfMY9e3tdGUTsP3uB9TxHkNMSMCxpVFF9QNhtv
+        role: model
+      - parts:
+        - functionResponse:
+            id: zeq8pw5c
+            name: get_user_country
+            response:
+              return_value: Mexico
+        role: user
+      generationConfig:
+        responseJsonSchema:
+          properties:
+            city:
+              type: string
+            country:
+              type: string
+          required:
+          - city
+          - country
+          title: CityLocation
+          type: object
+        responseMimeType: application/json
+        responseModalities:
+        - TEXT
+      tools:
+      - functionDeclarations:
+        - description: ''
+          name: get_user_country
+          parameters_json_schema:
+            additionalProperties: false
+            properties: {}
+            type: object
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:streamGenerateContent?alt=sse
+  response:
+    body:
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 59,\"candidatesTokenCount\": 1,\"totalTokenCount\": 96,\"promptTokensDetails\": [{\"modality\":
+        \"TEXT\",\"tokenCount\": 59}],\"thoughtsTokenCount\": 36},\"modelVersion\": \"gemini-3-flash-preview\",\"responseId\":
+        \"18nFaaz2H5aQjrEP2ruPIQ\"}\r\n\r\ndata: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\\n  \\\"city\\\":
+        \\\"Mexico City\\\",\\n  \\\"country\\\": \\\"Mexico\\\"\\n} \"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 59,\"candidatesTokenCount\": 21,\"totalTokenCount\": 116,\"promptTokensDetails\": [{\"modality\":
+        \"TEXT\",\"tokenCount\": 59}],\"thoughtsTokenCount\": 36},\"modelVersion\": \"gemini-3-flash-preview\",\"responseId\":
+        \"18nFaaz2H5aQjrEP2ruPIQ\"}\r\n\r\ndata: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EvEBCu4BAb4+9vt67+Q3/ZKMpkDKnkKOg62DlUafHYxAlkUgZDQ4A/u2KuIpPDSzYi2L9ivbWqblWNHjXjrGBdrxevAwMwWFRHOXABgJDYU9KOd5rkPFJKQyVYCXGZQLAK/8c8K+fBsOjl9uzHnPE3HVUU7WWi04ZJlqXC9eUa2ZfxwASIBQANd8ILQZHE8KRsgPdhEagtnpIabyLkdy2U/H6wMPpCeZw68NbxCEp6+vOI+AMC3ISjUtTiGwLovA5ssBjyJknQY3jQ45+DVk/1kZh3f3hEoF9l/fOGP3pZRHBrEAxyNOmztgo5sdggowGjtC3A==\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 174,\"candidatesTokenCount\":
+        21,\"totalTokenCount\": 231,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 174}],\"thoughtsTokenCount\":
+        36},\"modelVersion\": \"gemini-3-flash-preview\",\"responseId\": \"18nFaaz2H5aQjrEP2ruPIQ\"}\r\n\r\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-disposition:
+      - attachment
+      content-type:
+      - text/event-stream
+      server-timing:
+      - gfet4t7; dur=833
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_google_structured_output.py
+++ b/tests/models/test_google_structured_output.py
@@ -1,0 +1,230 @@
+"""Tests for Google `NativeOutput` combined with function tools (Gemini 3+).
+
+Gemini 3 lifts the historical restriction that prevented combining `response_schema`
+(`NativeOutput`) with `function_declarations` in the same request. These tests cover:
+
+1. The error still fires on Gemini 2.5 (and any other model whose profile does not set
+   `google_supports_tool_combination`).
+2. The combination works on Gemini 3+ for both sync and streaming requests.
+"""
+
+from __future__ import annotations as _annotations
+
+import re
+
+import pytest
+from pydantic import BaseModel
+
+from pydantic_ai import Agent
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.output import NativeOutput
+from pydantic_ai.usage import RequestUsage
+
+from .._inline_snapshot import snapshot
+from ..conftest import IsDatetime, IsStr, try_import
+
+with try_import() as imports_successful:
+    from pydantic_ai.models.google import GoogleModel
+    from pydantic_ai.providers.google import GoogleProvider
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='google-genai not installed'),
+    pytest.mark.anyio,
+    pytest.mark.vcr,
+]
+
+
+class CityLocation(BaseModel):
+    city: str
+    country: str
+
+
+@pytest.fixture
+def google_provider(gemini_api_key: str) -> GoogleProvider:
+    return GoogleProvider(api_key=gemini_api_key)
+
+
+async def test_native_output_with_function_tools_unsupported(
+    allow_model_requests: None, google_provider: GoogleProvider
+):
+    """Models without `google_supports_tool_combination` still raise on `NativeOutput` + function tools."""
+    m = GoogleModel('gemini-2.5-flash', provider=google_provider)
+    agent = Agent(m, output_type=NativeOutput(CityLocation))
+
+    @agent.tool_plain
+    async def get_user_country() -> str:
+        return 'Mexico'  # pragma: no cover
+
+    with pytest.raises(
+        UserError,
+        match=re.escape(
+            'This model does not support `NativeOutput` and function tools at the same time. '
+            'Use `output_type=ToolOutput(...)` instead.'
+        ),
+    ):
+        await agent.run('What is the largest city in the user country?')
+
+
+async def test_native_output_with_function_tools(allow_model_requests: None, google_provider: GoogleProvider):
+    m = GoogleModel('gemini-3-flash-preview', provider=google_provider)
+    agent = Agent(m, output_type=NativeOutput(CityLocation))
+
+    @agent.tool_plain
+    async def get_user_country() -> str:
+        return 'Mexico'
+
+    result = await agent.run('What is the largest city in the user country?')
+    assert isinstance(result.output, CityLocation)
+    assert result.output == snapshot(CityLocation(city='Mexico City', country='Mexico'))
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='What is the largest city in the user country?', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='get_user_country',
+                        args={},
+                        tool_call_id='433twugp',
+                        provider_name='google-gla',
+                        provider_details={'thought_signature': IsStr()},
+                    )
+                ],
+                usage=RequestUsage(
+                    input_tokens=29, output_tokens=76, details={'thoughts_tokens': 64, 'text_prompt_tokens': 29}
+                ),
+                model_name='gemini-3-flash-preview',
+                timestamp=IsDatetime(),
+                provider_name='google-gla',
+                provider_url='https://generativelanguage.googleapis.com/',
+                provider_details={'finish_reason': 'STOP'},
+                provider_response_id='1MnFaZLAD6Ky1MkP8Nrx4QQ',
+                finish_reason='stop',
+                run_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='get_user_country', content='Mexico', tool_call_id='433twugp', timestamp=IsDatetime()
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[
+                    TextPart(
+                        content="""\
+{
+  "city": "Mexico City",
+  "country": "Mexico"
+} \
+""",
+                        provider_name='google-gla',
+                        provider_details={'thought_signature': IsStr()},
+                    )
+                ],
+                usage=RequestUsage(
+                    input_tokens=123, output_tokens=52, details={'thoughts_tokens': 31, 'text_prompt_tokens': 123}
+                ),
+                model_name='gemini-3-flash-preview',
+                timestamp=IsDatetime(),
+                provider_name='google-gla',
+                provider_url='https://generativelanguage.googleapis.com/',
+                provider_details={'finish_reason': 'STOP'},
+                provider_response_id='1cnFaY76C47TjMcPkM6k0Qg',
+                finish_reason='stop',
+                run_id=IsStr(),
+            ),
+        ]
+    )
+
+
+async def test_native_output_with_function_tools_stream(allow_model_requests: None, google_provider: GoogleProvider):
+    m = GoogleModel('gemini-3-flash-preview', provider=google_provider)
+    agent = Agent(m, output_type=NativeOutput(CityLocation))
+
+    @agent.tool_plain
+    async def get_user_country() -> str:
+        return 'Mexico'
+
+    async with agent.run_stream('What is the largest city in the user country?') as result:
+        output = await result.get_output()
+    assert isinstance(output, CityLocation)
+    assert output == snapshot(CityLocation(city='Mexico City', country='Mexico'))
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='What is the largest city in the user country?', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='get_user_country',
+                        args={},
+                        tool_call_id='zeq8pw5c',
+                        provider_name='google-gla',
+                        provider_details={'thought_signature': IsStr()},
+                    )
+                ],
+                usage=RequestUsage(
+                    input_tokens=29, output_tokens=127, details={'thoughts_tokens': 115, 'text_prompt_tokens': 29}
+                ),
+                model_name='gemini-3-flash-preview',
+                timestamp=IsDatetime(),
+                provider_name='google-gla',
+                provider_url='https://generativelanguage.googleapis.com/',
+                provider_details={'finish_reason': 'STOP'},
+                provider_response_id='1snFaaeXKbjD-sAPtam9qQY',
+                finish_reason='stop',
+                run_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='get_user_country', content='Mexico', tool_call_id='zeq8pw5c', timestamp=IsDatetime()
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[
+                    TextPart(
+                        content="""\
+{
+  "city": "Mexico City",
+  "country": "Mexico"
+} \
+""",
+                        provider_name='google-gla',
+                        provider_details={'thought_signature': IsStr()},
+                    )
+                ],
+                usage=RequestUsage(
+                    input_tokens=174, output_tokens=57, details={'thoughts_tokens': 36, 'text_prompt_tokens': 174}
+                ),
+                model_name='gemini-3-flash-preview',
+                timestamp=IsDatetime(),
+                provider_name='google-gla',
+                provider_url='https://generativelanguage.googleapis.com/',
+                provider_details={'finish_reason': 'STOP'},
+                provider_response_id='18nFaaz2H5aQjrEP2ruPIQ',
+                finish_reason='stop',
+                run_id=IsStr(),
+            ),
+        ]
+    )

--- a/tests/profiles/test_google.py
+++ b/tests/profiles/test_google.py
@@ -10,9 +10,10 @@ from __future__ import annotations as _annotations
 
 from typing import Literal
 
+import pytest
 from pydantic import BaseModel
 
-from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer, google_model_profile
+from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer, GoogleModelProfile, google_model_profile
 
 from .._inline_snapshot import snapshot
 
@@ -193,11 +194,25 @@ def test_model_profile_gemini_2():
     assert profile.supports_json_schema_output is True
 
 
-def test_model_profile_gemini_3():
-    """Gemini 3.x models should support native output with builtin tools."""
+def test_model_profile_gemini_3_supports_tool_combination():
+    """Gemini 3.x models should support combining function declarations with builtin tools and `response_schema`."""
     profile = google_model_profile('gemini-3.0-pro')
-    assert profile is not None
-    assert profile.google_supports_native_output_with_builtin_tools is True  # type: ignore
+    assert isinstance(profile, GoogleModelProfile)
+    assert profile.google_supports_tool_combination is True
+
+
+def test_model_profile_gemini_2_does_not_support_tool_combination():
+    """Gemini 2.x models do not support the new tool combination capability."""
+    profile = google_model_profile('gemini-2.5-flash')
+    assert isinstance(profile, GoogleModelProfile)
+    assert profile.google_supports_tool_combination is False
+
+
+def test_deprecated_google_supports_native_output_with_builtin_tools_alias():
+    """The old field name still works but emits a DeprecationWarning and forwards to the new field."""
+    with pytest.warns(DeprecationWarning, match='google_supports_native_output_with_builtin_tools'):
+        profile = GoogleModelProfile(google_supports_native_output_with_builtin_tools=True)
+    assert profile.google_supports_tool_combination is True
 
 
 def test_model_profile_image_model():


### PR DESCRIPTION
- Closes #4801
- Carved out from #4848 per maintainer feedback so the structured-output relaxation can land independently of the larger function-tools + builtin-tools work, which stays on the `google-structured-outputs` branch and will be retargeted on top of this once it merges.

## Summary

Gemini 3+ lifts the historical restriction that prevented combining `response_schema` (`NativeOutput`) with `function_declarations` in the same request. This PR unblocks that combination on the supported models while keeping the existing `UserError` for older Gemini families.

- Rename `GoogleModelProfile.google_supports_native_output_with_builtin_tools` → `google_supports_tool_combination`. The old field stays as a deprecated alias that warns and forwards via `__post_init__`, so user-defined profiles keep working.
- Gate the `_build_generation_config` `UserError` on the new flag. Gemini 3+ models accept `response_schema` alongside `function_declarations`; Gemini 2.5 still raises with a slightly reworded message ("This model does not…" rather than "Google does not…") to match the per-model framing the flag introduces.
- Profile tests assert the flag for both generations and cover the deprecation alias.
- New `tests/models/test_google_structured_output.py` covers the unsupported error path on Gemini 2.5 and the sync + streaming happy paths on Gemini 3 with VCR cassettes.

The function-tools + builtin-tools rendering work and the test directory reorg from #4848 are deliberately not included here.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [ ] Updated **documentation** for new features and behaviors, including docstrings for API docs.