### PR TITLE
fix(temporal): strip args_validator_func inside workflow sandbox and invoke it in activity

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import inspect
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from pydantic import ConfigDict, Discriminator, Tag, with_config
@@ -109,6 +110,18 @@ class TemporalWrapperToolset(WrapperToolset[AgentDepsT], ABC):
         # Temporalized toolsets cannot be swapped out after the fact.
         return self
 
+    async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
+        tools = await self.wrapped.get_tools(ctx)
+        if workflow.in_workflow():
+            # Strip args_validator_func from tools in workflow context so that validators
+            # performing I/O are not invoked inside the deterministic workflow sandbox.
+            # The validator is instead called inside the activity via _call_tool_in_activity.
+            tools = {
+                name: replace(tool, args_validator_func=None) if tool.args_validator_func is not None else tool
+                for name, tool in tools.items()
+            }
+        return tools
+
     async def __aenter__(self) -> Self:
         if not workflow.in_workflow():  # pragma: no cover
             await self.wrapped.__aenter__()
@@ -165,6 +178,10 @@ class TemporalWrapperToolset(WrapperToolset[AgentDepsT], ABC):
         """
         toolset = toolset or self.wrapped
         args_dict = tool.args_validator.validate_python(tool_args)
+        if tool.args_validator_func is not None:
+            result = tool.args_validator_func(ctx, **args_dict)
+            if inspect.isawaitable(result):
+                await result
         return await self._wrap_call_tool_result(toolset.call_tool(name, args_dict, ctx, tool))
 
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_toolset.py
@@ -178,11 +178,16 @@ class TemporalWrapperToolset(WrapperToolset[AgentDepsT], ABC):
         """
         toolset = toolset or self.wrapped
         args_dict = tool.args_validator.validate_python(tool_args)
-        if tool.args_validator_func is not None:
-            result = tool.args_validator_func(ctx, **args_dict)
-            if inspect.isawaitable(result):
-                await result
-        return await self._wrap_call_tool_result(toolset.call_tool(name, args_dict, ctx, tool))
+        args_validator_func = tool.args_validator_func
+
+        async def _validate_and_call() -> Any:
+            if args_validator_func is not None:
+                result = args_validator_func(ctx, **args_dict)
+                if inspect.isawaitable(result):
+                    await result
+            return await toolset.call_tool(name, args_dict, ctx, tool)
+
+        return await self._wrap_call_tool_result(_validate_and_call())
 
 
 def temporalize_toolset(

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1414,6 +1414,67 @@ def test_temporal_wrapper_visit_and_replace():
     assert result is temporal_function_toolset
 
 
+async def test_temporal_wrapper_get_tools_strips_args_validator_func_in_workflow():
+    """TemporalWrapperToolset.get_tools should strip args_validator_func when inside a workflow.
+
+    This prevents I/O-performing validators from running in Temporal's deterministic
+    workflow sandbox. The validator is instead called inside the activity.
+    """
+    from unittest.mock import patch
+
+    from pydantic_ai.durable_exec.temporal._function_toolset import TemporalFunctionToolset
+    from pydantic_ai.exceptions import ModelRetry
+
+    agent_with_validator = Agent(TestModel(), name='validator_agent')
+
+    def my_validator(ctx: RunContext[None], city: str) -> None:
+        # Simulate a validator that would perform I/O (e.g. platform.uname())
+        if city == 'invalid':
+            raise ModelRetry('Invalid city')
+
+    @agent_with_validator.tool_plain(args_validator=my_validator)
+    def get_weather_validated(city: str) -> str:
+        """Get weather for a city."""
+        return f'sunny in {city}'
+
+    temporal = TemporalAgent(agent_with_validator, activity_config=BASE_ACTIVITY_CONFIG)
+
+    toolsets = temporal._toolsets  # pyright: ignore[reportPrivateUsage]
+    temporal_function_toolsets = [ts for ts in toolsets if isinstance(ts, TemporalFunctionToolset)]
+    assert len(temporal_function_toolsets) >= 1
+    temporal_toolset = temporal_function_toolsets[-1]  # last one has the registered tool
+
+    # Find a dummy run context
+    from pydantic_ai._run_context import RunContext as RC
+
+    ctx = RC(
+        deps=None,
+        model=TestModel(),
+        usage=RunUsage(),
+        prompt='',
+        messages=[],
+        run_id='test',
+        retries={},
+        run_step=0,
+        max_retries=1,
+        tracer=None,
+        trace_include_content=False,
+        instrumentation_version=None,
+        toolset=None,
+    )
+
+    # Outside workflow: args_validator_func should be preserved
+    tools_outside = await temporal_toolset.get_tools(ctx)
+    assert 'get_weather_validated' in tools_outside
+    assert tools_outside['get_weather_validated'].args_validator_func is my_validator
+
+    # Inside workflow: args_validator_func should be stripped
+    with patch('pydantic_ai.durable_exec.temporal._toolset.workflow.in_workflow', return_value=True):
+        tools_inside = await temporal_toolset.get_tools(ctx)
+    assert 'get_weather_validated' in tools_inside
+    assert tools_inside['get_weather_validated'].args_validator_func is None
+
+
 async def test_temporal_agent_run(allow_model_requests: None):
     result = await simple_temporal_agent.run('What is the capital of Mexico?')
     assert result.output == snapshot('The capital of Mexico is Mexico City.')

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1444,24 +1444,7 @@ async def test_temporal_wrapper_get_tools_strips_args_validator_func_in_workflow
     assert len(temporal_function_toolsets) >= 1
     temporal_toolset = temporal_function_toolsets[-1]  # last one has the registered tool
 
-    # Find a dummy run context
-    from pydantic_ai._run_context import RunContext as RC
-
-    ctx = RC(
-        deps=None,
-        model=TestModel(),
-        usage=RunUsage(),
-        prompt='',
-        messages=[],
-        run_id='test',
-        retries={},
-        run_step=0,
-        max_retries=1,
-        tracer=None,
-        trace_include_content=False,
-        instrumentation_version=None,
-        toolset=None,
-    )
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())
 
     # Outside workflow: args_validator_func should be preserved
     tools_outside = await temporal_toolset.get_tools(ctx)


### PR DESCRIPTION
When a tool is registered with an `args_validator` function, that validator could perform I/O (network calls, file access, etc.). Temporal's workflow sandbox enforces strict determinism and will raise an error or produce non-deterministic replays if such I/O happens inside a workflow coroutine.

`TemporalWrapperToolset` was previously passing `args_validator_func` through unchanged to tools returned by `get_tools`, meaning the validator would be called inside the deterministic workflow sandbox rather than inside the activity where I/O is safe.

The fix overrides `get_tools` in `TemporalWrapperToolset` so that, when the code is executing inside a Temporal workflow, it replaces each tool's `args_validator_func` with `None` before returning the tool dict. This prevents the validator from running in the sandbox.

To ensure the validator still runs, `_call_tool_in_activity` (which executes inside the activity) now explicitly calls `tool.args_validator_func` after `args_validator.validate_python`, awaiting the result if it is a coroutine.

A new test `test_temporal_wrapper_get_tools_strips_args_validator_func_in_workflow` in `tests/test_temporal.py` verifies that the validator is preserved outside a workflow context and stripped inside one.

Fixes #4456
