### PR TITLE
fix(openai): fallback streamed response timestamp

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1072,6 +1072,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             _provider_name=self._provider.name,
             _provider_url=self._provider.base_url,
             _provider_timestamp=number_to_datetime(first_chunk.created) if first_chunk.created else None,
+            _timestamp=number_to_datetime(first_chunk.created) if first_chunk.created else _now_utc(),
             _model_settings=model_settings,
         )
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -585,6 +585,23 @@ async def test_stream_text(allow_model_requests: None):
         assert result.usage() == snapshot(RunUsage(requests=1, input_tokens=6, output_tokens=3))
 
 
+async def test_stream_text_falls_back_to_local_timestamp_when_created_missing(allow_model_requests: None):
+    first_chunk = text_chunk('hello ')
+    first_chunk.created = 0
+    stream = [first_chunk, text_chunk('world', finish_reason='stop')]
+    mock_client = MockOpenAI.create_mock_stream(stream)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == ['hello ', 'hello world']
+        assert result.timestamp() != datetime(1970, 1, 1, tzinfo=timezone.utc)
+        async for response, is_last in result.stream_responses(debounce_by=None):
+            if is_last:
+                assert response.timestamp != datetime(1970, 1, 1, tzinfo=timezone.utc)
+                assert response.provider_details == {'finish_reason': 'stop'}
+
+
 async def test_stream_text_finish_reason(allow_model_requests: None):
     first_chunk = text_chunk('hello ')
     # Test that we get the model name from a later chunk if it is not set on the first one, like on Azure OpenAI with content filter enabled.


### PR DESCRIPTION
## Summary
- Use a local timestamp for OpenAI-compatible streamed chat responses when the first chunk has no `created` timestamp.
- Preserve provider timestamp metadata only when the provider supplies `created`.
- Add regression coverage for GitHub-style streamed chunks with missing `created`, avoiding the Unix epoch timestamp on `result.timestamp()` and final `ModelResponse.timestamp`.

Fixes #2997

## Verification
- `uv run pytest tests/models/test_openai.py -q -k "stream_text_falls_back_to_local_timestamp_when_created_missing or stream_text_finish_reason"`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/models/openai.py tests/models/test_openai.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/openai.py tests/models/test_openai.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright tests/models/test_openai.py`

## PR overlap check
- Searched open PRs for `2997 OR GitHubProvider streamed response timestamp`; no existing open PR covers this issue.