### PR TITLE
fix(agent): propagate original error when event_stream_handler swallows stream exceptions

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -369,14 +369,30 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                     n: _agent_graph.AgentNode[AgentDepsT, Any],
                 ) -> _agent_graph.AgentNode[AgentDepsT, Any] | End[FinalResult[Any]]:
                     if self.is_model_request_node(n) or self.is_call_tools_node(n):
+                        stream_error: BaseException | None = None
+
+                        async def _error_capturing_stream() -> AsyncIterator[_messages.AgentStreamEvent]:
+                            nonlocal stream_error
+                            try:
+                                async for event in stream:
+                                    yield event
+                            except BaseException as e:
+                                stream_error = e
+                                raise
+
                         async with n.stream(agent_run.ctx) as stream:
                             run_ctx = _agent_graph.build_run_context(agent_run.ctx)
-                            wrapped = agent_run.ctx.deps.root_capability.wrap_run_event_stream(run_ctx, stream=stream)
+                            wrapped = agent_run.ctx.deps.root_capability.wrap_run_event_stream(
+                                run_ctx, stream=_error_capturing_stream()
+                            )
                             if _handler is not None:
                                 await _handler(run_ctx, wrapped)
                             else:
                                 async for _ in wrapped:
                                     pass
+
+                        if stream_error is not None:
+                            raise stream_error
                     return await agent_run._advance_graph(n)  # pyright: ignore[reportPrivateUsage]
 
                 _stream_step = _stream_and_advance

--- a/pydantic_ai_slim/pydantic_ai/models/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/models/ollama.py
@@ -12,6 +12,7 @@ from ..settings import ModelSettings
 
 try:
     from openai import AsyncOpenAI
+    from openai.types import chat
 
     from .openai import OpenAIChatModel
 except ImportError as _import_error:
@@ -93,3 +94,10 @@ class OllamaModel(OpenAIChatModel):
             profile = replace(base_profile, supports_json_schema_output=False)
 
         super().__init__(model_name, provider=provider, profile=profile, settings=settings)
+
+    class _MapModelResponseContext(OpenAIChatModel._MapModelResponseContext):  # type: ignore[reportPrivateUsage]
+        def _into_message_param(self) -> chat.ChatCompletionAssistantMessageParam:
+            message_param = super()._into_message_param()
+            if message_param.get('content') is None:
+                message_param['content'] = ''
+            return message_param

--- a/tests/models/test_ollama.py
+++ b/tests/models/test_ollama.py
@@ -22,9 +22,16 @@ from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsStr, try_import
 
 with try_import() as imports_successful:
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
+    from openai.types.chat.chat_completion_message_function_tool_call import ChatCompletionMessageFunctionToolCall
+    from openai.types.chat.chat_completion_message_tool_call import Function
+    from openai.types.completion_usage import CompletionUsage
+
     from pydantic_ai.models.ollama import OllamaModel
     from pydantic_ai.profiles.openai import OpenAIModelProfile
     from pydantic_ai.providers.ollama import OllamaProvider
+
+    from ..models.mock_openai import MockOpenAI, completion_message, get_mock_chat_completion_kwargs
 
 
 pytestmark = [
@@ -335,3 +342,51 @@ We need to provide answer in JSON format. Let's do that.\
             ),
         ]
     )
+
+
+async def test_ollama_assistant_message_content_none_becomes_empty_string(
+    allow_model_requests: None, ollama_api_key: str
+) -> None:
+    """Ollama's OpenAI-compatible API rejects `content: null` in assistant messages.
+
+    When a tool call response has no text content, OpenAI's API accepts `content: None`,
+    but Ollama requires it to be an empty string. This test verifies that `OllamaModel`
+    normalizes `None` to `''` before sending the request.
+    See https://github.com/pydantic/pydantic-ai/issues/5206
+    """
+    responses = [
+        completion_message(
+            ChatCompletionMessage(
+                content=None,
+                role='assistant',
+                tool_calls=[
+                    ChatCompletionMessageFunctionToolCall(
+                        id='1',
+                        function=Function(arguments='{"value": 42}', name='get_value'),
+                        type='function',
+                    )
+                ],
+            ),
+            usage=CompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+        ),
+        completion_message(ChatCompletionMessage(content='The value is 42', role='assistant')),
+    ]
+    mock_client = MockOpenAI.create_mock(responses)
+    provider = OllamaProvider(openai_client=mock_client)
+    m = OllamaModel('qwen3:0.6b', provider=provider)
+    agent = Agent(m)
+
+    @agent.tool_plain
+    async def get_value(value: int) -> int:
+        return value
+
+    result = await agent.run('What is the value?')
+    assert result.output == 'The value is 42'
+
+    kwargs = get_mock_chat_completion_kwargs(mock_client)
+    # Second request includes the assistant message with the tool call
+    second_request_messages = kwargs[1]['messages']
+    assistant_message = second_request_messages[1]
+    assert assistant_message['role'] == 'assistant'
+    assert assistant_message['content'] == ''
+    assert 'tool_calls' in assistant_message

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -52,6 +52,7 @@ from pydantic_ai.output import PromptedOutput, TextOutput, ToolOutput
 from pydantic_ai.result import AgentStream, FinalResult, RunUsage, StreamedRunResult, StreamedRunResultSync
 from pydantic_ai.tool_manager import ToolManager
 from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolApproved, ToolDefinition, ToolDenied
+from pydantic_ai.ui import UIEventStream
 from pydantic_ai.usage import RequestUsage
 from pydantic_graph import End
 
@@ -3566,6 +3567,35 @@ async def test_run_stream_event_stream_handler():
             FinalResultEvent(tool_name=None, tool_call_id=None),
         ]
     )
+
+
+async def test_run_event_stream_handler_error_propagation():
+    """When a tool raises inside agent.run() with an event_stream_handler that uses transform_stream(),
+    the original exception should propagate instead of being masked by an AssertionError."""
+    m = TestModel(call_tools=['failing_tool'])
+
+    agent = Agent(m)
+
+    @agent.tool_plain
+    async def failing_tool() -> str:
+        raise RuntimeError('Tool execution failed!')
+
+    class MinimalEventStream(UIEventStream[None, str, None, str]):
+        run_input: None = None
+
+        def encode_event(self, event: str) -> str:
+            return event
+
+        async def on_error(self, error: Exception) -> AsyncIterator[str]:
+            yield f'error: {error}'
+
+    async def event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]):
+        event_stream = MinimalEventStream(run_input=None)
+        async for _event in event_stream.transform_stream(stream.__aiter__()):
+            pass
+
+    with pytest.raises(RuntimeError, match='Tool execution failed!'):
+        await agent.run('use the tool', event_stream_handler=event_stream_handler)
 
 
 async def test_stream_tool_returning_user_content():


### PR DESCRIPTION
- Closes #4796

## Summary

When agent.run() is used with an event_stream_handler that wraps the stream in UIEventStream.transform_stream(), tool execution errors were being swallowed by transform_stream()'s except block. This caused the graph to re-execute the same CallToolsNode instance, which hit an AssertionError because _next_node was never set — masking the real error.

## Changes

- Wrap the node's stream in _stream_and_advance with an error-capturing generator that stores any exception before re-raising it
- After the event_stream_handler completes, re-raise the captured error so the graph's normal error handling (on_node_run_error) can process it

## Testing

- Added test_run_event_stream_handler_error_propagation which reproduces the bug using a TestModel and a custom event_stream_handler that uses UIEventStream.transform_stream()
- Verified that without the fix, the test fails with AssertionError: the stream should set self._next_node before it ends
- Verified that with the fix, the original RuntimeError from the tool is propagated
- All existing UI and streaming tests continue to pass