### PR TITLE
chore: gitignore `local-notes/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ CLAUDE.local.md
 /.cursor/
 /.devcontainer/
 .claude/plans/
+
+# AICA mini-PR diagnostic scratch (see team.pydantic.work)
+local-notes/


### PR DESCRIPTION
Adds `local-notes/` to `.gitignore`.

This directory is used by the AICA `issue-fix-tdd` workflow on team.pydantic.work to drop MRE scratch scripts (`mre_release.py`, `mre_branch.py`) while reproducing an issue. The scripts are diagnostic-only — they reference the workspace as a `file://` editable install — and don't belong in PR diffs. Gitignoring them lets the workflow keep using the path as scratch without leaking the files into the eventual fix PR.

No code changes, just the ignore rule.