### PR TITLE
Use `anyio.run` and `anyio.get_cancelled_exc_class()` in CLI

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -1,15 +1,14 @@
 from __future__ import annotations as _annotations
 
 import argparse
-import asyncio
 import sys
-from asyncio import CancelledError
 from collections.abc import Sequence
 from contextlib import ExitStack
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import anyio
 from pydantic import ImportString, TypeAdapter, ValidationError
 from typing_inspection.introspection import get_literal_values
 
@@ -318,13 +317,13 @@ def _run_chat_command(
 
     if args.prompt:
         try:
-            asyncio.run(ask_agent(agent, args.prompt, stream, console, code_theme))
+            anyio.run(ask_agent, agent, args.prompt, stream, console, code_theme)
         except KeyboardInterrupt:
             pass
         return 0
 
     try:
-        return asyncio.run(run_chat(stream, agent, console, code_theme, prog_name))
+        return anyio.run(run_chat, stream, agent, console, code_theme, prog_name)
     except KeyboardInterrupt:  # pragma: no cover
         return 0
 
@@ -369,7 +368,7 @@ async def run_chat(
                 messages = await ask_agent(
                     agent, text, stream, console, code_theme, deps, messages, model_settings, usage_limits
                 )
-            except CancelledError:  # pragma: no cover
+            except anyio.get_cancelled_exc_class():  # pragma: no cover
                 console.print('[dim]Interrupted[/dim]')
             except Exception as e:  # pragma: no cover
                 cause = getattr(e, '__cause__', None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,11 @@
 import sys
 import types
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from io import StringIO
 from typing import Any
 
 import pytest
+import sniffio
 from pytest import CaptureFixture
 from pytest_mock import MockerFixture
 from rich.console import Console
@@ -28,6 +29,17 @@ with try_import() as imports_successful:
     from pydantic_ai.models.openai import OpenAIChatModel
 
 pytestmark = pytest.mark.skipif(not imports_successful(), reason='install cli extras to run cli tests')
+
+
+@pytest.fixture(autouse=True)
+def reset_sniffio_cvar() -> Iterator[None]:
+    # The anyio pytest plugin sets `current_async_library_cvar` to 'asyncio' at session
+    # start and the value leaks into sync tests, causing `anyio.run` to refuse to start.
+    token = sniffio.current_async_library_cvar.set(None)
+    try:
+        yield
+    finally:
+        sniffio.current_async_library_cvar.reset(token)
 
 
 def test_cli_version(capfd: CaptureFixture[str]):


### PR DESCRIPTION
## Summary

- Replace `asyncio.run` with `anyio.run` and `asyncio.CancelledError` with `anyio.get_cancelled_exc_class()` in `pydantic_ai/_cli/__init__.py`, picking up the easy wins from #3012 that aren't already in main.
- Add an autouse fixture in `tests/test_cli.py` to reset `sniffio.current_async_library_cvar`, which the anyio pytest plugin sets to `'asyncio'` at session start and which leaks into sync tests, causing `anyio.run` to refuse to start.

## Test plan

- [x] `uv run pytest tests/test_cli.py` (51 passed)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `make typecheck`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.