### PR TITLE
Keep xAI reasoning and tool calls together

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -475,11 +475,11 @@ class XaiModel(Model[AsyncClient]):
 
     @staticmethod
     def _append_tool_call(messages: list[chat_types.chat_pb2.Message], tool_call: chat_types.chat_pb2.ToolCall) -> None:
-        """Append a tool call to the most recent tool-call assistant message, or create a new one.
+        """Append a tool call to the most recent assistant message, or create a new one.
 
-        We keep tool calls grouped to avoid generating one assistant message per tool call.
+        We keep parts from one assistant response grouped to avoid generating one assistant message per tool call.
         """
-        if messages and messages[-1].tool_calls:
+        if messages and messages[-1].role == chat_types.chat_pb2.MessageRole.ROLE_ASSISTANT:
             messages[-1].tool_calls.append(tool_call)
         else:
             msg = assistant('')

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -387,6 +387,58 @@ async def test_xai_multiple_tool_calls_in_history_are_grouped(allow_model_reques
     )
 
 
+async def test_xai_thinking_tool_call_in_history_stays_on_same_message(allow_model_requests: None):
+    response = create_response(
+        content='done',
+        usage=create_usage(prompt_tokens=20, completion_tokens=5),
+    )
+    mock_client = MockXai.create_mock([response])
+    m = XaiModel(XAI_REASONING_MODEL, provider=XaiProvider(xai_client=mock_client))
+
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Run tool')]),
+        ModelResponse(
+            parts=[
+                ThinkingPart(content='Need current data', signature='encrypted_reasoning', provider_name='xai'),
+                ToolCallPart(tool_name='search', args={'query': 'weather'}, tool_call_id='call_search'),
+            ],
+            finish_reason='tool_call',
+        ),
+    ]
+
+    await m.request(messages, model_settings=None, model_request_parameters=ModelRequestParameters())
+
+    assert get_mock_chat_create_kwargs(mock_client) == snapshot(
+        [
+            {
+                'model': XAI_REASONING_MODEL,
+                'messages': [
+                    {'content': [{'text': 'Run tool'}], 'role': 'ROLE_USER'},
+                    {
+                        'content': [{'text': ''}],
+                        'reasoning_content': 'Need current data',
+                        'encrypted_content': 'encrypted_reasoning',
+                        'role': 'ROLE_ASSISTANT',
+                        'tool_calls': [
+                            {
+                                'id': 'call_search',
+                                'type': 'TOOL_CALL_TYPE_CLIENT_SIDE_TOOL',
+                                'status': 'TOOL_CALL_STATUS_COMPLETED',
+                                'function': {'name': 'search', 'arguments': '{"query":"weather"}'},
+                            }
+                        ],
+                    },
+                ],
+                'tools': None,
+                'tool_choice': None,
+                'response_format': None,
+                'use_encrypted_content': False,
+                'include': [],
+            }
+        ]
+    )
+
+
 async def test_xai_reorders_tool_return_parts_by_tool_call_id(allow_model_requests: None):
     response = create_response(
         content='done',


### PR DESCRIPTION
- Closes #5329

### Summary

- Attach mapped xAI tool calls to the preceding assistant message, not only to a preceding assistant message that already has tool calls.
- Add coverage for a native xAI `ThinkingPart` followed by a client-side `ToolCallPart`, preserving reasoning and tool call data on the same assistant message.

### Tests

- `PYTHONPATH=pydantic_ai_slim:pydantic_graph:pydantic_evals .venv/bin/python -m pytest tests/models/test_xai.py -k 'thinking_tool_call_in_history_stays_on_same_message or multiple_tool_calls_in_history_are_grouped'`
- `PYTHONPATH=pydantic_ai_slim:pydantic_graph:pydantic_evals .venv/bin/python -m ruff check pydantic_ai_slim/pydantic_ai/models/xai.py tests/models/test_xai.py`
- `PYTHONPATH=pydantic_ai_slim:pydantic_graph:pydantic_evals .venv/bin/python -m pyright pydantic_ai_slim/pydantic_ai/models/xai.py tests/models/test_xai.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).