### PR TITLE
ci: drop `safe-for-ci` label gating on harness-compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,26 +284,6 @@ jobs:
           path: htmlcov
           include-hidden-files: true
 
-  # Enforces the `safe-for-ci` label on fork PRs so the `harness compat` workflow
-  # (in `harness-compat.yml`) actually runs before merge. That workflow lives in a
-  # separate file so it can use a `pull_request` path filter and `labeled` event
-  # type without affecting the rest of CI; cross-workflow `needs:` doesn't exist
-  # in GitHub Actions, so this gate job is how we surface the label requirement to
-  # the `check` aggregate. Fork PR without label → gate fails → `check` fails →
-  # branch protection blocks merge until a maintainer labels and re-runs.
-  harness-compat-gate:
-    name: harness compat gate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require `safe-for-ci` label on fork PRs
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository &&
-          !contains(github.event.pull_request.labels.*.name, 'safe-for-ci')
-        run: |
-          echo "::error::Fork PRs need the 'safe-for-ci' label so the harness-compat workflow can run. A maintainer must add the label after reviewing the diff; CI will re-trigger automatically."
-          exit 1
-
   # https://github.com/marketplace/actions/alls-green#why used for branch protection checks
   check:
     if: always()
@@ -315,7 +295,6 @@ jobs:
       - test-lowest-versions
       - test-examples
       - coverage
-      - harness-compat-gate
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/harness-compat.yml
+++ b/.github/workflows/harness-compat.yml
@@ -7,25 +7,17 @@ name: Harness Compat
 #
 # Triggers:
 # - PRs touching `pydantic_ai_slim/**`: required to merge.
-# - Pushes to `main`: confirms the merged commit still works (catches
-#   anything that slipped through path-filter gaps).
+# - Pushes to `main`: confirms the merged commit still works.
 # - Push of `v*` tags: gates a release on harness compatibility.
 #
-# Fork PRs are gated behind the `safe-for-ci` label so a maintainer reviews
-# the diff before CI runs the fork's pydantic-ai code through the harness
-# suite. The called workflow itself runs without secrets and with
-# `contents: read` only — the label is defense-in-depth against running
-# unreviewed code on CI infrastructure, not a privilege escalation barrier.
-#
-# Fork PRs without the label produce a `skipped` job result. The
-# `harness-compat-gate` job in `ci.yml` enforces the label requirement via the
-# `check` gate so unlabeled fork PRs can't be merged (`check` fails when the
-# gate fails). Add `harness compat` to required-status-checks in branch
-# protection so the actual cross-repo run is also enforced when it runs.
+# Fork PRs run with `contents: read` only and no secrets passed to the called
+# workflow — same exposure as the regular test jobs in `ci.yml`. If the called
+# workflow ever grows steps that need elevated permissions or secrets, add a
+# fork gate (e.g. require a `safe-for-ci` label) before merging that change.
 
 on:
   pull_request:
-    types: [labeled, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
     paths:
       - 'pydantic_ai_slim/**'
       - '.github/workflows/harness-compat.yml'
@@ -39,10 +31,6 @@ permissions:
 jobs:
   harness-compat:
     name: harness compat
-    if: >-
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(github.event.pull_request.labels.*.name, 'safe-for-ci')
     # Same-org reusable workflow under shared maintenance; SHA pinning would force a coordination bump
     # on every harness change without security benefit. Ignore configured in `.github/zizmor.yml`.
     uses: pydantic/pydantic-ai-harness/.github/workflows/compat-test.yml@main

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -3,7 +3,7 @@ name: PR Guard
 on:
   # zizmor: ignore[dangerous-triggers] -- pull_request_target is needed to close duplicate PRs and manage issues; no fork code is checked out
   pull_request_target:
-    types: [opened, ready_for_review, edited, synchronize]
+    types: [opened, ready_for_review, edited]
 
 permissions: {}
 
@@ -13,10 +13,6 @@ concurrency:
 jobs:
   guard:
     name: Guard
-    # The duplicate / linking / assignment checks only need to run when the PR is
-    # opened, marked ready, or its body changes. `synchronize` (a push to the PR
-    # branch) is handled by `reset-safe-for-ci` below.
-    if: github.event.action != 'synchronize'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -181,25 +177,3 @@ jobs:
           GITHUB_EVENT_PULL_REQUEST_USER_LOGIN: ${{ github.event.pull_request.user.login }}
           GITHUB_EVENT_PULL_REQUEST_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           GITHUB_EVENT_PULL_REQUEST_DRAFT: ${{ github.event.pull_request.draft }}
-
-  # On every push to a fork PR, drop the `safe-for-ci` label so a maintainer has
-  # to re-review and re-add it before the harness-compat workflow runs against
-  # the new commits. Same-org PRs are exempt (they don't need the label to run
-  # cross-repo CI in the first place).
-  reset-safe-for-ci:
-    name: Reset `safe-for-ci` on push to fork PRs
-    if: |
-      github.event.action == 'synchronize' &&
-      github.event.pull_request.head.repo.fork &&
-      contains(github.event.pull_request.labels.*.name, 'safe-for-ci')
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Remove `safe-for-ci` label
-        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label safe-for-ci
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
- Closes #<issue>

### Summary

#5276 added a `safe-for-ci` label gate as deferred-defense against future scope creep in the called `compat-test.yml` reusable workflow. Reconsidering after merge: the called workflow runs with `contents: read` only and no secrets — the same exposure as pydantic-ai's regular `ci.yml` test jobs, which gate fork-PR risk reactively at the job level rather than via deny-by-default labels.

The forward-creep scenario (someone adds privileged scope to compat-test.yml, review misses the fork implication, malicious PR happens to be labeled in that window) requires a chain of human errors that the existing review process is unlikely to walk through. Meanwhile the cost is concrete and recurring: every community PR touching `pydantic_ai_slim/` was red-by-default until labeled, with `pr-guard`'s auto-remove on synchronize forcing relabel on every push during iteration.

### Cleanup

- `harness-compat.yml`: drop the fork-PR `if:` gate and the `labeled` event type from `pull_request:` triggers.
- `ci.yml`: drop the `harness-compat-gate` job and remove it from `check.needs`.
- `pr-guard.yml`: drop the `reset-safe-for-ci` job and the `synchronize` event type from `pull_request_target:` triggers.
- `harness-compat.yml` header comment now flags the fork-PR consideration for future expanders without enforcing it.

The `safe-for-ci` label can be deleted from the repo (the gate pattern is documented for re-introduction if the called workflow's scope grows). I'll do that after merge.

### Companion

pydantic/pydantic-ai-harness#229 updates the corresponding comment in `compat-test.yml`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).