### PR TITLE
refactor: dedupe model-request OTel span between `Instrumentation` and `InstrumentedModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Mapping, Sequence
+import warnings
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 from urllib.parse import urlparse
 
 from opentelemetry._logs import LogRecord
 from opentelemetry.baggage import get_baggage
-from opentelemetry.trace import INVALID_SPAN, get_current_span
+from opentelemetry.trace import INVALID_SPAN, SpanKind, get_current_span
 from opentelemetry.util.types import AttributeValue
 from pydantic import TypeAdapter
 from pydantic_core import to_json
@@ -20,6 +22,8 @@ if TYPE_CHECKING:
 
     from pydantic_ai.messages import ModelMessage, ModelResponse
     from pydantic_ai.models import Model, ModelRequestParameters
+    from pydantic_ai.models.instrumented import InstrumentationSettings
+    from pydantic_ai.settings import ModelSettings
 
 DEFAULT_INSTRUMENTATION_VERSION = 2
 """Default instrumentation version for `InstrumentationSettings`."""
@@ -168,6 +172,117 @@ def build_tool_definitions(model_request_parameters: ModelRequestParameters) -> 
         tool_definitions.append(tool_def)
 
     return tool_definitions
+
+
+@contextmanager
+def open_model_request_span(
+    settings: InstrumentationSettings,
+    model: Model,
+    messages: list[ModelMessage],
+    prepared_settings: ModelSettings | None,
+    prepared_parameters: ModelRequestParameters,
+) -> Iterator[Callable[[ModelResponse], None]]:
+    """Open a `chat <model>` CLIENT span and yield a `finish(response)` callback for outcome attrs.
+
+    Shared between `Instrumentation.wrap_model_request` (agent flow) and
+    `InstrumentedModel.request`/`request_stream` (standalone / `direct.model_request*`).
+    Caller passes `model.prepare_request(...)` output as `prepared_settings`/`prepared_parameters`
+    so attributes reflect what the provider will actually receive. Token/cost metrics are
+    recorded *after* the span closes so backends that aggregate from span attributes don't
+    double-count.
+    """
+    # TODO Missing attributes:
+    #  - error.type: unclear if we should do something here or just always rely on span exceptions
+    #  - gen_ai.request.stop_sequences/top_k: model_settings doesn't include these
+    operation = 'chat'
+    span_name = f'{operation} {model.model_name}'
+    attributes: dict[str, AttributeValue] = {
+        'gen_ai.operation.name': operation,
+        **model_attributes(model),
+        **model_request_parameters_attributes(prepared_parameters),
+        **get_agent_run_baggage_attributes(),
+        'logfire.json_schema': to_json(
+            {
+                'type': 'object',
+                'properties': {'model_request_parameters': {'type': 'object'}},
+            }
+        ).decode(),
+    }
+
+    tool_definitions = build_tool_definitions(prepared_parameters)
+    if tool_definitions:
+        attributes['gen_ai.tool.definitions'] = to_json(tool_definitions).decode()
+
+    if prepared_settings:
+        for key in MODEL_SETTING_ATTRIBUTES:
+            if isinstance(value := prepared_settings.get(key), float | int):
+                attributes[f'gen_ai.request.{key}'] = value
+
+    record_metrics: Callable[[], None] | None = None
+    try:
+        with settings.tracer.start_as_current_span(span_name, attributes=attributes, kind=SpanKind.CLIENT) as span:
+            # `finish` is a closure rather than inline so we can (a) set result attributes
+            # inside the `with span:` block — they attach to the span — and (b) call the
+            # captured `record_metrics` in the outer `finally` AFTER the span closes,
+            # so observability backends that aggregate metrics from span attributes
+            # don't double-count.
+            def finish(response: ModelResponse) -> None:
+                nonlocal record_metrics
+
+                # FallbackModel updates these span attributes via get_current_span().
+                attributes.update(getattr(span, 'attributes', {}))
+                request_model = attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]
+                system = cast(str, attributes[GEN_AI_SYSTEM_ATTRIBUTE])
+
+                response_model = response.model_name or request_model
+                price_calculation = None
+
+                def _record_metrics() -> None:
+                    metric_attributes = {
+                        GEN_AI_PROVIDER_NAME_ATTRIBUTE: system,
+                        GEN_AI_SYSTEM_ATTRIBUTE: system,
+                        'gen_ai.operation.name': operation,
+                        'gen_ai.request.model': request_model,
+                        'gen_ai.response.model': response_model,
+                    }
+                    settings.record_metrics(response, price_calculation, metric_attributes)
+
+                record_metrics = _record_metrics
+
+                # Compute cost before the `is_recording()` gate so `_record_metrics`
+                # always emits cost data, even when the span is dropped by sampling.
+                try:
+                    price_calculation = response.cost()
+                except LookupError:
+                    pass
+                except Exception as e:  # pragma: no cover — safety net for unexpected genai_prices errors
+                    warnings.warn(
+                        f'Failed to get cost from response: {type(e).__name__}: {e}',
+                        CostCalculationFailedWarning,
+                    )
+
+                if not span.is_recording():
+                    return
+
+                settings.handle_messages(messages, response, system, span, prepared_parameters)
+
+                attributes_to_set: dict[str, Any] = {
+                    **response.usage.opentelemetry_attributes(),
+                    'gen_ai.response.model': response_model,
+                }
+                if price_calculation is not None:
+                    attributes_to_set['operation.cost'] = float(price_calculation.total_price)
+                if response.provider_response_id is not None:
+                    attributes_to_set['gen_ai.response.id'] = response.provider_response_id
+                if response.finish_reason is not None:
+                    attributes_to_set['gen_ai.response.finish_reasons'] = [response.finish_reason]
+                span.set_attributes(attributes_to_set)
+                span.update_name(f'{operation} {request_model}')
+
+            yield finish
+    finally:
+        if record_metrics:
+            record_metrics()
 
 
 def get_instructions(

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -4,7 +4,7 @@ import itertools
 import warnings
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 from urllib.parse import urlparse
 
@@ -177,24 +177,26 @@ def build_tool_definitions(model_request_parameters: ModelRequestParameters) -> 
 def open_model_request_span(
     settings: InstrumentationSettings,
     request_context: ModelRequestContext,
-) -> Iterator[tuple[Callable[[ModelResponse], None], ModelRequestParameters]]:
-    """Open a `chat <model>` CLIENT span; yield `(finish, prepared_parameters)`.
+) -> Iterator[tuple[Callable[[ModelResponse], None], ModelRequestContext]]:
+    """Open a `chat <model>` CLIENT span; yield `(finish, prepared_request_context)`.
 
     Shared between `Instrumentation.wrap_model_request` (agent flow) and
     `InstrumentedModel.request`/`request_stream` (standalone / `direct.model_request*`).
-    Calls `model.prepare_request(...)` internally and exposes `prepared_parameters` to the
-    caller (the agent-flow capability uses it for end-of-run span attributes). `finish(response)`
-    annotates the response with OTel tool-call metadata and records outcome attributes. Token/cost
-    metrics are recorded *after* the span closes so backends that aggregate from span attributes
-    don't double-count.
+    Calls `model.prepare_request(...)` internally and yields a request context with the prepared
+    settings/parameters so callers don't have to re-prepare. `finish(response)` annotates the
+    response with OTel tool-call metadata and records outcome attributes. Token/cost metrics are
+    recorded *after* the span closes so backends that aggregate from span attributes don't
+    double-count.
     """
     # TODO Missing attributes:
     #  - error.type: unclear if we should do something here or just always rely on span exceptions
     #  - gen_ai.request.stop_sequences/top_k: model_settings doesn't include these
     model = request_context.model
-    messages = request_context.messages
     prepared_settings, prepared_parameters = model.prepare_request(
         request_context.model_settings, request_context.model_request_parameters
+    )
+    prepared_request_context = replace(
+        request_context, model_settings=prepared_settings, model_request_parameters=prepared_parameters
     )
     operation = 'chat'
     span_name = f'{operation} {model.model_name}'
@@ -268,7 +270,7 @@ def open_model_request_span(
                 if not span.is_recording():
                     return
 
-                settings.handle_messages(messages, response, system, span, prepared_parameters)
+                settings.handle_messages(prepared_request_context.messages, response, system, span, prepared_parameters)
 
                 attributes_to_set: dict[str, Any] = {
                     **response.usage.opentelemetry_attributes(),
@@ -283,7 +285,7 @@ def open_model_request_span(
                 span.set_attributes(attributes_to_set)
                 span.update_name(f'{operation} {request_model}')
 
-            yield finish, prepared_parameters
+            yield finish, prepared_request_context
     finally:
         if record_metrics:
             record_metrics()

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -255,7 +255,7 @@ def open_model_request_span(
                     price_calculation = response.cost()
                 except LookupError:
                     pass
-                except Exception as e:  # pragma: no cover — safety net for unexpected genai_prices errors
+                except Exception as e:
                     warnings.warn(
                         f'Failed to get cost from response: {type(e).__name__}: {e}',
                         CostCalculationFailedWarning,

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -21,9 +21,8 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from pydantic_ai.messages import ModelMessage, ModelResponse
-    from pydantic_ai.models import Model, ModelRequestParameters
+    from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
     from pydantic_ai.models.instrumented import InstrumentationSettings
-    from pydantic_ai.settings import ModelSettings
 
 DEFAULT_INSTRUMENTATION_VERSION = 2
 """Default instrumentation version for `InstrumentationSettings`."""
@@ -177,23 +176,26 @@ def build_tool_definitions(model_request_parameters: ModelRequestParameters) -> 
 @contextmanager
 def open_model_request_span(
     settings: InstrumentationSettings,
-    model: Model,
-    messages: list[ModelMessage],
-    prepared_settings: ModelSettings | None,
-    prepared_parameters: ModelRequestParameters,
-) -> Iterator[Callable[[ModelResponse], None]]:
-    """Open a `chat <model>` CLIENT span and yield a `finish(response)` callback for outcome attrs.
+    request_context: ModelRequestContext,
+) -> Iterator[tuple[Callable[[ModelResponse], None], ModelRequestParameters]]:
+    """Open a `chat <model>` CLIENT span; yield `(finish, prepared_parameters)`.
 
     Shared between `Instrumentation.wrap_model_request` (agent flow) and
     `InstrumentedModel.request`/`request_stream` (standalone / `direct.model_request*`).
-    Caller passes `model.prepare_request(...)` output as `prepared_settings`/`prepared_parameters`
-    so attributes reflect what the provider will actually receive. Token/cost metrics are
-    recorded *after* the span closes so backends that aggregate from span attributes don't
-    double-count.
+    Calls `model.prepare_request(...)` internally and exposes `prepared_parameters` to the
+    caller (the agent-flow capability uses it for end-of-run span attributes). `finish(response)`
+    annotates the response with OTel tool-call metadata and records outcome attributes. Token/cost
+    metrics are recorded *after* the span closes so backends that aggregate from span attributes
+    don't double-count.
     """
     # TODO Missing attributes:
     #  - error.type: unclear if we should do something here or just always rely on span exceptions
     #  - gen_ai.request.stop_sequences/top_k: model_settings doesn't include these
+    model = request_context.model
+    messages = request_context.messages
+    prepared_settings, prepared_parameters = model.prepare_request(
+        request_context.model_settings, request_context.model_request_parameters
+    )
     operation = 'chat'
     span_name = f'{operation} {model.model_name}'
     attributes: dict[str, AttributeValue] = {
@@ -228,6 +230,8 @@ def open_model_request_span(
             # don't double-count.
             def finish(response: ModelResponse) -> None:
                 nonlocal record_metrics
+
+                annotate_tool_call_otel_metadata(response, prepared_parameters)
 
                 # FallbackModel updates these span attributes via get_current_span().
                 attributes.update(getattr(span, 'attributes', {}))
@@ -279,7 +283,7 @@ def open_model_request_span(
                 span.set_attributes(attributes_to_set)
                 span.update_name(f'{operation} {request_model}')
 
-            yield finish
+            yield finish, prepared_parameters
     finally:
         if record_metrics:
             record_metrics()

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -2,29 +2,22 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from opentelemetry.baggage import set_baggage as _otel_set_baggage
 from opentelemetry.context import attach as _otel_attach, detach as _otel_detach
-from opentelemetry.trace import SpanKind, StatusCode
+from opentelemetry.trace import StatusCode
 from pydantic_core import to_json
 
 from pydantic_ai._instrumentation import (
-    GEN_AI_REQUEST_MODEL_ATTRIBUTE,
-    GEN_AI_SYSTEM_ATTRIBUTE,
-    MODEL_SETTING_ATTRIBUTES,
-    CostCalculationFailedWarning,
     InstrumentationNames,
     annotate_tool_call_otel_metadata,
-    build_tool_definitions,
     event_to_dict,
     get_agent_run_baggage_attributes,
     get_instructions,
-    model_attributes,
-    model_request_parameters_attributes,
+    open_model_request_span,
     serialize_any,
 )
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ToolRetryError
@@ -259,7 +252,6 @@ class Instrumentation(AbstractCapability[Any]):
         request_context: ModelRequestContext,
         handler: WrapModelRequestHandler,
     ) -> ModelResponse:
-        settings = self.settings
         model = request_context.model
 
         # Track the latest messages so _run_span_end_attributes has them on error paths
@@ -276,99 +268,13 @@ class Instrumentation(AbstractCapability[Any]):
         # instead of falling back to reading `ModelRequest.instructions` from history.
         self._last_model_request_parameters = prepared_parameters
 
-        operation = 'chat'
-        span_name = f'{operation} {model.model_name}'
-        attributes: dict[str, Any] = {
-            'gen_ai.operation.name': operation,
-            **model_attributes(model),
-            **model_request_parameters_attributes(prepared_parameters),
-            **get_agent_run_baggage_attributes(),
-            'logfire.json_schema': to_json(
-                {
-                    'type': 'object',
-                    'properties': {'model_request_parameters': {'type': 'object'}},
-                }
-            ).decode(),
-        }
-
-        tool_definitions = build_tool_definitions(prepared_parameters)
-        if tool_definitions:
-            attributes['gen_ai.tool.definitions'] = to_json(tool_definitions).decode()
-
-        if prepared_settings:
-            for key in MODEL_SETTING_ATTRIBUTES:
-                if isinstance(value := prepared_settings.get(key), float | int):
-                    attributes[f'gen_ai.request.{key}'] = value
-
-        record_metrics: Callable[[], None] | None = None
-        try:
-            with settings.tracer.start_as_current_span(span_name, attributes=attributes, kind=SpanKind.CLIENT) as span:
-                # `finish` is a closure rather than inline so we can (a) set result attributes
-                # inside the `with span:` block — they attach to the span — and (b) call the
-                # captured `record_metrics` in the outer `finally` AFTER the span closes,
-                # so observability backends that aggregate metrics from span attributes
-                # don't double-count.
-                def finish(response: ModelResponse) -> None:
-                    nonlocal record_metrics
-
-                    # FallbackModel updates these span attributes via get_current_span().
-                    attributes.update(getattr(span, 'attributes', {}))
-                    request_model = attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]
-                    system = cast(str, attributes[GEN_AI_SYSTEM_ATTRIBUTE])
-
-                    response_model = response.model_name or request_model
-                    price_calculation = None
-
-                    def _record_metrics() -> None:
-                        metric_attributes = {
-                            'gen_ai.provider.name': system,
-                            'gen_ai.system': system,
-                            'gen_ai.operation.name': operation,
-                            'gen_ai.request.model': request_model,
-                            'gen_ai.response.model': response_model,
-                        }
-                        settings.record_metrics(response, price_calculation, metric_attributes)
-
-                    record_metrics = _record_metrics
-
-                    # Compute cost before the `is_recording()` gate so `_record_metrics`
-                    # always emits cost data, even when the span is dropped by sampling.
-                    try:
-                        price_calculation = response.cost()
-                    except LookupError:
-                        pass
-                    except Exception as e:  # pragma: no cover — safety net for unexpected genai_prices errors
-                        warnings.warn(
-                            f'Failed to get cost from response: {type(e).__name__}: {e}',
-                            CostCalculationFailedWarning,
-                        )
-
-                    if not span.is_recording():
-                        return
-
-                    settings.handle_messages(request_context.messages, response, system, span, prepared_parameters)
-
-                    attributes_to_set: dict[str, Any] = {
-                        **response.usage.opentelemetry_attributes(),
-                        'gen_ai.response.model': response_model,
-                    }
-                    if price_calculation is not None:
-                        attributes_to_set['operation.cost'] = float(price_calculation.total_price)
-
-                    if response.provider_response_id is not None:
-                        attributes_to_set['gen_ai.response.id'] = response.provider_response_id
-                    if response.finish_reason is not None:
-                        attributes_to_set['gen_ai.response.finish_reasons'] = [response.finish_reason]
-                    span.set_attributes(attributes_to_set)
-                    span.update_name(f'{operation} {request_model}')
-
-                response = await handler(request_context)
-                annotate_tool_call_otel_metadata(response, prepared_parameters)
-                finish(response)
-                return response
-        finally:
-            if record_metrics:
-                record_metrics()
+        with open_model_request_span(
+            self.settings, model, request_context.messages, prepared_settings, prepared_parameters
+        ) as finish:
+            response = await handler(request_context)
+            annotate_tool_call_otel_metadata(response, prepared_parameters)
+            finish(response)
+            return response
 
     # ------------------------------------------------------------------
     # wrap_tool_execute — tool execution span

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -13,7 +13,6 @@ from pydantic_core import to_json
 
 from pydantic_ai._instrumentation import (
     InstrumentationNames,
-    annotate_tool_call_otel_metadata,
     event_to_dict,
     get_agent_run_baggage_attributes,
     get_instructions,
@@ -252,27 +251,18 @@ class Instrumentation(AbstractCapability[Any]):
         request_context: ModelRequestContext,
         handler: WrapModelRequestHandler,
     ) -> ModelResponse:
-        model = request_context.model
-
         # Track the latest messages so _run_span_end_attributes has them on error paths
         # (ctx.messages may be stale because UserPromptNode replaces the list reference).
         self._last_messages = request_context.messages
 
-        prepared_settings, prepared_parameters = model.prepare_request(
-            request_context.model_settings,
-            request_context.model_request_parameters,
-        )
-        # Stash for `_run_span_end_attributes`: feeding the parameters into
-        # `get_instructions` lets it use the canonical `instruction_parts` source
-        # (which includes prompted-output template instructions and is properly sorted)
-        # instead of falling back to reading `ModelRequest.instructions` from history.
-        self._last_model_request_parameters = prepared_parameters
+        with open_model_request_span(self.settings, request_context) as (finish, prepared_parameters):
+            # Stash for `_run_span_end_attributes`: feeding the parameters into
+            # `get_instructions` lets it use the canonical `instruction_parts` source
+            # (which includes prompted-output template instructions and is properly sorted)
+            # instead of falling back to reading `ModelRequest.instructions` from history.
+            self._last_model_request_parameters = prepared_parameters
 
-        with open_model_request_span(
-            self.settings, model, request_context.messages, prepared_settings, prepared_parameters
-        ) as finish:
             response = await handler(request_context)
-            annotate_tool_call_otel_metadata(response, prepared_parameters)
             finish(response)
             return response
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -255,12 +255,12 @@ class Instrumentation(AbstractCapability[Any]):
         # (ctx.messages may be stale because UserPromptNode replaces the list reference).
         self._last_messages = request_context.messages
 
-        with open_model_request_span(self.settings, request_context) as (finish, prepared_parameters):
+        with open_model_request_span(self.settings, request_context) as (finish, prepared_request_context):
             # Stash for `_run_span_end_attributes`: feeding the parameters into
             # `get_instructions` lets it use the canonical `instruction_parts` source
             # (which includes prompted-output template instructions and is properly sorted)
             # instead of falling back to reading `ModelRequest.instructions` from history.
-            self._last_model_request_parameters = prepared_parameters
+            self._last_model_request_parameters = prepared_request_context.model_request_parameters
 
             response = await handler(request_context)
             finish(response)

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import itertools
 import json
 import warnings
-from collections.abc import AsyncIterator, Callable, Iterator
-from contextlib import asynccontextmanager, contextmanager
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from genai_prices.types import PriceCalculation
 from opentelemetry._logs import (
@@ -16,24 +16,17 @@ from opentelemetry._logs import (
     get_logger_provider,
 )
 from opentelemetry.metrics import MeterProvider, get_meter_provider
-from opentelemetry.trace import Span, SpanKind, Tracer, TracerProvider, get_tracer_provider
+from opentelemetry.trace import Span, Tracer, TracerProvider, get_tracer_provider
 from opentelemetry.util.types import AttributeValue
 
 from pydantic_ai._instrumentation import (
     DEFAULT_INSTRUMENTATION_VERSION,
-    GEN_AI_PROVIDER_NAME_ATTRIBUTE,
-    GEN_AI_REQUEST_MODEL_ATTRIBUTE,
     GEN_AI_SYSTEM_ATTRIBUTE,
-    MODEL_SETTING_ATTRIBUTES,
     TOKEN_HISTOGRAM_BOUNDARIES,
-    CostCalculationFailedWarning,
     annotate_tool_call_otel_metadata,
-    build_tool_definitions,
     event_to_dict,
-    get_agent_run_baggage_attributes,
     get_instructions,
-    model_attributes,
-    model_request_parameters_attributes,
+    open_model_request_span,
     serialize_any,
 )
 
@@ -373,10 +366,12 @@ class InstrumentedModel(WrapperModel):
             model_settings,
             model_request_parameters,
         )
-        with self._instrument(messages, prepared_settings, prepared_parameters) as finish:
+        with open_model_request_span(
+            self.instrumentation_settings, self.wrapped, messages, prepared_settings, prepared_parameters
+        ) as finish:
             response = await self.wrapped.request(messages, model_settings, model_request_parameters)
             annotate_tool_call_otel_metadata(response, prepared_parameters)
-            finish(response, prepared_parameters)
+            finish(response)
             return response
 
     @asynccontextmanager
@@ -391,7 +386,9 @@ class InstrumentedModel(WrapperModel):
             model_settings,
             model_request_parameters,
         )
-        with self._instrument(messages, prepared_settings, prepared_parameters) as finish:
+        with open_model_request_span(
+            self.instrumentation_settings, self.wrapped, messages, prepared_settings, prepared_parameters
+        ) as finish:
             response_stream: StreamedResponse | None = None
             try:
                 async with self.wrapped.request_stream(
@@ -402,103 +399,4 @@ class InstrumentedModel(WrapperModel):
                 if response_stream:  # pragma: no branch
                     response = response_stream.get()
                     annotate_tool_call_otel_metadata(response, prepared_parameters)
-                    finish(response, prepared_parameters)
-
-    @contextmanager
-    def _instrument(
-        self,
-        messages: list[ModelMessage],
-        model_settings: ModelSettings | None,
-        model_request_parameters: ModelRequestParameters,
-    ) -> Iterator[Callable[[ModelResponse, ModelRequestParameters], None]]:
-        operation = 'chat'
-        span_name = f'{operation} {self.model_name}'
-        # TODO Missing attributes:
-        #  - error.type: unclear if we should do something here or just always rely on span exceptions
-        #  - gen_ai.request.stop_sequences/top_k: model_settings doesn't include these
-        attributes: dict[str, AttributeValue] = {
-            'gen_ai.operation.name': operation,
-            **model_attributes(self.wrapped),
-            **model_request_parameters_attributes(model_request_parameters),
-            **get_agent_run_baggage_attributes(),
-            'logfire.json_schema': json.dumps(
-                {
-                    'type': 'object',
-                    'properties': {'model_request_parameters': {'type': 'object'}},
-                }
-            ),
-        }
-
-        tool_definitions = build_tool_definitions(model_request_parameters)
-        if tool_definitions:
-            attributes['gen_ai.tool.definitions'] = json.dumps(tool_definitions)
-
-        if model_settings:
-            for key in MODEL_SETTING_ATTRIBUTES:
-                if isinstance(value := model_settings.get(key), float | int):
-                    attributes[f'gen_ai.request.{key}'] = value
-
-        record_metrics: Callable[[], None] | None = None
-        try:
-            with self.instrumentation_settings.tracer.start_as_current_span(
-                span_name, attributes=attributes, kind=SpanKind.CLIENT
-            ) as span:
-
-                def finish(response: ModelResponse, parameters: ModelRequestParameters):
-                    # FallbackModel updates these span attributes.
-                    attributes.update(getattr(span, 'attributes', {}))
-                    request_model = attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]
-                    system = cast(str, attributes[GEN_AI_SYSTEM_ATTRIBUTE])
-
-                    response_model = response.model_name or request_model
-                    price_calculation = None
-
-                    def _record_metrics():
-                        metric_attributes = {
-                            GEN_AI_PROVIDER_NAME_ATTRIBUTE: system,  # New OTel standard attribute
-                            GEN_AI_SYSTEM_ATTRIBUTE: system,  # Preserved for backward compatibility (deprecated)
-                            'gen_ai.operation.name': operation,
-                            'gen_ai.request.model': request_model,
-                            'gen_ai.response.model': response_model,
-                        }
-                        self.instrumentation_settings.record_metrics(response, price_calculation, metric_attributes)
-
-                    nonlocal record_metrics
-                    record_metrics = _record_metrics
-
-                    try:
-                        price_calculation = response.cost()
-                    except LookupError:
-                        # The cost of this provider/model is unknown, which is common.
-                        pass
-                    except Exception as e:
-                        warnings.warn(
-                            f'Failed to get cost from response: {type(e).__name__}: {e}', CostCalculationFailedWarning
-                        )
-
-                    if not span.is_recording():
-                        return
-
-                    self.instrumentation_settings.handle_messages(messages, response, system, span, parameters)
-
-                    attributes_to_set = {
-                        **response.usage.opentelemetry_attributes(),
-                        'gen_ai.response.model': response_model,
-                    }
-
-                    if price_calculation:
-                        attributes_to_set['operation.cost'] = float(price_calculation.total_price)
-
-                    if response.provider_response_id is not None:
-                        attributes_to_set['gen_ai.response.id'] = response.provider_response_id
-                    if response.finish_reason is not None:
-                        attributes_to_set['gen_ai.response.finish_reasons'] = [response.finish_reason]
-                    span.set_attributes(attributes_to_set)
-                    span.update_name(f'{operation} {request_model}')
-
-                yield finish
-        finally:
-            if record_metrics:
-                # We only want to record metrics after the span is finished,
-                # to prevent them from being redundantly recorded in the span itself by logfire.
-                record_metrics()
+                    finish(response)

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -367,8 +367,10 @@ class InstrumentedModel(WrapperModel):
             model_settings=model_settings,
             model_request_parameters=model_request_parameters,
         )
-        with open_model_request_span(self.instrumentation_settings, request_context) as (finish, _):
-            response = await self.wrapped.request(messages, model_settings, model_request_parameters)
+        with open_model_request_span(self.instrumentation_settings, request_context) as (finish, prepared_rc):
+            response = await self.wrapped.request(
+                prepared_rc.messages, prepared_rc.model_settings, prepared_rc.model_request_parameters
+            )
             finish(response)
             return response
 
@@ -386,11 +388,14 @@ class InstrumentedModel(WrapperModel):
             model_settings=model_settings,
             model_request_parameters=model_request_parameters,
         )
-        with open_model_request_span(self.instrumentation_settings, request_context) as (finish, _):
+        with open_model_request_span(self.instrumentation_settings, request_context) as (finish, prepared_rc):
             response_stream: StreamedResponse | None = None
             try:
                 async with self.wrapped.request_stream(
-                    messages, model_settings, model_request_parameters, run_context
+                    prepared_rc.messages,
+                    prepared_rc.model_settings,
+                    prepared_rc.model_request_parameters,
+                    run_context,
                 ) as response_stream:
                     yield response_stream
             finally:

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -23,7 +23,6 @@ from pydantic_ai._instrumentation import (
     DEFAULT_INSTRUMENTATION_VERSION,
     GEN_AI_SYSTEM_ATTRIBUTE,
     TOKEN_HISTOGRAM_BOUNDARIES,
-    annotate_tool_call_otel_metadata,
     event_to_dict,
     get_instructions,
     open_model_request_span,
@@ -39,7 +38,7 @@ from ..messages import (
     SystemPromptPart,
 )
 from ..settings import ModelSettings
-from . import KnownModelName, Model, ModelRequestParameters, StreamedResponse
+from . import KnownModelName, Model, ModelRequestContext, ModelRequestParameters, StreamedResponse
 from .wrapper import WrapperModel
 
 __all__ = 'instrument_model', 'InstrumentationSettings', 'InstrumentedModel'
@@ -362,15 +361,14 @@ class InstrumentedModel(WrapperModel):
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
     ) -> ModelResponse:
-        prepared_settings, prepared_parameters = self.wrapped.prepare_request(
-            model_settings,
-            model_request_parameters,
+        request_context = ModelRequestContext(
+            model=self.wrapped,
+            messages=messages,
+            model_settings=model_settings,
+            model_request_parameters=model_request_parameters,
         )
-        with open_model_request_span(
-            self.instrumentation_settings, self.wrapped, messages, prepared_settings, prepared_parameters
-        ) as finish:
+        with open_model_request_span(self.instrumentation_settings, request_context) as (finish, _):
             response = await self.wrapped.request(messages, model_settings, model_request_parameters)
-            annotate_tool_call_otel_metadata(response, prepared_parameters)
             finish(response)
             return response
 
@@ -382,13 +380,13 @@ class InstrumentedModel(WrapperModel):
         model_request_parameters: ModelRequestParameters,
         run_context: RunContext[Any] | None = None,
     ) -> AsyncIterator[StreamedResponse]:
-        prepared_settings, prepared_parameters = self.wrapped.prepare_request(
-            model_settings,
-            model_request_parameters,
+        request_context = ModelRequestContext(
+            model=self.wrapped,
+            messages=messages,
+            model_settings=model_settings,
+            model_request_parameters=model_request_parameters,
         )
-        with open_model_request_span(
-            self.instrumentation_settings, self.wrapped, messages, prepared_settings, prepared_parameters
-        ) as finish:
+        with open_model_request_span(self.instrumentation_settings, request_context) as (finish, _):
             response_stream: StreamedResponse | None = None
             try:
                 async with self.wrapped.request_stream(
@@ -397,6 +395,4 @@ class InstrumentedModel(WrapperModel):
                     yield response_stream
             finally:
                 if response_stream:  # pragma: no branch
-                    response = response_stream.get()
-                    annotate_tool_call_otel_metadata(response, prepared_parameters)
-                    finish(response)
+                    finish(response_stream.get())


### PR DESCRIPTION
- Follow-up to #5427.

## Summary

Both paths were independently building the same `chat <model>` CLIENT span: same attributes (operation, model, request parameters, baggage, tool definitions, model settings), same `finish(response)` closure, same cost/metrics ordering. Pre-#4967 this was fine because `InstrumentedModel` was the only path. #4967 introduced `Instrumentation.wrap_model_request` and planned to drop `InstrumentedModel` in v2; #5427 then un-deprecated `InstrumentedModel` because the official Logfire SDK uses it, making the duplication permanent.

This PR extracts the shared logic into `_instrumentation.open_model_request_span` (a `@contextmanager` yielding a `finish(response)` callback). Both call sites collapse to:

```python
prepared_settings, prepared_parameters = model.prepare_request(...)
with open_model_request_span(settings, model, messages, prepared_settings, prepared_parameters) as finish:
    response = await handler(...)
    annotate_tool_call_otel_metadata(response, prepared_parameters)
    finish(response)
    return response
```

Drops `InstrumentedModel._instrument`. Net -81 lines.

## Why this shape (and not option (ii))

#5400 sketched two dedupe options:
- **(i) Extract a shared helper** — chosen.
- **(ii) Have `InstrumentedModel.request` route through `Instrumentation.wrap_model_request` with a synthesized `RunContext`**.

The agent-side `wrap_model_request` happens to never reference its `ctx` parameter, but synthesizing a stub `RunContext` just to satisfy the signature would be carrying dead structure through a hot path. The free-function helper has the same dedupe benefit without that awkwardness, and keeps the agent-flow-specific bits (`_last_messages` / `_last_model_request_parameters` state for `_run_span_end_attributes`) where they belong — in `Instrumentation`, not leaking into the helper.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).