### PR TITLE
Quote `restate_sdk[serde]` in install command in Restate docs

### DIFF
--- a/docs/durable_execution/restate.md
+++ b/docs/durable_execution/restate.md
@@ -53,7 +53,7 @@ Any Pydantic AI agent can be made durable by wrapping it with `RestateAgent` fro
 Install the Restate SDK:
 
 ```bash
-pip/uv-add pydantic-ai restate_sdk[serde]
+pip/uv-add pydantic-ai "restate_sdk[serde]"
 ```
 
 Here is a complete example of a durable Pydantic AI agent with Restate:


### PR DESCRIPTION
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

The install command in the Restate durable execution docs was `pip/uv-add pydantic-ai restate_sdk[serde]`, but the unquoted `[serde]` is interpreted as a glob pattern by zsh (and other shells), causing the install to fail. Quoting matches the pattern used elsewhere in the docs (e.g. `"pydantic-ai-slim[openai]"`).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).