### PR TITLE
PoC: collapse run() overloads via Unpack[IterKwargs]

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_a2a.py
+++ b/pydantic_ai_slim/pydantic_ai/_a2a.py
@@ -140,7 +140,7 @@ class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]
         message_history.extend(self.build_message_history(task.get('history', [])))
 
         try:
-            result = await self.agent.run(message_history=message_history)  # type: ignore
+            result = await self.agent.run(message_history=message_history)
 
             await self.storage.update_context(task['context_id'], result.all_messages())
 

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeAlias, cast, overload
 
 import anyio
 from pydantic import TypeAdapter
-from typing_extensions import Self, TypeIs, TypeVar, deprecated
+from typing_extensions import Self, TypedDict, TypeIs, TypeVar, Unpack, deprecated
 
 from pydantic_graph import End
 
@@ -91,6 +91,36 @@ Instructions = AgentInstructions
 
 AgentModelSettings = ModelSettings | Callable[[RunContext[AgentDepsT]], ModelSettings]
 """Type alias for agent model settings — a static `ModelSettings` dict, or a callable receiving `RunContext` that returns one dynamically per request."""
+
+
+class IterKwargs(TypedDict, Generic[AgentDepsT], total=False):
+    """Shared kwargs for `iter` and (by composition with `event_stream_handler`) the run-style methods.
+
+    `run` / `run_sync` / `run_stream` / `run_stream_sync` / `run_stream_events`.
+
+    `total=False` makes every entry optional — impls treat a missing key as the
+    documented default.
+
+    Used via `**kwargs: Unpack[IterKwargs[AgentDepsT]]` (PEP 692). Keeps
+    overloads down to 2 per method (one per `output_type` shape) instead of 3
+    full-kwarg copies, so adding a kwarg is a one-line TypedDict edit.
+    """
+
+    message_history: Sequence[_messages.ModelMessage] | None
+    deferred_tool_results: DeferredToolResults | None
+    conversation_id: str | None
+    model: models.Model | models.KnownModelName | str | None
+    instructions: _instructions.AgentInstructions[AgentDepsT]
+    deps: AgentDepsT
+    model_settings: AgentModelSettings[AgentDepsT] | None
+    usage_limits: _usage.UsageLimits | None
+    usage: _usage.RunUsage | None
+    metadata: AgentMetadata[AgentDepsT] | None
+    infer_name: bool
+    toolsets: Sequence[AbstractToolset[AgentDepsT]] | None
+    builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None
+    capabilities: Sequence[AgentCapability[AgentDepsT]] | None
+    spec: dict[str, Any] | AgentSpec | None
 
 
 class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
@@ -221,22 +251,8 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: None = None,
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[OutputDataT]: ...
 
     @overload
@@ -245,22 +261,8 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: OutputSpec[RunOutputDataT],
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[RunOutputDataT]: ...
 
     async def run(
@@ -268,22 +270,8 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: OutputSpec[RunOutputDataT] | None = None,
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[Any]:
         """Run the agent with a user prompt in async mode.
 
@@ -329,7 +317,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         Returns:
             The result of the run.
         """
-        if infer_name and self.name is None:
+        if kwargs.get('infer_name', True) and self.name is None:
             self._infer_name(inspect.currentframe())
 
         event_stream_handler = event_stream_handler or self.event_stream_handler
@@ -337,20 +325,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         async with self.iter(
             user_prompt=user_prompt,
             output_type=output_type,
-            message_history=message_history,
-            deferred_tool_results=deferred_tool_results,
-            conversation_id=conversation_id,
-            model=model,
-            instructions=instructions,
-            deps=deps,
-            model_settings=model_settings,
-            usage_limits=usage_limits,
-            usage=usage,
-            metadata=metadata,
-            toolsets=toolsets,
-            builtin_tools=builtin_tools,
-            capabilities=capabilities,
-            spec=spec,
+            **kwargs,
         ) as agent_run:
             # Drive via next() so capability hooks fire for each node.
             # When event_stream_handler is set or a capability overrides wrap_run_event_stream,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -5,7 +5,7 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager, context
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from dbos import DBOS, DBOSConfiguredInstance
-from typing_extensions import Never
+from typing_extensions import Never, Unpack
 
 from pydantic_ai import (
     AbstractToolset,
@@ -24,7 +24,7 @@ from pydantic_ai.agent import (
     ParallelExecutionMode,
     WrapperAgent,
 )
-from pydantic_ai.agent.abstract import AgentMetadata, AgentModelSettings, RunOutputDataT
+from pydantic_ai.agent.abstract import AgentMetadata, AgentModelSettings, IterKwargs, RunOutputDataT
 from pydantic_ai.capabilities import AgentCapability
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import Model
@@ -150,45 +150,15 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
             user_prompt: str | Sequence[_messages.UserContent] | None = None,
             *,
             output_type: OutputSpec[RunOutputDataT] | None = None,
-            message_history: Sequence[_messages.ModelMessage] | None = None,
-            deferred_tool_results: DeferredToolResults | None = None,
-            conversation_id: str | None = None,
-            model: models.Model | models.KnownModelName | str | None = None,
-            instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-            deps: AgentDepsT,
-            model_settings: AgentModelSettings[AgentDepsT] | None = None,
-            usage_limits: _usage.UsageLimits | None = None,
-            usage: _usage.RunUsage | None = None,
-            metadata: AgentMetadata[AgentDepsT] | None = None,
-            infer_name: bool = True,
-            toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-            builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
             event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-            capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-            spec: dict[str, Any] | AgentSpec | None = None,
-            **_deprecated_kwargs: Never,
+            **kwargs: Unpack[IterKwargs[AgentDepsT]],
         ) -> AgentRunResult[Any]:
             with self._dbos_overrides():
                 return await super(WrapperAgent, self).run(
                     user_prompt,
                     output_type=output_type,
-                    message_history=message_history,
-                    deferred_tool_results=deferred_tool_results,
-                    conversation_id=conversation_id,
-                    model=model,
-                    instructions=instructions,
-                    deps=deps,
-                    model_settings=model_settings,
-                    usage_limits=usage_limits,
-                    usage=usage,
-                    metadata=metadata,
-                    infer_name=infer_name,
-                    toolsets=toolsets,
-                    builtin_tools=builtin_tools,
                     event_stream_handler=event_stream_handler,
-                    capabilities=capabilities,
-                    spec=spec,
-                    **_deprecated_kwargs,
+                    **kwargs,
                 )
 
         self.dbos_wrapped_run_workflow = wrapped_run_workflow
@@ -300,22 +270,8 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: None = None,
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[OutputDataT]: ...
 
     @overload
@@ -324,22 +280,8 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: OutputSpec[RunOutputDataT],
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[RunOutputDataT]: ...
 
     async def run(
@@ -347,23 +289,8 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: OutputSpec[RunOutputDataT] | None = None,
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
-        **_deprecated_kwargs: Never,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[Any]:
         """Run the agent with a user prompt in async mode.
 
@@ -407,6 +334,7 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
         Returns:
             The result of the run.
         """
+        model = kwargs.get('model')
         if model is not None and not isinstance(model, DBOSModel):
             raise UserError(
                 'Non-DBOS model cannot be set at agent run time inside a DBOS workflow, it must be set at agent creation time.'
@@ -414,23 +342,8 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
         return await self.dbos_wrapped_run_workflow(
             user_prompt,
             output_type=output_type,
-            message_history=message_history,
-            deferred_tool_results=deferred_tool_results,
-            conversation_id=conversation_id,
-            model=model,
-            instructions=instructions,
-            deps=deps,
-            model_settings=model_settings,
-            usage_limits=usage_limits,
-            usage=usage,
-            metadata=metadata,
-            infer_name=infer_name,
-            toolsets=toolsets,
-            builtin_tools=builtin_tools,
             event_stream_handler=event_stream_handler,
-            capabilities=capabilities,
-            spec=spec,
-            **_deprecated_kwargs,
+            **kwargs,
         )
 
     @overload

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, overload
 from prefect import flow, task
 from prefect.context import FlowRunContext
 from prefect.utilities.asyncutils import run_coro_as_sync
-from typing_extensions import Never
+from typing_extensions import Never, Unpack
 
 from pydantic_ai import (
     AbstractToolset,
@@ -20,7 +20,7 @@ from pydantic_ai import (
     usage as _usage,
 )
 from pydantic_ai.agent import AbstractAgent, AgentRun, AgentRunResult, EventStreamHandler, WrapperAgent
-from pydantic_ai.agent.abstract import AgentMetadata, AgentModelSettings, RunOutputDataT
+from pydantic_ai.agent.abstract import AgentMetadata, AgentModelSettings, IterKwargs, RunOutputDataT
 from pydantic_ai.capabilities import AgentCapability
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import Model
@@ -182,22 +182,8 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: None = None,
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[OutputDataT]: ...
 
     @overload
@@ -206,22 +192,8 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: OutputSpec[RunOutputDataT],
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[RunOutputDataT]: ...
 
     async def run(
@@ -229,23 +201,8 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: OutputSpec[RunOutputDataT] | None = None,
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
-        **_deprecated_kwargs: Never,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[Any]:
         """Run the agent with a user prompt in async mode.
 
@@ -292,28 +249,14 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
 
         @flow(name=f'{self._name} Run')
         async def wrapped_run_flow() -> AgentRunResult[Any]:
-            # Mark that we're inside a PrefectAgent flow
             token = self._in_prefect_agent_flow.set(True)
             try:
                 with self._prefect_overrides():
                     result = await super(WrapperAgent, self).run(
                         user_prompt,
                         output_type=output_type,
-                        message_history=message_history,
-                        deferred_tool_results=deferred_tool_results,
-                        conversation_id=conversation_id,
-                        model=model,
-                        instructions=instructions,
-                        deps=deps,
-                        model_settings=model_settings,
-                        usage_limits=usage_limits,
-                        usage=usage,
-                        metadata=metadata,
-                        infer_name=infer_name,
-                        toolsets=toolsets,
                         event_stream_handler=event_stream_handler,
-                        capabilities=capabilities,
-                        spec=spec,
+                        **kwargs,
                     )
                     return result
             finally:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -14,7 +14,7 @@ from pydantic_core import PydanticSerializationError
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 from temporalio.workflow import ActivityConfig
-from typing_extensions import Never
+from typing_extensions import Never, Unpack
 
 from pydantic_ai import (
     AbstractToolset,
@@ -26,7 +26,7 @@ from pydantic_ai import (
     usage as _usage,
 )
 from pydantic_ai.agent import AbstractAgent, AgentRun, AgentRunResult, EventStreamHandler, WrapperAgent
-from pydantic_ai.agent.abstract import AgentMetadata, AgentModelSettings, RunOutputDataT
+from pydantic_ai.agent.abstract import AgentMetadata, AgentModelSettings, IterKwargs, RunOutputDataT
 from pydantic_ai.capabilities import AgentCapability
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import Model
@@ -305,22 +305,8 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: None = None,
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[OutputDataT]: ...
 
     @overload
@@ -329,22 +315,8 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: OutputSpec[RunOutputDataT],
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[RunOutputDataT]: ...
 
     async def run(
@@ -352,23 +324,8 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         user_prompt: str | Sequence[_messages.UserContent] | None = None,
         *,
         output_type: OutputSpec[RunOutputDataT] | None = None,
-        message_history: Sequence[_messages.ModelMessage] | None = None,
-        deferred_tool_results: DeferredToolResults | None = None,
-        conversation_id: str | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
-        instructions: _instructions.AgentInstructions[AgentDepsT] = None,
-        deps: AgentDepsT = None,
-        model_settings: AgentModelSettings[AgentDepsT] | None = None,
-        usage_limits: _usage.UsageLimits | None = None,
-        usage: _usage.RunUsage | None = None,
-        metadata: AgentMetadata[AgentDepsT] | None = None,
-        infer_name: bool = True,
-        toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
-        builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
-        capabilities: Sequence[AgentCapability[AgentDepsT]] | None = None,
-        spec: dict[str, Any] | AgentSpec | None = None,
-        **_deprecated_kwargs: Never,
+        **kwargs: Unpack[IterKwargs[AgentDepsT]],
     ) -> AgentRunResult[Any]:
         """Run the agent with a user prompt in async mode.
 
@@ -413,6 +370,7 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         Returns:
             The result of the run.
         """
+        model = kwargs.get('model')
         if workflow.in_workflow():
             if event_stream_handler is not None:
                 raise UserError(
@@ -423,26 +381,12 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             resolved_model = self._temporal_model.resolve_model(model)
 
         with self._temporal_overrides(model=model):
+            kwargs['model'] = resolved_model
             return await super().run(
                 user_prompt,
                 output_type=output_type,
-                message_history=message_history,
-                deferred_tool_results=deferred_tool_results,
-                conversation_id=conversation_id,
-                model=resolved_model,
-                instructions=instructions,
-                deps=deps,
-                model_settings=model_settings,
-                usage_limits=usage_limits,
-                usage=usage,
-                metadata=metadata,
-                infer_name=infer_name,
-                toolsets=toolsets,
-                builtin_tools=builtin_tools,
                 event_stream_handler=event_stream_handler or self.event_stream_handler,
-                capabilities=capabilities,
-                spec=spec,
-                **_deprecated_kwargs,
+                **kwargs,
             )
 
     @overload


### PR DESCRIPTION
> [!NOTE]
> **Draft PoC — not for merge.** Opened to get CI signal on the
> Unpack[TypedDict] pattern before scaling it to all six run-style
> methods + override sites. Closing without merging is fine — this is a
> follow-up planned out of #5075 (the `rename-retry-fields` PR), item
> 3 under "Follow-ups after merge" in that branch's planning doc.

## What this PR does

Demonstrates the PEP 692 `**kwargs: Unpack[TypedDict]` pattern for
collapsing the 3-overload-per-method bloat in `AbstractAgent`'s
run-style methods. Scope is **intentionally narrow**: just `run()`
across `AbstractAgent` + the three `durable_exec` wrappers.

**Net diff: 5 files, -285 +60 lines on one method.** Full refactor
across all 6 run-style methods + override sites would scale ~6×–8×.

The pattern:

```python
class IterKwargs(TypedDict, Generic[AgentDepsT], total=False):
    message_history: Sequence[ModelMessage] | None
    # ... 14 more shared kwargs ...

@overload
async def run(self, user_prompt=..., *,
              output_type: None = None,
              event_stream_handler: ... = None,
              **kwargs: Unpack[IterKwargs[AgentDepsT]]) -> AgentRunResult[OutputDataT]: ...
```

`event_stream_handler` stays explicit because run-methods use it
locally and `iter` doesn't have it. The codebase already uses
`Unpack[TypedDict]` non-generically in `pydantic_graph/mermaid.py` —
the only new ingredient here is making the TypedDict generic over
`AgentDepsT`.

## What I'm asking CI to validate

| | Status |
|---|---|
| pyright (1.1.408, strict, py3.10 target) | ✅ clean locally |
| ruff format + check | ✅ clean locally |
| make typecheck pre-commit hook | ✅ clean locally |
| reportIncompatibleMethodOverride across DBOSAgent.run / PrefectAgent.run / TemporalAgent.run | ✅ satisfied |
| Runtime smoke test on Python 3.10 / 3.11 / 3.12 / 3.13 | ✅ all pass |
| Full test suite | 🟡 needs CI |
| mypy on tests/typed_agent.py | 🟡 needs CI |

## What I have NOT validated (flagging for review)

- **Pylance** — built on pyright, so almost certainly fine, but I did
  not open VSCode to confirm autocomplete / hover UX
- **PyCharm** — JetBrains shipped PEP 692 support in 2023.2 per their
  release notes, but I did not open PyCharm
- **mypy** — supports Unpack[TypedDict] since 1.0, but I did not run
  mypy locally against the diff

These should be smoke-tested before scaling to the full refactor.

## Python / typing-extensions floor

- `typing_extensions.Unpack` requires `typing_extensions>=4.4.0`
- Pydantic itself requires `typing-extensions>=4.14.1` — far past the
  floor
- Verified runtime + pyright on 3.10, 3.11, 3.12, 3.13

## Bonus: improved typing in `_a2a.py`

A pre-existing `# type: ignore` on `self.agent.run(message_history=...)`
became unnecessary because `message_history` is now properly typed via
`IterKwargs`. Removed.

## Out of scope (deferred to the real follow-up PR)

- `run_sync`, `run_stream`, `run_stream_sync`, `run_stream_events`, `iter`
- `Agent.iter`, `WrapperAgent.iter`
- `run_stream` overrides in the 3 `durable_exec` wrappers
- compile-time typing fixture under `tests/`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases) — though this PR is not intended to merge.