### PR TITLE
docs: fix admonition indentation and typo in beta graph API page

### DIFF
--- a/docs/graph/beta/index.md
+++ b/docs/graph/beta/index.md
@@ -2,7 +2,7 @@
 
 !!! warning "Beta API"
     This is the new beta graph API. It provides enhanced capabilities for parallel execution, conditional branching, and complex workflows.
-The original graph API is still available (and compatible of interop with the new beta API) and is documented in the [main graph documentation](../../graph.md).
+    The original graph API is still available (and compatible with the new beta API) and is documented in the [main graph documentation](../../graph.md).
 
 ## Overview
 


### PR DESCRIPTION
- Closes #5185

Fixes two issues on the [Beta Graph API docs page](https://ai.pydantic.dev/graph/beta/):

1. **Missing indentation** — The sentence about the original graph API was not indented under the `!!! warning "Beta API"` admonition, so it rendered as regular body text outside the warning box instead of inside it. MkDocs admonitions require child content to be indented by 4 spaces.

2. **Typo** — "compatible of interop with" → "compatible with".

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Local verification

```
PASS: admonition indentation correct
PASS: typo fixed (compatible of interop with -> compatible with)
PASS: line properly nested inside !!! warning block

=== LOCAL_TEST_PASSED ===
```
