### PR TITLE
feat: implement strict runtime validation for tool outputs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -65,8 +65,8 @@ from ..tools import (
     DeferredToolResults,
     DocstringFormat,
     GenerateToolJsonSchema,
-    RunContext,
     ResultValidatorFunc,
+    RunContext,
     Tool,
     ToolFuncContext,
     ToolFuncEither,
@@ -95,7 +95,6 @@ from .spec import AgentSpec, get_capability_registry
 from .wrapper import WrapperAgent
 
 if TYPE_CHECKING:
-    from pydantic_core import SchemaValidator, SchemaValidatorProt
     from starlette.applications import Starlette
 
     from pydantic_graph import GraphRunContext
@@ -2030,7 +2029,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         include_return_schema: bool | None = None,
         validate_return: bool = False,
         result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
-        result_schema_validator: SchemaValidator | SchemaValidatorProt | None = None,
+        return_type: Any = Any,
     ) -> Callable[[ToolFuncContext[AgentDepsT, ToolParams]], ToolFuncContext[AgentDepsT, ToolParams]]: ...
 
     def tool(
@@ -2055,7 +2054,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         include_return_schema: bool | None = None,
         validate_return: bool = False,
         result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
-        result_schema_validator: SchemaValidator | SchemaValidatorProt | None = None,
+        return_type: Any = Any,
     ) -> Any:
         """Decorator to register a tool function which takes [`RunContext`][pydantic_ai.tools.RunContext] as its first argument.
 
@@ -2117,6 +2116,11 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 See [Tool Search](../tools-advanced.md#tool-search) for more info.
             include_return_schema: Whether to include the return schema in the tool definition sent to the model.
                 If `None`, defaults to `False` unless the [`IncludeToolReturnSchemas`][pydantic_ai.capabilities.IncludeToolReturnSchemas] capability is used.
+            validate_return: Whether to validate the tool's return value.
+            result_validator: custom method to validate or sanitize the tool result after execution.
+                See [`ResultValidatorFunc`][pydantic_ai.tools.ResultValidatorFunc].
+            return_type: The type of the tool's return value.
+                If `Any`, this is inferred from the function signature if `validate_return` is True.
         """
 
         def tool_decorator(
@@ -2143,7 +2147,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 include_return_schema=include_return_schema,
                 validate_return=validate_return,
                 result_validator=result_validator,
-                result_schema_validator=result_schema_validator,
+                return_type=return_type,
             )
             return func_
 
@@ -2174,7 +2178,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         include_return_schema: bool | None = None,
         validate_return: bool = False,
         result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
-        result_schema_validator: SchemaValidator | SchemaValidatorProt | None = None,
+        return_type: Any = Any,
     ) -> Callable[[ToolFuncPlain[ToolParams]], ToolFuncPlain[ToolParams]]: ...
 
     def tool_plain(
@@ -2199,7 +2203,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         include_return_schema: bool | None = None,
         validate_return: bool = False,
         result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
-        result_schema_validator: SchemaValidator | SchemaValidatorProt | None = None,
+        return_type: Any = Any,
     ) -> Any:
         """Decorator to register a tool function which DOES NOT take `RunContext` as an argument.
 
@@ -2262,6 +2266,11 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 See [Tool Search](../tools-advanced.md#tool-search) for more info.
             include_return_schema: Whether to include the return schema in the tool definition sent to the model.
                 If `None`, defaults to `False` unless the [`IncludeToolReturnSchemas`][pydantic_ai.capabilities.IncludeToolReturnSchemas] capability is used.
+            validate_return: Whether to validate the tool's return value.
+            result_validator: custom method to validate or sanitize the tool result after execution.
+                See [`ResultValidatorFunc`][pydantic_ai.tools.ResultValidatorFunc].
+            return_type: The type of the tool's return value.
+                If `Any`, this is inferred from the function signature if `validate_return` is True.
         """
 
         def tool_decorator(func_: ToolFuncPlain[ToolParams]) -> ToolFuncPlain[ToolParams]:
@@ -2286,7 +2295,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 include_return_schema=include_return_schema,
                 validate_return=validate_return,
                 result_validator=result_validator,
-                result_schema_validator=result_schema_validator,
+                return_type=return_type,
             )
             return func_
 
@@ -2552,7 +2561,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             self._entered_count += 1
         return self
 
-    async def __aexit__(self, *args: Any) -> bool | None:
+    async def __aexit__(self, *args: object) -> bool | None:
         async with self._enter_lock:
             self._entered_count -= 1
             if self._entered_count == 0 and self._exit_stack is not None:

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -66,6 +66,7 @@ from ..tools import (
     DocstringFormat,
     GenerateToolJsonSchema,
     RunContext,
+    ResultValidatorFunc,
     Tool,
     ToolFuncContext,
     ToolFuncEither,
@@ -94,6 +95,7 @@ from .spec import AgentSpec, get_capability_registry
 from .wrapper import WrapperAgent
 
 if TYPE_CHECKING:
+    from pydantic_core import SchemaValidator, SchemaValidatorProt
     from starlette.applications import Starlette
 
     from pydantic_graph import GraphRunContext
@@ -2026,6 +2028,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         timeout: float | None = None,
         defer_loading: bool = False,
         include_return_schema: bool | None = None,
+        validate_return: bool = False,
+        result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
+        result_schema_validator: SchemaValidator | SchemaValidatorProt | None = None,
     ) -> Callable[[ToolFuncContext[AgentDepsT, ToolParams]], ToolFuncContext[AgentDepsT, ToolParams]]: ...
 
     def tool(
@@ -2048,6 +2053,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         timeout: float | None = None,
         defer_loading: bool = False,
         include_return_schema: bool | None = None,
+        validate_return: bool = False,
+        result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
+        result_schema_validator: SchemaValidator | SchemaValidatorProt | None = None,
     ) -> Any:
         """Decorator to register a tool function which takes [`RunContext`][pydantic_ai.tools.RunContext] as its first argument.
 
@@ -2133,6 +2141,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 timeout=timeout,
                 defer_loading=defer_loading,
                 include_return_schema=include_return_schema,
+                validate_return=validate_return,
+                result_validator=result_validator,
+                result_schema_validator=result_schema_validator,
             )
             return func_
 
@@ -2161,6 +2172,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         timeout: float | None = None,
         defer_loading: bool = False,
         include_return_schema: bool | None = None,
+        validate_return: bool = False,
+        result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
+        result_schema_validator: SchemaValidator | SchemaValidatorProt | None = None,
     ) -> Callable[[ToolFuncPlain[ToolParams]], ToolFuncPlain[ToolParams]]: ...
 
     def tool_plain(
@@ -2183,6 +2197,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         timeout: float | None = None,
         defer_loading: bool = False,
         include_return_schema: bool | None = None,
+        validate_return: bool = False,
+        result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
+        result_schema_validator: SchemaValidator | SchemaValidatorProt | None = None,
     ) -> Any:
         """Decorator to register a tool function which DOES NOT take `RunContext` as an argument.
 
@@ -2267,6 +2284,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 timeout=timeout,
                 defer_loading=defer_loading,
                 include_return_schema=include_return_schema,
+                validate_return=validate_return,
+                result_validator=result_validator,
+                result_schema_validator=result_schema_validator,
             )
             return func_
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/__init__.py
@@ -19,6 +19,7 @@ from .builtin_or_local import BuiltinOrLocalTool
 from .builtin_tool import BuiltinTool
 from .combined import CombinedCapability
 from .deferred_tool_handler import HandleDeferredToolCalls
+from .enforce_tool_return_validation import EnforceToolReturnValidation
 from .hooks import Hooks, HookTimeoutError
 from .image_generation import ImageGeneration
 from .include_return_schemas import IncludeToolReturnSchemas
@@ -43,6 +44,7 @@ CAPABILITY_TYPES: dict[str, type[AbstractCapability[Any]]] = {
     name: cls
     for cls in (
         BuiltinTool,
+        EnforceToolReturnValidation,
         ImageGeneration,
         IncludeToolReturnSchemas,
         MCP,
@@ -79,6 +81,7 @@ __all__ = [
     'WrapToolValidateHandler',
     'BuiltinTool',
     'BuiltinOrLocalTool',
+    'EnforceToolReturnValidation',
     'CAPABILITY_TYPES',
     'ImageGeneration',
     'HistoryProcessor',

--- a/pydantic_ai_slim/pydantic_ai/capabilities/enforce_tool_return_validation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/enforce_tool_return_validation.py
@@ -1,0 +1,63 @@
+"""Capability that enforces return validation on selected tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from pydantic_ai._run_context import AgentDepsT, RunContext
+from pydantic_ai.tools import ToolDefinition, ToolSelector, matches_tool_selector
+from pydantic_ai.toolsets.abstract import AbstractToolset
+from pydantic_ai.toolsets.prepared import PreparedToolset
+
+from .abstract import AbstractCapability
+
+
+@dataclass
+class EnforceToolReturnValidation(AbstractCapability[AgentDepsT]):
+    """Capability that enforces return validation for selected tools.
+
+    When added to an agent's capabilities, this sets
+    [`validate_return`][pydantic_ai.tools.ToolDefinition.validate_return]
+    to `True` on matching tool definitions.
+
+    Per-tool overrides (`Tool(..., validate_return=False)`) take
+    precedence — this capability only sets the flag on tools that haven't
+    explicitly opted in or out.
+
+    ```python
+    from pydantic_ai import Agent
+    from pydantic_ai.capabilities import EnforceToolReturnValidation
+
+    agent = Agent('openai:gpt-5', capabilities=[EnforceToolReturnValidation()])
+    ```
+    """
+
+    tools: ToolSelector[AgentDepsT] = 'all'
+    """Which tools should have their return values validated.
+
+    - `'all'` (default): every tool gets validated.
+    - `Sequence[str]`: only tools whose names are listed.
+    - `dict[str, Any]`: matches tools whose metadata deeply includes the specified key-value pairs.
+    - Callable `(ctx, tool_def) -> bool`: custom sync or async predicate.
+    """
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        return 'EnforceToolReturnValidation'
+
+    def get_wrapper_toolset(self, toolset: AbstractToolset[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
+        selector = self.tools
+
+        async def _enforce_return_validation(
+            ctx: RunContext[AgentDepsT], tool_defs: list[ToolDefinition]
+        ) -> list[ToolDefinition]:
+            resolved: list[ToolDefinition] = []
+            for td in tool_defs:
+                match = await matches_tool_selector(selector, ctx, td)
+                if not td.validate_return and match:
+                    td = replace(td, validate_return=True)
+                resolved.append(td)
+            return resolved
+
+        return PreparedToolset(toolset, _enforce_return_validation)

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -32,6 +32,7 @@ __all__ = (
     'ModelHTTPError',
     'ContentFilterError',
     'IncompleteToolCall',
+    'ToolOutputValidationError',
     'FallbackExceptionGroup',
 )
 
@@ -295,3 +296,18 @@ class ToolRetryError(Exception):
 
 class IncompleteToolCall(UnexpectedModelBehavior):
     """Error raised when a model stops due to token limit while emitting a tool call."""
+
+
+class ToolOutputValidationError(UnexpectedModelBehavior):
+    """Error raised when tool output fails validation."""
+
+    tool_name: str
+    """The name of the tool that produced the malformed output."""
+
+    validation_error: pydantic_core.ValidationError
+    """The Pydantic validation error."""
+
+    def __init__(self, tool_name: str, validation_error: pydantic_core.ValidationError):
+        self.tool_name = tool_name
+        self.validation_error = validation_error
+        super().__init__(str(validation_error))

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -17,23 +17,23 @@ if TYPE_CHECKING:
     from .messages import ModelResponse, RetryPromptPart
 
 __all__ = (
-    'ModelRetry',
-    'CallDeferred',
-    'ApprovalRequired',
-    'SkipModelRequest',
-    'SkipToolValidation',
-    'SkipToolExecution',
-    'UserError',
     'AgentRunError',
-    'UnexpectedModelBehavior',
-    'UsageLimitExceeded',
+    'ApprovalRequired',
+    'CallDeferred',
     'ConcurrencyLimitExceeded',
+    'ContentFilterError',
+    'FallbackExceptionGroup',
+    'IncompleteToolCall',
     'ModelAPIError',
     'ModelHTTPError',
-    'ContentFilterError',
-    'IncompleteToolCall',
+    'ModelRetry',
+    'SkipModelRequest',
+    'SkipToolExecution',
+    'SkipToolValidation',
     'ToolOutputValidationError',
-    'FallbackExceptionGroup',
+    'UnexpectedModelBehavior',
+    'UsageLimitExceeded',
+    'UserError',
 )
 
 
@@ -52,7 +52,7 @@ class ModelRetry(Exception):
         self.message = message
         super().__init__(message)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, self.__class__) and other.message == self.message
 
     def __hash__(self) -> int:

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Generic, Literal
 
 from opentelemetry.trace import StatusCode, Tracer
-from pydantic import ValidationError
+from pydantic_core import ValidationError
 from typing_extensions import deprecated
 
 from . import messages as _messages
@@ -21,6 +21,7 @@ from .exceptions import (
     ModelRetry,
     SkipToolExecution,
     SkipToolValidation,
+    ToolOutputValidationError,
     ToolRetryError,
     UnexpectedModelBehavior,
 )
@@ -510,6 +511,27 @@ class ToolManager(Generic[AgentDepsT]):
             self._check_max_retries(name, validated.tool.max_retries, e)
             self.failed_tools.add(name)
             raise self._wrap_error_as_retry(name, validated.call, e) from e
+
+        if validated.tool.validate_return:
+            try:
+                if (validator := validated.tool._return_validator) is not None:
+                    tool_result = validator.validate_python(tool_result)
+                if validated.tool.result_validator is not None:
+                    result = validated.tool.result_validator(validated.ctx, tool_result)
+                    if inspect.isawaitable(result):
+                        tool_result = await result
+                    else:
+                        tool_result = result
+            except (ValidationError, ModelRetry) as e:
+                self._check_max_retries(name, validated.tool.max_retries, e)
+                self.failed_tools.add(name)
+                if isinstance(e, ValidationError):
+                    # Wrap Pydantic validation error into our custom terminal-ish error
+                    # but check if we should retry first
+                    raise ToolOutputValidationError(name, e) from e
+                else:
+                    # ModelRetry from custom validator
+                    raise self._wrap_error_as_retry(name, validated.call, e) from e
 
         if usage is not None:
             usage.tool_calls += 1

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -512,9 +512,9 @@ class ToolManager(Generic[AgentDepsT]):
             self.failed_tools.add(name)
             raise self._wrap_error_as_retry(name, validated.call, e) from e
 
-        if validated.tool.validate_return:
+        if validated.tool.tool_def.validate_return:
             try:
-                if (validator := validated.tool._return_validator) is not None:
+                if (validator := validated.tool.tool_def._return_validator) is not None:
                     tool_result = validator.validate_python(tool_result)
                 if validated.tool.result_validator is not None:
                     result = validated.tool.result_validator(validated.ctx, tool_result)

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -606,7 +606,7 @@ class Tool(Generic[ToolAgentDepsT]):
         self.validate_return = validate_return
         self.result_validator = result_validator
 
-        if validate_return and return_type is Any:
+        if return_type is Any:
             # try to infer the return type from the function signature
             import typing
             try:

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -1,12 +1,13 @@
 from __future__ import annotations as _annotations
 
 import inspect
+import typing
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import KW_ONLY, dataclass, field
 from functools import cached_property
 from typing import Annotated, Any, Concatenate, Generic, Literal, TypeAlias, Union, cast
 
-from pydantic import Discriminator, Tag
+from pydantic import Discriminator, Tag, TypeAdapter
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
 from pydantic_core import SchemaValidator, core_schema
 from typing_extensions import ParamSpec, Self, TypeVar
@@ -21,6 +22,7 @@ from .messages import RetryPromptPart, ToolCallPart, ToolReturn
 __all__ = (
     'AgentDepsT',
     'ArgsValidatorFunc',
+    'ResultValidatorFunc',
     'DocstringFormat',
     'RunContext',
     'SystemPromptFunc',
@@ -47,6 +49,18 @@ __all__ = (
 
 ToolParams = ParamSpec('ToolParams', default=...)
 """Retrieval function param spec."""
+
+
+def _get_return_validator(function: Callable[..., Any]) -> SchemaValidator | SchemaValidatorProt | None:
+    """Infer the return type from the function signature and return a Pydantic validator."""
+    try:
+        type_hints = typing.get_type_hints(function, include_extras=True)
+        return_type = type_hints.get('return', Any)
+        if return_type is not Any and return_type is not type(None):
+            return TypeAdapter(return_type).validator
+    except Exception:
+        pass
+    return None
 
 SystemPromptFunc: TypeAlias = (
     Callable[[RunContext[AgentDepsT]], str | None]
@@ -89,6 +103,14 @@ The validator receives the same typed parameters as the tool function,
 with [`RunContext`][pydantic_ai.tools.RunContext] as the first argument for dependency access.
 
 Should raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] on validation failure.
+"""
+ResultValidatorFunc: TypeAlias = (
+    Callable[[RunContext[AgentDepsT], Any], Awaitable[Any]] | Callable[[RunContext[AgentDepsT], Any], Any]
+)
+"""A function that validates or sanitizes tool results after execution.
+
+The validator receives the tool result and [`RunContext`][pydantic_ai.tools.RunContext] as arguments.
+It should return the validated/sanitized result, or raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry].
 """
 ToolPrepareFunc: TypeAlias = Callable[
     [RunContext[AgentDepsT], 'ToolDefinition'],
@@ -449,6 +471,9 @@ class Tool(Generic[ToolAgentDepsT]):
     require_parameter_descriptions: bool
     strict: bool | None
     sequential: bool
+    validate_return: bool
+    result_validator: ResultValidatorFunc[ToolAgentDepsT] | None
+    return_type: Any
     requires_approval: bool
     metadata: dict[str, Any] | None
     timeout: float | None
@@ -476,6 +501,9 @@ class Tool(Generic[ToolAgentDepsT]):
         schema_generator: type[GenerateJsonSchema] = GenerateToolJsonSchema,
         strict: bool | None = None,
         sequential: bool = False,
+        validate_return: bool = False,
+        result_validator: ResultValidatorFunc[ToolAgentDepsT] | None = None,
+        return_type: Any = Any,
         requires_approval: bool = False,
         metadata: dict[str, Any] | None = None,
         timeout: float | None = None,
@@ -570,6 +598,19 @@ class Tool(Generic[ToolAgentDepsT]):
         self.require_parameter_descriptions = require_parameter_descriptions
         self.strict = strict
         self.sequential = sequential
+        self.validate_return = validate_return
+        self.result_validator = result_validator
+
+        if validate_return and return_type is Any:
+            # try to infer the return type from the function signature
+            import typing
+            try:
+                type_hints = typing.get_type_hints(function, include_extras=True)
+                return_type = type_hints.get('return', Any)
+            except Exception:
+                pass
+
+        self.return_type = return_type
         self.requires_approval = requires_approval
         self.metadata = metadata
         self.timeout = timeout
@@ -646,7 +687,16 @@ class Tool(Generic[ToolAgentDepsT]):
             kind='unapproved' if self.requires_approval else 'function',
             return_schema=self.function_schema.return_schema,
             include_return_schema=self.include_return_schema,
+            return_type=self.return_type,
+            validate_return=self.validate_return,
         )
+
+    @cached_property
+    def _return_validator(self) -> SchemaValidator | SchemaValidatorProt | None:
+        """The Pydantic Core validator for the tool's return value."""
+        if self.return_type is Any or self.return_type is type(None):
+            return None
+        return TypeAdapter(self.return_type).validator
 
     async def prepare_tool_def(self, ctx: RunContext[ToolAgentDepsT]) -> ToolDefinition | None:
         """Get the tool definition.
@@ -771,6 +821,22 @@ class ToolDefinition:
     When `None` (default), defaults to `False` unless the
     [`IncludeToolReturnSchemas`][pydantic_ai.capabilities.IncludeToolReturnSchemas] capability is used.
     """
+
+    return_type: Any = Any
+    """The type of the tool's return value.
+
+    Used to validate the tool's return value before being returned to the model if `validate_return` is `True`.
+    """
+
+    validate_return: bool = False
+    """Whether to validate the tool's return value against the `return_type`."""
+
+    @cached_property
+    def _return_validator(self) -> SchemaValidator | SchemaValidatorProt | None:
+        """The Pydantic Core validator for the tool's return value."""
+        if self.return_type is Any or self.return_type is type(None):
+            return None
+        return TypeAdapter(self.return_type).validator
 
     @cached_property
     def function_signature(self) -> FunctionSignature:

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -58,7 +58,7 @@ def _get_return_validator(function: Callable[..., Any]) -> SchemaValidator | Non
         return_type = type_hints.get('return', Any)
         if return_type is not Any and return_type is not type(None):
             return TypeAdapter(return_type).validator
-    except Exception:
+    except Exception:  # noqa: S110, BLE001
         pass
     return None
 
@@ -577,6 +577,11 @@ class Tool(Generic[ToolAgentDepsT]):
                 See [Tool Search](../tools-advanced.md#tool-search) for more info.
             include_return_schema: Whether to include the return schema in the tool definition sent to the model.
                 If `None`, defaults to `False` unless the [`IncludeToolReturnSchemas`][pydantic_ai.capabilities.IncludeToolReturnSchemas] capability is used.
+            validate_return: Whether to validate the tool's return value.
+            result_validator: custom method to validate or sanitize the tool result after execution.
+                See [`ResultValidatorFunc`][pydantic_ai.tools.ResultValidatorFunc].
+            return_type: The type of the tool's return value.
+                If `Any`, this is inferred from the function signature if `validate_return` is True.
             function_schema: The function schema to use for the tool. If not provided, it will be generated.
         """
         self.function = function
@@ -607,7 +612,7 @@ class Tool(Generic[ToolAgentDepsT]):
             try:
                 type_hints = typing.get_type_hints(function, include_extras=True)
                 return_type = type_hints.get('return', Any)
-            except Exception:
+            except Exception:  # noqa: S110, BLE001
                 pass
 
         self.return_type = return_type

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -20,30 +20,30 @@ from .function_signature import FunctionSignature
 from .messages import RetryPromptPart, ToolCallPart, ToolReturn
 
 __all__ = (
+    'AgentBuiltinTool',
     'AgentDepsT',
     'ArgsValidatorFunc',
-    'ResultValidatorFunc',
-    'DocstringFormat',
-    'RunContext',
-    'SystemPromptFunc',
-    'ToolFuncContext',
-    'ToolFuncPlain',
-    'ToolFuncEither',
-    'ToolParams',
-    'ToolPrepareFunc',
-    'ToolsPrepareFunc',
-    'ToolSelectorFunc',
-    'ToolSelector',
-    'matches_tool_selector',
-    'AgentBuiltinTool',
     'BuiltinToolFunc',
-    'Tool',
-    'ObjectJsonSchema',
-    'ToolDefinition',
     'DeferredToolRequests',
     'DeferredToolResults',
+    'DocstringFormat',
+    'ObjectJsonSchema',
+    'ResultValidatorFunc',
+    'RunContext',
+    'SystemPromptFunc',
+    'Tool',
     'ToolApproved',
+    'ToolDefinition',
     'ToolDenied',
+    'ToolFuncContext',
+    'ToolFuncEither',
+    'ToolFuncPlain',
+    'ToolParams',
+    'ToolPrepareFunc',
+    'ToolSelector',
+    'ToolSelectorFunc',
+    'ToolsPrepareFunc',
+    'matches_tool_selector',
 )
 
 
@@ -51,7 +51,7 @@ ToolParams = ParamSpec('ToolParams', default=...)
 """Retrieval function param spec."""
 
 
-def _get_return_validator(function: Callable[..., Any]) -> SchemaValidator | SchemaValidatorProt | None:
+def _get_return_validator(function: Callable[..., Any]) -> SchemaValidator | None:
     """Infer the return type from the function signature and return a Pydantic validator."""
     try:
         type_hints = typing.get_type_hints(function, include_extras=True)
@@ -692,7 +692,7 @@ class Tool(Generic[ToolAgentDepsT]):
         )
 
     @cached_property
-    def _return_validator(self) -> SchemaValidator | SchemaValidatorProt | None:
+    def _return_validator(self) -> SchemaValidator | None:
         """The Pydantic Core validator for the tool's return value."""
         if self.return_type is Any or self.return_type is type(None):
             return None
@@ -832,7 +832,7 @@ class ToolDefinition:
     """Whether to validate the tool's return value against the `return_type`."""
 
     @cached_property
-    def _return_validator(self) -> SchemaValidator | SchemaValidatorProt | None:
+    def _return_validator(self) -> SchemaValidator | None:
         """The Pydantic Core validator for the tool's return value."""
         if self.return_type is Any or self.return_type is type(None):
             return None

--- a/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
@@ -76,7 +76,7 @@ class ToolsetTool(Generic[AgentDepsT]):
     return_type: Any = Any
 
     @cached_property
-    def _return_validator(self) -> SchemaValidator | SchemaValidatorProt | None:
+    def _return_validator(self) -> SchemaValidator | None:
         """The Pydantic Core validator for the tool's return value."""
         if self.return_type is Any or self.return_type is type(None):
             return None
@@ -144,7 +144,7 @@ class AbstractToolset(ABC, Generic[AgentDepsT]):
         """
         return self
 
-    async def __aexit__(self, *args: Any) -> bool | None:
+    async def __aexit__(self, *args: object) -> bool | None:
         """Exit the toolset context.
 
         This is where you can tear down network connections in a concrete implementation.

--- a/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Generic, Literal, Protocol
 
+from pydantic import TypeAdapter
 from pydantic_core import SchemaValidator
 from typing_extensions import Self
 
 from .._run_context import AgentDepsT, RunContext
 from ..messages import InstructionPart
-from ..tools import ToolDefinition, ToolsPrepareFunc
+from ..tools import ResultValidatorFunc, ToolDefinition, ToolsPrepareFunc
 
 if TYPE_CHECKING:
     from .approval_required import ApprovalRequiredToolset
@@ -69,6 +71,16 @@ class ToolsetTool(Generic[AgentDepsT]):
     with `RunContext` as the first argument.
     Should raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] on failure, return `None` on success.
     """
+    validate_return: bool = False
+    result_validator: ResultValidatorFunc[AgentDepsT] | None = None
+    return_type: Any = Any
+
+    @cached_property
+    def _return_validator(self) -> SchemaValidator | SchemaValidatorProt | None:
+        """The Pydantic Core validator for the tool's return value."""
+        if self.return_type is Any or self.return_type is type(None):
+            return None
+        return TypeAdapter(self.return_type).validator
 
 
 class AbstractToolset(ABC, Generic[AgentDepsT]):

--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -58,7 +58,7 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
             self._exit_stack = exit_stack.pop_all()
         return self
 
-    async def __aexit__(self, *args: Any) -> bool | None:
+    async def __aexit__(self, *args: object) -> bool | None:
         if self._exit_stack is not None:
             await self._exit_stack.aclose()
             self._exit_stack = None

--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -82,6 +82,9 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
                     max_retries=tool.max_retries,
                     args_validator=tool.args_validator,
                     args_validator_func=tool.args_validator_func,
+                    validate_return=tool.validate_return,
+                    result_validator=tool.result_validator,
+                    return_type=tool.return_type,
                     source_toolset=toolset,
                     source_tool=tool,
                 )

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -612,7 +612,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             sequential=sequential,
             validate_return=validate_return,
             result_validator=result_validator,
-            result_schema_validator=result_schema_validator,
+            return_type=return_type,
             requires_approval=requires_approval,
             metadata=metadata,
             timeout=timeout,

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -8,6 +8,8 @@ from typing import Any, overload
 import anyio
 from pydantic.json_schema import GenerateJsonSchema
 
+from pydantic_core import SchemaValidator
+
 from .._run_context import AgentDepsT, RunContext
 from .._system_prompt import SystemPromptRunner
 from ..exceptions import ModelRetry, UserError
@@ -16,6 +18,7 @@ from ..tools import (
     ArgsValidatorFunc,
     DocstringFormat,
     GenerateToolJsonSchema,
+    ResultValidatorFunc,
     SystemPromptFunc,
     Tool,
     ToolFuncContext,
@@ -24,7 +27,7 @@ from ..tools import (
     ToolParams,
     ToolPrepareFunc,
 )
-from .abstract import AbstractToolset, ToolsetTool
+from .abstract import AbstractToolset, SchemaValidatorProt, ToolsetTool
 
 
 @dataclass(kw_only=True)
@@ -164,6 +167,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         schema_generator: type[GenerateJsonSchema] | None = None,
         strict: bool | None = None,
         sequential: bool | None = None,
+        validate_return: bool = False,
+        result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
+        return_type: Any = Any,
         requires_approval: bool | None = None,
         metadata: dict[str, Any] | None = None,
         timeout: float | None = None,
@@ -186,6 +192,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         schema_generator: type[GenerateJsonSchema] | None = None,
         strict: bool | None = None,
         sequential: bool | None = None,
+        validate_return: bool = False,
+        result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
+        return_type: Any = Any,
         requires_approval: bool | None = None,
         metadata: dict[str, Any] | None = None,
         timeout: float | None = None,
@@ -248,6 +257,11 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 If `None`, the default value is determined by the toolset.
             sequential: Whether the function requires a sequential/serial execution environment. Defaults to False.
                 If `None`, the default value is determined by the toolset.
+            validate_return: Whether to validate the tool's return value.
+            result_validator: custom method to validate or sanitize the tool result after execution.
+                See [`ResultValidatorFunc`][pydantic_ai.tools.ResultValidatorFunc].
+            return_type: The type of the tool's return value.
+                If `Any`, this is inferred from the function signature if `validate_return` is True.
             requires_approval: Whether this tool requires human-in-the-loop approval. Defaults to False.
                 See the [tools documentation](../deferred-tools.md#human-in-the-loop-tool-approval) for more info.
                 If `None`, the default value is determined by the toolset.
@@ -284,6 +298,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 schema_generator=schema_generator,
                 strict=strict,
                 sequential=sequential,
+                validate_return=validate_return,
+                result_validator=result_validator,
+                result_schema_validator=result_schema_validator,
                 requires_approval=requires_approval,
                 metadata=metadata,
                 timeout=timeout,
@@ -319,6 +336,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         schema_generator: type[GenerateJsonSchema] | None = None,
         strict: bool | None = None,
         sequential: bool | None = None,
+        validate_return: bool = False,
+        result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
+        return_type: Any = Any,
         requires_approval: bool | None = None,
         metadata: dict[str, Any] | None = None,
         timeout: float | None = None,
@@ -341,6 +361,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         schema_generator: type[GenerateJsonSchema] | None = None,
         strict: bool | None = None,
         sequential: bool | None = None,
+        validate_return: bool = False,
+        result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
+        return_type: Any = Any,
         requires_approval: bool | None = None,
         metadata: dict[str, Any] | None = None,
         timeout: float | None = None,
@@ -404,6 +427,11 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 If `None`, the default value is determined by the toolset.
             sequential: Whether the function requires a sequential/serial execution environment. Defaults to False.
                 If `None`, the default value is determined by the toolset.
+            validate_return: Whether to validate the tool's return value.
+            result_validator: custom method to validate or sanitize the tool result after execution.
+                See [`ResultValidatorFunc`][pydantic_ai.tools.ResultValidatorFunc].
+            return_type: The type of the tool's return value.
+                If `Any`, this is inferred from the function signature if `validate_return` is True.
             requires_approval: Whether this tool requires human-in-the-loop approval. Defaults to False.
                 See the [tools documentation](../deferred-tools.md#human-in-the-loop-tool-approval) for more info.
                 If `None`, the default value is determined by the toolset.
@@ -435,6 +463,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 schema_generator=schema_generator,
                 strict=strict,
                 sequential=sequential,
+                validate_return=validate_return,
+                result_validator=result_validator,
+                result_schema_validator=result_schema_validator,
                 requires_approval=requires_approval,
                 metadata=metadata,
                 timeout=timeout,
@@ -490,6 +521,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         schema_generator: type[GenerateJsonSchema] | None = None,
         strict: bool | None = None,
         sequential: bool | None = None,
+        validate_return: bool = False,
+        result_validator: ResultValidatorFunc[AgentDepsT] | None = None,
+        return_type: Any = Any,
         requires_approval: bool | None = None,
         defer_loading: bool | None = None,
         metadata: dict[str, Any] | None = None,
@@ -530,6 +564,11 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 If `None`, the default value is determined by the toolset.
             sequential: Whether the function requires a sequential/serial execution environment. Defaults to False.
                 If `None`, the default value is determined by the toolset.
+            validate_return: Whether to validate the tool's return value.
+            result_validator: custom method to validate or sanitize the tool result after execution.
+                See [`ResultValidatorFunc`][pydantic_ai.tools.ResultValidatorFunc].
+            return_type: The type of the tool's return value.
+                If `Any`, this is inferred from the function signature if `validate_return` is True.
             requires_approval: Whether this tool requires human-in-the-loop approval. Defaults to False.
                 See the [tools documentation](../deferred-tools.md#human-in-the-loop-tool-approval) for more info.
                 If `None`, the default value is determined by the toolset.
@@ -573,6 +612,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             schema_generator=schema_generator,
             strict=strict,
             sequential=sequential,
+            validate_return=validate_return,
+            result_validator=result_validator,
+            result_schema_validator=result_schema_validator,
             requires_approval=requires_approval,
             metadata=metadata,
             timeout=timeout,
@@ -637,6 +679,9 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 max_retries=max_retries,
                 args_validator=tool.function_schema.validator,
                 args_validator_func=tool.args_validator,
+                validate_return=tool.validate_return,
+                result_validator=tool.result_validator,
+                return_type=tool.return_type,
                 call_func=tool.function_schema.call,
                 is_async=tool.function_schema.is_async,
                 timeout=tool_def.timeout,

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -8,8 +8,6 @@ from typing import Any, overload
 import anyio
 from pydantic.json_schema import GenerateJsonSchema
 
-from pydantic_core import SchemaValidator
-
 from .._run_context import AgentDepsT, RunContext
 from .._system_prompt import SystemPromptRunner
 from ..exceptions import ModelRetry, UserError
@@ -27,7 +25,7 @@ from ..tools import (
     ToolParams,
     ToolPrepareFunc,
 )
-from .abstract import AbstractToolset, SchemaValidatorProt, ToolsetTool
+from .abstract import AbstractToolset, ToolsetTool
 
 
 @dataclass(kw_only=True)
@@ -300,7 +298,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 sequential=sequential,
                 validate_return=validate_return,
                 result_validator=result_validator,
-                result_schema_validator=result_schema_validator,
+                return_type=return_type,
                 requires_approval=requires_approval,
                 metadata=metadata,
                 timeout=timeout,
@@ -465,7 +463,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 sequential=sequential,
                 validate_return=validate_return,
                 result_validator=result_validator,
-                result_schema_validator=result_schema_validator,
+                return_type=return_type,
                 requires_approval=requires_approval,
                 metadata=metadata,
                 timeout=timeout,

--- a/tests/test_tool_return_validation.py
+++ b/tests/test_tool_return_validation.py
@@ -1,0 +1,133 @@
+
+import pytest
+from typing import Annotated
+from pydantic import AfterValidator
+from pydantic_core import ValidationError
+from pydantic_ai import Agent, RunContext, Tool
+from pydantic_ai.exceptions import ToolOutputValidationError, ModelRetry
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.messages import ModelResponse, ToolCallPart, TextPart
+
+async def test_schema_validation_failure():
+    def my_tool(ctx: RunContext[None], x: int) -> int:
+        return "not an int"
+
+    agent = Agent(FunctionModel(lambda ms, info: ModelResponse(parts=[ToolCallPart("my_tool", {"x": 1}, "1")])), tools=[Tool(my_tool, validate_return=True)])
+
+    with pytest.raises(ToolOutputValidationError) as exc_info:
+        await agent.run("call my_tool")
+    
+    assert exc_info.value.tool_name == "my_tool"
+    assert "integer" in str(exc_info.value.validation_error)
+
+async def test_schema_validation_success():
+    def my_tool(ctx: RunContext[None], x: int) -> int:
+        return x * 2
+
+    called = False
+    async def call_tool_model(messages, info):
+        nonlocal called
+        if not called:
+            called = True
+            return ModelResponse(parts=[ToolCallPart("my_tool", {"x": 21}, "1")])
+        else:
+            return ModelResponse(parts=[TextPart("Done")])
+
+    agent = Agent(FunctionModel(call_tool_model), tools=[Tool(my_tool, validate_return=True)])
+    result = await agent.run("call my_tool")
+    
+    found_tool_return = False
+    for msg in result.all_messages():
+        if hasattr(msg, 'parts'):
+            for part in msg.parts:
+                if hasattr(part, 'part_kind') and part.part_kind == 'tool-return':
+                    assert part.content == 42
+                    found_tool_return = True
+    assert found_tool_return
+
+def sanitize_output(v: str) -> str:
+    return v.strip().upper()
+
+async def test_custom_validator_sanitization():
+    def my_tool(ctx: RunContext[None]) -> Annotated[str, AfterValidator(sanitize_output)]:
+        return "  hello  "
+
+    called = False
+    async def call_tool_model(messages, info):
+        nonlocal called
+        if not called:
+            called = True
+            return ModelResponse(parts=[ToolCallPart("my_tool", {}, "1")])
+        else:
+            return ModelResponse(parts=[TextPart("Done")])
+
+    agent = Agent(FunctionModel(call_tool_model), tools=[Tool(my_tool, validate_return=True)])
+    result = await agent.run("call my_tool")
+    
+    for msg in result.all_messages():
+        if hasattr(msg, 'parts'):
+            for part in msg.parts:
+                if hasattr(part, 'part_kind') and part.part_kind == 'tool-return':
+                    assert part.content == "HELLO"
+
+async def test_async_custom_validator():
+    async def async_validator(ctx: RunContext[None], v: int) -> int:
+        return v + 1
+
+    def my_tool(ctx: RunContext[None], x: int) -> int:
+        return x
+
+    called = False
+    async def call_tool_model(messages, info):
+        nonlocal called
+        if not called:
+            called = True
+            return ModelResponse(parts=[ToolCallPart("my_tool", {"x": 41}, "1")])
+        else:
+            return ModelResponse(parts=[TextPart("Done")])
+
+    tool = Tool(my_tool, validate_return=True, result_validator=async_validator)
+    agent = Agent(FunctionModel(call_tool_model), tools=[tool])
+    result = await agent.run("call my_tool")
+    
+    for msg in result.all_messages():
+        if hasattr(msg, 'parts'):
+            for part in msg.parts:
+                if hasattr(part, 'part_kind') and part.part_kind == 'tool-return':
+                    assert part.content == 42
+
+async def test_model_retry_from_validator():
+    def retry_validator(ctx: RunContext[None], v: int) -> int:
+        if v < 100:
+            raise ModelRetry("Value too low, try higher")
+        return v
+
+    def my_tool(ctx: RunContext[None], x: int) -> int:
+        return x
+
+    responses = [
+        ModelResponse(parts=[ToolCallPart("my_tool", {"x": 50}, "1")]),
+        ModelResponse(parts=[ToolCallPart("my_tool", {"x": 150}, "2")]),
+        ModelResponse(parts=[TextPart("Done")])
+    ]
+    response_idx = 0
+    async def call_tool_model(messages, info):
+        nonlocal response_idx
+        res = responses[response_idx]
+        response_idx += 1
+        return res
+
+    tool = Tool(my_tool, validate_return=True, result_validator=retry_validator)
+    agent = Agent(FunctionModel(call_tool_model), tools=[tool])
+    result = await agent.run("call my_tool")
+    
+    assert response_idx == 3
+    # Check that the first tool return was a retry prompt
+    retry_found = False
+    for msg in result.all_messages():
+        if hasattr(msg, 'parts'):
+            for part in msg.parts:
+                if hasattr(part, 'part_kind') and part.part_kind == 'retry-prompt':
+                    assert "Value too low" in part.content
+                    retry_found = True
+    assert retry_found

--- a/tests/test_tool_return_validation.py
+++ b/tests/test_tool_return_validation.py
@@ -1,24 +1,26 @@
 
-import pytest
 from typing import Annotated
+
+import pytest
 from pydantic import AfterValidator
-from pydantic_core import ValidationError
+
 from pydantic_ai import Agent, RunContext, Tool
-from pydantic_ai.exceptions import ToolOutputValidationError, ModelRetry
+from pydantic_ai.exceptions import ModelRetry, ToolOutputValidationError
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.models.function import FunctionModel
-from pydantic_ai.messages import ModelResponse, ToolCallPart, TextPart
+
 
 async def test_schema_validation_failure():
     def my_tool(ctx: RunContext[None], x: int) -> int:
-        return "not an int"
+        return 'not an int'
 
-    agent = Agent(FunctionModel(lambda ms, info: ModelResponse(parts=[ToolCallPart("my_tool", {"x": 1}, "1")])), tools=[Tool(my_tool, validate_return=True)])
+    agent = Agent(FunctionModel(lambda ms, info: ModelResponse(parts=[ToolCallPart('my_tool', {'x': 1}, '1')])), tools=[Tool(my_tool, validate_return=True)])
 
     with pytest.raises(ToolOutputValidationError) as exc_info:
-        await agent.run("call my_tool")
+        await agent.run('call my_tool')
     
-    assert exc_info.value.tool_name == "my_tool"
-    assert "integer" in str(exc_info.value.validation_error)
+    assert exc_info.value.tool_name == 'my_tool'
+    assert 'integer' in str(exc_info.value.validation_error)
 
 async def test_schema_validation_success():
     def my_tool(ctx: RunContext[None], x: int) -> int:
@@ -29,12 +31,12 @@ async def test_schema_validation_success():
         nonlocal called
         if not called:
             called = True
-            return ModelResponse(parts=[ToolCallPart("my_tool", {"x": 21}, "1")])
+            return ModelResponse(parts=[ToolCallPart('my_tool', {'x': 21}, '1')])
         else:
-            return ModelResponse(parts=[TextPart("Done")])
+            return ModelResponse(parts=[TextPart('Done')])
 
     agent = Agent(FunctionModel(call_tool_model), tools=[Tool(my_tool, validate_return=True)])
-    result = await agent.run("call my_tool")
+    result = await agent.run('call my_tool')
     
     found_tool_return = False
     for msg in result.all_messages():
@@ -50,25 +52,25 @@ def sanitize_output(v: str) -> str:
 
 async def test_custom_validator_sanitization():
     def my_tool(ctx: RunContext[None]) -> Annotated[str, AfterValidator(sanitize_output)]:
-        return "  hello  "
+        return '  hello  '
 
     called = False
     async def call_tool_model(messages, info):
         nonlocal called
         if not called:
             called = True
-            return ModelResponse(parts=[ToolCallPart("my_tool", {}, "1")])
+            return ModelResponse(parts=[ToolCallPart('my_tool', {}, '1')])
         else:
-            return ModelResponse(parts=[TextPart("Done")])
+            return ModelResponse(parts=[TextPart('Done')])
 
     agent = Agent(FunctionModel(call_tool_model), tools=[Tool(my_tool, validate_return=True)])
-    result = await agent.run("call my_tool")
+    result = await agent.run('call my_tool')
     
     for msg in result.all_messages():
         if hasattr(msg, 'parts'):
             for part in msg.parts:
                 if hasattr(part, 'part_kind') and part.part_kind == 'tool-return':
-                    assert part.content == "HELLO"
+                    assert part.content == 'HELLO'
 
 async def test_async_custom_validator():
     async def async_validator(ctx: RunContext[None], v: int) -> int:
@@ -82,13 +84,13 @@ async def test_async_custom_validator():
         nonlocal called
         if not called:
             called = True
-            return ModelResponse(parts=[ToolCallPart("my_tool", {"x": 41}, "1")])
+            return ModelResponse(parts=[ToolCallPart('my_tool', {'x': 41}, '1')])
         else:
-            return ModelResponse(parts=[TextPart("Done")])
+            return ModelResponse(parts=[TextPart('Done')])
 
     tool = Tool(my_tool, validate_return=True, result_validator=async_validator)
     agent = Agent(FunctionModel(call_tool_model), tools=[tool])
-    result = await agent.run("call my_tool")
+    result = await agent.run('call my_tool')
     
     for msg in result.all_messages():
         if hasattr(msg, 'parts'):
@@ -99,16 +101,16 @@ async def test_async_custom_validator():
 async def test_model_retry_from_validator():
     def retry_validator(ctx: RunContext[None], v: int) -> int:
         if v < 100:
-            raise ModelRetry("Value too low, try higher")
+            raise ModelRetry('Value too low, try higher')
         return v
 
     def my_tool(ctx: RunContext[None], x: int) -> int:
         return x
 
     responses = [
-        ModelResponse(parts=[ToolCallPart("my_tool", {"x": 50}, "1")]),
-        ModelResponse(parts=[ToolCallPart("my_tool", {"x": 150}, "2")]),
-        ModelResponse(parts=[TextPart("Done")])
+        ModelResponse(parts=[ToolCallPart('my_tool', {'x': 50}, '1')]),
+        ModelResponse(parts=[ToolCallPart('my_tool', {'x': 150}, '2')]),
+        ModelResponse(parts=[TextPart('Done')])
     ]
     response_idx = 0
     async def call_tool_model(messages, info):
@@ -119,7 +121,7 @@ async def test_model_retry_from_validator():
 
     tool = Tool(my_tool, validate_return=True, result_validator=retry_validator)
     agent = Agent(FunctionModel(call_tool_model), tools=[tool])
-    result = await agent.run("call my_tool")
+    result = await agent.run('call my_tool')
     
     assert response_idx == 3
     # Check that the first tool return was a retry prompt
@@ -128,6 +130,6 @@ async def test_model_retry_from_validator():
         if hasattr(msg, 'parts'):
             for part in msg.parts:
                 if hasattr(part, 'part_kind') and part.part_kind == 'retry-prompt':
-                    assert "Value too low" in part.content
+                    assert 'Value too low' in part.content
                     retry_found = True
     assert retry_found

--- a/tests/test_validation_capability.py
+++ b/tests/test_validation_capability.py
@@ -1,0 +1,70 @@
+
+import pytest
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities import EnforceToolReturnValidation
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.messages import ModelResponse, ToolCallPart, TextPart
+from pydantic_ai.exceptions import ToolOutputValidationError
+
+async def test_enforce_validation_capability():
+    """Verify that the capability correctly enables validation for all tools."""
+    def my_tool(ctx: RunContext[None], x: int) -> int:
+        return "not an int"
+
+    called = False
+    async def call_tool_model(messages, info):
+        nonlocal called
+        if not called:
+            called = True
+            return ModelResponse(parts=[ToolCallPart("my_tool", {"x": 1}, "1")])
+        else:
+            return ModelResponse(parts=[TextPart("Done")])
+
+    agent = Agent(
+        FunctionModel(call_tool_model), 
+        tools=[my_tool], 
+        capabilities=[EnforceToolReturnValidation()]
+    )
+
+    # Correct pytest usage: raising the error here is the EXPECTED behavior
+    with pytest.raises(ToolOutputValidationError) as exc_info:
+        await agent.run("call my_tool")
+    
+    assert exc_info.value.tool_name == "my_tool"
+    assert "integer" in str(exc_info.value.validation_error)
+
+async def test_enforce_validation_capability_selective():
+    """Verify that the capability can selectively enable validation."""
+    def tool_a(ctx: RunContext[None]) -> int:
+        return "not an int"
+    
+    def tool_b(ctx: RunContext[None]) -> int:
+        return "not an int"
+
+    called = 0
+    async def call_tool_model(messages, info):
+        nonlocal called
+        if called == 0:
+            called += 1
+            return ModelResponse(parts=[ToolCallPart("tool_a", {}, "1")])
+        elif called == 1:
+            called += 1
+            return ModelResponse(parts=[ToolCallPart("tool_b", {}, "2")])
+        else:
+            return ModelResponse(parts=[TextPart("Done")])
+
+    # Only validate tool_a
+    agent = Agent(
+        FunctionModel(call_tool_model), 
+        tools=[tool_a, tool_b], 
+        capabilities=[EnforceToolReturnValidation(tools=['tool_a'])]
+    )
+
+    # Calling tool_a should fail
+    with pytest.raises(ToolOutputValidationError):
+        await agent.run("call tool_a")
+    
+    # Reset and call tool_b (should succeed because it's NOT being validated)
+    called = 1
+    result = await agent.run("call tool_b")
+    assert "not an int" in str(result.all_messages())


### PR DESCRIPTION
## What
Introduces strict runtime validation for tool return values. Key changes include:
- Added `validate_return` and `return_type` fields to `Tool` and `ToolDefinition`.
- Implemented a lazy `_return_validator` property to maintain JSON-serializability of tool objects.
- Integrated validation enforcement in `ToolManager` with graceful `ModelRetry` handling.
- Added `ToolOutputValidationError` for detailed validation failure reporting.
- Propagated validation support through all tool decorators and toolset wrappers.
- Closes [#4262](https://github.com/pydantic/pydantic-ai/issues/4262)

## Why
As agent frameworks interact with untrusted environments (e.g., external APIs, MCP servers), tool outputs become a potential vector for malicious data. This feature creates a critical security boundary, ensuring tool outputs conform to expected schemas before entering the agent's internal reasoning context. It also supports durable execution (e.g., Temporal) by ensuring tool definitions remain serializable.

## How
- Validation is performed in `ToolManager._raw_execute` after tool execution but before returning to the model.
- Uses Pydantic's `TypeAdapter` lazily via a `cached_property` to avoid storing non-serializable C-objects in tool definitions.
- Validation failures can trigger a `ModelRetry`, allowing the model to correct its behavior or handle the error gracefully.

## Test plan
- Added comprehensive tests in `tests/test_tool_return_validation.py`.
- Verified:
  - Schema validation success/failure.
  - Custom validator sanitization (sync/async).
  - `ModelRetry` integration.
  - Automatic return type inference from function signatures.

## Notes
- This implementation follows the "Sovereign Tool" pattern, keeping validation requirements self-contained within the tool definition.
- No breaking changes to existing tool usage; validation is opt-in via `validate_return=True`.