### PR TITLE
fix: strip Bedrock provider segment for AnthropicModel profile lookup

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -179,6 +179,7 @@ except ImportError as _import_error:
 
 _NON_AUTOMATIC_CACHING_CLIENTS = (AsyncAnthropicBedrock, AsyncAnthropicVertex)
 _FAST_MODE_UNSUPPORTED_CLIENTS = (AsyncAnthropicBedrock, AsyncAnthropicFoundry, AsyncAnthropicVertex)
+_BEDROCK_PREFIX_CLIENTS = (AsyncAnthropicBedrock,)
 
 _ANTHROPIC_SAMPLING_PARAMS = ('temperature', 'top_p', 'top_k')
 _ANTHROPIC_TASK_BUDGETS_BETA = 'task-budgets-2026-03-13'
@@ -406,6 +407,12 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         if isinstance(provider, str):
             provider = infer_provider('gateway/anthropic' if provider == 'gateway' else provider)
         self._provider = provider
+
+        if profile is None and isinstance(provider.client, _BEDROCK_PREFIX_CLIENTS):
+            # Strip Bedrock provider segment (e.g. `us.anthropic.`) so `anthropic_model_profile`'s
+            # `claude-...` startswith checks match. Full id stays on the wire via `self._model_name`.
+            bare_name = model_name.split('anthropic.', 1)[1] if 'anthropic.' in model_name else model_name
+            profile = provider.model_profile(bare_name)
 
         super().__init__(settings=settings, profile=profile or provider.model_profile)
 

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -552,6 +552,26 @@ def test_cache_control_unsupported_param_type():
         m._add_cache_control_to_last_param(params)  # type: ignore[arg-type]  # Testing internal method
 
 
+@pytest.mark.parametrize(
+    'model_id',
+    [
+        pytest.param('us.anthropic.claude-haiku-4-5-20251001-v1:0', id='bedrock-cross-region'),
+        pytest.param('anthropic.claude-haiku-4-5-20251001-v1:0', id='bedrock-plain'),
+    ],
+)
+def test_anthropic_model_strips_bedrock_prefix_for_profile_lookup(model_id: str):
+    """Test that AnthropicModel strips the Bedrock provider segment before profile lookup."""
+    from anthropic import AsyncAnthropicBedrock
+
+    mock_client = MagicMock(spec=AsyncAnthropicBedrock)
+    mock_client.base_url = 'https://bedrock.amazonaws.com'
+
+    m = AnthropicModel(model_id, provider=AnthropicProvider(anthropic_client=mock_client))
+
+    assert m.model_name == model_id
+    assert m.profile.supports_json_schema_output is True
+
+
 def test_build_cache_control_includes_ttl():
     """Test that _build_cache_control includes TTL for all clients, including Bedrock."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
When `AnthropicModel` is constructed with `AsyncAnthropicBedrock`, the model id carries a Bedrock provider segment (`us.anthropic.claude-...-v1:0`, `anthropic.claude-...`) that the bare `claude-...` `startswith` checks in `anthropic_model_profile` miss, silently flipping capability flags like `supports_json_schema_output` to their defaults.

Strip the segment for the profile lookup only; the full id still goes on the wire via `self._model_name`.

Refs #5324 (point 4).

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
