### PR TITLE
feat(openai): support gpt-image-2 options

### DIFF
--- a/docs/builtin-tools.md
+++ b/docs/builtin-tools.md
@@ -453,9 +453,11 @@ For more details, check the [API documentation][pydantic_ai.builtin_tools.ImageG
 
 | Parameter | OpenAI | Google |
 |-----------|--------|--------|
+| `action` | ✅ (auto (default), generate, edit) | ❌ |
 | `background` | ✅ | ❌ |
 | `input_fidelity` | ✅ | ❌ |
 | `moderation` | ✅ | ❌ |
+| `model` | ✅ | ❌ |
 | `output_compression` | ✅ (100 (default), jpeg or webp only) | ✅ (75 (default), jpeg only, Vertex AI only) |
 | `output_format` | ✅ | ✅ (Vertex AI only) |
 | `partial_images` | ✅ | ❌ |

--- a/docs/builtin-tools.md
+++ b/docs/builtin-tools.md
@@ -457,7 +457,7 @@ For more details, check the [API documentation][pydantic_ai.builtin_tools.ImageG
 | `background` | ✅ | ❌ |
 | `input_fidelity` | ✅ | ❌ |
 | `moderation` | ✅ | ❌ |
-| `model` | ✅ | ❌ |
+| `model` | ✅ (gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini, or another OpenAI image model ID) | ❌ |
 | `output_compression` | ✅ (100 (default), jpeg or webp only) | ✅ (75 (default), jpeg only, Vertex AI only) |
 | `output_format` | ✅ | ✅ (Vertex AI only) |
 | `partial_images` | ✅ | ❌ |

--- a/docs/builtin-tools.md
+++ b/docs/builtin-tools.md
@@ -383,8 +383,10 @@ agent = Agent(
     'openai-responses:gpt-5.2',
     builtin_tools=[
         ImageGenerationTool(
+            action='generate',
             background='transparent',
             input_fidelity='high',
+            model='gpt-image-2',
             moderation='low',
             output_compression=100,
             output_format='png',
@@ -405,6 +407,11 @@ _(This example is complete, it can be run "as is")_
 OpenAI Responses models also respect the `aspect_ratio` parameter. Because the OpenAI API only exposes discrete image sizes,
 Pydantic AI maps `'1:1'` -> `1024x1024`, `'2:3'` -> `1024x1536`, and `'3:2'` -> `1536x1024`. Providing any other aspect ratio
 results in an error, and if you also set `size` it must match the computed value.
+
+The OpenAI Responses image generation tool defaults to `action='auto'`, where the model decides whether to generate a new
+image or edit one already in context. Use `action='generate'` or `action='edit'` to force either behavior. You can also set
+`model` to select the underlying image generation model used by the tool, for example `model='gpt-image-2'`; this does not
+change the agent's conversational model.
 
 To control the aspect ratio when using Gemini image models, include the `ImageGenerationTool` explicitly:
 

--- a/pydantic_ai_slim/pydantic_ai/builtin_tools/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/builtin_tools/__init__.py
@@ -370,6 +370,14 @@ class ImageGenerationTool(AbstractBuiltinTool):
     * Google
     """
 
+    action: Literal['generate', 'edit', 'auto'] = 'auto'
+    """Whether to generate a new image or edit an existing image.
+
+    Supported by:
+
+    * OpenAI Responses. Default: 'auto'.
+    """
+
     background: Literal['transparent', 'opaque', 'auto'] = 'auto'
     """Background type for the generated image.
 
@@ -394,6 +402,17 @@ class ImageGenerationTool(AbstractBuiltinTool):
     Supported by:
 
     * OpenAI Responses
+    """
+
+    model: str | None = None
+    """The image generation model to use.
+
+    Supported by:
+
+    * OpenAI Responses. Defaults to the provider's image generation model selection.
+
+    This selects the underlying image generation model used by the tool; it does
+    not change the agent's conversational model.
     """
 
     output_compression: int | None = None

--- a/pydantic_ai_slim/pydantic_ai/builtin_tools/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/builtin_tools/__init__.py
@@ -18,6 +18,7 @@ __all__ = (
     'CodeExecutionTool',
     'WebFetchTool',
     'UrlContextTool',
+    'ImageGenerationModelName',
     'ImageGenerationTool',
     'MemoryTool',
     'MCPServerTool',
@@ -35,6 +36,9 @@ This dict is populated automatically via `__init_subclass__` when tool classes a
 
 ImageAspectRatio = Literal['21:9', '16:9', '4:3', '3:2', '1:1', '9:16', '3:4', '2:3', '5:4', '4:5']
 """Supported aspect ratios for image generation tools."""
+
+ImageGenerationModelName = Literal['gpt-image-2', 'gpt-image-1.5', 'gpt-image-1', 'gpt-image-1-mini'] | str
+"""Known OpenAI image generation model names, or another OpenAI image model ID."""
 
 
 @dataclass(kw_only=True)
@@ -404,12 +408,14 @@ class ImageGenerationTool(AbstractBuiltinTool):
     * OpenAI Responses
     """
 
-    model: str | None = None
+    model: ImageGenerationModelName | None = None
     """The image generation model to use.
 
     Supported by:
 
     * OpenAI Responses. Defaults to the provider's image generation model selection.
+      Known image generation models include `gpt-image-2`, `gpt-image-1.5`,
+      `gpt-image-1`, and `gpt-image-1-mini`.
 
     This selects the underlying image generation model used by the tool; it does
     not change the agent's conversational model.

--- a/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
@@ -72,7 +72,7 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
     Supported by: OpenAI Responses.
     """
 
-    model: ImageGenerationModelName | None
+    image_model: ImageGenerationModelName | None
     """The image generation model to use.
 
     Supported by: OpenAI Responses.
@@ -125,7 +125,7 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
         background: Literal['transparent', 'opaque', 'auto'] | None = None,
         input_fidelity: Literal['high', 'low'] | None = None,
         moderation: Literal['auto', 'low'] | None = None,
-        model: ImageGenerationModelName | None = None,
+        image_model: ImageGenerationModelName | None = None,
         output_compression: int | None = None,
         output_format: Literal['png', 'webp', 'jpeg'] | None = None,
         quality: Literal['low', 'medium', 'high', 'auto'] | None = None,
@@ -144,7 +144,7 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
         self.background = background
         self.input_fidelity = input_fidelity
         self.moderation = moderation
-        self.model = model
+        self.image_model = image_model
         self.output_compression = output_compression
         self.output_format = output_format
         self.quality = quality
@@ -163,8 +163,8 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
             kwargs['input_fidelity'] = self.input_fidelity
         if self.moderation is not None:
             kwargs['moderation'] = self.moderation
-        if self.model is not None:
-            kwargs['model'] = self.model
+        if self.image_model is not None:
+            kwargs['model'] = self.image_model
         if self.output_compression is not None:
             kwargs['output_compression'] = self.output_compression
         if self.output_format is not None:

--- a/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic_ai.builtin_tools import ImageAspectRatio, ImageGenerationTool
+from pydantic_ai.builtin_tools import ImageAspectRatio, ImageGenerationModelName, ImageGenerationTool
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import KnownModelName, Model
 from pydantic_ai.tools import AgentDepsT, RunContext, Tool
@@ -72,7 +72,7 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
     Supported by: OpenAI Responses.
     """
 
-    model: str | None
+    model: ImageGenerationModelName | None
     """The image generation model to use.
 
     Supported by: OpenAI Responses.
@@ -125,7 +125,7 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
         background: Literal['transparent', 'opaque', 'auto'] | None = None,
         input_fidelity: Literal['high', 'low'] | None = None,
         moderation: Literal['auto', 'low'] | None = None,
-        model: str | None = None,
+        model: ImageGenerationModelName | None = None,
         output_compression: int | None = None,
         output_format: Literal['png', 'webp', 'jpeg'] | None = None,
         quality: Literal['low', 'medium', 'high', 'auto'] | None = None,

--- a/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py
@@ -48,6 +48,12 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
 
     # Keep these fields in sync with ImageGenerationTool in builtin_tools.py.
 
+    action: Literal['generate', 'edit', 'auto'] | None
+    """Whether to generate a new image or edit an existing image.
+
+    Supported by: OpenAI Responses. Default: `'auto'`.
+    """
+
     background: Literal['transparent', 'opaque', 'auto'] | None
     """Background type for the generated image.
 
@@ -62,6 +68,12 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
 
     moderation: Literal['auto', 'low'] | None
     """Moderation level for the generated image.
+
+    Supported by: OpenAI Responses.
+    """
+
+    model: str | None
+    """The image generation model to use.
 
     Supported by: OpenAI Responses.
     """
@@ -109,9 +121,11 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
         | str
         | Callable[[RunContext[AgentDepsT]], Awaitable[Model] | Model]
         | None = None,
+        action: Literal['generate', 'edit', 'auto'] | None = None,
         background: Literal['transparent', 'opaque', 'auto'] | None = None,
         input_fidelity: Literal['high', 'low'] | None = None,
         moderation: Literal['auto', 'low'] | None = None,
+        model: str | None = None,
         output_compression: int | None = None,
         output_format: Literal['png', 'webp', 'jpeg'] | None = None,
         quality: Literal['low', 'medium', 'high', 'auto'] | None = None,
@@ -126,9 +140,11 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
         self.builtin = builtin
         self.local = local
         self.fallback_model = fallback_model
+        self.action = action
         self.background = background
         self.input_fidelity = input_fidelity
         self.moderation = moderation
+        self.model = model
         self.output_compression = output_compression
         self.output_format = output_format
         self.quality = quality
@@ -139,12 +155,16 @@ class ImageGeneration(BuiltinOrLocalTool[AgentDepsT]):
     def _image_gen_kwargs(self) -> dict[str, Any]:
         """Collect non-None ImageGenerationTool config fields."""
         kwargs: dict[str, Any] = {}
+        if self.action is not None:
+            kwargs['action'] = self.action
         if self.background is not None:
             kwargs['background'] = self.background
         if self.input_fidelity is not None:
             kwargs['input_fidelity'] = self.input_fidelity
         if self.moderation is not None:
             kwargs['moderation'] = self.moderation
+        if self.model is not None:
+            kwargs['model'] = self.model
         if self.output_compression is not None:
             kwargs['output_compression'] = self.output_compression
         if self.output_format is not None:

--- a/pydantic_ai_slim/pydantic_ai/common_tools/image_generation.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/image_generation.py
@@ -31,7 +31,10 @@ __all__ = (
 # Known image-only model names that don't support the conversational Agent loop
 # required by the subagent fallback, mapped to suggested LLM alternatives.
 _IMAGE_ONLY_MODELS: dict[str, str] = {
+    'gpt-image-2': 'openai-responses:gpt-5.5',
+    'gpt-image-1.5': 'openai-responses:gpt-5.5',
     'gpt-image-1': 'openai-responses:gpt-5.4',
+    'gpt-image-1-mini': 'openai-responses:gpt-5.4',
     'dall-e-3': 'openai-responses:gpt-5.4',
     'dall-e-2': 'openai-responses:gpt-5.4',
     'imagen-3.0-generate-002': 'google-gla:gemini-3-pro-image-preview',

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -315,6 +315,26 @@ def _resolve_openai_image_generation_size(
     return mapped_size
 
 
+def _map_openai_image_generation_tool(tool: ImageGenerationTool) -> responses.tool_param.ImageGeneration:
+    size = _resolve_openai_image_generation_size(tool)
+    output_compression = tool.output_compression if tool.output_compression is not None else 100
+    image_generation_tool = responses.tool_param.ImageGeneration(
+        type='image_generation',
+        action=tool.action,
+        background=tool.background,
+        input_fidelity=tool.input_fidelity,
+        moderation=tool.moderation,
+        output_compression=output_compression,
+        output_format=tool.output_format or 'png',
+        partial_images=tool.partial_images,
+        quality=tool.quality,
+        size=size,
+    )
+    if tool.model is not None:
+        image_generation_tool['model'] = tool.model
+    return image_generation_tool
+
+
 def _check_azure_content_filter(e: APIStatusError, system: str, model_name: str) -> ModelResponse | None:
     """Check if the error is an Azure content filter error."""
     # Assign to Any to avoid 'dict[Unknown, Unknown]' inference in strict mode
@@ -2142,21 +2162,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                 tools.append(mcp_tool)
             elif isinstance(tool, ImageGenerationTool):  # pragma: no branch
                 has_image_generating_tool = True
-                size = _resolve_openai_image_generation_size(tool)
-                output_compression = tool.output_compression if tool.output_compression is not None else 100
-                tools.append(
-                    responses.tool_param.ImageGeneration(
-                        type='image_generation',
-                        background=tool.background,
-                        input_fidelity=tool.input_fidelity,
-                        moderation=tool.moderation,
-                        output_compression=output_compression,
-                        output_format=tool.output_format or 'png',
-                        partial_images=tool.partial_images,
-                        quality=tool.quality,
-                        size=size,
-                    )
-                )
+                tools.append(_map_openai_image_generation_tool(tool))
             else:
                 raise UserError(  # pragma: no cover
                     f'`{tool.__class__.__name__}` is not supported by `OpenAIResponsesModel`. If it should be, please file an issue.'

--- a/tests/models/test_model_request_parameters.py
+++ b/tests/models/test_model_request_parameters.py
@@ -100,9 +100,11 @@ def test_model_request_parameters_are_serializable():
                 },
                 {
                     'kind': 'image_generation',
+                    'action': 'auto',
                     'background': 'auto',
                     'input_fidelity': None,
                     'moderation': 'auto',
+                    'model': None,
                     'output_compression': None,
                     'output_format': None,
                     'partial_images': 0,

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -225,6 +225,57 @@ def test_openai_responses_image_generation_tool_unsupported_size_raises_error() 
         _resolve_openai_image_generation_size(tool)
 
 
+async def test_openai_responses_image_generation_tool_options(allow_model_requests: None) -> None:
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('gpt-5.5', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(
+        model=model,
+        builtin_tools=[
+            ImageGenerationTool(
+                action='generate',
+                model='gpt-image-2',
+                background='opaque',
+                output_format='jpeg',
+                size='1536x1024',
+            )
+        ],
+    )
+
+    result = await agent.run('Generate an image.')
+
+    assert result.output == 'done'
+    response_kwargs = get_mock_responses_kwargs(mock_client)[0]
+    assert len(response_kwargs['tools']) == 1
+    assert response_kwargs['tools'] == snapshot(
+        [
+            {
+                'type': 'image_generation',
+                'action': 'generate',
+                'background': 'opaque',
+                'input_fidelity': None,
+                'moderation': 'auto',
+                'output_compression': 100,
+                'output_format': 'jpeg',
+                'partial_images': 0,
+                'quality': 'auto',
+                'size': '1536x1024',
+                'model': 'gpt-image-2',
+            }
+        ]
+    )
+
+
 async def test_openai_responses_model_simple_response_with_tool_call(allow_model_requests: None, openai_api_key: str):
     model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(api_key=openai_api_key))
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -494,7 +494,18 @@ def test_model_json_schema_with_capabilities():
                             'title': 'Moderation',
                             'type': 'string',
                         },
-                        'model': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'default': None, 'title': 'Model'},
+                        'model': {
+                            'anyOf': [
+                                {
+                                    'enum': ['gpt-image-2', 'gpt-image-1.5', 'gpt-image-1', 'gpt-image-1-mini'],
+                                    'type': 'string',
+                                },
+                                {'type': 'string'},
+                                {'type': 'null'},
+                            ],
+                            'default': None,
+                            'title': 'Model',
+                        },
                         'output_compression': {
                             'anyOf': [{'type': 'integer'}, {'type': 'null'}],
                             'default': None,
@@ -1307,7 +1318,17 @@ Supported by:
                             'anyOf': [{'enum': ['auto', 'low'], 'type': 'string'}, {'type': 'null'}],
                             'title': 'Moderation',
                         },
-                        'model': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'title': 'Model'},
+                        'model': {
+                            'anyOf': [
+                                {
+                                    'enum': ['gpt-image-2', 'gpt-image-1.5', 'gpt-image-1', 'gpt-image-1-mini'],
+                                    'type': 'string',
+                                },
+                                {'type': 'string'},
+                                {'type': 'null'},
+                            ],
+                            'title': 'Model',
+                        },
                         'output_compression': {
                             'anyOf': [{'type': 'integer'}, {'type': 'null'}],
                             'title': 'Output Compression',

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1318,7 +1318,7 @@ Supported by:
                             'anyOf': [{'enum': ['auto', 'low'], 'type': 'string'}, {'type': 'null'}],
                             'title': 'Moderation',
                         },
-                        'model': {
+                        'image_model': {
                             'anyOf': [
                                 {
                                     'enum': ['gpt-image-2', 'gpt-image-1.5', 'gpt-image-1', 'gpt-image-1-mini'],
@@ -1327,7 +1327,7 @@ Supported by:
                                 {'type': 'string'},
                                 {'type': 'null'},
                             ],
-                            'title': 'Model',
+                            'title': 'Image Model',
                         },
                         'output_compression': {
                             'anyOf': [{'type': 'integer'}, {'type': 'null'}],
@@ -4563,6 +4563,8 @@ class TestImageGenerationCapability:
         builtin_fields = {
             f.name for f in dataclasses.fields(ImageGenerationTool) if f.name not in ('kind', 'partial_images')
         }
+        builtin_fields.remove('model')
+        builtin_fields.add('image_model')
         init_params = set(inspect.signature(ImageGeneration.__init__).parameters.keys()) - {
             'self',
             'builtin',
@@ -4610,7 +4612,7 @@ class TestImageGenerationCapability:
             background='opaque',
             input_fidelity='high',
             moderation='low',
-            model='gpt-image-2',
+            image_model='gpt-image-2',
             output_compression=80,
             output_format='jpeg',
             quality='high',

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -471,6 +471,12 @@ def test_model_json_schema_with_capabilities():
                 'ImageGenerationTool': {
                     'properties': {
                         'kind': {'default': 'image_generation', 'title': 'Kind', 'type': 'string'},
+                        'action': {
+                            'default': 'auto',
+                            'enum': ['generate', 'edit', 'auto'],
+                            'title': 'Action',
+                            'type': 'string',
+                        },
                         'background': {
                             'default': 'auto',
                             'enum': ['transparent', 'opaque', 'auto'],
@@ -488,6 +494,7 @@ def test_model_json_schema_with_capabilities():
                             'title': 'Moderation',
                             'type': 'string',
                         },
+                        'model': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'default': None, 'title': 'Model'},
                         'output_compression': {
                             'anyOf': [{'type': 'integer'}, {'type': 'null'}],
                             'default': None,
@@ -1284,6 +1291,10 @@ Supported by:
                             'anyOf': [{'$ref': '#/$defs/KnownModelName'}, {'type': 'string'}, {'type': 'null'}],
                             'title': 'Fallback Model',
                         },
+                        'action': {
+                            'anyOf': [{'enum': ['generate', 'edit', 'auto'], 'type': 'string'}, {'type': 'null'}],
+                            'title': 'Action',
+                        },
                         'background': {
                             'anyOf': [{'enum': ['transparent', 'opaque', 'auto'], 'type': 'string'}, {'type': 'null'}],
                             'title': 'Background',
@@ -1296,6 +1307,7 @@ Supported by:
                             'anyOf': [{'enum': ['auto', 'low'], 'type': 'string'}, {'type': 'null'}],
                             'title': 'Moderation',
                         },
+                        'model': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'title': 'Model'},
                         'output_compression': {
                             'anyOf': [{'type': 'integer'}, {'type': 'null'}],
                             'title': 'Output Compression',
@@ -4573,9 +4585,11 @@ class TestImageGenerationCapability:
     def test_image_generation_forwards_config_to_builtin(self):
         """ImageGeneration config fields are forwarded to the ImageGenerationTool builtin."""
         cap = ImageGeneration(
+            action='generate',
             background='opaque',
             input_fidelity='high',
             moderation='low',
+            model='gpt-image-2',
             output_compression=80,
             output_format='jpeg',
             quality='high',
@@ -4586,9 +4600,11 @@ class TestImageGenerationCapability:
         assert len(builtins) == 1
         tool = builtins[0]
         assert isinstance(tool, ImageGenerationTool)
+        assert tool.action == 'generate'
         assert tool.background == 'opaque'
         assert tool.input_fidelity == 'high'
         assert tool.moderation == 'low'
+        assert tool.model == 'gpt-image-2'
         assert tool.output_compression == 80
         assert tool.output_format == 'jpeg'
         assert tool.quality == 'high'
@@ -4786,10 +4802,11 @@ class TestImageGenerationCapability:
             ]
         )
 
-    def test_image_generation_rejects_image_only_model(self):
-        """Using a dedicated image model like gpt-image-1 raises a clear error at construction."""
-        with pytest.raises(UserError, match="'gpt-image-1' is a dedicated image generation model"):
-            ImageGeneration(fallback_model='openai-responses:gpt-image-1')
+    @pytest.mark.parametrize('model_name', ['gpt-image-2', 'gpt-image-1.5', 'gpt-image-1', 'gpt-image-1-mini'])
+    def test_image_generation_rejects_image_only_model(self, model_name: str):
+        """Using a dedicated image model like gpt-image-2 raises a clear error at construction."""
+        with pytest.raises(UserError, match=f'{model_name!r} is a dedicated image generation model'):
+            ImageGeneration(fallback_model=f'openai-responses:{model_name}')
 
     @pytest.mark.vcr()
     @pytest.mark.filterwarnings('ignore:`BuiltinToolCallEvent` is deprecated:DeprecationWarning')


### PR DESCRIPTION
- Closes #5190
- Related context: #3898

## Context

Issue #5190 asks for `gpt-image-2` support. A maintainer noted that using `Agent('openai:gpt-image-2')` routes through the LLM/completions path, which is incompatible with image-only models and would need a separate adapter/profile for the image generation endpoint.

Issue #3898 covers the broader question of direct image/video generation model support. The maintainer guidance there is not to shoehorn non-LLM media models into `Agent`/`Model`; direct media generation likely wants dedicated types.

This PR therefore keeps the scope narrow: it does not make `Agent('openai:gpt-image-2')` a direct image model. Instead, it completes the existing OpenAI Responses `ImageGenerationTool` surface so an OpenAI Responses conversational model can invoke an image generation model via the built-in `image_generation` tool.

`ImageGenerationTool.model` now exposes known OpenAI image generation model names (`gpt-image-2`, `gpt-image-1.5`, `gpt-image-1`, and `gpt-image-1-mini`) while preserving a `str` escape hatch for future OpenAI image model IDs. The `gpt-image-2` entry in `_IMAGE_ONLY_MODELS` is only used to reject image-only models as `fallback_model` values with a clearer suggestion; it is separate from the tool's `model` field.

## Summary

- Add `action` and `model` options to `ImageGenerationTool` for OpenAI Responses image generation.
- Type `ImageGenerationTool.model` and `ImageGeneration.model` with known OpenAI image generation model names while still accepting arbitrary string model IDs.
- Forward those options when building the OpenAI Responses `image_generation` tool payload.
- Mirror the new options through the provider-adaptive `ImageGeneration` capability.
- Update docs, provider support tables, schema snapshots, and serialization snapshots.

## Test plan

- [x] `uv run pytest tests/test_capabilities.py`
- [x] `uv run pytest tests/models/test_google.py tests/models/test_model_request_parameters.py -k image_generation`
- [x] `uv run pytest tests/models/test_openai_responses.py -k image_generation`
- [x] `uv run pytest tests/models/test_model_request_parameters.py::test_model_request_parameters_are_serializable`
- [x] `uv run pytest tests/test_capabilities.py::test_model_json_schema_with_capabilities tests/models/test_model_request_parameters.py::test_model_request_parameters_are_serializable tests/models/test_openai_responses.py::test_openai_responses_image_generation_tool_options`
- [x] `uv run pytest tests/models/test_model_request_parameters.py tests/test_capabilities.py tests/models/test_openai_responses.py -k 'model_request_parameters_are_serializable or image_generation'`
- [x] `uv run ruff check pydantic_ai_slim/pydantic_ai/builtin_tools/__init__.py pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/common_tools/image_generation.py tests/models/test_openai_responses.py tests/test_capabilities.py tests/models/test_model_request_parameters.py`
- [x] `uv run ruff format --check pydantic_ai_slim/pydantic_ai/builtin_tools/__init__.py pydantic_ai_slim/pydantic_ai/capabilities/image_generation.py pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/common_tools/image_generation.py tests/models/test_openai_responses.py tests/test_capabilities.py tests/models/test_model_request_parameters.py`
- [x] `git diff --check`

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
