### PR TITLE
fix(fastmcp): respect is_error tool results

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/fastmcp.py
@@ -255,6 +255,12 @@ class FastMCPToolset(AbstractToolset[AgentDepsT]):
                 else:
                     raise e
 
+        if call_tool_result.is_error:
+            message = '\n'.join(part.text for part in call_tool_result.content if isinstance(part, TextContent))
+            if self.tool_error_behavior == 'model_retry':
+                raise ModelRetry(message=message or 'MCP tool call failed')
+            raise ToolError(message or 'MCP tool call failed')
+
         # Prefer structured content if there are only text parts, which per the docs would contain the JSON-encoded structured content for backward compatibility.
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
         if (structured := call_tool_result.structured_content) and all(

--- a/tests/test_fastmcp.py
+++ b/tests/test_fastmcp.py
@@ -6,6 +6,7 @@ import base64
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -562,6 +563,48 @@ class TestFastMCPToolsetToolCalling:
 
             with pytest.raises(ModelRetry, match='This is a test error'):
                 await toolset.call_tool('error_tool', {}, run_context, error_tool)
+
+    async def test_call_tool_with_is_error_result_model_retry(
+        self,
+        fastmcp_client: Client[FastMCPTransport],
+    ):
+        """`is_error=True` results should follow `tool_error_behavior='model_retry'`."""
+        toolset = FastMCPToolset(fastmcp_client, tool_error_behavior='model_retry')
+        fastmcp_client.call_tool = AsyncMock(
+            return_value=type(
+                'FakeCallToolResult',
+                (),
+                {
+                    'is_error': True,
+                    'content': [TextContent(type='text', text='failed from is_error')],
+                    'structured_content': None,
+                },
+            )()
+        )
+
+        with pytest.raises(ModelRetry, match='failed from is_error'):
+            await toolset.direct_call_tool('test_tool', {})
+
+    async def test_call_tool_with_is_error_result_tool_error(
+        self,
+        fastmcp_client: Client[FastMCPTransport],
+    ):
+        """`is_error=True` results should follow `tool_error_behavior='error'`."""
+        toolset = FastMCPToolset(fastmcp_client, tool_error_behavior='error')
+        fastmcp_client.call_tool = AsyncMock(
+            return_value=type(
+                'FakeCallToolResult',
+                (),
+                {
+                    'is_error': True,
+                    'content': [TextContent(type='text', text='failed from is_error')],
+                    'structured_content': None,
+                },
+            )()
+        )
+
+        with pytest.raises(ToolError, match='failed from is_error'):
+            await toolset.direct_call_tool('test_tool', {})
 
     async def test_process_tool_call_invoked(
         self,


### PR DESCRIPTION
## Summary
- handle FastMCP tool results with `is_error=True` in `direct_call_tool()`
- map the error result through `tool_error_behavior` so non-retryable tool errors do not silently bypass policy
- add focused regression tests for both `model_retry` and `error` behaviors

Closes #5217

## Testing
- `uv run pytest tests/test_fastmcp.py -k "is_error_result or error_behavior"`
