### PR TITLE
fix(evals): guarantee `CaseLifecycle.teardown()`

### DIFF
--- a/docs/evals/how-to/lifecycle.md
+++ b/docs/evals/how-to/lifecycle.md
@@ -40,7 +40,7 @@ class SetupFromMetadata(CaseLifecycle[str, str, dict]):
 
     async def teardown(
         self,
-        result: ReportCase[str, str, dict] | ReportCaseFailure[str, str, dict],
+        result: ReportCase[str, str, dict] | ReportCaseFailure[str, str, dict] | None,
     ) -> None:
         pass  # Clean up resources here
 
@@ -82,7 +82,7 @@ class ConditionalCleanup(CaseLifecycle[str, str, dict]):
 
     async def teardown(
         self,
-        result: ReportCase[str, str, dict] | ReportCaseFailure[str, str, dict],
+        result: ReportCase[str, str, dict] | ReportCaseFailure[str, str, dict] | None,
     ) -> None:
         keep_on_failure = (self.case.metadata or {}).get('keep_on_failure', False)
         if isinstance(result, ReportCaseFailure) and keep_on_failure:

--- a/docs/evals/how-to/lifecycle.md
+++ b/docs/evals/how-to/lifecycle.md
@@ -14,7 +14,7 @@ Each case follows this flow:
 2. **Task runs**
 3. **`prepare_context()`** — called after task, before evaluators
 4. **Evaluators run**
-5. **`teardown()`** — called after evaluators complete
+5. **`teardown()`** — called after evaluators complete, or during cleanup if the case is interrupted
 
 ## Per-Case Setup and Teardown
 
@@ -66,7 +66,7 @@ The case metadata drives per-case behavior without needing custom [`Case`][pydan
 
 ### Conditional Teardown
 
-The `teardown()` hook receives the full result, so you can vary cleanup logic based on success or failure — for example, keeping test environments up for manual inspection when a case fails:
+The `teardown()` hook receives the full result, so you can vary cleanup logic based on success or failure — for example, keeping test environments up for manual inspection when a case fails. The `result` can be `None` if evaluation is interrupted before the case produces a report result, so handle that branch when your cleanup depends on the case outcome:
 
 ```python
 from pydantic_evals import Case, Dataset
@@ -85,9 +85,14 @@ class ConditionalCleanup(CaseLifecycle[str, str, dict]):
         result: ReportCase[str, str, dict] | ReportCaseFailure[str, str, dict] | None,
     ) -> None:
         keep_on_failure = (self.case.metadata or {}).get('keep_on_failure', False)
-        if isinstance(result, ReportCaseFailure) and keep_on_failure:
+        if result is None:
+            # abnormal exit
+            cleaned_up.append(self.resource_id)
+        elif isinstance(result, ReportCaseFailure) and keep_on_failure:
+            # case failed
             pass  # Keep resource for inspection
         else:
+            # case succeeded
             cleaned_up.append(self.resource_id)
 
 

--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -1103,7 +1103,7 @@ async def _run_task_and_evaluators(
         A ReportCase containing the evaluation results.
     """
     lc: CaseLifecycle[Any, Any, Any] | None = None
-    result: ReportCase[InputsT, OutputT, MetadataT] | ReportCaseFailure[InputsT, OutputT, MetadataT]
+    result: ReportCase[InputsT, OutputT, MetadataT] | ReportCaseFailure[InputsT, OutputT, MetadataT] | None = None
     trace_id: str | None = None
     span_id: str | None = None
     with logfire_span(
@@ -1194,19 +1194,20 @@ async def _run_task_and_evaluators(
                 trace_id=trace_id,
                 span_id=span_id,
             )
-
-        # Teardown exceptions are intentionally not caught here — they propagate
-        # to the caller. If your teardown may raise and you don't want it to crash
-        # the evaluation, handle exceptions within your teardown() implementation.
-        # If you don't like this behavior, let us know and we can change it.
-        if lc is not None:
-            await lc.teardown(result)
+        finally:
+            # Teardown exceptions are intentionally not caught here — they propagate
+            # to the caller. If your teardown may raise and you don't want it to crash
+            # the evaluation, handle exceptions within your teardown() implementation.
+            # If you don't like this behavior, let us know and we can change it.
+            if lc is not None:
+                await lc.teardown(result)
 
     if isinstance(result, ReportCase):
         # Update the total duration to reflect the teardown time.
         # Note this means that modifications to this field inside the teardown will not be reflected.
         result.total_duration = _get_span_duration(case_span, time.time() - t0)
 
+    assert result is not None
     return result
 
 

--- a/pydantic_evals/pydantic_evals/lifecycle.py
+++ b/pydantic_evals/pydantic_evals/lifecycle.py
@@ -34,7 +34,7 @@ class CaseLifecycle(Generic[InputsT, OutputT, MetadataT]):
     2. Task runs
     3. `prepare_context()` — called after task, before evaluators; can enrich metrics/attributes
     4. Evaluators run
-    5. `teardown()` — called after evaluators complete; receives the full result
+    5. `teardown()` — called after evaluators complete; receives the full result (or `None` when interrupted)
 
     Exceptions raised by `setup()` or `prepare_context()` are caught and recorded as
     a `ReportCaseFailure`; `teardown()` is still called afterward so you can clean up.
@@ -96,7 +96,7 @@ class CaseLifecycle(Generic[InputsT, OutputT, MetadataT]):
 
     async def teardown(
         self,
-        result: ReportCase[InputsT, OutputT, MetadataT] | ReportCaseFailure[InputsT, OutputT, MetadataT],
+        result: ReportCase[InputsT, OutputT, MetadataT] | ReportCaseFailure[InputsT, OutputT, MetadataT] | None,
     ) -> None:
         """Called after evaluators complete.
 
@@ -105,7 +105,8 @@ class CaseLifecycle(Generic[InputsT, OutputT, MetadataT]):
         inspection on failure).
 
         Args:
-            result: The evaluation result — either a `ReportCase` (success) or `ReportCaseFailure`.
+            result: The evaluation result — a `ReportCase` (success), `ReportCaseFailure`,
+                or `None` if the run ended without a report object (e.g. cancellation).
         """
 
     def __repr__(self) -> str:

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -2114,9 +2114,10 @@ async def test_lifecycle_setup_and_teardown(example_dataset: Dataset[TaskInput, 
         async def teardown(
             self,
             result: ReportCase[TaskInput, TaskOutput, TaskMetadata]
-            | ReportCaseFailure[TaskInput, TaskOutput, TaskMetadata],
+            | ReportCaseFailure[TaskInput, TaskOutput, TaskMetadata]
+            | None,
         ) -> None:
-            events.append(f'teardown:{self.case.name}:{type(result).__name__}')
+            events.append(f'teardown:{self.case.name}:{type(result).__name__ if result is not None else "NoneType"}')
 
     async def task(inputs: TaskInput) -> TaskOutput:
         return TaskOutput(answer='test')
@@ -2130,10 +2131,10 @@ async def test_lifecycle_teardown_on_task_failure():
     """Test that teardown runs even when the task fails, and receives ReportCaseFailure."""
     from pydantic_evals.lifecycle import CaseLifecycle
 
-    teardown_results: list[ReportCase | ReportCaseFailure] = []
+    teardown_results: list[ReportCase | ReportCaseFailure | None] = []
 
     class TeardownTracker(CaseLifecycle[str, str, None]):
-        async def teardown(self, result: ReportCase[str, str, None] | ReportCaseFailure[str, str, None]) -> None:
+        async def teardown(self, result: ReportCase[str, str, None] | ReportCaseFailure[str, str, None] | None) -> None:
             teardown_results.append(result)
 
     dataset = Dataset[str, str, None](
@@ -2248,7 +2249,7 @@ async def test_lifecycle_teardown_exception_propagates():
     from pydantic_evals.lifecycle import CaseLifecycle
 
     class BrokenTeardown(CaseLifecycle[str, str, None]):
-        async def teardown(self, result: ReportCase[str, str, None] | ReportCaseFailure[str, str, None]) -> None:
+        async def teardown(self, result: ReportCase[str, str, None] | ReportCaseFailure[str, str, None] | None) -> None:
             raise RuntimeError('teardown exploded')
 
     dataset = Dataset[str, str, None](name='teardown_exception', cases=[Case(name='case1', inputs='hello')])
@@ -2270,9 +2271,10 @@ async def test_lifecycle_setup_failure_produces_case_failure_and_calls_teardown(
         async def setup(self) -> None:
             raise RuntimeError('setup failed')
 
-        async def teardown(self, result: ReportCase[str, str, None] | ReportCaseFailure[str, str, None]) -> None:
+        async def teardown(self, result: ReportCase[str, str, None] | ReportCaseFailure[str, str, None] | None) -> None:
             nonlocal teardown_called
             teardown_called = True
+            assert result is not None
             assert isinstance(result, ReportCaseFailure)
             assert 'setup failed' in result.error_message
 


### PR DESCRIPTION
move `lc.teardown(result)` into `finally` section and allow it to receive `None`

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #5319 

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
