### PR TITLE
feat: typed OTel metadata for code tool call syntax highlighting

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_otel_messages.py
+++ b/pydantic_ai_slim/pydantic_ai/_otel_messages.py
@@ -16,12 +16,25 @@ class TextPart(TypedDict):
     content: NotRequired[str]
 
 
+class ToolCallPartOtelMetadata(TypedDict, total=False):
+    """Typed metadata stored on `messages.BaseToolCallPart.otel_metadata` to inform OTel event rendering.
+
+    Used by Logfire for rendering hints (e.g. syntax highlighting of code arguments).
+    Not sent directly as part of OTel events; individual fields are extracted in `otel_message_parts()`.
+    """
+
+    code_arg_name: str
+    code_arg_language: str
+
+
 class ToolCallPart(TypedDict):
     type: Literal['tool_call']
     id: str
     name: str
     arguments: NotRequired[JsonValue]
     builtin: NotRequired[bool]  # Not (currently?) part of the spec, used by Logfire
+    code_arg_name: NotRequired[str]  # Not (currently?) part of the spec, used by Logfire
+    code_arg_language: NotRequired[str]  # Not (currently?) part of the spec, used by Logfire
 
 
 class ToolCallResponsePart(TypedDict):

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1710,6 +1710,15 @@ class BaseToolCallPart:
     When this field is set, `provider_name` is required to identify the provider that generated this data.
     """
 
+    otel_metadata: _otel_messages.ToolCallPartOtelMetadata | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    """Metadata from the tool definition to include in OpenTelemetry tool call events.
+
+    This is populated by the instrumentation layer from [`ToolDefinition.metadata`][pydantic_ai.tools.ToolDefinition.metadata]
+    and is not intended to be set directly. It is not serialized or sent to any model provider.
+    """
+
     def args_as_dict(self, *, raise_if_invalid: bool = False) -> dict[str, Any]:
         """Return the arguments as a Python dictionary.
 
@@ -2006,6 +2015,11 @@ class ModelResponse:
                 call_part = _otel_messages.ToolCallPart(type='tool_call', id=part.tool_call_id, name=part.tool_name)
                 if isinstance(part, BuiltinToolCallPart):
                     call_part['builtin'] = True
+                if part.otel_metadata:
+                    if code_arg_name := part.otel_metadata.get('code_arg_name'):
+                        call_part['code_arg_name'] = code_arg_name
+                    if code_arg_language := part.otel_metadata.get('code_arg_language'):
+                        call_part['code_arg_language'] = code_arg_language
                 if settings.include_content and part.args is not None:
                     if isinstance(part.args, str):
                         call_part['arguments'] = part.args

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1710,14 +1710,12 @@ class BaseToolCallPart:
     When this field is set, `provider_name` is required to identify the provider that generated this data.
     """
 
-    otel_metadata: _otel_messages.ToolCallPartOtelMetadata | None = field(
-        default=None, init=False, repr=False, compare=False
-    )
-    """Metadata from the tool definition to include in OpenTelemetry tool call events.
-
-    This is populated by the instrumentation layer from [`ToolDefinition.metadata`][pydantic_ai.tools.ToolDefinition.metadata]
-    and is not intended to be set directly. It is not serialized or sent to any model provider.
-    """
+    def __post_init__(self) -> None:
+        # Per-instance attribute populated by the instrumentation layer from
+        # `ToolDefinition.metadata` to drive OTel rendering hints (e.g. syntax highlighting).
+        # Declared here rather than as a dataclass field so it stays out of `__init__`,
+        # equality, repr, Pydantic JSON schema, and serialization.
+        self.otel_metadata: _otel_messages.ToolCallPartOtelMetadata | None = None
 
     def args_as_dict(self, *, raise_if_invalid: bool = False) -> dict[str, Any]:
         """Return the arguments as a Python dictionary.

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1971,12 +1971,14 @@ def _map_server_tool_use_block(item: BetaServerToolUseBlock, provider_name: str)
             tool_call_id=item.id,
         )
     elif item.name == 'code_execution':
-        return BuiltinToolCallPart(
+        part = BuiltinToolCallPart(
             provider_name=provider_name,
             tool_name=CodeExecutionTool.kind,
             args=tool_args,
             tool_call_id=item.id,
         )
+        part.otel_metadata = {'code_arg_name': 'code', 'code_arg_language': 'python'}
+        return part
     elif item.name == 'web_fetch':
         return BuiltinToolCallPart(
             provider_name=provider_name,

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -542,14 +542,14 @@ class BedrockConverseModel(Model[BaseClient]):
                 elif tool_use := item.get('toolUse'):
                     if tool_use.get('type') == 'server_tool_use':
                         if tool_use['name'] == 'nova_code_interpreter':  # pragma: no branch
-                            items.append(
-                                BuiltinToolCallPart(
-                                    provider_name=self.system,
-                                    tool_name=CodeExecutionTool.kind,
-                                    args=tool_use['input'],
-                                    tool_call_id=tool_use['toolUseId'],
-                                )
+                            call_part = BuiltinToolCallPart(
+                                provider_name=self.system,
+                                tool_name=CodeExecutionTool.kind,
+                                args=tool_use['input'],
+                                tool_call_id=tool_use['toolUseId'],
                             )
+                            call_part.otel_metadata = {'code_arg_name': 'snippet', 'code_arg_language': 'python'}
+                            items.append(call_part)
                     else:
                         items.append(
                             ToolCallPart(
@@ -1257,6 +1257,7 @@ class BedrockStreamedResponse(StreamedResponse):
                                         tool_call_id=tool_id,
                                         provider_name=self.provider_name,
                                     )
+                                    part.otel_metadata = {'code_arg_name': 'snippet', 'code_arg_language': 'python'}
                                     yield self._parts_manager.handle_part(vendor_part_id=index, part=part)
                             elif maybe_event := self._parts_manager.handle_tool_call_delta(
                                 vendor_part_id=index,

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -1604,12 +1604,14 @@ def _metadata_as_usage(response: GenerateContentResponse, provider: str, provide
 
 
 def _map_executable_code(executable_code: ExecutableCode, provider_name: str, tool_call_id: str) -> BuiltinToolCallPart:
-    return BuiltinToolCallPart(
+    part = BuiltinToolCallPart(
         provider_name=provider_name,
         tool_name=CodeExecutionTool.kind,
         args=executable_code.model_dump(mode='json', exclude_none=True),
         tool_call_id=tool_call_id,
     )
+    part.otel_metadata = {'code_arg_name': 'code', 'code_arg_language': 'python'}
+    return part
 
 
 def _map_code_execution_result(

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -26,6 +26,7 @@ from pydantic_ai._instrumentation import DEFAULT_INSTRUMENTATION_VERSION, get_ag
 from .. import _otel_messages
 from .._run_context import RunContext
 from ..messages import (
+    BaseToolCallPart,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -361,6 +362,27 @@ GEN_AI_REQUEST_MODEL_ATTRIBUTE = 'gen_ai.request.model'
 GEN_AI_PROVIDER_NAME_ATTRIBUTE = 'gen_ai.provider.name'
 
 
+def _annotate_tool_call_otel_metadata(response: ModelResponse, parameters: ModelRequestParameters) -> None:
+    """Copy OTel-relevant metadata from tool definitions onto matching tool call parts.
+
+    This allows tool definition metadata (e.g. code language hints set by the code-mode toolset)
+    to flow through to OTel events on both the model request span and the agent run span.
+    """
+    tool_defs = parameters.tool_defs
+    if not tool_defs:
+        return
+    for part in response.parts:
+        if isinstance(part, BaseToolCallPart) and (tool_def := tool_defs.get(part.tool_name)):
+            if tool_def.metadata:
+                otel_metadata: _otel_messages.ToolCallPartOtelMetadata = {}
+                if code_arg_name := tool_def.metadata.get('code_arg_name'):
+                    otel_metadata['code_arg_name'] = code_arg_name
+                if code_arg_language := tool_def.metadata.get('code_arg_language'):
+                    otel_metadata['code_arg_language'] = code_arg_language
+                if otel_metadata:
+                    part.otel_metadata = otel_metadata
+
+
 def _build_tool_definitions(model_request_parameters: ModelRequestParameters) -> list[dict[str, Any]]:
     """Build OTel-compliant tool definitions from model request parameters.
 
@@ -414,6 +436,7 @@ class InstrumentedModel(WrapperModel):
         )
         with self._instrument(messages, prepared_settings, prepared_parameters) as finish:
             response = await self.wrapped.request(messages, model_settings, model_request_parameters)
+            _annotate_tool_call_otel_metadata(response, prepared_parameters)
             finish(response, prepared_parameters)
             return response
 
@@ -438,7 +461,9 @@ class InstrumentedModel(WrapperModel):
                     yield response_stream
             finally:
                 if response_stream:  # pragma: no branch
-                    finish(response_stream.get(), prepared_parameters)
+                    response = response_stream.get()
+                    _annotate_tool_call_otel_metadata(response, prepared_parameters)
+                    finish(response, prepared_parameters)
 
     @contextmanager
     def _instrument(

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3636,16 +3636,19 @@ def _map_code_interpreter_tool_call(
     if logs:
         result['logs'] = logs
 
+    call_part = BuiltinToolCallPart(
+        tool_name=CodeExecutionTool.kind,
+        tool_call_id=item.id,
+        args={
+            'container_id': item.container_id,
+            'code': item.code or '',
+        },
+        provider_name=provider_name,
+    )
+    call_part.otel_metadata = {'code_arg_name': 'code', 'code_arg_language': 'python'}
+
     return (
-        BuiltinToolCallPart(
-            tool_name=CodeExecutionTool.kind,
-            tool_call_id=item.id,
-            args={
-                'container_id': item.container_id,
-                'code': item.code or '',
-            },
-            provider_name=provider_name,
-        ),
+        call_part,
         BuiltinToolReturnPart(
             tool_name=CodeExecutionTool.kind,
             tool_call_id=item.id,

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -990,6 +990,8 @@ class XaiStreamedResponse(StreamedResponse):
                 provider_name=self.system,
                 provider_details={'function_name': tool_call.function.name},
             )
+            if builtin_tool_name == CodeExecutionTool.kind:
+                call_part.otel_metadata = {'code_arg_name': 'code', 'code_arg_language': 'python'}
             yield self._parts_manager.handle_part(vendor_part_id=tool_call.id, part=call_part)
             return
 
@@ -1448,16 +1450,16 @@ def _create_tool_call_part(
                 args = _build_mcp_tool_call_args(tool_call)
             else:
                 args = _parse_tool_args(tool_call.function.arguments)
-            return (
-                tool_call.id,
-                BuiltinToolCallPart(
-                    tool_name=builtin_tool_name,
-                    args=args,
-                    tool_call_id=tool_call.id,
-                    provider_name=provider_name,
-                    provider_details={'function_name': tool_call.function.name},
-                ),
+            call_part = BuiltinToolCallPart(
+                tool_name=builtin_tool_name,
+                args=args,
+                tool_call_id=tool_call.id,
+                provider_name=provider_name,
+                provider_details={'function_name': tool_call.function.name},
             )
+            if builtin_tool_name == CodeExecutionTool.kind:
+                call_part.otel_metadata = {'code_arg_name': 'code', 'code_arg_language': 'python'}
+            return (tool_call.id, call_part)
     else:
         # Client-side tool call
         return (

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -2084,6 +2084,158 @@ def test_build_tool_definitions():
     ]
 
 
+def test_annotate_tool_call_otel_metadata():
+    """`_annotate_tool_call_otel_metadata` copies metadata from tool defs onto matching tool call parts."""
+    from pydantic_ai.models.instrumented import _annotate_tool_call_otel_metadata  # pyright: ignore[reportPrivateUsage]
+    from pydantic_ai.tools import ToolDefinition
+
+    response = ModelResponse(
+        parts=[
+            ToolCallPart(tool_name='run_code_with_tools', args={'code': 'print("hi")'}, tool_call_id='call_1'),
+            ToolCallPart(tool_name='other_tool', args={'x': 1}, tool_call_id='call_2'),
+            TextPart('some text'),
+        ]
+    )
+
+    params = ModelRequestParameters(
+        function_tools=[
+            ToolDefinition(
+                name='run_code_with_tools',
+                parameters_json_schema={'type': 'object', 'properties': {}},
+                metadata={'code_arg_name': 'code', 'code_arg_language': 'python'},
+            ),
+            ToolDefinition(
+                name='other_tool',
+                parameters_json_schema={'type': 'object', 'properties': {}},
+            ),
+        ],
+        builtin_tools=[],
+        output_tools=[],
+        output_mode='text',
+        output_object=None,
+        prompted_output_template=None,
+        allow_text_output=True,
+        allow_image_output=False,
+    )
+
+    _annotate_tool_call_otel_metadata(response, params)
+
+    code_part = response.parts[0]
+    assert isinstance(code_part, ToolCallPart)
+    assert code_part.otel_metadata == {'code_arg_name': 'code', 'code_arg_language': 'python'}
+
+    other_part = response.parts[1]
+    assert isinstance(other_part, ToolCallPart)
+    assert other_part.otel_metadata is None
+
+
+def test_builtin_code_execution_otel_metadata_in_otel_messages():
+    """Builtin code execution tool calls carry code_arg metadata in OTel output."""
+    call_part = BuiltinToolCallPart(
+        tool_name='code_execution', args={'code': '2 * 2'}, tool_call_id='call_1', provider_name='anthropic'
+    )
+    call_part.otel_metadata = {'code_arg_name': 'code', 'code_arg_language': 'python'}
+
+    messages: list[ModelMessage] = [ModelResponse(parts=[call_part])]
+    settings = InstrumentationSettings()
+    assert settings.messages_to_otel_messages(messages) == snapshot(
+        [
+            {
+                'role': 'assistant',
+                'parts': [
+                    {
+                        'type': 'tool_call',
+                        'id': 'call_1',
+                        'name': 'code_execution',
+                        'builtin': True,
+                        'code_arg_name': 'code',
+                        'code_arg_language': 'python',
+                        'arguments': {'code': '2 * 2'},
+                    }
+                ],
+            }
+        ]
+    )
+
+
+def test_builtin_code_execution_snippet_arg():
+    """Bedrock's 'snippet' arg name is preserved in OTel output."""
+    call_part = BuiltinToolCallPart(
+        tool_name='code_execution', args={'snippet': '1 + 1'}, tool_call_id='call_1', provider_name='bedrock'
+    )
+    call_part.otel_metadata = {'code_arg_name': 'snippet', 'code_arg_language': 'python'}
+
+    messages: list[ModelMessage] = [ModelResponse(parts=[call_part])]
+    settings = InstrumentationSettings()
+    assert settings.messages_to_otel_messages(messages) == snapshot(
+        [
+            {
+                'role': 'assistant',
+                'parts': [
+                    {
+                        'type': 'tool_call',
+                        'id': 'call_1',
+                        'name': 'code_execution',
+                        'builtin': True,
+                        'code_arg_name': 'snippet',
+                        'code_arg_language': 'python',
+                        'arguments': {'snippet': '1 + 1'},
+                    }
+                ],
+            }
+        ]
+    )
+
+
+def test_otel_metadata_in_otel_messages():
+    """`otel_metadata` on a function tool call flows through to OTel message output."""
+    tool_call = ToolCallPart(tool_name='run_code_with_tools', args={'code': 'x = 1 + 2'}, tool_call_id='call_1')
+    tool_call.otel_metadata = {'code_arg_name': 'code', 'code_arg_language': 'python'}
+
+    messages: list[ModelMessage] = [ModelResponse(parts=[tool_call])]
+    settings = InstrumentationSettings()
+    assert settings.messages_to_otel_messages(messages) == snapshot(
+        [
+            {
+                'role': 'assistant',
+                'parts': [
+                    {
+                        'type': 'tool_call',
+                        'id': 'call_1',
+                        'name': 'run_code_with_tools',
+                        'code_arg_name': 'code',
+                        'code_arg_language': 'python',
+                        'arguments': {'code': 'x = 1 + 2'},
+                    }
+                ],
+            }
+        ]
+    )
+
+
+def test_otel_metadata_not_present_without_annotation():
+    """`code_arg_name`/`code_arg_language` are absent when `otel_metadata` is not set."""
+    messages: list[ModelMessage] = [
+        ModelResponse(parts=[ToolCallPart(tool_name='some_tool', args={'x': 1}, tool_call_id='call_1')]),
+    ]
+    settings = InstrumentationSettings()
+    assert settings.messages_to_otel_messages(messages) == snapshot(
+        [
+            {
+                'role': 'assistant',
+                'parts': [
+                    {
+                        'type': 'tool_call',
+                        'id': 'call_1',
+                        'name': 'some_tool',
+                        'arguments': {'x': 1},
+                    }
+                ],
+            }
+        ]
+    )
+
+
 def test_messages_to_otel_messages_file_part_v4(document_content: BinaryContent):
     """Test that version 4 uses blob format for FilePart in ModelResponse (output messages)."""
     messages: list[ModelMessage] = [

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -2213,6 +2213,56 @@ def test_otel_metadata_in_otel_messages():
     )
 
 
+def test_otel_metadata_partial_only_arg_name():
+    """`otel_metadata` with only `code_arg_name` set surfaces just that key."""
+    tool_call = ToolCallPart(tool_name='run_code', args={'code': '1+1'}, tool_call_id='call_1')
+    tool_call.otel_metadata = {'code_arg_name': 'code'}
+
+    messages: list[ModelMessage] = [ModelResponse(parts=[tool_call])]
+    settings = InstrumentationSettings()
+    assert settings.messages_to_otel_messages(messages) == snapshot(
+        [
+            {
+                'role': 'assistant',
+                'parts': [
+                    {
+                        'type': 'tool_call',
+                        'id': 'call_1',
+                        'name': 'run_code',
+                        'code_arg_name': 'code',
+                        'arguments': {'code': '1+1'},
+                    }
+                ],
+            }
+        ]
+    )
+
+
+def test_otel_metadata_partial_only_arg_language():
+    """`otel_metadata` with only `code_arg_language` set surfaces just that key."""
+    tool_call = ToolCallPart(tool_name='run_code', args={'code': '1+1'}, tool_call_id='call_1')
+    tool_call.otel_metadata = {'code_arg_language': 'python'}
+
+    messages: list[ModelMessage] = [ModelResponse(parts=[tool_call])]
+    settings = InstrumentationSettings()
+    assert settings.messages_to_otel_messages(messages) == snapshot(
+        [
+            {
+                'role': 'assistant',
+                'parts': [
+                    {
+                        'type': 'tool_call',
+                        'id': 'call_1',
+                        'name': 'run_code',
+                        'code_arg_language': 'python',
+                        'arguments': {'code': '1+1'},
+                    }
+                ],
+            }
+        ]
+    )
+
+
 def test_otel_metadata_not_present_without_annotation():
     """`code_arg_name`/`code_arg_language` are absent when `otel_metadata` is not set."""
     messages: list[ModelMessage] = [


### PR DESCRIPTION
<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

Restores a `ToolCallPartOtelMetadata` typed dict carrying `code_arg_name` / `code_arg_language` on tool-call OTel events, so Logfire can syntax-highlight code arguments. The instrumentation layer copies these from `ToolDefinition.metadata` onto matching `BaseToolCallPart`s — that's how the harness `CodeModeToolset` (which already sets `metadata={'code_arg_name': 'code', 'code_arg_language': 'python'}` on its `run_code_with_tools` tool def) drives the rendering. The same metadata is also set directly on `BuiltinToolCallPart`s for code execution from Anthropic, Bedrock (`snippet`), Google, OpenAI, and xAI.

This is a port of the work originally on the reverted `code-mode-wip` branch (commit `ea4f5d8b`). The one fix vs. that original: `otel_metadata` uses `compare=False` on the dataclass field, so the new attribute doesn't break existing snapshot equality across the provider test suites.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).