### PR TITLE
docs(capabilities): surface `ToolSearch` in the capabilities reference

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -24,6 +24,7 @@ Pydantic AI ships with several capabilities that cover common needs:
 | [`WebFetch`][pydantic_ai.capabilities.WebFetch] | URL fetching — native when supported, [local fallback](common-tools.md#web-fetch-tool) with [`web-fetch` extra](install.md#slim-install) | Yes |
 | [`ImageGeneration`][pydantic_ai.capabilities.ImageGeneration] | Image generation — native when supported, subagent fallback via `fallback_model` | Yes |
 | [`MCP`][pydantic_ai.capabilities.MCP] | MCP server — native when supported, direct connection otherwise | Yes |
+| [`ToolSearch`][pydantic_ai.capabilities.ToolSearch] | Discovery of [deferred tools](tools-advanced.md#tool-search) — native when supported, local `search_tools` function tool otherwise | Yes |
 | [`PrepareTools`][pydantic_ai.capabilities.PrepareTools] | Filters or modifies function [tool definitions](tools.md) per step | — |
 | [`PrepareOutputTools`][pydantic_ai.capabilities.PrepareOutputTools] | Filters or modifies [output tool][pydantic_ai.output.ToolOutput] definitions per step | — |
 | [`PrefixTools`][pydantic_ai.capabilities.PrefixTools] | Wraps a capability and prefixes its tool names | Yes |
@@ -173,6 +174,21 @@ from pydantic_ai.capabilities import NativeOrLocalTool
 
 cap = NativeOrLocalTool(native=CodeExecutionTool(), local=my_local_executor)
 ```
+
+### ToolSearch
+
+The [`ToolSearch`][pydantic_ai.capabilities.ToolSearch] capability handles discovery of tools marked with `defer_loading=True`, so agents with large toolsets only pay tokens for the tools the model needs. Like the [provider-adaptive tools](#provider-adaptive-tools) above, it picks the best path for the active model — native server-executed search on Anthropic and OpenAI Responses, a local `search_tools` function tool elsewhere — and is auto-injected into every agent with zero overhead when no deferred tools exist.
+
+Pass an explicit [`ToolSearch`][pydantic_ai.capabilities.ToolSearch] to pick a specific [`strategy`][pydantic_ai.capabilities.ToolSearch.strategy] (`'keywords'`, `'bm25'`, `'regex'`, or a custom callable) or tune the local fallback:
+
+```python {title="tool_search_capability.py"}
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ToolSearch
+
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[ToolSearch(strategy='keywords')])
+```
+
+See [Tool Search](tools-advanced.md#tool-search) for when to reach for it, the full strategy table, and provider support details.
 
 ### PrepareTools and PrepareOutputTools
 


### PR DESCRIPTION
PR #5143 made [`ToolSearch`](https://github.com/pydantic/pydantic-ai/blob/main/pydantic_ai_slim/pydantic_ai/capabilities/_tool_search.py) a public, user-configurable capability (new `strategy`, `max_results`, `tool_description`, `parameter_description` fields), but `docs/capabilities.md` — the canonical capabilities page — wasn't updated, so the capability was effectively invisible from there.

- Adds a `ToolSearch` row to the Native capabilities table, grouped with the other provider-adaptive capabilities (Spec: Yes — it's in `CAPABILITY_TYPES`).
- Adds a `### ToolSearch` subsection right after `### Provider-adaptive tools` that frames the capability, shows the `strategy=` knob with a runnable example, and links to `tools-advanced.md#tool-search` for the full strategy table rather than duplicating it.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).