### PR TITLE
Populate `for_run` `RunContext` with `run_id`, `conversation_id`, and `metadata`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1170,7 +1170,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             instrumentation_settings = None
             tracer = NoOpTracer()
 
-        # Build initial RunContext for for_run lifecycle hooks
+        # Build initial RunContext for for_run lifecycle hooks. Includes every
+        # field that's already known here — `tool_manager` and `validation_context`
+        # are populated later by `build_run_context` once the run is iterating.
         initial_ctx = RunContext[AgentDepsT](
             deps=deps,
             agent=self,
@@ -1179,8 +1181,24 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             prompt=user_prompt,
             messages=state.message_history,
             tracer=tracer,
+            trace_include_content=instrumentation_settings is not None and instrumentation_settings.include_content,
+            instrumentation_version=instrumentation_settings.version
+            if instrumentation_settings
+            else DEFAULT_INSTRUMENTATION_VERSION,
             run_step=0,
+            run_id=state.run_id,
+            conversation_id=state.conversation_id,
         )
+
+        # Resolve run metadata up front so capability and toolset `for_run` hooks
+        # can see it on `RunContext.metadata`. Metadata factories receive the
+        # `initial_ctx` above (no `tool_manager` / `validation_context` yet); they
+        # will be invoked again at the end of the run with the full final state,
+        # so any field that becomes available later still ends up reflected in
+        # `agent_run.metadata`. Factories should be pure mappings over the run
+        # context, not perform IO or have side effects.
+        state.metadata = self._get_metadata(initial_ctx, metadata)
+        initial_ctx.metadata = state.metadata
 
         # Determine root capability: override > agent default
         override_cap = self._override_root_capability.get()
@@ -1337,7 +1355,10 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             instrumentation_names.get_agent_run_span_name(agent_name),
             attributes=span_attributes,
         )
-        run_metadata: dict[str, Any] | None = None
+        # `state.metadata` was resolved above (before `for_run`); reuse it here so
+        # `_run_span_end_attributes` has a value even on early exits. The finally
+        # block below re-resolves with the full final state once the run completes.
+        run_metadata: dict[str, Any] | None = state.metadata
         try:
             async with AsyncExitStack() as stack:
                 if run_span.is_recording():
@@ -1360,7 +1381,6 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 )
                 await stack.enter_async_context(toolset)
                 agent_run = AgentRun(graph_run)
-                run_metadata = self._resolve_and_store_metadata(agent_run.ctx, metadata)
 
                 # Build RunContext for run lifecycle hooks
                 run_ctx = _agent_graph.build_run_context(agent_run.ctx)

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -2324,6 +2324,36 @@ async def test_for_run_with_different_instructions():
     )
 
 
+async def test_for_run_receives_populated_run_context():
+    """`for_run` hooks receive a `RunContext` with run_id, conversation_id, and resolved metadata."""
+
+    captured: dict[str, Any] = {}
+
+    class CapturingCap(AbstractCapability[None]):
+        async def for_run(self, ctx: RunContext[None]) -> AbstractCapability[None]:
+            captured['run_id'] = ctx.run_id
+            captured['conversation_id'] = ctx.conversation_id
+            captured['metadata'] = ctx.metadata
+            captured['instrumentation_version'] = ctx.instrumentation_version
+            return self
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart('done')])
+
+    def metadata_factory(ctx: RunContext[None]) -> dict[str, Any]:
+        # Factory should be able to read run_id/conversation_id from the early ctx.
+        return {'run_id_seen': ctx.run_id, 'conversation_id_seen': ctx.conversation_id}
+
+    agent = Agent(FunctionModel(respond), capabilities=[CapturingCap()])
+
+    await agent.run('Hello', conversation_id='conv-123', metadata=metadata_factory)
+
+    assert captured['run_id'] is not None
+    assert captured['conversation_id'] == 'conv-123'
+    assert captured['metadata'] == {'run_id_seen': captured['run_id'], 'conversation_id_seen': 'conv-123'}
+    assert captured['instrumentation_version'] is not None
+
+
 async def test_concurrent_runs_capability_isolation():
     """Multiple concurrent runs don't share state on stateful capabilities."""
 


### PR DESCRIPTION
Capability and toolset `for_run` hooks previously received a near-empty `RunContext` — `run_id`, `conversation_id`, trace/instrumentation flags, and `metadata` were all unset until the run started iterating. They're already known by the time `Agent.iter` is about to call `effective_capability.for_run(initial_ctx)`, so populate them up front from `state` and `instrumentation_settings`.

Run `metadata` is also now resolved before `for_run` so hooks can read it on `RunContext.metadata`. The factory sees the initial `RunContext` (no `tool_manager` / `validation_context` yet); it's invoked again at the end of the run with the full final state, so `agent_run.metadata` still reflects any late-bound fields. Factories are expected to be pure mappings over `RunContext` rather than perform IO or have side effects.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).