### PR TITLE
fix(openai): respect `openai_system_prompt_role` in `OpenAIResponsesModel`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2155,11 +2155,12 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             # > Response input messages must contain the word 'json' in some form to use 'text.format' of type 'json_object'.
             # Apparently they're only checking input messages for "JSON", not instructions.
             assert isinstance(instructions, str)
+            system_prompt_role = profile.openai_system_prompt_role or 'system'
             system_prompt_count = next(
-                (i for i, m in enumerate(openai_messages) if m.get('role') != 'system'), len(openai_messages)
+                (i for i, m in enumerate(openai_messages) if m.get('role') != system_prompt_role), len(openai_messages)
             )
             openai_messages.insert(
-                system_prompt_count, responses.EasyInputMessageParam(role='system', content=instructions)
+                system_prompt_count, responses.EasyInputMessageParam(role=system_prompt_role, content=instructions)
             )
             instructions = OMIT
 
@@ -2590,7 +2591,11 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             if isinstance(message, ModelRequest):
                 for part in message.parts:
                     if isinstance(part, SystemPromptPart):
-                        openai_messages.append(responses.EasyInputMessageParam(role='system', content=part.content))
+                        openai_messages.append(
+                            responses.EasyInputMessageParam(
+                                role=profile.openai_system_prompt_role or 'system', content=part.content
+                            )
+                        )
                     elif isinstance(part, UserPromptPart):
                         openai_messages.append(await self._map_user_prompt(part))
                     elif isinstance(part, ToolReturnPart):

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -53,7 +53,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.native_tools import CodeExecutionTool, FileSearchTool, ImageAspectRatio, MCPServerTool, WebSearchTool
 from pydantic_ai.output import NativeOutput, PromptedOutput, TextOutput, ToolOutput
-from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
+from pydantic_ai.profiles.openai import OpenAIModelProfile, OpenAISystemPromptRole, openai_model_profile
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage, RunUsage
 
@@ -10813,6 +10813,38 @@ async def test_openai_responses_system_prompts_ordering(allow_model_requests: No
             {'role': 'user', 'content': 'Hello'},
         ]
     )
+
+
+@pytest.mark.parametrize('system_prompt_role', ['system', 'developer', 'user', None])
+async def test_openai_responses_system_prompt_role(
+    allow_model_requests: None, system_prompt_role: OpenAISystemPromptRole | None
+) -> None:
+    """`openai_system_prompt_role` profile setting drives the role used for `SystemPromptPart`s on the Responses API."""
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='msg_1',
+                content=cast(list[Content], [ResponseOutputText(text='world', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            ),
+        ],
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    profile = OpenAIModelProfile(openai_system_prompt_role=system_prompt_role)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client), profile=profile)
+    agent = Agent(model, system_prompt='some instructions')
+
+    result = await agent.run('hello')
+    assert result.output == 'world'
+
+    expected_role = system_prompt_role or 'system'
+    kwargs = get_mock_responses_kwargs(mock_client)[0]
+    assert kwargs['input'] == [
+        {'content': 'some instructions', 'role': expected_role},
+        {'content': 'hello', 'role': 'user'},
+    ]
 
 
 async def test_reasoning_summary_auto(allow_model_requests: None, openai_api_key: str):


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Part of #3976 

`OpenAIResponsesModel` now reads `openai_system_prompt_role` like `OpenAIChatModel` already did.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
