### PR TITLE
Fix OpenRouter chat `max_tokens` routing

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -929,7 +929,16 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     stream=stream,
                     stream_options=self._get_stream_options(model_settings) if stream else OMIT,
                     stop=model_settings.get('stop_sequences', OMIT),
-                    max_completion_tokens=model_settings.get('max_tokens', OMIT),
+                    max_tokens=(
+                        model_settings.get('max_tokens', OMIT)
+                        if profile.openai_chat_max_tokens_parameter == 'max_tokens'
+                        else OMIT
+                    ),
+                    max_completion_tokens=(
+                        model_settings.get('max_tokens', OMIT)
+                        if profile.openai_chat_max_tokens_parameter == 'max_completion_tokens'
+                        else OMIT
+                    ),
                     timeout=model_settings.get('timeout', NOT_GIVEN),
                     response_format=response_format or OMIT,
                     seed=model_settings.get('seed', OMIT),

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -79,6 +79,13 @@ class OpenAIModelProfile(ModelProfile):
     openai_supports_sampling_settings: bool = True
     """Turn off to don't send sampling settings like `temperature` and `top_p` to models that don't support them, like OpenAI's o-series reasoning models."""
 
+    openai_chat_max_tokens_parameter: Literal['max_completion_tokens', 'max_tokens'] = 'max_completion_tokens'
+    """Which Chat Completions token limit parameter should receive `ModelSettings.max_tokens`.
+
+    OpenAI reasoning models use `max_completion_tokens`, while some OpenAI-compatible providers still expect
+    the legacy `max_tokens` parameter and reject or ignore `max_completion_tokens`.
+    """
+
     openai_unsupported_model_settings: Sequence[str] = ()
     """A list of model settings that are not supported by this model."""
 

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -137,6 +137,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
             json_schema_transformer=OpenAIJsonSchemaTransformer,
             openai_chat_send_back_thinking_parts='field',
             openai_chat_thinking_field='reasoning',
+            openai_chat_max_tokens_parameter='max_tokens',
             openai_chat_supports_file_urls=True,
             openai_chat_supports_web_search=True,
         ).update(profile)

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -119,6 +119,20 @@ def test_init():
     assert m.model_name == 'gpt-4o'
 
 
+async def test_openai_chat_max_tokens_defaults_to_max_completion_tokens(allow_model_requests: None):
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m, model_settings=ModelSettings(max_tokens=123))
+
+    result = await agent.run('hello')
+
+    assert result.output == 'world'
+    request_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert request_kwargs['max_completion_tokens'] == 123
+    assert 'max_tokens' not in request_kwargs
+
+
 @pytest.mark.parametrize(
     'aspect_ratio,size,expected',
     [

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -45,14 +45,49 @@ with try_import() as imports_successful:
         _openrouter_settings_to_openai_settings,  # pyright: ignore[reportPrivateUsage]
         _OpenRouterChatCompletion,  # pyright: ignore[reportPrivateUsage]
         _OpenRouterChatCompletionChunk,  # pyright: ignore[reportPrivateUsage]
+        _OpenRouterChoice,  # pyright: ignore[reportPrivateUsage]
+        _OpenRouterCompletionMessage,  # pyright: ignore[reportPrivateUsage]
     )
     from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    from .mock_openai import MockOpenAI, get_mock_chat_completion_kwargs
 
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='openai not installed'),
     pytest.mark.vcr,
     pytest.mark.anyio,
 ]
+
+
+async def test_openrouter_max_tokens_uses_chat_max_tokens_parameter(allow_model_requests: None) -> None:
+    completion = _OpenRouterChatCompletion(
+        id='123',
+        choices=[
+            _OpenRouterChoice(
+                finish_reason='stop',
+                index=0,
+                message=_OpenRouterCompletionMessage(content='world', role='assistant'),
+            )
+        ],
+        created=0,
+        model='google/gemma-4-26b-a4b-it',
+        object='chat.completion',
+        provider='openai',
+    )
+    mock_client = MockOpenAI.create_mock(completion)
+    provider = OpenRouterProvider(openai_client=mock_client)
+    model = OpenRouterModel('google/gemma-4-26b-a4b-it', provider=provider)
+
+    response = await model_request(
+        model,
+        [ModelRequest.user_text_prompt('hello')],
+        model_settings=OpenRouterModelSettings(max_tokens=123),
+    )
+
+    assert response.parts == [TextPart(content='world')]
+    request_kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert request_kwargs['max_tokens'] == 123
+    assert 'max_completion_tokens' not in request_kwargs
 
 
 async def test_openrouter_with_preset(allow_model_requests: None, openrouter_api_key: str) -> None:


### PR DESCRIPTION
## Summary
- add an `OpenAIModelProfile.openai_chat_max_tokens_parameter` switch for Chat Completions token-limit routing
- keep the default OpenAI behavior unchanged by continuing to send `ModelSettings.max_tokens` as `max_completion_tokens`
- set OpenRouter's profile to send `ModelSettings.max_tokens` as the legacy `max_tokens` parameter, avoiding provider/model failures when `max_completion_tokens` is unsupported or ignored
- add regression coverage for both the default OpenAI route and the OpenRouter route

Fixes #5186

## Tests
- `uv run pytest tests/models/test_openai.py::test_openai_chat_max_tokens_defaults_to_max_completion_tokens tests/models/test_openrouter.py::test_openrouter_max_tokens_uses_chat_max_tokens_parameter -q`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/profiles/openai.py pydantic_ai_slim/pydantic_ai/providers/openrouter.py tests/models/test_openai.py tests/models/test_openrouter.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/profiles/openai.py pydantic_ai_slim/pydantic_ai/providers/openrouter.py tests/models/test_openai.py tests/models/test_openrouter.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/models/openai.py pydantic_ai_slim/pydantic_ai/profiles/openai.py pydantic_ai_slim/pydantic_ai/providers/openrouter.py tests/models/test_openai.py tests/models/test_openrouter.py`
- `git diff --check`
