### PR TITLE
fix(openai): mark bare list schemas non-strict

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -321,6 +321,10 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                 self.is_strict_compatible = False
 
         schema_type = schema.get('type')
+        if schema_type == 'array' and schema.get('items') == {}:
+            if self.strict is None:
+                self.is_strict_compatible = False
+
         if 'oneOf' in schema:
             # OpenAI does not support oneOf in strict mode
             if self.strict is True:

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -42,7 +42,7 @@ from pydantic_ai import (
     UserError,
     UserPromptPart,
 )
-from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer
+from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer, JsonSchema
 from pydantic_ai._utils import is_text_like_media_type as _is_text_like_media_type
 from pydantic_ai.builtin_tools import ImageGenerationTool, WebSearchTool
 from pydantic_ai.exceptions import ContentFilterError
@@ -5006,7 +5006,11 @@ def test_transformer_adds_properties_to_object_schemas():
 
 
 def test_transformer_marks_bare_list_items_as_not_strict_compatible():
-    schema = {'type': 'object', 'properties': {'items': {'type': 'array', 'items': {}}}, 'required': ['items']}
+    schema: JsonSchema = {
+        'type': 'object',
+        'properties': {'items': {'type': 'array', 'items': {}}},
+        'required': ['items'],
+    }
 
     transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
     result = transformer.walk()

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -5005,6 +5005,16 @@ def test_transformer_adds_properties_to_object_schemas():
     assert result['properties'] == {}
 
 
+def test_transformer_marks_bare_list_items_as_not_strict_compatible():
+    schema = {'type': 'object', 'properties': {'items': {'type': 'array', 'items': {}}}, 'required': ['items']}
+
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    result = transformer.walk()
+
+    assert result['properties']['items'] == {'type': 'array', 'items': {}}
+    assert transformer.is_strict_compatible is False
+
+
 def chunk_with_usage(
     delta: list[ChoiceDelta],
     finish_reason: FinishReason | None = None,


### PR DESCRIPTION
## Summary
- Detect array schemas with `items: {}` in `OpenAIJsonSchemaTransformer` auto-strict mode.
- Mark those schemas as not strict-compatible so OpenAI tools can fall back to lenient mode instead of being sent as `strict=True` and rejected by the API.
- Add regression coverage for the bare `list` schema shape.

Fixes #4425

## Verification
- `uv run pytest tests/models/test_openai.py -q -k "bare_list_items or transformer_adds_properties"`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/profiles/openai.py tests/models/test_openai.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/profiles/openai.py tests/models/test_openai.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright tests/models/test_openai.py`

## PR overlap check
- Searched open PRs for `4425 OR items {} strict incompatible json schema transformer`; no existing open PR covers this issue.