### PR TITLE
docs: use 'Pydantic AI' (two words) in multi-agent docs

### DIFF
--- a/docs/multi-agent-applications.md
+++ b/docs/multi-agent-applications.md
@@ -369,9 +369,9 @@ This is essential for understanding and optimizing complex agent workflows. When
 
 ### Full-Stack Visibility
 
-If your PydanticAI application includes a TypeScript frontend, API gateway, or services in other languages, Logfire can trace them too—Logfire provides SDKs for Python, JavaScript/TypeScript, and Rust, plus compatibility with any OpenTelemetry-instrumented application. See traces from your entire stack in a unified view. For details on sending data from other languages using standard OpenTelemetry, see the [alternative clients guide](https://logfire.pydantic.dev/docs/how-to-guides/alternative-clients/).
+If your Pydantic AI application includes a TypeScript frontend, API gateway, or services in other languages, Logfire can trace them too—Logfire provides SDKs for Python, JavaScript/TypeScript, and Rust, plus compatibility with any OpenTelemetry-instrumented application. See traces from your entire stack in a unified view. For details on sending data from other languages using standard OpenTelemetry, see the [alternative clients guide](https://logfire.pydantic.dev/docs/how-to-guides/alternative-clients/).
 
-PydanticAI's instrumentation is built on [OpenTelemetry](https://opentelemetry.io/), so you can also use any OTel-compatible backend. See the [Logfire integration guide](logfire.md) for details.
+Pydantic AI's instrumentation is built on [OpenTelemetry](https://opentelemetry.io/), so you can also use any OTel-compatible backend. See the [Logfire integration guide](logfire.md) for details.
 
 ## Examples
 


### PR DESCRIPTION
 Fix two occurrences of `PydanticAI` (one word) in `docs/multi-agent-applications.md` to
  `Pydantic AI` (two words), matching the rule documented in `docs/AGENTS.md`:

  > Write project name as `Pydantic AI` (two words) in docs — not `Pydantic-AI`, `PydanticAI`, or
  `pAI`

  Other `PydanticAI` occurrences in the docs (`PydanticAIPlugin`, `PydanticAIWorkflow`, etc.) are
  Python class names and left unchanged.

  ### Checklist
 - [x] No **breaking changes** in accordance with the [version
  policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
  - [x] **PR title** is fit for the [release
  changelog](https://github.com/pydantic/pydantic-ai/releases).
