### PR TITLE
feat(providers): add Eden AI as an OpenAI-compatible provider

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -882,3 +882,37 @@ model = OpenAIChatModel(
 agent = Agent(model)
 ...
 ```
+
+### Eden AI
+
+[Eden AI](https://www.edenai.co) is an OpenAI-compatible gateway exposing models from multiple providers (Anthropic, OpenAI, Google, Mistral, Cohere, and others) behind a single API. Follow the [getting started guide](https://www.edenai.co/docs/v3/quickstart/first-llm-call) to create an API key.
+
+You can set the `EDENAI_API_KEY` environment variable and use [`EdenAIProvider`][pydantic_ai.providers.edenai.EdenAIProvider] by name:
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('edenai:openai/gpt-5')
+result = agent.run_sync('What is the capital of France?')
+print(result.output)
+#> The capital of France is Paris.
+```
+
+Or initialise the model and provider directly:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.edenai import EdenAIProvider
+
+model = OpenAIChatModel(
+    'anthropic/claude-opus-4-7',
+    provider=EdenAIProvider(api_key='your-edenai-api-key'),
+)
+agent = Agent(model)
+result = agent.run_sync('What is the capital of France?')
+print(result.output)
+#> The capital of France is Paris.
+```
+
+Eden AI exposes models with vendor-prefixed ids, for example `openai/gpt-5`, `anthropic/claude-opus-4-7`, `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6`, `google/gemini-2.5-flash`, or `mistral/mistral-large-latest`. Anthropic ids on Eden AI use the hyphen form (`claude-opus-4-7`), not the dot form. The full catalog is available in [Eden AI's app](https://app.edenai.run/bricks/text/chat).

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -467,6 +467,7 @@ OpenAIChatCompatibleProvider = TypeAliasType(
         'azure',
         'cerebras',
         'deepseek',
+        'edenai',
         'fireworks',
         'github',
         'grok',

--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -125,6 +125,10 @@ def infer_provider_class(provider: str) -> type[Provider[Any]]:  # noqa: C901
         from .deepseek import DeepSeekProvider
 
         return DeepSeekProvider
+    elif provider == 'edenai':
+        from .edenai import EdenAIProvider
+
+        return EdenAIProvider
     elif provider == 'openrouter':
         from .openrouter import OpenRouterProvider
 

--- a/pydantic_ai_slim/pydantic_ai/providers/edenai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/edenai.py
@@ -1,0 +1,114 @@
+from __future__ import annotations as _annotations
+
+import os
+from typing import overload
+
+import httpx
+
+from pydantic_ai import ModelProfile
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles.amazon import amazon_model_profile
+from pydantic_ai.profiles.anthropic import anthropic_model_profile
+from pydantic_ai.profiles.cohere import cohere_model_profile
+from pydantic_ai.profiles.deepseek import deepseek_model_profile
+from pydantic_ai.profiles.google import google_model_profile
+from pydantic_ai.profiles.meta import meta_model_profile
+from pydantic_ai.profiles.mistral import mistral_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
+from pydantic_ai.providers import Provider
+
+try:
+    from openai import AsyncOpenAI
+except ImportError as _import_error:  # pragma: no cover
+    raise ImportError(
+        'Please install the `openai` package to use the Eden AI provider, '
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
+    ) from _import_error
+
+
+class EdenAIProvider(Provider[AsyncOpenAI]):
+    """Provider for Eden AI API."""
+
+    @property
+    def name(self) -> str:
+        return 'edenai'
+
+    @property
+    def base_url(self) -> str:
+        return 'https://api.edenai.run/v3'
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        return self._client
+
+    @staticmethod
+    def model_profile(model_name: str) -> ModelProfile | None:
+        # Eden AI exposes models via `<vendor>/<model-id>` ids. Route to the right
+        # underlying-provider profile so JSON-schema rules and other model-specific
+        # quirks line up with the actual upstream model.
+        provider_to_profile = {
+            'anthropic': anthropic_model_profile,
+            'openai': openai_model_profile,
+            'google': google_model_profile,
+            'mistral': mistral_model_profile,
+            'mistralai': mistral_model_profile,
+            'cohere': cohere_model_profile,
+            'meta': meta_model_profile,
+            'meta-llama': meta_model_profile,
+            'amazon': amazon_model_profile,
+            'bedrock': amazon_model_profile,
+            'deepseek': deepseek_model_profile,
+        }
+
+        profile = None
+
+        if '/' in model_name:
+            vendor_prefix, model_suffix = model_name.split('/', 1)
+            if vendor_prefix in provider_to_profile:
+                profile = provider_to_profile[vendor_prefix](model_suffix)
+
+        if profile is None:
+            profile = openai_model_profile(model_name)
+
+        # EdenAIProvider is used with OpenAIChatModel, which uses OpenAIJsonSchemaTransformer.
+        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, *, api_key: str) -> None: ...
+
+    @overload
+    def __init__(self, *, api_key: str, http_client: httpx.AsyncClient) -> None: ...
+
+    @overload
+    def __init__(self, *, openai_client: AsyncOpenAI | None = None) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        openai_client: AsyncOpenAI | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        api_key = api_key or os.getenv('EDENAI_API_KEY')
+        if not api_key and openai_client is None:
+            raise UserError(
+                'Set the `EDENAI_API_KEY` environment variable or pass it via '
+                '`EdenAIProvider(api_key=...)` to use the Eden AI provider.'
+            )
+
+        if openai_client is not None:
+            self._client = openai_client
+        elif http_client is not None:
+            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
+        else:
+            http_client = create_async_http_client()
+            self._own_http_client = http_client
+            self._http_client_factory = create_async_http_client
+            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
+
+    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
+        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]

--- a/tests/providers/test_edenai.py
+++ b/tests/providers/test_edenai.py
@@ -1,0 +1,136 @@
+import re
+
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from pydantic_ai.exceptions import UserError
+
+from ..conftest import TestEnv, try_import
+
+with try_import() as imports_successful:
+    from openai import AsyncOpenAI
+
+    from pydantic_ai.profiles.amazon import amazon_model_profile
+    from pydantic_ai.profiles.anthropic import anthropic_model_profile
+    from pydantic_ai.profiles.cohere import cohere_model_profile
+    from pydantic_ai.profiles.deepseek import deepseek_model_profile
+    from pydantic_ai.profiles.google import google_model_profile
+    from pydantic_ai.profiles.meta import meta_model_profile
+    from pydantic_ai.profiles.mistral import mistral_model_profile
+    from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
+    from pydantic_ai.providers.edenai import EdenAIProvider
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='OpenAI client not installed'),
+    pytest.mark.anyio,
+]
+
+
+def test_init_with_api_key():
+    provider = EdenAIProvider(api_key='test-key')
+    assert provider.name == 'edenai'
+    assert provider.base_url == 'https://api.edenai.run/v3'
+    assert provider.client.api_key == 'test-key'
+
+
+def test_init_from_env(env: TestEnv):
+    env.set('EDENAI_API_KEY', 'env-key')
+    provider = EdenAIProvider()
+    assert provider.client.api_key == 'env-key'
+
+
+def test_init_without_api_key_raises(env: TestEnv):
+    env.remove('EDENAI_API_KEY')
+    with pytest.raises(UserError, match=re.escape('Set the `EDENAI_API_KEY` environment variable')):
+        EdenAIProvider()
+
+
+def test_init_with_openai_client():
+    openai_client = AsyncOpenAI(api_key='custom-key', base_url='https://custom.example.com/v1')
+    provider = EdenAIProvider(openai_client=openai_client)
+    assert provider.client is openai_client
+
+
+async def test_init_with_http_client():
+    async with httpx.AsyncClient() as custom_client:
+        provider = EdenAIProvider(api_key='test-key', http_client=custom_client)
+        assert isinstance(provider.client, AsyncOpenAI)
+        assert provider.client.api_key == 'test-key'
+
+
+async def test_create_http_client_default(mocker: MockerFixture):
+    async with httpx.AsyncClient() as mock_client:
+        mock_create_func = mocker.patch(
+            'pydantic_ai.providers.edenai.create_async_http_client', return_value=mock_client
+        )
+        provider = EdenAIProvider(api_key='test-key')
+        mock_create_func.assert_called_once_with()
+        assert isinstance(provider.client, AsyncOpenAI)
+
+
+def test_model_profile_unknown_prefix_falls_back_to_openai(mocker: MockerFixture):
+    provider = EdenAIProvider(api_key='test-key')
+    mock_openai_profile = mocker.patch('pydantic_ai.providers.edenai.openai_model_profile', wraps=openai_model_profile)
+
+    profile = provider.model_profile('unknown-vendor/some-model')
+
+    mock_openai_profile.assert_called_once_with('unknown-vendor/some-model')
+    assert isinstance(profile, OpenAIModelProfile)
+    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+
+
+def test_model_profile_no_slash_falls_back_to_openai(mocker: MockerFixture):
+    provider = EdenAIProvider(api_key='test-key')
+    mock_openai_profile = mocker.patch('pydantic_ai.providers.edenai.openai_model_profile', wraps=openai_model_profile)
+
+    profile = provider.model_profile('gpt-4o-mini')
+
+    mock_openai_profile.assert_called_once_with('gpt-4o-mini')
+    assert isinstance(profile, OpenAIModelProfile)
+    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+
+
+def test_model_profile_routes_to_vendor_profile(mocker: MockerFixture):
+    # This test verifies routing of vendor prefixes to profile functions, not catalog
+    # availability — placeholder suffixes are deliberate so the test does not go stale
+    # when a specific Eden AI model id is deprecated.
+    provider = EdenAIProvider(api_key='test-key')
+
+    mocks = {
+        'anthropic': mocker.patch(
+            'pydantic_ai.providers.edenai.anthropic_model_profile', wraps=anthropic_model_profile
+        ),
+        'openai': mocker.patch('pydantic_ai.providers.edenai.openai_model_profile', wraps=openai_model_profile),
+        'google': mocker.patch('pydantic_ai.providers.edenai.google_model_profile', wraps=google_model_profile),
+        'mistral': mocker.patch('pydantic_ai.providers.edenai.mistral_model_profile', wraps=mistral_model_profile),
+        'cohere': mocker.patch('pydantic_ai.providers.edenai.cohere_model_profile', wraps=cohere_model_profile),
+        'meta': mocker.patch('pydantic_ai.providers.edenai.meta_model_profile', wraps=meta_model_profile),
+        'amazon': mocker.patch('pydantic_ai.providers.edenai.amazon_model_profile', wraps=amazon_model_profile),
+        'deepseek': mocker.patch('pydantic_ai.providers.edenai.deepseek_model_profile', wraps=deepseek_model_profile),
+    }
+
+    cases = [
+        ('anthropic/test-model', 'anthropic', 'test-model'),
+        ('openai/test-model', 'openai', 'test-model'),
+        ('google/test-model', 'google', 'test-model'),
+        ('mistral/test-model', 'mistral', 'test-model'),
+        ('mistralai/test-model', 'mistral', 'test-model'),
+        ('cohere/test-model', 'cohere', 'test-model'),
+        ('meta/test-model', 'meta', 'test-model'),
+        ('meta-llama/test-model', 'meta', 'test-model'),
+        ('amazon/test-model', 'amazon', 'test-model'),
+        ('bedrock/test-model', 'amazon', 'test-model'),
+        ('deepseek/test-model', 'deepseek', 'test-model'),
+    ]
+
+    for model_id, expected_vendor, expected_suffix in cases:
+        for mock in mocks.values():
+            mock.reset_mock()
+        profile = provider.model_profile(model_id)
+        # Always wrapped in OpenAIModelProfile (the OpenAI-chat-compat shape).
+        # We deliberately do not assert on `json_schema_transformer`: when the vendor
+        # profile sets one (e.g. GoogleJsonSchemaTransformer), .update() preserves it,
+        # matching how LiteLLMProvider, NebiusProvider, and OpenRouterProvider behave.
+        assert isinstance(profile, OpenAIModelProfile)
+        mocks[expected_vendor].assert_called_once_with(expected_suffix)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -206,6 +206,7 @@ def test_docs_examples(
     env.set('GROK_API_KEY', 'testing')
     env.set('MOONSHOTAI_API_KEY', 'testing')
     env.set('DEEPSEEK_API_KEY', 'testing')
+    env.set('EDENAI_API_KEY', 'testing')
     env.set('OVHCLOUD_API_KEY', 'testing')
     env.set('ALIBABA_API_KEY', 'testing')
     env.set('SAMBANOVA_API_KEY', 'testing')


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

_No GitHub issue yet; opening as a draft while the Eden AI team aligns with maintainers separately. Happy to convert this to issue-first if you'd prefer to defer review until after that conversation._

### Summary

Adds Eden AI as a model provider so users can do:

```python
from pydantic_ai import Agent

agent = Agent('edenai:openai/gpt-5')
```

[Eden AI](https://www.edenai.co) is an OpenAI-compatible gateway exposing 349 models from Anthropic, OpenAI, Google, Mistral, Cohere, and 16 other underlying providers behind a single `/chat/completions` endpoint. The integration mirrors the existing `NebiusProvider` / `LiteLLMProvider` shape (a `Provider` class with vendor-prefix profile routing, no new `Model` class), so it reuses `OpenAIChatModel` without introducing custom request/response handling.

### Files changed

| File | Change |
|---|---|
| `pydantic_ai_slim/pydantic_ai/providers/edenai.py` | New `EdenAIProvider` (114 lines) |
| `pydantic_ai_slim/pydantic_ai/providers/__init__.py` | Register `edenai` → `EdenAIProvider` in `infer_provider_class` |
| `pydantic_ai_slim/pydantic_ai/models/__init__.py` | Add `'edenai'` to `OpenAIChatCompatibleProvider` so `Agent('edenai:...')` routes through `OpenAIChatModel` |
| `docs/models/openai.md` | Add `### Eden AI` subsection mirroring the existing Nebius / SambaNova entries |
| `tests/providers/test_edenai.py` | 9 provider tests (init paths, missing-key error, vendor-prefix profile routing) |
| `tests/test_examples.py` | Seed `EDENAI_API_KEY` in the test env so the new docs example runs |

### Notes for reviewers

- **GitHub-org star count.** The Eden AI org has 12 stars, below the 20k bar in `CONTRIBUTING.md`. The change is small (one Provider class + registration + docs subsection + tests) and follows the same pattern as Nebius, LiteLLM, Together, and Fireworks. If a different shape would suit better (issue first, standalone package, docs-only entry), happy to adjust.
- **Anthropic model id format.** Eden AI's catalog uses the hyphen form (`claude-opus-4-7`), not the dot form. Documented in the new subsection.
- **JSON mode response.** Eden AI returns a JSON-fenced response when `response_format={"type": "json_object"}` is set; lenient parsers handle this transparently. No host-side change needed.

### How to test

```bash
uv run pytest tests/providers/test_edenai.py -v
uv run pytest tests/test_examples.py -k 'openai.md' -q
```

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
