### PR TITLE
fix: restore `wrap_validation_errors` on `ToolManager` function-tool methods

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -301,6 +301,7 @@ class ToolManager(Generic[AgentDepsT]):
         validated: ValidatedToolCall[AgentDepsT],
         *,
         usage: RunUsage,
+        wrap_validation_errors: bool = True,
     ) -> Any:
         """Run execution with before/wrap/after tool_execute hooks."""
         assert validated.tool is not None
@@ -313,7 +314,9 @@ class ToolManager(Generic[AgentDepsT]):
         async def do_execute(args: dict[str, Any]) -> Any:
             # Execute with potentially modified args
             modified_validated = replace(validated, validated_args=args)
-            return await self._raw_execute(modified_validated, usage=usage)
+            return await self._raw_execute(
+                modified_validated, usage=usage, wrap_validation_errors=wrap_validation_errors
+            )
 
         # Output tools are internal — they don't fire user-facing tool hooks, matching how
         # `WrapperToolset` and `prepare_tools` exclude them.
@@ -343,7 +346,9 @@ class ToolManager(Generic[AgentDepsT]):
             except (ValidationError, ModelRetry) as e:
                 # Hook raised ValidationError or ModelRetry (e.g. before/after_tool_execute
                 # doing additional Pydantic validation on args/result) — convert to
-                # ToolRetryError for retry handling.
+                # ToolRetryError for retry handling, unless the caller asked for raw errors.
+                if not wrap_validation_errors:
+                    raise
                 name = call.tool_name
                 self._check_max_retries(name, validated.tool.max_retries, e)
                 self.failed_tools.add(name)
@@ -395,8 +400,9 @@ class ToolManager(Generic[AgentDepsT]):
     ) -> ValidatedToolCall[AgentDepsT]:
         """Handle validation failure: check retries, mark failed, wrap error.
 
-        Only called on the non-streaming path (`wrap_validation_errors=True`); streaming
-        lets errors propagate without going through this helper.
+        Only called when wrapping is requested (`wrap_validation_errors=True`); when
+        False (streaming, or sandboxed callers that want raw errors), the caller lets
+        the exception propagate without going through this helper.
         """
         max_retries = tool.max_retries if tool is not None else self.default_max_retries
         cause = (
@@ -420,6 +426,7 @@ class ToolManager(Generic[AgentDepsT]):
         *,
         approved: bool = False,
         metadata: Any = None,
+        wrap_validation_errors: bool = True,
     ) -> ValidatedToolCall[AgentDepsT]:
         """Validate tool arguments without executing the tool.
 
@@ -432,6 +439,13 @@ class ToolManager(Generic[AgentDepsT]):
             call: The tool call part to validate.
             approved: Whether the tool call has been approved.
             metadata: Additional metadata from DeferredToolResults.metadata.
+            wrap_validation_errors: If True (default), wrap `ValidationError` / `ModelRetry`
+                as `ToolRetryError` on the returned `ValidatedToolCall.validation_error`,
+                count the call against the retry budget, and add it to `failed_tools`.
+                If False, propagate the raw `ValidationError` / `ModelRetry` and leave
+                retry-budget state untouched — useful for nested callers (e.g. sandboxed
+                tool dispatch) where validation failures shouldn't consume the agent's
+                retry budget and the raw exception is what the caller wants to surface.
 
         Returns:
             ValidatedToolCall with validation results, ready for execution via execute_tool_call().
@@ -450,22 +464,34 @@ class ToolManager(Generic[AgentDepsT]):
             # Hook asked us to skip validation entirely; accept the args it provided.
             return self._make_validation_success(call, tool, ctx, e.validated_args)
         except (ValidationError, ModelRetry) as e:
+            if not wrap_validation_errors:
+                raise
             return self._make_validation_failure(call.tool_name, call, tool, ctx, e)
 
     async def execute_tool_call(
         self,
         validated: ValidatedToolCall[AgentDepsT],
+        *,
+        wrap_validation_errors: bool = True,
     ) -> Any:
         """Execute a validated tool call, within a trace span for function tools.
 
         Args:
             validated: The validation result from validate_tool_call().
+            wrap_validation_errors: If True (default), `ModelRetry` raised by the tool
+                body or by execute-stage capability hooks (`before_tool_execute`,
+                `after_tool_execute`, `wrap_tool_execute`) is wrapped as `ToolRetryError`
+                after counting against the retry budget. If False, the raw
+                `ModelRetry` / `ValidationError` propagates and retry-budget state is
+                left untouched.
 
         Returns:
             The tool result if validation passed and execution succeeded.
 
         Raises:
-            ToolRetryError: If validation failed (contains the retry prompt).
+            ToolRetryError: If validation failed (contains the retry prompt) or the tool
+                raised `ModelRetry`. Only when `wrap_validation_errors=True`.
+            ModelRetry / ValidationError: When `wrap_validation_errors=False`.
             RuntimeError: If trying to execute an external tool.
         """
         if self.ctx is None:
@@ -477,6 +503,7 @@ class ToolManager(Generic[AgentDepsT]):
             include_content=self.ctx.trace_include_content,
             instrumentation_version=self.ctx.instrumentation_version,
             usage=self.ctx.usage,
+            wrap_validation_errors=wrap_validation_errors,
         )
 
     # --- Output tool methods (output hooks, no tool hooks) ---
@@ -682,15 +709,20 @@ class ToolManager(Generic[AgentDepsT]):
         validated: ValidatedToolCall[AgentDepsT],
         *,
         usage: RunUsage,
+        wrap_validation_errors: bool = True,
     ) -> Any:
         """Execute a validated tool call without tracing, with capability hooks.
 
-        Raises ToolRetryError if validation previously failed or the tool raises ModelRetry.
+        Raises ToolRetryError if validation previously failed or the tool raises ModelRetry
+        (when `wrap_validation_errors=True`); when False, the raw exception propagates.
         Raises UnexpectedModelBehavior if max retries exceeded.
         """
         # Asserts narrow types for pyright; invariants guaranteed by ValidatedToolCall construction
         if not validated.args_valid:
             assert validated.validation_error is not None
+            if not wrap_validation_errors and isinstance(validated.validation_error.__cause__, Exception):
+                # Surface the original cause (ValidationError / ModelRetry) for raw-mode callers.
+                raise validated.validation_error.__cause__
             raise validated.validation_error
 
         assert validated.tool is not None
@@ -700,7 +732,9 @@ class ToolManager(Generic[AgentDepsT]):
             raise RuntimeError('External tools cannot be called')
 
         try:
-            tool_result = await self._run_execute_hooks(validated, usage=usage)
+            tool_result = await self._run_execute_hooks(
+                validated, usage=usage, wrap_validation_errors=wrap_validation_errors
+            )
         except SkipToolExecution as e:
             usage.tool_calls += 1
             return e.result
@@ -712,6 +746,7 @@ class ToolManager(Generic[AgentDepsT]):
         validated: ValidatedToolCall[AgentDepsT],
         *,
         usage: RunUsage,
+        wrap_validation_errors: bool = True,
     ) -> Any:
         """Execute a validated tool call without hooks or tracing."""
         assert validated.tool is not None
@@ -727,6 +762,8 @@ class ToolManager(Generic[AgentDepsT]):
                 validated.tool,
             )
         except ModelRetry as e:
+            if not wrap_validation_errors:
+                raise
             self._check_max_retries(name, validated.tool.max_retries, e)
             self.failed_tools.add(name)
             raise self._wrap_error_as_retry(name, validated.call, e) from e
@@ -743,6 +780,7 @@ class ToolManager(Generic[AgentDepsT]):
         include_content: bool,
         instrumentation_version: int,
         usage: RunUsage,
+        wrap_validation_errors: bool = True,
     ) -> Any:
         """Execute a validated function tool call within a trace span.
 
@@ -786,7 +824,9 @@ class ToolManager(Generic[AgentDepsT]):
             set_status_on_exception=False,
         ) as span:
             try:
-                tool_result = await self._execute_tool_call_impl(validated, usage=usage)
+                tool_result = await self._execute_tool_call_impl(
+                    validated, usage=usage, wrap_validation_errors=wrap_validation_errors
+                )
                 if include_content and span.is_recording():
                     span.set_attribute(
                         instrumentation_names.tool_result_attr,
@@ -826,6 +866,7 @@ class ToolManager(Generic[AgentDepsT]):
         *,
         approved: bool = False,
         metadata: Any = None,
+        wrap_validation_errors: bool = True,
     ) -> ToolDenied | ToolReturn[Any] | Any:
         """Handle a tool call by validating the arguments, calling the tool, and handling retries.
 
@@ -839,6 +880,12 @@ class ToolManager(Generic[AgentDepsT]):
             call: The tool call part to handle.
             approved: Whether the tool call has been approved.
             metadata: Additional metadata from DeferredToolResults.metadata.
+            wrap_validation_errors: If True (default), validation failures surface as
+                `ToolRetryError` (after counting against the retry budget). If False,
+                the raw `ValidationError` / `ModelRetry` propagates and retry-budget
+                state is left untouched — useful for nested callers (e.g. sandboxed
+                tool dispatch) where the call shouldn't consume the agent's retry
+                budget and the raw exception is what the caller wants to surface.
 
         Returns:
             The tool's return value on success — possibly a [`ToolReturn`][pydantic_ai.messages.ToolReturn]
@@ -855,7 +902,9 @@ class ToolManager(Generic[AgentDepsT]):
 
         Raises:
             ToolRetryError: The handler requested a retry, or the (re-)executed tool
-                raised `ModelRetry`.
+                raised `ModelRetry`. Only when `wrap_validation_errors=True`.
+            ValidationError / ModelRetry: When `wrap_validation_errors=False` and the
+                arguments fail validation or a hook raises `ModelRetry`.
             CallDeferred / ApprovalRequired: No handler resolved the call, or the
                 approved tool re-raised a deferral.
         """
@@ -863,9 +912,10 @@ class ToolManager(Generic[AgentDepsT]):
             call,
             approved=approved,
             metadata=metadata,
+            wrap_validation_errors=wrap_validation_errors,
         )
         try:
-            return await self.execute_tool_call(validated)
+            return await self.execute_tool_call(validated, wrap_validation_errors=wrap_validation_errors)
         except (CallDeferred, ApprovalRequired) as exc:
             return await self._resolve_single_deferred(call, exc)
 

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -713,16 +713,18 @@ class ToolManager(Generic[AgentDepsT]):
     ) -> Any:
         """Execute a validated tool call without tracing, with capability hooks.
 
+        `wrap_validation_errors` here only governs errors raised *during* execution
+        (tool body or execute-stage hooks). A `ValidatedToolCall` that already failed
+        validation carries a pre-wrapped `ToolRetryError`; raw-mode callers get raw
+        errors at the `validate_tool_call(wrap_validation_errors=False)` boundary.
+
         Raises ToolRetryError if validation previously failed or the tool raises ModelRetry
-        (when `wrap_validation_errors=True`); when False, the raw exception propagates.
-        Raises UnexpectedModelBehavior if max retries exceeded.
+        (when `wrap_validation_errors=True`); when False, ModelRetry from the tool body
+        or hooks propagates raw. Raises UnexpectedModelBehavior if max retries exceeded.
         """
         # Asserts narrow types for pyright; invariants guaranteed by ValidatedToolCall construction
         if not validated.args_valid:
             assert validated.validation_error is not None
-            if not wrap_validation_errors and isinstance(validated.validation_error.__cause__, Exception):
-                # Surface the original cause (ValidationError / ModelRetry) for raw-mode callers.
-                raise validated.validation_error.__cause__
             raise validated.validation_error
 
         assert validated.tool is not None

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -917,7 +917,7 @@ class ToolManager(Generic[AgentDepsT]):
         try:
             return await self.execute_tool_call(validated, wrap_validation_errors=wrap_validation_errors)
         except (CallDeferred, ApprovalRequired) as exc:
-            return await self._resolve_single_deferred(call, exc)
+            return await self._resolve_single_deferred(call, exc, wrap_validation_errors=wrap_validation_errors)
 
     async def resolve_deferred_tool_calls(
         self,
@@ -940,6 +940,8 @@ class ToolManager(Generic[AgentDepsT]):
         self,
         call: ToolCallPart,
         exc: CallDeferred | ApprovalRequired,
+        *,
+        wrap_validation_errors: bool = True,
     ) -> ToolDenied | ToolReturn[Any] | Any:
         """Resolve a single deferred tool call inline using the capability handler.
 
@@ -952,6 +954,13 @@ class ToolManager(Generic[AgentDepsT]):
         [`_call_tool`][pydantic_ai._agent_graph._call_tool] — both paths must accept the
         full [`DeferredToolResult`][pydantic_ai.tools.DeferredToolResult] surface.
 
+        `wrap_validation_errors` is forwarded to the post-approval re-validation and
+        re-execution so callers passing `False` (e.g. sandboxed dispatch) keep the
+        same raw-error contract through deferred-tool resolution. Handler-constructed
+        retry signals (`ModelRetry` / `RetryPromptPart` returned by the handler) still
+        surface as `ToolRetryError` regardless — those are handler outputs, not
+        exceptions raised by validation or the tool body.
+
         Returns:
             For approved calls, the raw tool return (possibly a `ToolReturn` wrapper).
             For external-call results, the value the handler supplied verbatim (plain
@@ -962,7 +971,10 @@ class ToolManager(Generic[AgentDepsT]):
 
         Raises:
             ToolRetryError: Handler requested a retry via `ModelRetry` or `RetryPromptPart`,
-                or the approved tool re-raised `ModelRetry`.
+                or the approved tool re-raised `ModelRetry` (only when
+                `wrap_validation_errors=True`).
+            ValidationError / ModelRetry: When `wrap_validation_errors=False` and the
+                approved tool's re-validation fails or its body raises `ModelRetry`.
             CallDeferred / ApprovalRequired: Handler couldn't resolve the call, or the
                 approved tool re-raised a deferral.
         """
@@ -991,8 +1003,13 @@ class ToolManager(Generic[AgentDepsT]):
             if tool_call_result.override_args is not None:
                 validate_call = replace(call, args=tool_call_result.override_args)
             call_metadata = deferred_results.metadata.get(call.tool_call_id)
-            validated = await self.validate_tool_call(validate_call, approved=True, metadata=call_metadata)
-            return await self.execute_tool_call(validated)
+            validated = await self.validate_tool_call(
+                validate_call,
+                approved=True,
+                metadata=call_metadata,
+                wrap_validation_errors=wrap_validation_errors,
+            )
+            return await self.execute_tool_call(validated, wrap_validation_errors=wrap_validation_errors)
         if isinstance(tool_call_result, ModelRetry):
             raise ToolRetryError(
                 _messages.RetryPromptPart(

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -14679,13 +14679,13 @@ async def test_deferred_tool_handler_via_handle_call_wrap_validation_errors_fals
     # in its return value; if wrap_validation_errors hadn't been forwarded through
     # _resolve_single_deferred, outer_tool would have seen a ToolRetryError instead.
     inner_message = next(
-        msg for msg in result.all_messages() if isinstance(msg, ModelRequest) and any(
-            isinstance(part, ToolReturnPart) and part.tool_name == 'outer_tool' for part in msg.parts
-        )
+        msg
+        for msg in result.all_messages()
+        if isinstance(msg, ModelRequest)
+        and any(isinstance(part, ToolReturnPart) and part.tool_name == 'outer_tool' for part in msg.parts)
     )
     outer_return = next(
-        part for part in inner_message.parts
-        if isinstance(part, ToolReturnPart) and part.tool_name == 'outer_tool'
+        part for part in inner_message.parts if isinstance(part, ToolReturnPart) and part.tool_name == 'outer_tool'
     )
     assert outer_return.content == 'raw ModelRetry: post-approval retry'
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -14635,6 +14635,61 @@ async def test_deferred_tool_handler_via_handle_call():
     assert result.output == 'All done.'
 
 
+async def test_deferred_tool_handler_via_handle_call_wrap_validation_errors_false():
+    """`wrap_validation_errors=False` propagates through deferred-tool resolution.
+
+    Regression for the case where a sandboxed caller (`handle_call(wrap_validation_errors=False)`)
+    invokes a tool that requires approval: after the handler approves, the re-execution must
+    keep the raw-error contract — `ModelRetry` from the approved tool body should propagate
+    as-is, not wrapped as `ToolRetryError`.
+    """
+
+    async def handle_deferred(ctx: RunContext[None], requests: DeferredToolRequests) -> DeferredToolResults:
+        return DeferredToolResults(approvals={call.tool_call_id: True for call in requests.approvals})
+
+    def llm(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(parts=[ToolCallPart('outer_tool', {}, tool_call_id='outer1')])
+        return ModelResponse(parts=[TextPart('Done.')])
+
+    agent = Agent(
+        FunctionModel(llm),
+        capabilities=[HandleDeferredToolCalls(handler=handle_deferred)],
+    )
+
+    @agent.tool
+    async def outer_tool(ctx: RunContext[None]) -> str:
+        assert ctx.tool_manager is not None
+        inner_call = ToolCallPart(tool_name='inner_tool', args={}, tool_call_id='inner1')
+        try:
+            await ctx.tool_manager.handle_call(inner_call, wrap_validation_errors=False)
+        except ModelRetry as e:
+            return f'raw ModelRetry: {e}'
+        return 'no error'  # pragma: no cover
+
+    @agent.tool
+    def inner_tool(ctx: RunContext[None]) -> str:
+        if not ctx.tool_call_approved:
+            raise ApprovalRequired
+        raise ModelRetry('post-approval retry')
+
+    result = await agent.run('Hello')
+    assert result.output == 'Done.'
+    # outer_tool caught the raw ModelRetry from the approved inner_tool body and surfaced it
+    # in its return value; if wrap_validation_errors hadn't been forwarded through
+    # _resolve_single_deferred, outer_tool would have seen a ToolRetryError instead.
+    inner_message = next(
+        msg for msg in result.all_messages() if isinstance(msg, ModelRequest) and any(
+            isinstance(part, ToolReturnPart) and part.tool_name == 'outer_tool' for part in msg.parts
+        )
+    )
+    outer_return = next(
+        part for part in inner_message.parts
+        if isinstance(part, ToolReturnPart) and part.tool_name == 'outer_tool'
+    )
+    assert outer_return.content == 'raw ModelRetry: post-approval retry'
+
+
 async def test_deferred_tool_handler_via_handle_call_no_handler():
     """handle_call(resolve_deferred=True) re-raises when no handler is available."""
     from pydantic_ai.toolsets import FunctionToolset

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -783,11 +783,7 @@ async def test_handle_call_wrap_validation_errors_false():
     Mirrors the `wrap_validation_errors` flag on the output-tool methods.
     """
 
-    @dataclass
-    class TestDeps:
-        pass
-
-    toolset = FunctionToolset[TestDeps](max_retries=2)
+    toolset = FunctionToolset[None](max_retries=2)
 
     @toolset.tool_plain
     def needs_int(x: int) -> int:
@@ -797,7 +793,7 @@ async def test_handle_call_wrap_validation_errors_false():
     def retrying() -> int:
         raise ModelRetry('please retry')
 
-    tool_manager = await ToolManager[TestDeps](toolset).for_run_step(build_run_context(TestDeps()))
+    tool_manager = await ToolManager[None](toolset).for_run_step(build_run_context(None))
 
     # Pydantic ValidationError on bad args propagates raw, not as ToolRetryError.
     with pytest.raises(ValidationError):

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -795,6 +795,15 @@ async def test_handle_call_wrap_validation_errors_false():
 
     tool_manager = await ToolManager[None](toolset).for_run_step(build_run_context(None))
 
+    # Sanity: a valid call still works in raw mode (no path differences for happy paths).
+    assert (
+        await tool_manager.handle_call(
+            ToolCallPart(tool_name='needs_int', args={'x': 5}),
+            wrap_validation_errors=False,
+        )
+        == 10
+    )
+
     # Pydantic ValidationError on bad args propagates raw, not as ToolRetryError.
     with pytest.raises(ValidationError):
         await tool_manager.handle_call(

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 
 import anyio
 import pytest
+from pydantic import ValidationError
 from typing_extensions import Self
 
 if sys.version_info < (3, 11):
@@ -771,6 +772,57 @@ async def test_tool_manager_retry_logic():
     # Call the failing tool _again_, now we should finally hit the limit
     with pytest.raises(UnexpectedModelBehavior, match="Tool 'failing_tool' exceeded max retries count of 2"):
         await another_tool_manager.handle_call(ToolCallPart(tool_name='failing_tool', args={'x': 1}))
+
+
+async def test_handle_call_wrap_validation_errors_false():
+    """`handle_call(wrap_validation_errors=False)` propagates raw errors and leaves retry-budget state untouched.
+
+    Used by sandboxed callers (e.g. code-mode dispatch) that want validation and
+    `ModelRetry` failures to surface at the sandbox `await` site as the original
+    exception type, without consuming the agent's retry budget for the wrapping call.
+    Mirrors the `wrap_validation_errors` flag on the output-tool methods.
+    """
+
+    @dataclass
+    class TestDeps:
+        pass
+
+    toolset = FunctionToolset[TestDeps](max_retries=2)
+
+    @toolset.tool_plain
+    def needs_int(x: int) -> int:
+        return x * 2
+
+    @toolset.tool_plain
+    def retrying() -> int:
+        raise ModelRetry('please retry')
+
+    tool_manager = await ToolManager[TestDeps](toolset).for_run_step(build_run_context(TestDeps()))
+
+    # Pydantic ValidationError on bad args propagates raw, not as ToolRetryError.
+    with pytest.raises(ValidationError):
+        await tool_manager.handle_call(
+            ToolCallPart(tool_name='needs_int', args={'x': 'not an int'}),
+            wrap_validation_errors=False,
+        )
+    assert tool_manager.failed_tools == set()
+
+    # ModelRetry from the tool body propagates raw too.
+    with pytest.raises(ModelRetry, match='please retry'):
+        await tool_manager.handle_call(
+            ToolCallPart(tool_name='retrying', args={}),
+            wrap_validation_errors=False,
+        )
+    assert tool_manager.failed_tools == set()
+
+    # Default (wrap=True) still wraps as ToolRetryError and tracks failed tools.
+    with pytest.raises(ToolRetryError):
+        await tool_manager.handle_call(ToolCallPart(tool_name='needs_int', args={'x': 'not an int'}))
+    assert tool_manager.failed_tools == {'needs_int'}
+
+    with pytest.raises(ToolRetryError):
+        await tool_manager.handle_call(ToolCallPart(tool_name='retrying', args={}))
+    assert tool_manager.failed_tools == {'needs_int', 'retrying'}
 
 
 async def test_toolset_max_retries_inherits_from_agent():


### PR DESCRIPTION
- Closes #<issue>

### Summary

Restores `wrap_validation_errors` (kw-only, default `True`) on `ToolManager.validate_tool_call`, `execute_tool_call`, and `handle_call`, and properly threads it through `_resolve_single_deferred` so the flag is honored across the full function-tool surface — validation, capability hooks, the tool body, and post-approval re-execution after deferred-tool resolution.

### Origin: regression from two PRs that compounded

This issue is the interaction of two recent merges that each got part of the way:

- **#5142 (`HandleDeferredToolCalls`)** introduced `_resolve_single_deferred`, called from inside `handle_call` when an approved tool needs re-validation + re-execution. At the time, `handle_call` *did* accept `wrap_validation_errors`, but the new helper didn't receive it — so the flag was already silently failing on the deferred-with-handler path. **Latent bug.**
- **#4859 (output hooks)** then refactored `validate_tool_call` to always return `ValidatedToolCall` and dropped the `wrap_validation_errors` keyword from `validate_tool_call`, `execute_tool_call`, and `handle_call` entirely (it was kept on the output-tool counterparts: `validate_output_tool_call` / `execute_output_tool_call` / `handle_output_tool_call`). **The flag's complete disappearance also hid the #5142 gap.**

Together they broke `pydantic-ai-harness`'s code-mode dispatch, which has been calling `tool_manager.handle_call(call_part, wrap_validation_errors=False)` to surface raw validation/`ModelRetry` errors at the sandbox `await` site.

### Behavior

When `wrap_validation_errors=False`:
- raw `ValidationError` / `ModelRetry` propagates from validation, capability hooks (`before_tool_execute` / `wrap_tool_execute` / `after_tool_execute`), the tool body itself, **and** post-approval re-execution after deferred-tool resolution
- `_check_max_retries` and `failed_tools.add` are skipped, so out-of-band callers (e.g. nested sandboxed dispatch) don't consume the agent's retry budget

When `wrap_validation_errors=True` (default), behavior is unchanged from current `main`.

Capabilities themselves see raw exceptions in both modes — the wrap happens at the outer edge of `_run_execute_hooks`, so the boundary visible to hooks is unchanged.

Handler-constructed retry signals (`ModelRetry` / `RetryPromptPart` returned by a `HandleDeferredToolCalls` handler) still surface as `ToolRetryError` regardless of the flag — those are handler outputs, not exceptions raised by validation or the tool body. Documented in `_resolve_single_deferred`.

### Slight semantic change vs. pre-#4859 (deliberate)

The pre-#4859 flag only governed *validation-time* errors; tool-body `ModelRetry` always wrapped as `ToolRetryError` regardless. This restoration makes the flag govern the full validate→hooks→execute pipeline, matching how `wrap_validation_errors` already works on the output-tool methods. The function-tool and output-tool paths now offer the same opt-out semantics.

This is technically a behavior change for callers passing `wrap_validation_errors=False` pre-#4859, but it's a strict improvement: anyone passing `False` was clearly trying to get raw exceptions, and the broader semantics avoid double-wrapping (e.g. for the harness, `ModelRetry → ToolRetryError → MontyRuntimeError → ModelRetry` collapses to `ModelRetry → MontyRuntimeError → ModelRetry`).

### Test plan

- [x] `test_handle_call_wrap_validation_errors_false` (`tests/test_toolsets.py`) covers raw-error propagation for both `ValidationError` (bad args) and tool-body `ModelRetry`, plus the `failed_tools` invariant in raw vs default mode.
- [x] `test_deferred_tool_handler_via_handle_call_wrap_validation_errors_false` (`tests/test_capabilities.py`) covers the deferred-with-handler path: an approved tool re-raising `ModelRetry` propagates raw through `_resolve_single_deferred` when `wrap_validation_errors=False` is forwarded.
- [x] All existing toolsets/tools/capabilities tests pass.
- [x] All existing streaming/agent tests pass (covering the output-tool `wrap_validation_errors` path that was unaffected).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).