### PR TITLE
fix: restore per-block `cache_control` for `anthropic_cache_messages`

### DIFF
--- a/docs/models/anthropic.md
+++ b/docs/models/anthropic.md
@@ -188,7 +188,7 @@ This is ideal for multi-turn conversations where the cache breakpoint should mov
 
 ### Per-block Message Caching
 
-Use [`AnthropicModelSettings.anthropic_cache_messages`][pydantic_ai.models.anthropic.AnthropicModelSettings.anthropic_cache_messages] to add per-block `cache_control` to the last content block in the final message. This is useful for Anthropic-compatible providers and gateways that support per-block caching in the Anthropic message format:
+As an alternative to `anthropic_cache`, [`AnthropicModelSettings.anthropic_cache_messages`][pydantic_ai.models.anthropic.AnthropicModelSettings.anthropic_cache_messages] adds per-block `cache_control` to the last content block of the final message instead of using Anthropic's top-level automatic caching parameter. Use this with Anthropic-compatible gateways and proxies (such as MiniMax, OpenRouter, or LiteLLM) that accept the Anthropic message format but don't support top-level automatic caching:
 
 ```python {test="skip"}
 from anthropic import AsyncAnthropic
@@ -217,7 +217,7 @@ result = agent.run_sync('What is the capital of France?')
 print(result.output)
 ```
 
-You can also specify a custom TTL with `anthropic_cache_messages='1h'`. Use either `anthropic_cache` or `anthropic_cache_messages` for message caching in a given request.
+You can also specify a custom TTL with `anthropic_cache_messages='1h'`. `anthropic_cache_messages` cannot be combined with `anthropic_cache`.
 
 ### Explicit Cache Breakpoints
 
@@ -348,7 +348,7 @@ Cache points can come from several sources:
 4. **Tool Definitions**: Via `anthropic_cache_tool_definitions` setting (adds cache point to last tool definition)
 5. **Messages**: Via `CachePoint` markers (adds cache points to message content)
 
-Each setting uses **at most 1 cache point**, but you can combine them. Use either `anthropic_cache` or `anthropic_cache_messages` in a given request. If the total exceeds 4, Pydantic AI automatically trims excess cache points from older messages.
+Each setting uses **at most 1 cache point**, but you can combine them — except `anthropic_cache` and `anthropic_cache_messages`, which are mutually exclusive. If the total exceeds 4, Pydantic AI automatically trims excess cache points from older messages.
 
 #### Example: Combining Automatic and Explicit Caching
 

--- a/docs/models/anthropic.md
+++ b/docs/models/anthropic.md
@@ -154,7 +154,7 @@ See [Anthropic's Microsoft Foundry documentation](https://platform.claude.com/do
 
 ## Prompt Caching
 
-Anthropic supports [prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) to reduce costs by caching parts of your prompts. Pydantic AI supports both automatic and explicit caching approaches:
+Anthropic supports [prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) to reduce costs by caching parts of your prompts. Pydantic AI supports automatic caching, per-block message caching, and explicit cache breakpoints:
 
 ### Automatic Caching
 
@@ -186,13 +186,47 @@ This is ideal for multi-turn conversations where the cache breakpoint should mov
 !!! note "Bedrock and Vertex"
     Bedrock and Vertex [do not yet support automatic caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#automatic-caching). On these platforms, `anthropic_cache` falls back to per-block caching on the last user message, providing the same benefit for multi-turn conversations.
 
+### Per-block Message Caching
+
+Use [`AnthropicModelSettings.anthropic_cache_messages`][pydantic_ai.models.anthropic.AnthropicModelSettings.anthropic_cache_messages] to add per-block `cache_control` to the last content block in the final message. This is useful for Anthropic-compatible providers and gateways that support per-block caching in the Anthropic message format:
+
+```python {test="skip"}
+from anthropic import AsyncAnthropic
+
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
+from pydantic_ai.providers.anthropic import AnthropicProvider
+
+client = AsyncAnthropic(
+    api_key='your-api-key',
+    base_url='https://your-anthropic-compatible-gateway.example.com',
+)
+
+model = AnthropicModel(
+    'claude-sonnet-4-6',
+    provider=AnthropicProvider(anthropic_client=client),
+)
+agent = Agent(
+    model,
+    model_settings=AnthropicModelSettings(
+        anthropic_cache_messages=True,
+    ),
+)
+
+result = agent.run_sync('What is the capital of France?')
+print(result.output)
+```
+
+You can also specify a custom TTL with `anthropic_cache_messages='1h'`. Use either `anthropic_cache` or `anthropic_cache_messages` for message caching in a given request.
+
 ### Explicit Cache Breakpoints
 
 In addition to automatic caching, Pydantic AI provides several ways to place cache breakpoints on specific content:
 
 1. **Cache User Messages with [`CachePoint`][pydantic_ai.messages.CachePoint]**: Insert a `CachePoint` marker in your user messages to cache everything before it
-2. **Cache System Instructions**: Set [`AnthropicModelSettings.anthropic_cache_instructions`][pydantic_ai.models.anthropic.AnthropicModelSettings.anthropic_cache_instructions] to `True` (uses 5m TTL by default) or specify `'5m'` / `'1h'` directly
-3. **Cache Tool Definitions**: Set [`AnthropicModelSettings.anthropic_cache_tool_definitions`][pydantic_ai.models.anthropic.AnthropicModelSettings.anthropic_cache_tool_definitions] to `True` (uses 5m TTL by default) or specify `'5m'` / `'1h'` directly
+2. **Cache the Final Message Block**: Set [`AnthropicModelSettings.anthropic_cache_messages`][pydantic_ai.models.anthropic.AnthropicModelSettings.anthropic_cache_messages] to `True` (uses 5m TTL by default) or specify `'5m'` / `'1h'` directly
+3. **Cache System Instructions**: Set [`AnthropicModelSettings.anthropic_cache_instructions`][pydantic_ai.models.anthropic.AnthropicModelSettings.anthropic_cache_instructions] to `True` (uses 5m TTL by default) or specify `'5m'` / `'1h'` directly
+4. **Cache Tool Definitions**: Set [`AnthropicModelSettings.anthropic_cache_tool_definitions`][pydantic_ai.models.anthropic.AnthropicModelSettings.anthropic_cache_tool_definitions] to `True` (uses 5m TTL by default) or specify `'5m'` / `'1h'` directly
 
 #### Example: Comprehensive Caching Strategy
 
@@ -309,11 +343,12 @@ Anthropic enforces a maximum of 4 cache points per request. Pydantic AI automati
 Cache points can come from several sources:
 
 1. **Automatic caching**: Via `anthropic_cache` (the server applies 1 cache point to the last cacheable block)
-2. **System Prompt**: Via `anthropic_cache_instructions` setting (adds cache point to last system prompt block)
-3. **Tool Definitions**: Via `anthropic_cache_tool_definitions` setting (adds cache point to last tool definition)
-4. **Messages**: Via `CachePoint` markers (adds cache points to message content)
+2. **Final message block**: Via `anthropic_cache_messages` setting (adds cache point to last message content block)
+3. **System Prompt**: Via `anthropic_cache_instructions` setting (adds cache point to last system prompt block)
+4. **Tool Definitions**: Via `anthropic_cache_tool_definitions` setting (adds cache point to last tool definition)
+5. **Messages**: Via `CachePoint` markers (adds cache points to message content)
 
-Each setting uses **at most 1 cache point**, but you can combine them. If the total exceeds 4, Pydantic AI automatically trims excess cache points from older messages.
+Each setting uses **at most 1 cache point**, but you can combine them. Use either `anthropic_cache` or `anthropic_cache_messages` in a given request. If the total exceeds 4, Pydantic AI automatically trims excess cache points from older messages.
 
 #### Example: Combining Automatic and Explicit Caching
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -244,10 +244,9 @@ class AnthropicModelSettings(ModelSettings, total=False):
     anthropic_cache_messages: bool | Literal['5m', '1h']
     """Whether to add `cache_control` to the last message content block.
 
-    When enabled, this adds per-block `cache_control` to the last content block in the
-    final message. This is useful for Anthropic-compatible providers and gateways that
-    support explicit per-block caching but don't support Anthropic's top-level automatic
-    caching parameter.
+    This is an alternative to `anthropic_cache` for Anthropic-compatible gateways and
+    proxies that accept the Anthropic message format but don't support the top-level
+    automatic caching parameter.
 
     If `True`, uses TTL='5m'. You can also specify '5m' or '1h' directly.
     Cannot be combined with `anthropic_cache`.
@@ -1201,23 +1200,10 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         instruction_parts = self._get_instruction_parts(messages, model_request_parameters)
         system_prompt = '\n\n'.join(system_prompt_parts)
 
-        # Add cache_control to the last message content if anthropic_cache_messages is enabled.
-        if anthropic_messages and (cache_messages := model_settings.get('anthropic_cache_messages')):
-            ttl: Literal['5m', '1h'] = '5m' if cache_messages is True else cache_messages
-            message = anthropic_messages[-1]
-            content = message['content']
-            if isinstance(content, str):  # pragma: no cover
-                message['content'] = [
-                    BetaTextBlockParam(
-                        text=content,
-                        type='text',
-                        cache_control=self._build_cache_control(ttl),
-                    )
-                ]
-            else:
-                content_blocks = cast(list[BetaContentBlockParam], content)
-                if content_blocks and 'cache_control' not in cast(dict[str, Any], content_blocks[-1]):
-                    self._add_cache_control_to_last_param(content_blocks, ttl)
+        if cache_messages := model_settings.get('anthropic_cache_messages'):
+            self._apply_message_cache_control(
+                anthropic_messages, '5m' if cache_messages is True else cache_messages
+            )
 
         # Build system prompt blocks: each instruction part becomes a separate text block.
         # When anthropic_cache_instructions is enabled, the cache point goes after the last
@@ -1391,15 +1377,25 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         `anthropic_cache` for automatic caching. As a fallback, this applies per-block
         `cache_control` to the last content block of the last user message.
 
-        If the last block already has `cache_control` (e.g. from an explicit `CachePoint`),
-        it is left unchanged to preserve the user's chosen TTL.
-
         Args:
             resolved_ttl: The resolved TTL from `_build_automatic_cache_control`, or None
                 if caching is not enabled.
             anthropic_messages: The list of Anthropic message params to apply fallback to.
         """
-        if not resolved_ttl or not isinstance(self.client, _NON_AUTOMATIC_CACHING_CLIENTS) or not anthropic_messages:
+        if resolved_ttl and isinstance(self.client, _NON_AUTOMATIC_CACHING_CLIENTS):
+            self._apply_message_cache_control(anthropic_messages, resolved_ttl)
+
+    def _apply_message_cache_control(
+        self,
+        anthropic_messages: list[BetaMessageParam],
+        ttl: Literal['5m', '1h'],
+    ) -> None:
+        """Apply per-block `cache_control` to the last content block of the last message.
+
+        If the last block already has `cache_control` (e.g. from an explicit `CachePoint`),
+        it is left unchanged to preserve the user's chosen TTL.
+        """
+        if not anthropic_messages:
             return
 
         last_message = anthropic_messages[-1]
@@ -1409,13 +1405,13 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                 BetaTextBlockParam(
                     type='text',
                     text=content,
-                    cache_control=self._build_cache_control(resolved_ttl),
+                    cache_control=self._build_cache_control(ttl),
                 )
             ]
         else:
-            content_list = cast(list[BetaContentBlockParam], content)
-            if content_list and 'cache_control' not in cast(dict[str, Any], content_list[-1]):
-                self._add_cache_control_to_last_param(content_list, resolved_ttl)
+            content_blocks = cast(list[BetaContentBlockParam], content)
+            if content_blocks and 'cache_control' not in cast(dict[str, Any], content_blocks[-1]):
+                self._add_cache_control_to_last_param(content_blocks, ttl)
 
     def _add_cache_control_to_last_param(
         self, params: list[BetaContentBlockParam], ttl: Literal['5m', '1h'] = '5m'

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -596,6 +596,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         auto_cache_control, resolved_cache_ttl = self._build_automatic_cache_control(model_settings)
         system_prompt, anthropic_messages = await self._map_message(messages, model_request_parameters, model_settings)
         self._apply_per_block_caching_fallback(resolved_cache_ttl, anthropic_messages)
+        self._apply_explicit_message_caching(model_settings, anthropic_messages)
         self._limit_cache_points(
             system_prompt, anthropic_messages, tools, automatic_caching=auto_cache_control is not None
         )
@@ -749,6 +750,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         auto_cache_control, resolved_cache_ttl = self._build_automatic_cache_control(model_settings)
         system_prompt, anthropic_messages = await self._map_message(messages, model_request_parameters, model_settings)
         self._apply_per_block_caching_fallback(resolved_cache_ttl, anthropic_messages)
+        self._apply_explicit_message_caching(model_settings, anthropic_messages)
         self._limit_cache_points(
             system_prompt, anthropic_messages, tools, automatic_caching=auto_cache_control is not None
         )
@@ -1200,9 +1202,6 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         instruction_parts = self._get_instruction_parts(messages, model_request_parameters)
         system_prompt = '\n\n'.join(system_prompt_parts)
 
-        if cache_messages := model_settings.get('anthropic_cache_messages'):
-            self._apply_message_cache_control(anthropic_messages, '5m' if cache_messages is True else cache_messages)
-
         # Build system prompt blocks: each instruction part becomes a separate text block.
         # When anthropic_cache_instructions is enabled, the cache point goes after the last
         # static instruction (or at the end if all instructions are static).
@@ -1382,6 +1381,19 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         """
         if resolved_ttl and isinstance(self.client, _NON_AUTOMATIC_CACHING_CLIENTS):
             self._apply_message_cache_control(anthropic_messages, resolved_ttl)
+
+    def _apply_explicit_message_caching(
+        self,
+        model_settings: AnthropicModelSettings,
+        anthropic_messages: list[BetaMessageParam],
+    ) -> None:
+        """Apply per-block message caching when `anthropic_cache_messages` is enabled.
+
+        Mutually exclusive with `anthropic_cache` (enforced by `_build_automatic_cache_control`).
+        """
+        if cache_messages := model_settings.get('anthropic_cache_messages'):
+            ttl: Literal['5m', '1h'] = '5m' if cache_messages is True else cache_messages
+            self._apply_message_cache_control(anthropic_messages, ttl)
 
     def _apply_message_cache_control(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -239,10 +239,14 @@ class AnthropicModelSettings(ModelSettings, total=False):
     """
 
     anthropic_cache_messages: bool | Literal['5m', '1h']
-    """Deprecated: use `anthropic_cache` instead.
+    """Whether to add `cache_control` to the last message content block.
 
-    Behaves the same as `anthropic_cache`: uses automatic caching where supported,
-    falls back to per-block caching on Bedrock and Vertex. Emits a deprecation warning.
+    When enabled, this adds per-block `cache_control` to the last content block in the
+    final message. This is useful for Anthropic-compatible providers and gateways that
+    support explicit per-block caching but don't support Anthropic's top-level automatic
+    caching parameter.
+
+    If `True`, uses TTL='5m'. You can also specify '5m' or '1h' directly.
     Cannot be combined with `anthropic_cache`.
     """
 
@@ -1155,6 +1159,24 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         instruction_parts = self._get_instruction_parts(messages, model_request_parameters)
         system_prompt = '\n\n'.join(system_prompt_parts)
 
+        # Add cache_control to the last message content if anthropic_cache_messages is enabled.
+        if anthropic_messages and (cache_messages := model_settings.get('anthropic_cache_messages')):
+            ttl: Literal['5m', '1h'] = '5m' if cache_messages is True else cache_messages
+            message = anthropic_messages[-1]
+            content = message['content']
+            if isinstance(content, str):  # pragma: no cover
+                message['content'] = [
+                    BetaTextBlockParam(
+                        text=content,
+                        type='text',
+                        cache_control=self._build_cache_control(ttl),
+                    )
+                ]
+            else:
+                content_blocks = cast(list[BetaContentBlockParam], content)
+                if content_blocks and 'cache_control' not in cast(dict[str, Any], content_blocks[-1]):
+                    self._add_cache_control_to_last_param(content_blocks, ttl)
+
         # Build system prompt blocks: each instruction part becomes a separate text block.
         # When anthropic_cache_instructions is enabled, the cache point goes after the last
         # static instruction (or at the end if all instructions are static).
@@ -1302,14 +1324,6 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
 
         if auto_cache and cache_messages:
             raise UserError('`anthropic_cache` and `anthropic_cache_messages` cannot both be enabled.')
-
-        if cache_messages:
-            warnings.warn(
-                '`anthropic_cache_messages` is deprecated, use `anthropic_cache` instead',
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            auto_cache = cache_messages
 
         if not auto_cache:
             return None, None

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1392,10 +1392,9 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
 
         If the last block already has `cache_control` (e.g. from an explicit `CachePoint`),
         it is left unchanged to preserve the user's chosen TTL.
-        """
-        if not anthropic_messages:
-            return
 
+        Assumes `anthropic_messages` is non-empty.
+        """
         last_message = anthropic_messages[-1]
         content = last_message['content']
         if isinstance(content, str):  # pragma: no cover

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1201,9 +1201,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         system_prompt = '\n\n'.join(system_prompt_parts)
 
         if cache_messages := model_settings.get('anthropic_cache_messages'):
-            self._apply_message_cache_control(
-                anthropic_messages, '5m' if cache_messages is True else cache_messages
-            )
+            self._apply_message_cache_control(anthropic_messages, '5m' if cache_messages is True else cache_messages)
 
         # Build system prompt blocks: each instruction part becomes a separate text block.
         # When anthropic_cache_instructions is enabled, the cache point goes after the last

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -1314,10 +1314,12 @@ async def test_limit_cache_points_with_cache_messages(allow_model_requests: None
     await agent.run(
         [
             'Context 1',
-            CachePoint(),
+            CachePoint(),  # oldest, trimmed because total cache points (4 explicit + 1 from cache_messages) exceeds the budget of 4
             'Context 2',
             CachePoint(),
             'Context 3',
+            CachePoint(),
+            'Context 4',
             CachePoint(),
             'Question',
         ]
@@ -1332,9 +1334,10 @@ async def test_limit_cache_points_with_cache_messages(allow_model_requests: None
             {
                 'role': 'user',
                 'content': [
-                    {'text': 'Context 1', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
+                    {'text': 'Context 1', 'type': 'text'},
                     {'text': 'Context 2', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
                     {'text': 'Context 3', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
+                    {'text': 'Context 4', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
                     {'text': 'Question', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
                 ],
             }

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -557,36 +557,67 @@ async def test_anthropic_cache_fallback_on_unsupported_clients(
         pytest.param('1h', '1h', id='custom-1h'),
     ],
 )
-async def test_anthropic_cache_messages_deprecated_fallback_on_bedrock(
+async def test_anthropic_cache_messages_uses_per_block_cache_control(
     allow_model_requests: None,
     cache_value: bool | Literal['1h'],
     expected_ttl: str,
 ):
-    """Test that deprecated anthropic_cache_messages triggers per-block fallback on Bedrock."""
-    from unittest.mock import AsyncMock, MagicMock
-
-    import anthropic
-    from anthropic import AsyncAnthropicBedrock
-
     c = completion_message([BetaTextBlock(text='Response', type='text')], BetaUsage(input_tokens=10, output_tokens=5))
-
-    mock_client = MagicMock()
-    mock_client.__class__ = AsyncAnthropicBedrock  # pyright: ignore[reportAttributeAccessIssue]
-    mock_client.base_url = 'https://bedrock.amazonaws.com'
-    mock_client.beta.messages.create = AsyncMock(return_value=c)
+    mock_client = MockAnthropic.create_mock(c)
 
     model = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
     agent = Agent(model, model_settings=AnthropicModelSettings(anthropic_cache_messages=cache_value))
 
-    with pytest.warns(DeprecationWarning, match='`anthropic_cache_messages` is deprecated'):
-        result = await agent.run('Hello')
+    result = await agent.run('Hello')
     assert result.output == 'Response'
 
-    call_kwargs = mock_client.beta.messages.create.call_args.kwargs
-    assert call_kwargs['cache_control'] is anthropic.omit
-    last_user_msg = call_kwargs['messages'][-1]
-    content = last_user_msg['content']
-    assert content[-1]['cache_control'] == {'type': 'ephemeral', 'ttl': expected_ttl}
+    completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert completion_kwargs['cache_control'] is OMIT
+    assert completion_kwargs['messages'] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'text': 'Hello',
+                        'type': 'text',
+                        'cache_control': {'type': 'ephemeral', 'ttl': expected_ttl},
+                    }
+                ],
+            }
+        ]
+    )
+
+
+async def test_anthropic_cache_messages_preserves_existing_cache_point(allow_model_requests: None):
+    c = completion_message([BetaTextBlock(text='Response', type='text')], BetaUsage(input_tokens=10, output_tokens=5))
+    mock_client = MockAnthropic.create_mock(c)
+
+    model = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+    agent = Agent(model, model_settings=AnthropicModelSettings(anthropic_cache_messages=True))
+
+    result = await agent.run(['Some context', CachePoint(ttl='1h')])
+    assert result.output == 'Response'
+
+    completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    content = completion_kwargs['messages'][-1]['content']
+    assert content == snapshot(
+        [{'text': 'Some context', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '1h'}}]
+    )
+
+
+async def test_anthropic_cache_and_cache_messages_conflict(allow_model_requests: None):
+    c = completion_message([BetaTextBlock(text='Response', type='text')], BetaUsage(input_tokens=10, output_tokens=5))
+    mock_client = MockAnthropic.create_mock(c)
+
+    model = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+    agent = Agent(
+        model,
+        model_settings=AnthropicModelSettings(anthropic_cache=True, anthropic_cache_messages=True),
+    )
+
+    with pytest.raises(UserError, match='`anthropic_cache` and `anthropic_cache_messages` cannot both be enabled'):
+        await agent.run('Hello')
 
 
 async def test_anthropic_cache_fallback_preserves_existing_cache_control(allow_model_requests: None):
@@ -1263,80 +1294,7 @@ async def test_anthropic_mixed_strict_tool_run(allow_model_requests: None, anthr
     )
 
 
-async def test_anthropic_cache_messages_deprecated(allow_model_requests: None):
-    """Test that anthropic_cache_messages is deprecated and maps to anthropic_cache."""
-    c = completion_message(
-        [BetaTextBlock(text='Response', type='text')],
-        usage=BetaUsage(input_tokens=10, output_tokens=5),
-    )
-    mock_client = MockAnthropic.create_mock(c)
-    m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
-    agent = Agent(
-        m,
-        system_prompt='System instructions to cache.',
-        model_settings=AnthropicModelSettings(
-            anthropic_cache_messages=True,
-        ),
-    )
-
-    with pytest.warns(DeprecationWarning, match='`anthropic_cache_messages` is deprecated'):
-        await agent.run('User message')
-
-    completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
-    # Should use top-level cache_control (server-side automatic caching)
-    assert completion_kwargs['cache_control'] == snapshot({'type': 'ephemeral', 'ttl': '5m'})
-    # Messages should NOT have per-block cache_control
-    last_msg = completion_kwargs['messages'][-1]
-    for block in last_msg['content']:
-        assert 'cache_control' not in block
-
-
-async def test_anthropic_cache_messages_deprecated_custom_ttl(allow_model_requests: None):
-    """Test that deprecated anthropic_cache_messages passes through custom TTL."""
-    c = completion_message(
-        [BetaTextBlock(text='Response', type='text')],
-        usage=BetaUsage(input_tokens=10, output_tokens=5),
-    )
-    mock_client = MockAnthropic.create_mock(c)
-    m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
-    agent = Agent(
-        m,
-        system_prompt='System instructions.',
-        model_settings=AnthropicModelSettings(
-            anthropic_cache_messages='1h',
-        ),
-    )
-
-    with pytest.warns(DeprecationWarning, match='`anthropic_cache_messages` is deprecated'):
-        await agent.run('User message')
-
-    completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
-    assert completion_kwargs['cache_control'] == snapshot({'type': 'ephemeral', 'ttl': '1h'})
-
-
-async def test_anthropic_cache_and_cache_messages_conflict(allow_model_requests: None):
-    """Test that enabling both anthropic_cache and anthropic_cache_messages raises UserError."""
-    c = completion_message(
-        [BetaTextBlock(text='Response', type='text')],
-        usage=BetaUsage(input_tokens=10, output_tokens=5),
-    )
-    mock_client = MockAnthropic.create_mock(c)
-    m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
-    agent = Agent(
-        m,
-        system_prompt='System instructions.',
-        model_settings=AnthropicModelSettings(
-            anthropic_cache=True,
-            anthropic_cache_messages=True,
-        ),
-    )
-
-    with pytest.raises(UserError, match='cannot both be enabled'):
-        await agent.run('User message')
-
-
-async def test_limit_cache_points_with_deprecated_cache_messages(allow_model_requests: None):
-    """Test that deprecated anthropic_cache_messages maps to anthropic_cache for cache point limiting."""
+async def test_limit_cache_points_with_cache_messages(allow_model_requests: None):
     c = completion_message(
         [BetaTextBlock(text='Response', type='text')],
         usage=BetaUsage(input_tokens=10, output_tokens=5),
@@ -1351,36 +1309,35 @@ async def test_limit_cache_points_with_deprecated_cache_messages(allow_model_req
         ),
     )
 
-    # anthropic_cache_messages now maps to anthropic_cache (top-level cache_control),
-    # which reduces the explicit cache point budget from 4 to 3.
-    # With 4 CachePoint markers, the oldest should be removed to fit budget of 3.
-    with pytest.warns(DeprecationWarning, match='`anthropic_cache_messages` is deprecated'):
-        await agent.run(
-            [
-                'Context 1',
-                CachePoint(),  # Oldest, should be removed
-                'Context 2',
-                CachePoint(),  # Should be kept
-                'Context 3',
-                CachePoint(),  # Should be kept
-                'Context 4',
-                CachePoint(),  # Should be kept
-                'Question',
-            ]
-        )
+    await agent.run(
+        [
+            'Context 1',
+            CachePoint(),
+            'Context 2',
+            CachePoint(),
+            'Context 3',
+            CachePoint(),
+            'Question',
+        ]
+    )
 
     completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
     messages = completion_kwargs['messages']
-    assert completion_kwargs['cache_control'] == {'type': 'ephemeral', 'ttl': '5m'}
+    assert completion_kwargs['cache_control'] is OMIT
 
-    cache_count = 0
-    for msg in messages:
-        for block in msg['content']:
-            if 'cache_control' in block:
-                cache_count += 1
-
-    # Budget is 3 (reduced from 4 by automatic caching). 4 CachePoint markers means 1 removed.
-    assert cache_count == 3
+    assert messages == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'Context 1', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
+                    {'text': 'Context 2', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
+                    {'text': 'Context 3', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
+                    {'text': 'Question', 'type': 'text', 'cache_control': {'type': 'ephemeral', 'ttl': '5m'}},
+                ],
+            }
+        ]
+    )
 
 
 async def test_limit_cache_points_all_settings(allow_model_requests: None):


### PR DESCRIPTION
## Summary

This PR restores `anthropic_cache_messages` as a per-block Anthropic `cache_control` setting for the final message content block.

PR #4840 introduced Anthropic automatic caching via the top-level `cache_control` parameter and changed `anthropic_cache_messages` to map to that new behavior with a deprecation warning. That made sense for the official Anthropic API, where automatic caching is the recommended simple path for multi-turn conversations, but it changed the existing behavior of an established Pydantic AI setting.

The previous behavior still matters because several Anthropic-compatible providers and proxy layers continue to use the explicit per-block Anthropic cache format. Restoring it keeps the original setting useful for those integrations while preserving `anthropic_cache` for Anthropic's top-level automatic caching.

## Problem

`anthropic_cache_messages` previously added explicit `cache_control` metadata to message content blocks. After #4840, enabling it produced a top-level `cache_control` request parameter instead.

That created a breaking behavior change for users whose provider expects explicit per-block cache control in the Anthropic message body:

```json
{
  "role": "user",
  "content": [
    {
      "type": "text",
      "text": "...",
      "cache_control": {"type": "ephemeral", "ttl": "5m"}
    }
  ]
}
```

Common affected scenarios include:

- Anthropic-compatible providers that implement explicit prompt caching in the message format.
- Gateways and proxy layers that translate Vertex AI or Bedrock APIs into Anthropic-compatible request bodies.
- Routing providers where top-level automatic caching has provider-specific support, while explicit block-level cache controls remain the portable Anthropic-compatible format.

## Evidence from provider documentation

The explicit per-block format is still used across current provider and gateway documentation:

- MiniMax documents an "Explicit Prompt Caching (Anthropic API)" page and states that MiniMax supports Anthropic API compatible caching managed through explicit `cache_control` settings: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
- Amazon Bedrock documents prompt caching for Anthropic Claude `InvokeModel` requests using `cache_control` on content blocks inside `messages`, with supported fields including `system`, `messages`, and `tools`: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
- Google Vertex AI documents Claude prompt caching through the Anthropic partner model surface and refers to `cache_control` as part of the matching cache key: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/prompt-caching
- LiteLLM lists Anthropic API, Vertex AI, and Bedrock among providers with prompt caching support, reflecting the need for gateway-compatible prompt caching behavior across multiple provider backends: https://docs.litellm.ai/docs/completion/prompt_caching
- OpenRouter's prompt caching documentation describes provider-specific support for automatic caching and calls out Bedrock and Vertex behavior separately, which reinforces the need to keep explicit message-level caching available for compatible routing paths: https://openrouter.ai/docs/guides/best-practices/prompt-caching

## Change

This PR makes the two settings distinct:

- `anthropic_cache` keeps the top-level automatic caching behavior introduced by #4840.
- `anthropic_cache_messages` again adds per-block `cache_control` to the final message content block.

It also keeps the conflict check between the two settings, since a request should use one message caching strategy at a time.

## Tests

Added and updated Anthropic model tests for:

- `anthropic_cache_messages=True` and custom TTL values adding per-block `cache_control`.
- Preserving an existing explicit `CachePoint` cache control.
- Raising `UserError` when `anthropic_cache` and `anthropic_cache_messages` are enabled together.
- Cache point budgeting when message-level cache control is used.

Command run:

```bash
uv run pytest tests/models/test_anthropic.py -k 'cache_messages or anthropic_cache_fallback_on_unsupported_clients or limit_cache_points'
```

Result:

```text
11 passed
```

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
