### PR TITLE
Improve `ty` compatibility in `pydantic_ai_slim`

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -94,7 +94,9 @@ jobs:
       skip: ${{ steps.check-label.outputs.has_label }}
     steps:
       - name: Check for modified config files
-        if: github.event.pull_request.head.repo.fork
+        if: >-
+          github.event.pull_request.head.repo.fork &&
+          !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
         run: |
           CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
           if echo "$CHANGED" | grep -qiE '(^|/)AGENTS\.md$|(^|/)CLAUDE\.md$|(^|/)\.claude/'; then
@@ -226,7 +228,9 @@ jobs:
           persist-credentials: false
 
       - name: Check for modified config files
-        if: github.event.pull_request.head.repo.fork
+        if: >-
+          github.event.pull_request.head.repo.fork &&
+          !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
         run: |
           CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
           if echo "$CHANGED" | grep -qiE '(^|/)AGENTS\.md$|(^|/)CLAUDE\.md$|(^|/)\.claude/'; then

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Check for modified config files
         if: >-
           github.event.pull_request.head.repo.fork &&
-          !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+          !contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)
         run: |
           CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
           if echo "$CHANGED" | grep -qiE '(^|/)AGENTS\.md$|(^|/)CLAUDE\.md$|(^|/)\.claude/'; then
@@ -230,7 +230,7 @@ jobs:
       - name: Check for modified config files
         if: >-
           github.event.pull_request.head.repo.fork &&
-          !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+          !contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)
         run: |
           CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
           if echo "$CHANGED" | grep -qiE '(^|/)AGENTS\.md$|(^|/)CLAUDE\.md$|(^|/)\.claude/'; then

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -60,5 +60,5 @@ jobs:
         env:
           TY_BIN: ${{ github.workspace }}/.ty/ruff/target/release/ty
           TY_OUTPUT_FORMAT: github
-          TY_PATHS: pydantic_ai_slim/pydantic_ai
+          TY_PATHS: pydantic_ai_slim
         run: uvx pre-commit run typecheck-ty --hook-stage manual --all-files --verbose

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -11,7 +11,7 @@ env:
   UV_PYTHON: 3.13
   UV_FROZEN: "1"
   TY_FORK_REPOSITORY: dsfaccini/ruff
-  TY_FORK_SHA: afe245870007732a82e61e9b4aed51c76451a0de
+  TY_FORK_SHA: fd0315a391e25961c9211a9fbd6e5491c3e17e3d
 
 permissions:
   contents: read

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -11,7 +11,7 @@ env:
   UV_PYTHON: 3.13
   UV_FROZEN: "1"
   TY_FORK_REPOSITORY: dsfaccini/ruff
-  TY_FORK_REF: codex/ty-pydantic-compat
+  TY_FORK_SHA: afe245870007732a82e61e9b4aed51c76451a0de
 
 permissions:
   contents: read
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ env.TY_FORK_REPOSITORY }}
-          ref: ${{ env.TY_FORK_REF }}
+          ref: ${{ env.TY_FORK_SHA }}
           path: .ty/ruff
           persist-credentials: false
 
@@ -47,10 +47,9 @@ jobs:
           path: |
             ~/.cargo/git
             ~/.cargo/registry
-            .ty/ruff/target
-          key: ty-${{ runner.os }}-${{ env.TY_FORK_REF }}-${{ hashFiles('.github/workflows/ty.yml') }}
+          key: ty-${{ runner.os }}-${{ env.TY_FORK_SHA }}-${{ hashFiles('.github/workflows/ty.yml') }}
           restore-keys: |
-            ty-${{ runner.os }}-${{ env.TY_FORK_REF }}-
+            ty-${{ runner.os }}-${{ env.TY_FORK_SHA }}-
 
       - name: Build Ty fork
         working-directory: .ty/ruff
@@ -61,4 +60,4 @@ jobs:
           TY_BIN: ${{ github.workspace }}/.ty/ruff/target/release/ty
           TY_OUTPUT_FORMAT: github
           TY_PATHS: pydantic_ai_slim
-        run: uvx pre-commit run typecheck-ty --hook-stage manual --all-files --verbose
+        run: uvx --from pre-commit==4.6.0 pre-commit run typecheck-ty --hook-stage manual --all-files --verbose

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -1,0 +1,64 @@
+name: Ty
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+env:
+  COLUMNS: 150
+  UV_PYTHON: 3.13
+  UV_FROZEN: "1"
+  TY_FORK_REPOSITORY: dsfaccini/ruff
+  TY_FORK_REF: codex/ty-pydantic-compat
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: ty (experimental)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          cache-suffix: ty
+
+      - name: Install dependencies
+        run: uv sync --all-extras --no-extra outlines-vllm-offline --all-packages --group lint
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ env.TY_FORK_REPOSITORY }}
+          ref: ${{ env.TY_FORK_REF }}
+          path: .ty/ruff
+          persist-credentials: false
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            .ty/ruff/target
+          key: ty-${{ runner.os }}-${{ env.TY_FORK_REF }}-${{ hashFiles('.github/workflows/ty.yml') }}
+          restore-keys: |
+            ty-${{ runner.os }}-${{ env.TY_FORK_REF }}-
+
+      - name: Build Ty fork
+        working-directory: .ty/ruff
+        run: cargo build --release --package ty --bin ty
+
+      - name: Run Ty
+        env:
+          TY_BIN: ${{ github.workspace }}/.ty/ruff/target/release/ty
+          TY_OUTPUT_FORMAT: github
+          TY_PATHS: pydantic_ai_slim/pydantic_ai
+        run: uvx pre-commit run typecheck-ty --hook-stage manual --all-files --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,13 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      - id: typecheck-ty
+        name: Typecheck with Ty
+        entry: bash
+        args: [scripts/typecheck_ty.sh]
+        language: system
+        pass_filenames: false
+        stages: [manual]
       - id: check-cassettes
         name: Check cassettes
         entry: uv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ The project uses:
 - `pre-commit`, can be installed with `uv tool install pre-commit`
 - `ruff` via `make lint` and `make format`
 - `pyright` via `make typecheck`
+- Ty compatibility is advisory, checked for `pydantic_ai_slim/pydantic_ai` by `.github/workflows/ty.yml` and the manual pre-commit hook `typecheck-ty` against `dsfaccini/ruff@codex/ty-pydantic-compat`. Pyright remains the required type checker. If Ty fails, fix real typing issues with the smallest Pyright-compatible refactor; if Ty is wrong, open an issue against the Ty fork with a minimal `uv` inline-dependencies repro, then add a narrow `# ty: ignore[...]` with the issue link.
 - `pytest` in `tests/`, via `make test`, with:
     - `inline-snapshot` for inline assertions
     - `pytest-recording` and `vcrpy` for recording and playing back requests to model APIs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,6 @@ The project uses:
 - `pre-commit`, can be installed with `uv tool install pre-commit`
 - `ruff` via `make lint` and `make format`
 - `pyright` via `make typecheck`
-- Ty compatibility is advisory, checked for `pydantic_ai_slim` by `.github/workflows/ty.yml` and the manual pre-commit hook `typecheck-ty` against `dsfaccini/ruff@codex/ty-pydantic-compat`. Pyright remains the required type checker. If Ty fails, fix real typing issues with the smallest Pyright-compatible refactor; if Ty is wrong, open an issue against the Ty fork with a minimal `uv` inline-dependencies repro, then add a narrow `# ty: ignore[...]` with the issue link.
 - `pytest` in `tests/`, via `make test`, with:
     - `inline-snapshot` for inline assertions
     - `pytest-recording` and `vcrpy` for recording and playing back requests to model APIs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ The project uses:
 - `pre-commit`, can be installed with `uv tool install pre-commit`
 - `ruff` via `make lint` and `make format`
 - `pyright` via `make typecheck`
-- Ty compatibility is advisory, checked for `pydantic_ai_slim/pydantic_ai` by `.github/workflows/ty.yml` and the manual pre-commit hook `typecheck-ty` against `dsfaccini/ruff@codex/ty-pydantic-compat`. Pyright remains the required type checker. If Ty fails, fix real typing issues with the smallest Pyright-compatible refactor; if Ty is wrong, open an issue against the Ty fork with a minimal `uv` inline-dependencies repro, then add a narrow `# ty: ignore[...]` with the issue link.
+- Ty compatibility is advisory, checked for `pydantic_ai_slim` by `.github/workflows/ty.yml` and the manual pre-commit hook `typecheck-ty` against `dsfaccini/ruff@codex/ty-pydantic-compat`. Pyright remains the required type checker. If Ty fails, fix real typing issues with the smallest Pyright-compatible refactor; if Ty is wrong, open an issue against the Ty fork with a minimal `uv` inline-dependencies repro, then add a narrow `# ty: ignore[...]` with the issue link.
 - `pytest` in `tests/`, via `make test`, with:
     - `inline-snapshot` for inline assertions
     - `pytest-recording` and `vcrpy` for recording and playing back requests to model APIs

--- a/pydantic_ai_slim/pydantic_ai/_a2a.py
+++ b/pydantic_ai_slim/pydantic_ai/_a2a.py
@@ -140,7 +140,7 @@ class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]
         message_history.extend(self.build_message_history(task.get('history', [])))
 
         try:
-            result = await self.agent.run(message_history=message_history)  # type: ignore
+            result = await self.agent.run(message_history=message_history)  # pyright: ignore[reportArgumentType]
 
             await self.storage.update_context(task['context_id'], result.all_messages())
 

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1865,7 +1865,8 @@ async def _call_tools(  # noqa: C901
             if event := await handle_call_or_result(
                 _call_tool(
                     tool_manager,
-                    validated_calls.get(call.tool_call_id, call),
+                    call,
+                    validated_calls.get(call.tool_call_id),
                     tool_call_results.get(call.tool_call_id),
                 ),
                 index,
@@ -1877,7 +1878,8 @@ async def _call_tools(  # noqa: C901
             asyncio.create_task(
                 _call_tool(
                     tool_manager,
-                    validated_calls.get(call.tool_call_id, call),
+                    call,
+                    validated_calls.get(call.tool_call_id),
                     tool_call_results.get(call.tool_call_id),
                 ),
                 name=call.tool_name,
@@ -1943,16 +1945,10 @@ def _populate_deferred_calls(
 
 async def _call_tool(
     tool_manager: ToolManager[DepsT],
-    tool_call: ValidatedToolCall[DepsT] | _messages.ToolCallPart,
+    call: _messages.ToolCallPart,
+    validated: ValidatedToolCall[DepsT] | None,
     tool_call_result: DeferredToolResult | None,
 ) -> tuple[_messages.ToolReturnPart | _messages.RetryPromptPart, str | Sequence[_messages.UserContent] | None]:
-    if isinstance(tool_call, ValidatedToolCall):
-        validated = tool_call
-        call = tool_call.call
-    else:
-        validated = None
-        call = tool_call
-
     tool_result: Any
     try:
         if tool_call_result is None or isinstance(tool_call_result, ToolApproved):

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -296,7 +296,9 @@ def _run_chat_command(
             console.print(f'Error initializing [magenta]{args.model}[/magenta]:\n[red]{e}[/red]')
             return 1
 
-    model_name = agent.model if isinstance(agent.model, str) else agent.model.model_id
+    model = agent.model
+    assert model is not None
+    model_name = model if isinstance(model, str) else model.model_id
     if args.agent and model_arg_set:
         console.print(
             f'{name_version} using custom agent [magenta]{args.agent}[/magenta] with [magenta]{model_name}[/magenta]',

--- a/pydantic_ai_slim/pydantic_ai/_function_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_function_schema.py
@@ -26,6 +26,8 @@ from ._griffe import doc_descriptions
 from ._run_context import RunContext
 from ._utils import (
     check_object_json_schema,
+    get_callable_name,
+    get_callable_qualname,
     is_async_callable,
     is_model_like,
     run_in_executor,
@@ -122,7 +124,9 @@ def function_schema(  # noqa: C901
     Returns:
         A `FunctionSchema` instance.
     """
-    config = ConfigDict(title=function.__name__, use_attribute_docstrings=True)
+    function_name = get_callable_name(function, 'function')
+    function_qualname = get_callable_qualname(function, function_name)
+    config = ConfigDict(title=function_name, use_attribute_docstrings=True)
     config_wrapper = ConfigWrapper(config)
     gen_schema = _generate_schema.GenerateSchema(config_wrapper)
     errors: list[str] = []
@@ -133,7 +137,9 @@ def function_schema(  # noqa: C901
         errors.append(str(e))
         sig = signature(lambda: None)
     original_func = function.func if isinstance(function, partial) else function
-    function = cast(Callable[..., Any], function)  # cope with pyright changing the type from the isinstance() check.
+    function = cast(
+        Callable[..., Any], function
+    )  # pyright needs this after the partial narrowing.  # ty: ignore[redundant-cast]
 
     type_hints = get_type_hints(original_func, include_extras=True)
 
@@ -212,7 +218,7 @@ def function_schema(  # noqa: C901
         from .exceptions import UserError
 
         error_details = '\n  '.join(errors)
-        raise UserError(f'Error generating schema for {function.__qualname__}:\n  {error_details}')
+        raise UserError(f'Error generating schema for {function_qualname}:\n  {error_details}')
 
     core_config = config_wrapper.core_config(None)
 
@@ -223,7 +229,7 @@ def function_schema(  # noqa: C901
         schema,
         function,
         function.__module__,
-        function.__qualname__,
+        function_qualname,
         'validate_call',
         core_config,
         config_wrapper.plugin_settings,
@@ -240,7 +246,7 @@ def function_schema(  # noqa: C901
         # and set it on the tool
         description = json_schema.pop('description', None)
 
-    name = tool_name or function.__name__
+    name = tool_name or function_name
     checked_json_schema = check_object_json_schema(json_schema)
 
     # Compute return schema eagerly (before Temporal sandbox where TypeAdapter is too slow)
@@ -251,8 +257,9 @@ def function_schema(  # noqa: C901
             schema_generator=schema_generator, mode='serialization'
         )
     except (PydanticSchemaGenerationError, PydanticUserError):
+        original_func_qualname = get_callable_qualname(original_func, function_qualname)
         warnings.warn(
-            f'Could not generate return schema for {original_func.__qualname__!r}: '
+            f'Could not generate return schema for {original_func_qualname!r}: '
             f'unsupported return type {return_annotation!r}. Falling back to unconstrained schema.',
             UserWarning,
             stacklevel=2,
@@ -313,7 +320,7 @@ def _build_schema(
     if len(fields) == 1 and var_kwargs_schema is None:
         name = next(iter(fields))
         td_field = fields[name]
-        if td_field['metadata']['is_model_like']:  # type: ignore
+        if td_field['metadata']['is_model_like']:  # pyright: ignore[reportTypedDictNotRequiredAccess]
             # The JSON schema sent to the model is the model-like parameter's schema directly (unwrapped),
             # so the model generates its fields at the top level rather than inside a redundant wrapper.
             # The validator output is wrapped to `{name: value}` so validated args are always a dict

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -112,12 +112,19 @@ def model_request_parameters_attributes(
 
 def event_to_dict(event: LogRecord) -> dict[str, Any]:
     if not event.body:
-        body = {}  # pragma: no cover
+        body: Mapping[str, Any] = {}  # pragma: no cover
     elif isinstance(event.body, Mapping):
         body = event.body
     else:
         body = {'body': event.body}
-    return {**body, **(event.attributes or {})}
+    attributes: Mapping[str, Any] = event.attributes or {}
+    result: dict[str, Any] = {}
+    for key, value in body.items():
+        if isinstance(key, str):
+            result[key] = value
+    for key, value in attributes.items():
+        result[key] = value
+    return result
 
 
 def annotate_tool_call_otel_metadata(response: ModelResponse, parameters: ModelRequestParameters) -> None:

--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -12,13 +12,12 @@ from pydantic import Json, TypeAdapter, ValidationError
 from pydantic_core import SchemaValidator
 from typing_extensions import Self, TypedDict, TypeVar
 
-from pydantic_ai._utils import get_function_type_hints
+from pydantic_ai._utils import get_callable_name, get_function_type_hints
 
 from . import _function_schema, _utils, messages as _messages
 from ._run_context import AgentDepsT, RunContext
 from .exceptions import ModelRetry, ToolRetryError, UserError
 from .output import (
-    DeferredToolRequests,
     NativeOutput,
     OutputContext,
     OutputDataT,
@@ -32,7 +31,7 @@ from .output import (
     ToolOutput,
     _OutputSpecItem,  # type: ignore[reportPrivateUsage]
 )
-from .tools import GenerateToolJsonSchema, ObjectJsonSchema, ToolDefinition
+from .tools import DeferredToolRequests, GenerateToolJsonSchema, ObjectJsonSchema, ToolDefinition
 from .toolsets.abstract import AbstractToolset, ToolsetTool
 
 if TYPE_CHECKING:
@@ -426,16 +425,17 @@ class OutputValidator(Generic[AgentDepsT, OutputDataT_inv]):
         (`run_output_process_hooks`, `stream_text`, etc.) decides whether to wrap in
         `ToolRetryError` for retry handling or re-raise.
         """
-        if self._takes_ctx:
-            args = run_context, result
-        else:
-            args = (result,)
-
         if self._is_async:
-            function = cast(Callable[[Any], Awaitable[T]], self.function)
-            return await function(*args)
-        function = cast(Callable[[Any], T], self.function)
-        return await _utils.run_in_executor(function, *args)
+            if self._takes_ctx:
+                function_with_ctx = cast(Callable[[RunContext[AgentDepsT], T], Awaitable[T]], self.function)
+                return await function_with_ctx(run_context, result)
+            function_no_ctx = cast(Callable[[T], Awaitable[T]], self.function)
+            return await function_no_ctx(result)
+        if self._takes_ctx:
+            sync_function_with_ctx = cast(Callable[[RunContext[AgentDepsT], T], T], self.function)
+            return await _utils.run_in_executor(sync_function_with_ctx, run_context, result)
+        sync_function_no_ctx = cast(Callable[[T], T], self.function)
+        return await _utils.run_in_executor(sync_function_no_ctx, result)
 
 
 @dataclass(kw_only=True)
@@ -1094,7 +1094,7 @@ class UnionOutputProcessor(BaseObjectOutputProcessor[OutputDataT]):
             processor = ObjectOutputProcessor(output=output, strict=strict)
             object_def = processor.object_def
 
-            object_key = object_def.name or output.__name__
+            object_key = object_def.name or get_callable_name(output, 'output')
             i = 1
             original_key = object_key
             while object_key in self._processors:

--- a/pydantic_ai_slim/pydantic_ai/_spec.py
+++ b/pydantic_ai_slim/pydantic_ai/_spec.py
@@ -141,7 +141,7 @@ class _SerializedNamedSpec(RootModel[str | dict[str, Any]]):
                 return cast(dict[str, Any], value)
 
         # Anything else is passed as a single positional argument
-        return (cast(Any, value),)
+        return (cast(Any, value),)  # ty: ignore[redundant-cast]
 
     def to_named_spec(self, cls: type[NamedSpec] = NamedSpec) -> NamedSpec:
         return cls(name=self._name, arguments=self._args)
@@ -336,7 +336,7 @@ def build_schema_types(
 
         # Shortest form: just the name
         if len(type_hints) == 0 or not required_type_hints:
-            schema_types.append(Literal[name])
+            schema_types.append(Literal[name])  # ty: ignore[invalid-type-form]
 
         # Short form: can be called with only one parameter
         if len(type_hints) == 1:

--- a/pydantic_ai_slim/pydantic_ai/_system_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/_system_prompt.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 import inspect
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Generic, cast
+from typing import Generic, cast
 
 from . import _utils
 from ._run_context import AgentDepsT, RunContext
@@ -23,17 +23,20 @@ class SystemPromptRunner(Generic[AgentDepsT]):
         self._is_async = _utils.is_async_callable(self.function)
 
     async def run(self, run_context: RunContext[AgentDepsT]) -> str | None:
-        if self._takes_ctx:
-            args = (run_context,)
-        else:
-            args = ()
-
         if self._is_async:
-            function = cast(Callable[[Any], Awaitable[str | None]], self.function)
-            return await function(*args)
+            if self._takes_ctx:
+                function_with_ctx = cast(Callable[[RunContext[AgentDepsT]], Awaitable[str | None]], self.function)
+                return await function_with_ctx(run_context)
+            else:
+                function_no_ctx = cast(Callable[[], Awaitable[str | None]], self.function)
+                return await function_no_ctx()
         else:
-            function = cast(Callable[[Any], str | None], self.function)
-            return await _utils.run_in_executor(function, *args)
+            if self._takes_ctx:
+                sync_function_with_ctx = cast(Callable[[RunContext[AgentDepsT]], str | None], self.function)
+                return await _utils.run_in_executor(sync_function_with_ctx, run_context)
+            else:
+                sync_function_no_ctx = cast(Callable[[], str | None], self.function)
+                return await _utils.run_in_executor(sync_function_no_ctx)
 
 
 async def resolve_system_prompts(
@@ -51,7 +54,7 @@ async def resolve_system_prompts(
     for runner in runners:
         prompt = await runner.run(run_context)
         if runner.dynamic:
-            parts.append(SystemPromptPart(prompt or '', dynamic_ref=runner.function.__qualname__))
+            parts.append(SystemPromptPart(prompt or '', dynamic_ref=_utils.get_callable_qualname(runner.function)))
         elif prompt:
             parts.append(SystemPromptPart(prompt))
     return parts

--- a/pydantic_ai_slim/pydantic_ai/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_search.py
@@ -94,6 +94,22 @@ class ToolSearchArgs(TypedDict):
     """
 
 
+def _typed_tool_search_args(args: str | ToolSearchArgs | None) -> ToolSearchArgs | None:
+    if args is None:
+        return None
+    if isinstance(args, dict):
+        return args
+    if not isinstance(args, str):
+        return None
+    try:
+        parsed = pydantic_core.from_json(args)
+    except ValueError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return cast('ToolSearchArgs', parsed)
+
+
 class ToolSearchReturnContent(TypedDict):
     """Typed return value of the framework-managed tool-search builtin.
 
@@ -162,17 +178,7 @@ class NativeToolSearchCallPart(NativeToolCallPart):
         in-progress JSON string the model hasn't finished emitting. For raw
         string-tolerant access, use the inherited `args_as_dict()`.
         """
-        if self.args is None:
-            return None
-        if isinstance(self.args, dict):
-            return self.args
-        try:
-            parsed = pydantic_core.from_json(self.args)
-        except ValueError:
-            return None
-        if not isinstance(parsed, dict):
-            return None
-        return cast('ToolSearchArgs', parsed)
+        return _typed_tool_search_args(self.args)
 
     @property
     def queries(self) -> list[str]:
@@ -284,17 +290,7 @@ class ToolSearchCallPart(ToolCallPart):
         in-progress JSON string the model hasn't finished emitting. For raw
         string-tolerant access, use the inherited `args_as_dict()`.
         """
-        if self.args is None:
-            return None
-        if isinstance(self.args, dict):
-            return self.args
-        try:
-            parsed = pydantic_core.from_json(self.args)
-        except ValueError:
-            return None
-        if not isinstance(parsed, dict):
-            return None
-        return cast('ToolSearchArgs', parsed)
+        return _typed_tool_search_args(self.args)
 
     @property
     def queries(self) -> list[str]:

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -121,6 +121,31 @@ async def run_in_executor(func: Callable[_P, _R], *args: _P.args, **kwargs: _P.k
     return await run_sync(wrapped_func)
 
 
+def get_callable_name(function: object, default: str) -> str:
+    value = getattr(function, '__name__', None)
+    if isinstance(value, str):
+        return value
+
+    if isinstance(function, functools.partial):
+        return get_callable_name(function.func, default)
+
+    return default
+
+
+def get_callable_qualname(function: object, default: str | None = None) -> str:
+    value = getattr(function, '__qualname__', None)
+    if isinstance(value, str):
+        return value
+
+    if isinstance(function, functools.partial):
+        return get_callable_qualname(function.func, default)
+
+    if default is not None:
+        return default
+
+    return type(function).__qualname__
+
+
 def is_async_generator_already_running(exc: RuntimeError) -> bool:
     return 'asynchronous generator is already running' in str(exc)
 
@@ -790,7 +815,7 @@ def install_deprecated_kwarg_alias(
             kwargs[new] = kwargs.pop(old)
         orig_init(self, *args, **kwargs)
 
-    cls.__init__ = wrapper
+    cls.__init__ = wrapper  # ty: ignore[invalid-assignment]
 
 
 _T = TypeVar('_T')

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -512,7 +512,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             for toolset in agent_toolsets
             if not isinstance(toolset, AbstractToolset)
         ]
-        self._user_toolsets = [toolset for toolset in agent_toolsets if isinstance(toolset, AbstractToolset)]
+        self._user_toolsets = [toolset for toolset in agent_toolsets if isinstance(toolset, AbstractToolset)]  # ty: ignore[invalid-assignment]
 
         # Capability-contributed toolsets (stored separately for per-run re-extraction)
         cap_toolset = self._root_capability.get_toolset()
@@ -740,7 +740,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
         agent = Agent(
             model=effective_model,
-            output_type=effective_output_type,
+            output_type=effective_output_type,  # ty: ignore[invalid-argument-type]
             instructions=merged_instructions or None,
             system_prompt=system_prompt,
             deps_type=deps_type,
@@ -2062,7 +2062,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 runner = _system_prompt.SystemPromptRunner[AgentDepsT](func_, dynamic=dynamic)
                 self._system_prompt_functions.append(runner)
                 if dynamic:  # pragma: lax no cover
-                    self._system_prompt_dynamic_functions[func_.__qualname__] = runner
+                    self._system_prompt_dynamic_functions[_utils.get_callable_qualname(func_)] = runner
                 return func_
 
             return decorator

--- a/pydantic_ai_slim/pydantic_ai/capabilities/_dynamic.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/_dynamic.py
@@ -5,6 +5,8 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from typing import TypeAlias
 
+from typing_extensions import TypeIs
+
 from pydantic_ai._run_context import AgentDepsT, RunContext
 
 from .abstract import AbstractCapability
@@ -43,12 +45,22 @@ class DynamicCapability(AbstractCapability[AgentDepsT]):
         return await capability.for_run(ctx)
 
 
+def _is_capability(
+    capability: AbstractCapability[AgentDepsT] | CapabilityFunc[AgentDepsT],
+) -> TypeIs[AbstractCapability[AgentDepsT]]:
+    return isinstance(capability, AbstractCapability)
+
+
 def wrap_capability_funcs(
     capabilities: Sequence[AbstractCapability[AgentDepsT] | CapabilityFunc[AgentDepsT]] | None,
 ) -> list[AbstractCapability[AgentDepsT]]:
     """Wrap any [`CapabilityFunc`][pydantic_ai.capabilities.CapabilityFunc] entries in a `DynamicCapability`."""
     if not capabilities:
         return []
-    return [
-        cap if isinstance(cap, AbstractCapability) else DynamicCapability(capability_func=cap) for cap in capabilities
-    ]
+    wrapped: list[AbstractCapability[AgentDepsT]] = []
+    for cap in capabilities:
+        if _is_capability(cap):
+            wrapped.append(cap)
+        else:
+            wrapped.append(DynamicCapability(capability_func=cap))
+    return wrapped

--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -186,7 +186,7 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
                 )
                 return self.get_native_tools()
 
-            cls.get_builtin_tools = _get_builtin_tools_delegating
+            cls.get_builtin_tools = _get_builtin_tools_delegating  # ty: ignore[invalid-assignment]
 
     def apply(self, visitor: Callable[[AbstractCapability[AgentDepsT]], None]) -> None:
         """Run a visitor function on all leaf capabilities in this tree.

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -200,8 +200,9 @@ class Instrumentation(AbstractCapability[Any]):
         settings = self.settings
         new_message_index = self._new_message_index
 
+        attrs: dict[str, str | int | float | bool]
         if settings.version == 1:
-            attrs: dict[str, Any] = {
+            attrs = {
                 'all_messages_events': to_json(
                     [event_to_dict(e) for e in settings.messages_to_otel_events(message_history)]
                 ).decode()

--- a/pydantic_ai_slim/pydantic_ai/common_tools/tavily.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/tavily.py
@@ -1,5 +1,5 @@
 from dataclasses import KW_ONLY, dataclass
-from functools import partial
+from functools import partial, update_wrapper as copy_callable_metadata
 from inspect import signature
 from typing import Literal, overload
 
@@ -165,8 +165,7 @@ def tavily_search_tool(
     if kwargs:
         original = func
         func = partial(func, **kwargs)
-        func.__name__ = original.__name__  # type: ignore[union-attr]
-        func.__qualname__ = original.__qualname__
+        copy_callable_metadata(func, original)
         # partial with keyword args only updates defaults, not removes params.
         # Set __signature__ explicitly to exclude bound params from the tool schema.
         orig_sig = signature(original)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -87,8 +87,8 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
             )
 
         # Merge the config with the default DBOS config
-        self._mcp_step_config = mcp_step_config or {}
-        self._model_step_config = model_step_config or {}
+        self._mcp_step_config: StepConfig = mcp_step_config or {}
+        self._model_step_config: StepConfig = model_step_config or {}
 
         if not isinstance(wrapped.model, Model):
             raise UserError(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
@@ -39,7 +39,7 @@ from ._toolset import prefectify_toolset
 if TYPE_CHECKING:
     from pydantic_ai.agent.spec import AgentSpec
 
-from ._types import TaskConfig, default_task_config
+from ._types import TaskConfig, default_task_config, merge_task_configs
 
 
 class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
@@ -86,11 +86,13 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             )
 
         # Merge the config with the default Prefect config
-        self._mcp_task_config = default_task_config | (mcp_task_config or {})
-        self._model_task_config = default_task_config | (model_task_config or {})
-        self._tool_task_config = default_task_config | (tool_task_config or {})
+        self._mcp_task_config = merge_task_configs(default_task_config, mcp_task_config)
+        self._model_task_config = merge_task_configs(default_task_config, model_task_config)
+        self._tool_task_config = merge_task_configs(default_task_config, tool_task_config)
         self._tool_task_config_by_name = tool_task_config_by_name or {}
-        self._event_stream_handler_task_config = default_task_config | (event_stream_handler_task_config or {})
+        self._event_stream_handler_task_config = merge_task_configs(
+            default_task_config, event_stream_handler_task_config
+        )
 
         if not isinstance(wrapped.model, Model):
             raise UserError(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -8,7 +8,7 @@ from pydantic_ai import FunctionToolset, ToolsetTool
 from pydantic_ai.tools import AgentDepsT, RunContext
 
 from ._toolset import PrefectWrapperToolset
-from ._types import TaskConfig, default_task_config
+from ._types import TaskConfig, default_task_config, merge_task_configs
 
 
 class PrefectFunctionToolset(PrefectWrapperToolset[AgentDepsT]):
@@ -22,7 +22,7 @@ class PrefectFunctionToolset(PrefectWrapperToolset[AgentDepsT]):
         tool_task_config: dict[str, TaskConfig | None],
     ):
         super().__init__(wrapped)
-        self._task_config = default_task_config | (task_config or {})
+        self._task_config = merge_task_configs(default_task_config, task_config)
         self._tool_task_config = tool_task_config or {}
 
         @task
@@ -45,13 +45,16 @@ class PrefectFunctionToolset(PrefectWrapperToolset[AgentDepsT]):
     ) -> Any:
         """Call a tool, wrapped as a Prefect task with a descriptive name."""
         # Check if this specific tool has custom config or is disabled
-        tool_specific_config = self._tool_task_config.get(name, default_task_config)
-        if tool_specific_config is None:
-            # None means this tool should not be wrapped as a task
-            return await super().call_tool(name, tool_args, ctx, tool)
+        if name in self._tool_task_config:
+            tool_specific_config = self._tool_task_config[name]
+            if tool_specific_config is None:
+                # None means this tool should not be wrapped as a task
+                return await super().call_tool(name, tool_args, ctx, tool)
+        else:
+            tool_specific_config = None
 
         # Merge tool-specific config with default config
-        merged_config = self._task_config | tool_specific_config
+        merged_config = merge_task_configs(self._task_config, tool_specific_config)
 
         return await self._call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(
             name, tool_args, ctx, tool

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_server.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_server.py
@@ -10,7 +10,7 @@ from pydantic_ai import ToolsetTool
 from pydantic_ai.tools import AgentDepsT, RunContext
 
 from ._toolset import PrefectWrapperToolset
-from ._types import TaskConfig, default_task_config
+from ._types import TaskConfig, default_task_config, merge_task_configs
 
 if TYPE_CHECKING:
     from pydantic_ai.mcp import MCPServer, ToolResult
@@ -26,7 +26,7 @@ class PrefectMCPServer(PrefectWrapperToolset[AgentDepsT], ABC):
         task_config: TaskConfig,
     ):
         super().__init__(wrapped)
-        self._task_config = default_task_config | (task_config or {})
+        self._task_config = merge_task_configs(default_task_config, task_config)
         self._mcp_id = wrapped.id
 
         @task

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_model.py
@@ -17,7 +17,7 @@ from pydantic_ai.models.wrapper import CompletedStreamedResponse, WrapperModel
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import RunContext
 
-from ._types import TaskConfig, default_task_config
+from ._types import TaskConfig, default_task_config, merge_task_configs
 
 
 class PrefectModel(WrapperModel):
@@ -31,7 +31,7 @@ class PrefectModel(WrapperModel):
         event_stream_handler: EventStreamHandler[Any] | None = None,
     ):
         super().__init__(model)
-        self.task_config = default_task_config | (task_config or {})
+        self.task_config = merge_task_configs(default_task_config, task_config)
         self.event_stream_handler = event_stream_handler
 
         @task

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_types.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_types.py
@@ -42,3 +42,11 @@ default_task_config = TaskConfig(
     log_prints=False,
     cache_policy=DEFAULT_PYDANTIC_AI_CACHE_POLICY,
 )
+
+
+def merge_task_configs(*configs: TaskConfig | None) -> TaskConfig:
+    merged = TaskConfig()
+    for config in configs:
+        if config is not None:
+            merged.update(config)
+    return merged

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -14,6 +14,7 @@ from pydantic_core import PydanticSerializationError
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 from temporalio.workflow import ActivityConfig
+from typing_extensions import Protocol, TypeVar
 
 from pydantic_ai import (
     AbstractToolset,
@@ -46,6 +47,33 @@ from ._toolset import TemporalWrapperToolset, temporalize_toolset
 if TYPE_CHECKING:
     from pydantic_ai.agent.spec import AgentSpec
 
+TemporalAgentDepsT = TypeVar('TemporalAgentDepsT', default=None)
+
+
+class TemporalizeToolsetFunc(Protocol[TemporalAgentDepsT]):
+    @overload
+    def __call__(
+        self,
+        toolset: AbstractToolset[TemporalAgentDepsT],
+        activity_name_prefix: str,
+        activity_config: ActivityConfig,
+        tool_activity_config: dict[str, ActivityConfig | Literal[False]],
+        deps_type: type,
+        run_context_type: type[TemporalRunContext[TemporalAgentDepsT]],
+    ) -> AbstractToolset[TemporalAgentDepsT]: ...
+
+    @overload
+    def __call__(
+        self,
+        toolset: AbstractToolset[TemporalAgentDepsT],
+        activity_name_prefix: str,
+        activity_config: ActivityConfig,
+        tool_activity_config: dict[str, ActivityConfig | Literal[False]],
+        deps_type: type,
+        run_context_type: type[TemporalRunContext[TemporalAgentDepsT]],
+        agent: AbstractAgent[TemporalAgentDepsT, Any] | None,
+    ) -> AbstractToolset[TemporalAgentDepsT]: ...
+
 
 @dataclass
 @with_config(ConfigDict(arbitrary_types_allowed=True))
@@ -68,18 +96,7 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         toolset_activity_config: dict[str, ActivityConfig] | None = None,
         tool_activity_config: dict[str, dict[str, ActivityConfig | Literal[False]]] | None = None,
         run_context_type: type[TemporalRunContext[AgentDepsT]] = TemporalRunContext[AgentDepsT],
-        temporalize_toolset_func: Callable[
-            [
-                AbstractToolset[AgentDepsT],
-                str,
-                ActivityConfig,
-                dict[str, ActivityConfig | Literal[False]],
-                type[AgentDepsT],
-                type[TemporalRunContext[AgentDepsT]],
-                AbstractAgent[AgentDepsT, Any] | None,
-            ],
-            AbstractToolset[AgentDepsT],
-        ] = temporalize_toolset,
+        temporalize_toolset_func: TemporalizeToolsetFunc[AgentDepsT] = temporalize_toolset,
     ):
         """Wrap an agent to enable it to be used inside a Temporal workflow, by automatically offloading model requests, tool calls, and MCP server communication to Temporal activities.
 
@@ -189,22 +206,32 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                     "Toolsets that are 'leaves' (i.e. those that implement their own tool listing and calling) need to have a unique `id` in order to be used with Temporal. The ID will be used to identify the toolset's activities within the workflow."
                 )
 
-            args: tuple[Any, ...] = (
-                toolset,
-                activity_name_prefix,
-                activity_config | toolset_activity_config.get(id, {}),
-                tool_activity_config.get(id, {}),
-                self.deps_type,
-                self.run_context_type,
-            )
+            toolset_activity_config_for_id = activity_config | toolset_activity_config.get(id, {})
+            tool_activity_config_for_id = tool_activity_config.get(id, {})
             # Pass agent if the function accepts it (backward compat with old 6-arg callables)
             positional_kinds = {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD}
             n_positional = sum(
                 1 for p in inspect.signature(temporalize_toolset_func).parameters.values() if p.kind in positional_kinds
             )
             if n_positional > 6:
-                args = (*args, self.wrapped)
-            toolset = temporalize_toolset_func(*args)
+                toolset = temporalize_toolset_func(
+                    toolset,
+                    activity_name_prefix,
+                    toolset_activity_config_for_id,
+                    tool_activity_config_for_id,
+                    self.deps_type,
+                    self.run_context_type,
+                    self.wrapped,
+                )
+            else:
+                toolset = temporalize_toolset_func(
+                    toolset,
+                    activity_name_prefix,
+                    toolset_activity_config_for_id,
+                    tool_activity_config_for_id,
+                    self.deps_type,
+                    self.run_context_type,
+                )
             if isinstance(toolset, TemporalWrapperToolset):
                 activities.extend(toolset.temporal_activities)
             return toolset

--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Literal, cast
+from typing import Literal
 
 from pydantic_ai import _utils
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, UserError
@@ -122,7 +122,6 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         self, inputs: str | Sequence[str], *, input_type: EmbedInputType, settings: EmbeddingSettings | None = None
     ) -> EmbeddingResult:
         inputs, settings = self.prepare_embed(inputs, settings)
-        settings = cast(OpenAIEmbeddingSettings, settings)  # ty: ignore[redundant-cast]
 
         try:
             response = await self._client.embeddings.create(

--- a/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/openai.py
@@ -122,7 +122,7 @@ class OpenAIEmbeddingModel(EmbeddingModel):
         self, inputs: str | Sequence[str], *, input_type: EmbedInputType, settings: EmbeddingSettings | None = None
     ) -> EmbeddingResult:
         inputs, settings = self.prepare_embed(inputs, settings)
-        settings = cast(OpenAIEmbeddingSettings, settings)
+        settings = cast(OpenAIEmbeddingSettings, settings)  # ty: ignore[redundant-cast]
 
         try:
             response = await self._client.embeddings.create(

--- a/pydantic_ai_slim/pydantic_ai/ext/aci.py
+++ b/pydantic_ai_slim/pydantic_ai/ext/aci.py
@@ -7,7 +7,7 @@ from pydantic_ai import FunctionToolset
 from pydantic_ai.tools import Tool
 
 try:
-    from aci import ACI
+    from aci import ACI  # ty: ignore[unresolved-import]
 except ImportError as _import_error:
     raise ImportError('Please install `aci-sdk` to use ACI.dev tools') from _import_error
 

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -981,7 +981,10 @@ class UserPromptPart:
     """Part type identifier, this is available on all parts as a discriminator."""
 
     def otel_event(self, settings: InstrumentationSettings) -> LogRecord:
-        content: Any = [{'kind': part.pop('type'), **part} for part in self.otel_message_parts(settings)]
+        content: Any = []
+        for part in self.otel_message_parts(settings):
+            part_content = dict(part)
+            content.append({'kind': part_content.pop('type'), **part_content})
         for part in content:
             if part['kind'] == 'binary' and 'content' in part:
                 part['binary_content'] = part.pop('content')

--- a/pydantic_ai_slim/pydantic_ai/models/_tool_choice.py
+++ b/pydantic_ai_slim/pydantic_ai/models/_tool_choice.py
@@ -1,13 +1,23 @@
 import warnings
 from typing import Literal
 
-from typing_extensions import assert_never
+from typing_extensions import TypeIs, assert_never
 
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import ModelRequestParameters
-from pydantic_ai.settings import ModelSettings, ToolOrOutput
+from pydantic_ai.settings import ModelSettings, ToolChoice, ToolOrOutput
 
 ResolvedToolChoice = Literal['none', 'auto', 'required'] | tuple[Literal['auto', 'required'], set[str]]
+
+
+def _is_tool_choice_list(tool_choice: ToolChoice) -> TypeIs[list[str]]:
+    return isinstance(tool_choice, list)
+
+
+def is_restricted_tool_choice(
+    tool_choice: ResolvedToolChoice,
+) -> TypeIs[tuple[Literal['auto', 'required'], set[str]]]:
+    return isinstance(tool_choice, tuple)
 
 
 def resolve_tool_choice(  # noqa: C901
@@ -47,7 +57,7 @@ def resolve_tool_choice(  # noqa: C901
         - `('auto', tool_names)`: Only these tools are available, direct output is allowed.
         - `('required', tool_names)`: Only these tools are available, must use one.
     """
-    function_tool_choice = (model_settings or {}).get('tool_choice')
+    function_tool_choice: ToolChoice = model_settings.get('tool_choice') if model_settings is not None else None
 
     allow_direct_output = model_request_parameters.allow_text_output or model_request_parameters.allow_image_output
 
@@ -106,7 +116,7 @@ def resolve_tool_choice(  # noqa: C901
         return 'required'
 
     # list[str]: required, restricted to these tools
-    elif isinstance(function_tool_choice, list):
+    elif _is_tool_choice_list(function_tool_choice):
         chosen_set = set(function_tool_choice)
         _check_invalid_tools(chosen_set, available_tools, available_label='Available tools')
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -10,7 +10,7 @@ from typing import Any, Literal, TypeAlias, cast, overload
 
 import pydantic_core
 from pydantic import TypeAdapter
-from typing_extensions import assert_never
+from typing_extensions import TypeIs, assert_never
 
 from .. import ModelHTTPError, UnexpectedModelBehavior, _utils, usage
 from .._run_context import RunContext
@@ -237,6 +237,16 @@ _BM25_TOOL_SEARCH_UNSUPPORTED_CLIENTS = (AsyncAnthropicBedrock,)
 _ANTHROPIC_SAMPLING_PARAMS = ('temperature', 'top_p', 'top_k')
 _ANTHROPIC_TASK_BUDGETS_BETA = 'task-budgets-2026-03-13'
 _ANTHROPIC_COMPACT_EDIT_TYPE = 'compact_20260112'
+
+
+def _is_plain_text_media_type(media_type: str) -> TypeIs[Literal['text/plain']]:
+    """Narrow `text/plain` for the Anthropic plain-text source type.
+
+    Ty does not yet infer the literal after a string equality check. The other
+    media-type branches either pass literals already or use SDK types that accept
+    the original media-type string.
+    """
+    return media_type == 'text/plain'
 
 
 @contextmanager
@@ -631,7 +641,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             }
 
         for setting in _ANTHROPIC_SAMPLING_PARAMS:
-            model_settings.pop(setting, None)
+            model_settings.pop(setting, None)  # ty: ignore[no-matching-overload]
 
         if dropped:
             ordered = [setting for setting in _ANTHROPIC_SAMPLING_PARAMS if setting in dropped]
@@ -1798,7 +1808,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                 ),
                 type='document',
             )
-        elif media_type == 'text/plain':
+        elif _is_plain_text_media_type(media_type):
             return BetaRequestDocumentBlockParam(
                 source=BetaPlainTextSourceParam(data=data.decode('utf-8'), media_type=media_type, type='text'),
                 type='document',
@@ -1815,15 +1825,16 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
 
     @staticmethod
     async def _map_document_url(item: DocumentUrl) -> BetaRequestDocumentBlockParam:
-        if item.media_type == 'application/pdf':
+        media_type = item.media_type
+        if media_type == 'application/pdf':
             if item.force_download:
                 downloaded = await download_item(item, data_format='bytes')
-                return AnthropicModel._map_binary_data(downloaded['data'], item.media_type)  # pyright: ignore[reportReturnType]
+                return AnthropicModel._map_binary_data(downloaded['data'], media_type)  # pyright: ignore[reportReturnType]
             return BetaRequestDocumentBlockParam(source={'url': item.url, 'type': 'url'}, type='document')
-        elif item.media_type == 'text/plain':
+        elif _is_plain_text_media_type(media_type):
             downloaded_item = await download_item(item, data_format='text')
             return BetaRequestDocumentBlockParam(
-                source=BetaPlainTextSourceParam(data=downloaded_item['data'], media_type=item.media_type, type='text'),
+                source=BetaPlainTextSourceParam(data=downloaded_item['data'], media_type=media_type, type='text'),
                 type='document',
             )
         else:  # pragma: no cover

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -940,7 +940,9 @@ class BedrockConverseModel(Model[BaseClient]):
                             and item.signature
                             and profile.bedrock_send_back_thinking_parts
                         ):
-                            reasoning_content: ReasoningContentBlockOutputTypeDef
+                            # Ty does not preserve the nested TypedDict shape across these branch
+                            # assignments.
+                            reasoning_content: ReasoningContentBlockOutputTypeDef  # ty: ignore[invalid-declaration]
                             if item.id == 'redacted_content':
                                 reasoning_content = {
                                     'redactedContent': item.signature.encode('utf-8'),
@@ -950,9 +952,9 @@ class BedrockConverseModel(Model[BaseClient]):
                                     'reasoningText': {
                                         'text': item.content,
                                         'signature': item.signature,
-                                    }
+                                    },
                                 }
-                            content.append({'reasoningContent': reasoning_content})
+                            content.append({'reasoningContent': reasoning_content})  # ty: ignore[invalid-argument-type]
                         else:
                             start_tag, end_tag = self.profile.thinking_tags
                             content.append({'text': '\n'.join([start_tag, item.content, end_tag])})

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -144,7 +144,7 @@ class CohereModel(Model[AsyncClientV2]):
 
     @property
     def base_url(self) -> str:
-        client_wrapper = self.client._client_wrapper  # type: ignore
+        client_wrapper = self.client._client_wrapper  # pyright: ignore[reportPrivateUsage]
         return str(client_wrapper.get_base_url())
 
     @property

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -112,8 +112,10 @@ class FunctionModel(Model):
         self.function = function
         self.stream_function = stream_function
 
-        function_name = self.function.__name__ if self.function is not None else ''
-        stream_function_name = self.stream_function.__name__ if self.stream_function is not None else ''
+        function_name = _utils.get_callable_name(self.function, '') if self.function is not None else ''
+        stream_function_name = (
+            _utils.get_callable_name(self.stream_function, '') if self.stream_function is not None else ''
+        )
         self._model_name = model_name or f'function:{function_name}:{stream_function_name}'
 
         # Use a default profile that supports JSON schema and object output if none provided

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -112,10 +112,8 @@ class FunctionModel(Model):
         self.function = function
         self.stream_function = stream_function
 
-        function_name = _utils.get_callable_name(self.function, '') if self.function is not None else ''
-        stream_function_name = (
-            _utils.get_callable_name(self.stream_function, '') if self.stream_function is not None else ''
-        )
+        function_name = _utils.get_callable_name(self.function, '')
+        stream_function_name = _utils.get_callable_name(self.stream_function, '')
         self._model_name = model_name or f'function:{function_name}:{stream_function_name}'
 
         # Use a default profile that supports JSON schema and object output if none provided

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -62,7 +62,7 @@ from . import (
     download_item,
     get_user_agent,
 )
-from ._tool_choice import resolve_tool_choice
+from ._tool_choice import is_restricted_tool_choice, resolve_tool_choice
 
 try:
     from google.genai import Client, errors
@@ -667,7 +667,7 @@ class GoogleModel(Model[Client]):
         }
 
         allowed_function_names: list[str] = []
-        if isinstance(resolved_tool_choice, tuple):
+        if is_restricted_tool_choice(resolved_tool_choice):
             tool_choice_mode, tool_names = resolved_tool_choice
             if tool_choice_mode == 'auto':
                 # Breaks caching, but Google doesn't support AUTO mode with allowed_function_names
@@ -675,10 +675,12 @@ class GoogleModel(Model[Client]):
             else:
                 # Use ANY mode with allowed_function_names to force one of the specified tools
                 allowed_function_names = list(tool_names)
+            function_calling_mode = function_calling_config_modes[tool_choice_mode]
         else:
             tool_choice_mode = resolved_tool_choice
+            function_calling_mode = function_calling_config_modes[tool_choice_mode]
 
-        function_calling_config: FunctionCallingConfigDict = {'mode': function_calling_config_modes[tool_choice_mode]}
+        function_calling_config: FunctionCallingConfigDict = {'mode': function_calling_mode}
         if allowed_function_names:
             function_calling_config['allowed_function_names'] = allowed_function_names
         tool_config = ToolConfigDict(function_calling_config=function_calling_config)

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -685,10 +685,11 @@ class GroqStreamedResponse(StreamedResponse):
 
                     # Handle the tool calls
                     for dtc in choice.delta.tool_calls or []:
+                        function = dtc.function
                         maybe_event = self._parts_manager.handle_tool_call_delta(
                             vendor_part_id=dtc.index,
-                            tool_name=dtc.function and dtc.function.name,
-                            args=dtc.function and dtc.function.arguments,
+                            tool_name=function.name if function is not None else None,
+                            args=function.arguments if function is not None else None,
                             tool_call_id=dtc.id,
                         )
                         if maybe_event is not None:

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -257,9 +257,9 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
         hf_messages = await self._map_messages(messages, model_request_parameters)
 
         with _map_api_errors(self.model_name):
-            return await self.client.chat.completions.create(  # type: ignore
+            return await self.client.chat.completions.create(  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType,reportCallIssue]
                 model=self._model_name,
-                messages=hf_messages,  # type: ignore
+                messages=hf_messages,  # pyright: ignore[reportArgumentType]
                 tools=tools,
                 tool_choice=tool_choice or None,
                 stream=stream,
@@ -270,10 +270,10 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                 seed=model_settings.get('seed', None),
                 presence_penalty=model_settings.get('presence_penalty', None),
                 frequency_penalty=model_settings.get('frequency_penalty', None),
-                logit_bias=model_settings.get('logit_bias', None),  # type: ignore
+                logit_bias=model_settings.get('logit_bias', None),  # pyright: ignore[reportArgumentType]
                 logprobs=model_settings.get('logprobs', None),
                 top_logprobs=model_settings.get('top_logprobs', None),
-                extra_body=model_settings.get('extra_body'),  # type: ignore
+                extra_body=model_settings.get('extra_body'),  # pyright: ignore[reportArgumentType]
             )
 
     def _process_response(self, response: ChatCompletionOutput) -> ModelResponse:
@@ -426,7 +426,7 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
 
     @staticmethod
     def _map_tool_call(t: ToolCallPart) -> ChatCompletionInputToolCall:
-        return ChatCompletionInputToolCall.parse_obj_as_instance(  # type: ignore
+        return ChatCompletionInputToolCall.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
             {
                 'id': _guard_tool_call_id(t=t),
                 'type': 'function',
@@ -439,7 +439,7 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
 
     @staticmethod
     def _map_tool_definition(f: ToolDefinition) -> ChatCompletionInputTool:
-        tool_param: ChatCompletionInputTool = ChatCompletionInputTool.parse_obj_as_instance(  # type: ignore
+        tool_param: ChatCompletionInputTool = ChatCompletionInputTool.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
             {
                 'type': 'function',
                 'function': {
@@ -456,11 +456,13 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
     ) -> AsyncIterable[ChatCompletionInputMessage | ChatCompletionOutputMessage]:
         for part in message.parts:
             if isinstance(part, SystemPromptPart):
-                yield ChatCompletionInputMessage.parse_obj_as_instance({'role': 'system', 'content': part.content})  # type: ignore
+                yield ChatCompletionInputMessage.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
+                    {'role': 'system', 'content': part.content}
+                )
             elif isinstance(part, UserPromptPart):
                 yield await self._map_user_prompt(part)
             elif isinstance(part, ToolReturnPart):
-                yield ChatCompletionOutputMessage.parse_obj_as_instance(  # type: ignore
+                yield ChatCompletionOutputMessage.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
                     {
                         'role': 'tool',
                         'tool_call_id': _guard_tool_call_id(t=part),
@@ -469,11 +471,11 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                 )
             elif isinstance(part, RetryPromptPart):
                 if part.tool_name is None:
-                    yield ChatCompletionInputMessage.parse_obj_as_instance(  # type: ignore
+                    yield ChatCompletionInputMessage.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
                         {'role': 'user', 'content': part.model_response()}
                     )
                 else:
-                    yield ChatCompletionInputMessage.parse_obj_as_instance(  # type: ignore
+                    yield ChatCompletionInputMessage.parse_obj_as_instance(  # pyright: ignore[reportUnknownMemberType]
                         {
                             'role': 'tool',
                             'tool_call_id': _guard_tool_call_id(t=part),
@@ -485,7 +487,7 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
 
     @staticmethod
     async def _map_user_prompt(part: UserPromptPart) -> ChatCompletionInputMessage:
-        content: str | list[ChatCompletionInputMessage]
+        content: str | list[ChatCompletionInputMessageChunk]
         if isinstance(part.content, str):
             content = part.content
         else:
@@ -493,14 +495,14 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
             for item in part.content:
                 if isinstance(item, str | TextContent):
                     text = item if isinstance(item, str) else item.content
-                    content.append(ChatCompletionInputMessageChunk(type='text', text=text))  # type: ignore
+                    content.append(ChatCompletionInputMessageChunk(type='text', text=text))
                 elif isinstance(item, ImageUrl):
                     url = ChatCompletionInputURL(url=item.url)
-                    content.append(ChatCompletionInputMessageChunk(type='image_url', image_url=url))  # type: ignore
+                    content.append(ChatCompletionInputMessageChunk(type='image_url', image_url=url))
                 elif isinstance(item, BinaryContent):
                     if item.is_image:
                         url = ChatCompletionInputURL(url=item.data_uri)
-                        content.append(ChatCompletionInputMessageChunk(type='image_url', image_url=url))  # type: ignore
+                        content.append(ChatCompletionInputMessageChunk(type='image_url', image_url=url))
                     else:  # pragma: no cover
                         raise RuntimeError(f'Unsupported binary content type: {item.media_type}')
                 elif isinstance(item, AudioUrl):
@@ -516,7 +518,7 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                     pass
                 else:
                     assert_never(item)
-        return ChatCompletionInputMessage(role='user', content=content)  # type: ignore
+        return ChatCompletionInputMessage(role='user', content=content)
 
 
 @dataclass
@@ -571,13 +573,24 @@ class HuggingFaceStreamedResponse(StreamedResponse):
                         yield event
 
                 for dtc in choice.delta.tool_calls or []:
+                    function = dtc.function
+                    if function is None:  # pyright: ignore[reportUnnecessaryComparison]
+                        maybe_event = self._parts_manager.handle_tool_call_delta(
+                            vendor_part_id=dtc.index,
+                            tool_name=None,
+                            args=None,
+                            tool_call_id=dtc.id,
+                        )
+                        if maybe_event is not None:
+                            yield maybe_event
+                        continue
                     maybe_event = self._parts_manager.handle_tool_call_delta(
                         vendor_part_id=dtc.index,
-                        tool_name=dtc.function and dtc.function.name,  # type: ignore
-                        args=dtc.function and dtc.function.arguments,
+                        tool_name=function.name,
+                        args=function.arguments,
                         tool_call_id=dtc.id,
                     )
-                    if maybe_event is not None:
+                    if maybe_event is not None:  # pragma: no branch
                         yield maybe_event
 
     @property

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -624,7 +624,7 @@ class MistralModel(Model[Mistral]):
                 next_message = mistral_messages[i + 1]
                 if isinstance(next_message, MistralUserMessage):
                     # Insert a dummy assistant message
-                    processed_messages.append(MistralAssistantMessage(content=[MistralTextChunk(text='OK')]))
+                    processed_messages.append(MistralAssistantMessage(content='OK'))
 
         return processed_messages
 
@@ -863,7 +863,7 @@ def _map_content(content: MistralOptionalNullable[MistralContent]) -> tuple[str 
                 text = (text or '') + chunk.text
             elif isinstance(chunk, MistralThinkChunk):
                 for thought in chunk.thinking:
-                    if thought.type == 'text':  # pragma: no branch
+                    if isinstance(thought, MistralTextChunk):  # pragma: no branch
                         thinking.append(thought.text)
             elif isinstance(chunk, MistralReferenceChunk):
                 pass

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -9,7 +9,7 @@ from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from functools import cached_property
-from typing import Any, Literal, cast, overload
+from typing import Any, Literal, cast, get_args, overload
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from pydantic_core import to_json
@@ -17,7 +17,7 @@ from typing_extensions import Never, assert_never, deprecated
 
 from .. import ModelAPIError, ModelHTTPError, UnexpectedModelBehavior, _utils, usage
 from .._instrumentation import get_instructions
-from .._output import DEFAULT_OUTPUT_TOOL_NAME, OutputObjectDefinition
+from .._output import DEFAULT_OUTPUT_TOOL_NAME
 from .._run_context import RunContext
 from .._thinking_part import split_content_into_text_and_thinking
 from .._utils import (
@@ -79,6 +79,7 @@ from ..native_tools._tool_search import (
     ToolSearchMatch,
     ToolSearchTool,
 )
+from ..output import OutputObjectDefinition
 from ..profiles import ModelProfile, ModelProfileSpec
 from ..profiles.openai import OPENAI_REASONING_EFFORT_MAP, SAMPLING_PARAMS, OpenAIModelProfile, OpenAISystemPromptRole
 from ..providers import Provider, infer_provider
@@ -255,7 +256,7 @@ _OPENAI_ASPECT_RATIO_TO_SIZE: dict[ImageAspectRatio, Literal['1024x1024', '1024x
 }
 
 _OPENAI_IMAGE_SIZE = Literal['auto', '1024x1024', '1024x1536', '1536x1024']
-_OPENAI_IMAGE_SIZES: tuple[_OPENAI_IMAGE_SIZE, ...] = _utils.get_args(_OPENAI_IMAGE_SIZE)
+_OPENAI_IMAGE_SIZES: tuple[_OPENAI_IMAGE_SIZE, ...] = get_args(_OPENAI_IMAGE_SIZE)
 
 
 class _ChatCompletion(chat.ChatCompletion):
@@ -455,7 +456,7 @@ def _drop_unsupported_params(profile: OpenAIModelProfile, model_settings: OpenAI
     Used currently only by Cerebras
     """
     for setting in profile.openai_unsupported_model_settings:
-        model_settings.pop(setting, None)
+        model_settings.pop(setting, None)  # ty: ignore[no-matching-overload]
 
 
 class OpenAIChatModelSettings(ModelSettings, total=False):
@@ -1303,7 +1304,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             # shouldn't merge multiple texts into one unless you switch models between runs:
             if self.thinkings:
                 for field_name, contents in self.thinkings.items():
-                    message_param[field_name] = '\n\n'.join(contents)
+                    message_param[field_name] = '\n\n'.join(contents)  # ty: ignore[invalid-key]
             if self.texts:
                 message_param['content'] = '\n\n'.join(self.texts)
             else:
@@ -3189,10 +3190,11 @@ class OpenAIStreamedResponse(StreamedResponse):
         This method may be overridden by subclasses of `OpenAIStreamResponse` to customize the mapping.
         """
         for dtc in choice.delta.tool_calls or []:
+            function = dtc.function
             maybe_event = self._parts_manager.handle_tool_call_delta(
                 vendor_part_id=dtc.index,
-                tool_name=dtc.function and dtc.function.name,
-                args=dtc.function and dtc.function.arguments,
+                tool_name=function.name if function is not None else None,
+                args=function.arguments if function is not None else None,
                 tool_call_id=dtc.id,
             )
             if maybe_event is not None:

--- a/pydantic_ai_slim/pydantic_ai/models/outlines.py
+++ b/pydantic_ai_slim/pydantic_ai/models/outlines.py
@@ -320,7 +320,7 @@ class OutlinesModel(Model):
 
     def format_inference_kwargs(self, model_settings: ModelSettings | None) -> dict[str, Any]:
         """Format the model settings for the inference kwargs."""
-        settings_dict: dict[str, Any] = dict(model_settings) if model_settings else {}
+        settings_dict: dict[str, Any] = {**model_settings} if model_settings else {}
 
         if isinstance(self.model, Transformers):
             settings_dict = self._format_transformers_inference_kwargs(settings_dict)

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime, timedelta
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import httpx
 import pydantic_core
@@ -347,10 +347,11 @@ class TestStreamedResponse(StreamedResponse):
                 # `ToolCallPart` subclasses (e.g. `ToolSearchCallPart`) narrow `args` to a
                 # `TypedDict`, which is structurally a `dict[str, Any]` but pyright keeps
                 # the narrower union here.
+                args = dict(part.args) if isinstance(part.args, dict) else part.args
                 yield self._parts_manager.handle_tool_call_part(
                     vendor_part_id=i,
                     tool_name=part.tool_name,
-                    args=cast('str | dict[str, Any] | None', part.args),
+                    args=args,
                     tool_call_id=part.tool_call_id,
                 )
             elif isinstance(part, NativeToolCallPart | NativeToolReturnPart):  # pragma: no cover

--- a/pydantic_ai_slim/pydantic_ai/models/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/models/wrapper.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
+from types import TracebackType
 from typing import Any
 
 from typing_extensions import Self
@@ -79,8 +80,13 @@ class WrapperModel(Model):
         await self.wrapped.__aenter__()
         return self
 
-    async def __aexit__(self, *args: Any) -> bool | None:
-        return await self.wrapped.__aexit__(*args)
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        return await self.wrapped.__aexit__(exc_type, exc_val, exc_tb)
 
     async def request(
         self,

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -11,7 +11,6 @@ from typing import Any, Literal, cast
 from typing_extensions import assert_never
 
 from .. import ModelHTTPError, _utils
-from .._output import OutputObjectDefinition
 from .._run_context import RunContext
 from .._utils import install_deprecated_kwarg_alias
 from ..capabilities.native_or_local import NativeOrLocalTool
@@ -52,7 +51,15 @@ from ..models import (
     check_allow_model_requests,
     download_item,
 )
-from ..native_tools import CodeExecutionTool, FileSearchTool, MCPServerTool, WebSearchTool, XSearchTool
+from ..native_tools import (
+    AbstractNativeTool,
+    CodeExecutionTool,
+    FileSearchTool,
+    MCPServerTool,
+    WebSearchTool,
+    XSearchTool,
+)
+from ..output import OutputObjectDefinition
 from ..profiles import ModelProfileSpec
 from ..profiles.grok import GrokModelProfile
 from ..providers import Provider, infer_provider
@@ -92,8 +99,16 @@ def _map_api_errors(model_name: str) -> Iterator[None]:
     try:
         yield
     except grpc.RpcError as e:
-        status_code = _GRPC_STATUS_TO_HTTP.get(e.code())
-        details = e.details() or str(e)
+        code_method = getattr(e, 'code', None)
+        details_method = getattr(e, 'details', None)
+        if callable(code_method) and callable(details_method):
+            code = code_method()
+            status_code = _GRPC_STATUS_TO_HTTP.get(code) if isinstance(code, grpc.StatusCode) else None
+            details_value = details_method()
+            details = details_value if isinstance(details_value, str) and details_value else str(e)
+        else:
+            status_code = None
+            details = str(e)
         if status_code is not None:
             raise ModelHTTPError(status_code=status_code, model_name=model_name, body=details) from e
         raise ModelAPIError(model_name=model_name, message=details) from e
@@ -344,7 +359,7 @@ class XaiModel(Model[AsyncClient]):
         return 'xai'
 
     @classmethod
-    def supported_native_tools(cls) -> frozenset[type]:
+    def supported_native_tools(cls) -> frozenset[type[AbstractNativeTool]]:
         """Return the set of builtin tool types this model can handle."""
         return frozenset({WebSearchTool, CodeExecutionTool, MCPServerTool, XSearchTool, FileSearchTool})
 

--- a/pydantic_ai_slim/pydantic_ai/native_tools/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/native_tools/__init__.py
@@ -97,8 +97,8 @@ class AbstractNativeTool(ABC):
         if len(tools) == 1:  # pragma: no cover
             tools_type = next(iter(tools))
         else:
-            tools_annotated = [Annotated[tool, pydantic.Tag(tool.kind)] for tool in tools]
-            tools_type = Annotated[Union[tuple(tools_annotated)], pydantic.Discriminator(_tool_discriminator)]  # noqa: UP007
+            tools_annotated = [Annotated[tool, pydantic.Tag(tool.kind)] for tool in tools]  # ty: ignore[invalid-type-form]
+            tools_type = Annotated[Union[tuple(tools_annotated)], pydantic.Discriminator(_tool_discriminator)]  # noqa: UP007  # ty: ignore[invalid-type-form]
 
         return handler(tools_type)
 
@@ -611,7 +611,7 @@ from . import _tool_search as _tool_search  # noqa: E402
 
 def _tool_discriminator(tool_data: dict[str, Any] | AbstractNativeTool) -> str:
     if isinstance(tool_data, dict):
-        return tool_data.get('kind', AbstractNativeTool.kind)
+        return tool_data.get('kind', AbstractNativeTool.kind)  # ty: ignore[no-matching-overload]
     else:
         return tool_data.kind
 

--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -117,7 +117,8 @@ class GoogleProvider(Provider[Client]):
             # configured on the httpx client. We must set the timeout here to ensure
             # requests actually time out. Read the timeout from the http_client if set,
             # otherwise use the default. The value is converted from seconds to milliseconds.
-            timeout_seconds = http_client.timeout.read or DEFAULT_HTTP_TIMEOUT
+            read_timeout = http_client.timeout.read
+            timeout_seconds = read_timeout if isinstance(read_timeout, int | float) else DEFAULT_HTTP_TIMEOUT
             timeout_ms = int(timeout_seconds * 1000)
             http_options = HttpOptions(
                 base_url=base_url,

--- a/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google_vertex.py
@@ -204,7 +204,10 @@ class _VertexAIAuth(httpx.Auth):
 
 
 async def _async_google_auth() -> tuple[BaseCredentials, str | None]:
-    return await anyio.to_thread.run_sync(google.auth.default, ['https://www.googleapis.com/auth/cloud-platform'])  # type: ignore
+    return await anyio.to_thread.run_sync(  # pyright: ignore[reportUnknownVariableType]
+        google.auth.default,  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+        ['https://www.googleapis.com/auth/cloud-platform'],
+    )
 
 
 async def _creds_from_file(service_account_file: str | Path) -> ServiceAccountCredentials:

--- a/pydantic_ai_slim/pydantic_ai/retries.py
+++ b/pydantic_ai_slim/pydantic_ai/retries.py
@@ -36,9 +36,11 @@ except ImportError as _import_error:
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import TypedDict
+
+_parse_retry_after_date: Callable[[str], datetime] = parsedate_to_datetime
 
 if TYPE_CHECKING:
     from tenacity.asyncio.retry import RetryBaseT
@@ -365,7 +367,7 @@ def wait_retry_after(
                 except ValueError:
                     # Try parsing as HTTP date
                     try:
-                        retry_time = cast(datetime, parsedate_to_datetime(retry_after))  # ty: ignore[redundant-cast]
+                        retry_time = _parse_retry_after_date(retry_after)
                         assert isinstance(retry_time, datetime)
                         now = datetime.now(timezone.utc)
                         wait_seconds = (retry_time - now).total_seconds()

--- a/pydantic_ai_slim/pydantic_ai/retries.py
+++ b/pydantic_ai_slim/pydantic_ai/retries.py
@@ -365,7 +365,7 @@ def wait_retry_after(
                 except ValueError:
                     # Try parsing as HTTP date
                     try:
-                        retry_time = cast(datetime, parsedate_to_datetime(retry_after))
+                        retry_time = cast(datetime, parsedate_to_datetime(retry_after))  # ty: ignore[redundant-cast]
                         assert isinstance(retry_time, datetime)
                         now = datetime.now(timezone.utc)
                         wait_seconds = (retry_time - now).total_seconds()

--- a/pydantic_ai_slim/pydantic_ai/run.py
+++ b/pydantic_ai_slim/pydantic_ai/run.py
@@ -222,7 +222,7 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
     ) -> _agent_graph.AgentNode[AgentDepsT, OutputDataT] | End[FinalResult[OutputDataT]]:
         if isinstance(task, Sequence) and len(task) == 1:
             first_task = task[0]
-            if isinstance(first_task.inputs, BaseNode):  # pragma: no branch
+            if isinstance(first_task.inputs, BaseNode):  # pragma: no branch  # ty: ignore[unresolved-attribute]
                 base_node: BaseNode[  # pyright: ignore[reportUnknownVariableType]
                     _agent_graph.GraphAgentState,
                     _agent_graph.GraphAgentDeps[AgentDepsT, OutputDataT],
@@ -231,7 +231,7 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
                 if _agent_graph.is_agent_node(node=base_node):  # pragma: no branch
                     return base_node
         if isinstance(task, EndMarker):
-            return End(task.value)
+            return End(task.value)  # ty: ignore[invalid-return-type]
         raise exceptions.AgentRunError(f'Unexpected node: {task}')  # pragma: no cover
 
     def _node_to_task(self, node: _agent_graph.AgentNode[AgentDepsT, OutputDataT]) -> GraphTaskRequest:
@@ -245,7 +245,7 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
         be updated so that `output` and `next_node` reflect the hook's decision.
         """
         if isinstance(result, End):
-            self._graph_run.override_next(EndMarker(result.data))
+            self._graph_run.override_next(EndMarker(result.data))  # ty: ignore[invalid-argument-type]
         else:
             self._graph_run.override_next([self._node_to_task(result)])
 

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -220,7 +220,7 @@ async def matches_tool_selector(
         return result
     if isinstance(selector, dict):
         metadata: dict[str, Any] = tool_def.metadata or {}
-        return _metadata_includes(metadata, selector)
+        return _metadata_includes(metadata, selector)  # ty: ignore[invalid-argument-type]
     if isinstance(selector, str):
         return tool_def.name == selector
     # Sequence[str] — match by tool name
@@ -440,7 +440,7 @@ ToolAgentDepsT = TypeVar('ToolAgentDepsT', default=object, contravariant=True)
 class Tool(Generic[ToolAgentDepsT]):
     """A tool function for an agent."""
 
-    function: ToolFuncEither[ToolAgentDepsT]
+    function: ToolFuncEither[ToolAgentDepsT, ...]
     takes_ctx: bool
     max_retries: int | None
     name: str
@@ -554,7 +554,7 @@ class Tool(Generic[ToolAgentDepsT]):
             function_schema: The function schema to use for the tool. If not provided, it will be generated.
         """
         self.function = function
-        self.name = name or function.__name__
+        self.name = name or _utils.get_callable_name(function, 'tool')
         self.function_schema = function_schema or _function_schema.function_schema(
             function,
             schema_generator,

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
@@ -120,7 +120,11 @@ def create_api_app(
     all_models: list[tuple[str | None, Model | str]] = []
     if agent.model is not None:
         all_models.append((None, agent.model))
-    items = list(models.items()) if isinstance(models, Mapping) else [(None, m) for m in (models or [])]
+    items: list[tuple[str | None, Model | str]]
+    if isinstance(models, Mapping):
+        items = list(models.items())  # ty: ignore[invalid-assignment]
+    else:
+        items = [(None, m) for m in (models or [])]
     all_models.extend(items)
 
     seen_model_ids: set[str] = set()

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -347,7 +347,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
 
                                     user_prompt_content.append(multimodal_input_to_content(part))
                                 case _:
-                                    assert_never(part)
+                                    assert_never(part)  # ty: ignore[type-assertion-failure]
 
                         if user_prompt_content:
                             content_to_add = (

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -314,13 +314,7 @@ class UsageLimits:
         output_tokens_limit: int | None = None,
         total_tokens_limit: int | None = None,
         count_tokens_before_request: bool = False,
-    ) -> None:
-        self.request_limit = request_limit
-        self.tool_calls_limit = tool_calls_limit
-        self.input_tokens_limit = input_tokens_limit
-        self.output_tokens_limit = output_tokens_limit
-        self.total_tokens_limit = total_tokens_limit
-        self.count_tokens_before_request = count_tokens_before_request
+    ) -> None: ...
 
     @overload
     @deprecated(
@@ -335,13 +329,7 @@ class UsageLimits:
         response_tokens_limit: int | None = None,
         total_tokens_limit: int | None = None,
         count_tokens_before_request: bool = False,
-    ) -> None:
-        self.request_limit = request_limit
-        self.tool_calls_limit = tool_calls_limit
-        self.input_tokens_limit = request_tokens_limit
-        self.output_tokens_limit = response_tokens_limit
-        self.total_tokens_limit = total_tokens_limit
-        self.count_tokens_before_request = count_tokens_before_request
+    ) -> None: ...
 
     def __init__(
         self,

--- a/scripts/typecheck_ty.sh
+++ b/scripts/typecheck_ty.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${TY_BIN:-}" ]]; then
+  if command -v ty >/dev/null 2>&1; then
+    TY_BIN=ty
+  else
+    echo "Set TY_BIN to a ty executable, for example a build of dsfaccini/ruff@codex/ty-pydantic-compat." >&2
+    exit 127
+  fi
+fi
+
+TY_OUTPUT_FORMAT="${TY_OUTPUT_FORMAT:-concise}"
+TY_PATHS="${TY_PATHS:-pydantic_ai_slim/pydantic_ai}"
+read -r -a ty_paths <<< "$TY_PATHS"
+
+"$TY_BIN" check \
+  --python-version 3.13 \
+  --output-format "$TY_OUTPUT_FORMAT" \
+  "${ty_paths[@]}"

--- a/scripts/typecheck_ty.sh
+++ b/scripts/typecheck_ty.sh
@@ -11,7 +11,7 @@ if [[ -z "${TY_BIN:-}" ]]; then
 fi
 
 TY_OUTPUT_FORMAT="${TY_OUTPUT_FORMAT:-concise}"
-TY_PATHS="${TY_PATHS:-pydantic_ai_slim/pydantic_ai}"
+TY_PATHS="${TY_PATHS:-pydantic_ai_slim}"
 read -r -a ty_paths <<< "$TY_PATHS"
 
 "$TY_BIN" check \

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -34,7 +34,8 @@ from pydantic_ai import (
 )
 from pydantic_ai._utils import PeekableAsyncStream
 from pydantic_ai.exceptions import ModelHTTPError
-from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.messages import PartStartEvent
+from pydantic_ai.models import DEFAULT_PROFILE, ModelRequestParameters
 from pydantic_ai.result import RunUsage
 from pydantic_ai.run import AgentRunResult, AgentRunResultEvent
 from pydantic_ai.settings import ModelSettings
@@ -634,6 +635,52 @@ async def test_stream_structured(allow_model_requests: None):
         assert result.usage() == snapshot(RunUsage(requests=1, input_tokens=20, output_tokens=10))
         # double check usage matches stream count
         assert result.usage().output_tokens == len(stream)
+
+
+async def test_stream_structured_multiple_tool_deltas_in_chunk() -> None:
+    function_1_name = ChatCompletionStreamOutputFunction.parse_obj_as_instance(  # type: ignore
+        {'name': 'first_tool', 'arguments': None}
+    )
+    function_1_args = ChatCompletionStreamOutputFunction.parse_obj_as_instance(  # type: ignore
+        {'name': None, 'arguments': '{"value": 1}'}
+    )
+    function_2 = ChatCompletionStreamOutputFunction.parse_obj_as_instance(  # type: ignore
+        {'name': 'second_tool', 'arguments': '{}'}
+    )
+    stream = [
+        chunk(
+            [
+                ChatCompletionStreamOutputDelta(
+                    role='assistant',
+                    tool_calls=[
+                        ChatCompletionStreamOutputDeltaToolCall(
+                            id='0', type='function', index=0, function=function_1_name
+                        ),
+                        ChatCompletionStreamOutputDeltaToolCall(
+                            id='0', type='function', index=0, function=function_1_args
+                        ),
+                        ChatCompletionStreamOutputDeltaToolCall(id='1', type='function', index=1, function=function_2),
+                    ],
+                )
+            ]
+        )
+    ]
+    response = HuggingFaceStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='hf-model',
+        _model_profile=DEFAULT_PROFILE,
+        _response=PeekableAsyncStream(MockAsyncStream(iter(stream))),
+        _provider_name='huggingface',
+        _provider_url='https://api-inference.huggingface.co',
+    )
+
+    events = [event async for event in response._get_event_iterator()]  # pyright: ignore[reportPrivateUsage]
+    tool_names: list[str] = []
+    for event in events:
+        if isinstance(event, PartStartEvent) and isinstance(event.part, ToolCallPart):
+            tool_names.append(event.part.tool_name)
+
+    assert tool_names == ['first_tool', 'second_tool']
 
 
 async def test_stream_structured_finish_reason(allow_model_requests: None):

--- a/tests/test_streaming_errors.py
+++ b/tests/test_streaming_errors.py
@@ -144,7 +144,7 @@ with try_import() as mistral_imports:
 with try_import() as xai_imports:
     import grpc
 
-    from pydantic_ai.models.xai import XaiModel
+    from pydantic_ai.models.xai import XaiModel, _map_api_errors  # pyright: ignore[reportPrivateUsage]
     from pydantic_ai.providers.xai import XaiProvider
 
     from .models.mock_xai import MockXai, get_grok_text_chunk
@@ -161,6 +161,12 @@ with try_import() as xai_imports:
 
         def details(self) -> str:
             return self._details
+
+    class _BareRpcError(grpc.RpcError):
+        """Stub gRPC error without status helpers."""
+
+        def __str__(self) -> str:
+            return 'bare gRPC error'
 
 
 # ---------------------------------------------------------------------------
@@ -926,6 +932,13 @@ async def test_xai_midstream_error(
     if expected_status is not None:
         assert isinstance(exc_info.value, ModelHTTPError)
         assert exc_info.value.status_code == expected_status
+
+
+@pytest.mark.skipif(not xai_imports(), reason='xai-sdk not installed')
+def test_xai_error_without_status_helpers() -> None:
+    with pytest.raises(ModelAPIError, match='bare gRPC error'):
+        with _map_api_errors('grok-test'):
+            raise _BareRpcError()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -26,6 +26,7 @@ from pydantic_ai import Agent, FunctionToolset, ToolCallPart
 from pydantic_ai._agent_graph import _clean_message_history  # pyright: ignore[reportPrivateUsage]
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._tool_search import (
+    _typed_tool_search_args,  # pyright: ignore[reportPrivateUsage]
     synthesize_local_from_native_call,
     synthesize_local_tool_search_messages,
 )
@@ -2796,6 +2797,10 @@ def test_narrow_type_promotes_builtin_call_to_tool_search() -> None:
 
     already_narrowed = NativeToolSearchCallPart(args={'queries': ['x']}, tool_call_id='c2')
     assert NativeToolCallPart.narrow_type(already_narrowed) is already_narrowed
+
+
+def test_tool_search_args_rejects_runtime_non_string() -> None:
+    assert _typed_tool_search_args(1) is None  # pyright: ignore[reportArgumentType]
 
 
 def test_narrow_type_promotes_builtin_return_to_tool_search() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,12 +10,16 @@ from concurrent.futures import ThreadPoolExecutor
 from importlib.metadata import distributions
 
 import pytest
+from opentelemetry._logs import LogRecord
 
 from pydantic_ai import UserError
+from pydantic_ai._instrumentation import event_to_dict
 from pydantic_ai._utils import (
     UNSET,
     PeekableAsyncStream,
     check_object_json_schema,
+    get_callable_name,
+    get_callable_qualname,
     group_by_temporal,
     is_async_callable,
     merge_json_schema_defs,
@@ -118,6 +122,31 @@ def test_check_object_json_schema():
     array_schema = {'type': 'array', 'items': {'type': 'string'}}
     with pytest.raises(UserError, match='^Schema must be an object$'):
         check_object_json_schema(array_schema)
+
+
+def test_event_to_dict_keeps_string_body_keys_and_attributes() -> None:
+    body: dict[object, object] = {'body-key': 1, 2: 'ignored'}
+    event = LogRecord(  # pyright: ignore[reportCallIssue]
+        body=body,  # pyright: ignore[reportArgumentType]
+        attributes={'attr-1': 2, 'attr-2': 3},
+    )
+
+    assert event_to_dict(event) == {'body-key': 1, 'attr-1': 2, 'attr-2': 3}
+
+
+def test_callable_name_helpers_handle_partials_and_defaults() -> None:
+    def named_function() -> None:
+        pass
+
+    partial_function = functools.partial(named_function)
+    anonymous_object = object()
+    expected_qualname = 'test_callable_name_helpers_handle_partials_and_defaults.<locals>.named_function'
+
+    assert get_callable_name(partial_function, 'fallback') == 'named_function'
+    assert get_callable_name(anonymous_object, 'fallback') == 'fallback'
+    assert get_callable_qualname(partial_function) == expected_qualname
+    assert get_callable_qualname(anonymous_object, 'fallback') == 'fallback'
+    assert get_callable_qualname(anonymous_object) == 'object'
 
 
 @pytest.mark.parametrize('peek_first', [True, False])


### PR DESCRIPTION
As per our team discussion on Thu 14 of May, we won't be merging this PR bc it would increase maintenance load (by urging contributors and team member to address `ty` specific issues, that we don't currently have a standard for, so we'd need to come up with some rules first...)

Instead I, David, will be responsible of keeping this branch up to date and addressing any new diagnostics that come up where appropriate, i.e., as a change in `pydantic-ai` when the diagnostic is valid, or as a change in the fork if the diagnostic stems from a functionality gap in `ty`

---
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes N/A

This improves compatibility with Astral's Ty type checker across `pydantic_ai_slim` while keeping Pyright clean. The changes are mostly local type-shape cleanups, narrow Ty suppressions for dynamic runtime typing patterns, and small helper annotations where Ty currently loses precision.

Related: #3970 tracks Ty readiness for pydantic-ai.

This PR also adds an advisory Ty workflow that builds a pinned commit from David's Ty fork ([`dsfaccini/ruff`](https://github.com/dsfaccini/ruff/tree/codex/ty-pydantic-compat)) and runs it against `pydantic_ai_slim` in parallel with the existing required Pyright checks. The workflow is allowed to fail, so it can track compatibility drift without blocking regular development while Ty is still unstable.

Verified locally:

- `/Users/david/projects/forks/ruff/target/debug/ty check --python-version 3.13 --output-format concise pydantic_ai_slim`
- `uv run --frozen pyright <modified python files>`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).