### PR TITLE
docs: fix GitHub capitalization in Algolia hook comment

### DIFF
--- a/docs/.hooks/algolia.py
+++ b/docs/.hooks/algolia.py
@@ -57,7 +57,7 @@ def on_page_content(html: str, page: Page, config: Config, files: Files) -> str:
     for element in soup.find_all(['autoref']):
         element.decompose()
 
-    # this removes the large source code embeds from Github
+    # this removes the large source code embeds from GitHub
     for element in soup.find_all('details'):
         element.decompose()
 


### PR DESCRIPTION
Small docs-comment cleanup: capitalize `GitHub` in the Algolia docs hook comment.

This only touches an internal comment in `docs/.hooks/algolia.py`; no runtime behavior, docs output, or generated index content changes.

- Closes #<issue>

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
