### PR TITLE
fix(openrouter): always set reasoning.enabled=true when thinking is truthy

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -570,6 +570,10 @@ def _openrouter_settings_to_openai_settings(
                 'xhigh': 'high',
             }
             unified_reasoning['effort'] = effort_map[thinking]  # type: ignore[typeddict-item]
+            # Explicitly enable reasoning. For reasoning-by-default models (e.g. openai/gpt-oss-20b)
+            # OpenRouter treats this as a no-op, but for reasoning-optional models (e.g. gemma family)
+            # omitting `enabled` leaves reasoning disabled on some routes despite `effort` being set.
+            unified_reasoning['enabled'] = True
             model_settings['openrouter_reasoning'] = unified_reasoning
 
     if reasoning := model_settings.pop('openrouter_reasoning', None):

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -1013,6 +1013,63 @@ async def test_openrouter_settings_to_openai_settings_with_web_search() -> None:
     assert extra_body['web_search_options'] == {'search_context_size': 'high'}
 
 
+@pytest.mark.parametrize(
+    ('thinking', 'expected_effort'),
+    [
+        (True, 'medium'),
+        ('minimal', 'low'),
+        ('low', 'low'),
+        ('medium', 'medium'),
+        ('high', 'high'),
+        ('xhigh', 'high'),
+    ],
+)
+async def test_openrouter_settings_to_openai_settings_thinking_sets_enabled(
+    thinking: bool | Literal['minimal', 'low', 'medium', 'high', 'xhigh'],
+    expected_effort: str,
+) -> None:
+    """Unified `thinking` must translate to `reasoning.enabled=True` plus mapped `effort`.
+
+    For reasoning-optional models on OpenRouter (e.g. some gemma routes), omitting
+    `enabled: True` leaves reasoning disabled despite `effort` being set. The explicit
+    flag is a no-op for reasoning-by-default models, so this is safe across the board.
+    """
+    settings = OpenRouterModelSettings()
+    model_request_parameters = ModelRequestParameters(thinking=thinking)
+
+    result = _openrouter_settings_to_openai_settings(settings, model_request_parameters)
+
+    extra_body = cast(dict[str, Any], result.get('extra_body', {}))
+    assert 'reasoning' in extra_body
+    reasoning = extra_body['reasoning']
+    assert reasoning['effort'] == expected_effort
+    assert reasoning['enabled'] is True
+
+
+async def test_openrouter_settings_to_openai_settings_thinking_false_omits_reasoning() -> None:
+    """`thinking=False` must not inject a reasoning block."""
+    settings = OpenRouterModelSettings()
+    model_request_parameters = ModelRequestParameters(thinking=False)
+
+    result = _openrouter_settings_to_openai_settings(settings, model_request_parameters)
+
+    extra_body = cast(dict[str, Any], result.get('extra_body', {}))
+    assert 'reasoning' not in extra_body
+
+
+async def test_openrouter_settings_to_openai_settings_explicit_reasoning_wins() -> None:
+    """Explicit `openrouter_reasoning` is honoured verbatim; the unified-thinking fallback is skipped."""
+    explicit_reasoning: dict[str, Any] = {'effort': 'low'}
+    settings = OpenRouterModelSettings(openrouter_reasoning=cast(Any, explicit_reasoning))
+    model_request_parameters = ModelRequestParameters(thinking=True)
+
+    result = _openrouter_settings_to_openai_settings(settings, model_request_parameters)
+
+    extra_body = cast(dict[str, Any], result.get('extra_body', {}))
+    assert extra_body['reasoning'] == {'effort': 'low'}
+    assert 'enabled' not in extra_body['reasoning']
+
+
 async def test_openrouter_prepare_request_loop_with_non_websearch_first(openrouter_api_key: str) -> None:
     """Test prepare_request loop continuation when first tool is not WebSearchTool."""
     from unittest.mock import Mock


### PR DESCRIPTION
## The bug

In `pydantic_ai/models/openrouter.py`, when a user sets `ModelRequestParameters.thinking` to a truthy value, `_openrouter_settings_to_openai_settings` converts it to:

```python
extra_body['reasoning'] = {'effort': <mapped>}
```

It never populates `enabled: true`, even though `OpenRouterReasoning` declares the field.

For models that are **reasoning-by-default** on OpenRouter (e.g. `openai/gpt-oss-20b`, `openai/o3`) this is fine — OpenRouter treats reasoning as enabled implicitly. For **reasoning-optional** models on certain routes (e.g. some `google/gemma-*` providers), the omission leaves reasoning disabled despite the user's explicit `thinking=True`. This is a silent-disable that's hard to diagnose because no error is raised — the model simply doesn't think.

I hit this while building a triage agent at work. A direct curl with `reasoning: {enabled: true, effort: "medium"}` produced reasoning tokens; pydantic-ai's translation produced none. OpenRouter's catalog (`https://openrouter.ai/api/v1/models`) lists `reasoning` in the model's `supported_parameters` — the gap is purely in pydantic-ai's payload construction.

## The fix

One line, in the unified-thinking fallback at `pydantic_ai/models/openrouter.py:572`:

```python
unified_reasoning['effort'] = effort_map[thinking]
unified_reasoning['enabled'] = True  # <-- new
model_settings['openrouter_reasoning'] = unified_reasoning
```

## Backwards compatibility

- **Reasoning-by-default models** (gpt-oss-*, o3, etc.): no behavior change — OpenRouter already treats `enabled` as `True` implicitly.
- **Reasoning-optional models**: previously-silent-disabled requests now correctly enable reasoning, matching the user's `thinking=True` intent.
- **Users who want explicit control** can still pass `OpenRouterModelSettings.openrouter_reasoning={...}` directly; that path is untouched and overrides the unified-thinking fallback entirely (test added asserts this).

## Tests

Added unit tests against `_openrouter_settings_to_openai_settings` in `tests/models/test_openrouter.py` (8 new test cases):

- Parametrized over every `ThinkingLevel` value (`True`, `'minimal'`, `'low'`, `'medium'`, `'high'`, `'xhigh'`): asserts `reasoning.effort` is mapped correctly AND `reasoning.enabled is True`.
- `thinking=False` does not inject a reasoning block.
- Explicit `openrouter_reasoning` is honoured verbatim and the unified-thinking fallback is skipped (no `enabled` flag injected when the user passed only `effort`).

Test invocation:

```
$ python -m pytest tests/models/test_openrouter.py
50 passed in 2.91s
```

Full `tests/models/` suite: `1756 passed, 217 skipped`.

## Notes

- Diff is +4 lines source / +57 lines tests.
- The unit tests cover the translation function directly (no cassettes / no network), so they're cheap and stable.