### PR TITLE
Drain spawned tasks during agent cancellation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -17,7 +17,7 @@ from typing_extensions import TypeVar, assert_never
 
 from pydantic_ai._history_processor import HistoryProcessor
 from pydantic_ai._instrumentation import DEFAULT_INSTRUMENTATION_VERSION
-from pydantic_ai._utils import dataclasses_no_defaults_repr, now_utc
+from pydantic_ai._utils import cancel_and_drain, dataclasses_no_defaults_repr, now_utc
 from pydantic_ai._uuid import uuid7
 from pydantic_ai.builtin_tools import AbstractBuiltinTool
 from pydantic_ai.capabilities.abstract import AbstractCapability
@@ -652,10 +652,21 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             )
         )
 
-        # Wait for handler to start or wrap to complete (short-circuit)
+        # Wait for handler to start or wrap to complete (short-circuit).
+        # If outer cancellation arrives during this wait, drain both tasks before re-raising
+        # so the user's `wrap_model_request` cleanup runs instead of orphaning.
         ready_waiter = asyncio.create_task(stream_ready.wait())
-        await asyncio.wait({ready_waiter, wrap_task}, return_when=asyncio.FIRST_COMPLETED)
-        ready_waiter.cancel()
+        try:
+            await asyncio.wait({ready_waiter, wrap_task}, return_when=asyncio.FIRST_COMPLETED)
+        except BaseException:
+            # `BaseException` to also catch `CancelledError`. Handoff hasn't completed,
+            # so both tasks are still ours; drain them so cleanup runs before we re-raise.
+            await cancel_and_drain(ready_waiter, wrap_task)
+            raise
+        else:
+            # Handoff succeeded: `wrap_task` is owned by the rest of the streaming
+            # lifecycle below. Only the throwaway readiness waiter is ours to clean up.
+            await cancel_and_drain(ready_waiter)
 
         if wrap_task.done() and not stream_ready.is_set():
             # wrap_model_request completed without calling handler — short-circuited or raised SkipModelRequest
@@ -1815,18 +1826,14 @@ async def _call_tools(  # noqa: C901
                             yield event
 
         except asyncio.CancelledError as e:
-            for task in tasks:
-                if not task.done():
-                    task.cancel(msg=e.args[0] if len(e.args) != 0 else None)
+            await cancel_and_drain(*tasks, msg=e.args[0] if len(e.args) != 0 else None)
             raise
         except BaseException:
             # Cancel any still-running sibling tasks so they don't become
             # orphaned asyncio tasks when a non-CancelledError exception
             # (e.g. RuntimeError, ConnectionError) propagates out of
             # handle_call_or_result().
-            for task in tasks:
-                if not task.done():
-                    task.cancel()
+            await cancel_and_drain(*tasks)
             raise
 
     # We append the results at the end, rather than as they are received, to retain a consistent ordering

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -220,6 +220,26 @@ async def gather(*coros: Awaitable[T]) -> list[T]:
     return final_results
 
 
+async def cancel_and_drain(*tasks: asyncio.Task[Any], msg: object = None) -> None:
+    """Cancel any tasks still running and wait for them to finish unwinding.
+
+    Cleanup-only: results and exceptions from `tasks` are intentionally discarded so a
+    cancelled child cannot replace an exception already propagating in the caller.
+    Use after `asyncio.create_task` when an outer cancel/exception means the spawned
+    tasks must be torn down before the caller exits.
+    """
+    for task in tasks:
+        if not task.done():
+            task.cancel(msg=msg)
+
+    # Pydantic Graph runs nodes under AnyIO cancel scopes. Once the outer scope
+    # is cancelled, AnyIO uses level cancellation and can keep re-cancelling at
+    # each await. Shield the drain so child tasks get one explicit cancel above,
+    # then can finish normal async `finally` cleanup before we re-raise.
+    with anyio.CancelScope(shield=True):
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
 class Unset:
     """A singleton to represent an unset value."""
 

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1503,11 +1503,15 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
                 _outer_context = contextvars.copy_context()
                 _wrap_task = asyncio.create_task(run_capability.wrap_run(run_ctx, handler=_do_run))
-
                 # Wait for handler to start or wrap_run to complete (short-circuit)
                 _ready_waiter = asyncio.create_task(_run_ready.wait())
-                await asyncio.wait({_ready_waiter, _wrap_task}, return_when=asyncio.FIRST_COMPLETED)
-                _ready_waiter.cancel()
+                try:
+                    await asyncio.wait({_ready_waiter, _wrap_task}, return_when=asyncio.FIRST_COMPLETED)
+                except BaseException:
+                    await _utils.cancel_and_drain(_ready_waiter, _wrap_task)
+                    raise
+                else:
+                    await _utils.cancel_and_drain(_ready_waiter)
 
                 # Propagate context vars set by wrap_run/before_run to
                 # the outer task so that agent_run.next() (and therefore

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import asyncio
-import contextlib
 import inspect
 from abc import ABC, abstractmethod
 from collections.abc import (
@@ -1239,19 +1238,14 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                     yield message
 
         except asyncio.CancelledError as e:
-            task.cancel(msg=e.args[0] if len(e.args) != 0 else None)
-            with contextlib.suppress(BaseException):
-                await task
+            await _utils.cancel_and_drain(task, msg=e.args[0] if len(e.args) != 0 else None)
             raise
 
         except BaseException:
-            task.cancel()
-
             # The consumer side is already exiting. Await the producer only to
             # retrieve its exception and finish cleanup; it must not replace the
             # exception that is already propagating from the consumer side.
-            with contextlib.suppress(BaseException):
-                await task
+            await _utils.cancel_and_drain(task)
             raise
 
         else:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -67,6 +67,7 @@ from pydantic_ai.builtin_tools import (
     WebSearchTool,
     WebSearchUserLocation,
 )
+from pydantic_ai.capabilities import AbstractCapability, WrapRunHandler
 from pydantic_ai.exceptions import ContentFilterError
 from pydantic_ai.messages import ModelResponseStreamEvent
 from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
@@ -8117,6 +8118,94 @@ async def test_parallel_tool_outer_cancellation_only_cancels_pending_tool_tasks(
         await task
 
     assert pending_tool_cancelled.is_set()
+
+
+async def test_wrap_run_readiness_wait_cancels_wrapper_task_on_outer_cancellation():
+    """Outer cancellation while waiting for `wrap_run` readiness should clean up the wrapper task.
+
+    Target boundary: `Agent.iter()` creates `_wrap_task` and `_ready_waiter`, then waits for
+    `asyncio.wait({_ready_waiter, _wrap_task}, return_when=asyncio.FIRST_COMPLETED)`.
+    The test should cancel the parent task while that wait is pending, then assert the
+    capability's `wrap_run` cleanup has completed before cancellation returns.
+    """
+
+    cleanup_finished = asyncio.Event()
+    started = asyncio.Event()
+    unblock = asyncio.Event()
+
+    class WrapRunCapability(AbstractCapability[None]):
+        async def wrap_run(self, ctx: RunContext[None], *, handler: WrapRunHandler) -> AgentRunResult[Any]:
+            try:
+                started.set()
+                await unblock.wait()
+                return await handler()
+            finally:
+                cleanup_finished.set()
+
+    agent = Agent(TestModel(), capabilities=[WrapRunCapability()])
+
+    task = asyncio.create_task(agent.run('test'))
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cleanup_finished.is_set()
+
+
+async def test_parallel_tool_outer_cancellation_waits_for_tool_cleanup():
+    """Outer cancellation during parallel tool execution should await cancelled tool cleanup.
+
+    Target boundary: parallel tool execution creates one task per tool call and waits with
+    `asyncio.wait(...)`. The cancel handler must drain those tasks so each tool's `finally`
+    runs before the parent function exits; otherwise cleanup races against the parent
+    unwinding.
+    """
+    started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    cleanup_can_finish = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+
+    async def call_two_tools(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(tool_name='slow_tool_a'),
+                ToolCallPart(tool_name='slow_tool_b'),
+            ]
+        )
+
+    agent = Agent(FunctionModel(call_two_tools))
+
+    @agent.tool_plain
+    async def slow_tool_a() -> str:
+        started.set()
+        try:
+            await asyncio.sleep(10)
+        finally:
+            cleanup_started.set()
+            await cleanup_can_finish.wait()
+            cleanup_finished.set()
+        return 'done'  # pragma: no cover
+
+    @agent.tool_plain
+    async def slow_tool_b() -> str:
+        await asyncio.sleep(10)
+        return 'done'  # pragma: no cover
+
+    task = asyncio.create_task(agent.run('call tools'))
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    task.cancel()
+
+    await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+    assert not task.done()
+    cleanup_can_finish.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cleanup_finished.is_set()
 
 
 @pytest.mark.parametrize('mode', ['argument', 'contextmanager'])

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -8131,14 +8131,13 @@ async def test_wrap_run_readiness_wait_cancels_wrapper_task_on_outer_cancellatio
 
     cleanup_finished = asyncio.Event()
     started = asyncio.Event()
-    unblock = asyncio.Event()
+    never_finishes = asyncio.Future[AgentRunResult[Any]]()
 
     class WrapRunCapability(AbstractCapability[None]):
         async def wrap_run(self, ctx: RunContext[None], *, handler: WrapRunHandler) -> AgentRunResult[Any]:
             try:
                 started.set()
-                await unblock.wait()
-                return await handler()
+                return await never_finishes
             finally:
                 cleanup_finished.set()
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -4580,7 +4580,7 @@ async def test_stream_wrap_model_request_readiness_wait_cancels_wrapper_task_on_
     """
     cleanup_finished = asyncio.Event()
     started = asyncio.Event()
-    unblock = asyncio.Event()
+    never_finishes = asyncio.Future[ModelResponse]()
 
     class WrapModelRequestCapability(AbstractCapability[None]):
         async def wrap_model_request(
@@ -4592,10 +4592,9 @@ async def test_stream_wrap_model_request_readiness_wait_cancels_wrapper_task_on_
         ) -> ModelResponse:
             try:
                 started.set()
-                # Block before calling handler() so we sit inside the readiness wait at
+                # Suspend before calling handler() so we sit inside the readiness wait at
                 # `_agent_graph.py:asyncio.wait({ready_waiter, wrap_task}, ...)`.
-                await unblock.wait()
-                return await handler(request_context)
+                return await never_finishes
             finally:
                 # Without the drain on the readiness wait, this finally never runs.
                 cleanup_finished.set()

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -30,6 +30,7 @@ from pydantic_ai import (
     ImageUrl,
     ModelMessage,
     ModelRequest,
+    ModelRequestContext,
     ModelResponse,
     PartDeltaEvent,
     PartEndEvent,
@@ -49,7 +50,7 @@ from pydantic_ai import (
 from pydantic_ai._agent_graph import GraphAgentState
 from pydantic_ai._output import TextOutputProcessor, TextOutputSchema
 from pydantic_ai.agent import AgentRun
-from pydantic_ai.capabilities import CombinedCapability
+from pydantic_ai.capabilities import AbstractCapability, CombinedCapability, WrapModelRequestHandler
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.models.test import TestModel, TestStreamedResponse as ModelTestStreamedResponse
@@ -4563,6 +4564,53 @@ async def test_run_stream_events_managed_cancellation_waits_for_cleanup():
     await first_event_seen.wait()
     task.cancel()
 
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cleanup_finished.is_set()
+
+
+async def test_stream_wrap_model_request_readiness_wait_cancels_wrapper_task_on_outer_cancellation():
+    """Outer cancellation while waiting for streaming model wrapper readiness should clean up the wrapper task.
+
+    Target boundary: `ModelRequestNode.stream()` creates `wrap_task` and `ready_waiter`, then waits for
+    `asyncio.wait({ready_waiter, wrap_task}, return_when=asyncio.FIRST_COMPLETED)`. If the outer task is
+    cancelled while parked on that wait, the wrapper task must be drained; otherwise the user's
+    `wrap_model_request` cleanup never runs.
+    """
+    cleanup_finished = asyncio.Event()
+    started = asyncio.Event()
+    unblock = asyncio.Event()
+
+    class WrapModelRequestCapability(AbstractCapability[None]):
+        async def wrap_model_request(
+            self,
+            ctx: RunContext[None],
+            *,
+            request_context: ModelRequestContext,
+            handler: WrapModelRequestHandler,
+        ) -> ModelResponse:
+            try:
+                started.set()
+                # Block before calling handler() so we sit inside the readiness wait at
+                # `_agent_graph.py:asyncio.wait({ready_waiter, wrap_task}, ...)`.
+                await unblock.wait()
+                return await handler(request_context)
+            finally:
+                # Without the drain on the readiness wait, this finally never runs.
+                cleanup_finished.set()
+
+    agent = Agent(TestModel(), capabilities=[WrapModelRequestCapability()])
+
+    async def consume() -> None:
+        async with agent.run_stream_events('Hello') as stream:
+            async for _ in stream:  # pragma: no cover - cancelled before any event
+                pass
+
+    task = asyncio.create_task(consume())
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -4603,7 +4603,7 @@ async def test_stream_wrap_model_request_readiness_wait_cancels_wrapper_task_on_
 
     async def consume() -> None:
         async with agent.run_stream_events('Hello') as stream:
-            async for _ in stream:  # pragma: no cover - cancelled before any event
+            async for _ in stream:
                 pass
 
     task = asyncio.create_task(consume())


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->

<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

Fixes cancellation cleanup for agent runs that spawn internal asyncio tasks. When an outer run task was cancelled while waiting for a capability wrapper or parallel tool execution, child tasks could be cancelled without being drained, so user cleanup in `finally` blocks could race with or outlive the parent cancellation.

This adds a shared `cancel_and_drain` helper and uses it when cancelling readiness waiters, wrapper tasks, and parallel tool tasks. The drain is shielded so cancellation already active in the surrounding AnyIO cancel scope does not interrupt child task cleanup before the original cancellation is re-raised.

### Changes

- Drain `wrap_run` readiness tasks when an outer cancellation arrives before the capability hands off to the run handler.
- Drain streaming `wrap_model_request` readiness tasks under the same cancellation boundary.
- Drain parallel tool call tasks when parent cancellation or another exception aborts tool execution.
- Add regression coverage for wrapper cleanup and parallel tool cleanup completing before parent cancellation returns.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
