### PR TITLE
fix: un-deprecate `Agent.instrument` setter and `InstrumentedModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -21,7 +21,6 @@ from typing_extensions import Self, TypeVar, deprecated
 
 from pydantic_ai._instrumentation import DEFAULT_INSTRUMENTATION_VERSION
 from pydantic_ai._spec import load_from_registry
-from pydantic_ai._warnings import PydanticAIDeprecationWarning
 
 from .. import (
     _agent_graph,
@@ -53,7 +52,7 @@ from ..capabilities._ordering import has_capability_type
 from ..capabilities.instrumentation import Instrumentation as InstrumentationCap
 from ..capabilities.prepare_tools import PrepareOutputTools, PrepareTools
 from ..capabilities.process_history import ProcessHistory
-from ..models.instrumented import InstrumentationSettings, InstrumentedModel  # pyright: ignore[reportDeprecated]
+from ..models.instrumented import InstrumentationSettings, InstrumentedModel
 from ..output import OutputDataT, OutputSpec, StructuredDict
 from ..run import AgentRun, AgentRunResult
 from ..settings import ModelSettings, merge_model_settings
@@ -188,9 +187,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
     _output_type: OutputSpec[OutputDataT]
 
     _instrument: InstrumentationSettings | bool | None
-    """Backing store for the deprecated `instrument` attribute. Read internally by
-    `_resolve_instrumentation_settings()`; reads/writes through `agent.instrument` go through
-    the deprecated property below."""
+    """Backing store for the `instrument` attribute. Read internally by
+    `_resolve_instrumentation_settings()`; the public `agent.instrument` property reads/writes
+    this field directly."""
 
     _instrument_default: ClassVar[InstrumentationSettings | bool] = False
     _metadata: AgentMetadata[AgentDepsT] | None = dataclasses.field(repr=False)
@@ -413,17 +412,6 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
         capabilities.extend(_utils.consume_deprecated_builtin_tools_as_capabilities(_deprecated_kwargs, 'Agent'))
 
-        # Bridge the deprecated `instrument=` kwarg into an `Instrumentation` capability so the
-        # rest of the flow goes through the same capability path.
-        legacy_instrument = _utils.consume_deprecated_instrument(_deprecated_kwargs, 'Agent')
-        if legacy_instrument:
-            legacy_settings = (
-                legacy_instrument
-                if isinstance(legacy_instrument, InstrumentationSettings)
-                else InstrumentationSettings()
-            )
-            capabilities.append(InstrumentationCap(settings=legacy_settings))
-
         if prepare_tools is not None:
             capabilities.append(PrepareTools(prepare_tools))
         if prepare_output_tools is not None:
@@ -436,7 +424,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         self.model_settings = model_settings
 
         self._output_type = output_type
-        self._instrument = None
+        self._instrument = _utils.consume_deprecated_instrument(_deprecated_kwargs, 'Agent')
         self._metadata = metadata
         self._deps_type = deps_type
 
@@ -715,22 +703,13 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         if extra_capabilities:
             all_capabilities.extend(extra_capabilities)
 
-        # Bridge the deprecated `instrument=` kwarg and the deprecated `spec.instrument` field
-        # into an `Instrumentation` capability so the rest of the flow goes through the same
-        # capability path. Read the spec field only when set so we don't trigger its
-        # deprecation warning for users who didn't opt in.
+        # Read the deprecated spec field only when set so we don't trigger its warning
+        # for users who didn't opt in. The kwarg takes precedence over the spec field.
         legacy_instrument = (
             instrument
             if instrument is not None
             else (validated_spec.instrument if 'instrument' in validated_spec.model_fields_set else None)
         )
-        if legacy_instrument:
-            legacy_settings = (
-                legacy_instrument
-                if isinstance(legacy_instrument, InstrumentationSettings)
-                else InstrumentationSettings()
-            )
-            all_capabilities.append(InstrumentationCap(settings=legacy_settings))
 
         effective_model = model or validated_spec.model
         if effective_model is None:
@@ -769,6 +748,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             max_concurrency=max_concurrency,
             capabilities=all_capabilities,
         )
+        agent._instrument = legacy_instrument
         return agent
 
     @overload
@@ -886,14 +866,9 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         merged_capabilities: list[AgentCapability[Any]] = list(capabilities or ())
         if extra_capabilities:
             merged_capabilities.extend(extra_capabilities)
-        if instrument:
-            legacy_settings = (
-                instrument if isinstance(instrument, InstrumentationSettings) else InstrumentationSettings()
-            )
-            merged_capabilities.append(InstrumentationCap(settings=legacy_settings))
 
         spec = AgentSpec.from_file(path, fmt=fmt)
-        return cls.from_spec(
+        agent = cls.from_spec(
             spec,
             deps_type=deps_type,
             custom_capability_types=custom_capability_types,
@@ -920,6 +895,10 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             max_concurrency=max_concurrency,
             capabilities=merged_capabilities or None,
         )
+        # `from_file(instrument=...)` overrides any `spec.instrument` from the loaded file.
+        if instrument is not None:
+            agent._instrument = instrument
+        return agent
 
     @staticmethod
     def instrument_all(instrument: InstrumentationSettings | bool = True) -> None:
@@ -928,21 +907,11 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
     @property
     def instrument(self) -> InstrumentationSettings | bool | None:
-        """Deprecated: use `capabilities=[Instrumentation(...)]` instead."""
-        warnings.warn(
-            '`Agent.instrument` is deprecated, use `capabilities=[Instrumentation(...)]` instead.',
-            PydanticAIDeprecationWarning,
-            stacklevel=2,
-        )
+        """Instrumentation settings applied to this agent."""
         return self._instrument
 
     @instrument.setter
     def instrument(self, value: InstrumentationSettings | bool | None) -> None:
-        warnings.warn(
-            '`Agent.instrument` is deprecated, use `capabilities=[Instrumentation(...)]` instead.',
-            PydanticAIDeprecationWarning,
-            stacklevel=2,
-        )
         self._instrument = value
 
     @property
@@ -1307,16 +1276,13 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
         usage_limits = usage_limits or _usage.UsageLimits()
 
-        # TODO(v2): drop this whole detect-and-unwrap-and-reinject block. In v2 we'll only
-        # support `capabilities=[Instrumentation(...)]` as the way to enable instrumentation,
-        # so all the legacy bridges below — `model=InstrumentedModel(...)`,
-        # `Agent.instrument_all(...)` (via `_resolve_instrumentation_settings`) — go away.
         # Resolve instrumentation: an explicit `InstrumentedModel` (passed by the user
-        # to `Agent(model=...)`) wins, then `Agent.instrument_all()` / the legacy
-        # `agent.instrument = ...` setter (read via `_resolve_instrumentation_settings`).
-        # When detected, unwrap so the rest of the run uses the plain model — the
-        # `Instrumentation` capability injected below provides the spans.
-        if isinstance(model_used, InstrumentedModel):  # pyright: ignore[reportDeprecated]
+        # to `Agent(model=...)`, e.g. by `logfire.instrument_pydantic_ai(model)`) wins,
+        # then `Agent.instrument_all()` / `agent.instrument = ...` (read via
+        # `_resolve_instrumentation_settings`). When detected, unwrap so the rest of the
+        # run uses the plain model — the `Instrumentation` capability injected below
+        # provides the spans.
+        if isinstance(model_used, InstrumentedModel):
             instrumentation_settings: InstrumentationSettings | None = model_used.instrumentation_settings
             model_used = model_used.wrapped
         else:
@@ -2476,9 +2442,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         return model_
 
     def _resolve_instrumentation_settings(self) -> InstrumentationSettings | None:
-        """Resolve effective `InstrumentationSettings` for the legacy `Agent.instrument_all` path."""
-        # Reads the private `_instrument` backing field directly so this internal access
-        # doesn't trigger the deprecated property's warning.
+        """Resolve effective `InstrumentationSettings` from `Agent.instrument_all` / `agent.instrument`."""
         instrument = self._instrument if self._instrument is not None else self._instrument_default
         if not instrument:
             return None

--- a/pydantic_ai_slim/pydantic_ai/direct.py
+++ b/pydantic_ai_slim/pydantic_ai/direct.py
@@ -11,7 +11,6 @@ from __future__ import annotations as _annotations
 import dataclasses
 import queue
 import threading
-import warnings
 from collections.abc import Iterator, Sequence
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
@@ -22,7 +21,6 @@ from pydantic_ai.usage import RequestUsage
 from pydantic_graph._utils import get_event_loop as _get_event_loop
 
 from . import agent, messages, models, settings
-from ._warnings import PydanticAIDeprecationWarning
 from .models import StreamedResponse, instrumented as instrumented_models
 
 __all__ = (
@@ -302,12 +300,7 @@ def _prepare_model(
     if instrument is None:
         instrument = agent.Agent._instrument_default  # pyright: ignore[reportPrivateUsage]
 
-    # `instrument_model` is deprecated, but `direct.model_request*` still uses it internally.
-    # Suppress the warning here; a follow-up PR will route this through the `Instrumentation`
-    # capability instead.
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', PydanticAIDeprecationWarning)
-        return instrumented_models.instrument_model(model_instance, instrument)  # pyright: ignore[reportDeprecated]
+    return instrumented_models.instrument_model(model_instance, instrument)
 
 
 @dataclass

--- a/pydantic_ai_slim/pydantic_ai/direct.py
+++ b/pydantic_ai_slim/pydantic_ai/direct.py
@@ -302,9 +302,9 @@ def _prepare_model(
     if instrument is None:
         instrument = agent.Agent._instrument_default  # pyright: ignore[reportPrivateUsage]
 
-    # `instrument_model` (and the `InstrumentedModel` it constructs) are deprecated, but the
-    # `direct.model_request*` API still uses them internally. Suppress the warning here; a
-    # follow-up PR will route this through the `Instrumentation` capability instead.
+    # `instrument_model` is deprecated, but `direct.model_request*` still uses it internally.
+    # Suppress the warning here; a follow-up PR will route this through the `Instrumentation`
+    # capability instead.
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', PydanticAIDeprecationWarning)
         return instrumented_models.instrument_model(model_instance, instrument)  # pyright: ignore[reportDeprecated]

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -18,7 +18,6 @@ from opentelemetry._logs import (
 from opentelemetry.metrics import MeterProvider, get_meter_provider
 from opentelemetry.trace import Span, SpanKind, Tracer, TracerProvider, get_tracer_provider
 from opentelemetry.util.types import AttributeValue
-from typing_extensions import deprecated
 
 from pydantic_ai._instrumentation import (
     DEFAULT_INSTRUMENTATION_VERSION,
@@ -40,7 +39,6 @@ from pydantic_ai._instrumentation import (
 
 from .. import _otel_messages
 from .._run_context import RunContext
-from .._warnings import PydanticAIDeprecationWarning
 from ..messages import (
     ModelMessage,
     ModelRequest,
@@ -54,14 +52,8 @@ from .wrapper import WrapperModel
 __all__ = 'instrument_model', 'InstrumentationSettings', 'InstrumentedModel'
 
 
-@deprecated(
-    '`pydantic_ai.models.instrumented.instrument_model` is deprecated, '
-    'use `capabilities=[Instrumentation(...)]` instead. '
-    'This helper will be removed in v2.',
-    category=PydanticAIDeprecationWarning,
-)
 def instrument_model(model: Model, instrument: InstrumentationSettings | bool) -> Model:
-    """Instrument a model with OpenTelemetry/logfire."""
+    """Wrap `model` in an `InstrumentedModel` so OTel/Logfire spans are emitted around requests."""
     if instrument and not isinstance(model, InstrumentedModel):
         if instrument is True:
             instrument = InstrumentationSettings()

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -62,16 +62,11 @@ __all__ = 'instrument_model', 'InstrumentationSettings', 'InstrumentedModel'
 )
 def instrument_model(model: Model, instrument: InstrumentationSettings | bool) -> Model:
     """Instrument a model with OpenTelemetry/logfire."""
-    if instrument and not isinstance(model, InstrumentedModel):  # pyright: ignore[reportDeprecated]
+    if instrument and not isinstance(model, InstrumentedModel):
         if instrument is True:
             instrument = InstrumentationSettings()
 
-        with warnings.catch_warnings():
-            # Suppress `InstrumentedModel`'s own deprecation warning — the user already saw
-            # the `instrument_model` warning above (or is on the internal `direct.py` path
-            # which suppresses both).
-            warnings.simplefilter('ignore', PydanticAIDeprecationWarning)
-            model = InstrumentedModel(model, instrument)  # pyright: ignore[reportDeprecated]
+        model = InstrumentedModel(model, instrument)
 
     return model
 
@@ -358,19 +353,9 @@ class InstrumentationSettings:
             self.cost_histogram.record(cost, attributes)
 
 
-@deprecated(
-    '`pydantic_ai.models.instrumented.InstrumentedModel` is deprecated, '
-    'use `capabilities=[Instrumentation(...)]` instead. '
-    'The class will be removed in v2.',
-    category=PydanticAIDeprecationWarning,
-)
 @dataclass(init=False)
 class InstrumentedModel(WrapperModel):
     """Model which wraps another model so that requests are instrumented with OpenTelemetry.
-
-    Deprecated: add the [`Instrumentation`][pydantic_ai.capabilities.Instrumentation]
-    capability to your agent's `capabilities=[...]` list instead of wrapping a model in
-    `InstrumentedModel`. The class will be removed in v2.
 
     See the [Debugging and Monitoring guide](https://ai.pydantic.dev/logfire/) for more info.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,10 +253,9 @@ filterwarnings = [
     "ignore:websockets.server.WebSocketServerProtocol is deprecated:DeprecationWarning",
     # AgentEventStream standalone iteration deprecation — existing tests will be migrated to `async with` incrementally
     "ignore:Iterating `AgentEventStream` directly with `async for event in stream.* is deprecated:DeprecationWarning",
-    # `InstrumentedModel` / `instrument_model` direct construction is deprecated; tests for those classes
-    # (`tests/models/test_instrumented.py`) and the backwards-compat path test in `tests/test_logfire.py`
-    # exercise the deprecated entry points on purpose.
-    "ignore:.*(InstrumentedModel|instrument_model).*:pydantic_ai._warnings.PydanticAIDeprecationWarning",
+    # `instrument_model` helper is deprecated; `tests/models/test_instrumented.py` exercises it
+    # on purpose, and `direct.py` uses it internally with the warning suppressed.
+    "ignore:`pydantic_ai\\.models\\.instrumented\\.instrument_model` is deprecated:pydantic_ai._warnings.PydanticAIDeprecationWarning",
     # `Agent(instrument=...)` / `Agent.from_spec(instrument=...)` / `Agent.from_file(instrument=...)`
     # are deprecated in favor of `capabilities=[Instrumentation(...)]`. Many existing tests still
     # exercise the legacy kwarg on purpose; dedicated tests (`test_agent_*_instrument*` in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,9 +253,6 @@ filterwarnings = [
     "ignore:websockets.server.WebSocketServerProtocol is deprecated:DeprecationWarning",
     # AgentEventStream standalone iteration deprecation — existing tests will be migrated to `async with` incrementally
     "ignore:Iterating `AgentEventStream` directly with `async for event in stream.* is deprecated:DeprecationWarning",
-    # `instrument_model` helper is deprecated; `tests/models/test_instrumented.py` exercises it
-    # on purpose, and `direct.py` uses it internally with the warning suppressed.
-    "ignore:`pydantic_ai\\.models\\.instrumented\\.instrument_model` is deprecated:pydantic_ai._warnings.PydanticAIDeprecationWarning",
     # `Agent(instrument=...)` / `Agent.from_spec(instrument=...)` / `Agent.from_file(instrument=...)`
     # are deprecated in favor of `capabilities=[Instrumentation(...)]`. Many existing tests still
     # exercise the legacy kwarg on purpose; dedicated tests (`test_agent_*_instrument*` in

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -30,10 +30,7 @@ from pydantic_ai.messages import InstructionPart, NativeToolCallPart, NativeTool
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.fallback import FallbackModel, ResponseRejected
 from pydantic_ai.models.function import AgentInfo, FunctionModel
-from pydantic_ai.models.instrumented import (
-    InstrumentationSettings,
-    InstrumentedModel,  # pyright: ignore[reportDeprecated]
-)
+from pydantic_ai.models.instrumented import InstrumentationSettings, InstrumentedModel
 from pydantic_ai.output import OutputObjectDefinition
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import RequestUsage
@@ -1679,7 +1676,7 @@ async def test_fallback_model_instrumented_lifecycle():
     model2 = OpenAIChatModel('gpt-4o', provider=provider2)
 
     fallback = FallbackModel(model1, model2)
-    instrumented = InstrumentedModel(fallback, InstrumentationSettings())  # pyright: ignore[reportDeprecated]
+    instrumented = InstrumentedModel(fallback, InstrumentationSettings())
 
     async with instrumented:
         assert provider1._own_http_client is not None  # pyright: ignore[reportPrivateUsage]

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -1,7 +1,3 @@
-# pyright: reportDeprecated=false
-# This file exercises both `InstrumentedModel` (not deprecated) and the deprecated
-# `instrument_model` helper, so we silence `reportDeprecated` at the file level
-# rather than annotating individual usages.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
@@ -43,9 +39,8 @@ from pydantic_ai import (
 )
 from pydantic_ai._instrumentation import event_to_dict
 from pydantic_ai._run_context import RunContext
-from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
-from pydantic_ai.models.instrumented import InstrumentationSettings, InstrumentedModel, instrument_model
+from pydantic_ai.models.instrumented import InstrumentationSettings, InstrumentedModel
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import RequestUsage
 
@@ -2621,12 +2616,3 @@ async def test_instrumented_model_request_error(capfire: CaptureLogfire):
     # finish() was never called, so response-specific attributes are absent
     assert 'gen_ai.response.id' not in spans[0]['attributes']
     assert 'gen_ai.usage.input_tokens' not in spans[0]['attributes']
-
-
-def test_instrument_model_helper_emits_deprecation_warning():
-    """User-facing `instrument_model(...)` helper emits a deprecation warning."""
-    with pytest.warns(
-        PydanticAIDeprecationWarning,
-        match=r'`pydantic_ai\.models\.instrumented\.instrument_model` is deprecated',
-    ):
-        instrument_model(MyModel(), True)

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -1,7 +1,7 @@
 # pyright: reportDeprecated=false
-# This file's whole purpose is to exercise the deprecated `InstrumentedModel` /
-# `instrument_model` direct-construction path, so we silence the deprecation
-# warning at the file level rather than annotating every individual usage.
+# This file exercises both `InstrumentedModel` (not deprecated) and the deprecated
+# `instrument_model` helper, so we silence `reportDeprecated` at the file level
+# rather than annotating individual usages.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
@@ -13,9 +13,6 @@ import pytest
 from opentelemetry._logs import NoOpLoggerProvider
 from opentelemetry.trace import NoOpTracerProvider
 
-# These tests legitimately exercise the (now-deprecated) `InstrumentedModel` /
-# `instrument_model` direct construction path. The corresponding deprecation
-# warning is silenced project-wide via the `filterwarnings` config in `pyproject.toml`.
 from pydantic_ai import (
     AudioUrl,
     BinaryContent,
@@ -2624,14 +2621,6 @@ async def test_instrumented_model_request_error(capfire: CaptureLogfire):
     # finish() was never called, so response-specific attributes are absent
     assert 'gen_ai.response.id' not in spans[0]['attributes']
     assert 'gen_ai.usage.input_tokens' not in spans[0]['attributes']
-
-
-def test_instrumented_model_constructor_emits_deprecation_warning():
-    """User-facing `InstrumentedModel(...)` construction emits a deprecation warning."""
-    with pytest.warns(
-        PydanticAIDeprecationWarning, match=r'`pydantic_ai\.models\.instrumented\.InstrumentedModel` is deprecated'
-    ):
-        InstrumentedModel(MyModel(), InstrumentationSettings())
 
 
 def test_instrument_model_helper_emits_deprecation_warning():

--- a/tests/models/test_model_settings.py
+++ b/tests/models/test_model_settings.py
@@ -9,7 +9,7 @@ from pydantic_ai.direct import model_request as direct_model_request
 from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.function import AgentInfo, FunctionModel
-from pydantic_ai.models.instrumented import InstrumentedModel  # pyright: ignore[reportDeprecated]
+from pydantic_ai.models.instrumented import InstrumentedModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.models.wrapper import WrapperModel
 from pydantic_ai.profiles import ModelProfile
@@ -89,12 +89,12 @@ def test_instrumented_model_settings_delegation():
     base_model = TestModel(settings=base_settings)
 
     # InstrumentedModel should delegate settings to wrapped model
-    instrumented = InstrumentedModel(base_model)  # pyright: ignore[reportDeprecated]
+    instrumented = InstrumentedModel(base_model)
     assert instrumented.settings == base_settings
 
     # Test with wrapped model without settings
     base_model_no_settings = TestModel()
-    instrumented_no_settings = InstrumentedModel(base_model_no_settings)  # pyright: ignore[reportDeprecated]
+    instrumented_no_settings = InstrumentedModel(base_model_no_settings)
     assert instrumented_no_settings.settings is None
 
 
@@ -116,7 +116,7 @@ def test_wrapper_model_profile_delegation_is_dynamic():
 
     inner = _DynamicProfileModel()
     wrapper = WrapperModel(inner)
-    instrumented = InstrumentedModel(inner)  # pyright: ignore[reportDeprecated]
+    instrumented = InstrumentedModel(inner)
 
     assert wrapper.profile is profile_a
     assert instrumented.profile is profile_a

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -42,7 +42,6 @@ from pydantic_ai.capabilities import (
     WebSearch,
     WrapperCapability,
 )
-from pydantic_ai.capabilities._ordering import has_capability_type
 from pydantic_ai.capabilities.abstract import AbstractCapability
 from pydantic_ai.capabilities.combined import CombinedCapability
 from pydantic_ai.capabilities.hooks import Hooks, HookTimeoutError
@@ -468,22 +467,18 @@ def test_agent_from_spec_tool_timeout_override():
     assert agent._tool_timeout == 5.0  # pyright: ignore[reportPrivateUsage]
 
 
-def _has_instrumentation_capability(agent: Agent[Any, Any]) -> bool:
-    return has_capability_type([agent._root_capability], Instrumentation)  # pyright: ignore[reportPrivateUsage]
-
-
 def test_agent_from_spec_instrument():
-    """The deprecated spec `instrument` field bridges to an `Instrumentation` capability."""
+    """The deprecated spec `instrument` field configures `agent.instrument`."""
     with pytest.warns(PydanticAIDeprecationWarning, match=r'`AgentSpec\.instrument` is deprecated'):
         agent = Agent.from_spec({'model': 'test', 'instrument': True})
-    assert _has_instrumentation_capability(agent)
+    assert agent.instrument is True
 
 
 def test_agent_from_spec_instrument_kwarg_deprecated():
     """The `instrument=` kwarg on `from_spec` is deprecated; the agent still gets configured."""
     with pytest.warns(PydanticAIDeprecationWarning, match=r'`Agent\.from_spec\(instrument=\.\.\.\)` is deprecated'):
         agent = Agent.from_spec({'model': 'test'}, instrument=True)  # type: ignore[call-arg]
-    assert _has_instrumentation_capability(agent)  # pyright: ignore[reportUnknownArgumentType]
+    assert agent.instrument is True  # pyright: ignore[reportUnknownMemberType]
 
 
 def test_agent_from_file_instrument_kwarg_deprecated(tmp_path: Path):
@@ -492,25 +487,14 @@ def test_agent_from_file_instrument_kwarg_deprecated(tmp_path: Path):
     spec_path.write_text('model: test\n')
     with pytest.warns(PydanticAIDeprecationWarning, match=r'`Agent\.from_file\(instrument=\.\.\.\)` is deprecated'):
         agent = Agent.from_file(spec_path, instrument=True)  # type: ignore[call-arg]
-    assert _has_instrumentation_capability(agent)  # pyright: ignore[reportUnknownArgumentType]
+    assert agent.instrument is True  # pyright: ignore[reportUnknownMemberType]
 
 
 def test_agent_init_instrument_kwarg_deprecated():
     """The `instrument=` kwarg on `Agent(...)` is deprecated; the agent still gets configured."""
     with pytest.warns(PydanticAIDeprecationWarning, match=r'`Agent\(instrument=\.\.\.\)` is deprecated'):
         agent = Agent(model='test', instrument=True)  # type: ignore[call-arg]
-    assert _has_instrumentation_capability(agent)
-
-
-def test_agent_instrument_reader_deprecated():
-    """Reading/writing `agent.instrument` is deprecated."""
-    agent = Agent(model='test')
-    with pytest.warns(PydanticAIDeprecationWarning, match=r'`Agent\.instrument` is deprecated'):
-        _ = agent.instrument
-    with pytest.warns(PydanticAIDeprecationWarning, match=r'`Agent\.instrument` is deprecated'):
-        agent.instrument = True
-    with pytest.warns(PydanticAIDeprecationWarning, match=r'`Agent\.instrument` is deprecated'):
-        assert agent.instrument is True
+    assert agent.instrument is True
 
 
 def test_agent_from_spec_metadata():

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -28,7 +28,7 @@ from pydantic_ai.messages import (
     ToolCallPart,
 )
 from pydantic_ai.models import ModelRequestParameters
-from pydantic_ai.models.instrumented import InstrumentedModel  # pyright: ignore[reportDeprecated]
+from pydantic_ai.models.instrumented import InstrumentedModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage
@@ -285,11 +285,11 @@ def test_prepare_model():
         assert isinstance(model, TestModel)
 
         model = _prepare_model('test', True)
-        assert isinstance(model, InstrumentedModel)  # pyright: ignore[reportDeprecated]
+        assert isinstance(model, InstrumentedModel)
 
     with set_instrument_default(True):
         model = _prepare_model('test', None)
-        assert isinstance(model, InstrumentedModel)  # pyright: ignore[reportDeprecated]
+        assert isinstance(model, InstrumentedModel)
 
         model = _prepare_model('test', False)
         assert isinstance(model, TestModel)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3892,6 +3892,33 @@ def test_agent_with_user_provided_instrumented_model(
 
 
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+def test_agent_instrument_setter(
+    get_logfire_summary: Callable[[], LogfireSummary],
+) -> None:
+    """`agent.instrument = settings` configures instrumentation post-construction.
+
+    This is the path `logfire.instrument_pydantic_ai(agent)` uses on its `Agent` branch.
+    """
+    agent = Agent(model=TestModel())
+    agent.instrument = InstrumentationSettings()
+
+    result = agent.run_sync('Hello')
+    assert result.output == snapshot('success (no tool calls)')
+
+    summary = get_logfire_summary()
+    assert summary.traces == snapshot(
+        [
+            {
+                'id': 0,
+                'name': 'agent run',
+                'message': 'agent run',
+                'children': [{'id': 1, 'name': 'chat test', 'message': 'chat test'}],
+            }
+        ]
+    )
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
 def test_instrumentation_capability_template_description(
     capfire: CaptureLogfire,
 ) -> None:

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3870,10 +3870,10 @@ def test_agent_with_user_provided_instrumented_model(
     settings drive the agent's instrumentation — the model is unwrapped and the
     `Instrumentation` capability emits the spans.
     """
-    from pydantic_ai.models.instrumented import InstrumentedModel  # pyright: ignore[reportDeprecated]
+    from pydantic_ai.models.instrumented import InstrumentedModel
 
     settings = InstrumentationSettings()
-    agent = Agent(model=InstrumentedModel(TestModel(), settings))  # pyright: ignore[reportDeprecated]
+    agent = Agent(model=InstrumentedModel(TestModel(), settings))
 
     result = agent.run_sync('Hello')
     assert result.output == snapshot('success (no tool calls)')


### PR DESCRIPTION
- Closes #5400

## Summary

The `logfire.instrument_pydantic_ai()` integration writes to `Agent.instrument` and constructs `InstrumentedModel` on its `Agent` and `Model` branches, so every user of the official Logfire integration was seeing visible `PydanticAIDeprecationWarning`s after #4967. Pydantic AI has no public alternatives for either branch yet (option (b) in #5400), so un-deprecate both for now and revisit in v2.

Also collapses the construction-time `instrument=` → `InstrumentationCap` bridge in `Agent.__init__`, `from_spec`, and `from_file` into a single run-time path through `_resolve_instrumentation_settings()`. All four legacy entry points (`Agent(instrument=...)`, `from_spec(instrument=...)`, `from_file(instrument=...)`, `agent.instrument = ...`, plus `Agent.instrument_all(...)`) now write to `_instrument` and converge in one place — net -82 lines.

## Deprecation state after this PR

| Surface | Status |
|---|---|
| `Agent.instrument` setter/getter | ✅ un-deprecated (used by logfire) |
| `InstrumentedModel` class | ✅ un-deprecated (used by logfire) |
| `Agent(instrument=...)` constructor kwarg | ❌ stays deprecated |
| `Agent.from_spec(instrument=...)` / `from_file(instrument=...)` | ❌ stay deprecated |
| `AgentSpec.instrument` field | ❌ stays deprecated |
| `instrument_model` helper | ❌ stays deprecated |
| `Agent.instrument_all(...)` | ✅ never deprecated |

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).