### PR TITLE
Send OpenRouter reasoning disable flag

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -558,7 +558,9 @@ def _openrouter_settings_to_openai_settings(
     # Fall back to unified thinking when openrouter_reasoning is not set
     if 'openrouter_reasoning' not in model_settings and model_request_parameters.thinking is not None:
         thinking = model_request_parameters.thinking
-        if thinking is not False:
+        if thinking is False:
+            model_settings['openrouter_reasoning'] = {'enabled': False}
+        else:
             unified_reasoning: OpenRouterReasoning = {}
             # OpenRouter only supports low/medium/high; map others to closest
             effort_map: dict[ThinkingLevel, str] = {

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1013,6 +1013,17 @@ async def test_openrouter_settings_to_openai_settings_with_web_search() -> None:
     assert extra_body['web_search_options'] == {'search_context_size': 'high'}
 
 
+async def test_openrouter_prepare_request_with_thinking_false() -> None:
+    provider = OpenRouterProvider(api_key='test-key')
+    model = OpenRouterModel('anthropic/claude-sonnet-4.5', provider=provider)
+
+    result, _ = model.prepare_request(OpenRouterModelSettings(thinking=False), ModelRequestParameters())
+
+    assert result is not None
+    extra_body = cast(dict[str, Any], result.get('extra_body', {}))
+    assert extra_body['reasoning'] == {'enabled': False}
+
+
 async def test_openrouter_prepare_request_loop_with_non_websearch_first(openrouter_api_key: str) -> None:
     """Test prepare_request loop continuation when first tool is not WebSearchTool."""
     from unittest.mock import Mock

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -686,12 +686,12 @@ class TestOpenRouterThinkingTranslation:
         extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
         assert extra_body.get('reasoning') == {'effort': 'high'}
 
-    def test_thinking_false_no_reasoning(self):
+    def test_thinking_false_disables_reasoning(self):
         settings = OpenRouterModelSettings()
         params = ModelRequestParameters(thinking=False)
         result = _openrouter_settings_to_openai_settings(settings, params)
         extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert 'reasoning' not in extra_body
+        assert extra_body.get('reasoning') == {'enabled': False}
 
     def test_openai_reasoning_effort_passthrough(self):
         """Explicit openai_reasoning_effort on OpenRouter is passed through."""


### PR DESCRIPTION
Refs #5379

This addresses the OpenRouter transformer path described in #5379. It does not change the separate profile-gate handling for Moonshot/Qwen/Z.ai/gpt-oss, or the xAI/Bedrock transformer paths.

### Summary

- Emit OpenRouter `extra_body.reasoning = {'enabled': False}` when unified `thinking=False` reaches OpenRouter request preparation.
- Preserve the existing effort mapping for enabled thinking levels.
- Add a regression test through `OpenRouterModel.prepare_request`.
- Update the existing unified-thinking OpenRouter expectation to match the new disabled reasoning payload.

### Tests

- Pre-fix regression check: `uv run --python 3.12 --no-default-groups --group dev pytest tests/models/test_openrouter.py::test_openrouter_prepare_request_with_thinking_false -q` failed with `KeyError: 'reasoning'`
- CI-failure follow-up check: `uv run --python 3.12 --no-default-groups --group dev pytest tests/test_thinking.py::TestOpenRouterThinkingTranslation::test_thinking_false_disables_reasoning tests/models/test_openrouter.py::test_openrouter_prepare_request_with_thinking_false -q` -> 2 passed
- `uv run --python 3.12 --no-default-groups --group dev pytest tests/test_thinking.py::TestOpenRouterThinkingTranslation tests/models/test_openrouter.py -q` -> 47 passed
- `uv run --python 3.12 --no-default-groups --group lint ruff check pydantic_ai_slim/pydantic_ai/models/openrouter.py tests/models/test_openrouter.py tests/test_thinking.py` -> All checks passed

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).