### PR TITLE
Restore ability to swap the Bedrock client at runtime

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -433,9 +433,7 @@ class BedrockConverseModel(Model[BaseClient]):
         provider pick up the new client. Once you've assigned a client here, you're responsible for keeping it valid;
         the provider's client is no longer consulted.
         """
-        if self._client is not None:
-            return cast('BedrockRuntimeClient', self._client)
-        return cast('BedrockRuntimeClient', self._provider.client)
+        return cast('BedrockRuntimeClient', self._client or self._provider.client)
 
     @client.setter
     def client(self, client: BedrockRuntimeClient) -> None:

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -392,6 +392,7 @@ class BedrockConverseModel(Model[BaseClient]):
 
     _model_name: BedrockModelName = field(repr=False)
     _provider: Provider[BaseClient] = field(repr=False)
+    _client: BaseClient | None = field(default=None, repr=False)
 
     def __init__(
         self,
@@ -414,6 +415,7 @@ class BedrockConverseModel(Model[BaseClient]):
             settings: Model-specific settings that will be used as defaults for this model.
         """
         self._model_name = model_name
+        self._client = None
 
         if isinstance(provider, str):
             provider = infer_provider('gateway/bedrock' if provider == 'gateway' else provider)
@@ -423,7 +425,23 @@ class BedrockConverseModel(Model[BaseClient]):
 
     @property
     def client(self) -> BedrockRuntimeClient:
+        """The boto3 client used to make requests to the Bedrock Converse API.
+
+        Defaults to the client from the [`Provider`][pydantic_ai.providers.Provider]. It can be reassigned, e.g. to
+        rotate short-lived credentials in a long-running service, but prefer assigning to
+        [`BedrockProvider.client`][pydantic_ai.providers.bedrock.BedrockProvider.client] so all models sharing the
+        provider pick up the new client. Once you've assigned a client here, you're responsible for keeping it valid;
+        the provider's client is no longer consulted.
+        """
+        if self._client is not None:
+            return cast('BedrockRuntimeClient', self._client)
         return cast('BedrockRuntimeClient', self._provider.client)
+
+    @client.setter
+    def client(self, client: BedrockRuntimeClient) -> None:
+        # Kept for backward compatibility (this used to be a plain attribute); `BedrockProvider.client` is the cleaner
+        # place to swap the client, as it's shared by all models using the provider.
+        self._client = client
 
     @property
     def base_url(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -117,6 +117,16 @@ class BedrockProvider(Provider[BaseClient]):
     def client(self) -> BaseClient:
         return self._client
 
+    @client.setter
+    def client(self, client: BaseClient) -> None:
+        """Replace the underlying boto3 client.
+
+        Useful for rotating short-lived credentials (e.g. temporary STS credentials) in a long-running service:
+        construct a fresh `bedrock-runtime` client and assign it here, and every [`BedrockConverseModel`]
+        [pydantic_ai.models.bedrock.BedrockConverseModel] using this provider will pick it up.
+        """
+        self._client = client
+
     @staticmethod
     def model_profile(model_name: str) -> ModelProfile | None:
         provider_to_profile: dict[str, Callable[[str], ModelProfile | None]] = {

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -4,7 +4,7 @@ import os
 from datetime import date, datetime, timezone
 from itertools import count
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from pytest_mock import MockerFixture
@@ -127,6 +127,16 @@ class _StubBedrockProvider(Provider[Any]):
 async def test_bedrock_client_property_delegates_to_provider(bedrock_provider: BedrockProvider):
     model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
     assert model.client is bedrock_provider.client
+
+
+async def test_bedrock_client_property_can_be_reassigned(bedrock_provider: BedrockProvider):
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    assert model.client is bedrock_provider.client
+
+    new_client = cast(Any, SimpleNamespace(meta=SimpleNamespace(endpoint_url='https://bedrock-runtime.example.com')))
+    model.client = new_client
+    assert model.client is new_client
+    assert model.base_url == 'https://bedrock-runtime.example.com'
 
 
 def _bedrock_model_with_client_error(error: ClientError) -> BedrockConverseModel:

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -39,6 +39,20 @@ def test_bedrock_provider(env: TestEnv):
     assert provider.base_url == 'https://bedrock-runtime.us-east-1.amazonaws.com'
 
 
+def test_bedrock_provider_client_setter(env: TestEnv):
+    env.set('AWS_DEFAULT_REGION', 'us-east-1')
+    provider = BedrockProvider()
+    original_client = provider.client
+
+    env.set('AWS_DEFAULT_REGION', 'us-west-2')
+    new_client = BedrockProvider().client
+    provider.client = new_client
+
+    assert provider.client is new_client
+    assert provider.client is not original_client
+    assert provider.base_url == 'https://bedrock-runtime.us-west-2.amazonaws.com'
+
+
 def test_bedrock_provider_bearer_token_env_var(env: TestEnv, mocker: MockerFixture):
     """Test that AWS_BEARER_TOKEN_BEDROCK env var is used for bearer token auth."""
     env.set('AWS_DEFAULT_REGION', 'us-east-1')


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #5386

In #4276, `BedrockConverseModel.client` went from a plain (settable) attribute to a read-only `@property`, which broke code that reassigned it — e.g. swapping the boto3 client to rotate short-lived STS credentials in a long-running service.

This restores that ability:

- `BedrockProvider.client` now has a setter — the preferred place to swap the client, since it's shared by every model using the provider.
- `BedrockConverseModel.client` gets its setter back for backward compatibility. A model-level assignment stores a local client that shadows the provider's; once you've assigned one, you own keeping it valid (so the stale-reference fix from #4276 still holds for everyone who doesn't opt in).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).