### PR TITLE
Fix slack lead qualifier example path in docs

### DIFF
--- a/docs/examples/slack-lead-qualifier.md
+++ b/docs/examples/slack-lead-qualifier.md
@@ -41,7 +41,7 @@ You need to have a Slack workspace and the necessary permissions to create apps.
     - `#new-slack-leads`
     - `#daily-slack-leads-summary`
 
-    These names are hard-coded in the example. If you want to use different channels, you can clone the repo and change them in `examples/pydantic_examples/slack_lead_qualifier/functions.py`.
+    These names are hard-coded in the example. If you want to use different channels, you can clone the repo and change them in `examples/pydantic_ai_examples/slack_lead_qualifier/functions.py`.
 
 ### Logfire Write Token
 


### PR DESCRIPTION
Fixes an outdated example path in the Slack lead qualifier docs.

The docs referenced `examples/pydantic_examples/slack_lead_qualifier/functions.py`, but the actual example lives under `examples/pydantic_ai_examples/slack_lead_qualifier/functions.py`.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
