### PR TITLE
ci: label-triggered docs preview dispatcher

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,106 @@
+name: Docs Preview
+
+# Label-triggered docs preview. Adding `trigger:docs` to a PR dispatches a
+# preview build to pydantic/unified-docs; that repo builds the unified docs
+# against this PR's head SHA, deploys to a shared Cloudflare Worker, and
+# updates a comment on this PR with the preview URL.
+#
+# This workflow is purely a dispatcher — the build, deploy, and final
+# URL-comment all happen in the unified-docs repo. The `trigger:docs` label
+# is removed at the end so re-adding it re-runs the preview.
+
+on:
+  # zizmor: ignore[dangerous-triggers] -- pull_request_target is required so fork PRs can
+  # access the DOCS_APP credentials. The dispatch is gated on a maintainer adding the
+  # `trigger:docs` label, and this workflow does not check out or execute PR code.
+  pull_request_target:
+    types: [labeled]
+
+permissions: {}
+
+concurrency:
+  group: docs-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    if: github.event.label.name == 'trigger:docs'
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to post the "queued" comment and to remove the trigger:docs label.
+      pull-requests: write
+
+    steps:
+      - name: Generate app token (for dispatching to unified-docs)
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: unified-docs
+
+      - name: Dispatch preview build
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api repos/pydantic/unified-docs/dispatches \
+            --method POST \
+            -f event_type=docs-preview \
+            -f "client_payload[library]=ai" \
+            -f "client_payload[source_repo]=${REPO}" \
+            -f "client_payload[source_pr]=${PR_NUMBER}" \
+            -f "client_payload[source_sha]=${HEAD_SHA}"
+
+      - name: Acknowledge on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          sha7=$(echo "$HEAD_SHA" | cut -c1-7)
+          body=$(cat <<EOF
+          ## Docs Preview — queued
+
+          The preview build for commit \`${sha7}\` has been dispatched to [pydantic/unified-docs](https://github.com/pydantic/unified-docs/actions/workflows/docs-preview.yml). This comment will be updated with the preview URL once the build completes.
+          EOF
+          )
+
+          # Update an existing "Docs Preview" comment if present (covers re-runs); otherwise post a new one.
+          existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("## Docs Preview")))][0].url // empty')
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "$existing" -f body="$body"
+          else
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body"
+          fi
+
+      - name: Comment failure on PR
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          body=$(cat <<EOF
+          ## Docs Preview — dispatch failed
+
+          The dispatch to pydantic/unified-docs failed. See [the workflow run](${RUN_URL}) for details.
+
+          <sub>Re-add the \`trigger:docs\` label to retry.</sub>
+          EOF
+          )
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body"
+
+      - name: Remove trigger:docs label
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/trigger:docs" || true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -18,6 +18,7 @@ rules:
       - at-claude.yml
       - bots.yml
       - ci.yml
+      - docs-preview.yml
       - manually-deploy-docs.yml
 
   # `harness-compat.yml` calls a reusable workflow in `pydantic/pydantic-ai-harness`, an


### PR DESCRIPTION
Adds a `trigger:docs` label-gated workflow that dispatches a docs-preview build to [`pydantic/unified-docs`](https://github.com/pydantic/unified-docs/pull/21), which holds the shared preview Worker config + receiver workflow. The build, deploy, and final preview-URL comment all happen there; this workflow only dispatches and posts a "queued" acknowledgement.

The existing per-PR mkdocs preview in `after-ci.yml` is left intact — this is purely additive.

## How it works

1. Maintainer adds `trigger:docs` label to a PR.
2. This workflow fires (`pull_request_target: types: [labeled]`).
3. It generates a `DOCS_APP` token scoped to `unified-docs` and POSTs `repository_dispatch: docs-preview` with payload `{library: \"ai\", source_repo, source_pr, source_sha}`.
4. Posts/updates a `## Docs Preview — queued` comment on the PR.
5. Removes the `trigger:docs` label (always — re-add to retry).

The unified-docs receiver workflow then builds, deploys to a per-version Cloudflare Worker alias (`ai-pr<N>-<sha7>`), and updates the same comment with the preview URL.

## Companion PR

[pydantic/unified-docs#21](https://github.com/pydantic/unified-docs/pull/21) — adds the receiver workflow, Worker config, and `BUILD_ONLY=<slug>` env-var support in `astro.config.mjs`. Must be merged + bootstrap workflow run before this dispatcher does anything useful.

## Pre-requisites for the dispatcher to actually do something

1. Merge & set up [pydantic/unified-docs#21](https://github.com/pydantic/unified-docs/pull/21) (Worker creation + receiver workflow).
2. Ensure the existing `DOCS_APP` GitHub App has `pull-requests: write` on this repo (for the receiver in unified-docs to comment back). It already has metadata-read for dispatch.
3. Create a `trigger:docs` label in this repo (or rely on first-use auto-create).

## Why a separate workflow file (vs editing `after-ci.yml`)

`after-ci.yml` triggers on `workflow_run` (post-CI completion). The label gate needs `pull_request_target: types: [labeled]` — different trigger, different file. The existing mkdocs preview job stays where it is.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).