### PR TITLE
feat(openai): add `openai_chat_supports_multiple_system_messages` profile flag

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -361,9 +361,9 @@ model = OpenAIChatModel(
         base_url='https://<openai-compatible-api-endpoint>.com', api_key='your-api-key'
     ),
     profile=OpenAIModelProfile(
-        json_schema_transformer=InlineDefsJsonSchemaTransformer,  # Supported by any model class on a plain ModelProfile
-        openai_supports_strict_tool_definition=False,  # Supported by OpenAIModel only, requires OpenAIModelProfile
-        openai_chat_supports_multiple_system_messages=False,  # For strict providers (e.g. some vLLM/LiteLLM setups) that require exactly one initial system message
+        json_schema_transformer=InlineDefsJsonSchemaTransformer,  # Supported by any model class via the base ModelProfile
+        openai_supports_strict_tool_definition=False,  # Supported by OpenAIChatModel and OpenAIResponsesModel
+        openai_chat_supports_multiple_system_messages=False,  # Supported by OpenAIChatModel only — for strict providers (e.g. some vLLM/LiteLLM setups) that require exactly one initial system message
     )
 )
 agent = Agent(model)

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -362,7 +362,8 @@ model = OpenAIChatModel(
     ),
     profile=OpenAIModelProfile(
         json_schema_transformer=InlineDefsJsonSchemaTransformer,  # Supported by any model class on a plain ModelProfile
-        openai_supports_strict_tool_definition=False  # Supported by OpenAIModel only, requires OpenAIModelProfile
+        openai_supports_strict_tool_definition=False,  # Supported by OpenAIModel only, requires OpenAIModelProfile
+        openai_chat_supports_multiple_system_messages=False,  # For strict providers (e.g. some vLLM/LiteLLM setups) that require exactly one initial system message
     )
 )
 agent = Agent(model)

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -4,7 +4,7 @@ import base64
 import itertools
 import json
 import warnings
-from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Iterator, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import datetime
@@ -383,25 +383,18 @@ def _merge_leading_system_messages(
     if system_prompt_role not in ('system', 'developer'):
         return openai_messages
 
-    leading: list[chat.ChatCompletionMessageParam] = []
-    for m in openai_messages:
-        if m.get('role') != system_prompt_role:
-            break
-        leading.append(m)
-    if len(leading) < 2:
+    leading_count = next(
+        (i for i, m in enumerate(openai_messages) if m.get('role') != system_prompt_role),
+        len(openai_messages),
+    )
+    if leading_count < 2:
         return openai_messages
 
-    contents: list[str] = []
-    for m in leading:
-        content = m.get('content')
-        if isinstance(content, str):
-            contents.append(content)
-        elif isinstance(content, Iterable):
-            for part in content:
-                if isinstance(part, Mapping) and part.get('type') == 'text':
-                    contents.append(str(part.get('text', '')))
-    merged: chat.ChatCompletionMessageParam = {**leading[0], 'content': '\n\n'.join(contents)}  # type: ignore[typeddict-item]
-    return [merged, *openai_messages[len(leading) :]]
+    # Content is always `str` here: it originates from `SystemPromptPart.content` or instruction
+    # `TextPart.content`, both of which are typed as `str`.
+    merged_content = '\n\n'.join(m['content'] for m in openai_messages[:leading_count])  # type: ignore[misc]
+    merged: chat.ChatCompletionMessageParam = {**openai_messages[0], 'content': merged_content}  # type: ignore[typeddict-item]
+    return [merged, *openai_messages[leading_count:]]
 
 
 def _drop_sampling_params_for_reasoning(

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -4,7 +4,7 @@ import base64
 import itertools
 import json
 import warnings
-from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Iterator, Sequence
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import datetime
@@ -367,6 +367,41 @@ def _check_azure_content_filter(e: APIStatusError, system: str, model_name: str)
         except ValidationError:
             pass
     return None
+
+
+def _merge_leading_system_messages(
+    openai_messages: list[chat.ChatCompletionMessageParam], system_prompt_role: str
+) -> list[chat.ChatCompletionMessageParam]:
+    """Merge consecutive messages with `system_prompt_role` at the start of the list into a single message.
+
+    Required by strict OpenAI-compatible backends (some LiteLLM/vLLM deployments) that reject more than one
+    initial system message with `System message must be at the beginning.`
+
+    Only applies when system prompts are sent as `'system'` or `'developer'` role; with `'user'` role we
+    can't distinguish a system prompt cast as user from an actual user turn.
+    """
+    if system_prompt_role not in ('system', 'developer'):
+        return openai_messages
+
+    leading: list[chat.ChatCompletionMessageParam] = []
+    for m in openai_messages:
+        if m.get('role') != system_prompt_role:
+            break
+        leading.append(m)
+    if len(leading) < 2:
+        return openai_messages
+
+    contents: list[str] = []
+    for m in leading:
+        content = m.get('content')
+        if isinstance(content, str):
+            contents.append(content)
+        elif isinstance(content, Iterable):
+            for part in content:
+                if isinstance(part, Mapping) and part.get('type') == 'text':
+                    contents.append(str(part.get('text', '')))
+    merged: chat.ChatCompletionMessageParam = {**leading[0], 'content': '\n\n'.join(contents)}  # type: ignore[typeddict-item]
+    return [merged, *openai_messages[len(leading) :]]
 
 
 def _drop_sampling_params_for_reasoning(
@@ -1343,8 +1378,9 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     openai_messages.append(mapped)
             else:
                 assert_never(message)
+        profile = OpenAIModelProfile.from_profile(self.profile)
+        system_prompt_role = profile.openai_system_prompt_role or 'system'
         if instruction_parts := self._get_instruction_parts(messages, model_request_parameters):
-            system_prompt_role = OpenAIModelProfile.from_profile(self.profile).openai_system_prompt_role or 'system'
             system_prompt_count = next(
                 (i for i, m in enumerate(openai_messages) if m.get('role') != system_prompt_role), len(openai_messages)
             )
@@ -1363,6 +1399,8 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     for part in instruction_parts
                 ]
             openai_messages[system_prompt_count:system_prompt_count] = instruction_messages
+        if not profile.openai_chat_supports_multiple_system_messages:
+            openai_messages = _merge_leading_system_messages(openai_messages, system_prompt_role)
         return openai_messages
 
     @staticmethod

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -92,6 +92,14 @@ class OpenAIModelProfile(ModelProfile):
     openai_system_prompt_role: OpenAISystemPromptRole | None = None
     """The role to use for the system prompt message. If not provided, defaults to `'system'`."""
 
+    openai_chat_supports_multiple_system_messages: bool = True
+    """Whether the Chat Completions API accepts more than one system-role message at the start of the conversation.
+
+    OpenAI itself and most compatible providers accept multiple system messages, so this defaults to `True`.
+    Set to `False` for strict OpenAI-compatible backends (e.g. some LiteLLM/vLLM deployments) that require
+    exactly one initial system message; consecutive system messages at the start will be merged into one
+    (joined with two newlines) before being sent."""
+
     openai_chat_supports_web_search: bool = False
     """Whether the model supports web search in Chat Completions API."""
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -890,6 +890,54 @@ async def test_system_prompt_role(
     ]
 
 
+async def test_merge_leading_system_messages(allow_model_requests: None) -> None:
+    """When `openai_chat_supports_multiple_system_messages=False`, consecutive system messages at the start are merged."""
+
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel(
+        'gpt-4o',
+        provider=OpenAIProvider(openai_client=mock_client),
+        profile=OpenAIModelProfile(openai_chat_supports_multiple_system_messages=False),
+    )
+    agent = Agent(m, system_prompt='static prompt', instructions='dynamic instructions')
+
+    @agent.system_prompt
+    def extra_system_prompt() -> str:
+        return 'extra static prompt'
+
+    result = await agent.run('hello')
+    assert result.output == 'world'
+
+    assert get_mock_chat_completion_kwargs(mock_client)[0]['messages'] == [
+        {'content': 'static prompt\n\nextra static prompt\n\ndynamic instructions', 'role': 'system'},
+        {'content': 'hello', 'role': 'user'},
+    ]
+
+
+async def test_merge_leading_system_messages_disabled_by_default(allow_model_requests: None) -> None:
+    """Default behavior is preserved: multiple system messages are sent as separate messages."""
+
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m, system_prompt='static prompt', instructions='dynamic instructions')
+
+    @agent.system_prompt
+    def extra_system_prompt() -> str:
+        return 'extra static prompt'
+
+    result = await agent.run('hello')
+    assert result.output == 'world'
+
+    assert get_mock_chat_completion_kwargs(mock_client)[0]['messages'] == [
+        {'content': 'static prompt', 'role': 'system'},
+        {'content': 'extra static prompt', 'role': 'system'},
+        {'content': 'dynamic instructions', 'role': 'system'},
+        {'content': 'hello', 'role': 'user'},
+    ]
+
+
 async def test_system_prompt_role_o1_mini(allow_model_requests: None, openai_api_key: str):
     model = OpenAIChatModel('o1-mini', provider=OpenAIProvider(api_key=openai_api_key))
     agent = Agent(model=model, system_prompt='You are a helpful assistant.')

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -915,6 +915,54 @@ async def test_merge_leading_system_messages(allow_model_requests: None) -> None
     ]
 
 
+async def test_merge_leading_system_messages_single_system_message(allow_model_requests: None) -> None:
+    """With only one leading system message, the merge flag is a no-op."""
+
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel(
+        'gpt-4o',
+        provider=OpenAIProvider(openai_client=mock_client),
+        profile=OpenAIModelProfile(openai_chat_supports_multiple_system_messages=False),
+    )
+    agent = Agent(m, system_prompt='only one')
+
+    await agent.run('hello')
+
+    assert get_mock_chat_completion_kwargs(mock_client)[0]['messages'] == [
+        {'content': 'only one', 'role': 'system'},
+        {'content': 'hello', 'role': 'user'},
+    ]
+
+
+async def test_merge_leading_system_messages_user_role_unchanged(allow_model_requests: None) -> None:
+    """When system prompts are sent as `user` role, the merge flag does not collapse them."""
+
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel(
+        'gpt-4o',
+        provider=OpenAIProvider(openai_client=mock_client),
+        profile=OpenAIModelProfile(
+            openai_chat_supports_multiple_system_messages=False,
+            openai_system_prompt_role='user',
+        ),
+    )
+    agent = Agent(m, system_prompt='static prompt')
+
+    @agent.system_prompt
+    def extra_system_prompt() -> str:
+        return 'extra static prompt'
+
+    await agent.run('hello')
+
+    assert get_mock_chat_completion_kwargs(mock_client)[0]['messages'] == [
+        {'content': 'static prompt', 'role': 'user'},
+        {'content': 'extra static prompt', 'role': 'user'},
+        {'content': 'hello', 'role': 'user'},
+    ]
+
+
 async def test_merge_leading_system_messages_disabled_by_default(allow_model_requests: None) -> None:
     """Default behavior is preserved: multiple system messages are sent as separate messages."""
 


### PR DESCRIPTION
<!-- Discussion on Slack rather than a GitHub issue; no `Closes #<issue>` line. -->

### What

Some OpenAI-compatible backends (e.g. some LiteLLM/vLLM deployments serving Qwen and similar) reject requests with more than one initial system message:

> System message must be at the beginning.

Pydantic AI currently sends static `system_prompt`s and dynamic `instructions` as separate system-role messages (and likewise for multiple `@agent.system_prompt`-decorated functions), so users hit this on strict backends today.

### How

New `OpenAIModelProfile` flag, defaulting to OpenAI's behavior:

```python
profile=OpenAIModelProfile(openai_chat_supports_multiple_system_messages=False)
```

When `False`, consecutive `system`/`developer`-role messages at the start of the request are merged into one (joined with `\n\n`) inside `OpenAIChatModel._map_messages`. `user`-role system prompts (`openai_system_prompt_role='user'`) are intentionally skipped — we can't tell a system-prompt-cast-as-user apart from a real user turn.

The default (`True`) preserves OpenAI/most-providers behavior; this is opt-in for strict OpenAI-compatible backends, matching the existing `openai_chat_supports_*` pattern (web_search, file_urls, document_input).

Docs example in `docs/models/openai.md` updated to mention the flag alongside `openai_supports_strict_tool_definition`.

### Coordination

I left a comment on #5340 (TypedDict redesign) so the new field is folded into that migration (drop the `= True` default, document as `Default: \`True\``, switch read site to `.get('openai_chat_supports_multiple_system_messages', True)`).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).