### PR TITLE
fix(pydantic-graph): replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -51,12 +51,23 @@ except ImportError:  # pragma: no cover
 
 
 def get_event_loop():
+    """Return the running event loop, or create and set a new one if none exists.
+
+    Uses ``asyncio.get_running_loop()`` when called from within a coroutine or
+    callback, falling back to ``asyncio.new_event_loop()`` when there is no
+    running loop (e.g. in a synchronous context or a fresh thread).
+
+    Note:
+        ``asyncio.get_event_loop()`` is deprecated since Python 3.12 and emits
+        a ``DeprecationWarning`` when there is no current event loop. This
+        implementation avoids that warning while preserving the same behaviour.
+    """
     try:
-        event_loop = asyncio.get_event_loop()
+        return asyncio.get_running_loop()
     except RuntimeError:
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
-    return event_loop
+        return event_loop
 
 
 def get_union_args(tp: Any) -> tuple[Any, ...]:


### PR DESCRIPTION
Fixes #1196

## Problem

`asyncio.get_event_loop()` is deprecated since Python 3.12 and emits a `DeprecationWarning` when called outside of a running event loop (e.g. in tests, fresh threads, or synchronous entry points):

```
DeprecationWarning: There is no current event loop
```

This warning is triggered by `get_event_loop()` in `pydantic_graph/_utils.py`.

## Fix

Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()`, which is the recommended replacement in Python 3.10+:

- When called from within a coroutine or task, `get_running_loop()` returns the running loop immediately — no deprecation warning, no overhead.
- When called outside a running loop (synchronous context, fresh thread), it raises `RuntimeError`, which is caught to create and set a new event loop — the same fallback behaviour as before, without the warning.

A docstring is added explaining the rationale.

## Change

```python
# Before
def get_event_loop():
    try:
        event_loop = asyncio.get_event_loop()
    except RuntimeError:
        event_loop = asyncio.new_event_loop()
        asyncio.set_event_loop(event_loop)
    return event_loop

# After
def get_event_loop():
    try:
        return asyncio.get_running_loop()
    except RuntimeError:
        event_loop = asyncio.new_event_loop()
        asyncio.set_event_loop(event_loop)
        return event_loop
```

No behaviour change for callers — the function still returns a usable event loop in all cases.