### PR TITLE
feat: add `import_capability_types` to `AgentSpec`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_spec.py
+++ b/pydantic_ai_slim/pydantic_ai/_spec.py
@@ -377,7 +377,7 @@ def resolve_capability_path(path: str) -> type[AbstractCapability[Any]]:
         p = Path(source)
         spec = importlib.util.spec_from_file_location(f'__pydantic_ai_capability_{p.stem}', str(p.resolve()))
         if spec is None or spec.loader is None:
-            raise ValueError(f'Could not load module from {source!r}')
+            raise ValueError(f'Could not load module from {source!r}') # pragma: no cover
         mod = importlib.util.module_from_spec(spec)
         sys.modules[spec.name] = mod
         spec.loader.exec_module(mod)

--- a/pydantic_ai_slim/pydantic_ai/_spec.py
+++ b/pydantic_ai_slim/pydantic_ai/_spec.py
@@ -377,7 +377,7 @@ def resolve_capability_path(path: str) -> type[AbstractCapability[Any]]:
         p = Path(source)
         spec = importlib.util.spec_from_file_location(f'__pydantic_ai_capability_{p.stem}', str(p.resolve()))
         if spec is None or spec.loader is None:
-            raise ValueError(f'Could not load module from {source!r}') # pragma: no cover
+            raise ValueError(f'Could not load module from {source!r}')  # pragma: no cover
         mod = importlib.util.module_from_spec(spec)
         sys.modules[spec.name] = mod
         spec.loader.exec_module(mod)

--- a/pydantic_ai_slim/pydantic_ai/_spec.py
+++ b/pydantic_ai_slim/pydantic_ai/_spec.py
@@ -6,10 +6,13 @@ and registry/loading utilities that can be reused by both the evaluator system a
 
 from __future__ import annotations
 
+import importlib.util
 import inspect
+import sys
 import types
 import typing
 from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 from pydantic import (
@@ -29,6 +32,8 @@ from pydantic_ai._utils import get_function_type_hints
 
 if TYPE_CHECKING:
     from pydantic import ModelWrapValidatorHandler
+
+    from pydantic_ai.capabilities.abstract import AbstractCapability
 
 T = TypeVar('T')
 
@@ -336,3 +341,57 @@ def build_schema_types(
             schema_types.append(_make_typed_dict('spec', {name: params_td}))
 
     return schema_types
+
+
+def resolve_capability_path(path: str) -> type[AbstractCapability[Any]]:
+    """Resolve a `source:ClassName` spec string to a capability class.
+
+    Supports two forms for `source`:
+    - dotted module path, e.g. `pkg.mod:MyCapability`
+    - `.py` file path, e.g. `./caps.py:MyCapability`
+
+    The resolved class must be a concrete subclass of
+    [`AbstractCapability`][pydantic_ai.capabilities.AbstractCapability].
+
+    Args:
+        path: A spec string in the format `source:ClassName`.
+
+    Returns:
+        The resolved capability class.
+
+    Raises:
+        ValueError: If the path format is invalid, the module cannot be loaded,
+            or the resolved target isn't an `AbstractCapability` subclass.
+    """
+    # Local import avoids circular import (capabilities.__init__ imports from _spec)
+    from pydantic_ai.capabilities.abstract import AbstractCapability
+
+    # Split into source and class name, validate format
+    source, _, name = path.rpartition(':')
+    if not source or not name:
+        raise ValueError(f"capability path must be 'source:ClassName', got {path!r}")
+
+    # Import the module — file paths use importlib, dotted paths use import_module
+    if source.endswith('.py'):
+        # Load from a file path using importlib
+        p = Path(source)
+        spec = importlib.util.spec_from_file_location(f'__pydantic_ai_capability_{p.stem}', str(p.resolve()))
+        if spec is None or spec.loader is None:
+            raise ValueError(f'Could not load module from {source!r}')
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+    else:
+        # Load from a dotted module path using standard import
+        mod = importlib.import_module(source)
+
+    # Look up the class in the module and validate it
+    cls = getattr(mod, name, None)
+    if cls is None:
+        raise ValueError(f'{source}:{name} does not exist in module')
+    if not isinstance(cls, type):
+        raise ValueError(f'{source}:{name} is not a class, got {type(cls).__name__}')
+    if not issubclass(cls, AbstractCapability):
+        raise ValueError(f'{source}:{name} is not an AbstractCapability subclass')
+
+    return cast(type[AbstractCapability[Any]], cls)

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -2916,9 +2916,14 @@ def _capabilities_from_spec(
 
     Shared by `Agent.from_spec()` and `Agent._resolve_spec()`.
     """
+    from pydantic_ai._spec import resolve_capability_path
     from pydantic_ai.agent import spec as _agent_spec
 
-    registry = get_capability_registry(custom_capability_types)
+    resolved_types: list[type[AbstractCapability[Any]]] = [
+        resolve_capability_path(path) for path in spec.import_capability_types
+    ]
+    merged = [*resolved_types, *custom_capability_types]
+    registry = get_capability_registry(merged)
 
     def _instantiate_cap(
         cap_cls: type[AbstractCapability[Any]],

--- a/pydantic_ai_slim/pydantic_ai/agent/spec.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/spec.py
@@ -55,6 +55,7 @@ class AgentSpec(BaseModel):
     instrument: bool | None = None
     metadata: dict[str, Any] | None = None
     capabilities: list[CapabilitySpec] = []
+    import_capability_types: list[str] = []
 
     @classmethod
     def from_file(
@@ -216,6 +217,7 @@ class AgentSpec(BaseModel):
             metadata: dict[str, Any] | None = None
             if capability_schema_types:  # pragma: no branch
                 capabilities: list[Union[tuple(capability_schema_types)]] = []  # pyright: ignore  # noqa: UP007
+            import_capability_types: list[str] | None = None
 
         json_schema = _AgentSpecSchema.model_json_schema()
         json_schema['title'] = 'AgentSpec'

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1652,6 +1652,11 @@ Supported by:
                     'title': 'Capabilities',
                     'type': 'array',
                 },
+                'import_capability_types': {
+                    'anyOf': [{'items': {'type': 'string'}, 'type': 'array'}, {'type': 'null'}],
+                    'default': None,
+                    'title': 'Import Capability Types',
+                },
                 '$schema': {'type': 'string'},
             },
             'title': 'AgentSpec',

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,11 +1,13 @@
 """Tests for the shared _spec.py module."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 import pytest
 
-from pydantic_ai._spec import NamedSpec, build_registry, build_schema_types, load_from_registry
+from pydantic_ai._spec import NamedSpec, build_registry, build_schema_types, load_from_registry, resolve_capability_path
+from pydantic_ai.capabilities.abstract import AbstractCapability
 
 
 class TestNamedSpec:
@@ -254,3 +256,55 @@ class TestBuildSchemaTypes:
             get_schema_target=lambda c: my_factory,
         )
         assert len(types) >= 1
+
+
+CAPABILITY_SOURCE_CODE = """\
+from __future__ import annotations
+from dataclasses import dataclass
+from pydantic_ai.capabilities.abstract import AbstractCapability
+
+@dataclass
+class MyCap(AbstractCapability[None]):
+    pass
+"""
+
+
+class TestResolveCapabilityPath:
+    """Test resolution of source:ClassName spec strings to capability classes."""
+
+    def test_resolve_file_path(self, create_module: Callable[[str], Any]):
+        mod = create_module(CAPABILITY_SOURCE_CODE)
+        cls = resolve_capability_path(f'{mod.__file__}:MyCap')
+        assert issubclass(cls, AbstractCapability)
+        assert cls.__name__ == 'MyCap'
+
+    def test_resolve_dotted_module(self, create_module: Callable[[str], Any]):
+        mod = create_module(CAPABILITY_SOURCE_CODE)
+        cls = resolve_capability_path(f'{mod.__name__}:MyCap')
+        assert cls is mod.MyCap
+
+    def test_resolve_invalid_format(self):
+        for path in ['NoColon', ':EmptySource', 'source:']:
+            with pytest.raises(ValueError, match="must be 'source:ClassName'"):
+                resolve_capability_path(path)
+
+    def test_resolve_module_not_found(self):
+        with pytest.raises((FileNotFoundError, ModuleNotFoundError)):
+            resolve_capability_path('/nonexistent/path.py:MyCap')
+        with pytest.raises(ModuleNotFoundError):
+            resolve_capability_path('nonexistent_module:MyCap')
+
+    def test_resolve_class_not_found(self, create_module: Callable[[str], Any]):
+        mod = create_module(CAPABILITY_SOURCE_CODE)
+        with pytest.raises(ValueError, match='does not exist in module'):
+            resolve_capability_path(f'{mod.__name__}:NonExistent')
+
+    def test_resolve_not_a_class(self, create_module: Callable[[str], Any]):
+        mod = create_module('x = 42')
+        with pytest.raises(ValueError, match='is not a class'):
+            resolve_capability_path(f'{mod.__name__}:x')
+
+    def test_resolve_not_capability(self, create_module: Callable[[str], Any]):
+        mod = create_module('class Plain: pass')
+        with pytest.raises(ValueError, match='is not an AbstractCapability subclass'):
+            resolve_capability_path(f'{mod.__name__}:Plain')


### PR DESCRIPTION
This PR adds `import_capability_types` to `AgentSpec`. It lets a spec load capability classes from files or modules.

What this PR does.

- Add `resolve_capability_path` to load a class from a file path or module path.
- Add the `import_capability_types` field to the `AgentSpec` model.
- Wire the new field into `_capabilities_from_spec` for agent creation.
- Add basic unit tests for `resolve_capability_path`.

Current state and next steps.

- The feature works but is not finished.
- I am new to this codebase. I do not yet know the project style for docs and tests.
- The tests cover the new function. They may need changes to match the project patterns.
- More tests and docs will come after I get feedback.
- This PR is a starting point for review and discussion.
- Closes #5266