### PR TITLE
Fix Temporal dynamic toolset instructions

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+import inspect
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -9,7 +10,9 @@ from temporalio.workflow import ActivityConfig
 
 from pydantic_ai import ToolsetTool
 from pydantic_ai.exceptions import UserError
+from pydantic_ai.messages import InstructionPart
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
+from pydantic_ai.toolsets import AbstractToolset
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 from pydantic_ai.toolsets.external import TOOL_SCHEMA_VALIDATOR
 
@@ -33,6 +36,28 @@ class _ToolInfo:
     max_retries: int
 
 
+def _mcp_instructions_disabled(toolset: AbstractToolset[AgentDepsT]) -> bool:
+    mcp_toolset_types: tuple[type, ...] = ()
+    try:
+        from pydantic_ai.mcp import MCPServer
+
+        mcp_toolset_types += (MCPServer,)
+    except ImportError:
+        pass
+
+    try:
+        from pydantic_ai.toolsets.fastmcp import FastMCPToolset
+
+        mcp_toolset_types += (FastMCPToolset,)
+    except ImportError:
+        pass
+
+    if mcp_toolset_types and isinstance(toolset, mcp_toolset_types):
+        return not toolset.include_instructions  # type: ignore[union-attr]
+
+    return False
+
+
 class TemporalDynamicToolset(TemporalWrapperToolset[AgentDepsT]):
     """Temporal wrapper for DynamicToolset.
 
@@ -52,6 +77,7 @@ class TemporalDynamicToolset(TemporalWrapperToolset[AgentDepsT]):
         agent: AbstractAgent[AgentDepsT, Any] | None = None,
     ):
         super().__init__(toolset)
+        self._dynamic_toolset = toolset
         self._agent = agent
         self.activity_config = activity_config
         self.tool_activity_config = tool_activity_config
@@ -77,6 +103,31 @@ class TemporalDynamicToolset(TemporalWrapperToolset[AgentDepsT]):
         self.get_tools_activity = activity.defn(name=f'{activity_name_prefix}__dynamic_toolset__{self.id}__get_tools')(
             get_tools_activity
         )
+
+        async def get_instructions_activity(
+            params: GetToolsParams, deps: AgentDepsT
+        ) -> str | InstructionPart | Sequence[str | InstructionPart] | None:
+            """Activity that calls the dynamic function and returns toolset instructions."""
+            ctx = deserialize_run_context(
+                self.run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
+            )
+
+            toolset = self._dynamic_toolset.toolset_func(ctx)
+            if inspect.isawaitable(toolset):
+                toolset = await toolset
+
+            # MCP instructions only exist when explicitly enabled; don't open a server session otherwise.
+            if toolset is None or _mcp_instructions_disabled(toolset):
+                return None
+
+            async with toolset:
+                return await toolset.get_instructions(ctx)
+
+        get_instructions_activity.__annotations__['deps'] = deps_type
+
+        self.get_instructions_activity = activity.defn(
+            name=f'{activity_name_prefix}__dynamic_toolset__{self.id}__get_instructions'
+        )(get_instructions_activity)
 
         async def call_tool_activity(params: CallToolParams, deps: AgentDepsT) -> CallToolResult:
             """Activity that instantiates the dynamic toolset and calls the tool."""
@@ -105,7 +156,24 @@ class TemporalDynamicToolset(TemporalWrapperToolset[AgentDepsT]):
 
     @property
     def temporal_activities(self) -> list[Callable[..., Any]]:
-        return [self.get_tools_activity, self.call_tool_activity]
+        return [self.get_instructions_activity, self.get_tools_activity, self.call_tool_activity]
+
+    async def get_instructions(
+        self, ctx: RunContext[AgentDepsT]
+    ) -> str | InstructionPart | Sequence[str | InstructionPart] | None:
+        if not workflow.in_workflow():  # pragma: no cover
+            return await super().get_instructions(ctx)
+
+        serialized_run_context = self.run_context_type.serialize_run_context(ctx)
+        activity_config: ActivityConfig = {'summary': f'get instructions: {self.id}', **self.activity_config}
+        return await workflow.execute_activity(
+            activity=self.get_instructions_activity,
+            args=[
+                GetToolsParams(serialized_run_context=serialized_run_context),
+                ctx.deps,
+            ],
+            **activity_config,
+        )
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         if not workflow.in_workflow():  # pragma: no cover

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1293,6 +1293,55 @@ async def test_dynamic_toolset_outside_workflow():
     assert result.output == snapshot('{"get_dynamic_weather":"Weather in a for Bob: sunny."}')
 
 
+def return_dynamic_toolset_instructions(messages: list[ModelMessage], agent_info: AgentInfo) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(agent_info.instructions or '')])
+
+
+dynamic_toolset_instructions_agent = Agent(
+    FunctionModel(return_dynamic_toolset_instructions), name='dynamic_toolset_instructions_agent'
+)
+
+
+@dynamic_toolset_instructions_agent.toolset(id='dynamic_instruction_toolset', per_run_step=False)
+async def my_dynamic_instruction_toolset(ctx: RunContext[None]) -> FunctionToolset[None]:
+    toolset = FunctionToolset[None](
+        id='dynamic_instruction_tools',
+        instructions='IMPORTANT_SENTINEL_INSTRUCTION_FROM_DYNAMIC_TOOLSET',
+    )
+    return toolset
+
+
+dynamic_toolset_instructions_temporal_agent = TemporalAgent(
+    dynamic_toolset_instructions_agent,
+    activity_config=BASE_ACTIVITY_CONFIG,
+)
+
+
+@workflow.defn
+class DynamicToolsetInstructionsWorkflow:
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        result = await dynamic_toolset_instructions_temporal_agent.run(prompt)
+        return result.output
+
+
+async def test_dynamic_toolset_instructions_in_workflow(client: Client):
+    """Instructions from a dynamic toolset should propagate through Temporal activities."""
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[DynamicToolsetInstructionsWorkflow],
+        plugins=[AgentPlugin(dynamic_toolset_instructions_temporal_agent)],
+    ):
+        output = await client.execute_workflow(
+            DynamicToolsetInstructionsWorkflow.run,
+            args=['Use the dynamic toolset instructions'],
+            id=DynamicToolsetInstructionsWorkflow.__name__,
+            task_queue=TASK_QUEUE,
+        )
+        assert output == snapshot('IMPORTANT_SENTINEL_INSTRUCTION_FROM_DYNAMIC_TOOLSET')
+
+
 # --- MCP-based DynamicToolset test ---
 # Tests that @agent.toolset with an MCP toolset works with Temporal workflows.
 # Uses MCPServerStreamableHTTP (HTTP-based) rather than subprocess-based MCP servers.


### PR DESCRIPTION
- Closes #5282

### Summary

This fixes `TemporalDynamicToolset` so instructions from a resolved dynamic toolset are fetched through a Temporal activity, matching the existing activity-backed handling for dynamic tool discovery and tool calls.

The previous workflow path kept the wrapped `DynamicToolset` unresolved in workflow memory, so inherited `get_instructions()` delegated to an unresolved toolset and returned `None`. The new `get_instructions` activity resolves the dynamic toolset inside the activity, enters it, applies the run-step resolution, and returns its toolset instructions.

### Tests

- `uv run pytest tests/test_temporal.py::test_dynamic_toolset_instructions_in_workflow tests/test_temporal.py::test_temporal_mcp_toolset_instructions_propagate -q`
- `uv run pytest tests/test_temporal.py::test_dynamic_toolset_in_workflow tests/test_temporal.py::test_dynamic_toolset_outside_workflow tests/test_temporal.py::test_dynamic_toolset_instructions_in_workflow -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py tests/test_temporal.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py tests/test_temporal.py`
- `uv run pyright pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py`

Repo-wide pre-commit `typecheck` was skipped during commit because this fresh worktree is missing optional dependencies used by unrelated examples/tests (`fastapi`, `pandas`, `dbos`, `prefect`, etc.). The changed source file passes Pyright directly.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).