### PR TITLE
Fix OpenAI strict detection for empty array items

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -321,6 +321,9 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                 self.is_strict_compatible = False
 
         schema_type = schema.get('type')
+        if schema_type == 'array' and schema.get('items') == {} and self.strict is None:
+            self.is_strict_compatible = False
+
         if 'oneOf' in schema:
             # OpenAI does not support oneOf in strict mode
             if self.strict is True:

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -2070,6 +2070,10 @@ def tool_with_lists(x: list[int], y: list[MyDefaultDc]) -> str:
     return f'{x} {y}'  # pragma: no cover
 
 
+def tool_with_any_list(x: list[Any]) -> str:
+    return f'{x}'  # pragma: no cover
+
+
 def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
     return f'{x} {y}'  # pragma: no cover
 
@@ -2497,6 +2501,19 @@ def tool_with_tuples(x: tuple[int], y: tuple[str] = ('abc',)) -> str:
                 }
             ),
             snapshot(True),
+        ),
+        (
+            tool_with_any_list,
+            None,
+            snapshot(
+                {
+                    'additionalProperties': False,
+                    'properties': {'x': {'items': {}, 'type': 'array'}},
+                    'required': ['x'],
+                    'type': 'object',
+                }
+            ),
+            snapshot(None),
         ),
         (
             tool_with_tuples,

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -176,6 +176,45 @@ async def test_parallel_tool_calls_not_sent_without_tools(allow_model_requests: 
     assert 'parallel_tool_calls' not in get_mock_responses_kwargs(mock_client)[0]
 
 
+async def test_any_list_tool_disables_strict(allow_model_requests: None) -> None:
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='output-1',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('gpt-5.1', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    @agent.tool_plain
+    def tool_with_any_list(items: list[Any]) -> str:
+        return f'{items}'  # pragma: no cover
+
+    await agent.run('Hello')
+    assert get_mock_responses_kwargs(mock_client)[0]['tools'] == snapshot(
+        [
+            {
+                'name': 'tool_with_any_list',
+                'parameters': {
+                    'additionalProperties': False,
+                    'properties': {'items': {'items': {}, 'type': 'array'}},
+                    'required': ['items'],
+                    'type': 'object',
+                },
+                'type': 'function',
+                'description': None,
+                'strict': False,
+            }
+        ]
+    )
+
+
 @pytest.mark.parametrize(
     ('aspect_ratio', 'explicit_size', 'expected_size'),
     [


### PR DESCRIPTION
- Closes #4425

### Summary

This updates the OpenAI JSON schema transformer to treat array schemas with `items: {}` as not compatible with inferred strict mode.

That schema is produced for untyped array items, such as `list[Any]` or bare `list`, and OpenAI rejects it in strict mode because the array item schema has no `type`.

With this change, inferred strict mode is disabled for those schemas instead of sending an invalid strict tool schema.

### Tests

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/models/test_openai.py -k strict_mode_cannot_infer_strict`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/models/test_openai_responses.py -k any_list_tool_disables_strict`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check pydantic_ai_slim/pydantic_ai/profiles/openai.py tests/models/test_openai.py tests/models/test_openai_responses.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check pydantic_ai_slim/pydantic_ai/profiles/openai.py tests/models/test_openai.py tests/models/test_openai_responses.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pyright pydantic_ai_slim/pydantic_ai/profiles/openai.py tests/models/test_openai.py tests/models/test_openai_responses.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
