### PR TITLE
fix(evals): use non-daemon thread for background evaluators

### DIFF
--- a/pydantic_evals/pydantic_evals/_online.py
+++ b/pydantic_evals/pydantic_evals/_online.py
@@ -176,7 +176,7 @@ def dispatch_in_background_thread(coro: Coroutine[Any, Any, None]) -> None:
             with _background_lock:
                 _background_threads.discard(thread)
 
-    thread = threading.Thread(target=_thread_target, daemon=True)
+    thread = threading.Thread(target=_thread_target, daemon=False)
     with _background_lock:
         _background_threads.add(thread)
     try:


### PR DESCRIPTION
Daemon threads are killed abruptly when the main program exits, which can cause evaluation results to be lost if the program finishes before the background thread completes. Using a non-daemon thread ensures the evaluation work completes properly.

https://claude.ai/code/session_01GnKTzs55m2DtdnaCVnXvRs

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #<issue>

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
