### PR TITLE
docs: drop nonexistent `logfire.current_span()` from `Instrumentation` docstring

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -56,9 +56,8 @@ class Instrumentation(AbstractCapability[Any]):
     When added to an agent via `capabilities=[Instrumentation(...)]`, this capability
     creates OpenTelemetry spans for the agent run, model requests, and tool executions.
 
-    Other capabilities can add attributes to these spans using either the OpenTelemetry API
-    (`opentelemetry.trace.get_current_span().set_attribute(key, value)`) or the Logfire SDK
-    (`logfire.current_span().set_attribute(key, value)`).
+    Other capabilities can add attributes to these spans using the OpenTelemetry API
+    (`opentelemetry.trace.get_current_span().set_attribute(key, value)`).
     """
 
     settings: InstrumentationSettings = field(default_factory=lambda: _default_settings())


### PR DESCRIPTION
<!-- Trivial doc fix — no linked issue. -->

The `Instrumentation` capability docstring suggested adding span attributes via either `opentelemetry.trace.get_current_span().set_attribute(...)` or `logfire.current_span().set_attribute(...)`. The Logfire SDK has no `current_span()` function (only `logfire.span(...)` as a context-manager constructor), so the second example would `AttributeError` at runtime.

Dropped the Logfire example; the OTel one works under Logfire too, since Logfire spans are OTel spans.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).