### PR TITLE
chore: Revert "docs: add Aegis to third-party capabilities"

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1208,7 +1208,6 @@ Capabilities for spawning and delegating to specialized subagents help agents ta
 Capabilities for cost control, input/output filtering, and tool permissions help keep agents safe and within budget:
 
 * [`pydantic-ai-shields`](https://github.com/vstorm-co/pydantic-ai-shields) - Ready-to-use guardrail capabilities: `CostTracking` (tracks token usage and USD cost per run, raises `BudgetExceededError` on budget overrun); `ToolGuard` (block or require approval for specific tools); `InputGuard` and `OutputGuard` (custom sync or async validation functions); `PromptInjection`, `PiiDetector`, `SecretRedaction`, `BlockedKeywords`, and `NoRefusals` content shields.
-* [`agent-aegis`](https://github.com/Acacian/aegis) - `AegisCapability` (`from aegis.contrib.pydantic_ai`) wraps a guardrail engine into capability lifecycle hooks: prompt injection detection (13 categories, multi-language, encoding evasion), PII masking (Luhn/IBAN validation), toxicity filtering, hallucination pattern detection, prompt-leak detection, keyword/regex matching, and YAML policy-as-code rules via `GuardrailEngine.from_pack()`. Supports `on_block="raise"/"warn"` and per-agent `check_input`/`check_output` control.
 
 ### File Operations & Sandboxing
 


### PR DESCRIPTION
Reverts #4888.

This removes `agent-aegis` from the third-party capabilities list. The project does not currently meet the popularity bar we use for listing general-purpose third-party tools in the Pydantic AI docs.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).