### PR TITLE
fix: emit warning when `get_first_param_type` cannot resolve type hints

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -8,6 +8,7 @@ import re
 import sys
 import time
 import uuid
+import warnings
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Iterable, Iterator
 from concurrent.futures import Executor
 from contextlib import asynccontextmanager, contextmanager, suppress
@@ -600,7 +601,14 @@ def get_first_param_type(callable_obj: Callable[..., Any]) -> Any | None:
 
     try:
         type_hints = _typing_extra.get_function_type_hints(_decorators.unwrap_wrapped_function(callable_for_hints))
-    except (NameError, TypeError, AttributeError):
+    except (NameError, TypeError, AttributeError) as e:
+        warnings.warn(
+            f'Could not resolve type hints for {callable_obj!r}: {e}. '
+            f'If the first parameter is annotated as `RunContext` under '
+            f'`if TYPE_CHECKING:`, move the import to module scope.',
+            UserWarning,
+            stacklevel=2,
+        )
         return None
 
     return type_hints.get(first_param_name)


### PR DESCRIPTION
Closes #5358

---

`get_first_param_type()` silently returns `None` when type hint resolution raises `NameError` / `TypeError` / `AttributeError`. This causes `takes_run_context()` to return `False` for callables whose `RunContext` annotation is imported only under `if TYPE_CHECKING:` — leading to a confusing `TypeError` at invocation time with zero diagnostic at registration time.

This adds a `UserWarning` so developers get an actionable message pointing at the unresolvable annotation during registration, without changing the existing fallback behavior (still returns `None`).

The warning text specifically mentions the `TYPE_CHECKING` pattern since that's the most common trigger.

---

*This contribution was made with AI-agent assistance.*