### PR TITLE
feat: support OpenAI Responses `phase` on assistant messages

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2838,8 +2838,8 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
             # Track annotations by item_id and content_index
             _annotations_by_item: dict[str, list[Any]] = {}
             # Track `phase` (commentary | final_answer) on assistant message items, captured
-            # from the `output_item.added`/`output_item.done` events and merged into the
-            # corresponding `TextPart.provider_details` on `output_text.done`.
+            # from the `output_item.added` event and merged into the corresponding
+            # `TextPart.provider_details` on `output_text.done`.
             _phase_by_item: dict[str, Literal['commentary', 'final_answer']] = {}
 
             if self._provider_timestamp is not None:  # pragma: no branch

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1768,6 +1768,9 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                             part_provider_details['annotations'] = responses_output_text_annotations_ta.dump_python(
                                 list(content.annotations), warnings=False
                             )
+                        if item.phase is not None:
+                            part_provider_details = part_provider_details or {}
+                            part_provider_details['phase'] = item.phase
                         # Some OpenAI-compatible gateways (e.g. Bifrost) return text=null;
                         # coalesce to '' so the part (and its ID) is preserved for round-tripping.
                         items.append(
@@ -2268,6 +2271,12 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     )
 
                     if isinstance(item, TextPart):
+                        phase = (item.provider_details or {}).get('phase')
+                        send_phase = (
+                            profile.openai_supports_phase
+                            and item.provider_name == self.system
+                            and phase in ('commentary', 'final_answer')
+                        )
                         if item.id and should_send_item_id:
                             if message_item is None or message_item['id'] != item.id:  # pragma: no branch
                                 message_item = responses.ResponseOutputMessageParam(
@@ -2285,10 +2294,13 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                     text=item.content, type='output_text', annotations=[]
                                 ),
                             ]
+                            if send_phase:
+                                message_item['phase'] = phase
                         else:
-                            openai_messages.append(
-                                responses.EasyInputMessageParam(role='assistant', content=item.content)
-                            )
+                            easy_message_item = responses.EasyInputMessageParam(role='assistant', content=item.content)
+                            if send_phase:
+                                easy_message_item['phase'] = phase
+                            openai_messages.append(easy_message_item)
                     elif isinstance(item, ToolCallPart):
                         call_id = _guard_tool_call_id(t=item)
                         call_id, id = _split_combined_tool_call_id(call_id)
@@ -2825,6 +2837,10 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
         with _map_api_errors(self._model_name):
             # Track annotations by item_id and content_index
             _annotations_by_item: dict[str, list[Any]] = {}
+            # Track `phase` (commentary | final_answer) on assistant message items, captured
+            # from the `output_item.added`/`output_item.done` events and merged into the
+            # corresponding `TextPart.provider_details` on `output_text.done`.
+            _phase_by_item: dict[str, Literal['commentary', 'final_answer']] = {}
 
             if self._provider_timestamp is not None:  # pragma: no branch
                 self.provider_details = {'timestamp': self._provider_timestamp}
@@ -2889,7 +2905,8 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                     elif isinstance(chunk.item, responses.ResponseReasoningItem):
                         pass
                     elif isinstance(chunk.item, responses.ResponseOutputMessage):
-                        pass
+                        if chunk.item.phase is not None:
+                            _phase_by_item[chunk.item.id] = chunk.item.phase
                     elif isinstance(chunk.item, responses.ResponseFunctionWebSearch):
                         call_part, _ = _map_web_search_tool_call(chunk.item, self.provider_name)
                         yield self._parts_manager.handle_part(
@@ -3098,6 +3115,8 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                         )
                     if chunk.logprobs:
                         provider_details['logprobs'] = _map_logprobs(chunk.logprobs)
+                    if (phase := _phase_by_item.get(chunk.item_id)) is not None:
+                        provider_details['phase'] = phase
                     if provider_details:
                         for event in self._parts_manager.handle_text_delta(
                             vendor_part_id=chunk.item_id,

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -130,6 +130,19 @@ class OpenAIModelProfile(ModelProfile):
     See https://github.com/pydantic/pydantic-ai/issues/3245 for more details.
     """
 
+    openai_supports_phase: bool = False
+    """Whether the Responses API supports the `phase` field on assistant messages.
+
+    `phase` labels an assistant message as intermediate `commentary` or the `final_answer`. When the model
+    supports it, OpenAI recommends preserving and sending it back unchanged on every assistant message in
+    follow-up requests; dropping it can cause preambles to be interpreted as final answers and degrade
+    behavior in long-running or tool-heavy flows.
+
+    Supported by `gpt-5.3-codex`, `gpt-5.4` and later mainline models. The official OpenAI Responses API
+    silently ignores the field on older models, but defaults to `False` so we don't risk sending an
+    unrecognized field to OpenAI-compatible APIs (vLLM, Bifrost, ...) that haven't been verified to accept it.
+    """
+
     openai_chat_supports_document_input: bool = True
     """Whether the Chat Completions API supports document content parts (`type='file'`).
 
@@ -159,6 +172,10 @@ def openai_model_profile(model_name: str) -> ModelProfile:
     # doesn't support `reasoning={"effort": "none"}` -  default is set at 'medium'
     # see https://platform.openai.com/docs/guides/reasoning
     is_gpt_5 = model_name.startswith('gpt-5') and not is_gpt_5_1_plus
+
+    # `phase` is supported by gpt-5.3-codex, gpt-5.4 and later mainline models.
+    # See https://developers.openai.com/api/docs/guides/prompt-guidance.
+    supports_phase = model_name.startswith(('gpt-5.3-codex', 'gpt-5.4', 'gpt-5.5'))
 
     # always reasoning
     is_o_series = model_name.startswith('o')
@@ -196,6 +213,7 @@ def openai_model_profile(model_name: str) -> ModelProfile:
         openai_supports_encrypted_reasoning_content=supports_reasoning,
         openai_supports_reasoning=supports_reasoning,
         openai_supports_reasoning_effort_none=is_gpt_5_1_plus and not is_gpt_5_3_chat,
+        openai_supports_phase=supports_phase,
     )
 
 

--- a/tests/models/cassettes/test_openai_responses/test_openai_responses_phase_live.yaml
+++ b/tests/models/cassettes/test_openai_responses/test_openai_responses_phase_live.yaml
@@ -1,0 +1,305 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '498'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: What is the capital of PotatoLand?
+        role: user
+      instructions: Briefly narrate what you are about to do before calling each tool.
+      model: gpt-5.5
+      stream: false
+      tool_choice: auto
+      tools:
+      - description: null
+        name: get_capital
+        parameters:
+          additionalProperties: false
+          properties:
+            country:
+              type: string
+          required:
+          - country
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '3089'
+      content-type:
+      - application/json
+      openai-organization:
+      - pydantic-28gund
+      openai-processing-ms:
+      - '2503'
+      openai-project:
+      - proj_dKobscVY9YJxeEaDJen54e3d
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1777325443
+      created_at: 1777325441
+      error: null
+      frequency_penalty: 0.0
+      id: resp_094ebefab06f6c100069efd5814cd881958cfa10878ca4446d
+      incomplete_details: null
+      instructions: Briefly narrate what you are about to do before calling each tool.
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.5-2026-04-23
+      moderation: null
+      object: response
+      output:
+      - encrypted_content: gAAAAABp79WDw4XrgvYRqT5JP7i32L_akJcFj0qu_nMCyUCtjbEMQGwDZSpHyjRxJJQdYmXCpM1vh_d5-7eMIJA1RXSROanolwja0DZ7B-InlWppyW1j9kmI-KwE-YiGBKmDnwdv4GYM2iqZCCI1QWKgKn8qTaz_Lp4ewtpMsbo3Z1stP9TX3Z5z7AbC76Vq4cjHtSzAv5i1iF40n5MnTbCJ9icumdKPR2hZnDkn4QxHw3aQztcesFeS2toYk3J5hvpmiECARvOxwwDBaH7sEC4-lItCMQxX431OgDjNVB8t3AK1d9AvHIYHz0GnnkmwI-iVyRXPGbNylasUUuhYTEvvw_3J_tWGYohLZZfPyVzDbIzhYG9xSn8nHxt14qOrj4XnmrxkdEfyBtY2BwYKik2eoQs1m9B7Jff4uDwQAqC6xX8CGi1-WkNKcKqlTFA_uD8nVoMP7Swigid7hwHjwsk0cr56PN6jXUcCqrTF2HuxWXcCdgsV_3j1KIiwR_-uF-VBrWG297MgYWc_n9pGeuLI3wWjfrecq84FN5o1LkunKU4kjGYGeBbN-MT-xgOdhqO--4swSkI9rkvKInHt0ucZVtfI49jCynD-T3R-S_VvXbfzWFDzzdGf7HwwBax3nkUmwp2_VdHgK0gz23tOZPubj8a89_C0rY6v1ZmDWtvvmTbEfrIAeogLe_8unvtz0RHfLWSz2FWNsiYN6AvYiPzA6o_NVOPqXrRwC4bWqPNkoRH7J8-2gjAK-eu1uVAZ1YBDWq_hn66NGjblP5KE2wtV7349kLT3icboqEgWiofbX5DQh0mK1Z7x8Zntw1oUm5BpQu2QFZp03pCfV0t8bpyzemEeZ_izFIBu8pgecAGT88zy9iL4HuVw-p1cGjDrimrwwL5_1K2bS7FUNy_csUlCLAfylb5xyAdAwqFf1EODjx2H3KmSjDVkYSerHO3WP5PHumHnLfxfGFY9EXf5mRBLyOu9Ivnyf5H7O5k6EKMKo0cm8yb3frplojn2OzOkM6O7vSAZS0KFqstxhF8hdhLSy7AdMntmDCD7NhR-r5llqeCgcuClk0XzMxa20wB11mgSQOoqknc5
+        id: rs_094ebefab06f6c100069efd58250cc8195b3b443e9b3d9bd84
+        summary: []
+        type: reasoning
+      - content:
+        - annotations: []
+          logprobs: []
+          text: I'll check the capital lookup tool for "PotatoLand."
+          type: output_text
+        id: msg_094ebefab06f6c100069efd58302b4819587854b18d82b5690
+        phase: commentary
+        role: assistant
+        status: completed
+        type: message
+      - arguments: '{"country":"PotatoLand"}'
+        call_id: call_ALAJMWK9buNN7RXxxXbECcHa
+        id: fc_094ebefab06f6c100069efd5833ce081959f3a131863e89e53
+        name: get_capital
+        status: completed
+        type: function_call
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        effort: medium
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tools:
+      - description: null
+        name: get_capital
+        parameters:
+          additionalProperties: false
+          properties:
+            country:
+              type: string
+          required:
+          - country
+          type: object
+        strict: true
+        type: function
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 63
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 72
+        output_tokens_details:
+          reasoning_tokens: 29
+        total_tokens: 135
+      user: null
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '2304'
+      content-type:
+      - application/json
+      cookie:
+      - __cf_bm=71X64KTFkMn2Buo._qgOI4pKvY4mIeBHBOx8reVpKWI-1777325440.7317507-1.0.1.1-qhcRrx6PpVYa5neET3sVpXqBOakKdEULAIj6nb6vjiWktGg4VbS96enuittMn8Ap9tMFsPFWqyykYI9uWA6JvpOQ5e_zL4.4zbeqM4nIld.ciRxx4OV8_wrv.BVvjiIx
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: What is the capital of PotatoLand?
+        role: user
+      - encrypted_content: gAAAAABp79WDw4XrgvYRqT5JP7i32L_akJcFj0qu_nMCyUCtjbEMQGwDZSpHyjRxJJQdYmXCpM1vh_d5-7eMIJA1RXSROanolwja0DZ7B-InlWppyW1j9kmI-KwE-YiGBKmDnwdv4GYM2iqZCCI1QWKgKn8qTaz_Lp4ewtpMsbo3Z1stP9TX3Z5z7AbC76Vq4cjHtSzAv5i1iF40n5MnTbCJ9icumdKPR2hZnDkn4QxHw3aQztcesFeS2toYk3J5hvpmiECARvOxwwDBaH7sEC4-lItCMQxX431OgDjNVB8t3AK1d9AvHIYHz0GnnkmwI-iVyRXPGbNylasUUuhYTEvvw_3J_tWGYohLZZfPyVzDbIzhYG9xSn8nHxt14qOrj4XnmrxkdEfyBtY2BwYKik2eoQs1m9B7Jff4uDwQAqC6xX8CGi1-WkNKcKqlTFA_uD8nVoMP7Swigid7hwHjwsk0cr56PN6jXUcCqrTF2HuxWXcCdgsV_3j1KIiwR_-uF-VBrWG297MgYWc_n9pGeuLI3wWjfrecq84FN5o1LkunKU4kjGYGeBbN-MT-xgOdhqO--4swSkI9rkvKInHt0ucZVtfI49jCynD-T3R-S_VvXbfzWFDzzdGf7HwwBax3nkUmwp2_VdHgK0gz23tOZPubj8a89_C0rY6v1ZmDWtvvmTbEfrIAeogLe_8unvtz0RHfLWSz2FWNsiYN6AvYiPzA6o_NVOPqXrRwC4bWqPNkoRH7J8-2gjAK-eu1uVAZ1YBDWq_hn66NGjblP5KE2wtV7349kLT3icboqEgWiofbX5DQh0mK1Z7x8Zntw1oUm5BpQu2QFZp03pCfV0t8bpyzemEeZ_izFIBu8pgecAGT88zy9iL4HuVw-p1cGjDrimrwwL5_1K2bS7FUNy_csUlCLAfylb5xyAdAwqFf1EODjx2H3KmSjDVkYSerHO3WP5PHumHnLfxfGFY9EXf5mRBLyOu9Ivnyf5H7O5k6EKMKo0cm8yb3frplojn2OzOkM6O7vSAZS0KFqstxhF8hdhLSy7AdMntmDCD7NhR-r5llqeCgcuClk0XzMxa20wB11mgSQOoqknc5
+        id: rs_094ebefab06f6c100069efd58250cc8195b3b443e9b3d9bd84
+        summary: []
+        type: reasoning
+      - content:
+        - annotations: []
+          text: I'll check the capital lookup tool for "PotatoLand."
+          type: output_text
+        id: msg_094ebefab06f6c100069efd58302b4819587854b18d82b5690
+        phase: commentary
+        role: assistant
+        status: completed
+        type: message
+      - arguments: '{"country":"PotatoLand"}'
+        call_id: call_ALAJMWK9buNN7RXxxXbECcHa
+        id: fc_094ebefab06f6c100069efd5833ce081959f3a131863e89e53
+        name: get_capital
+        type: function_call
+      - call_id: call_ALAJMWK9buNN7RXxxXbECcHa
+        output: Potato City
+        type: function_call_output
+      instructions: Briefly narrate what you are about to do before calling each tool.
+      model: gpt-5.5
+      stream: false
+      tool_choice: auto
+      tools:
+      - description: null
+        name: get_capital
+        parameters:
+          additionalProperties: false
+          properties:
+            country:
+              type: string
+          required:
+          - country
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '1631'
+      content-type:
+      - application/json
+      openai-organization:
+      - pydantic-28gund
+      openai-processing-ms:
+      - '1407'
+      openai-project:
+      - proj_dKobscVY9YJxeEaDJen54e3d
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1777325445
+      created_at: 1777325443
+      error: null
+      frequency_penalty: 0.0
+      id: resp_094ebefab06f6c100069efd583f3f48195963668b2d25fdcf0
+      incomplete_details: null
+      instructions: Briefly narrate what you are about to do before calling each tool.
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.5-2026-04-23
+      moderation: null
+      object: response
+      output:
+      - content:
+        - annotations: []
+          logprobs: []
+          text: The capital of PotatoLand is **Potato City**.
+          type: output_text
+        id: msg_094ebefab06f6c100069efd584c2708195a132acaac66f5f56
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        effort: medium
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tools:
+      - description: null
+        name: get_capital
+        parameters:
+          additionalProperties: false
+          properties:
+            country:
+              type: string
+          required:
+          - country
+          type: object
+        strict: true
+        type: function
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 150
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 16
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 166
+      user: null
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -11172,9 +11172,7 @@ async def test_openai_responses_phase_round_trip_without_item_id(allow_model_req
             [
                 ResponseOutputMessage.model_construct(
                     id='msg_999',
-                    content=cast(
-                        list[Content], [ResponseOutputText(text='ok', type='output_text', annotations=[])]
-                    ),
+                    content=cast(list[Content], [ResponseOutputText(text='ok', type='output_text', annotations=[])]),
                     role='assistant',
                     status='completed',
                     type='message',

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -10923,3 +10923,282 @@ async def test_openai_responses_compact_stateful_mode(allow_model_requests: None
     assert compaction.provider_name == 'openai'
     assert compaction.provider_details is not None
     assert 'encrypted_content' in compaction.provider_details
+
+
+async def test_openai_responses_phase_non_streamed(allow_model_requests: None):
+    """`phase` on ResponseOutputMessage is captured into TextPart.provider_details."""
+    c = response_message(
+        [
+            ResponseOutputMessage.model_construct(
+                id='msg_commentary',
+                content=cast(
+                    list[Content],
+                    [ResponseOutputText(text='Looking it up...', type='output_text', annotations=[])],
+                ),
+                role='assistant',
+                status='completed',
+                type='message',
+                phase='commentary',
+            ),
+            ResponseOutputMessage.model_construct(
+                id='msg_final',
+                content=cast(
+                    list[Content],
+                    [ResponseOutputText(text='Paris.', type='output_text', annotations=[])],
+                ),
+                role='assistant',
+                status='completed',
+                type='message',
+                phase='final_answer',
+            ),
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('gpt-5.5', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    result = await agent.run('What is the capital of France?')
+    response = result.all_messages()[-1]
+    assert isinstance(response, ModelResponse)
+    text_parts = [p for p in response.parts if isinstance(p, TextPart)]
+    assert [(p.id, p.content, (p.provider_details or {}).get('phase')) for p in text_parts] == snapshot(
+        [
+            ('msg_commentary', 'Looking it up...', 'commentary'),
+            ('msg_final', 'Paris.', 'final_answer'),
+        ]
+    )
+
+
+async def test_openai_responses_phase_streamed(allow_model_requests: None):
+    """`phase` on streamed ResponseOutputMessage is captured into TextPart.provider_details."""
+    base_response = resp.Response(
+        id='resp_001',
+        model='gpt-5.5',
+        object='response',
+        created_at=1704067200,
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice='auto',
+        tools=[],
+    )
+
+    stream: list[resp.ResponseStreamEvent] = [
+        resp.ResponseCreatedEvent(response=base_response, type='response.created', sequence_number=0),
+        resp.ResponseInProgressEvent(response=base_response, type='response.in_progress', sequence_number=1),
+        resp.ResponseOutputItemAddedEvent(
+            item=ResponseOutputMessage.model_construct(
+                id='msg_001',
+                content=[],
+                role='assistant',
+                status='in_progress',
+                type='message',
+                phase='final_answer',
+            ),
+            output_index=0,
+            type='response.output_item.added',
+            sequence_number=2,
+        ),
+        resp.ResponseContentPartAddedEvent(
+            content_index=0,
+            item_id='msg_001',
+            output_index=0,
+            part=resp.ResponseOutputText(text='', type='output_text', annotations=[]),
+            type='response.content_part.added',
+            sequence_number=3,
+        ),
+        resp.ResponseTextDeltaEvent(
+            content_index=0,
+            delta='Paris.',
+            item_id='msg_001',
+            output_index=0,
+            type='response.output_text.delta',
+            sequence_number=4,
+            logprobs=[],
+        ),
+        resp.ResponseTextDoneEvent(
+            content_index=0,
+            item_id='msg_001',
+            output_index=0,
+            text='Paris.',
+            type='response.output_text.done',
+            sequence_number=5,
+            logprobs=[],
+        ),
+        resp.ResponseOutputItemDoneEvent(
+            item=ResponseOutputMessage.model_construct(
+                id='msg_001',
+                content=cast(list[Content], [ResponseOutputText(text='Paris.', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+                phase='final_answer',
+            ),
+            output_index=0,
+            type='response.output_item.done',
+            sequence_number=6,
+        ),
+        resp.ResponseCompletedEvent(
+            response=base_response.model_copy(update={'status': 'completed'}),
+            type='response.completed',
+            sequence_number=7,
+        ),
+    ]
+
+    mock_client = MockOpenAIResponses.create_mock_stream(stream)
+    model = OpenAIResponsesModel('gpt-5.5', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    async with agent.run_stream('What is the capital of France?') as result:
+        await result.get_output()
+
+    response = result.all_messages()[-1]
+    assert isinstance(response, ModelResponse)
+    text_parts = [p for p in response.parts if isinstance(p, TextPart)]
+    assert len(text_parts) == 1
+    assert text_parts[0].provider_details == snapshot({'phase': 'final_answer'})
+
+
+async def test_openai_responses_phase_round_trip(allow_model_requests: None):
+    """When the profile supports phase, it's sent back on the assistant ResponseOutputMessageParam."""
+    mock_client = MockOpenAIResponses.create_mock(
+        response_message(
+            [
+                ResponseOutputMessage.model_construct(
+                    id='msg_999',
+                    content=cast(
+                        list[Content],
+                        [ResponseOutputText(text='ok', type='output_text', annotations=[])],
+                    ),
+                    role='assistant',
+                    status='completed',
+                    type='message',
+                    phase='final_answer',
+                ),
+            ]
+        )
+    )
+    model = OpenAIResponsesModel(
+        'gpt-5.5',
+        provider=OpenAIProvider(openai_client=mock_client),
+        settings=OpenAIResponsesModelSettings(openai_send_reasoning_ids=True),
+    )
+    agent = Agent(model=model)
+
+    history: list[ModelRequest | ModelResponse] = [
+        ModelRequest(parts=[UserPromptPart(content='Hi')]),
+        ModelResponse(
+            parts=[
+                TextPart(
+                    content='Working on it...',
+                    id='msg_a',
+                    provider_name='openai',
+                    provider_details={'phase': 'commentary'},
+                ),
+                TextPart(
+                    content='All done.',
+                    id='msg_b',
+                    provider_name='openai',
+                    provider_details={'phase': 'final_answer'},
+                ),
+            ],
+            model_name='gpt-5.5',
+            provider_name='openai',
+        ),
+    ]
+
+    await agent.run('And again?', message_history=history)
+
+    sent_input = cast(list[dict[str, Any]], get_mock_responses_kwargs(mock_client)[0]['input'])
+    assistant_messages = [m for m in sent_input if isinstance(m, dict) and m.get('role') == 'assistant']
+    assert [(m['id'], m.get('phase')) for m in assistant_messages] == snapshot(
+        [('msg_a', 'commentary'), ('msg_b', 'final_answer')]
+    )
+
+
+async def test_openai_responses_phase_skipped_when_profile_unsupported(allow_model_requests: None):
+    """When the profile does NOT support phase, it must not leak into the request payload."""
+    mock_client = MockOpenAIResponses.create_mock(
+        response_message(
+            [
+                ResponseOutputMessage.model_construct(
+                    id='msg_999',
+                    content=cast(
+                        list[Content],
+                        [ResponseOutputText(text='ok', type='output_text', annotations=[])],
+                    ),
+                    role='assistant',
+                    status='completed',
+                    type='message',
+                ),
+            ]
+        )
+    )
+    # gpt-5.2 doesn't support phase; verify we don't send the field even if a previous turn carried it.
+    model = OpenAIResponsesModel(
+        'gpt-5.2',
+        provider=OpenAIProvider(openai_client=mock_client),
+        settings=OpenAIResponsesModelSettings(openai_send_reasoning_ids=True),
+    )
+    agent = Agent(model=model)
+
+    history: list[ModelRequest | ModelResponse] = [
+        ModelRequest(parts=[UserPromptPart(content='Hi')]),
+        ModelResponse(
+            parts=[
+                TextPart(
+                    content='Done.',
+                    id='msg_a',
+                    provider_name='openai',
+                    provider_details={'phase': 'final_answer'},
+                ),
+            ],
+            model_name='gpt-5.2',
+            provider_name='openai',
+        ),
+    ]
+
+    await agent.run('And again?', message_history=history)
+
+    sent_input = cast(list[dict[str, Any]], get_mock_responses_kwargs(mock_client)[0]['input'])
+    assistant_messages = [m for m in sent_input if isinstance(m, dict) and m.get('role') == 'assistant']
+    assert assistant_messages
+    assert all('phase' not in m for m in assistant_messages)
+
+
+async def test_openai_responses_phase_live(allow_model_requests: None, openai_api_key: str):
+    """Real cassette: gpt-5.5 sets `phase` on the preamble (commentary) and the final answer."""
+    model = OpenAIResponsesModel('gpt-5.5', provider=OpenAIProvider(api_key=openai_api_key))
+    agent = Agent(
+        model=model,
+        instructions='Briefly narrate what you are about to do before calling each tool.',
+    )
+
+    @agent.tool_plain
+    async def get_capital(country: str) -> str:
+        return 'Potato City'
+
+    result = await agent.run('What is the capital of PotatoLand?')
+    text_parts_with_phase = [
+        (part.content, (part.provider_details or {}).get('phase'))
+        for msg in result.all_messages()
+        if isinstance(msg, ModelResponse)
+        for part in msg.parts
+        if isinstance(part, TextPart)
+    ]
+    assert text_parts_with_phase == snapshot(
+        [
+            ('I\'ll check the capital lookup tool for "PotatoLand."', 'commentary'),
+            ('The capital of PotatoLand is **Potato City**.', 'final_answer'),
+        ]
+    )
+
+
+def test_openai_responses_phase_profile_flag():
+    """Profile flag tracks the documented set of supporting models."""
+    assert cast(Any, openai_model_profile('gpt-5.5')).openai_supports_phase is True
+    assert cast(Any, openai_model_profile('gpt-5.4')).openai_supports_phase is True
+    assert cast(Any, openai_model_profile('gpt-5.3-codex')).openai_supports_phase is True
+    assert cast(Any, openai_model_profile('gpt-5.3')).openai_supports_phase is False
+    assert cast(Any, openai_model_profile('gpt-5.2')).openai_supports_phase is False
+    assert cast(Any, openai_model_profile('gpt-5')).openai_supports_phase is False
+    assert cast(Any, openai_model_profile('gpt-4o')).openai_supports_phase is False

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -11165,6 +11165,57 @@ async def test_openai_responses_phase_skipped_when_profile_unsupported(allow_mod
     assert all('phase' not in m for m in assistant_messages)
 
 
+async def test_openai_responses_phase_round_trip_without_item_id(allow_model_requests: None):
+    """Phase travels via `EasyInputMessageParam` when item ids aren't being sent."""
+    mock_client = MockOpenAIResponses.create_mock(
+        response_message(
+            [
+                ResponseOutputMessage.model_construct(
+                    id='msg_999',
+                    content=cast(
+                        list[Content], [ResponseOutputText(text='ok', type='output_text', annotations=[])]
+                    ),
+                    role='assistant',
+                    status='completed',
+                    type='message',
+                    phase='final_answer',
+                ),
+            ]
+        )
+    )
+    model = OpenAIResponsesModel(
+        'gpt-5.5',
+        provider=OpenAIProvider(openai_client=mock_client),
+        settings=OpenAIResponsesModelSettings(openai_send_reasoning_ids=False),
+    )
+    agent = Agent(model=model)
+
+    history: list[ModelRequest | ModelResponse] = [
+        ModelRequest(parts=[UserPromptPart(content='Hi')]),
+        ModelResponse(
+            parts=[
+                TextPart(
+                    content='Working on it...',
+                    id='msg_a',
+                    provider_name='openai',
+                    provider_details={'phase': 'commentary'},
+                ),
+            ],
+            model_name='gpt-5.5',
+            provider_name='openai',
+        ),
+    ]
+
+    await agent.run('And again?', message_history=history)
+
+    sent_input = cast(list[dict[str, Any]], get_mock_responses_kwargs(mock_client)[0]['input'])
+    assistant_messages = [m for m in sent_input if isinstance(m, dict) and m.get('role') == 'assistant']
+    # No item id was sent, so we used EasyInputMessageParam — but phase still rides along.
+    assert [(m.get('id'), m.get('phase'), m.get('type')) for m in assistant_messages] == snapshot(
+        [(None, 'commentary', None)]
+    )
+
+
 async def test_openai_responses_phase_live(allow_model_requests: None, openai_api_key: str):
     """Real cassette: gpt-5.5 sets `phase` on the preamble (commentary) and the final answer."""
     model = OpenAIResponsesModel('gpt-5.5', provider=OpenAIProvider(api_key=openai_api_key))


### PR DESCRIPTION
- Closes #<issue>

### Summary

GPT-5.3-codex / GPT-5.4+ label assistant messages with a new `phase` field on the OpenAI Responses API (`commentary` for preambles before tool calls, `final_answer` for the completed answer). OpenAI [recommends](https://developers.openai.com/api/docs/guides/prompt-guidance) preserving and round-tripping it on every follow-up request — dropping it can cause preambles to be interpreted as final answers and degrade behavior in long-running or tool-heavy flows.

This PR captures `phase` into `TextPart.provider_details['phase']` (non-streamed and streamed) and sends it back on the assistant `ResponseOutputMessageParam` / `EasyInputMessageParam` when the model profile opts in via a new `OpenAIModelProfile.openai_supports_phase` flag. The flag is enabled for `gpt-5.3-codex`, `gpt-5.4*`, and `gpt-5.5*` and defaults to `False` everywhere else, so unverified OpenAI-compatible APIs (vLLM, Bifrost, …) never see the field. Empirically the official OpenAI API silently ignores `phase` on older models (gpt-5.2, gpt-4o), so the flag is an extra guard for non-OpenAI providers rather than a hard requirement.

### Test plan

- [x] `tests/models/test_openai_responses.py::test_openai_responses_phase_live` — real cassette against `gpt-5.5` with a tool call, captures `commentary` preamble and `final_answer`, and (visible in the cassette) verifies pydantic-ai sends `phase: commentary` back to the API on the follow-up turn.
- [x] `test_openai_responses_phase_non_streamed` — non-streamed read into `provider_details`.
- [x] `test_openai_responses_phase_streamed` — streamed read via `output_item.added` → `output_text.done`.
- [x] `test_openai_responses_phase_round_trip` — supporting model preserves both `commentary` and `final_answer` on subsequent requests.
- [x] `test_openai_responses_phase_skipped_when_profile_unsupported` — `gpt-5.2` (flag off) does NOT send the field even when it's in history.
- [x] `test_openai_responses_phase_profile_flag` — flag tracks the documented model list.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).