### PR TITLE
Fix TemporalDynamicToolset instruction propagation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -9,6 +9,7 @@ from temporalio.workflow import ActivityConfig
 
 from pydantic_ai import ToolsetTool
 from pydantic_ai.exceptions import UserError
+from pydantic_ai.messages import InstructionPart
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 from pydantic_ai.toolsets.external import TOOL_SCHEMA_VALIDATOR
@@ -78,6 +79,25 @@ class TemporalDynamicToolset(TemporalWrapperToolset[AgentDepsT]):
             get_tools_activity
         )
 
+        async def get_instructions_activity(
+            params: GetToolsParams, deps: AgentDepsT
+        ) -> str | InstructionPart | Sequence[str | InstructionPart] | None:
+            """Activity that resolves dynamic toolset and returns instructions."""
+            ctx = deserialize_run_context(
+                self.run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
+            )
+
+            run_toolset = await self.wrapped.for_run(ctx)
+            async with run_toolset:
+                run_toolset = await run_toolset.for_run_step(ctx)
+                return await run_toolset.get_instructions(ctx)
+
+        get_instructions_activity.__annotations__['deps'] = deps_type
+
+        self.get_instructions_activity = activity.defn(
+            name=f'{activity_name_prefix}__dynamic_toolset__{self.id}__get_instructions'
+        )(get_instructions_activity)
+
         async def call_tool_activity(params: CallToolParams, deps: AgentDepsT) -> CallToolResult:
             """Activity that instantiates the dynamic toolset and calls the tool."""
             ctx = deserialize_run_context(
@@ -105,7 +125,24 @@ class TemporalDynamicToolset(TemporalWrapperToolset[AgentDepsT]):
 
     @property
     def temporal_activities(self) -> list[Callable[..., Any]]:
-        return [self.get_tools_activity, self.call_tool_activity]
+        return [self.get_instructions_activity, self.get_tools_activity, self.call_tool_activity]
+
+    async def get_instructions(
+        self, ctx: RunContext[AgentDepsT]
+    ) -> str | InstructionPart | Sequence[str | InstructionPart] | None:
+        if not workflow.in_workflow():  # pragma: no cover
+            return await super().get_instructions(ctx)
+
+        serialized_run_context = self.run_context_type.serialize_run_context(ctx)
+        activity_config: ActivityConfig = {'summary': f'get instructions: {self.id}', **self.activity_config}
+        return await workflow.execute_activity(
+            activity=self.get_instructions_activity,
+            args=[
+                GetToolsParams(serialized_run_context=serialized_run_context),
+                ctx.deps,
+            ],
+            **activity_config,
+        )
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         if not workflow.in_workflow():  # pragma: no cover

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -2536,6 +2536,53 @@ async def test_temporal_mcp_toolset_instructions_propagate(client: Client):
         assert output == snapshot('Be a helpful assistant.')
 
 
+def return_dynamic_toolset_instructions(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(agent_info.instructions or '')])
+
+
+dynamic_instructions_agent = Agent(
+    FunctionModel(return_dynamic_toolset_instructions),
+    name='dynamic_instructions_agent',
+    deps_type=DynamicToolsetDeps,
+)
+
+
+@dynamic_instructions_agent.toolset(id='dynamic_instructions_toolset')
+def dynamic_instructions_toolset(ctx: RunContext[DynamicToolsetDeps]) -> FunctionToolset[DynamicToolsetDeps]:
+    return FunctionToolset(
+        id='dynamic_instructions_inner',
+        instructions=f'Address user {ctx.deps.user_name}.',
+    )
+
+
+dynamic_instructions_temporal_agent = TemporalAgent(dynamic_instructions_agent, activity_config=BASE_ACTIVITY_CONFIG)
+
+
+@workflow.defn
+class DynamicInstructionsWorkflow:
+    @workflow.run
+    async def run(self, prompt: str, deps: DynamicToolsetDeps) -> str:
+        result = await dynamic_instructions_temporal_agent.run(prompt, deps=deps)
+        return result.output
+
+
+async def test_temporal_dynamic_toolset_instructions_propagate(client: Client):
+    """Dynamic toolset instructions should propagate through Temporal wrapper toolsets."""
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[DynamicInstructionsWorkflow],
+        plugins=[AgentPlugin(dynamic_instructions_temporal_agent)],
+    ):
+        output = await client.execute_workflow(
+            DynamicInstructionsWorkflow.run,
+            args=['Use dynamic toolset instructions', DynamicToolsetDeps(user_name='Alice')],
+            id=DynamicInstructionsWorkflow.__name__,
+            task_queue=TASK_QUEUE,
+        )
+        assert output == snapshot('Address user Alice.')
+
+
 image_agent = Agent(model, name='image_agent', output_type=BinaryImage)
 
 # This needs to be done before the `TemporalAgent` is bound to the workflow.


### PR DESCRIPTION
## Summary
- route TemporalDynamicToolset.get_instructions() through a Temporal activity, matching the existing remote handling for tools and calls
- preserve instructions from dynamically resolved toolsets inside Temporal workflows
- add a regression test covering dynamic toolset instruction propagation

Closes #5282

## Testing
- uv run pytest tests/test_temporal.py -k " dynamic_toolset_instructions_propagate or temporal_mcp_toolset_instructions_propagate\