### PR TITLE
Handle text-only content-filter Responses outputs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -768,12 +768,17 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
 
                                 await agent_run.next(_agent_graph.SetFinalResult(final_result))
 
-                            yield StreamedRunResult(
+                            streamed_run_result = StreamedRunResult(
                                 messages,
                                 graph_ctx.deps.new_message_index,
                                 stream,
                                 on_complete,
                             )
+                            try:
+                                yield streamed_run_result
+                            finally:
+                                if not streamed_run_result.is_complete:
+                                    await streamed_run_result._marked_completed(streamed_run_result.response)  # pyright: ignore[reportPrivateUsage]
                             # Note: wrap_node_run/after_node_run are intentionally skipped here.
                             # before_node_run fired above; on_complete() later calls
                             # agent_run.next(SetFinalResult(...)) which fires the full lifecycle

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -227,6 +227,26 @@ _RESPONSES_FINISH_REASON_MAP: dict[Literal['max_output_tokens', 'content_filter'
     'failed': 'error',
 }
 
+
+def _normalize_responses_content_filter_parts(
+    parts: list[ModelResponsePart],
+    finish_reason: FinishReason | None,
+    provider_details: dict[str, Any],
+) -> tuple[list[ModelResponsePart], dict[str, Any]]:
+    """Convert Responses API text refusals into empty content plus refusal metadata."""
+    if finish_reason != 'content_filter' or 'refusal' in provider_details:
+        return parts, provider_details
+
+    refusal_parts = [part.content for part in parts if isinstance(part, TextPart)]
+    if refusal_parts and len(refusal_parts) == len(parts):
+        normalized_details = provider_details.copy()
+        normalized_details.pop('finish_reason', None)
+        normalized_details['refusal'] = ''.join(refusal_parts)
+        return [], normalized_details
+
+    return parts, provider_details
+
+
 _OPENAI_ASPECT_RATIO_TO_SIZE: dict[ImageAspectRatio, Literal['1024x1024', '1024x1536', '1536x1024']] = {
     '1:1': '1024x1024',
     '2:3': '1024x1536',
@@ -1841,6 +1861,8 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             finish_reason = 'content_filter'
             provider_details.pop('finish_reason', None)
             provider_details['refusal'] = refusal_text
+        else:
+            items, provider_details = _normalize_responses_content_filter_parts(items, finish_reason, provider_details)
 
         return ModelResponse(
             parts=items,
@@ -3230,6 +3252,22 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
 
             if self._refusal_text:
                 self.provider_details = {**(self.provider_details or {}), 'refusal': self._refusal_text}
+
+    def get(self) -> ModelResponse:
+        parts, provider_details = _normalize_responses_content_filter_parts(
+            self._parts_manager.get_parts(), self.finish_reason, self.provider_details or {}
+        )
+        return ModelResponse(
+            parts=parts,
+            model_name=self.model_name,
+            timestamp=self.timestamp,
+            usage=self.usage(),
+            provider_name=self.provider_name,
+            provider_url=self.provider_url,
+            provider_response_id=self.provider_response_id,
+            provider_details=provider_details or None,
+            finish_reason=self.finish_reason,
+        )
 
     def _map_usage(self, response: responses.Response) -> usage.RequestUsage:
         return _map_usage(response, self._provider_name, self._provider_url, self.model_name)

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -44,6 +44,25 @@ T = TypeVar('T')
 """An invariant TypeVar."""
 
 
+def _raise_if_content_filtered(message: _messages.ModelResponse) -> None:
+    if message.parts or message.finish_reason != 'content_filter':
+        return
+
+    details = message.provider_details or {}
+    body = _messages.ModelMessagesTypeAdapter.dump_json([message]).decode()
+
+    if reason := details.get('finish_reason'):
+        error_message = f"Content filter triggered. Finish reason: '{reason}'"
+    elif reason := details.get('block_reason'):
+        error_message = f"Content filter triggered. Block reason: '{reason}'"
+    elif refusal := details.get('refusal'):
+        error_message = f'Content filter triggered. Refusal: {refusal!r}'
+    else:  # pragma: no cover
+        error_message = 'Content filter triggered.'
+
+    raise exceptions.ContentFilterError(error_message, body=body)
+
+
 @dataclass(kw_only=True)
 class AgentStream(Generic[AgentDepsT, OutputDataT]):
     _raw_stream_response: models.StreamedResponse
@@ -190,6 +209,7 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
         self, message: _messages.ModelResponse, *, allow_partial: bool = False
     ) -> OutputDataT:
         """Validate a structured result message."""
+        _raise_if_content_filtered(message)
         final_result_event = self._raw_stream_response.final_result_event
         if final_result_event is None:
             raise exceptions.UnexpectedModelBehavior('Invalid response, unable to find output')  # pragma: no cover

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -61,6 +61,7 @@ with try_import() as imports_successful:
     from openai import AsyncOpenAI
     from openai.types import responses as resp
     from openai.types.responses import ResponseFunctionWebSearch
+    from openai.types.responses.response import IncompleteDetails
     from openai.types.responses.response_output_message import Content, ResponseOutputMessage
     from openai.types.responses.response_output_refusal import ResponseOutputRefusal
     from openai.types.responses.response_output_text import ResponseOutputText
@@ -10373,6 +10374,41 @@ async def test_openai_responses_refusal_non_streaming(allow_model_requests: None
     assert response_msg['provider_details']['refusal'] == "I can't help with that request."
 
 
+async def test_openai_responses_text_content_filter_non_streaming(allow_model_requests: None):
+    """Test that text-only content-filter responses raise ContentFilterError."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='msg_001',
+                content=cast(
+                    list[Content],
+                    [ResponseOutputText(text="I can't help with that request.", type='output_text', annotations=[])],
+                ),
+                role='assistant',
+                status='incomplete',
+                type='message',
+            )
+        ]
+    ).model_copy(update={'status': 'incomplete', 'incomplete_details': IncompleteDetails(reason='content_filter')})
+
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    with pytest.raises(
+        ContentFilterError,
+        match=re.escape('Content filter triggered. Refusal: "I can\'t help with that request."'),
+    ) as exc_info:
+        await agent.run('harmful prompt')
+
+    assert exc_info.value.body is not None
+    body_json = json.loads(exc_info.value.body)
+    response_msg = body_json[0]
+    assert response_msg['parts'] == []
+    assert response_msg['finish_reason'] == 'content_filter'
+    assert response_msg['provider_details']['refusal'] == "I can't help with that request."
+
+
 async def test_openai_responses_refusal_streaming(allow_model_requests: None):
     """Test that ResponseRefusalDeltaEvent/DoneEvent in streaming triggers ContentFilterError."""
     base_response = resp.Response(
@@ -10429,6 +10465,100 @@ async def test_openai_responses_refusal_streaming(allow_model_requests: None):
             response=base_response.model_copy(update={'status': 'completed'}),
             type='response.completed',
             sequence_number=6,
+        ),
+    ]
+
+    mock_client = MockOpenAIResponses.create_mock_stream(stream)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    with pytest.raises(ContentFilterError, match='Content filter triggered') as exc_info:
+        async with agent.run_stream('harmful prompt'):
+            pass
+
+    assert exc_info.value.body is not None
+    body_json = json.loads(exc_info.value.body)
+    response_msg = body_json[0]
+    assert response_msg['parts'] == []
+    assert response_msg['finish_reason'] == 'content_filter'
+    assert response_msg['provider_details']['refusal'] == "I can't help with that."
+
+
+async def test_openai_responses_text_content_filter_streaming(allow_model_requests: None):
+    """Test that text-only streamed content-filter responses raise ContentFilterError."""
+    base_response = resp.Response(
+        id='resp_001',
+        model='gpt-4o',
+        object='response',
+        created_at=1704067200,
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice='auto',
+        tools=[],
+    )
+
+    stream: list[resp.ResponseStreamEvent] = [
+        resp.ResponseCreatedEvent(response=base_response, type='response.created', sequence_number=0),
+        resp.ResponseInProgressEvent(response=base_response, type='response.in_progress', sequence_number=1),
+        resp.ResponseOutputItemAddedEvent(
+            item=ResponseOutputMessage(
+                id='msg_001',
+                content=[],
+                role='assistant',
+                status='in_progress',
+                type='message',
+            ),
+            output_index=0,
+            type='response.output_item.added',
+            sequence_number=2,
+        ),
+        resp.ResponseContentPartAddedEvent(
+            content_index=0,
+            item_id='msg_001',
+            output_index=0,
+            part=resp.ResponseOutputText(text='', type='output_text', annotations=[]),
+            type='response.content_part.added',
+            sequence_number=3,
+        ),
+        resp.ResponseTextDeltaEvent(
+            content_index=0,
+            delta="I can't help with that.",
+            item_id='msg_001',
+            output_index=0,
+            type='response.output_text.delta',
+            sequence_number=4,
+            logprobs=[],
+        ),
+        resp.ResponseTextDoneEvent(
+            content_index=0,
+            item_id='msg_001',
+            output_index=0,
+            text="I can't help with that.",
+            type='response.output_text.done',
+            sequence_number=5,
+            logprobs=[],
+        ),
+        resp.ResponseOutputItemDoneEvent(
+            item=ResponseOutputMessage(
+                id='msg_001',
+                content=cast(
+                    list[Content],
+                    [ResponseOutputText(text="I can't help with that.", type='output_text', annotations=[])],
+                ),
+                role='assistant',
+                status='incomplete',
+                type='message',
+            ),
+            output_index=0,
+            type='response.output_item.done',
+            sequence_number=6,
+        ),
+        resp.ResponseCompletedEvent(
+            response=base_response.model_copy(
+                update={'status': 'incomplete', 'incomplete_details': IncompleteDetails(reason='content_filter')}
+            ),
+            type='response.completed',
+            sequence_number=7,
         ),
     ]
 


### PR DESCRIPTION
- Closes #5221

## Summary
- normalize OpenAI Responses API text-only `content_filter` completions into refusal metadata with no output parts
- raise `ContentFilterError` for the same case in `run_stream()` even when a provisional text result was seen before the stream finished
- add regression coverage for both non-streaming and streaming text-only content-filter responses

## Testing
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/result.py pydantic_ai_slim/pydantic_ai/agent/abstract.py tests/models/test_openai_responses.py`
- `uv run pytest tests/models/test_openai_responses.py`
