### PR TITLE
fix(mcp): inherit FastMCP retries in durable wrappers

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_fastmcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_fastmcp_toolset.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pydantic_ai import ToolsetTool
-from pydantic_ai.tools import AgentDepsT, ToolDefinition
+from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
 from ._mcp import DBOSMCPToolset
@@ -24,6 +24,8 @@ class DBOSFastMCPToolset(DBOSMCPToolset[AgentDepsT]):
             step_config=step_config,
         )
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(
+        self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT] | None = None
+    ) -> ToolsetTool[AgentDepsT]:
         assert isinstance(self.wrapped, FastMCPToolset)
-        return self.wrapped.tool_for_tool_def(tool_def, max_retries=max_retries)
+        return self.wrapped.tool_for_tool_def(tool_def, ctx=ctx)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_fastmcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_fastmcp_toolset.py
@@ -24,6 +24,6 @@ class DBOSFastMCPToolset(DBOSMCPToolset[AgentDepsT]):
             step_config=step_config,
         )
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
         assert isinstance(self.wrapped, FastMCPToolset)
-        return self.wrapped.tool_for_tool_def(tool_def)
+        return self.wrapped.tool_for_tool_def(tool_def, max_retries=max_retries)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp.py
@@ -78,7 +78,9 @@ class DBOSMCPToolset(WrapperToolset[AgentDepsT], ABC):
         self._dbos_wrapped_call_tool_step = wrapped_call_tool_step
 
     @abstractmethod
-    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(
+        self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT] | None = None
+    ) -> ToolsetTool[AgentDepsT]:
         raise NotImplementedError
 
     @property
@@ -101,9 +103,7 @@ class DBOSMCPToolset(WrapperToolset[AgentDepsT], ABC):
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         tool_defs = await self._dbos_wrapped_get_tools_step(ctx)
-        return {
-            name: self.tool_for_tool_def(tool_def, max_retries=ctx.max_retries) for name, tool_def in tool_defs.items()
-        }
+        return {name: self.tool_for_tool_def(tool_def, ctx=ctx) for name, tool_def in tool_defs.items()}
 
     async def get_instructions(
         self, ctx: RunContext[AgentDepsT]

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp.py
@@ -78,7 +78,7 @@ class DBOSMCPToolset(WrapperToolset[AgentDepsT], ABC):
         self._dbos_wrapped_call_tool_step = wrapped_call_tool_step
 
     @abstractmethod
-    def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
         raise NotImplementedError
 
     @property
@@ -101,7 +101,9 @@ class DBOSMCPToolset(WrapperToolset[AgentDepsT], ABC):
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         tool_defs = await self._dbos_wrapped_get_tools_step(ctx)
-        return {name: self.tool_for_tool_def(tool_def) for name, tool_def in tool_defs.items()}
+        return {
+            name: self.tool_for_tool_def(tool_def, max_retries=ctx.max_retries) for name, tool_def in tool_defs.items()
+        }
 
     async def get_instructions(
         self, ctx: RunContext[AgentDepsT]

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp.py
@@ -121,7 +121,7 @@ class DBOSMCPToolset(WrapperToolset[AgentDepsT], ABC):
             _mcp_types += (MCPServer, FastMCPToolset)
         except ImportError:
             pass
-        if _mcp_types and isinstance(self.wrapped, _mcp_types) and self.wrapped.include_instructions:  # type: ignore[union-attr]
+        if _mcp_types and isinstance(self.wrapped, _mcp_types) and self.wrapped.include_instructions:
             return await self._dbos_wrapped_get_instructions_step(ctx)
         return None
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp.py
@@ -116,14 +116,9 @@ class DBOSMCPToolset(WrapperToolset[AgentDepsT], ABC):
         _mcp_types: tuple[type, ...] = ()
         try:
             from pydantic_ai.mcp import MCPServer
-
-            _mcp_types += (MCPServer,)
-        except ImportError:
-            pass
-        try:
             from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-            _mcp_types += (FastMCPToolset,)
+            _mcp_types += (MCPServer, FastMCPToolset)
         except ImportError:
             pass
         if _mcp_types and isinstance(self.wrapped, _mcp_types) and self.wrapped.include_instructions:  # type: ignore[union-attr]

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_server.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_server.py
@@ -37,12 +37,14 @@ class DBOSMCPServer(DBOSMCPToolset[AgentDepsT]):
         assert isinstance(self.wrapped, MCPServer)
         return self.wrapped
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(
+        self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT] | None = None
+    ) -> ToolsetTool[AgentDepsT]:
         return self._server.tool_for_tool_def(tool_def)
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         if self._server.cache_tools and self._cached_tool_defs is not None:
-            return {name: self.tool_for_tool_def(td) for name, td in self._cached_tool_defs.items()}
+            return {name: self.tool_for_tool_def(td, ctx=ctx) for name, td in self._cached_tool_defs.items()}
 
         result = await super().get_tools(ctx)
         if self._server.cache_tools:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_server.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_server.py
@@ -37,7 +37,7 @@ class DBOSMCPServer(DBOSMCPToolset[AgentDepsT]):
         assert isinstance(self.wrapped, MCPServer)
         return self.wrapped
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
         return self._server.tool_for_tool_def(tool_def)
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_fastmcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_fastmcp_toolset.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from temporalio.workflow import ActivityConfig
 
 from pydantic_ai import ToolsetTool
-from pydantic_ai.tools import AgentDepsT, ToolDefinition
+from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
 if TYPE_CHECKING:
@@ -37,6 +37,8 @@ class TemporalFastMCPToolset(TemporalMCPToolset[AgentDepsT]):
             agent=agent,
         )
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(
+        self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT] | None = None
+    ) -> ToolsetTool[AgentDepsT]:
         assert isinstance(self.wrapped, FastMCPToolset)
-        return self.wrapped.tool_for_tool_def(tool_def, max_retries=max_retries)
+        return self.wrapped.tool_for_tool_def(tool_def, ctx=ctx)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_fastmcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_fastmcp_toolset.py
@@ -37,6 +37,6 @@ class TemporalFastMCPToolset(TemporalMCPToolset[AgentDepsT]):
             agent=agent,
         )
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
         assert isinstance(self.wrapped, FastMCPToolset)
-        return self.wrapped.tool_for_tool_def(tool_def)
+        return self.wrapped.tool_for_tool_def(tool_def, max_retries=max_retries)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp.py
@@ -130,7 +130,7 @@ class TemporalMCPToolset(TemporalWrapperToolset[AgentDepsT], ABC):
             _mcp_types += (MCPServer, FastMCPToolset)
         except ImportError:
             pass
-        if _mcp_types and isinstance(self.wrapped, _mcp_types) and self.wrapped.include_instructions:  # type: ignore[union-attr]
+        if _mcp_types and isinstance(self.wrapped, _mcp_types) and self.wrapped.include_instructions:
             serialized_run_context = self.run_context_type.serialize_run_context(ctx)
             activity_config: ActivityConfig = {'summary': f'get instructions: {self.id}', **self.activity_config}
             return await workflow.execute_activity(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp.py
@@ -94,7 +94,7 @@ class TemporalMCPToolset(TemporalWrapperToolset[AgentDepsT], ABC):
                     params.name,
                     params.tool_args,
                     run_context,
-                    self.tool_for_tool_def(params.tool_def),
+                    self.tool_for_tool_def(params.tool_def, max_retries=run_context.max_retries),
                 )
             )
 
@@ -106,7 +106,7 @@ class TemporalMCPToolset(TemporalWrapperToolset[AgentDepsT], ABC):
         )
 
     @abstractmethod
-    def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
         raise NotImplementedError
 
     @property
@@ -160,7 +160,9 @@ class TemporalMCPToolset(TemporalWrapperToolset[AgentDepsT], ABC):
             ],
             **activity_config,
         )
-        return {name: self.tool_for_tool_def(tool_def) for name, tool_def in tool_defs.items()}
+        return {
+            name: self.tool_for_tool_def(tool_def, max_retries=ctx.max_retries) for name, tool_def in tool_defs.items()
+        }
 
     async def call_tool(
         self,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp.py
@@ -94,7 +94,7 @@ class TemporalMCPToolset(TemporalWrapperToolset[AgentDepsT], ABC):
                     params.name,
                     params.tool_args,
                     run_context,
-                    self.tool_for_tool_def(params.tool_def, max_retries=run_context.max_retries),
+                    self.tool_for_tool_def(params.tool_def, ctx=run_context),
                 )
             )
 
@@ -106,7 +106,9 @@ class TemporalMCPToolset(TemporalWrapperToolset[AgentDepsT], ABC):
         )
 
     @abstractmethod
-    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(
+        self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT] | None = None
+    ) -> ToolsetTool[AgentDepsT]:
         raise NotImplementedError
 
     @property
@@ -160,9 +162,7 @@ class TemporalMCPToolset(TemporalWrapperToolset[AgentDepsT], ABC):
             ],
             **activity_config,
         )
-        return {
-            name: self.tool_for_tool_def(tool_def, max_retries=ctx.max_retries) for name, tool_def in tool_defs.items()
-        }
+        return {name: self.tool_for_tool_def(tool_def, ctx=ctx) for name, tool_def in tool_defs.items()}
 
     async def call_tool(
         self,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp.py
@@ -125,14 +125,9 @@ class TemporalMCPToolset(TemporalWrapperToolset[AgentDepsT], ABC):
         _mcp_types: tuple[type, ...] = ()
         try:
             from pydantic_ai.mcp import MCPServer
-
-            _mcp_types += (MCPServer,)
-        except ImportError:
-            pass
-        try:
             from pydantic_ai.toolsets.fastmcp import FastMCPToolset
 
-            _mcp_types += (FastMCPToolset,)
+            _mcp_types += (MCPServer, FastMCPToolset)
         except ImportError:
             pass
         if _mcp_types and isinstance(self.wrapped, _mcp_types) and self.wrapped.include_instructions:  # type: ignore[union-attr]

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_server.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_server.py
@@ -52,12 +52,14 @@ class TemporalMCPServer(TemporalMCPToolset[AgentDepsT]):
         assert isinstance(self.wrapped, MCPServer)
         return self.wrapped
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(
+        self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT] | None = None
+    ) -> ToolsetTool[AgentDepsT]:
         return self._server.tool_for_tool_def(tool_def)
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         if self._server.cache_tools and self._cached_tool_defs is not None:
-            return {name: self.tool_for_tool_def(td) for name, td in self._cached_tool_defs.items()}
+            return {name: self.tool_for_tool_def(td, ctx=ctx) for name, td in self._cached_tool_defs.items()}
 
         result = await super().get_tools(ctx)
         if self._server.cache_tools:  # pragma: no branch

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_server.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_server.py
@@ -52,7 +52,7 @@ class TemporalMCPServer(TemporalMCPToolset[AgentDepsT]):
         assert isinstance(self.wrapped, MCPServer)
         return self.wrapped
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
         return self._server.tool_for_tool_def(tool_def)
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -272,11 +272,16 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         else:
             return await self.direct_call_tool(name, tool_args)
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
+        if self.max_retries is not None:
+            max_retries = self.max_retries
+        elif max_retries is None:
+            max_retries = 1
+
         return ToolsetTool[AgentDepsT](
             tool_def=tool_def,
             toolset=self,
-            max_retries=self.max_retries if self.max_retries is not None else 1,
+            max_retries=max_retries,
             args_validator=TOOL_SCHEMA_VALIDATOR,
         )
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -272,10 +272,14 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         else:
             return await self.direct_call_tool(name, tool_args)
 
-    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[AgentDepsT]:
+    def tool_for_tool_def(
+        self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT] | None = None
+    ) -> ToolsetTool[AgentDepsT]:
         if self.max_retries is not None:
             max_retries = self.max_retries
-        elif max_retries is None:
+        elif ctx is not None:
+            max_retries = ctx.max_retries
+        else:
             max_retries = 1
 
         return ToolsetTool[AgentDepsT](

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1576,9 +1576,7 @@ async def test_dbos_mcp_toolset_instructions_propagate(dbos: DBOS):
 
 
 class _TestDBOSMCPToolset(DBOSMCPToolset[int]):
-    def tool_for_tool_def(
-        self, tool_def: ToolDefinition, *, ctx: RunContext[int] | None = None
-    ) -> ToolsetTool[int]:
+    def tool_for_tool_def(self, tool_def: ToolDefinition, *, ctx: RunContext[int] | None = None) -> ToolsetTool[int]:
         raise AssertionError('tool_for_tool_def should not be invoked in this test')  # pragma: no cover
 
 
@@ -1649,7 +1647,9 @@ def test_dbos_fastmcp_tool_for_tool_def_uses_run_context():
 
     tool_def = ToolDefinition(name='x', description='', parameters_json_schema={})
     run_context = RunContext(deps=0, model=TestModel(), usage=RunUsage(), max_retries=4)
-    wrapped = FastMCPToolset('https://mcp.deepwiki.com/mcp', id='deepwiki')
-    toolset = DBOSFastMCPToolset(wrapped, step_name_prefix='coverage_test_fastmcp', step_config={})
+    wrapped: FastMCPToolset[int] = FastMCPToolset('https://mcp.deepwiki.com/mcp', id='deepwiki')
+    toolset: DBOSFastMCPToolset[int] = DBOSFastMCPToolset(
+        wrapped, step_name_prefix='coverage_test_fastmcp', step_config={}
+    )
 
     assert toolset.tool_for_tool_def(tool_def, ctx=run_context).max_retries == 4

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1576,7 +1576,9 @@ async def test_dbos_mcp_toolset_instructions_propagate(dbos: DBOS):
 
 
 class _TestDBOSMCPToolset(DBOSMCPToolset[int]):
-    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[int]:
+    def tool_for_tool_def(
+        self, tool_def: ToolDefinition, *, ctx: RunContext[int] | None = None
+    ) -> ToolsetTool[int]:
         raise AssertionError('tool_for_tool_def should not be invoked in this test')  # pragma: no cover
 
 
@@ -1639,3 +1641,15 @@ def test_dbos_mcp_wrapper_visit_and_replace():
     # visit_and_replace should return self for DBOS wrappers
     result = dbos_mcp_toolset.visit_and_replace(lambda t: FunctionToolset(id='replaced'))
     assert result is dbos_mcp_toolset
+
+
+def test_dbos_fastmcp_tool_for_tool_def_uses_run_context():
+    """DBOS FastMCP wrappers should preserve run context when recreating tools."""
+    from pydantic_ai.durable_exec.dbos._fastmcp_toolset import DBOSFastMCPToolset
+
+    tool_def = ToolDefinition(name='x', description='', parameters_json_schema={})
+    run_context = RunContext(deps=0, model=TestModel(), usage=RunUsage(), max_retries=4)
+    wrapped = FastMCPToolset('https://mcp.deepwiki.com/mcp', id='deepwiki')
+    toolset = DBOSFastMCPToolset(wrapped, step_name_prefix='coverage_test_fastmcp', step_config={})
+
+    assert toolset.tool_for_tool_def(tool_def, ctx=run_context).max_retries == 4

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1576,7 +1576,7 @@ async def test_dbos_mcp_toolset_instructions_propagate(dbos: DBOS):
 
 
 class _TestDBOSMCPToolset(DBOSMCPToolset[int]):
-    def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[int]:
+    def tool_for_tool_def(self, tool_def: ToolDefinition, *, max_retries: int | None = None) -> ToolsetTool[int]:
         raise AssertionError('tool_for_tool_def should not be invoked in this test')  # pragma: no cover
 
 

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -322,16 +322,18 @@ class TestFastMCPToolsetToolDiscovery:
                 }
             )
 
-    async def test_fastmcp_tool_for_tool_def_uses_effective_max_retries(self, fastmcp_client: Client[FastMCPTransport]):
+    async def test_fastmcp_tool_for_tool_def_uses_effective_max_retries(
+        self, fastmcp_client: Client[FastMCPTransport], run_context: RunContext[None]
+    ):
         tool_def = ToolDefinition(name='x', description='', parameters_json_schema={})
 
         toolset_default = FastMCPToolset(fastmcp_client)
         assert toolset_default.tool_for_tool_def(tool_def).max_retries == 1
-        assert toolset_default.tool_for_tool_def(tool_def, max_retries=3).max_retries == 3
+        assert toolset_default.tool_for_tool_def(tool_def, ctx=run_context).max_retries == run_context.max_retries
 
         toolset_explicit = FastMCPToolset(fastmcp_client, max_retries=5)
         assert toolset_explicit.tool_for_tool_def(tool_def).max_retries == 5
-        assert toolset_explicit.tool_for_tool_def(tool_def, max_retries=3).max_retries == 5
+        assert toolset_explicit.tool_for_tool_def(tool_def, ctx=run_context).max_retries == 5
 
     async def test_get_tools_with_empty_server(self, run_context: RunContext[None]):
         """Test getting tools from an empty FastMCP server."""

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -322,16 +322,16 @@ class TestFastMCPToolsetToolDiscovery:
                 }
             )
 
-    async def test_fastmcp_tool_for_tool_def_uses_toolset_max_retries(self, fastmcp_client: Client[FastMCPTransport]):
-        """`tool_for_tool_def` resolves `self.max_retries`: explicit int when set, fallback to `1`
-        when unset (durable-execution path has no `ctx` to inherit from)."""
+    async def test_fastmcp_tool_for_tool_def_uses_effective_max_retries(self, fastmcp_client: Client[FastMCPTransport]):
         tool_def = ToolDefinition(name='x', description='', parameters_json_schema={})
 
         toolset_default = FastMCPToolset(fastmcp_client)
         assert toolset_default.tool_for_tool_def(tool_def).max_retries == 1
+        assert toolset_default.tool_for_tool_def(tool_def, max_retries=3).max_retries == 3
 
         toolset_explicit = FastMCPToolset(fastmcp_client, max_retries=5)
         assert toolset_explicit.tool_for_tool_def(tool_def).max_retries == 5
+        assert toolset_explicit.tool_for_tool_def(tool_def, max_retries=3).max_retries == 5
 
     async def test_get_tools_with_empty_server(self, run_context: RunContext[None]):
         """Test getting tools from an empty FastMCP server."""


### PR DESCRIPTION
- Closes #5180

### Summary

Ensure FastMCP tools reconstructed from serialized tool definitions can inherit the effective agent retry count in durable execution wrappers. Explicit FastMCPToolset(max_retries=...) values still take precedence, while direct tool_for_tool_def(...) calls keep the existing fallback of 1 retry.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).