### PR TITLE
fix(openrouter): honor thinking=False across all routed models

### DIFF
--- a/docs/thinking.md
+++ b/docs/thinking.md
@@ -45,7 +45,7 @@ The unified `thinking` setting maps to each provider's native format:
 | Google (Gemini 3+) | `include_thoughts=True` | `thinking_level='HIGH'` | |
 | Google (Gemini 2.5) | `include_thoughts=True` | `thinking_budget=24576` | |
 | Groq | `reasoning_format='parsed'` | `reasoning_format='parsed'` | `thinking=False` → `'hidden'` (no true disable) |
-| OpenRouter | `reasoning.effort='medium'` | `reasoning.effort='high'` | Via `extra_body` |
+| OpenRouter | `reasoning.effort='medium'` | `reasoning.effort='high'` | `thinking=False` → `reasoning.enabled=False`; via `extra_body` |
 | Cerebras | `disable_reasoning=False` | `disable_reasoning=False` | `thinking=False` → `disable_reasoning=True` |
 | xAI | `reasoning_effort='high'` | `reasoning_effort='high'` | Only `'low'` and `'high'` |
 | Bedrock (Claude) | `thinking.type='enabled'` | `budget_tokens=16384` | No adaptive support |
@@ -270,6 +270,9 @@ settings = OpenRouterModelSettings(openrouter_reasoning={'effort': 'high'})
 agent = Agent(model, model_settings=settings)
 ...
 ```
+
+!!! note "Disabling reasoning"
+    Setting [`thinking=False`][pydantic_ai.settings.ModelSettings.thinking] via the unified setting sends `reasoning={'enabled': False}` in the request body, which OpenRouter forwards as the disable signal to the underlying model. This is honored across providers that expose a way to turn reasoning off (e.g. hybrid models like `anthropic/claude-sonnet-4.5` or `moonshotai/kimi-k2.6` whose default is to reason); for models without a disable mechanism, OpenRouter silently no-ops.
 
 ## Mistral
 

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -558,8 +558,12 @@ def _openrouter_settings_to_openai_settings(
     # Fall back to unified thinking when openrouter_reasoning is not set
     if 'openrouter_reasoning' not in model_settings and model_request_parameters.thinking is not None:
         thinking = model_request_parameters.thinking
-        if thinking is not False:
-            unified_reasoning: OpenRouterReasoning = {}
+        unified_reasoning: OpenRouterReasoning = {}
+        if thinking is False:
+            # Explicit disable: OpenRouter routes this to the underlying model's
+            # native disable mechanism where one exists; otherwise it silently no-ops.
+            unified_reasoning['enabled'] = False
+        else:
             # OpenRouter only supports low/medium/high; map others to closest
             effort_map: dict[ThinkingLevel, str] = {
                 True: 'medium',
@@ -570,7 +574,7 @@ def _openrouter_settings_to_openai_settings(
                 'xhigh': 'high',
             }
             unified_reasoning['effort'] = effort_map[thinking]  # type: ignore[typeddict-item]
-            model_settings['openrouter_reasoning'] = unified_reasoning
+        model_settings['openrouter_reasoning'] = unified_reasoning
 
     if reasoning := model_settings.pop('openrouter_reasoning', None):
         extra_body['reasoning'] = reasoning

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -132,13 +132,19 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
             profile = provider_to_profile[provider](model_name)
 
         # As OpenRouterProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
-        # we need to maintain that behavior unless json_schema_transformer is set explicitly
+        # we need to maintain that behavior unless json_schema_transformer is set explicitly.
+        # `supports_thinking=True` is set at the provider level: OpenRouter accepts the
+        # `reasoning` passthrough (effort / enabled / max_tokens / exclude) for every model it
+        # routes to. Underlying-model profiles that report `supports_thinking=False` would
+        # otherwise cause `prepare_request` to silently strip `thinking` before
+        # `_openrouter_settings_to_openai_settings` ever sees it (#5379).
         return OpenAIModelProfile(
             json_schema_transformer=OpenAIJsonSchemaTransformer,
             openai_chat_send_back_thinking_parts='field',
             openai_chat_thinking_field='reasoning',
             openai_chat_supports_file_urls=True,
             openai_chat_supports_web_search=True,
+            supports_thinking=True,
         ).update(profile)
 
     @overload

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -686,12 +686,34 @@ class TestOpenRouterThinkingTranslation:
         extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
         assert extra_body.get('reasoning') == {'effort': 'high'}
 
-    def test_thinking_false_no_reasoning(self):
+    def test_thinking_false_emits_enabled_false(self):
+        """`thinking=False` must be forwarded to OpenRouter as `reasoning.enabled=False`
+        so the routing layer can disable reasoning on hybrid models whose default is on
+        (e.g. moonshotai/kimi-k2.6, claude-sonnet-4.5). See pydantic/pydantic-ai#5379."""
         settings = OpenRouterModelSettings()
         params = ModelRequestParameters(thinking=False)
         result = _openrouter_settings_to_openai_settings(settings, params)
         extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert 'reasoning' not in extra_body
+        assert extra_body.get('reasoning') == {'enabled': False}
+
+    def test_provider_profile_passes_thinking_through_gate(self):
+        """`OpenRouterProvider.model_profile()` must set `supports_thinking=True` so
+        `Model.prepare_request` doesn't strip `thinking` based on the underlying
+        model's profile — OpenRouter accepts the reasoning passthrough universally.
+        Regression for #5379."""
+        from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+        # Models whose intrinsic profiles report `supports_thinking=False`, but for
+        # which the user can still meaningfully request `thinking=False` via OpenRouter.
+        for model_name in (
+            'moonshotai/kimi-k2.6',
+            'qwen/qwen3-235b-a22b',
+            'z-ai/glm-4.6',
+            'openai/gpt-oss-120b',
+        ):
+            profile = OpenRouterProvider.model_profile(model_name)
+            assert profile is not None
+            assert profile.supports_thinking is True, model_name
 
     def test_openai_reasoning_effort_passthrough(self):
         """Explicit openai_reasoning_effort on OpenRouter is passed through."""


### PR DESCRIPTION
<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->

- Closes #5379

## Impact

Multi-turn OpenRouter agents that pass `thinking=False` were having their off-signal silently dropped: the HTTP body sent to OpenRouter contained no `reasoning` field at all, so OpenRouter deferred to the upstream model's default — which for newer hybrid models is *on*. Wire bodies, varying only the unified setting:

| Model | `thinking=True` (before / after) | `thinking=False` (before / after) |
|---|---|---|
| `moonshotai/kimi-k2.6` | _none_ → `effort='medium'` | _none_ → `enabled=False` |
| `qwen/qwen3-235b-a22b` | _none_ → `effort='medium'` | _none_ → `enabled=False` |
| `z-ai/glm-4.6` | _none_ → `effort='medium'` | _none_ → `enabled=False` |
| `openai/gpt-oss-120b` | _none_ → `effort='medium'` | _none_ → `enabled=False` |
| `anthropic/claude-sonnet-4.5` | `effort='medium'` (unchanged) | _none_ → `enabled=False` |
| `x-ai/grok-3-mini` | `effort='medium'` (unchanged) | _none_ → `enabled=False` |

## Cause

Two distinct paths drop the off-signal:

1. **Profile gate** (`models/__init__.py` — `prepare_request`) strips `thinking` from settings when the merged model profile reports `supports_thinking=False`. For hybrid reasoning models routed through OpenRouter (kimi-k2.6, qwen3-235b, glm-4.6, gpt-oss-120b) the gate fires because their intrinsic profiles don't declare reasoning support — even though OpenRouter itself accepts the reasoning passthrough universally.

2. **Transformer guard** (`_openrouter_settings_to_openai_settings`) had `if thinking is not False:` around the emit, so the off-signal produced no wire field at all. (Same `is not False` pattern lives in `models/xai.py` and `models/bedrock.py` — see "Out of scope" below.)

## Fix

1. `OpenRouterProvider.model_profile()` now sets `supports_thinking=True` on the base profile so the gate passes `thinking` through regardless of the routed model's intrinsic profile. `ModelProfile.update()` won't downgrade this because `supports_thinking=False` is the default and `update()` only copies non-default fields from the upstream profile (`profiles/__init__.py:148-154`).
2. The transformer emits `reasoning={'enabled': False}` on the `thinking is False` branch — the canonical OpenRouter disable signal, mirroring the existing Cerebras `disable_reasoning=True` pattern.

Together these restore the user's intent on the wire for all 6 reporter rows.

## Out of scope (intentional)

The reporter noted that the same `if thinking is not False:` pattern appears in `models/xai.py` and `models/bedrock.py`. Those stay as-is because the underlying APIs have no way to express "off":

- **xAI direct**: `reasoning_effort` only accepts `'low'` / `'high'` — there's no `'none'`. Silent-degrade per `models/AGENTS.md` ("document unsupported model settings in docstrings and silently ignore at runtime").
- **Bedrock-OpenAI variant**: Converse rejects `reasoning_effort='none'` (existing source comment at `models/bedrock.py:656`). Silent-degrade.
- **Bedrock-Anthropic variant**: already handles `False` correctly via `thinking={'type': 'disabled'}`.
- **Bedrock-Qwen variant**: not verified by the reporter; left untouched.

If maintainers want me to extend any of those in this PR (e.g. emit something on Bedrock-Qwen disable, or revisit the xAI degrade), happy to follow up.

## Tests

- `tests/test_thinking.py::TestOpenRouterThinkingTranslation::test_thinking_false_emits_enabled_false` — was previously asserting the buggy behavior; flipped to assert `reasoning={'enabled': False}`.
- New `TestOpenRouterThinkingTranslation::test_provider_profile_passes_thinking_through_gate` — pins `supports_thinking=True` on the four profile-gated model names from the reporter table, guarding against regression if someone later removes the provider-level flag.
- `tests/test_thinking.py` (103 tests) + `tests/models/test_openrouter.py` (42 tests) all green; `tests/test_examples.py -k thinking` (15 tests) all green; adjacent providers (`test_xai.py` + `test_openai.py`, 308 tests) unaffected.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).