### PR TITLE
fix: close response body on redirect error paths to prevent resource leak

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -386,11 +386,13 @@ async def safe_download(
             if response.is_redirect:
                 redirects_followed += 1
                 if redirects_followed > max_redirects:
+                    response.close()
                     raise ValueError(f'Too many redirects ({redirects_followed}). Maximum allowed: {max_redirects}')
 
                 # Get redirect location
                 location = response.headers.get('location')
                 if not location:
+                    response.close()
                     raise ValueError('Redirect response missing Location header')
 
                 current_url = resolve_redirect_url(current_url, location)

--- a/pydantic_ai_slim/pydantic_ai/format_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/format_prompt.py
@@ -158,7 +158,7 @@ class _ToXml:
         element = ElementTree.Element(tag)
         if path in self._fields_info:
             field_repr, field_info = self._fields_info[path]
-            if self.include_field_info and self.include_field_info != 'once' or field_repr not in self._included_fields:
+            if (self.include_field_info and self.include_field_info != 'once') or (self.include_field_info == 'once' and field_repr not in self._included_fields):
                 field_attributes = self._extract_attributes(field_info)
                 for k, v in field_attributes.items():
                     element.set(k, v)

--- a/pydantic_ai_slim/pydantic_ai/run.py
+++ b/pydantic_ai_slim/pydantic_ai/run.py
@@ -251,7 +251,7 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
         try:
             task = await self._graph_run.next(task)
         except StopAsyncIteration:
-            pass
+            return self._task_to_node(End(None))
         return self._task_to_node(task)
 
     async def _wrap_and_advance(


### PR DESCRIPTION
## Summary

Three bug fixes for pydantic-ai:

### 1. Response body leak on redirect error (`_ssrf.py`)
When `_request_url` exceeds max redirects or is missing Location header, the response body was not consumed before raising `ValueError`, leaving the connection unclosed until GC.

**Fix:** Call `response.close()` before raising in both error paths.

### 2. Operator precedence bug in format_prompt (`format_prompt.py:161`)
The condition `include_field_info and include_field_info != 'once' or field_repr not in _included_fields` parsed as `(A and B) or C`, causing field attributes to be always included for new fields regardless of `include_field_info` setting.

**Fix:** Explicit parentheses: `(A and B) or (A == 'once' and C)`.

### 3. Stale task value after StopAsyncIteration (`run.py:253-255`)
When `_advance_graph` catches `StopAsyncIteration`, it was returning `self._task_to_node(task)` where `task` still held the pre-await value `[self._node_to_task(node)]`. On normal graph termination, this stale task could cause "Unexpected node" errors.

**Fix:** Return `self._task_to_node(End(None))` instead.

## Test plan

- [x] Code review