### PR TITLE
Stop draining streamed responses after early exit

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -69,7 +69,7 @@ There are five ways to run an agent:
 1. [`agent.run()`][pydantic_ai.agent.AbstractAgent.run] — an async function which returns a [`RunResult`][pydantic_ai.agent.AgentRunResult] containing a completed response.
 2. [`agent.run_sync()`][pydantic_ai.agent.AbstractAgent.run_sync] — a plain, synchronous function which returns a [`RunResult`][pydantic_ai.agent.AgentRunResult] containing a completed response (internally, this just calls `loop.run_until_complete(self.run())`).
 3. [`agent.run_stream()`][pydantic_ai.agent.AbstractAgent.run_stream] — an async context manager which returns a [`StreamedRunResult`][pydantic_ai.result.StreamedRunResult], which contains methods to stream text and structured output as an async iterable. [`agent.run_stream_sync()`][pydantic_ai.agent.AbstractAgent.run_stream_sync] is a synchronous variation that returns a [`StreamedRunResultSync`][pydantic_ai.result.StreamedRunResultSync] with synchronous versions of the same methods.
-4. [`agent.run_stream_events()`][pydantic_ai.agent.AbstractAgent.run_stream_events] — a function which returns an async iterable of [`AgentStreamEvent`s][pydantic_ai.messages.AgentStreamEvent] and a [`AgentRunResultEvent`][pydantic_ai.run.AgentRunResultEvent] containing the final run result.
+4. [`agent.run_stream_events()`][pydantic_ai.agent.AbstractAgent.run_stream_events] — a function which returns an async context manager for streaming [`AgentStreamEvent`s][pydantic_ai.messages.AgentStreamEvent] and a [`AgentRunResultEvent`][pydantic_ai.run.AgentRunResultEvent] containing the final run result.
 5. [`agent.iter()`][pydantic_ai.agent.Agent.iter] — a context manager which returns an [`AgentRun`][pydantic_ai.agent.AgentRun], an async iterable over the nodes of the agent's underlying [`Graph`][pydantic_graph.graph.Graph].
 
 Here's a simple example demonstrating the first four:
@@ -97,8 +97,9 @@ async def main():
             #> The capital of the UK is London.
 
     events: list[AgentStreamEvent | AgentRunResultEvent] = []
-    async for event in agent.run_stream_events('What is the capital of Mexico?'):
-        events.append(event)
+    async with agent.run_stream_events('What is the capital of Mexico?') as stream:
+        async for event in stream:
+            events.append(event)
     print(events)
     """
     [
@@ -237,7 +238,7 @@ Like `agent.run_stream()`, [`agent.run()`][pydantic_ai.agent.AbstractAgent.run_s
 argument that lets you stream all events from the model's streaming response and the agent's execution of tools.
 Unlike `run_stream()`, it always runs the agent graph to completion even if text was received ahead of tool calls that looked like it could've been the final result.
 
-For convenience, a [`agent.run_stream_events()`][pydantic_ai.agent.AbstractAgent.run_stream_events] method is also available as a wrapper around `run(event_stream_handler=...)`, which returns an async iterable of [`AgentStreamEvent`s][pydantic_ai.messages.AgentStreamEvent] and a [`AgentRunResultEvent`][pydantic_ai.run.AgentRunResultEvent] containing the final run result.
+For convenience, a [`agent.run_stream_events()`][pydantic_ai.agent.AbstractAgent.run_stream_events] method is also available as a wrapper around `run(event_stream_handler=...)`, which returns an async context manager for streaming [`AgentStreamEvent`s][pydantic_ai.messages.AgentStreamEvent] and a [`AgentRunResultEvent`][pydantic_ai.run.AgentRunResultEvent] containing the final run result.
 
 !!! note
     As they return raw events as they come in, the `run_stream_events()` and `run(event_stream_handler=...)` methods require you to piece together the streamed text and structured output yourself from the `PartStartEvent` and subsequent `PartDeltaEvent`s.
@@ -255,11 +256,12 @@ from run_stream_event_stream_handler import handle_event, output_messages, weath
 async def main():
     user_prompt = 'What will the weather be like in Paris on Tuesday?'
 
-    async for event in weather_agent.run_stream_events(user_prompt):
-        if isinstance(event, AgentRunResultEvent):
-            output_messages.append(f'[Final Output] {event.result.output}')
-        else:
-            await handle_event(event)
+    async with weather_agent.run_stream_events(user_prompt) as stream:
+        async for event in stream:
+            if isinstance(event, AgentRunResultEvent):
+                output_messages.append(f'[Final Output] {event.result.output}')
+            else:
+                await handle_event(event)
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -122,6 +122,7 @@ from .profiles import (
     ModelProfile,
     ModelProfileSpec,
 )
+from .result import AgentEventStream
 from .run import AgentRun, AgentRunResult, AgentRunResultEvent
 from .settings import ModelSettings
 from .tools import (
@@ -314,6 +315,8 @@ __all__ = (
     'RunUsage',
     'RequestUsage',
     'UsageLimits',
+    # result
+    'AgentEventStream',
     # run
     'AgentRun',
     'AgentRunResult',

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -666,11 +666,9 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
 
         # Normal path: handler was called, stream is ready
         stream_error: BaseException | None = None
+        agent_stream = agent_stream_holder[0]
         try:
-            yield agent_stream_holder[0]
-            # Ensure stream is fully consumed for proper usage counting
-            async for _ in agent_stream_holder[0]:
-                pass
+            yield agent_stream
         except BaseException as exc:
             stream_error = exc
             raise

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -16,7 +16,19 @@ from dataclasses import dataclass, fields, is_dataclass
 from datetime import datetime, timezone
 from functools import partial
 from types import GenericAlias
-from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeGuard, TypeVar, get_args, get_origin, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Protocol,
+    TypeAlias,
+    TypeGuard,
+    TypeVar,
+    get_args,
+    get_origin,
+    overload,
+    runtime_checkable,
+)
 
 import anyio
 from anyio.to_thread import run_sync
@@ -165,6 +177,16 @@ def _contains_ref(obj: JsonSchemaValue | list[JsonSchemaValue]) -> bool:
 T = TypeVar('T')
 
 
+@runtime_checkable
+class _AsyncCloseable(Protocol):
+    async def aclose(self) -> None: ...
+
+
+async def aclose_if_available(value: object) -> None:
+    if isinstance(value, _AsyncCloseable):
+        await value.aclose()
+
+
 @dataclass
 class Some(Generic[T]):
     """Analogous to Rust's `Option::Some` type."""
@@ -229,9 +251,7 @@ async def _cleanup_temporal_group(
         task.cancel('Cancelling group_by_temporal pending task')
         with suppress(asyncio.CancelledError, StopAsyncIteration):
             await task
-    aclose = getattr(aiterator, 'aclose', None)
-    if aclose is not None:  # pragma: no branch
-        await aclose()
+    await aclose_if_available(aiterator)
 
 
 @asynccontextmanager
@@ -450,6 +470,13 @@ class PeekableAsyncStream(Generic[T]):
         except StopAsyncIteration:
             self._exhausted = True
             raise
+
+    async def aclose(self) -> None:
+        self._exhausted = True
+        if self._source_iter is not None:
+            await aclose_if_available(self._source_iter)
+        else:
+            await aclose_if_available(self._source)
 
 
 def get_traceparent(x: AgentRun | AgentRunResult | GraphRun | GraphRunResult) -> str:

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1060,8 +1060,9 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
 
         async def main():
             events: list[AgentStreamEvent | AgentRunResultEvent] = []
-            async for event in agent.run_stream_events('What is the capital of France?'):
-                events.append(event)
+            async with agent.run_stream_events('What is the capital of France?') as stream:
+                async for event in stream:
+                    events.append(event)
             print(events)
             '''
             [
@@ -1079,7 +1080,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         ```
 
         Arguments are the same as for [`self.run`][pydantic_ai.agent.AbstractAgent.run],
-        except that `event_stream_handler` is now allowed.
+        except that `event_stream_handler` is managed internally by this method.
 
         Args:
             user_prompt: User input to start/continue the conversation.
@@ -1105,8 +1106,8 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             spec: Optional agent spec to apply for this run. At run time, spec values are additive.
 
         Returns:
-            An async iterable of stream events `AgentStreamEvent` and finally a `AgentRunResultEvent` with the final
-            run result.
+            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which is both an async iterator of stream
+            events and an async context manager for deterministic cleanup.
         """
         if infer_name and self.name is None:
             self._infer_name(inspect.currentframe())

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1203,8 +1203,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             raise
 
         except BaseException:
-            if not task.done():
-                task.cancel()
+            task.cancel()
 
             # The consumer side is already exiting. Await the producer only to
             # retrieve its exception and finish cleanup; it must not replace the

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -5,7 +5,7 @@ import inspect
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Iterator, Mapping, Sequence
 from concurrent.futures import Executor
-from contextlib import AbstractAsyncContextManager, asynccontextmanager, contextmanager
+from contextlib import AbstractAsyncContextManager, asynccontextmanager, contextmanager, suppress
 from types import FrameType
 from typing import TYPE_CHECKING, Any, Generic, TypeAlias, cast, overload
 
@@ -1001,7 +1001,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]]: ...
+    ) -> result.AgentEventStream[OutputDataT]: ...
 
     @overload
     def run_stream_events(
@@ -1024,7 +1024,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[RunOutputDataT]]: ...
+    ) -> result.AgentEventStream[RunOutputDataT]: ...
 
     def run_stream_events(
         self,
@@ -1046,7 +1046,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[Any]]:
+    ) -> result.AgentEventStream[Any]:
         """Run the agent with a user prompt in async mode and stream events from the run.
 
         This is a convenience method that wraps [`self.run`][pydantic_ai.agent.AbstractAgent.run] and
@@ -1114,23 +1114,25 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         # unfortunately this hack of returning a generator rather than defining it right here is
         # required to allow overloads of this method to work in python's typing system, or at least with pyright
         # or at least I couldn't make it work without
-        return self._run_stream_events(
-            user_prompt,
-            output_type=output_type,
-            message_history=message_history,
-            deferred_tool_results=deferred_tool_results,
-            conversation_id=conversation_id,
-            model=model,
-            instructions=instructions,
-            deps=deps,
-            model_settings=model_settings,
-            usage_limits=usage_limits,
-            usage=usage,
-            metadata=metadata,
-            toolsets=toolsets,
-            builtin_tools=builtin_tools,
-            capabilities=capabilities,
-            spec=spec,
+        return result.AgentEventStream(
+            self._run_stream_events(
+                user_prompt,
+                output_type=output_type,
+                message_history=message_history,
+                deferred_tool_results=deferred_tool_results,
+                conversation_id=conversation_id,
+                model=model,
+                instructions=instructions,
+                deps=deps,
+                model_settings=model_settings,
+                usage_limits=usage_limits,
+                usage=usage,
+                metadata=metadata,
+                toolsets=toolsets,
+                builtin_tools=builtin_tools,
+                capabilities=capabilities,
+                spec=spec,
+            )
         )
 
     async def _run_stream_events(
@@ -1187,6 +1189,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                 )
 
         task = asyncio.create_task(run_agent())
+        task_cancel_sent = False
 
         try:
             async with receive_stream:
@@ -1197,7 +1200,14 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
 
         except asyncio.CancelledError as e:
             task.cancel(msg=e.args[0] if len(e.args) != 0 else None)
+            task_cancel_sent = True
             raise
+        finally:
+            if not task.done() and not task_cancel_sent:
+                task.cancel()
+
+            with suppress(asyncio.CancelledError, anyio.BrokenResourceError, anyio.ClosedResourceError):
+                await task
 
         yield AgentRunResultEvent(result)
 

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1190,27 +1190,32 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                 )
 
         task = asyncio.create_task(run_agent())
-        task_cancel_sent = False
 
         try:
             async with receive_stream:
                 async for message in receive_stream:
                     yield message
 
-            result = await task
-
         except asyncio.CancelledError as e:
             task.cancel(msg=e.args[0] if len(e.args) != 0 else None)
-            task_cancel_sent = True
+            with suppress(BaseException):
+                await task
             raise
-        finally:
-            if not task.done() and not task_cancel_sent:
+
+        except BaseException:
+            if not task.done():
                 task.cancel()
 
-            with suppress(asyncio.CancelledError, anyio.BrokenResourceError, anyio.ClosedResourceError):
+            # The consumer side is already exiting. Await the producer only to
+            # retrieve its exception and finish cleanup; it must not replace the
+            # exception that is already propagating from the consumer side.
+            with suppress(BaseException):
                 await task
+            raise
 
-        yield AgentRunResultEvent(result)
+        else:
+            result = await task
+            yield AgentRunResultEvent(result)
 
     @overload
     def iter(

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1106,8 +1106,8 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             spec: Optional agent spec to apply for this run. At run time, spec values are additive.
 
         Returns:
-            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which is both an async iterator of stream
-            events and an async context manager for deterministic cleanup.
+            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which should be used as an async context
+            manager for deterministic cleanup. Direct iteration without `async with` is deprecated.
         """
         if infer_name and self.name is None:
             self._infer_name(inspect.currentframe())

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -790,8 +790,9 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
 
         async def main():
             events: list[AgentStreamEvent | AgentRunResultEvent] = []
-            async for event in agent.run_stream_events('What is the capital of France?'):
-                events.append(event)
+            async with agent.run_stream_events('What is the capital of France?') as stream:
+                async for event in stream:
+                    events.append(event)
             print(events)
             '''
             [
@@ -809,7 +810,7 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
         ```
 
         Arguments are the same as for [`self.run`][pydantic_ai.agent.AbstractAgent.run],
-        except that `event_stream_handler` is now allowed.
+        except that `event_stream_handler` is managed internally by this method.
 
         Args:
             user_prompt: User input to start/continue the conversation.
@@ -833,8 +834,8 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
             spec: Optional agent spec to apply for this run.
 
         Returns:
-            An async iterable of stream events `AgentStreamEvent` and finally a `AgentRunResultEvent` with the final
-            run result.
+            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which is both an async iterator of stream
+            events and an async context manager for deterministic cleanup.
         """
         raise UserError(
             '`agent.run_stream_events()` cannot be used with DBOS. '

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -9,7 +9,6 @@ from typing_extensions import Never
 
 from pydantic_ai import (
     AbstractToolset,
-    AgentRunResultEvent,
     _instructions,
     _utils,
     messages as _messages,
@@ -29,7 +28,7 @@ from pydantic_ai.capabilities import AgentCapability
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import Model
 from pydantic_ai.output import OutputDataT, OutputSpec
-from pydantic_ai.result import StreamedRunResult
+from pydantic_ai.result import AgentEventStream, StreamedRunResult
 from pydantic_ai.tools import (
     AgentBuiltinTool,
     AgentDepsT,
@@ -732,7 +731,7 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]]: ...
+    ) -> AgentEventStream[OutputDataT]: ...
 
     @overload
     def run_stream_events(
@@ -755,7 +754,7 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[RunOutputDataT]]: ...
+    ) -> AgentEventStream[RunOutputDataT]: ...
 
     def run_stream_events(
         self,
@@ -777,7 +776,7 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[Any]]:
+    ) -> AgentEventStream[Any]:
         """Run the agent with a user prompt in async mode and stream events from the run.
 
         This is a convenience method that wraps [`self.run`][pydantic_ai.agent.AbstractAgent.run] and

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -834,8 +834,8 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
             spec: Optional agent spec to apply for this run.
 
         Returns:
-            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which is both an async iterator of stream
-            events and an async context manager for deterministic cleanup.
+            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which should be used as an async context
+            manager for deterministic cleanup. Direct iteration without `async with` is deprecated.
         """
         raise UserError(
             '`agent.run_stream_events()` cannot be used with DBOS. '

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
@@ -687,8 +687,9 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
 
         async def main():
             events: list[AgentStreamEvent | AgentRunResultEvent] = []
-            async for event in agent.run_stream_events('What is the capital of France?'):
-                events.append(event)
+            async with agent.run_stream_events('What is the capital of France?') as stream:
+                async for event in stream:
+                    events.append(event)
             print(events)
             '''
             [
@@ -706,7 +707,7 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         ```
 
         Arguments are the same as for [`self.run`][pydantic_ai.agent.AbstractAgent.run],
-        except that `event_stream_handler` is now allowed.
+        except that `event_stream_handler` is managed internally by this method.
 
         Args:
             user_prompt: User input to start/continue the conversation.
@@ -730,8 +731,8 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             spec: Optional agent spec to apply for this run.
 
         Returns:
-            An async iterable of stream events `AgentStreamEvent` and finally a `AgentRunResultEvent` with the final
-            run result.
+            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which is both an async iterator of stream
+            events and an async context manager for deterministic cleanup.
         """
         if FlowRunContext.get() is not None:
             raise UserError(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
@@ -12,7 +12,6 @@ from typing_extensions import Never
 
 from pydantic_ai import (
     AbstractToolset,
-    AgentRunResultEvent,
     _instructions,
     _utils,
     messages as _messages,
@@ -25,7 +24,7 @@ from pydantic_ai.capabilities import AgentCapability
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import Model
 from pydantic_ai.output import OutputDataT, OutputSpec
-from pydantic_ai.result import StreamedRunResult
+from pydantic_ai.result import AgentEventStream, StreamedRunResult
 from pydantic_ai.tools import (
     AgentBuiltinTool,
     AgentDepsT,
@@ -629,7 +628,7 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]]: ...
+    ) -> AgentEventStream[OutputDataT]: ...
 
     @overload
     def run_stream_events(
@@ -652,7 +651,7 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[RunOutputDataT]]: ...
+    ) -> AgentEventStream[RunOutputDataT]: ...
 
     def run_stream_events(
         self,
@@ -674,7 +673,7 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[Any]]:
+    ) -> AgentEventStream[Any]:
         """Run the agent with a user prompt in async mode and stream events from the run.
 
         This is a convenience method that wraps [`self.run`][pydantic_ai.agent.AbstractAgent.run] and

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
@@ -731,8 +731,8 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             spec: Optional agent spec to apply for this run.
 
         Returns:
-            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which is both an async iterator of stream
-            events and an async context manager for deterministic cleanup.
+            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which should be used as an async context
+            manager for deterministic cleanup. Direct iteration without `async with` is deprecated.
         """
         if FlowRunContext.get() is not None:
             raise UserError(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -847,8 +847,8 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             spec: Optional agent spec to apply for this run.
 
         Returns:
-            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which is both an async iterator of stream
-            events and an async context manager for deterministic cleanup.
+            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which should be used as an async context
+            manager for deterministic cleanup. Direct iteration without `async with` is deprecated.
         """
         if workflow.in_workflow():
             raise UserError(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -803,8 +803,9 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
 
         async def main():
             events: list[AgentStreamEvent | AgentRunResultEvent] = []
-            async for event in agent.run_stream_events('What is the capital of France?'):
-                events.append(event)
+            async with agent.run_stream_events('What is the capital of France?') as stream:
+                async for event in stream:
+                    events.append(event)
             print(events)
             '''
             [
@@ -822,7 +823,7 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         ```
 
         Arguments are the same as for [`self.run`][pydantic_ai.agent.AbstractAgent.run],
-        except that `event_stream_handler` is now allowed.
+        except that `event_stream_handler` is managed internally by this method.
 
         Args:
             user_prompt: User input to start/continue the conversation.
@@ -846,8 +847,8 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             spec: Optional agent spec to apply for this run.
 
         Returns:
-            An async iterable of stream events `AgentStreamEvent` and finally a `AgentRunResultEvent` with the final
-            run result.
+            An [`AgentEventStream`][pydantic_ai.result.AgentEventStream], which is both an async iterator of stream
+            events and an async context manager for deterministic cleanup.
         """
         if workflow.in_workflow():
             raise UserError(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -18,7 +18,6 @@ from typing_extensions import Never
 
 from pydantic_ai import (
     AbstractToolset,
-    AgentRunResultEvent,
     _instructions,
     _utils,
     messages as _messages,
@@ -31,7 +30,7 @@ from pydantic_ai.capabilities import AgentCapability
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import Model
 from pydantic_ai.output import OutputDataT, OutputSpec
-from pydantic_ai.result import StreamedRunResult
+from pydantic_ai.result import AgentEventStream, StreamedRunResult
 from pydantic_ai.tools import (
     AgentBuiltinTool,
     AgentDepsT,
@@ -745,7 +744,7 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]]: ...
+    ) -> AgentEventStream[OutputDataT]: ...
 
     @overload
     def run_stream_events(
@@ -768,7 +767,7 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[RunOutputDataT]]: ...
+    ) -> AgentEventStream[RunOutputDataT]: ...
 
     def run_stream_events(
         self,
@@ -790,7 +789,7 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | AgentSpec | None = None,
-    ) -> AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[Any]]:
+    ) -> AgentEventStream[Any]:
         """Run the agent with a user prompt in async mode and stream events from the run.
 
         This is a convenience method that wraps [`self.run`][pydantic_ai.agent.AbstractAgent.run] and

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -187,11 +187,14 @@ class FunctionModel(Model):
         if isinstance(first, _utils.Unset):
             raise ValueError('Stream function must return at least one item')
 
-        yield FunctionStreamedResponse(
-            model_request_parameters=model_request_parameters,
-            _model_name=self._model_name,
-            _iter=response_stream,
-        )
+        try:
+            yield FunctionStreamedResponse(
+                model_request_parameters=model_request_parameters,
+                _model_name=self._model_name,
+                _iter=response_stream,
+            )
+        finally:
+            await response_stream.aclose()
 
     @property
     def provider(self) -> None:

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -538,7 +538,10 @@ class GoogleModel(Model[Client]):
         )
         model_settings = cast(GoogleModelSettings, model_settings or {})
         response = await self._generate_content(messages, True, model_settings, model_request_parameters)
-        yield await self._process_streamed_response(response, model_request_parameters)  # type: ignore
+        try:
+            yield await self._process_streamed_response(response, model_request_parameters)  # type: ignore
+        finally:
+            await _utils.aclose_if_available(response)
 
     def _build_image_config(self, tool: ImageGenerationTool) -> ImageConfigDict:
         """Build ImageConfigDict from ImageGenerationTool with validation."""

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -217,7 +217,10 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
         response = await self._completions_create(
             messages, True, cast(HuggingFaceModelSettings, model_settings or {}), model_request_parameters
         )
-        yield await self._process_streamed_response(response, model_request_parameters)
+        try:
+            yield await self._process_streamed_response(response, model_request_parameters)
+        finally:
+            await _utils.aclose_if_available(response)
 
     @overload
     async def _completions_create(

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -784,7 +784,10 @@ class XaiModel(Model[AsyncClient]):
 
         chat = await self._create_chat(messages, cast(XaiModelSettings, model_settings or {}), model_request_parameters)
         response_stream = chat.stream()
-        yield await self._process_streamed_response(response_stream, model_request_parameters)
+        try:
+            yield await self._process_streamed_response(response_stream, model_request_parameters)
+        finally:
+            await _utils.aclose_if_available(response_stream)
 
     def _process_response(self, response: chat_types.Response) -> ModelResponse:
         """Convert xAI SDK response to pydantic_ai ModelResponse.

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterable, Iterator
 from contextlib import aclosing
 from copy import deepcopy
@@ -351,27 +352,53 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
 class AgentEventStream(Generic[OutputDataT]):
     """Async event stream returned by `Agent.run_stream_events()`.
 
-    Wraps the underlying async generator so callers can either iterate over it
-    directly or use it as an async context manager for deterministic cleanup.
+    Use it as an async context manager for deterministic cleanup.
+
+    Direct iteration with `async for event in stream:` (without `async with`)
+    is deprecated and will be removed in v2.
     """
 
     def __init__(self, generator: AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]]) -> None:
         self._generator = generator
+        self._managed = False
+        self._closed = False
 
     def __aiter__(self) -> AgentEventStream[OutputDataT]:
+        # TODO(v2): remove standalone iteration support and require `async with`.
+        if not self._managed:
+            warnings.warn(
+                'Iterating `AgentEventStream` directly with `async for event in stream:` is deprecated. '
+                'Use `async with agent.run_stream_events(...) as stream:` and '
+                '`async for event in stream:` instead to ensure proper cleanup.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return self
 
     async def __anext__(self) -> _messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]:
-        return await anext(self._generator)
+        if self._closed:
+            raise StopAsyncIteration
+
+        try:
+            return await anext(self._generator)
+        except StopAsyncIteration:
+            # Not strictly necessary (aclose() on an exhausted generator is a no-op),
+            # but keeps _closed accurate after natural exhaustion so __aexit__/aclose()
+            # don't call aclose() unnecessarily.
+            self._closed = True
+            raise
 
     async def __aenter__(self) -> AgentEventStream[OutputDataT]:
+        self._managed = True
         return self
 
     async def __aexit__(self, *args: object) -> None:
         await self.aclose()
 
     async def aclose(self) -> None:
-        await _utils.aclose_if_available(self._generator)
+        if not self._closed:
+            self._closed = True
+            await _utils.aclose_if_available(self._generator)
 
 
 @dataclass(init=False)

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -32,7 +32,7 @@ from .usage import RunUsage, UsageLimits
 
 if TYPE_CHECKING:
     from .capabilities.abstract import AbstractCapability
-    from .run import AgentRunResult
+    from .run import AgentRunResult, AgentRunResultEvent
 
 __all__ = (
     'OutputDataT',
@@ -345,6 +345,28 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
             )
 
         return self._agent_stream_iterator
+
+
+@dataclass
+class AgentEventStream(Generic[OutputDataT]):
+    """Async event stream returned by `Agent.run_stream_events()`."""
+
+    _events: AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]]
+
+    def __aiter__(self) -> AgentEventStream[OutputDataT]:
+        return self
+
+    async def __anext__(self) -> _messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]:
+        return await anext(self._events)
+
+    async def __aenter__(self) -> AgentEventStream[OutputDataT]:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        await _utils.aclose_if_available(self._events)
 
 
 @dataclass(init=False)

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from .run import AgentRunResult, AgentRunResultEvent
 
 __all__ = (
+    'AgentEventStream',
     'OutputDataT',
     'OutputDataT_inv',
     'ToolOutput',
@@ -347,17 +348,21 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
         return self._agent_stream_iterator
 
 
-@dataclass
 class AgentEventStream(Generic[OutputDataT]):
-    """Async event stream returned by `Agent.run_stream_events()`."""
+    """Async event stream returned by `Agent.run_stream_events()`.
 
-    _events: AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]]
+    Wraps the underlying async generator so callers can either iterate over it
+    directly or use it as an async context manager for deterministic cleanup.
+    """
+
+    def __init__(self, generator: AsyncIterator[_messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]]) -> None:
+        self._generator = generator
 
     def __aiter__(self) -> AgentEventStream[OutputDataT]:
         return self
 
     async def __anext__(self) -> _messages.AgentStreamEvent | AgentRunResultEvent[OutputDataT]:
-        return await anext(self._events)
+        return await anext(self._generator)
 
     async def __aenter__(self) -> AgentEventStream[OutputDataT]:
         return self
@@ -366,7 +371,7 @@ class AgentEventStream(Generic[OutputDataT]):
         await self.aclose()
 
     async def aclose(self) -> None:
-        await _utils.aclose_if_available(self._events)
+        await _utils.aclose_if_available(self._generator)
 
 
 @dataclass(init=False)

--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -457,7 +457,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         """
         return self.build_event_stream().streaming_response(stream)
 
-    def run_stream_native(
+    async def run_stream_native(
         self,
         *,
         output_type: OutputSpec[Any] | None = None,
@@ -527,7 +527,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         if self.manage_system_prompt == 'server':
             capabilities.append(ReinjectSystemPrompt(replace_existing=True))
 
-        return self.agent.run_stream_events(
+        async with self.agent.run_stream_events(
             output_type=output_type,
             message_history=message_history,
             deferred_tool_results=deferred_tool_results,
@@ -543,7 +543,9 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             toolsets=toolsets,
             builtin_tools=builtin_tools,
             capabilities=capabilities,
-        )
+        ) as stream:
+            async for event in stream:
+                yield event
 
     def run_stream(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,8 @@ filterwarnings = [
     # uvicorn (mcp server)
     "ignore:websockets.legacy is deprecated.*:DeprecationWarning:websockets.legacy",
     "ignore:websockets.server.WebSocketServerProtocol is deprecated:DeprecationWarning",
+    # AgentEventStream standalone iteration deprecation - existing tests will be migrated to `async with` incrementally
+    "ignore:Iterating `AgentEventStream` directly with `async for event in stream.* is deprecated:DeprecationWarning",
     # Provider.__del__ emits ResourceWarning when GC'd with an open HTTP client.
     # Most tests create providers without async context managers, so this is expected.
     "ignore:.*was garbage collected with an open HTTP client:ResourceWarning",

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import asyncio
 import datetime
 import json
 import re
@@ -3943,6 +3944,52 @@ async def test_stream_text_early_break_cleanup(delta: bool, debounce_by: float |
             break
 
     assert cleanup_called, 'stream function cleanup should have been called by aclosing propagation'
+
+
+async def test_run_stream_early_break_does_not_drain_response():
+    cleanup_called = False
+    pulled_after_break = False
+
+    async def sf(_: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+        nonlocal cleanup_called, pulled_after_break
+        try:
+            yield 'first'
+            pulled_after_break = True  # pragma: no cover
+            yield 'second'  # pragma: no cover
+        finally:
+            cleanup_called = True
+
+    agent = Agent(FunctionModel(stream_function=sf))
+
+    async with agent.run_stream('test') as result:
+        async for text in result.stream_text(delta=True, debounce_by=None):
+            assert text == 'first'
+            break
+
+    assert cleanup_called
+    assert not pulled_after_break
+    assert result.response.text == 'first'
+
+
+async def test_run_stream_events_context_manager_closes_producer():
+    cleanup_called = False
+    never_resume = asyncio.Event()
+
+    async def sf(_: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+        nonlocal cleanup_called
+        try:
+            yield 'first'
+            await never_resume.wait()  # pragma: no cover
+        finally:
+            cleanup_called = True
+
+    agent = Agent(FunctionModel(stream_function=sf))
+
+    async with agent.run_stream_events('test') as events:
+        async for _event in events:
+            break
+
+    assert cleanup_called
 
 
 async def test_args_validator_failure_events():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -4002,6 +4002,34 @@ async def test_run_stream_events_context_manager_closes_producer():
     assert cleanup_called
 
 
+async def test_run_stream_events_early_exit_preserves_consumer_close():
+    async def sf(_: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+        try:
+            yield 'first'
+            await asyncio.Event().wait()  # pragma: no cover
+        finally:
+            raise RuntimeError('producer cleanup failed')
+
+    agent = Agent(FunctionModel(stream_function=sf))
+
+    async with agent.run_stream_events('test') as events:
+        async for _event in events:
+            break
+
+
+async def test_run_stream_events_propagates_producer_error():
+    async def sf(_: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+        yield 'first'
+        raise RuntimeError('producer failed')
+
+    agent = Agent(FunctionModel(stream_function=sf))
+
+    with pytest.raises(RuntimeError, match='producer failed'):
+        async with agent.run_stream_events('test') as events:
+            async for _event in events:
+                pass
+
+
 async def test_args_validator_failure_events():
     """Test that failed validation emits args_valid=False, retries with error message, then succeeds."""
     validator_calls = 0

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3950,7 +3950,7 @@ async def test_stream_text_early_break_cleanup(delta: bool, debounce_by: float |
     agent = Agent(FunctionModel(stream_function=sf))
 
     async with agent.run_stream('test') as result:
-        async for _text in result.stream_text(delta=delta, debounce_by=debounce_by):
+        async for _text in result.stream_text(delta=delta, debounce_by=debounce_by):  # pragma: no branch
             break
 
     assert cleanup_called, 'stream function cleanup should have been called by aclosing propagation'
@@ -3964,16 +3964,17 @@ async def test_run_stream_early_break_does_not_drain_response():
     async def sf(_: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
         nonlocal cleanup_called
         try:
-            for chunk in ['first', 'second']:
-                pulled_chunks.append(chunk)
-                yield chunk
+            pulled_chunks.append('first')
+            yield 'first'
+            pulled_chunks.append('second')  # pragma: no cover
+            yield 'second'  # pragma: no cover
         finally:
             cleanup_called = True
 
     agent = Agent(FunctionModel(stream_function=sf))
 
     async with agent.run_stream('test') as result:
-        async for text in result.stream_text(delta=True, debounce_by=None):
+        async for text in result.stream_text(delta=True, debounce_by=None):  # pragma: no branch
             streamed_text.append(text)
             break
 
@@ -4018,10 +4019,11 @@ async def test_run_stream_events_context_manager_closes_producer():
     agent = Agent(FunctionModel(stream_function=sf))
 
     async with agent.run_stream_events('test') as events:
-        async for _event in events:
+        async for _event in events:  # pragma: no branch
             break
 
     assert cleanup_called
+    assert [event async for event in events] == []
 
 
 async def test_run_stream_events_early_exit_preserves_consumer_close():
@@ -4035,7 +4037,7 @@ async def test_run_stream_events_early_exit_preserves_consumer_close():
     agent = Agent(FunctionModel(stream_function=sf))
 
     async with agent.run_stream_events('test') as events:
-        async for _event in events:
+        async for _event in events:  # pragma: no branch
             break
 
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3958,14 +3958,15 @@ async def test_stream_text_early_break_cleanup(delta: bool, debounce_by: float |
 
 async def test_run_stream_early_break_does_not_drain_response():
     cleanup_called = False
-    pulled_after_break = False
+    pulled_chunks: list[str] = []
+    streamed_text: list[str] = []
 
     async def sf(_: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
-        nonlocal cleanup_called, pulled_after_break
+        nonlocal cleanup_called
         try:
-            yield 'first'
-            pulled_after_break = True  # pragma: no cover
-            yield 'second'  # pragma: no cover
+            for chunk in ['first', 'second']:
+                pulled_chunks.append(chunk)
+                yield chunk
         finally:
             cleanup_called = True
 
@@ -3973,12 +3974,33 @@ async def test_run_stream_early_break_does_not_drain_response():
 
     async with agent.run_stream('test') as result:
         async for text in result.stream_text(delta=True, debounce_by=None):
-            assert text == 'first'
+            streamed_text.append(text)
             break
 
-    assert cleanup_called
-    assert not pulled_after_break
-    assert result.response.text == 'first'
+    assert {
+        'streamed_text': streamed_text,
+        'pulled_chunks': pulled_chunks,
+        'cleanup_called': cleanup_called,
+        'response_text': result.response.text,
+        'usage': result.usage(),
+        'message_history': result.all_messages(),
+    } == snapshot(
+        {
+            'streamed_text': ['first'],
+            'pulled_chunks': ['first'],
+            'cleanup_called': True,
+            'response_text': 'first',
+            'usage': RunUsage(requests=1, input_tokens=50, output_tokens=1),
+            'message_history': [
+                ModelRequest(
+                    parts=[UserPromptPart(content='test', timestamp=IsNow(tz=timezone.utc))],
+                    timestamp=IsNow(tz=timezone.utc),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                )
+            ],
+        }
+    )
 
 
 async def test_run_stream_events_context_manager_closes_producer():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3798,7 +3798,8 @@ async def test_run_stream_events():
     async def ret_a(x: str) -> str:
         return f'{x}-apple'
 
-    events = [event async for event in test_agent.run_stream_events('Hello')]
+    async with test_agent.run_stream_events('Hello') as stream:
+        events = [event async for event in stream]
     assert test_agent.name == 'test_agent'
 
     assert events == snapshot(
@@ -3830,6 +3831,15 @@ async def test_run_stream_events():
             AgentRunResultEvent(result=AgentRunResult(output='{"ret_a":"a-apple"}')),
         ]
     )
+
+
+async def test_run_stream_events_direct_iteration_warns():
+    agent = Agent(TestModel())
+
+    with pytest.warns(DeprecationWarning, match='Iterating `AgentEventStream` directly'):
+        events = [event async for event in agent.run_stream_events('Hello')]
+
+    assert any(isinstance(event, AgentRunResultEvent) for event in events)
 
 
 def test_structured_response_sync_validation():

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -143,6 +143,8 @@ async def test_streamed_text_limits() -> None:
                     tool_calls=1,
                 )
             )
+            async for _ in result.stream_text(debounce_by=None):
+                pass
             succeeded = True
 
     assert succeeded

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,6 +144,22 @@ async def test_peekable_async_stream(peek_first: bool):
     assert items == [1, 2, 3]
 
 
+async def test_peekable_async_stream_closes_unstarted_source() -> None:
+    class ClosableAsyncStream(MockAsyncStream[int]):
+        closed = False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    async_stream = ClosableAsyncStream(iter([1]))
+    peekable_async_stream = PeekableAsyncStream(async_stream)
+
+    await peekable_async_stream.aclose()
+
+    assert async_stream.closed
+    assert await peekable_async_stream.is_exhausted()
+
+
 def test_package_versions(capsys: pytest.CaptureFixture[str]):
     if os.getenv('CI'):
         with capsys.disabled():  # pragma: lax no cover


### PR DESCRIPTION
- Closes #1524
- Related #5132

### Summary

This is a narrower replacement for #5031. The previous PR tried to define explicit cancellation behavior for streams, event streams, and runs. That quickly runs into unresolved semantics around whether cancellation means "stop this model response stream", "stop the whole agent graph", or "interrupt currently running tool calls".

This PR only fixes the smaller bug from #1524: if a caller exits `run_stream()` early, Pydantic AI should not keep consuming the provider stream in the background.

The main changes are:

- `ModelRequestNode.stream()` no longer drains `AgentStream` to EOF after yielding it to the caller.
- Exiting the stream context now lets the underlying `model.request_stream(...)` context manager unwind instead of continuing to pull chunks for usage accounting.
- `PeekableAsyncStream` now supports `aclose()`, and `FunctionModel`, Google, HuggingFace, and xAI streaming request paths close their async iterators in `finally` blocks.
- `run_stream_events()` now returns a small async context manager wrapper, so callers can use `async with agent.run_stream_events(...) as events:` for deterministic producer cleanup. This does not add a `cancel()` method or define run-level cancellation semantics.

### Why this is different from #5031

This PR does not add:

- `StreamedRunResult.cancel()`
- `AgentEventStream.cancel()`
- `RunCancelled`
- `cancel(end_run=...)`
- cancellation semantics for tool execution
- synthetic tool-return messages for interrupted tool calls
- an incomplete/interrupted response field in serialized message history

Those are still worth discussing, but they are larger API and behavior questions. This PR is intentionally only about not continuing to read a provider stream after the user stops consuming it.

### What happens to the socket/underlying provider stream?

This PR does not expose a new public cancellation hook, but it still closes the stream by unwinding the existing provider context.

The flow is:

1. The user exits `async with agent.run_stream(...)` or breaks from the streamed output and leaves the context.
2. `ModelRequestNode.stream()` no longer drains the `AgentStream` to EOF.
3. `stream_done` is set.
4. The internal `_streaming_handler` resumes and exits `async with req_ctx.model.request_stream(...) as sr:`.
5. The provider's `request_stream()` cleanup runs.

For providers that already wrap SDK streams in an async context manager, such as OpenAI, Anthropic, Groq, Mistral, and the custom Gemini path, that means the SDK/http response context exits. For Google GenAI, HuggingFace, and xAI, this PR adds best-effort `aclose()` cleanup around the runtime async iterator. xAI in particular is still best-effort: the SDK stream object exposes async-generator cleanup locally, but this PR does not claim a documented transport-level RPC cancellation hook.

The important behavior is that Pydantic AI itself stops pulling chunks. If a provider SDK properly maps stream close/finalization to connection close, token generation should stop there. If a provider SDK does not expose real transport cancellation, this PR still avoids our previous behavior of actively reading the rest of the response.

### Tests

- `uv run pytest tests/test_streaming.py`
- `uv run pytest tests/test_messages.py tests/test_streaming.py`
- `uv run pytest tests/test_direct.py -k "model_request_stream"`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/_utils.py pydantic_ai_slim/pydantic_ai/agent/abstract.py pydantic_ai_slim/pydantic_ai/models/function.py pydantic_ai_slim/pydantic_ai/models/google.py pydantic_ai_slim/pydantic_ai/models/huggingface.py pydantic_ai_slim/pydantic_ai/models/xai.py pydantic_ai_slim/pydantic_ai/result.py pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py tests/test_streaming.py`
- `uv run pyright pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/_utils.py pydantic_ai_slim/pydantic_ai/agent/abstract.py pydantic_ai_slim/pydantic_ai/messages.py pydantic_ai_slim/pydantic_ai/models/__init__.py pydantic_ai_slim/pydantic_ai/models/function.py pydantic_ai_slim/pydantic_ai/models/google.py pydantic_ai_slim/pydantic_ai/models/huggingface.py pydantic_ai_slim/pydantic_ai/models/xai.py pydantic_ai_slim/pydantic_ai/result.py tests/test_streaming.py`

The local commit hook's full-repo pyright target was not usable in this fresh worktree because optional example/durable dependencies such as FastAPI, Prefect, DBOS, pandas, and others were not installed. The targeted pyright checks above passed.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
