### PR TITLE
ci: split release job into build and publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,18 +376,15 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.sha }}
 
-  # TODO(Marcelo): We need to split this into two jobs: `build` and `release`.
-  release:
+  # Build wheels in an isolated job with no publish credentials. If anything in
+  # `uv build` (build backend, transitive build deps, restored cache) is
+  # compromised, the OIDC token for PyPI is in a separate job that only runs
+  # `pypi-publish` against the already-built artifacts.
+  release-build:
+    name: build release artifacts
     needs: [check]
     if: success() && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-
-    environment:
-      name: release
-      url: https://pypi.org/project/pydantic-ai/${{ steps.inspect_package.outputs.version }}
-
-    permissions:
-      id-token: write
 
     outputs:
       package-version: ${{ steps.inspect_package.outputs.version }}
@@ -410,6 +407,35 @@ jobs:
           uv tool install --with uv-dynamic-versioning hatchling
           version=$(uvx hatchling version)
           echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-dist
+          path: dist/
+
+  release:
+    name: publish to PyPI
+    needs: [release-build]
+    if: success() && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+
+    environment:
+      name: release
+      url: https://pypi.org/project/pydantic-ai/${{ needs.release-build.outputs.package-version }}
+
+    permissions:
+      id-token: write
+
+    outputs:
+      package-version: ${{ needs.release-build.outputs.package-version }}
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-dist
+          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
<!-- No issue — this implements an existing TODO(Marcelo) in `.github/workflows/ci.yml`. -->

### Summary

Splits the single `release` job into two:

- **`release-build`** — checkout, `uv build --all-packages`, inspect version, upload `dist/` as an artifact. No `id-token: write`, no `environment`.
- **`release`** — downloads the `dist/` artifact and runs `pypa/gh-action-pypi-publish`. Keeps `environment: release`, `id-token: write`, and the `package-version` output (passed through from `release-build`) so `send-tweet` works unchanged.

### Why

The OIDC token that publishes to PyPI is currently in the same job that runs `uv build`. If anything in the build step is compromised — a poisoned wheel surfaced by a restored cache, a malicious transitive build-backend dep, etc. — the credentials are right there to publish the result.

This isn't theoretical: the [TanStack npm attack](https://blog.tanstack.com/post-mortem-of-tanstack-attack) used PR-time CI cache poisoning to plant files that the release workflow later baked into signed npm packages. The cache vector itself is largely closed in this repo by `cache-suffix: release` plus GitHub's ref-scoped caches, but the shared-job structure leaves the publish credential exposed to anything the build step pulls in.

After this PR, the publish job's only steps are `download-artifact` + `pypi-publish` — a minimal surface that can be additionally gated by required reviewers on the `release` environment.

This is the change Marcelo already flagged with a TODO at the top of the `release` job.

### Out of scope

- Sigstore attestations are already emitted by `pypa/gh-action-pypi-publish` under Trusted Publishing; not changing that here.
- The `attestations: write` permission is intentionally not added — keeps the surface narrow until we decide whether to expose attestations.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).