### PR TITLE
fix(openai): preserve empty MCP tool args in history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2495,7 +2495,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                 elif (  # pragma: no branch
                                     action == 'call_tool'
                                     and (tool_name := args.get('tool_name'))
-                                    and (tool_args := args.get('tool_args'))
+                                    and (tool_args := args.get('tool_args')) is not None
                                 ):
                                     mcp_call_item = responses.response_input_item_param.McpCall(
                                         id=item.tool_call_id,

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -260,7 +260,8 @@ async def test_openai_responses_maps_mcp_call_with_empty_tool_args():
 
     mcp_calls = [message for message in openai_messages if message.get('type') == 'mcp_call']
     assert len(mcp_calls) == 1
-    assert mcp_calls[0]['arguments'] == '{}'
+    mcp_call = cast(resp.response_input_item_param.McpCall, mcp_calls[0])
+    assert mcp_call['arguments'] == '{}'
 
 
 async def test_openai_responses_model_simple_response_with_tool_call(allow_model_requests: None, openai_api_key: str):

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -225,6 +225,44 @@ def test_openai_responses_image_generation_tool_unsupported_size_raises_error() 
         _resolve_openai_image_generation_size(tool)
 
 
+async def test_openai_responses_maps_mcp_call_with_empty_tool_args():
+    model = OpenAIResponsesModel(
+        'gpt-4o',
+        provider=OpenAIProvider(api_key='sk-placeholder'),
+    )
+
+    tool_call_id = 'call_abc123'
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content='Please call get_info')]),
+        ModelResponse(
+            parts=[
+                BuiltinToolCallPart(
+                    tool_name='mcp_server:my-mcp',
+                    tool_call_id=tool_call_id,
+                    args={'action': 'call_tool', 'tool_name': 'get_info', 'tool_args': {}},
+                    provider_name='openai',
+                ),
+                BuiltinToolReturnPart(
+                    tool_name='mcp_server:my-mcp',
+                    tool_call_id=tool_call_id,
+                    content={'output': 'some result', 'error': None},
+                    provider_name='openai',
+                ),
+            ],
+            provider_name='openai',
+        ),
+        ModelRequest(parts=[UserPromptPart(content='What did you just do?')]),
+    ]
+
+    _, openai_messages = await model._map_messages(  # pyright: ignore[reportPrivateUsage]
+        messages, {'openai_send_reasoning_ids': True}, ModelRequestParameters()
+    )
+
+    mcp_calls = [message for message in openai_messages if message.get('type') == 'mcp_call']
+    assert len(mcp_calls) == 1
+    assert mcp_calls[0]['arguments'] == '{}'
+
+
 async def test_openai_responses_model_simple_response_with_tool_call(allow_model_requests: None, openai_api_key: str):
     model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(api_key=openai_api_key))
 


### PR DESCRIPTION
## Summary
- Preserve OpenAI Responses MCP call history items when `tool_args` is `{}`.
- Treat empty dict tool arguments as present instead of dropping the `mcp_call` item via a truthiness check.
- Add regression coverage for MCP tools with no parameters.

Fixes #5308

## Verification
- `uv run pytest tests/models/test_openai_responses.py -q -k "maps_mcp_call_with_empty_tool_args"`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/openai.py tests/models/test_openai_responses.py`

## PR overlap check
- Searched open PRs for `5308 OR McpCall history item tool_args`; no existing open PR covers this issue.