### PR TITLE
Fix MCP history replay for empty tool arguments

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1149,7 +1149,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                                 and (server_id := response_part.tool_name.split(':', 1)[1])
                                 and (args := response_part.args_as_dict())
                                 and (tool_name := args.get('tool_name'))
-                                and (tool_args := args.get('tool_args'))
+                                and (tool_args := args.get('tool_args')) is not None
                             ):  # pragma: no branch
                                 mcp_tool_use_block_param = BetaMCPToolUseBlockParam(
                                     id=tool_use_id,

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2495,7 +2495,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                 elif (  # pragma: no branch
                                     action == 'call_tool'
                                     and (tool_name := args.get('tool_name'))
-                                    and (tool_args := args.get('tool_args'))
+                                    and (tool_args := args.get('tool_args')) is not None
                                 ):
                                     mcp_call_item = responses.response_input_item_param.McpCall(
                                         id=item.tool_call_id,

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -6314,6 +6314,47 @@ async def test_anthropic_web_fetch_tool_domain_filtering():
     assert web_fetch_tool_param.get('allowed_domains') is None
 
 
+async def test_anthropic_mcp_call_replays_empty_tool_args(allow_model_requests: None):
+    c = completion_message([BetaTextBlock(text='ok', type='text')], BetaUsage(input_tokens=1, output_tokens=1))
+    mock_client = MockAnthropic.create_mock(c)
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    messages: list[ModelRequest | ModelResponse] = [
+        ModelRequest(parts=[UserPromptPart(content='Call current_time')]),
+        ModelResponse(
+            parts=[
+                BuiltinToolCallPart(
+                    tool_name='mcp_server:clock',
+                    tool_call_id='mcptoolu_123',
+                    args={'action': 'call_tool', 'tool_name': 'current_time', 'tool_args': {}},
+                    provider_name='anthropic',
+                ),
+                BuiltinToolReturnPart(
+                    tool_name='mcp_server:clock',
+                    tool_call_id='mcptoolu_123',
+                    content={'content': [{'type': 'text', 'text': '2026-05-06T00:00:00Z'}], 'is_error': False},
+                    provider_name='anthropic',
+                ),
+            ],
+            provider_name='anthropic',
+        ),
+        ModelRequest(parts=[UserPromptPart(content='What did you call?')]),
+    ]
+
+    await model.request(
+        messages,
+        {},
+        ModelRequestParameters(
+            builtin_tools=[MCPServerTool(id='clock', url='https://example.com/mcp', allowed_tools=['current_time'])]
+        ),
+    )
+
+    completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert completion_kwargs['messages'][1]['content'][0] == snapshot(
+        {'id': 'mcptoolu_123', 'type': 'mcp_tool_use', 'server_name': 'clock', 'name': 'current_time', 'input': {}}
+    )
+
+
 @pytest.mark.vcr()
 async def test_anthropic_mcp_servers(allow_model_requests: None, anthropic_api_key: str):
     m = AnthropicModel('claude-sonnet-4-0', provider=AnthropicProvider(api_key=anthropic_api_key))

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -8548,6 +8548,65 @@ async def test_openai_responses_builtin_tool_call_id_uses_id_field(allow_model_r
     assert web_search_item['id'] == long_id
 
 
+async def test_openai_responses_mcp_call_replays_empty_tool_args(allow_model_requests: None):
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='msg_123',
+                content=cast(list[Content], [ResponseOutputText(text='ok', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('gpt-5', provider=OpenAIProvider(openai_client=mock_client))
+
+    messages: list[ModelRequest | ModelResponse] = [
+        ModelRequest(parts=[UserPromptPart(content='Call current_time')]),
+        ModelResponse(
+            parts=[
+                BuiltinToolCallPart(
+                    tool_name='mcp_server:clock',
+                    tool_call_id='mcp_123',
+                    args={'action': 'call_tool', 'tool_name': 'current_time', 'tool_args': {}},
+                    provider_name='openai',
+                ),
+                BuiltinToolReturnPart(
+                    tool_name='mcp_server:clock',
+                    tool_call_id='mcp_123',
+                    content={'output': '2026-05-06T00:00:00Z', 'error': None},
+                    provider_name='openai',
+                ),
+            ],
+            provider_name='openai',
+        ),
+        ModelRequest(parts=[UserPromptPart(content='What did you call?')]),
+    ]
+
+    await model.request(
+        messages,
+        cast(OpenAIResponsesModelSettings, {'openai_send_reasoning_ids': True}),
+        ModelRequestParameters(
+            builtin_tools=[MCPServerTool(id='clock', url='https://example.com/mcp', allowed_tools=['current_time'])]
+        ),
+    )
+
+    response_kwargs = get_mock_responses_kwargs(mock_client)[0]
+    assert response_kwargs['input'][1] == snapshot(
+        {
+            'id': 'mcp_123',
+            'server_label': 'clock',
+            'name': 'current_time',
+            'arguments': '{}',
+            'error': None,
+            'output': None,
+            'type': 'mcp_call',
+        }
+    )
+
+
 async def test_openai_responses_model_mcp_server_tool(allow_model_requests: None, openai_api_key: str):
     m = OpenAIResponsesModel(
         'o4-mini',


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #5308

This fixes provider-native MCP history replay for parameterless MCP tools. OpenAI Responses and Anthropic both stored no-argument MCP calls as `tool_args: {}`, but their replay mappers used a truthiness check, so the prior MCP call was silently omitted from the next provider request.

The replay checks now accept `tool_args` values that are present and not `None`, preserving `{}` for no-argument tools while keeping missing values skipped. Regression tests cover both OpenAI Responses `mcp_call` replay and Anthropic `mcp_tool_use` replay with empty tool arguments.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Tests

- `uv run pytest tests/models/test_openai_responses.py::test_openai_responses_mcp_call_replays_empty_tool_args tests/models/test_anthropic.py::test_anthropic_mcp_call_replays_empty_tool_args`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/models/anthropic.py tests/models/test_openai_responses.py tests/models/test_anthropic.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/models/anthropic.py tests/models/test_openai_responses.py tests/models/test_anthropic.py`
- `git diff --check`

Full local pre-commit typecheck was blocked by missing optional dependencies in unrelated examples/tests (`fastapi`, `datasets`, `prefect`, etc.).