### PR TITLE
models/mistral: distinguish missing module from missing name on import

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -90,10 +90,14 @@ try:
     from mistralai.client.types.basemodel import Unset as MistralUnset
     from mistralai.client.utils.eventstreaming import EventStreamAsync as MistralEventStreamAsync
 except ImportError as e:  # pragma: lax no cover
-    raise ImportError(
-        'Please install `mistral` to use the Mistral model, '
-        'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
-    ) from e
+    import importlib.util
+
+    if importlib.util.find_spec('mistralai') is None:
+        raise ImportError(
+            'Please install `mistral` to use the Mistral model, '
+            'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
+        ) from e
+    raise
 
 
 @contextmanager


### PR DESCRIPTION
Closes #4927. Use `importlib.util.find_spec` to tell apart module-not-installed vs. name-not-found in the import block, so users see the real error (e.g. `cannot import name 'UNSET'`) instead of being told to install mistralai.