### PR TITLE
fix(evals): constrain judge `reason` to retry-safe prose (#5034)

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
+++ b/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
@@ -25,11 +25,40 @@ _default_model: models.Model | models.KnownModelName = 'openai:gpt-5.2'
 
 
 class GradingOutput(BaseModel, populate_by_name=True):
-    """The output of a grading operation."""
+    """The output of a grading operation.
+
+    `reason` is intended to be short and stable enough to be fed back to the
+    judged model as repair feedback (for example through `ModelRetry`). See
+    `_REASON_FIELD_GUIDANCE` for the contract that judge prompts impose on
+    this field.
+    """
 
     reason: str
     pass_: bool = Field(validation_alias='pass', serialization_alias='pass')
     score: float
+
+
+# Rules appended to every judge system prompt. The `reason` field is
+# frequently fed back into a retry loop (`ModelRetry(grading.reason)`), so
+# we constrain it to be concise, stable, and free of visible thinking. We
+# don't try to suppress *internal* reasoning — reasoning models can still
+# think; we just don't want their scratchpad leaking into the public
+# `reason` text that callers use as repair feedback.
+_REASON_FIELD_GUIDANCE = dedent(
+    """
+    Rules for the `reason` field:
+
+    - One or two short sentences. Plain prose. No markdown, no lists, no
+      step-by-step narration.
+    - State the rule(s) that were violated (or the rule(s) that were
+      satisfied) and stop. Treat it like a commit message for a failing
+      test, not a thought log.
+    - Do not re-check, retract, hedge, or contradict yourself inside the
+      field. Whatever value you assign to `pass` must agree with `reason`.
+    - Do not echo internal reasoning or chain-of-thought into `reason`. If
+      you reasoned to reach the verdict, summarise the conclusion only.
+    """
+).strip()
 
 
 _judge_output_agent = Agent(
@@ -48,7 +77,9 @@ _judge_output_agent = Agent(
         <Rubric>Does not speak like a pirate</Rubric>
         {"reason": "'avast ye' is a common pirate term", "pass": false, "score": 0.0}
         """
-    ),
+    )
+    + '\n'
+    + _REASON_FIELD_GUIDANCE,
     output_type=GradingOutput,
 )
 
@@ -88,7 +119,9 @@ _judge_input_output_agent = Agent(
         <Rubric>Does not speak in the style described by the input</Rubric>
         {"reason": "'avast ye' is a common pirate term", "pass": false, "score": 0.0}
         """
-    ),
+    )
+    + '\n'
+    + _REASON_FIELD_GUIDANCE,
     output_type=GradingOutput,
 )
 
@@ -132,7 +165,9 @@ _judge_input_output_expected_agent = Agent(
         <Rubric>The output is factually consistent with the expected output</Rubric>
         {"reason": "Spiders have 8 legs", "pass": false, "score": 0.0}
         """
-    ),
+    )
+    + '\n'
+    + _REASON_FIELD_GUIDANCE,
     output_type=GradingOutput,
 )
 
@@ -177,7 +212,9 @@ _judge_output_expected_agent = Agent(
         <Rubric>The output should be a number written in words which matches the number written in digits in the expected output</Rubric>
         {"reason": "The output is 'Six' which is a different number than 8", "pass": false, "score": 0.0}
         """
-    ),
+    )
+    + '\n'
+    + _REASON_FIELD_GUIDANCE,
     output_type=GradingOutput,
 )
 

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -8,7 +8,9 @@ from ..conftest import BinaryContent, try_import
 
 with try_import() as imports_successful:
     from pydantic_ai.settings import ModelSettings
+    from pydantic_evals.evaluators import llm_as_a_judge as _llm_judge_mod
     from pydantic_evals.evaluators.llm_as_a_judge import (
+        _REASON_FIELD_GUIDANCE,  # pyright: ignore[reportPrivateUsage]
         GradingOutput,
         _stringify,  # pyright: ignore[reportPrivateUsage]
         judge_input_output,
@@ -39,6 +41,27 @@ def test_grading_output():
     assert output.reason == 'Test passed'
     assert output.pass_ is True
     assert output.score == 1.0
+
+
+def test_all_judge_agents_carry_reason_guidance():
+    """Pins the contract from #5034: every built-in judge agent's system prompt
+    must include the `_REASON_FIELD_GUIDANCE` block, so `reason` stays
+    retry-safe (concise, stable, no leaked chain-of-thought) regardless of
+    which judge function the caller picks.
+    """
+    agents = [
+        _llm_judge_mod._judge_output_agent,  # pyright: ignore[reportPrivateUsage]
+        _llm_judge_mod._judge_input_output_agent,  # pyright: ignore[reportPrivateUsage]
+        _llm_judge_mod._judge_input_output_expected_agent,  # pyright: ignore[reportPrivateUsage]
+        _llm_judge_mod._judge_output_expected_agent,  # pyright: ignore[reportPrivateUsage]
+    ]
+    assert _REASON_FIELD_GUIDANCE, 'guidance block must not be empty'
+    for agent in agents:
+        rendered = '\n'.join(agent._system_prompts)  # pyright: ignore[reportPrivateUsage]
+        assert _REASON_FIELD_GUIDANCE in rendered, (
+            f'agent {agent.name!r} lost reason-field guidance — '
+            'judge `reason` outputs can drift back to verbose self-reflection.'
+        )
 
 
 def test_stringify():


### PR DESCRIPTION
Closes #5034.

Opening as **Draft** per CONTRIBUTING — the issue is assigned to @adtyavrdhn and @DouweM voiced one concrete concern in the thread ("regressions for people who are using it with the reasoning"). I've tried to address that concern below; happy to close, rework, or hand this off if maintainers prefer a different direction.

## The bug, recapped

`judge_output()` / `judge_input_output*()` return `GradingOutput.reason: str`. With reasoning-capable judges, that field routinely ends up containing:

- visible self-correction and re-checking,
- mid-paragraph retractions of earlier claims,
- contradictions of the `pass` value the judge returned.

That makes `reason` unsafe to feed into a retry loop like:

```python
@agent.output_validator
async def llm_judge_validator(ctx, data):
    grading = await judge_output(output=data, rubric=..., model=...)
    if not grading.pass_:
        raise ModelRetry(grading.reason)  # ← now a noisy thought log
    return data
```

## The fix

Prompt-only. A shared `_REASON_FIELD_GUIDANCE` block is appended to each of the four built-in judge agents (`_judge_output_agent`, `_judge_input_output_agent`, `_judge_input_output_expected_agent`, `_judge_output_expected_agent`):

> Rules for the `reason` field:
> - One or two short sentences. Plain prose. No markdown, no lists, no step-by-step narration.
> - State the rule(s) that were violated (or satisfied) and stop. Treat it like a commit message for a failing test, not a thought log.
> - Do not re-check, retract, hedge, or contradict yourself inside the field. Whatever value you assign to `pass` must agree with `reason`.
> - Do not echo internal reasoning or chain-of-thought into `reason`. If you reasoned to reach the verdict, summarise the conclusion only.

## Addressing @DouweM's regression concern

> I am skeptical about is if it will cause any regressions for people who are using it with the reasoning.

The guidance explicitly says *"do not echo internal reasoning into `reason`"*, not *"do not reason"*. Reasoning models keep their internal chain-of-thought; they just don't surface it through the structured output field. Concretely:

- `GradingOutput` schema is unchanged.
- `set_default_judge_model` is unchanged.
- Public function signatures are unchanged.
- Examples inside each system prompt are unchanged.
- The block is additive — no existing instruction is removed or contradicted.

Users who *want* the previous verbose-reason behavior can:
- subclass and override the system prompts,
- swap in their own agent via `set_default_judge_model` + a custom prompt,
- or post-process `grading.reason` in their validator.

So I'd call this a behavior tightening (reason becomes shorter and more stable) rather than a behavior change (judge still reasons, score and pass still come from the same model).

## Tests

- New `test_all_judge_agents_carry_reason_guidance` pins the contract: every built-in judge agent's system prompt must include the `_REASON_FIELD_GUIDANCE` block. Drift on any of the four prompts now fails CI.
- The existing 13 tests in `tests/evals/test_llm_as_a_judge.py` continue to pass — the mocked-agent tests don't snapshot system prompts, and the snapshot-asserting tests are over user-prompt sections.

```
$ uv run pytest tests/evals/test_llm_as_a_judge.py
====================== 14 passed in 0.48s ======================
```

`ruff check` and `ruff format --check` are both clean on the two touched files.

## Out of scope

This PR is the minimum that addresses the operational pain from #5034 without breaking the public contract. The deeper question raised in the thread — whether `GradingOutput.reason` should grow stronger structural constraints (`Field(max_length=...)`, a separate `summary` field, or a v2 schema split) — is left for #5335 / v2 prep. Happy to follow up there if maintainers think the schema is the right place to enforce this.