### PR TITLE
fix: raise ContentFilterError when partial text returned with content_filter finish_reason

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -988,6 +988,26 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                     isinstance(p, _messages.ThinkingPart) for p in self.model_response.parts
                 )
 
+                # Raise ContentFilterError for any response flagged by the content filter,
+                # regardless of whether the model returned partial text alongside it.
+                # Some providers (e.g. Azure OpenAI) return text parts with finish_reason='content_filter'
+                # when the response is cut mid-generation, so the previous is_empty gate caused the
+                # error to be silently swallowed and the partial text treated as a valid response.
+                if self.model_response.finish_reason == 'content_filter':
+                    details = self.model_response.provider_details or {}
+                    body = _messages.ModelMessagesTypeAdapter.dump_json([self.model_response]).decode()
+
+                    if reason := details.get('finish_reason'):
+                        message = f"Content filter triggered. Finish reason: '{reason}'"
+                    elif reason := details.get('block_reason'):
+                        message = f"Content filter triggered. Block reason: '{reason}'"
+                    elif refusal := details.get('refusal'):
+                        message = f'Content filter triggered. Refusal: {refusal!r}'
+                    else:
+                        message = 'Content filter triggered.'
+
+                    raise exceptions.ContentFilterError(message, body=body)
+
                 if is_empty or is_thinking_only:
                     # No actionable output was returned by the model.
 
@@ -996,22 +1016,6 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                         raise exceptions.UnexpectedModelBehavior(
                             f'Model token limit ({ctx.state.last_max_tokens or "provider default"}) exceeded before any response was generated. Increase the `max_tokens` model setting, or simplify the prompt to result in a shorter response that will fit within the limit.'
                         )
-
-                    # Check for content filter on empty response
-                    if is_empty and self.model_response.finish_reason == 'content_filter':
-                        details = self.model_response.provider_details or {}
-                        body = _messages.ModelMessagesTypeAdapter.dump_json([self.model_response]).decode()
-
-                        if reason := details.get('finish_reason'):
-                            message = f"Content filter triggered. Finish reason: '{reason}'"
-                        elif reason := details.get('block_reason'):
-                            message = f"Content filter triggered. Block reason: '{reason}'"
-                        elif refusal := details.get('refusal'):
-                            message = f'Content filter triggered. Refusal: {refusal!r}'
-                        else:  # pragma: no cover
-                            message = 'Content filter triggered.'
-
-                        raise exceptions.ContentFilterError(message, body=body)
 
                     # If the output type allows None, an empty response is a valid result.
                     if is_empty and output_schema.allows_none:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9276,8 +9276,9 @@ async def test_central_content_filter_handling():
 
 async def test_central_content_filter_with_partial_content():
     """
-    Test that the agent graph returns partial content (does not raise exception)
-    even if finish_reason='content_filter', provided parts are not empty.
+    Test that ContentFilterError is raised even when the model returns partial text
+    alongside finish_reason='content_filter'. Providers like Azure OpenAI can return
+    text parts AND trigger the content filter in the same response.
     """
 
     async def filtered_response(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -9288,9 +9289,9 @@ async def test_central_content_filter_with_partial_content():
     model = FunctionModel(function=filtered_response, model_name='test-model')
     agent = Agent(model)
 
-    # Should NOT raise ContentFilterError
-    result = await agent.run('Trigger filter')
-    assert result.output == 'Partially generated content...'
+    # Should raise ContentFilterError regardless of whether parts are present
+    with pytest.raises(ContentFilterError, match='Content filter triggered'):
+        await agent.run('Trigger filter')
 
 
 async def test_agent_allows_none_output_empty_response():


### PR DESCRIPTION
## Summary

Fixes #5221

The `ContentFilterError` was only raised when the model response was completely empty (`is_empty`) and had `finish_reason == 'content_filter'`. But some providers (notably Azure OpenAI and standard OpenAI) return partial text content alongside `finish_reason == 'content_filter'` when the response is cut mid-generation by the safety filter.

In `_run_stream` inside `HandleResponseNode`, the check looked like this:

```python
if is_empty or is_thinking_only:
    ...
    if is_empty and self.model_response.finish_reason == 'content_filter':
        raise exceptions.ContentFilterError(...)
```

When a non-empty response arrives with `finish_reason == 'content_filter'`, the outer `if is_empty or is_thinking_only` block is skipped entirely. The code then falls through to process the parts as a normal response, silently treating potentially harmful or incomplete content as a valid model output.

## Fix

Moved the `ContentFilterError` check before the `is_empty or is_thinking_only` block so it fires for any response where `finish_reason == 'content_filter'`, regardless of whether parts are present:

```python
# Raise ContentFilterError for any response flagged by the content filter,
# regardless of whether the model returned partial text alongside it.
if self.model_response.finish_reason == 'content_filter':
    ...
    raise exceptions.ContentFilterError(message, body=body)

if is_empty or is_thinking_only:
    # Don't retry if the token limit was exceeded...
    if self.model_response.finish_reason == 'length':
        ...
```

Also removed the `# pragma: no cover` on the fallback `else` clause since that path is now reachable through the non-empty case.

## How to reproduce

With Azure OpenAI or OpenAI, send a prompt that triggers the content filter on a long response. The model returns some text parts plus `finish_reason == 'content_filter'` (via `response.status == 'incomplete'` + `incomplete_details.reason == 'content_filter'`). Before this fix, no error is raised and the partial text is returned as a normal response. After this fix, `ContentFilterError` is correctly raised.