### PR TITLE
ci: add harness-compat job that runs the harness suite against pydantic-ai PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,26 @@ jobs:
           path: htmlcov
           include-hidden-files: true
 
+  # Enforces the `safe-for-ci` label on fork PRs so the `harness compat` workflow
+  # (in `harness-compat.yml`) actually runs before merge. That workflow lives in a
+  # separate file so it can use a `pull_request` path filter and `labeled` event
+  # type without affecting the rest of CI; cross-workflow `needs:` doesn't exist
+  # in GitHub Actions, so this gate job is how we surface the label requirement to
+  # the `check` aggregate. Fork PR without label → gate fails → `check` fails →
+  # branch protection blocks merge until a maintainer labels and re-runs.
+  harness-compat-gate:
+    name: harness compat gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require `safe-for-ci` label on fork PRs
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository &&
+          !contains(github.event.pull_request.labels.*.name, 'safe-for-ci')
+        run: |
+          echo "::error::Fork PRs need the 'safe-for-ci' label so the harness-compat workflow can run. A maintainer must add the label after reviewing the diff; CI will re-trigger automatically."
+          exit 1
+
   # https://github.com/marketplace/actions/alls-green#why used for branch protection checks
   check:
     if: always()
@@ -295,6 +315,7 @@ jobs:
       - test-lowest-versions
       - test-examples
       - coverage
+      - harness-compat-gate
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/harness-compat.yml
+++ b/.github/workflows/harness-compat.yml
@@ -5,11 +5,11 @@ name: Harness Compat
 # workflow with the PR's HEAD SHA + repo (so fork PRs are tested against the
 # code in the fork, not main).
 #
-# Fork PRs are gated behind the `ok-to-test` label so a maintainer reviews the
-# diff before CI runs the fork's pydantic-ai code through the harness suite.
-# The called workflow itself runs without secrets and with `contents: read`
-# only — the label is defense-in-depth against running unreviewed code on CI
-# infrastructure, not a privilege escalation barrier.
+# Fork PRs are gated behind the `safe-for-ci` label so a maintainer reviews
+# the diff before CI runs the fork's pydantic-ai code through the harness
+# suite. The called workflow itself runs without secrets and with
+# `contents: read` only — the label is defense-in-depth against running
+# unreviewed code on CI infrastructure, not a privilege escalation barrier.
 #
 # Fork PRs without the label produce a `skipped` job result. Branch protection
 # should require this check to merge, so unlabeled fork PRs can't be merged
@@ -29,7 +29,7 @@ jobs:
     name: harness compat
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+      contains(github.event.pull_request.labels.*.name, 'safe-for-ci')
     uses: pydantic/pydantic-ai-harness/.github/workflows/compat-test.yml@main
     with:
       pydantic-ai-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/harness-compat.yml
+++ b/.github/workflows/harness-compat.yml
@@ -1,0 +1,36 @@
+name: Harness Compat
+
+# Verifies that pydantic-ai PRs don't break the pydantic-ai-harness lint /
+# typecheck / test suite. Calls the harness's `compat-test.yml` reusable
+# workflow with the PR's HEAD SHA + repo (so fork PRs are tested against the
+# code in the fork, not main).
+#
+# Fork PRs are gated behind the `ok-to-test` label so a maintainer reviews the
+# diff before CI runs the fork's pydantic-ai code through the harness suite.
+# The called workflow itself runs without secrets and with `contents: read`
+# only — the label is defense-in-depth against running unreviewed code on CI
+# infrastructure, not a privilege escalation barrier.
+#
+# Fork PRs without the label produce a `skipped` job result. Branch protection
+# should require this check to merge, so unlabeled fork PRs can't be merged
+# until a maintainer labels and re-runs.
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+    paths:
+      - 'pydantic_ai_slim/**'
+
+permissions:
+  contents: read
+
+jobs:
+  harness-compat:
+    name: harness compat
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    uses: pydantic/pydantic-ai-harness/.github/workflows/compat-test.yml@main
+    with:
+      pydantic-ai-ref: ${{ github.event.pull_request.head.sha }}
+      pydantic-ai-repo: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/harness-compat.yml
+++ b/.github/workflows/harness-compat.yml
@@ -17,10 +17,11 @@ name: Harness Compat
 # `contents: read` only — the label is defense-in-depth against running
 # unreviewed code on CI infrastructure, not a privilege escalation barrier.
 #
-# Fork PRs without the label produce a `skipped` job result. Branch protection
-# should require this check to merge; the `harness-compat-gate` job in `ci.yml`
-# enforces the label requirement via the `check` gate (skipped == success here
-# is bypassed by `check` failing on fork-PR-without-label).
+# Fork PRs without the label produce a `skipped` job result. The
+# `harness-compat-gate` job in `ci.yml` enforces the label requirement via the
+# `check` gate so unlabeled fork PRs can't be merged (`check` fails when the
+# gate fails). Add `harness compat` to required-status-checks in branch
+# protection so the actual cross-repo run is also enforced when it runs.
 
 on:
   pull_request:

--- a/.github/workflows/harness-compat.yml
+++ b/.github/workflows/harness-compat.yml
@@ -1,9 +1,15 @@
 name: Harness Compat
 
-# Verifies that pydantic-ai PRs don't break the pydantic-ai-harness lint /
+# Verifies that pydantic-ai changes don't break the pydantic-ai-harness lint /
 # typecheck / test suite. Calls the harness's `compat-test.yml` reusable
-# workflow with the PR's HEAD SHA + repo (so fork PRs are tested against the
-# code in the fork, not main).
+# workflow with the change's HEAD SHA + repo (so fork PRs are tested against
+# the code in the fork, not main).
+#
+# Triggers:
+# - PRs touching `pydantic_ai_slim/**`: required to merge.
+# - Pushes to `main`: confirms the merged commit still works (catches
+#   anything that slipped through path-filter gaps).
+# - Push of `v*` tags: gates a release on harness compatibility.
 #
 # Fork PRs are gated behind the `safe-for-ci` label so a maintainer reviews
 # the diff before CI runs the fork's pydantic-ai code through the harness
@@ -20,6 +26,9 @@ on:
     types: [labeled, opened, synchronize, reopened]
     paths:
       - 'pydantic_ai_slim/**'
+  push:
+    branches: [main]
+    tags: ['v*']
 
 permissions:
   contents: read
@@ -28,9 +37,10 @@ jobs:
   harness-compat:
     name: harness compat
     if: >-
+      github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository ||
       contains(github.event.pull_request.labels.*.name, 'safe-for-ci')
     uses: pydantic/pydantic-ai-harness/.github/workflows/compat-test.yml@main
     with:
-      pydantic-ai-ref: ${{ github.event.pull_request.head.sha }}
-      pydantic-ai-repo: ${{ github.event.pull_request.head.repo.full_name }}
+      pydantic-ai-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      pydantic-ai-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/harness-compat.yml
+++ b/.github/workflows/harness-compat.yml
@@ -40,6 +40,8 @@ jobs:
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository ||
       contains(github.event.pull_request.labels.*.name, 'safe-for-ci')
+    # Same-org reusable workflow under shared maintenance; SHA pinning would force a coordination bump
+    # on every harness change without security benefit. Ignore configured in `.github/zizmor.yml`.
     uses: pydantic/pydantic-ai-harness/.github/workflows/compat-test.yml@main
     with:
       pydantic-ai-ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/harness-compat.yml
+++ b/.github/workflows/harness-compat.yml
@@ -18,14 +18,16 @@ name: Harness Compat
 # unreviewed code on CI infrastructure, not a privilege escalation barrier.
 #
 # Fork PRs without the label produce a `skipped` job result. Branch protection
-# should require this check to merge, so unlabeled fork PRs can't be merged
-# until a maintainer labels and re-runs.
+# should require this check to merge; the `harness-compat-gate` job in `ci.yml`
+# enforces the label requirement via the `check` gate (skipped == success here
+# is bypassed by `check` failing on fork-PR-without-label).
 
 on:
   pull_request:
     types: [labeled, opened, synchronize, reopened]
     paths:
       - 'pydantic_ai_slim/**'
+      - '.github/workflows/harness-compat.yml'
   push:
     branches: [main]
     tags: ['v*']

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -3,7 +3,7 @@ name: PR Guard
 on:
   # zizmor: ignore[dangerous-triggers] -- pull_request_target is needed to close duplicate PRs and manage issues; no fork code is checked out
   pull_request_target:
-    types: [opened, ready_for_review, edited]
+    types: [opened, ready_for_review, edited, synchronize]
 
 permissions: {}
 
@@ -13,6 +13,10 @@ concurrency:
 jobs:
   guard:
     name: Guard
+    # The duplicate / linking / assignment checks only need to run when the PR is
+    # opened, marked ready, or its body changes. `synchronize` (a push to the PR
+    # branch) is handled by `reset-safe-for-ci` below.
+    if: github.event.action != 'synchronize'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -177,3 +181,30 @@ jobs:
           GITHUB_EVENT_PULL_REQUEST_USER_LOGIN: ${{ github.event.pull_request.user.login }}
           GITHUB_EVENT_PULL_REQUEST_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           GITHUB_EVENT_PULL_REQUEST_DRAFT: ${{ github.event.pull_request.draft }}
+
+  # On every push to a fork PR, drop the `safe-for-ci` label so a maintainer has
+  # to re-review and re-add it before the harness-compat workflow runs against
+  # the new commits. Same-org PRs are exempt (they don't need the label to run
+  # cross-repo CI in the first place).
+  reset-safe-for-ci:
+    name: Reset `safe-for-ci` on push to fork PRs
+    if: |
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.fork &&
+      contains(github.event.pull_request.labels.*.name, 'safe-for-ci')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove `safe-for-ci` label and notify
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label safe-for-ci
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+            "New commits detected — removing the \`safe-for-ci\` label so the harness-compat workflow doesn't run unreviewed code. A maintainer should re-review the diff and re-add the label to retrigger." \
+            || true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -197,13 +197,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Remove `safe-for-ci` label and notify
-        run: |
-          set -euo pipefail
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label safe-for-ci
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
-            "New commits detected — removing the \`safe-for-ci\` label so the harness-compat workflow doesn't run unreviewed code. A maintainer should re-review the diff and re-add the label to retrigger." \
-            || true
+      - name: Remove `safe-for-ci` label
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label safe-for-ci
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,3 +19,11 @@ rules:
       - bots.yml
       - ci.yml
       - manually-deploy-docs.yml
+
+  # `harness-compat.yml` calls a reusable workflow in `pydantic/pydantic-ai-harness`, an
+  # org-internal repo under the same maintenance group. SHA-pinning the cross-repo reference
+  # would force coordinated bumps on every harness change without meaningful security benefit
+  # (the maintainer set is identical, so no additional supply-chain boundary is crossed).
+  unpinned-uses:
+    ignore:
+      - harness-compat.yml


### PR DESCRIPTION
- Closes #<issue>

### Summary

Adds a `Harness Compat` workflow that calls the harness's reusable `compat-test.yml` workflow on every pydantic-ai PR touching \`pydantic_ai_slim/**\`. The harness's lint / typecheck / test suite runs against the PR's HEAD SHA — the missing signal that would have caught the recent \`wrap_validation_errors\` regression before merge.

### How it works

- `.github/workflows/harness-compat.yml` triggers on `pull_request` with a path filter on `pydantic_ai_slim/**`.
- The job calls `pydantic/pydantic-ai-harness/.github/workflows/compat-test.yml@main` (added in pydantic/pydantic-ai-harness#223 — **must merge first**).
- The reusable workflow checks out harness@main, checks out pydantic-ai at the PR's `head.sha` from `head.repo.full_name`, rewrites `[tool.uv.sources]` to point `pydantic-ai-slim` at the local checkout, re-locks, then runs `ruff format --check`, `ruff check`, `pyright`, and `pytest`.
- Same-org reusable workflow calls don't need a PAT; status flows back as a normal PR check.

### Fork PR gating (`safe-for-ci` label)

Fork PRs check out and execute the fork's pydantic-ai code through the harness's CI runner. The called workflow runs **without secrets** and with `contents: read` only — there's no privileged access to leak — but we still don't want to spend CI minutes on every random PR that touches `pydantic_ai_slim/`, and a maintainer reviewing the diff first is reasonable defense-in-depth.

The job's `if:` only runs when:
- the PR is from the same repo (maintainer PRs auto-run), **or**
- the PR has the `safe-for-ci` label

Workflow trigger types include `labeled` so adding the label after the fact triggers a run. The `safe-for-ci` label has been created in this repo (green, `#0E8A16`).

**Maintainer follow-up after merge:** add `harness compat` to the required-status-checks list in branch protection so unlabeled fork PRs can't be merged until labeled and run.

Note that GitHub treats `synchronize` events on labeled PRs as eligible to re-run with the existing label still applied — i.e. the label persists across pushes. If strict per-push re-review is desired later, that's a separate change (a `pr-guard` workflow that auto-removes the label on `synchronize`).

### Order of operations

1. Merge pydantic/pydantic-ai-harness#223 first — the reusable workflow has to exist at `@main` before this job can call it.
2. Then merge this PR.

### Test plan

- [ ] Maintainer merges the harness PR.
- [ ] Open a no-op pydantic-ai PR that touches `pydantic_ai_slim/` from a fork to verify the gate (job is skipped without label, runs after label add).
- [ ] Open a same-org PR to verify the job auto-runs.
- [ ] Configure branch protection to require the `harness compat` check.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).