### PR TITLE
docs(toolsets): fix duplicate-word typo "is is" in WrapperToolset section

### DIFF
--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -388,7 +388,7 @@ _(This example is complete, it can be run "as is")_
 
 [`WrapperToolset`][pydantic_ai.toolsets.WrapperToolset] wraps another toolset and delegates all responsibility to it.
 
-It is is a no-op by default, but you can subclass `WrapperToolset` to change the wrapped toolset's tool execution behavior by overriding the [`call_tool()`][pydantic_ai.toolsets.AbstractToolset.call_tool] method.
+It is a no-op by default, but you can subclass `WrapperToolset` to change the wrapped toolset's tool execution behavior by overriding the [`call_tool()`][pydantic_ai.toolsets.AbstractToolset.call_tool] method.
 
 ```python {title="logging_toolset.py" requires="function_toolset.py,combined_toolset.py,renamed_toolset.py,prepared_toolset.py"}
 import asyncio


### PR DESCRIPTION
Tiny one-character fix. The `WrapperToolset` paragraph in `docs/toolsets.md` has a stray duplicated `is`:

> It **is is** a no-op by default, but you can subclass `WrapperToolset`...

Reads more cleanly as just "It is a no-op by default".

No code change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>