### PR TITLE
fix(agent): preserve provider for run model strings

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -2378,7 +2378,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 )
             model_ = some_model.value
         elif model is not None:
-            model_ = models.infer_model(model)
+            model_ = self._infer_run_model(model)
         elif self.model is not None:
             # noinspection PyTypeChecker
             model_ = self.model = models.infer_model(self.model)
@@ -2390,6 +2390,27 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             instrument = self._instrument_default
 
         return instrument_model(model_, instrument)
+
+    def _infer_run_model(self, model: models.Model | models.KnownModelName | str) -> models.Model:
+        if isinstance(model, models.Model):
+            return model
+
+        base_model = self.model
+        if isinstance(model, str) and ':' not in model and isinstance(base_model, models.Model):
+            if provider := base_model.provider:
+                with warnings.catch_warnings(record=True) as caught_warnings:
+                    warnings.simplefilter('always', DeprecationWarning)
+                    try:
+                        inferred_model = models.infer_model(model, provider_factory=lambda _: provider)
+                    except (TypeError, ValueError, exceptions.UserError):
+                        inferred_model = None
+
+                if isinstance(inferred_model, type(base_model)):
+                    for warning in caught_warnings:
+                        warnings.warn(warning.message, warning.category, stacklevel=3)
+                    return inferred_model
+
+        return models.infer_model(model)
 
     def _get_deps(self: Agent[T, OutputDataT], deps: T) -> T:
         """Get deps for a run.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -66,6 +66,7 @@ from pydantic_ai.builtin_tools import (
     WebSearchTool,
     WebSearchUserLocation,
 )
+from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.exceptions import ContentFilterError
 from pydantic_ai.messages import ModelResponseStreamEvent
 from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
@@ -4001,6 +4002,78 @@ def test_set_model(env: TestEnv):
 
     result = agent.run_sync('Hello')
     assert result.output == snapshot((0, 'a'))
+
+
+class _RecordRunModel(AbstractCapability[None]):
+    model: Model | None = None
+
+    async def for_run(self, ctx: RunContext[None]) -> Self:
+        self.model = ctx.model
+        return self
+
+
+@requires_google
+async def test_run_model_string_reuses_agent_provider_for_same_model_family():
+    assert GoogleProvider is not None
+    from pydantic_ai.models.google import GoogleModel
+
+    provider = GoogleProvider(project='test-project', location='us-central1')
+    agent = Agent(GoogleModel('gemini-2.5-flash', provider=provider))
+    record_model = _RecordRunModel()
+
+    with pytest.warns(DeprecationWarning, match='without a provider prefix'):
+        async with agent.iter('Hello', model='gemini-3-flash-preview', capabilities=[record_model]):
+            pass
+
+    model = record_model.model
+    assert isinstance(model, GoogleModel)
+    assert model.provider is provider
+    assert model.model_name == 'gemini-3-flash-preview'
+    assert model.system == 'google-vertex'
+
+
+@requires_google
+@requires_openai
+async def test_run_model_string_only_reuses_provider_for_same_model_family(env: TestEnv):
+    assert OpenAIProvider is not None
+    from pydantic_ai.models.google import GoogleModel
+    from pydantic_ai.models.openai import OpenAIChatModel
+
+    env.set('GOOGLE_API_KEY', 'foobar')
+    openai_provider = OpenAIProvider(api_key='foobar')
+    agent = Agent(OpenAIChatModel('gpt-5-mini', provider=openai_provider))
+    record_model = _RecordRunModel()
+
+    with pytest.warns(DeprecationWarning, match='without a provider prefix'):
+        async with agent.iter('Hello', model='gemini-3-flash-preview', capabilities=[record_model]):
+            pass
+
+    model = record_model.model
+    assert isinstance(model, GoogleModel)
+    assert model.provider is not openai_provider
+
+
+async def test_run_model_string_without_agent_provider_uses_standard_inference():
+    agent = Agent(FunctionModel(lambda _messages, _info: ModelResponse(parts=[TextPart('ok')])))
+    record_model = _RecordRunModel()
+
+    async with agent.iter('Hello', model='test', capabilities=[record_model]):
+        pass
+
+    assert isinstance(record_model.model, TestModel)
+
+
+@requires_google
+async def test_run_model_string_unknown_name_still_raises_after_provider_reuse_attempt():
+    assert GoogleProvider is not None
+    from pydantic_ai.models.google import GoogleModel
+
+    provider = GoogleProvider(project='test-project', location='us-central1')
+    agent = Agent(GoogleModel('gemini-2.5-flash', provider=provider))
+
+    with pytest.raises(UserError, match='Unknown model: not-a-known-model'):
+        async with agent.iter('Hello', model='not-a-known-model'):
+            pass
 
 
 def test_override_model_no_model():


### PR DESCRIPTION
Closes #5273

### Summary

- Reuse the agent model provider when a run-level legacy model string resolves to the same model family.
- Preserve existing behavior when the run-level string resolves to a different model family.
- Add public `Agent.iter(...)` coverage for the Google Vertex case and the cross-family fallback case.

### Tests

- `uv run pytest tests/test_agent.py::test_run_model_string_reuses_agent_provider_for_same_model_family tests/test_agent.py::test_run_model_string_only_reuses_provider_for_same_model_family -q`
- `uv run pytest tests/test_agent.py::test_set_model tests/test_agent.py::test_override_model tests/test_agent.py::test_run_model_string_reuses_agent_provider_for_same_model_family tests/test_agent.py::test_run_model_string_only_reuses_provider_for_same_model_family -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/agent/__init__.py tests/test_agent.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/agent/__init__.py tests/test_agent.py`
- `uv run pyright pydantic_ai_slim/pydantic_ai/agent/__init__.py tests/test_agent.py`
- `git diff --check`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).