### PR TITLE
Add RetryCount evaluator + tool-retry span plumbing

### DIFF
--- a/docs/evals/evaluators/agentic.md
+++ b/docs/evals/evaluators/agentic.md
@@ -28,6 +28,7 @@ Agentic evaluators answer a class of "did the agent do the right thing?" questio
 - **Trajectory shape** — did it call them in the right order, or at least use the right set? ([`TrajectoryMatch`][pydantic_evals.evaluators.TrajectoryMatch])
 - **Argument quality** — did the tool receive the expected inputs? ([`ArgumentCorrectness`][pydantic_evals.evaluators.ArgumentCorrectness])
 - **Budget discipline** — did the agent finish within a tool-call and/or model-request budget? ([`StepEfficiency`][pydantic_evals.evaluators.StepEfficiency])
+- **Retries** — did the model get tool arguments right on the first try, or did it need retries? ([`RetryCount`][pydantic_evals.evaluators.RetryCount])
 
 They are all deterministic, never call an LLM, and are cheap enough to run on every case in every experiment.
 
@@ -157,6 +158,36 @@ dataset = Dataset(
 - `'model_requests_under_budget'` — set when `max_model_requests` is provided.
 
 Stable key names make reports render consistently across runs and across cases.
+
+## RetryCount
+
+Surface the number of tool-call retries the agent had to issue. Each retry is a `ToolRetryError` raised inside the tool wrapper — covering Pydantic AI's tool argument-validation failures, tool-raised [`ModelRetry`][pydantic_ai.exceptions.ModelRetry], missing tool names, and structured-output validation. A non-zero count means the model did not get its arguments right on the first try.
+
+```python
+from pydantic_evals import Case, Dataset
+from pydantic_evals.evaluators import RetryCount
+
+dataset = Dataset(
+    name='retry_aware',
+    cases=[Case(inputs='Run the daily report')],
+    evaluators=[
+        # Surface the metric every run; also fail when retries exceed 2.
+        RetryCount(max_retries=2),
+    ],
+)
+```
+
+**How retries are detected:** Pydantic AI marks tool spans whose call ended in a retry with the `pydantic_ai.tool.retry` attribute. `pydantic_evals.dataset._extract_span_tree_metrics` reads that attribute into `ctx.metrics['retries']` automatically; `RetryCount` prefers that metric and falls back to walking the span tree directly.
+
+**Parameters:**
+
+- `max_retries` (`int | None`): Maximum allowed retries before the run is over budget. `None` disables the budget check; only the count metric is returned.
+- `evaluation_name` (`str | None`): Unused — results are emitted under fixed keys.
+
+**Returns:** a mapping under these **stable, documented** keys:
+
+- `'retries'` — always set, an [`EvaluationReason`][pydantic_evals.evaluators.EvaluationReason] whose `value` is the retry count (`int`). Useful for charting the retry-rate trend over time.
+- `'retries_under_budget'` — set when `max_retries` is provided. `True` when within budget.
 
 ## Recipes
 

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -47,6 +47,14 @@ class InstrumentationNames:
     tool_deferral_name_attr: ClassVar[str] = 'pydantic_ai.tool.deferral.name'
     tool_deferral_metadata_attr: ClassVar[str] = 'pydantic_ai.tool.deferral.metadata'
 
+    # Retry span attribute. Set to True on a tool span that ended in a
+    # ToolRetryError - the model will see the retry prompt and try again
+    # (subject to the tool's `max_retries`). Distinct from `tool_deferral_*`
+    # (which marks a tool that was deferred to the user) and from a final
+    # tool failure that exhausts retries (the latter has no dedicated marker
+    # and is only visible via the span's OTel Status).
+    tool_retry_attr: ClassVar[str] = 'pydantic_ai.tool.retry'
+
     @classmethod
     def for_version(cls, version: int) -> Self:
         """Create instrumentation configuration for a specific version.

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -584,6 +584,12 @@ class ToolManager(Generic[AgentDepsT]):
                 raise
             except ToolRetryError as e:
                 part = e.tool_retry
+                if span.is_recording():
+                    # Mark the span as a retry so downstream evaluators can
+                    # distinguish "agent retried after this call" from "tool
+                    # finally failed". Set unconditionally - it does not
+                    # carry user content.
+                    span.set_attribute(instrumentation_names.tool_retry_attr, True)
                 if include_content and span.is_recording():
                     span.set_attribute(instrumentation_names.tool_result_attr, part.model_response())
                 span.record_exception(e, escaped=True)

--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -984,20 +984,28 @@ class _TaskRun:
 
 
 def _extract_span_tree_metrics(task_run: _TaskRun, span_tree: SpanTree) -> None:
-    """Extract standard metrics (requests, cost, token usage) from a span tree.
+    """Extract standard metrics (requests, cost, token usage, retries) from a span tree.
 
-    Iterates the span tree looking for LLM request spans (identified by the
-    ``gen_ai.request.model`` attribute) and extracts:
+    Iterates the span tree looking for:
 
-    - ``requests``: count of ``gen_ai.operation.name == 'chat'`` spans
-    - ``cost``: sum of ``operation.cost`` values
-    - Token usage from ``gen_ai.usage.*`` and ``gen_ai.usage.details.*`` attributes
+    - LLM request spans (identified by the ``gen_ai.request.model`` attribute):
+        - ``requests``: count of ``gen_ai.operation.name == 'chat'`` spans
+        - ``cost``: sum of ``operation.cost`` values
+        - Token usage from ``gen_ai.usage.*`` and ``gen_ai.usage.details.*`` attributes
+    - Tool spans whose pydantic-ai tool wrapper marked them with
+      ``pydantic_ai.tool.retry``:
+        - ``retries``: count of tool calls that ended in a retry prompt
+          (validation error, ``ModelRetry``, missing tool name, or
+          structured-output validation). A non-zero value means the model
+          did not get its arguments right on the first try.
     """
     # Idea for making this more configurable: replace the following logic with a call to a user-provided function
     #   of type Callable[[_TaskRun, SpanTree], None] or similar, (maybe no _TaskRun and just use the public APIs).
     #   That way users can customize this logic. We'd default to a function that does the current thing but also
     #   allow `None` to disable it entirely.
     for node in span_tree:
+        if node.attributes.get('pydantic_ai.tool.retry') is True:
+            task_run.increment_metric('retries', 1)
         if 'gen_ai.request.model' not in node.attributes:
             continue  # we only want to count the below specifically for the individual LLM requests, not agent runs
         for k, v in node.attributes.items():

--- a/pydantic_evals/pydantic_evals/evaluators/__init__.py
+++ b/pydantic_evals/pydantic_evals/evaluators/__init__.py
@@ -1,4 +1,4 @@
-from .agentic import ArgumentCorrectness, StepEfficiency, ToolCorrectness, TrajectoryMatch
+from .agentic import ArgumentCorrectness, RetryCount, StepEfficiency, ToolCorrectness, TrajectoryMatch
 from .common import (
     Contains,
     Equals,
@@ -34,6 +34,7 @@ __all__ = (
     'TrajectoryMatch',
     'ArgumentCorrectness',
     'StepEfficiency',
+    'RetryCount',
     # context
     'EvaluatorContext',
     # evaluator

--- a/pydantic_evals/pydantic_evals/evaluators/agentic.py
+++ b/pydantic_evals/pydantic_evals/evaluators/agentic.py
@@ -37,6 +37,7 @@ __all__ = (
     'TrajectoryMatch',
     'ArgumentCorrectness',
     'StepEfficiency',
+    'RetryCount',
 )
 
 
@@ -504,4 +505,93 @@ class StepEfficiency(Evaluator[object, object, object]):
                 reason=(f'{request_count} model request(s) (from {source}), budget={self.max_model_requests}'),
             )
 
+        return results
+
+
+# ---------------------------------------------------------------------------
+# RetryCount
+# ---------------------------------------------------------------------------
+
+# Stable keys for the mapping returned by `RetryCount`. Documented and
+# considered part of the evaluator's public contract.
+RETRY_COUNT_KEY = 'retries'
+RETRY_COUNT_UNDER_BUDGET_KEY = 'retries_under_budget'
+
+# Span attribute set by `pydantic_ai.tool_manager._CallToolsHandler` on a tool
+# span that ended in a `ToolRetryError` - the model gets a retry prompt and
+# tries again (subject to the tool's `max_retries`). Duplicated here rather
+# than imported because `pydantic_ai._instrumentation` is private.
+_TOOL_RETRY_ATTR = 'pydantic_ai.tool.retry'
+
+
+def _count_tool_retries(span_tree: SpanTree) -> int:
+    """Count tool-call spans marked as a retry by the pydantic-ai tool wrapper."""
+    return sum(1 for node in span_tree if node.attributes.get(_TOOL_RETRY_ATTR) is True)
+
+
+@dataclass(repr=False)
+class RetryCount(Evaluator[object, object, object]):
+    """Number of times a tool call had to be retried during the run.
+
+    Each retry is a `ToolRetryError` raised inside the tool wrapper - covering
+    pydantic-ai's tool argument-validation failures, tool-raised
+    [`ModelRetry`][pydantic_ai.exceptions.ModelRetry], missing tool names, and
+    structured-output validation errors. A non-zero count means the model did
+    not get its arguments right on the first try.
+
+    Reads `ctx.metrics['retries']` when available (populated by
+    `pydantic_evals.dataset._extract_span_tree_metrics` from the
+    `pydantic_ai.tool.retry` span attribute) and falls back to scanning the
+    span tree directly.
+
+    Returns a mapping with these stable keys:
+
+    - `'retries'`: always set, an `EvaluationReason` whose `value` is the
+      retry count (as an `int`). Surfaced as a metric so reports can chart
+      the distribution over time.
+    - `'retries_under_budget'`: only set when `max_retries` is configured -
+      an `EvaluationReason` whose `value` is `True` when the count is within
+      the budget.
+
+    Args:
+        max_retries: Maximum allowed retries before the run is considered
+            over budget. `None` disables the budget check; only the count
+            metric is returned.
+        evaluation_name: Unused - results are returned under stable keys.
+    """
+
+    max_retries: int | None = None
+    evaluation_name: str | None = field(default=None)
+
+    def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> dict[str, EvaluationReason]:
+        # Prefer the pre-extracted metric (populated by Dataset.evaluate via
+        # `_extract_span_tree_metrics`). Fall back to walking the span tree
+        # directly so the evaluator also works when invoked outside of a
+        # Dataset run (e.g. from `OnlineEvaluation`).
+        metric = ctx.metrics.get(RETRY_COUNT_KEY)
+        if isinstance(metric, int | float):
+            count = int(metric)
+            source = "ctx.metrics['retries']"
+        else:
+            try:
+                span_tree = ctx.span_tree
+            except SpanTreeRecordingError:
+                results: dict[str, EvaluationReason] = {
+                    RETRY_COUNT_KEY: EvaluationReason(value=0, reason=_NO_SPAN_TREE_REASON),
+                }
+                if self.max_retries is not None:
+                    results[RETRY_COUNT_UNDER_BUDGET_KEY] = EvaluationReason(value=False, reason=_NO_SPAN_TREE_REASON)
+                return results
+            count = _count_tool_retries(span_tree)
+            source = 'span tree'
+
+        results = {
+            RETRY_COUNT_KEY: EvaluationReason(value=count, reason=f'{count} tool retry(ies) (from {source})'),
+        }
+        if self.max_retries is not None:
+            within = count <= self.max_retries
+            results[RETRY_COUNT_UNDER_BUDGET_KEY] = EvaluationReason(
+                value=within,
+                reason=f'{count} retry(ies) (from {source}), budget={self.max_retries}',
+            )
         return results

--- a/tests/evals/test_agentic_evaluators.py
+++ b/tests/evals/test_agentic_evaluators.py
@@ -14,11 +14,14 @@ with try_import() as imports_successful:
         ArgumentCorrectness,
         EvaluationReason,
         EvaluatorContext,
+        RetryCount,
         StepEfficiency,
         ToolCorrectness,
         TrajectoryMatch,
     )
     from pydantic_evals.evaluators.agentic import (
+        RETRY_COUNT_KEY,
+        RETRY_COUNT_UNDER_BUDGET_KEY,
         STEP_EFFICIENCY_MODEL_REQUESTS_KEY,
         STEP_EFFICIENCY_TOOL_CALLS_KEY,
         _extract_tool_calls,  # pyright: ignore[reportPrivateUsage]
@@ -868,3 +871,108 @@ def test_step_efficiency_metrics_non_numeric_falls_back_to_spans():
     ctx = _ctx(tree=tree, metrics={})  # empty metrics -> falls back to span tree
     result = StepEfficiency(max_model_requests=5).evaluate(ctx)
     assert result[STEP_EFFICIENCY_MODEL_REQUESTS_KEY].value is True
+
+
+# ---------------------------------------------------------------------------
+# RetryCount
+# ---------------------------------------------------------------------------
+
+
+def _v2_retried_tool_span(*, name: str, span_id: int, start_offset: float) -> SpanNode:
+    """Build a v2 tool span marked with `pydantic_ai.tool.retry=True`.
+
+    The pydantic-ai tool wrapper sets this attribute on a tool span that
+    ended in a `ToolRetryError` (see `pydantic_ai.tool_manager`).
+    """
+    return _make_span(
+        name='running tool',
+        span_id=span_id,
+        attributes={
+            'gen_ai.tool.name': name,
+            'logfire.msg': f'running tool: {name}',
+            'pydantic_ai.tool.retry': True,
+        },
+        start_offset=start_offset,
+    )
+
+
+def test_retry_count_metric_only_when_no_budget():
+    # Two retried spans, no budget configured: only the count key is returned.
+    tree = _build_tree(
+        [
+            _v2_retried_tool_span(name='search', span_id=1, start_offset=0.0),
+            _v2_retried_tool_span(name='search', span_id=2, start_offset=0.1),
+        ]
+    )
+    result = RetryCount().evaluate(_ctx(tree=tree))
+    assert set(result.keys()) == {RETRY_COUNT_KEY}
+    reason = result[RETRY_COUNT_KEY]
+    assert reason.value == 2
+    assert reason.reason is not None
+    assert 'from span tree' in reason.reason
+
+
+def test_retry_count_zero_for_clean_run():
+    tree = _build_tree([_v2_tool_span(name='search', span_id=1, args='{}', start_offset=0.0)])
+    result = RetryCount().evaluate(_ctx(tree=tree))
+    assert result[RETRY_COUNT_KEY].value == 0
+
+
+def test_retry_count_prefers_metrics():
+    # Empty span tree but the extracted metric is present: trust the metric.
+    result = RetryCount().evaluate(_ctx(tree=_build_tree([]), metrics={'retries': 5}))
+    reason = result[RETRY_COUNT_KEY]
+    assert reason.value == 5
+    assert reason.reason is not None
+    assert "ctx.metrics['retries']" in reason.reason
+
+
+def test_retry_count_falls_back_to_span_tree_when_metric_missing():
+    tree = _build_tree(
+        [
+            _v2_retried_tool_span(name='search', span_id=1, start_offset=0.0),
+            _v2_tool_span(name='search', span_id=2, args='{}', start_offset=0.1),
+        ]
+    )
+    result = RetryCount().evaluate(_ctx(tree=tree, metrics={}))
+    assert result[RETRY_COUNT_KEY].value == 1
+
+
+def test_retry_count_under_budget_when_within():
+    result = RetryCount(max_retries=3).evaluate(_ctx(tree=_build_tree([]), metrics={'retries': 2}))
+    assert set(result.keys()) == {RETRY_COUNT_KEY, RETRY_COUNT_UNDER_BUDGET_KEY}
+    assert result[RETRY_COUNT_UNDER_BUDGET_KEY].value is True
+
+
+def test_retry_count_over_budget():
+    result = RetryCount(max_retries=1).evaluate(_ctx(tree=_build_tree([]), metrics={'retries': 4}))
+    reason = result[RETRY_COUNT_UNDER_BUDGET_KEY]
+    assert reason.value is False
+    assert reason.reason is not None
+    assert '4 retry(ies)' in reason.reason
+    assert 'budget=1' in reason.reason
+
+
+def test_retry_count_no_span_tree_falls_back_when_metric_present():
+    # Even with no span tree, a populated metric is enough to score.
+    ctx = _ctx(tree=SpanTreeRecordingError('spans were not recorded'), metrics={'retries': 2})
+    result = RetryCount(max_retries=5).evaluate(ctx)
+    assert result[RETRY_COUNT_KEY].value == 2
+    assert result[RETRY_COUNT_UNDER_BUDGET_KEY].value is True
+
+
+def test_retry_count_no_span_tree_and_no_metric_skips_with_reason():
+    ctx = _ctx(tree=SpanTreeRecordingError('spans were not recorded'))
+    result = RetryCount(max_retries=3).evaluate(ctx)
+    assert set(result.keys()) == {RETRY_COUNT_KEY, RETRY_COUNT_UNDER_BUDGET_KEY}
+    for reason in result.values():
+        assert reason.reason is not None
+        assert 'logfire' in reason.reason
+    assert result[RETRY_COUNT_KEY].value == 0
+    assert result[RETRY_COUNT_UNDER_BUDGET_KEY].value is False
+
+
+def test_retry_count_no_span_tree_and_no_metric_no_budget_returns_only_count():
+    ctx = _ctx(tree=SpanTreeRecordingError('spans were not recorded'))
+    result = RetryCount().evaluate(ctx)
+    assert set(result.keys()) == {RETRY_COUNT_KEY}

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -850,6 +850,30 @@ async def test_genai_attribute_collection(example_dataset: Dataset[TaskInput, Ta
     )
 
 
+@needs_logfire
+async def test_retry_metric_collection(example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata]):
+    """Spans marked with `pydantic_ai.tool.retry` are counted into `metrics['retries']`.
+
+    The pydantic-ai tool wrapper sets this attribute on a tool span that ended
+    in a `ToolRetryError`. The dataset's metric extractor surfaces it so
+    evaluators can read `ctx.metrics['retries']` (or chart the trend over time).
+    """
+
+    async def my_task(inputs: TaskInput) -> TaskOutput:
+        with logfire.span('running tool', **{'pydantic_ai.tool.retry': True}):  # type: ignore
+            pass
+        with logfire.span('running tool', **{'pydantic_ai.tool.retry': True}):  # type: ignore
+            pass
+        # A non-retry tool span - should not be counted.
+        with logfire.span('running tool', **{'gen_ai.tool.name': 'search'}):  # type: ignore
+            pass
+        return TaskOutput(answer=f'answer to {inputs.query}')
+
+    report = await example_dataset.evaluate(my_task)
+    for case in report.cases:
+        assert case.metrics.get('retries') == 2, case
+
+
 async def test_serialization_to_yaml(example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata], tmp_path: Path):
     """Test serializing a dataset to YAML."""
     yaml_path = tmp_path / 'test_cases.yaml'

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -1351,6 +1351,7 @@ def test_include_tool_args_span_attributes(
                     'logfire.span_type': 'span',
                     'gen_ai.agent.name': 'my_agent',
                     'gen_ai.agent.call.id': IsStr(),
+                    'pydantic_ai.tool.retry': True,
                     'tool_response': """\
 Tool error
 
@@ -1406,6 +1407,7 @@ Fix the errors and try again.\
                     'logfire.span_type': 'span',
                     'gen_ai.agent.name': 'my_agent',
                     'gen_ai.agent.call.id': IsStr(),
+                    'pydantic_ai.tool.retry': True,
                     'logfire.level_num': 17,
                 }
             )


### PR DESCRIPTION
## Summary

Surfaces tool-call retries as a first-class signal in pydantic-evals. Builds on top of #5130 so `RetryCount` sits naturally next to `StepEfficiency` and `ArgumentCorrectness`.

End-to-end plumbing across three layers:

- **`pydantic_ai.tool_manager`**: when a tool call ends in a `ToolRetryError`, set `pydantic_ai.tool.retry = True` on the tool span before re-raising. The attribute name is centralised on `InstrumentationNames.tool_retry_attr` next to the existing `tool_deferral_*` attributes. Already-set Status/exception on the span is unchanged - this is purely additive.
- **`pydantic_evals.dataset._extract_span_tree_metrics`**: count spans with `pydantic_ai.tool.retry == True` into `ctx.metrics['retries']`, same shape as the existing `'requests'` / `'cost'` / token-usage extraction.
- **`pydantic_evals.evaluators.agentic.RetryCount`**: new evaluator, exported from `pydantic_evals.evaluators`. Mirrors `StepEfficiency`'s shape - returns a mapping under stable keys `'retries'` (always set, numeric metric) and `'retries_under_budget'` (only when `max_retries` is configured). Prefers `ctx.metrics['retries']` and falls back to scanning the span tree directly so it also works in `OnlineEvaluation` contexts where no metric extraction has run.

**Why a new attribute rather than reusing the OTel Status?** `pydantic_evals.otel.span_tree.SpanNode` doesn't expose Status / StatusMessage / events - so a span-tree-only evaluator can't tell a clean tool span from a retried one even when the tool wrapper already calls `span.record_exception(escaped=True)` and `span.set_status(StatusCode.ERROR)`. A boolean attribute is the smallest change that makes this signal observable without changing `SpanNode`.

## Tests

- 9 new tests in `tests/evals/test_agentic_evaluators.py` covering metric-only, span-tree fallback, budget within/over, and all `SpanTreeRecordingError` paths.
- 1 new test in `tests/evals/test_dataset.py` confirming the metric flows through `Dataset.evaluate` end-to-end.
- Updated 2 inline snapshots in `tests/test_logfire.py` (`test_include_tool_args_span_attributes` for `tool_error=True` with and without `include_content`) to include the new attribute.
- `make lint`, `make format` clean. Pyright clean on the modified files (only one pre-existing `reportPrivateImportUsage` on the unrelated `tenacity` import in `dataset.py`).
- Full `tests/evals/` suite: 444 passed.
- `tests/test_logfire.py` and `tests/test_tools.py`: 193 passed.

## Caveat

The retry attribute is set in `tool_manager._call_tool_span` for both v2 and v3+ instrumentation versions (the same code path handles both). It's set unconditionally when a `ToolRetryError` is caught, regardless of `include_content`, since it carries no user content.

## Checklist

- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).