### PR TITLE
Add `google_tool_config` field to `GoogleModelSettings`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -280,6 +280,16 @@ class GoogleModelSettings(ModelSettings, total=False):
     google_service_tier: GoogleServiceTier
     """Deprecated: use `service_tier` for Gemini API (GLA) or `google_vertex_service_tier` for Vertex AI."""
 
+    google_tool_config: ToolConfigDict
+    """Override the tool_config sent to Gemini.
+
+    When set, this takes precedence over the tool_config derived from the cross-provider `tool_choice` setting.
+    Use this to opt into modes not exposed by the cross-provider abstraction — most notably `VALIDATED`,
+    which enforces schema at the API layer and rejects hallucinated function names before they reach user code.
+
+    See <https://ai.google.dev/gemini-api/docs/function-calling> for more information.
+    """
+
 
 def _get_deprecated_google_service_tier(model_settings: GoogleModelSettings) -> GoogleServiceTier | None:
     """Return `google_service_tier`, emitting a `DeprecationWarning` when it is set."""
@@ -662,6 +672,8 @@ class GoogleModel(Model[Client]):
         if allowed_function_names:
             function_calling_config['allowed_function_names'] = allowed_function_names
         tool_config = ToolConfigDict(function_calling_config=function_calling_config)
+        if override_config := model_settings.get('google_tool_config'):
+            tool_config = override_config
 
         tools: list[ToolDict] = [
             ToolDict(function_declarations=[_function_declaration_from_tool(t)]) for t in tool_defs.values()

--- a/tests/models/test_tool_choice_unit.py
+++ b/tests/models/test_tool_choice_unit.py
@@ -517,6 +517,29 @@ def test_google_auto_tuple_filters_tool_defs():
     assert tool_config['function_calling_config']['mode'].name == 'AUTO'  # pyright: ignore[reportTypedDictNotRequiredAccess,reportOptionalMemberAccess,reportOptionalSubscript,reportUnknownMemberType]
 
 
+@pytest.mark.skipif(not google_available(), reason='google not installed')
+def test_google_tool_config_override_takes_precedence():
+    """google_tool_config in model settings overrides the tool_config computed from tool_choice."""
+    from google.genai.types import FunctionCallingConfigDict, FunctionCallingConfigMode, ToolConfigDict
+
+    mock_client = MagicMock()
+    provider = GoogleProvider(client=mock_client)
+    m = GoogleModel('gemini-2.0-flash', provider=provider)
+    params = ModelRequestParameters(
+        function_tools=[make_tool('my_tool')],
+        allow_text_output=True,
+    )
+    validated_config = ToolConfigDict(
+        function_calling_config=FunctionCallingConfigDict(mode=FunctionCallingConfigMode.VALIDATED)
+    )
+
+    tools, tool_config, _ = m._get_tool_config(params, {'google_tool_config': validated_config})  # pyright: ignore[reportPrivateUsage]
+
+    assert tool_config is not None
+    assert tool_config['function_calling_config']['mode'].name == 'VALIDATED'  # pyright: ignore[reportTypedDictNotRequiredAccess,reportOptionalMemberAccess,reportOptionalSubscript,reportUnknownMemberType]
+    assert tools is not None
+
+
 @pytest.mark.skipif(not xai_available(), reason='xai not installed')
 async def test_xai_fallback_single_tool_without_required_support(allow_model_requests: None):
     """Single tool with unsupported required falls back to auto and filters tool_defs to preserve user intent."""


### PR DESCRIPTION
Exposes ToolConfigDict as a user-overridable setting so callers can opt into Gemini function-calling modes (notably VALIDATED) that the cross-provider tool_choice abstraction does not cover.

Closes #5366

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
