### PR TITLE
fix(examples): import `BaseModel` from pydantic in `question_graph`

### DIFF
--- a/examples/pydantic_ai_examples/question_graph.py
+++ b/examples/pydantic_ai_examples/question_graph.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import logfire
-from groq import BaseModel
+from pydantic import BaseModel
 
 from pydantic_ai import Agent, ModelMessage, format_as_xml
 from pydantic_graph import (


### PR DESCRIPTION
 Closes #5402

In examples/pydantic_ai_examples/question_graph.py (line 14), BaseModel is imported from the groq package instead of pydantic:
```
from groq import BaseModel

...
ask_agent = Agent('openai:gpt-5.2', output_type=str)
```
This is clearly an mistake - no other symbol from groq is used examples files. All used other example in examples/pydantic_ai_examples/ imports BaseModel from pydantic. And The example itself only uses the OpenAI provider ('openai:gpt-5.2')


 
 
