### PR TITLE
docs: convert RST docstring syntax to Markdown + pre-commit guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: no-rst-syntax
+        name: No RST syntax (use Markdown in docstrings and docs)
+        description: |
+          Bans RST-only constructs that mkdocstrings/Markdown won't render:
+          `` ``foo`` `` (use single backticks) and trailing `::` (use ```` ```python ```` fences).
+        language: pygrep
+        entry: '(?<!`)``(?!`)|::\s*$'
+        types_or: [python, markdown]
       - id: clai-help
         name: clai help output
         entry: uv

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -2877,7 +2877,7 @@ _AUTO_INJECT_CAPABILITY_TYPES: tuple[type[AbstractCapability[Any]], ...] = (Tool
 def _inject_auto_capabilities(capabilities: list[AbstractCapability[Any]]) -> None:
     """Ensure all auto-injected infrastructure capabilities are present.
 
-    Each capability's own ``CapabilityOrdering`` (e.g. ``position='outermost'``)
+    Each capability's own `CapabilityOrdering` (e.g. `position='outermost'`)
     determines its final placement, so insertion order here doesn't matter.
     """
     for cap_type in _AUTO_INJECT_CAPABILITY_TYPES:

--- a/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
@@ -6,7 +6,7 @@ for registering hook functions.
 
 Hook functions are registered via the `hooks.on` namespace:
 
-```python {test="skip"}
+```python {test="skip" lint="skip"}
 hooks = Hooks()
 
 @hooks.on.before_model_request
@@ -317,7 +317,7 @@ class _HookRegistration(Generic[AgentDepsT]):
     Accessed via `hooks.on`. Each method corresponds to a lifecycle hook and
     can be used as a bare decorator or a parameterized decorator:
 
-    ```python {test="skip"}
+    ```python {test="skip" lint="skip"}
     @hooks.on.before_model_request
     async def my_hook(ctx, request_context):
         return request_context
@@ -720,7 +720,7 @@ class Hooks(AbstractCapability[AgentDepsT]):
 
     Example using decorators:
 
-    ```python {test="skip"}
+    ```python {test="skip" lint="skip"}
     hooks = Hooks()
 
     @hooks.on.before_model_request
@@ -733,7 +733,7 @@ class Hooks(AbstractCapability[AgentDepsT]):
 
     Example using constructor kwargs:
 
-    ```python {test="skip"}
+    ```python {test="skip" lint="skip"}
     agent = Agent('openai:gpt-5', capabilities=[
         Hooks(before_model_request=log_request)
     ])

--- a/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/hooks.py
@@ -4,16 +4,18 @@ Provides the [`Hooks`][pydantic_ai.capabilities.Hooks] class as an ergonomic
 alternative to subclassing [`AbstractCapability`][pydantic_ai.capabilities.AbstractCapability]
 for registering hook functions.
 
-Hook functions are registered via the `hooks.on` namespace::
+Hook functions are registered via the `hooks.on` namespace:
 
-    hooks = Hooks()
+```python {test="skip"}
+hooks = Hooks()
 
-    @hooks.on.before_model_request
-    async def log_request(ctx, request_context):
-        print(f'Request: {request_context}')
-        return request_context
+@hooks.on.before_model_request
+async def log_request(ctx, request_context):
+    print(f'Request: {request_context}')
+    return request_context
 
-    agent = Agent('openai:gpt-5', capabilities=[hooks])
+agent = Agent('openai:gpt-5', capabilities=[hooks])
+```
 """
 
 from __future__ import annotations
@@ -313,15 +315,17 @@ class _HookRegistration(Generic[AgentDepsT]):
     """Decorator namespace for registering hooks on a [`Hooks`][pydantic_ai.capabilities.Hooks] instance.
 
     Accessed via `hooks.on`. Each method corresponds to a lifecycle hook and
-    can be used as a bare decorator or a parameterized decorator::
+    can be used as a bare decorator or a parameterized decorator:
 
-        @hooks.on.before_model_request
-        async def my_hook(ctx, request_context):
-            return request_context
+    ```python {test="skip"}
+    @hooks.on.before_model_request
+    async def my_hook(ctx, request_context):
+        return request_context
 
-        @hooks.on.before_tool_execute(tools=['dangerous'], timeout=5.0)
-        async def guard(ctx, *, call, tool_def, args):
-            return args
+    @hooks.on.before_tool_execute(tools=['dangerous'], timeout=5.0)
+    async def guard(ctx, *, call, tool_def, args):
+        return args
+    ```
     """
 
     def __init__(self, hooks: Hooks[AgentDepsT]) -> None:
@@ -714,22 +718,26 @@ class Hooks(AbstractCapability[AgentDepsT]):
     For application code that needs a few hooks without the ceremony of a subclass,
     use `Hooks`.
 
-    Example using decorators::
+    Example using decorators:
 
-        hooks = Hooks()
+    ```python {test="skip"}
+    hooks = Hooks()
 
-        @hooks.on.before_model_request
-        async def log_request(ctx, request_context):
-            print(f'Request: {request_context}')
-            return request_context
+    @hooks.on.before_model_request
+    async def log_request(ctx, request_context):
+        print(f'Request: {request_context}')
+        return request_context
 
-        agent = Agent('openai:gpt-5', capabilities=[hooks])
+    agent = Agent('openai:gpt-5', capabilities=[hooks])
+    ```
 
-    Example using constructor kwargs::
+    Example using constructor kwargs:
 
-        agent = Agent('openai:gpt-5', capabilities=[
-            Hooks(before_model_request=log_request)
-        ])
+    ```python {test="skip"}
+    agent = Agent('openai:gpt-5', capabilities=[
+        Hooks(before_model_request=log_request)
+    ])
+    ```
     """
 
     _registry: dict[str, list[_HookEntry[Any]]]

--- a/pydantic_ai_slim/pydantic_ai/capabilities/web_fetch.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/web_fetch.py
@@ -18,9 +18,11 @@ class WebFetch(BuiltinOrLocalTool[AgentDepsT]):
     Uses the model's builtin URL fetching when available, falling back to a local
     function tool (markdownify-based fetch by default) when it isn't.
 
-    The local fallback requires the `web-fetch` optional group::
+    The local fallback requires the `web-fetch` optional group:
 
-        pip install "pydantic-ai-slim[web-fetch]"
+    ```bash
+    pip install "pydantic-ai-slim[web-fetch]"
+    ```
     """
 
     allowed_domains: list[str] | None

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1811,15 +1811,17 @@ class AnthropicCompaction(AbstractCapability[AgentDepsT]):
     API parameter. Compaction triggers server-side when input tokens exceed
     the configured threshold.
 
-    Example usage::
+    Example usage:
 
-        from pydantic_ai import Agent
-        from pydantic_ai.models.anthropic import AnthropicCompaction
+    ```python {test="skip"}
+    from pydantic_ai import Agent
+    from pydantic_ai.models.anthropic import AnthropicCompaction
 
-        agent = Agent(
-            'anthropic:claude-sonnet-4-6',
-            capabilities=[AnthropicCompaction(token_threshold=100_000)],
-        )
+    agent = Agent(
+        'anthropic:claude-sonnet-4-6',
+        capabilities=[AnthropicCompaction(token_threshold=100_000)],
+    )
+    ```
     """
 
     def __init__(

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -247,7 +247,7 @@ class _ChatCompletion(chat.ChatCompletion):
     model_config = {'title': 'ChatCompletion'}
 
     service_tier: str | None = None  # type: ignore[reportIncompatibleVariableOverride]
-    """OpenAI-compatible providers can return arbitrary ``service_tier`` values (e.g. ``"standard"``, ``"on_demand"``)."""
+    """OpenAI-compatible providers can return arbitrary `service_tier` values (e.g. `"standard"`, `"on_demand"`)."""
 
 
 class _ChatCompletionChunk(ChatCompletionChunk):  # pyright: ignore[reportUnusedClass] — subclassed in openrouter.py
@@ -256,7 +256,7 @@ class _ChatCompletionChunk(ChatCompletionChunk):  # pyright: ignore[reportUnused
     model_config = {'title': 'ChatCompletionChunk'}
 
     service_tier: str | None = None  # type: ignore[reportIncompatibleVariableOverride]
-    """OpenAI-compatible providers can return arbitrary ``service_tier`` values (e.g. ``"standard"``, ``"on_demand"``)."""
+    """OpenAI-compatible providers can return arbitrary `service_tier` values (e.g. `"standard"`, `"on_demand"`)."""
 
 
 class _AzureContentFilterResultDetail(BaseModel):
@@ -3511,28 +3511,30 @@ class OpenAICompaction(AbstractCapability[AgentDepsT]):
     provide: passing any stateless-only parameter (`message_count_threshold`
     or `trigger`) implies `stateless=True`; otherwise stateful mode is used.
 
-    Example usage::
+    Example usage:
 
-        from pydantic_ai import Agent
-        from pydantic_ai.models.openai import OpenAICompaction
+    ```python {test="skip"}
+    from pydantic_ai import Agent
+    from pydantic_ai.models.openai import OpenAICompaction
 
-        # Stateful mode with OpenAI's server-side default threshold:
-        agent = Agent(
-            'openai-responses:gpt-5.2',
-            capabilities=[OpenAICompaction()],
-        )
+    # Stateful mode with OpenAI's server-side default threshold:
+    agent = Agent(
+        'openai-responses:gpt-5.2',
+        capabilities=[OpenAICompaction()],
+    )
 
-        # Stateful mode with a custom token threshold:
-        agent = Agent(
-            'openai-responses:gpt-5.2',
-            capabilities=[OpenAICompaction(token_threshold=100_000)],
-        )
+    # Stateful mode with a custom token threshold:
+    agent = Agent(
+        'openai-responses:gpt-5.2',
+        capabilities=[OpenAICompaction(token_threshold=100_000)],
+    )
 
-        # Stateless mode for ZDR environments or explicit control:
-        agent = Agent(
-            'openai-responses:gpt-5.2',
-            capabilities=[OpenAICompaction(message_count_threshold=20)],
-        )
+    # Stateless mode for ZDR environments or explicit control:
+    agent = Agent(
+        'openai-responses:gpt-5.2',
+        capabilities=[OpenAICompaction(message_count_threshold=20)],
+    )
+    ```
     """
 
     def __init__(
@@ -3744,7 +3746,7 @@ def _support_tool_forcing(
 
 
 def _map_compaction_item(item: ResponseCompactionItem, system: str) -> CompactionPart:
-    """Convert an OpenAI ``ResponseCompactionItem`` to a ``CompactionPart``."""
+    """Convert an OpenAI `ResponseCompactionItem` to a `CompactionPart`."""
     return CompactionPart(
         content=None,
         id=item.id,

--- a/pydantic_ai_slim/pydantic_ai/profiles/grok.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/grok.py
@@ -17,7 +17,7 @@ class GrokModelProfile(ModelProfile):
     """Whether the model supports builtin tools (web_search, x_search, code_execution, mcp)."""
 
     grok_supports_tool_choice_required: bool = True
-    """Whether the provider accepts the value ``tool_choice='required'`` in the request payload."""
+    """Whether the provider accepts the value `tool_choice='required'` in the request payload."""
 
 
 def grok_model_profile(model_name: str) -> ModelProfile | None:

--- a/pydantic_evals/pydantic_evals/online.py
+++ b/pydantic_evals/pydantic_evals/online.py
@@ -92,10 +92,10 @@ SamplingMode = Literal['independent', 'correlated']
 """Controls how per-evaluator sample rates interact across evaluators for a single call.
 
 - `'independent'` (default): Each evaluator flips its own coin. With N evaluators each at
-  rate *r*, the probability of *any* evaluation overhead is ``1 − (1−r)^N``.
+  rate *r*, the probability of *any* evaluation overhead is `1 − (1−r)^N`.
 - `'correlated'`: A single random seed is generated per call and shared across evaluators.
-  An evaluator runs when ``call_seed < rate``, so lower-rate evaluators' calls are always
-  a subset of higher-rate ones. The probability of *any* overhead equals ``max(rate_i)``.
+  An evaluator runs when `call_seed < rate`, so lower-rate evaluators' calls are always
+  a subset of higher-rate ones. The probability of *any* overhead equals `max(rate_i)`.
 """
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -489,7 +489,7 @@ def track_httpx_clients(monkeypatch: pytest.MonkeyPatch) -> Iterator[_HttpClient
     httpx.AsyncClient. On teardown, all clients are closed — no process-global state leaks.
 
     This is a sync fixture so it applies to both sync and async tests. For async tests, the
-    companion ``close_httpx_clients`` fixture handles async cleanup first.
+    companion `close_httpx_clients` fixture handles async cleanup first.
     """
     cache: _HttpClientCache = {}
     original = pydantic_ai.models.create_async_http_client

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -39,8 +39,8 @@ def mock_ssrf_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     """Patch HTTP client creation in _ssrf to prevent real network calls.
 
     The wrapper configures the returned mock as an async context manager that yields
-    itself (matching ``httpx.AsyncClient`` behavior), so tests work regardless of
-    whether ``safe_download`` uses the client directly or via ``async with``.
+    itself (matching `httpx.AsyncClient` behavior), so tests work regardless of
+    whether `safe_download` uses the client directly or via `async with`.
     """
     mock = MagicMock()
 


### PR DESCRIPTION
Two RST-only patterns were rendering as literal text in mkdocstrings-generated API docs instead of formatted output:

- `` ``foo`` `` (double backticks — Markdown uses single)
- `Example::` followed by indented code (RST code-block marker — Markdown uses ```` ```python ```` fences)

Marcelo flagged one on `AnthropicCompaction` (`models/anthropic.py:1814`); a repo-wide grep surfaced 11 more across 9 files. All converted to Markdown.

## Files touched

- `pydantic_ai_slim/pydantic_ai/`: `agent/__init__.py`, `capabilities/hooks.py`, `capabilities/web_fetch.py`, `models/anthropic.py`, `models/openai.py`, `profiles/grok.py`
- `pydantic_evals/pydantic_evals/online.py`
- `tests/conftest.py`, `tests/test_ssrf.py`

## Prevention

New local `pygrep` pre-commit hook `no-rst-syntax` in `.pre-commit-config.yaml` bans both patterns in `.py` / `.md` files:

```yaml
entry: '(?<!\`)\`\`(?!\`)|::\s*$'
```

The existing CI `lint` job in `.github/workflows/ci.yml` already runs `pre-commit/action --all-files`, so the hook runs on every PR automatically — no workflow changes. Verified passing on the cleaned tree and failing on a minimal RST test file.

## Notes

The four converted `Example usage::` blocks become ```` ```python {test="skip"} ```` fences to preserve their prior "not tested" state — the existing docstring example runner (`tests/test_examples.py`) only sees Markdown fences, so the RST blocks had been silently skipped. Making them runnable would require non-trivial example rewriting (imports + \`TestModel\`) and is out of scope here.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).