### PR TITLE
Defer `anyio.Lock` creation via `cached_property` to bind to running loop

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -16,39 +16,25 @@ from dataclasses import dataclass, fields, is_dataclass
 from datetime import datetime, timezone
 from functools import partial
 from types import GenericAlias
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    TypeAlias,
-    TypeGuard,
-    TypeVar,
-    get_args,
-    get_origin,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeGuard, TypeVar, get_args, get_origin, overload
 
 import anyio
 from anyio.to_thread import run_sync
-
-if sys.version_info < (3, 11):
-    from exceptiongroup import BaseExceptionGroup as BaseExceptionGroup  # pragma: lax no cover
-else:
-    BaseExceptionGroup = BaseExceptionGroup  # pragma: lax no cover
 from pydantic import BaseModel, TypeAdapter
 from pydantic._internal import _decorators, _typing_extra
 from pydantic.json_schema import JsonSchemaValue
-from typing_extensions import (
-    ParamSpec,
-    TypeIs,
-    is_typeddict,
-)
+from typing_extensions import ParamSpec, TypeIs, is_typeddict
 from typing_inspection import typing_objects
 from typing_inspection.introspection import is_union_origin
 
 from pydantic_graph._utils import AbstractSpan
 
 from . import exceptions
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup as BaseExceptionGroup  # pragma: lax no cover
+else:
+    BaseExceptionGroup = BaseExceptionGroup  # pragma: lax no cover
 
 AbstractSpan = AbstractSpan
 

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -3,10 +3,10 @@ from __future__ import annotations as _annotations
 import asyncio
 import contextvars
 import dataclasses
+import functools
 import inspect
 import json
 import warnings
-from asyncio import Lock
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequence
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager, contextmanager
 from contextvars import ContextVar
@@ -14,6 +14,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast, overload
 
+import anyio
 from opentelemetry.baggage import set_baggage as _otel_set_baggage
 from opentelemetry.context import attach as _otel_attach, detach as _otel_detach
 from opentelemetry.trace import NoOpTracer, use_span
@@ -216,9 +217,15 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
     _concurrency_limiter: _concurrency.AbstractConcurrencyLimiter | None = dataclasses.field(repr=False)
 
-    _enter_lock: Lock = dataclasses.field(repr=False)
     _entered_count: int = dataclasses.field(repr=False)
     _exit_stack: AsyncExitStack | None = dataclasses.field(repr=False)
+
+    @functools.cached_property
+    def _enter_lock(self) -> anyio.Lock:
+        # We use a cached_property for this because `anyio.Lock` binds to the event loop on which
+        # it's first used; deferring creation until first access ensures it binds to the correct
+        # running loop and avoids issues with Temporal's workflow sandbox.
+        return anyio.Lock()
 
     @overload
     def __init__(
@@ -506,7 +513,6 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         self._override_root_capability: ContextVar[_utils.Option[CombinedCapability[AgentDepsT]]] = ContextVar(
             '_override_root_capability', default=None
         )
-        self._enter_lock = Lock()
         self._entered_count = 0
         self._exit_stack = None
 

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import base64
+import functools
 import os
 import re
 import warnings
 from abc import ABC, abstractmethod
-from asyncio import Lock
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, replace
 from datetime import timedelta
 from pathlib import Path
 from typing import Annotated, Any, overload
@@ -374,7 +374,6 @@ class MCPServer(AbstractToolset[Any], ABC):
 
     _id: str | None
 
-    _enter_lock: Lock = field(compare=False)
     _running_count: int
     _exit_stack: AsyncExitStack | None
 
@@ -387,6 +386,10 @@ class MCPServer(AbstractToolset[Any], ABC):
 
     _cached_tools: list[mcp_types.Tool] | None
     _cached_resources: list[Resource] | None
+
+    @functools.cached_property
+    def _enter_lock(self) -> anyio.Lock:
+        return anyio.Lock()
 
     # TODO (v2): enforce the arguments to be passed as keyword arguments only
     def __init__(
@@ -430,7 +433,6 @@ class MCPServer(AbstractToolset[Any], ABC):
         self.__post_init__()
 
     def __post_init__(self):
-        self._enter_lock = Lock()
         self._running_count = 0
         self._exit_stack = None
         self._cached_tools = None

--- a/pydantic_ai_slim/pydantic_ai/models/fallback.py
+++ b/pydantic_ai_slim/pydantic_ai/models/fallback.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-from asyncio import Lock
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass, field
@@ -8,6 +7,7 @@ from functools import cached_property
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, NoReturn, TypeGuard
 
+import anyio
 from opentelemetry.trace import get_current_span
 from typing_extensions import assert_never
 
@@ -78,6 +78,13 @@ class FallbackModel(Model):
     _exception_handlers: list[ExceptionHandler] = field(repr=False)
     _response_handlers: list[ResponseHandler] = field(repr=False)
 
+    @cached_property
+    def _enter_lock(self) -> anyio.Lock:
+        # We use a cached_property for this because `anyio.Lock` binds to the event loop on which
+        # it's first used; deferring creation until first access ensures it binds to the correct
+        # running loop and avoids issues with Temporal's workflow sandbox.
+        return anyio.Lock()
+
     def __init__(
         self,
         default_model: Model | KnownModelName | str,
@@ -103,7 +110,6 @@ class FallbackModel(Model):
         super().__init__()
         self.models = [infer_model(default_model), *[infer_model(m) for m in fallback_models]]
         self._entered_count = 0
-        self._enter_lock = Lock()
 
         # Parse fallback_on into exception handlers and response handlers
         self._exception_handlers = []

--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -91,6 +91,9 @@ class Provider(ABC, Generic[InterfaceClient]):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> bool | None:
+        if self._entered_count == 0:
+            # No matching `__aenter__` - keep this a no-op so the provider can be re-entered cleanly.
+            return
         async with self._enter_lock:
             self._entered_count -= 1
             if self._entered_count == 0 and self._own_http_client is not None:

--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -5,12 +5,13 @@ The providers are in charge of providing an authenticated client to the API.
 
 from __future__ import annotations as _annotations
 
+import functools
 from abc import ABC, abstractmethod
-from asyncio import Lock
 from collections.abc import Callable
 from types import TracebackType
 from typing import Any, Generic
 
+import anyio
 import httpx
 from typing_extensions import Self, TypeVar
 
@@ -36,7 +37,13 @@ class Provider(ABC, Generic[InterfaceClient]):
     _own_http_client: httpx.AsyncClient | None = None
     _http_client_factory: Callable[[], httpx.AsyncClient] | None = None
     _entered_count: int = 0
-    _enter_lock: Lock | None = None
+
+    @functools.cached_property
+    def _enter_lock(self) -> anyio.Lock:
+        # We use a cached_property for this because `anyio.Lock` binds to the event loop on which
+        # it's first used; deferring creation until first access ensures it binds to the correct
+        # running loop and avoids issues with Temporal's workflow sandbox.
+        return anyio.Lock()
 
     @property
     @abstractmethod
@@ -69,8 +76,6 @@ class Provider(ABC, Generic[InterfaceClient]):
         """
 
     async def __aenter__(self) -> Self:
-        if self._enter_lock is None:
-            self._enter_lock = Lock()
         async with self._enter_lock:
             if self._entered_count == 0 and self._own_http_client is not None:
                 if self._own_http_client.is_closed and self._http_client_factory is not None:
@@ -86,8 +91,6 @@ class Provider(ABC, Generic[InterfaceClient]):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> bool | None:
-        if self._enter_lock is None:
-            return
         async with self._enter_lock:
             self._entered_count -= 1
             if self._entered_count == 0 and self._own_http_client is not None:

--- a/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
@@ -1,11 +1,11 @@
 from __future__ import annotations as _annotations
 
 import functools
-from asyncio import Lock
 from collections.abc import AsyncGenerator, Mapping
 from pathlib import Path
 from typing import Literal, overload
 
+import anyio
 import anyio.to_thread
 import httpx
 from typing_extensions import deprecated
@@ -134,9 +134,14 @@ class GoogleVertexProvider(Provider[httpx.AsyncClient]):
 class _VertexAIAuth(httpx.Auth):
     """Auth class for Vertex AI API."""
 
-    _refresh_lock: Lock = Lock()
-
     credentials: BaseCredentials | ServiceAccountCredentials | None
+
+    @functools.cached_property
+    def _refresh_lock(self) -> anyio.Lock:
+        # We use a cached_property for this because `anyio.Lock` binds to the event loop on which
+        # it's first used; deferring creation until first access ensures it binds to the correct
+        # running loop and avoids issues with Temporal's workflow sandbox.
+        return anyio.Lock()
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
@@ -141,7 +141,7 @@ class _VertexAIAuth(httpx.Auth):
         # We use a cached_property for this because `anyio.Lock` binds to the event loop on which
         # it's first used; deferring creation until first access ensures it binds to the correct
         # running loop and avoids issues with Temporal's workflow sandbox.
-        return anyio.Lock()
+        return anyio.Lock()  # pragma: no cover
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import base64
-from asyncio import Lock
+import functools
 from contextlib import AsyncExitStack
 from dataclasses import KW_ONLY, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+import anyio
 from pydantic import AnyUrl
 from typing_extensions import Self, assert_never
 
@@ -99,6 +100,13 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
 
     _instructions: str | None
 
+    @functools.cached_property
+    def _enter_lock(self) -> anyio.Lock:
+        # We use a cached_property for this because `anyio.Lock` binds to the event loop on which
+        # it's first used; deferring creation until first access ensures it binds to the correct
+        # running loop and avoids issues with Temporal's workflow sandbox.
+        return anyio.Lock()
+
     def __init__(
         self,
         client: Client[Any]
@@ -130,7 +138,6 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
         self.include_return_schema = include_return_schema
         self.process_tool_call = process_tool_call
 
-        self._enter_lock: Lock = Lock()
         self._running_count: int = 0
         self._exit_stack: AsyncExitStack | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ convention = "google"
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "typing.TypedDict".msg = "Use typing_extensions.TypedDict instead."
 "typing.assert_never".msg = "Use typing_extensions.assert_never instead."
+"asyncio.Lock".msg = "Use anyio.Lock instead."
 
 [tool.ruff.format]
 # don't format python in docstrings, pytest-examples takes care of it

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -7055,6 +7055,17 @@ async def test_provider_aexit_without_aenter():
     await provider._own_http_client.aclose()  # pyright: ignore[reportPrivateUsage]
 
 
+@requires_openai
+async def test_provider_aexit_without_aenter_then_async_with():
+    """Bare __aexit__ before any __aenter__ must not corrupt later lifecycle state."""
+    provider = OpenAIProvider(api_key='test-key')
+    await provider.__aexit__(None, None, None)
+    async with provider:
+        assert provider._own_http_client is not None  # pyright: ignore[reportPrivateUsage]
+        assert not provider._own_http_client.is_closed  # pyright: ignore[reportPrivateUsage]
+    assert provider._own_http_client.is_closed  # pyright: ignore[reportPrivateUsage]
+
+
 # TODO(v2): uncomment when we re-enable the ResourceWarning in Provider.__del__
 # @requires_openai
 # async def test_provider_del_warns_on_unclosed_client():

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -7,9 +7,10 @@ import base64
 import re
 from datetime import timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import anyio
 import pytest
 
 from pydantic_ai import (
@@ -170,12 +171,13 @@ async def test_aexit_concurrent_does_not_corrupt_running_count():
 
     # Replace the real lock with one that yields before acquiring,
     # opening the interleaving window the old code left unprotected.
-    class InterleavingLock(asyncio.Lock):
-        async def acquire(self) -> Literal[True]:
-            await asyncio.sleep(0)  # yield — lets the other task reach the same point
-            return await super().acquire()
+    class InterleavingLock(anyio.Lock):
+        async def acquire(self) -> None:
+            await anyio.sleep(0)  # yield - lets the other task reach the same point
+            await super().acquire()
 
-    server._enter_lock = InterleavingLock()  # pyright: ignore[reportPrivateUsage]
+    # `_enter_lock` is a `cached_property`; seeding the instance dict primes the cache.
+    vars(server)['_enter_lock'] = InterleavingLock()
 
     results = await asyncio.gather(
         server.__aexit__(None, None, None),

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -169,10 +169,6 @@ async def test_aexit_concurrent_does_not_corrupt_running_count():
     # One active entry — the race only matters when both tasks see count > 0.
     server._running_count = 1  # pyright: ignore[reportPrivateUsage]
 
-    # Replace the real lock with a wrapper that yields before acquiring,
-    # opening the interleaving window the old code left unprotected. We can't
-    # subclass `anyio.Lock` directly because it returns a backend-specific
-    # adapter via `__new__` and bypasses subclass methods.
     class InterleavingLock:
         def __init__(self) -> None:
             self._inner = anyio.Lock()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -169,12 +169,20 @@ async def test_aexit_concurrent_does_not_corrupt_running_count():
     # One active entry — the race only matters when both tasks see count > 0.
     server._running_count = 1  # pyright: ignore[reportPrivateUsage]
 
-    # Replace the real lock with one that yields before acquiring,
-    # opening the interleaving window the old code left unprotected.
-    class InterleavingLock(anyio.Lock):
-        async def acquire(self) -> None:
+    # Replace the real lock with a wrapper that yields before acquiring,
+    # opening the interleaving window the old code left unprotected. We can't
+    # subclass `anyio.Lock` directly because it returns a backend-specific
+    # adapter via `__new__` and bypasses subclass methods.
+    class InterleavingLock:
+        def __init__(self) -> None:
+            self._inner = anyio.Lock()
+
+        async def __aenter__(self) -> None:
             await anyio.sleep(0)  # yield - lets the other task reach the same point
-            await super().acquire()
+            await self._inner.__aenter__()
+
+        async def __aexit__(self, *args: Any) -> None:
+            await self._inner.__aexit__(*args)
 
     # `_enter_lock` is a `cached_property`; seeding the instance dict primes the cache.
     vars(server)['_enter_lock'] = InterleavingLock()


### PR DESCRIPTION
Replaces eager `asyncio.Lock` instantiation at class/instance-init time with `functools.cached_property`-wrapped `anyio.Lock` across `Agent`, `MCPServer`, `FallbackModel`, `Provider`, `_VertexAIAuth`, and `FastMCPToolset`.

`anyio.Lock` binds to the event loop on which it's first used, so deferring creation until first access ensures it binds to the correct running loop and avoids issues with Temporal's workflow sandbox (which blocks dynamic imports and initialization happening inside workflow code).

Picks up the lock-related portion of #3012, leaving the broader asyncio→anyio migration for a follow-up that won't conflict with the agent graph refactor.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.