### PR TITLE
fix(anthropic): normalize Bedrock model IDs for capability profile lookup

### DIFF
--- a/docs/models/anthropic.md
+++ b/docs/models/anthropic.md
@@ -133,8 +133,6 @@ agent = Agent(model)
 ...
 ```
 
-The transport-specific model ID (e.g. `anthropic.claude-haiku-4-5` or `us.anthropic.claude-sonnet-4-5-20250929-v1:0`) is used as-is on the wire; the model's [`ModelProfile`][pydantic_ai.profiles.ModelProfile] (which capability flags it gets) is looked up from the underlying `claude-...` name.
-
 !!! note "Bedrock vs BedrockConverseModel"
     This approach uses Anthropic's SDK with AWS Bedrock credentials. For an alternative using AWS SDK (boto3) directly, see [`BedrockConverseModel`](bedrock.md).
 
@@ -158,9 +156,6 @@ model = AnthropicModel('claude-sonnet-4-5', provider=provider)
 agent = Agent(model)
 ...
 ```
-
-!!! note "Vertex vs GoogleModel"
-    This approach uses Anthropic's SDK with Vertex AI credentials. For an alternative using Google's Vertex AI SDK directly, see [`GoogleModel`](google.md).
 
 ### Microsoft Foundry
 

--- a/docs/models/anthropic.md
+++ b/docs/models/anthropic.md
@@ -117,24 +117,29 @@ You can use Anthropic models through cloud platforms by passing a custom client 
 
 ### AWS Bedrock
 
-To use Claude models via [AWS Bedrock](https://aws.amazon.com/bedrock/claude/), follow the [Anthropic documentation](https://docs.anthropic.com/en/api/claude-on-amazon-bedrock) on how to set up an `AsyncAnthropicBedrock` client and then pass it to `AnthropicProvider`:
+To use Claude models via [AWS Bedrock](https://aws.amazon.com/bedrock/claude/), follow the [Anthropic documentation](https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock) on how to set up a Bedrock client and then pass it to `AnthropicProvider`. Both the newer `AsyncAnthropicBedrockMantle` client (recommended by Anthropic, using the Messages API) and the legacy `AsyncAnthropicBedrock` client (using the `InvokeModel` API with ARN-versioned model IDs) are supported:
 
 ```python {test="skip"}
-from anthropic import AsyncAnthropicBedrock
+from anthropic import AsyncAnthropicBedrockMantle
 
 from pydantic_ai import Agent
 from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.providers.anthropic import AnthropicProvider
 
-bedrock_client = AsyncAnthropicBedrock()  # Uses AWS credentials from environment
+bedrock_client = AsyncAnthropicBedrockMantle()  # Uses AWS credentials from environment
 provider = AnthropicProvider(anthropic_client=bedrock_client)
-model = AnthropicModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=provider)
+model = AnthropicModel('anthropic.claude-haiku-4-5', provider=provider)
 agent = Agent(model)
 ...
 ```
 
+The transport-specific model ID (e.g. `anthropic.claude-haiku-4-5` or `us.anthropic.claude-sonnet-4-5-20250929-v1:0`) is used as-is on the wire; the model's [`ModelProfile`][pydantic_ai.profiles.ModelProfile] (which capability flags it gets) is looked up from the underlying `claude-...` name.
+
 !!! note "Bedrock vs BedrockConverseModel"
     This approach uses Anthropic's SDK with AWS Bedrock credentials. For an alternative using AWS SDK (boto3) directly, see [`BedrockConverseModel`](bedrock.md).
+
+!!! note "Tool search on the legacy `AsyncAnthropicBedrock` client"
+    The legacy `InvokeModel` API doesn't support the `bm25` [tool search](../tools-advanced.md#tool-search) variant, so [`ToolSearch`][pydantic_ai.capabilities.ToolSearch] defaults to `'regex'` on the `AsyncAnthropicBedrock` client (instead of `'bm25'`), and passing `ToolSearch(strategy='bm25')` raises a `UserError`.
 
 ### Google Vertex AI
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -100,6 +100,7 @@ try:
         APIConnectionError,
         APIStatusError,
         AsyncAnthropicBedrock,
+        AsyncAnthropicBedrockMantle,
         AsyncAnthropicFoundry,
         AsyncAnthropicVertex,
         AsyncStream,
@@ -216,12 +217,21 @@ except ImportError as _import_error:
         'you can use the `anthropic` optional group — `pip install "pydantic-ai-slim[anthropic]"`'
     ) from _import_error
 
+# `AsyncAnthropicBedrockMantle` uses the Messages API and supports automatic prompt caching (unlike the
+# legacy `AsyncAnthropicBedrock` InvokeModel API), so it's not in `_NON_AUTOMATIC_CACHING_CLIENTS`. Fast
+# mode is not available on any Bedrock transport, so it goes in `_FAST_MODE_UNSUPPORTED_CLIENTS`.
 _NON_AUTOMATIC_CACHING_CLIENTS = (AsyncAnthropicBedrock, AsyncAnthropicVertex)
-_FAST_MODE_UNSUPPORTED_CLIENTS = (AsyncAnthropicBedrock, AsyncAnthropicFoundry, AsyncAnthropicVertex)
+_FAST_MODE_UNSUPPORTED_CLIENTS = (
+    AsyncAnthropicBedrock,
+    AsyncAnthropicBedrockMantle,
+    AsyncAnthropicFoundry,
+    AsyncAnthropicVertex,
+)
 # The legacy Bedrock InvokeModel API (`AsyncAnthropicBedrock`) doesn't support the `bm25` tool-search
 # variant — it 400s with `BM25 tool search is not supported on Bedrock. Use tool_search_tool_regex instead.`
-# — so we default to `regex` there. (`AsyncAnthropicBedrockMantle` uses the Messages API and is treated
-# like the direct API.)
+# — so we default to `regex` there. The other transports (Vertex, Foundry, and the Messages-API-based
+# `AsyncAnthropicBedrockMantle`) expose the full Messages API, including both tool-search variants, so they
+# keep the `bm25` default.
 _BM25_TOOL_SEARCH_UNSUPPORTED_CLIENTS = (AsyncAnthropicBedrock,)
 
 _ANTHROPIC_SAMPLING_PARAMS = ('temperature', 'top_p', 'top_k')

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -218,6 +218,11 @@ except ImportError as _import_error:
 
 _NON_AUTOMATIC_CACHING_CLIENTS = (AsyncAnthropicBedrock, AsyncAnthropicVertex)
 _FAST_MODE_UNSUPPORTED_CLIENTS = (AsyncAnthropicBedrock, AsyncAnthropicFoundry, AsyncAnthropicVertex)
+# The legacy Bedrock InvokeModel API (`AsyncAnthropicBedrock`) doesn't support the `bm25` tool-search
+# variant — it 400s with `BM25 tool search is not supported on Bedrock. Use tool_search_tool_regex instead.`
+# — so we default to `regex` there. (`AsyncAnthropicBedrockMantle` uses the Messages API and is treated
+# like the direct API.)
+_BM25_TOOL_SEARCH_UNSUPPORTED_CLIENTS = (AsyncAnthropicBedrock,)
 
 _ANTHROPIC_SAMPLING_PARAMS = ('temperature', 'top_p', 'top_k')
 _ANTHROPIC_TASK_BUDGETS_BETA = 'task-budgets-2026-03-13'
@@ -975,6 +980,21 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             )
         return version
 
+    def _resolve_tool_search_strategy(self, strategy: Literal['bm25', 'regex'] | None) -> Literal['bm25', 'regex']:
+        """Resolve which native tool-search variant to send.
+
+        `bm25` is the default, except on clients that don't support it (the legacy Bedrock
+        InvokeModel API), where `regex` is the default and an explicit `bm25` is rejected.
+        """
+        if isinstance(self.client, _BM25_TOOL_SEARCH_UNSUPPORTED_CLIENTS):
+            if strategy == 'bm25':
+                raise UserError(
+                    "ToolSearch(strategy='bm25') is not supported by the `AsyncAnthropicBedrock` client; "
+                    "use ToolSearch(strategy='regex') instead, or leave the strategy unset to use the default."
+                )
+            return 'regex'
+        return strategy or 'bm25'
+
     def _add_native_tools(
         self,
         tools: list[BetaToolUnionParam],
@@ -1025,23 +1045,21 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             elif isinstance(tool, ToolSearchTool):  # pragma: no branch
                 # Custom-callable strategies go through the regular `search_tools` function tool
                 # (which is already in `function_tools`), so no server-side builtin is emitted.
-                if tool.strategy == 'custom':
-                    pass
-                # Default strategy is BM25; regex is the alternative named strategy.
-                elif tool.strategy == 'regex':
-                    tools.append(
-                        BetaToolSearchToolRegex20251119Param(
-                            type='tool_search_tool_regex_20251119',
-                            name='tool_search_tool_regex',
+                if tool.strategy != 'custom':
+                    if self._resolve_tool_search_strategy(tool.strategy) == 'regex':
+                        tools.append(
+                            BetaToolSearchToolRegex20251119Param(
+                                type='tool_search_tool_regex_20251119',
+                                name='tool_search_tool_regex',
+                            )
                         )
-                    )
-                else:
-                    tools.append(
-                        BetaToolSearchToolBm25_20251119Param(
-                            type='tool_search_tool_bm25_20251119',
-                            name='tool_search_tool_bm25',
+                    else:
+                        tools.append(
+                            BetaToolSearchToolBm25_20251119Param(
+                                type='tool_search_tool_bm25_20251119',
+                                name='tool_search_tool_bm25',
+                            )
                         )
-                    )
                 # No `beta_features.add(...)`: tool search is GA on Sonnet/Opus/Haiku 4.5+ and the
                 # provisional `tool-search-tool-2025-11-19` beta header is rejected by the API.
             elif isinstance(tool, MCPServerTool) and tool.url:
@@ -1350,10 +1368,14 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                                     continue
                                 # Round-trip the native variant (bm25/regex) so we don't
                                 # silently rewrite the algorithm. `_map_server_tool_use_block`
-                                # stashes it in `provider_details['strategy']`.
+                                # stashes it in `provider_details['strategy']`. Clients that don't
+                                # support `bm25` (legacy Bedrock InvokeModel) always replay as `regex`.
                                 details = response_part.provider_details or {}
                                 strategy: Literal['bm25', 'regex'] = (
-                                    'regex' if details.get('strategy') == 'regex' else 'bm25'
+                                    'regex'
+                                    if details.get('strategy') == 'regex'
+                                    or isinstance(self.client, _BM25_TOOL_SEARCH_UNSUPPORTED_CLIENTS)
+                                    else 'bm25'
                                 )
                                 native_name = (
                                     'tool_search_tool_regex' if strategy == 'regex' else 'tool_search_tool_bm25'

--- a/pydantic_ai_slim/pydantic_ai/providers/_bedrock_model_names.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/_bedrock_model_names.py
@@ -1,0 +1,57 @@
+"""Helpers for normalizing Amazon Bedrock model identifiers.
+
+Bedrock model IDs carry a `<provider>.` segment (e.g. `anthropic.`, `amazon.`) and,
+on the legacy `InvokeModel`/`Converse` APIs, a `-v<n>(:<m>)?` version suffix and an
+optional cross-region inference geo prefix (`us.`, `eu.`, ...): e.g.
+`us.anthropic.claude-haiku-4-5-20251001-v1:0`.
+
+These live in a boto3-free module so both [`BedrockProvider`][pydantic_ai.providers.bedrock.BedrockProvider]
+(which needs boto3) and [`AnthropicProvider`][pydantic_ai.providers.anthropic.AnthropicProvider]
+(which talks to Bedrock via `AsyncAnthropicBedrock`/`AsyncAnthropicBedrockMantle` and doesn't)
+can share them.
+"""
+
+from __future__ import annotations as _annotations
+
+import re
+
+__all__ = ('BEDROCK_GEO_PREFIXES', 'remove_bedrock_geo_prefix', 'split_bedrock_model_id')
+
+# Known geo prefixes for cross-region inference profile IDs
+BEDROCK_GEO_PREFIXES: tuple[str, ...] = ('us', 'eu', 'apac', 'jp', 'au', 'ca', 'global', 'us-gov')
+
+_VERSION_SUFFIX_RE = re.compile(r'(.+)-v\d+(?::\d+)?$')
+
+
+def remove_bedrock_geo_prefix(model_name: str) -> str:
+    """Remove the cross-region inference geographic prefix from a model ID if present.
+
+    Bedrock supports cross-region inference using geographic prefixes like
+    `us.`, `eu.`, `apac.`, etc. This function strips those prefixes.
+
+    Example:
+        `us.amazon.titan-embed-text-v2:0` -> `amazon.titan-embed-text-v2:0`
+        `amazon.titan-embed-text-v2:0` -> `amazon.titan-embed-text-v2:0`
+    """
+    for prefix in BEDROCK_GEO_PREFIXES:
+        if model_name.startswith(f'{prefix}.'):
+            return model_name.removeprefix(f'{prefix}.')
+    return model_name
+
+
+def split_bedrock_model_id(model_id: str) -> tuple[str | None, str]:
+    """Split a Bedrock model ID into its `<provider>` segment and the bare model name.
+
+    Strips any cross-region inference geo prefix and `-v<n>(:<m>)?` version suffix.
+
+    Example:
+        `us.anthropic.claude-haiku-4-5-20251001-v1:0` -> `('anthropic', 'claude-haiku-4-5-20251001')`
+        `anthropic.claude-haiku-4-5` -> `('anthropic', 'claude-haiku-4-5')`
+        `claude-haiku-4-5` -> `(None, 'claude-haiku-4-5')`
+    """
+    provider, _, name = remove_bedrock_geo_prefix(model_id).partition('.')
+    if not name:  # no `<provider>.` segment
+        return None, model_id
+    if version_match := _VERSION_SUFFIX_RE.match(name):
+        name = version_match.group(1)
+    return provider, name

--- a/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
@@ -12,11 +12,18 @@ from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles.anthropic import AnthropicModelProfile, anthropic_model_profile
 from pydantic_ai.providers import Provider
+from pydantic_ai.providers._bedrock_model_names import split_bedrock_model_id
 
 from .._json_schema import JsonSchema, JsonSchemaTransformer
 
 try:
-    from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, AsyncAnthropicFoundry, AsyncAnthropicVertex
+    from anthropic import (
+        AsyncAnthropic,
+        AsyncAnthropicBedrock,
+        AsyncAnthropicBedrockMantle,
+        AsyncAnthropicFoundry,
+        AsyncAnthropicVertex,
+    )
 except ImportError as _import_error:
     raise ImportError(
         'Please install the `anthropic` package to use the Anthropic provider, '
@@ -24,7 +31,9 @@ except ImportError as _import_error:
     ) from _import_error
 
 
-AsyncAnthropicClient: TypeAlias = AsyncAnthropic | AsyncAnthropicBedrock | AsyncAnthropicFoundry | AsyncAnthropicVertex
+AsyncAnthropicClient: TypeAlias = (
+    AsyncAnthropic | AsyncAnthropicBedrock | AsyncAnthropicBedrockMantle | AsyncAnthropicFoundry | AsyncAnthropicVertex
+)
 
 
 class AnthropicProvider(Provider[AsyncAnthropicClient]):
@@ -44,6 +53,14 @@ class AnthropicProvider(Provider[AsyncAnthropicClient]):
 
     @staticmethod
     def model_profile(model_name: str) -> ModelProfile | None:
+        # When the underlying client is `AsyncAnthropicBedrock`/`AsyncAnthropicBedrockMantle`, the model
+        # name carries a Bedrock `anthropic.` provider segment (and, on the legacy InvokeModel API, a
+        # `-v<n>(:<m>)?` version suffix and optional cross-region geo prefix), e.g.
+        # `us.anthropic.claude-haiku-4-5-20251001-v1:0`. Strip it so `anthropic_model_profile`'s
+        # `claude-...` prefix checks match; the full model name still goes on the wire via `AnthropicModel._model_name`.
+        bedrock_provider, base_model_name = split_bedrock_model_id(model_name)
+        if bedrock_provider == 'anthropic':
+            model_name = base_model_name
         profile = anthropic_model_profile(model_name)
         return AnthropicModelProfile(json_schema_transformer=AnthropicJsonSchemaTransformer).update(profile)
 
@@ -71,7 +88,8 @@ class AnthropicProvider(Provider[AsyncAnthropicClient]):
             base_url: The base URL to use for the Anthropic API.
             anthropic_client: An existing Anthropic client to use. Accepts
                 [`AsyncAnthropic`](https://github.com/anthropics/anthropic-sdk-python),
-                [`AsyncAnthropicBedrock`](https://docs.anthropic.com/en/api/claude-on-amazon-bedrock),
+                [`AsyncAnthropicBedrock`](https://platform.claude.com/docs/en/build-with-claude/claude-on-amazon-bedrock-legacy),
+                [`AsyncAnthropicBedrockMantle`](https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock),
                 [`AsyncAnthropicFoundry`](https://platform.claude.com/docs/en/build-with-claude/claude-in-microsoft-foundry), or
                 [`AsyncAnthropicVertex`](https://docs.anthropic.com/en/api/claude-on-vertex-ai).
                 If provided, the `api_key` and `http_client` arguments will be ignored.

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import os
-import re
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Any, Literal, overload
@@ -16,6 +15,11 @@ from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.providers import Provider
+from pydantic_ai.providers._bedrock_model_names import (
+    BEDROCK_GEO_PREFIXES as BEDROCK_GEO_PREFIXES,  # re-exported for backwards compatibility
+    remove_bedrock_geo_prefix as remove_bedrock_geo_prefix,  # re-exported for backwards compatibility
+    split_bedrock_model_id,
+)
 
 try:
     import boto3
@@ -76,26 +80,6 @@ def bedrock_deepseek_model_profile(model_name: str) -> ModelProfile | None:
     if 'r1' in model_name:
         return BedrockModelProfile(bedrock_send_back_thinking_parts=True).update(profile)
     return profile  # pragma: no cover
-
-
-# Known geo prefixes for cross-region inference profile IDs
-BEDROCK_GEO_PREFIXES: tuple[str, ...] = ('us', 'eu', 'apac', 'jp', 'au', 'ca', 'global', 'us-gov')
-
-
-def remove_bedrock_geo_prefix(model_name: str) -> str:
-    """Remove inference geographic prefix from model ID if present.
-
-    Bedrock supports cross-region inference using geographic prefixes like
-    'us.', 'eu.', 'apac.', etc. This function strips those prefixes.
-
-    Example:
-        'us.amazon.titan-embed-text-v2:0' -> 'amazon.titan-embed-text-v2:0'
-        'amazon.titan-embed-text-v2:0' -> 'amazon.titan-embed-text-v2:0'
-    """
-    for prefix in BEDROCK_GEO_PREFIXES:
-        if model_name.startswith(f'{prefix}.'):
-            return model_name.removeprefix(f'{prefix}.')
-    return model_name
 
 
 def _without_builtin_tools(profile: ModelProfile | None) -> ModelProfile:
@@ -160,27 +144,9 @@ class BedrockProvider(Provider[BaseClient]):
             ),
         }
 
-        # Split the model name into parts
-        parts = model_name.split('.', 2)
-
-        # Handle regional prefixes
-        if len(parts) > 2 and parts[0] in BEDROCK_GEO_PREFIXES:
-            parts = parts[1:]
-
-        # required format is provider.model-name-with-version
-        if len(parts) < 2:
-            return None
-
-        provider = parts[0]
-        model_name_with_version = parts[1]
-
-        # Remove version suffix if it matches the format (e.g. "-v1:0" or "-v14")
-        version_match = re.match(r'(.+)-v\d+(?::\d+)?$', model_name_with_version)
-        if version_match:
-            model_name = version_match.group(1)
-        else:
-            model_name = model_name_with_version
-
+        # Bedrock model IDs are `<provider>.<model-name>-v<n>(:<m>)?`, optionally with a
+        # cross-region inference geo prefix (e.g. `us.anthropic.claude-haiku-4-5-20251001-v1:0`).
+        provider, model_name = split_bedrock_model_id(model_name)
         if provider in provider_to_profile:
             return provider_to_profile[provider](model_name)
 

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -61,6 +61,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.native_tools import CodeExecutionTool, MCPServerTool, MemoryTool, WebFetchTool, WebSearchTool
+from pydantic_ai.native_tools._tool_search import ToolSearchTool
 from pydantic_ai.output import NativeOutput, PromptedOutput, TextOutput, ToolOutput
 from pydantic_ai.result import RunUsage
 from pydantic_ai.settings import ModelSettings
@@ -78,6 +79,7 @@ with try_import() as imports_successful:
         APIStatusError,
         AsyncAnthropic,
         AsyncAnthropicBedrock,
+        AsyncAnthropicBedrockMantle,
         AsyncAnthropicFoundry,
         AsyncAnthropicVertex,
         AsyncStream,
@@ -137,7 +139,7 @@ with try_import() as imports_successful:
     MockRawMessageStreamEvent = BetaRawMessageStreamEvent | Exception
 
 if not imports_successful():  # pragma: lax no cover
-    AsyncAnthropicBedrock = AsyncAnthropicVertex = AsyncAnthropicFoundry = None
+    AsyncAnthropicBedrock = AsyncAnthropicBedrockMantle = AsyncAnthropicVertex = AsyncAnthropicFoundry = None
 
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='anthropic not installed'),
@@ -570,6 +572,90 @@ def test_build_cache_control_includes_ttl():
 
     cache_control_1h = m._build_cache_control('1h')  # pyright: ignore[reportPrivateUsage]
     assert cache_control_1h == {'type': 'ephemeral', 'ttl': '1h'}
+
+
+def _mock_anthropic_client(client_cls: Any, base_url: str) -> Any:
+    from unittest.mock import MagicMock
+
+    client = MagicMock(spec=client_cls)
+    client.base_url = base_url
+    return client
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    [
+        'anthropic.claude-haiku-4-5',
+        'anthropic.claude-haiku-4-5-20251001-v1:0',
+        'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    ],
+)
+@pytest.mark.parametrize(
+    'client_cls,base_url',
+    [
+        pytest.param(AsyncAnthropicBedrock, 'https://bedrock-runtime.us-east-1.amazonaws.com', id='bedrock'),
+        pytest.param(AsyncAnthropicBedrockMantle, 'https://bedrock-mantle.us-east-1.api.aws', id='bedrock-mantle'),
+    ],
+)
+def test_anthropic_model_resolves_profile_for_bedrock_model_ids(model_name: str, client_cls: Any, base_url: str):
+    """A Bedrock-shaped model id resolves to the right capability profile, while the full id still goes on the wire."""
+    m = AnthropicModel(
+        model_name, provider=AnthropicProvider(anthropic_client=_mock_anthropic_client(client_cls, base_url))
+    )
+    assert m.model_name == model_name
+    assert m.profile.supports_json_schema_output is True
+    assert ToolSearchTool in m.profile.supported_native_tools
+
+
+def _tool_search_param(client_cls: Any, base_url: str, tool: ToolSearchTool) -> dict[str, Any]:
+    m = AnthropicModel(
+        'claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=_mock_anthropic_client(client_cls, base_url))
+    )
+    tools, _, _ = m._add_native_tools(  # pyright: ignore[reportPrivateUsage]
+        [], ModelRequestParameters(native_tools=[tool]), AnthropicModelSettings()
+    )
+    return cast('dict[str, Any]', next(t for t in tools if str(t.get('name', '')).startswith('tool_search_tool_')))
+
+
+def test_anthropic_tool_search_defaults_to_regex_on_legacy_bedrock():
+    """The legacy Bedrock InvokeModel API doesn't support `bm25`, so the default strategy is `regex` there."""
+    base_url = 'https://bedrock-runtime.us-east-1.amazonaws.com'
+    param = _tool_search_param(AsyncAnthropicBedrock, base_url, ToolSearchTool())
+    assert param == {'type': 'tool_search_tool_regex_20251119', 'name': 'tool_search_tool_regex'}
+    # An explicit `regex` is honored.
+    param = _tool_search_param(AsyncAnthropicBedrock, base_url, ToolSearchTool(strategy='regex'))
+    assert param == {'type': 'tool_search_tool_regex_20251119', 'name': 'tool_search_tool_regex'}
+
+
+def test_anthropic_tool_search_bm25_rejected_on_legacy_bedrock():
+    """An explicit `bm25` strategy on the legacy Bedrock InvokeModel API is a `UserError`, not an opaque 400."""
+    m = AnthropicModel(
+        'claude-haiku-4-5',
+        provider=AnthropicProvider(
+            anthropic_client=_mock_anthropic_client(
+                AsyncAnthropicBedrock, 'https://bedrock-runtime.us-east-1.amazonaws.com'
+            )
+        ),
+    )
+    with pytest.raises(
+        UserError, match="ToolSearch\\(strategy='bm25'\\) is not supported by the `AsyncAnthropicBedrock` client"
+    ):
+        m._add_native_tools(  # pyright: ignore[reportPrivateUsage]
+            [], ModelRequestParameters(native_tools=[ToolSearchTool(strategy='bm25')]), AnthropicModelSettings()
+        )
+
+
+@pytest.mark.parametrize(
+    'client_cls,base_url',
+    [
+        pytest.param(AsyncAnthropic, 'https://api.anthropic.com', id='direct'),
+        pytest.param(AsyncAnthropicBedrockMantle, 'https://bedrock-mantle.us-east-1.api.aws', id='bedrock-mantle'),
+    ],
+)
+def test_anthropic_tool_search_defaults_to_bm25(client_cls: Any, base_url: str):
+    """`bm25` remains the default on the direct API and the (Messages-API-based) Bedrock Mantle client."""
+    param = _tool_search_param(client_cls, base_url, ToolSearchTool())
+    assert param == {'type': 'tool_search_tool_bm25_20251119', 'name': 'tool_search_tool_bm25'}
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -645,16 +645,12 @@ def test_anthropic_tool_search_bm25_rejected_on_legacy_bedrock():
         )
 
 
-@pytest.mark.parametrize(
-    'client_cls,base_url',
-    [
-        pytest.param(AsyncAnthropic, 'https://api.anthropic.com', id='direct'),
-        pytest.param(AsyncAnthropicBedrockMantle, 'https://bedrock-mantle.us-east-1.api.aws', id='bedrock-mantle'),
-    ],
-)
-def test_anthropic_tool_search_defaults_to_bm25(client_cls: Any, base_url: str):
-    """`bm25` remains the default on the direct API and the (Messages-API-based) Bedrock Mantle client."""
-    param = _tool_search_param(client_cls, base_url, ToolSearchTool())
+def test_anthropic_tool_search_defaults_to_bm25_on_non_legacy_bedrock_clients():
+    """`bm25` stays the default on clients not in `_BM25_TOOL_SEARCH_UNSUPPORTED_CLIENTS` —
+    e.g. the (Messages-API-based) Bedrock Mantle client, like the direct Anthropic API."""
+    param = _tool_search_param(
+        AsyncAnthropicBedrockMantle, 'https://bedrock-mantle.us-east-1.api.aws', ToolSearchTool()
+    )
     assert param == {'type': 'tool_search_tool_bm25_20251119', 'name': 'tool_search_tool_bm25'}
 
 

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -7,6 +7,8 @@ from ..conftest import try_import
 with try_import() as imports_successful:
     from anthropic import AsyncAnthropic, AsyncAnthropicBedrock
 
+    from pydantic_ai.native_tools._tool_search import ToolSearchTool
+    from pydantic_ai.profiles.anthropic import AnthropicModelProfile
     from pydantic_ai.providers.anthropic import AnthropicProvider
 
 
@@ -42,3 +44,36 @@ def test_anthropic_provider_with_env_base_url(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setenv('ANTHROPIC_BASE_URL', custom_base_url)
     provider = AnthropicProvider(api_key='api-key')
     assert provider.base_url.rstrip('/') == custom_base_url.rstrip('/')
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    [
+        # Direct Anthropic API ids (with and without date suffix)
+        'claude-haiku-4-5',
+        'claude-haiku-4-5-20251001',
+        # Amazon Bedrock ids: `anthropic.` provider segment, optional geo prefix and `-vN(:M)?` version suffix
+        'anthropic.claude-haiku-4-5',
+        'anthropic.claude-haiku-4-5-20251001-v1:0',
+        'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+        'global.anthropic.claude-haiku-4-5',
+        # Anthropic on Vertex AI: `@`-delimited version
+        'claude-haiku-4-5@20251001',
+    ],
+)
+def test_anthropic_provider_model_profile_normalizes_transport_specific_ids(model_name: str):
+    """`AnthropicProvider.model_profile` resolves capability flags from the bare `claude-...` name,
+    even when the underlying client (Bedrock/Vertex) carries a transport-specific model id."""
+    profile = AnthropicProvider.model_profile(model_name)
+    assert isinstance(profile, AnthropicModelProfile)
+    assert profile.supports_json_schema_output is True
+    assert ToolSearchTool in profile.supported_native_tools
+
+
+def test_anthropic_provider_model_profile_older_model_still_resolves():
+    """Normalization must not over-strip: an older model without structured-output support
+    still resolves to the right (negative) flags."""
+    profile = AnthropicProvider.model_profile('anthropic.claude-3-5-sonnet-20240620-v1:0')
+    assert isinstance(profile, AnthropicModelProfile)
+    assert profile.supports_json_schema_output is False
+    assert ToolSearchTool not in profile.supported_native_tools

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -11,6 +11,7 @@ from pydantic_ai.profiles.cohere import cohere_model_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
+from pydantic_ai.providers._bedrock_model_names import split_bedrock_model_id
 
 from ..conftest import TestEnv, try_import
 
@@ -178,6 +179,24 @@ def test_bedrock_provider_model_profile(env: TestEnv, mocker: MockerFixture):
 )
 def test_remove_inference_geo_prefix(model_name: str, expected: str):
     assert remove_bedrock_geo_prefix(model_name) == expected
+
+
+@pytest.mark.parametrize(
+    ('model_id', 'expected'),
+    [
+        ('us.anthropic.claude-haiku-4-5-20251001-v1:0', ('anthropic', 'claude-haiku-4-5-20251001')),
+        ('anthropic.claude-haiku-4-5-20251001-v1:0', ('anthropic', 'claude-haiku-4-5-20251001')),
+        ('anthropic.claude-haiku-4-5', ('anthropic', 'claude-haiku-4-5')),
+        ('eu.amazon.nova-micro-v1:0', ('amazon', 'nova-micro')),
+        ('cohere.command-r-v1:0', ('cohere', 'command-r')),
+        ('meta.llama3-8b-instruct-v14', ('meta', 'llama3-8b-instruct')),
+        # Not a `<provider>.<name>` shape — returned unchanged.
+        ('claude-haiku-4-5', (None, 'claude-haiku-4-5')),
+        ('claude-haiku-4-5@20251001', (None, 'claude-haiku-4-5@20251001')),
+    ],
+)
+def test_split_bedrock_model_id(model_id: str, expected: tuple[str | None, str]):
+    assert split_bedrock_model_id(model_id) == expected
 
 
 @pytest.mark.parametrize('prefix', BEDROCK_GEO_PREFIXES)


### PR DESCRIPTION
- Closes #5324

> [!NOTE]
> Targets the `tool-search` branch (#5143), since the tool-search default-strategy part of #5324 builds on code introduced there. Will retarget to `main` once #5143 merges. Supersedes #5344 (thanks @kclisp for the original report and PR).

### What this does

**1. Model-name normalization for Bedrock clients (issue point 4).**
`AnthropicProvider.model_profile` now strips the Bedrock `anthropic.` provider segment — plus the cross-region geo prefix and the `-vN(:M)?` version suffix — before calling `anthropic_model_profile`, so `model_name.startswith('claude-…')` checks match for a model id like `us.anthropic.claude-haiku-4-5-20251001-v1:0`. Previously these silently flipped `supports_json_schema_output`, tool-search support, `anthropic_supports_adaptive_thinking`, etc. to their defaults. The full transport-specific id still goes on the wire via `AnthropicModel._model_name`.

The geo/version parsing is extracted from `BedrockProvider.model_profile` into a boto3-free `pydantic_ai.providers._bedrock_model_names` helper (`split_bedrock_model_id`, plus `remove_bedrock_geo_prefix` / `BEDROCK_GEO_PREFIXES`, re-exported from `providers.bedrock` for backwards compat) so both providers share it. `BedrockProvider.model_profile` is refactored onto the shared helper.

**2. `AsyncAnthropicBedrockMantle` support.** Added to the `AsyncAnthropicClient` union and the provider docstring — the newer "Claude in Amazon Bedrock" (Messages-API) client Anthropic now recommends. It uses the same `anthropic.claude-…` model-id shape, so it's covered by the normalization above.

**3. Tool-search default strategy on Bedrock (issue point 5).**
The legacy Bedrock InvokeModel API (`AsyncAnthropicBedrock`) 400s on `tool_search_tool_bm25_*` (`BM25 tool search is not supported on Bedrock. Use tool_search_tool_regex instead.`). So on that client, `ToolSearch(strategy=None)` resolves to `regex` instead of `bm25`, and an explicit `ToolSearch(strategy='bm25')` raises a `UserError` rather than an opaque 400. (`AsyncAnthropicBedrockMantle` uses the Messages API and keeps the `bm25` default.) This follows the existing `_FAST_MODE_UNSUPPORTED_CLIENTS` / `_client_supports_fast_speed` pattern — a request-time transport check, not a profile flag, since bm25-vs-regex is a transport property (every tool-search-capable Claude model supports both on the direct API).

### Test plan

- `AnthropicProvider.model_profile` resolves the right capability flags for direct, Bedrock (`anthropic.…`, `…-v1:0`, geo-prefixed), and Vertex (`@`-versioned) model ids — and doesn't over-strip (an older `claude-3-5-sonnet` id still resolves to the right negative flags).
- `AnthropicModel` with `AsyncAnthropicBedrock` / `AsyncAnthropicBedrockMantle` clients: profile resolved from the bare name, full id kept on the wire.
- Tool search: `regex` default + explicit `bm25` `UserError` on `AsyncAnthropicBedrock`; `bm25` default on the direct and Mantle clients.
- `split_bedrock_model_id` unit tests; existing `BedrockProvider.model_profile` / `remove_bedrock_geo_prefix` tests still pass after the refactor.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).