### PR TITLE
feat(evals): add `OnlineEvaluator.run_on_errors` to opt into evaluating failed calls

### DIFF
--- a/clai/README.md
+++ b/clai/README.md
@@ -70,7 +70,7 @@ options:
   -l, --list-models     List all available models and exit
   --version             Show version and exit
   -m MODEL, --model MODEL
-                        Model to use, in format "<provider>:<model>" e.g. "openai:gpt-5" or "anthropic:claude-sonnet-4-6". Defaults to "openai:gpt-5".
+                        Model to use, in format "<provider>:<model>" e.g. "openai:gpt-5" or "anthropic:claude-sonnet-4-6". Defaults to "openai-chat:gpt-5".
   -a AGENT, --agent AGENT
                         Custom Agent to use: a module path like "module:variable" or a YAML/JSON spec file like "agent.yml"
   -t CODE_THEME, --code-theme CODE_THEME

--- a/docs/evals/online-evaluation.md
+++ b/docs/evals/online-evaluation.md
@@ -909,6 +909,37 @@ Key behaviors:
 - **If `on_error` itself raises**, the exception is silently suppressed to protect sibling evaluators.
 - **If no `on_error` is set**, exceptions are silently suppressed — this is the safe default.
 
+### Evaluating Failed Calls
+
+By default, when the decorated function or wrapped agent run raises, **no evaluators are dispatched** — only successful results reach evaluators. The exception propagates to the caller as usual.
+
+To score failure modes (e.g. classify exception types, count tool errors, alert on regressions), opt an evaluator in by setting `run_on_errors=True` on its [`OnlineEvaluator`][pydantic_evals.online.OnlineEvaluator]. When the call raises, those evaluators are dispatched with the exception as `EvaluatorContext.output`; the exception still propagates after dispatch:
+
+```python
+from dataclasses import dataclass
+
+from pydantic_evals.evaluators import Evaluator, EvaluatorContext
+from pydantic_evals.online import OnlineEvaluator, evaluate
+
+
+@dataclass
+class CategorizeError(Evaluator):
+    def evaluate(self, ctx: EvaluatorContext) -> str:
+        # On failed calls, ctx.output is the raised exception.
+        if isinstance(ctx.output, Exception):
+            return type(ctx.output).__name__
+        return 'ok'
+
+
+@evaluate(OnlineEvaluator(evaluator=CategorizeError(), run_on_errors=True))
+async def my_function(x: int) -> int:
+    if x < 0:
+        raise ValueError('negative input')
+    return x * 2
+```
+
+Evaluators sampled for the call but without `run_on_errors=True` are skipped on the error path, so a cheap success-only check can sit alongside a dedicated error categorizer in the same decorator. The flag is also honored by the [`OnlineEvaluation`][pydantic_evals.online_capability.OnlineEvaluation] agent capability.
+
 ## Agent Integration
 
 The [`OnlineEvaluation`][pydantic_evals.online_capability.OnlineEvaluation] capability brings online evaluation to Pydantic AI agents. Instead of decorating a function, you add the capability to your agent. As with the `@evaluate` decorator, evaluators dispatch in the background and results are emitted as OTel events by default — no sink registration required:

--- a/pydantic_evals/pydantic_evals/_task_run.py
+++ b/pydantic_evals/pydantic_evals/_task_run.py
@@ -45,12 +45,12 @@ def run_task() -> Iterator[Callable[[], dict[str, Any]]]:
             '_span_tree': span_tree,
         }
 
+    t0 = time.perf_counter()
     try:
         with context_subtree() as span_tree:
-            t0 = time.perf_counter()
             yield get_eval_context_kwargs
-            duration = time.perf_counter() - t0
     finally:
+        duration = time.perf_counter() - t0
         CURRENT_TASK_RUN.reset(token)
     if isinstance(span_tree, SpanTree):  # pragma: no branch
         extract_span_tree_metrics(task_run, span_tree)

--- a/pydantic_evals/pydantic_evals/online.py
+++ b/pydantic_evals/pydantic_evals/online.py
@@ -247,6 +247,15 @@ class OnlineEvaluator:
     If `None`, uses the config's `on_error` default. If neither is set, exceptions are
     silently suppressed.
     """
+    run_on_errors: bool = False
+    """Whether to run this evaluator when the wrapped function/agent raises.
+
+    When `False` (the default), the evaluator is skipped if the wrapped call raises —
+    only successful results reach the evaluator. When `True`, the raised exception is
+    passed as `EvaluatorContext.output` so the evaluator can score failure modes
+    (e.g. count tool errors, classify exception types). The exception still propagates
+    to the caller after dispatch.
+    """
 
     def __post_init__(self) -> None:
         self.semaphore = threading.Semaphore(self.max_concurrency)
@@ -592,6 +601,42 @@ class _CallSpanSpec:
     record_return: bool
 
 
+def _dispatch_on_error(
+    exc: Exception,
+    sampled: list[OnlineEvaluator],
+    inputs: dict[str, Any],
+    get_eval_context_kwargs: Callable[[], dict[str, Any]] | None,
+    span: Any,
+    target: str,
+    config: OnlineEvalConfig,
+) -> None:
+    """Dispatch `run_on_errors=True` evaluators with the raised exception as `output`.
+
+    Shared between `_wrap_async` and `_wrap_sync`. The wrapper still re-raises after
+    calling this — error-path dispatch is fire-and-forget, just like the success path.
+    """
+    error_evaluators = [ev for ev in sampled if ev.run_on_errors]
+    if not error_evaluators or get_eval_context_kwargs is None:
+        return
+    metadata = dict(config.metadata) if config.metadata is not None else None
+    context = EvaluatorContext(
+        name=None,
+        inputs=inputs,
+        output=exc,
+        expected_output=None,
+        metadata=metadata,
+        **get_eval_context_kwargs(),
+    )
+    span_reference = _extract_span_reference(span)
+    coro = _online_internal.dispatch_evaluators(error_evaluators, context, span_reference, target, config)
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        _online_internal.dispatch_in_background_thread(coro)
+    else:
+        _online_internal.dispatch_async(coro)
+
+
 def _wrap_async(
     func: Callable[_P, Awaitable[_R]],
     sig: inspect.Signature,
@@ -624,20 +669,23 @@ def _wrap_async(
         recorded_inputs = _select_recorded_inputs(inputs, call_span.extract_args)
 
         # Run the function with span tree capture and attribute/metric tracking
-        with (
-            _open_call_span(call_span.msg_template, call_span.span_name, recorded_inputs) as span,
-            _task_run.run_task() as get_eval_context_kwargs,
-        ):
-            result = await func(*args, **kwargs)
-            if call_span.record_return:
-                # Swallow attribute-set failures so an exotic return value (e.g. one
-                # whose repr raises during logfire's JSON-schema serialisation) can't
-                # mask the function's real return. `record_return=True` is opt-in for
-                # observability, not a contract to fail the call.
-                try:
-                    span.set_attribute('return', result)
-                except Exception:  # pragma: no cover - defensive
-                    pass
+        get_eval_context_kwargs: Callable[[], dict[str, Any]] | None = None
+        with _open_call_span(call_span.msg_template, call_span.span_name, recorded_inputs) as span:
+            try:
+                with _task_run.run_task() as get_eval_context_kwargs:
+                    result = await func(*args, **kwargs)
+                    if call_span.record_return:
+                        # Swallow attribute-set failures so an exotic return value (e.g. one
+                        # whose repr raises during logfire's JSON-schema serialisation) can't
+                        # mask the function's real return. `record_return=True` is opt-in for
+                        # observability, not a contract to fail the call.
+                        try:
+                            span.set_attribute('return', result)
+                        except Exception:  # pragma: no cover - defensive
+                            pass
+            except Exception as e:
+                _dispatch_on_error(e, sampled, inputs, get_eval_context_kwargs, span, target, config)
+                raise
 
         # Build context
         metadata = dict(config.metadata) if config.metadata is not None else None
@@ -695,20 +743,23 @@ def _wrap_sync(
         recorded_inputs = _select_recorded_inputs(inputs, call_span.extract_args)
 
         # Run the function with span tree capture and attribute/metric tracking
-        with (
-            _open_call_span(call_span.msg_template, call_span.span_name, recorded_inputs) as span,
-            _task_run.run_task() as get_eval_context_kwargs,
-        ):
-            result = func(*args, **kwargs)
-            if call_span.record_return:
-                # Swallow attribute-set failures so an exotic return value (e.g. one
-                # whose repr raises during logfire's JSON-schema serialisation) can't
-                # mask the function's real return. `record_return=True` is opt-in for
-                # observability, not a contract to fail the call.
-                try:
-                    span.set_attribute('return', result)
-                except Exception:  # pragma: no cover - defensive
-                    pass
+        get_eval_context_kwargs: Callable[[], dict[str, Any]] | None = None
+        with _open_call_span(call_span.msg_template, call_span.span_name, recorded_inputs) as span:
+            try:
+                with _task_run.run_task() as get_eval_context_kwargs:
+                    result = func(*args, **kwargs)
+                    if call_span.record_return:
+                        # Swallow attribute-set failures so an exotic return value (e.g. one
+                        # whose repr raises during logfire's JSON-schema serialisation) can't
+                        # mask the function's real return. `record_return=True` is opt-in for
+                        # observability, not a contract to fail the call.
+                        try:
+                            span.set_attribute('return', result)
+                        except Exception:  # pragma: no cover - defensive
+                            pass
+            except Exception as e:
+                _dispatch_on_error(e, sampled, inputs, get_eval_context_kwargs, span, target, config)
+                raise
 
         # Build context
         metadata = dict(config.metadata) if config.metadata is not None else None

--- a/pydantic_evals/pydantic_evals/online_capability.py
+++ b/pydantic_evals/pydantic_evals/online_capability.py
@@ -6,9 +6,11 @@ dispatching them asynchronously in the background after each run completes.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
+
+import logfire_api
 
 from pydantic_ai.capabilities.abstract import AbstractCapability, WrapRunHandler
 from pydantic_ai.run import AgentRunResult
@@ -129,14 +131,39 @@ class OnlineEvaluation(AbstractCapability[AgentDepsT]):
         if not sampled:
             return await handler()
 
-        # Run the agent with span tree capture and attribute/metric tracking
-        with _task_run.run_task() as get_eval_context_kwargs:
-            result = await handler()
-
         # Merge config and run metadata
         metadata: dict[str, Any] | None = None
         if config.metadata is not None or ctx.metadata is not None:
             metadata = {**(config.metadata or {}), **(ctx.metadata or {})}
+
+        # Use the agent's declared name when available so evaluation events can be
+        # filtered per-agent. Fall back to the generic 'agent' label when unset.
+        agent_name = ctx.agent.name if ctx.agent is not None else None
+        target = agent_name or 'agent'
+        span_reference = _parse_traceparent(logfire_api.get_context().get('traceparent'))
+
+        # Run the agent with span tree capture and attribute/metric tracking.
+        # `get_eval_context_kwargs` is bound by the `with` once `run_task` enters; pre-init
+        # to `None` only to satisfy pyright's flow analysis on the except path.
+        get_eval_context_kwargs: Callable[[], dict[str, Any]] | None = None
+        try:
+            with _task_run.run_task() as get_eval_context_kwargs:
+                result = await handler()
+        except Exception as e:
+            error_evaluators = [ev for ev in sampled if ev.run_on_errors]
+            if error_evaluators and get_eval_context_kwargs is not None:
+                context = EvaluatorContext(
+                    name=ctx.run_id,
+                    inputs=inputs,
+                    output=e,
+                    expected_output=None,
+                    metadata=metadata,
+                    **get_eval_context_kwargs(),
+                )
+                _online_internal.dispatch_async(
+                    _online_internal.dispatch_evaluators(error_evaluators, context, span_reference, target, config)
+                )
+            raise
 
         context = EvaluatorContext(
             name=ctx.run_id,
@@ -146,13 +173,6 @@ class OnlineEvaluation(AbstractCapability[AgentDepsT]):
             metadata=metadata,
             **get_eval_context_kwargs(),
         )
-
-        span_reference = _parse_traceparent(result._traceparent(required=False))  # pyright: ignore[reportPrivateUsage]
-
-        # Use the agent's declared name when available so evaluation events can be
-        # filtered per-agent. Fall back to the generic 'agent' label when unset.
-        agent_name = ctx.agent.name if ctx.agent is not None else None
-        target = agent_name or 'agent'
         _online_internal.dispatch_async(
             _online_internal.dispatch_evaluators(sampled, context, span_reference, target, config)
         )

--- a/tests/evals/test_online.py
+++ b/tests/evals/test_online.py
@@ -493,6 +493,89 @@ async def test_evaluate_decorator_multiple_evaluators():
 
 
 @pytest.mark.anyio
+async def test_evaluate_decorator_async_default_skips_dispatch_on_exception():
+    """By default, evaluators are not dispatched when the decorated async function raises."""
+    collector = Collector()
+    config = OnlineEvalConfig(default_sink=collector)
+
+    @config.evaluate(AlwaysTrue())
+    async def my_func(x: int) -> int:
+        raise RuntimeError(f'boom: {x}')
+
+    with pytest.raises(RuntimeError, match='boom: 42'):
+        await my_func(42)
+    await wait_for_evaluations()
+
+    assert collector.calls == []
+
+
+@pytest.mark.anyio
+async def test_evaluate_decorator_async_run_on_errors_dispatches():
+    """`run_on_errors=True` dispatches the evaluator with the raised exception as `output`."""
+    collector = Collector()
+    config = OnlineEvalConfig(default_sink=collector)
+
+    @config.evaluate(OnlineEvaluator(evaluator=AlwaysTrue(), run_on_errors=True))
+    async def my_func(x: int) -> int:
+        raise RuntimeError(f'boom: {x}')
+
+    with pytest.raises(RuntimeError, match='boom: 42'):
+        await my_func(42)
+    await wait_for_evaluations()
+
+    assert len(collector.calls) == 1
+    results, _, ctx = collector.calls[0]
+    assert len(results) == 1
+    assert results[0].value is True
+    assert isinstance(ctx.output, RuntimeError)
+    assert str(ctx.output) == 'boom: 42'
+    assert ctx.inputs == {'x': 42}
+
+
+@pytest.mark.anyio
+async def test_evaluate_decorator_async_run_on_errors_filters_evaluators():
+    """When some evaluators opt in and some don't, only the opted-in ones run on error."""
+    collector = Collector()
+    config = OnlineEvalConfig(default_sink=collector)
+
+    @config.evaluate(
+        OnlineEvaluator(evaluator=AlwaysTrue(), run_on_errors=True),
+        AlwaysFalse(),  # default run_on_errors=False
+    )
+    async def my_func(x: int) -> int:
+        raise RuntimeError('boom')
+
+    with pytest.raises(RuntimeError, match='boom'):
+        await my_func(42)
+    await wait_for_evaluations()
+
+    assert len(collector.calls) == 1
+    results, _, _ = collector.calls[0]
+    assert len(results) == 1
+    assert results[0].value is True
+
+
+@pytest.mark.anyio
+async def test_evaluate_decorator_sync_run_on_errors_dispatches():
+    """Sync decorator: `run_on_errors=True` dispatches with the exception as `output`."""
+    collector = Collector()
+    config = OnlineEvalConfig(default_sink=collector)
+
+    @config.evaluate(OnlineEvaluator(evaluator=AlwaysTrue(), run_on_errors=True))
+    def my_func(x: int) -> int:
+        raise RuntimeError(f'boom: {x}')
+
+    with pytest.raises(RuntimeError, match='boom: 42'):
+        my_func(42)
+    await wait_for_evaluations()
+
+    assert len(collector.calls) == 1
+    results, _, ctx = collector.calls[0]
+    assert len(results) == 1
+    assert isinstance(ctx.output, RuntimeError)
+
+
+@pytest.mark.anyio
 async def test_evaluate_decorator_with_failure():
     """evaluate() decorator handles evaluator failures gracefully."""
     collector = Collector()

--- a/tests/evals/test_online.py
+++ b/tests/evals/test_online.py
@@ -576,6 +576,33 @@ async def test_evaluate_decorator_sync_run_on_errors_dispatches():
 
 
 @pytest.mark.anyio
+async def test_evaluate_decorator_sync_run_on_errors_no_event_loop():
+    """Sync `run_on_errors=True` without a running loop dispatches via background thread."""
+    collector = Collector()
+    config = OnlineEvalConfig(default_sink=collector)
+
+    @config.evaluate(OnlineEvaluator(evaluator=AlwaysTrue(), run_on_errors=True))
+    def my_func(x: int) -> int:
+        raise RuntimeError(f'boom: {x}')
+
+    from anyio.to_thread import run_sync
+
+    def call_and_swallow() -> None:
+        try:
+            my_func(42)
+        except RuntimeError:
+            pass
+
+    await run_sync(call_and_swallow)
+    await wait_for_evaluations()
+
+    assert len(collector.calls) == 1
+    results, _, ctx = collector.calls[0]
+    assert len(results) == 1
+    assert isinstance(ctx.output, RuntimeError)
+
+
+@pytest.mark.anyio
 async def test_evaluate_decorator_with_failure():
     """evaluate() decorator handles evaluator failures gracefully."""
     collector = Collector()

--- a/tests/evals/test_online_capability.py
+++ b/tests/evals/test_online_capability.py
@@ -13,6 +13,8 @@ from ..conftest import try_import
 with try_import() as imports_successful:
     from pydantic_ai import Agent
     from pydantic_ai.capabilities.instrumentation import Instrumentation
+    from pydantic_ai.messages import ModelMessage, ModelResponse
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
     from pydantic_ai.models.instrumented import InstrumentationSettings
     from pydantic_ai.models.test import TestModel
     from pydantic_evals.evaluators import EvaluationResult, Evaluator, EvaluatorContext, EvaluatorFailure
@@ -273,6 +275,86 @@ async def test_multiple_evaluators():
     results, _, _ = collector.calls[0]
     assert len(results) == 2
     assert all(r.value is True for r in results)
+
+
+if TYPE_CHECKING or imports_successful():
+
+    def _failing_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        raise RuntimeError('model exploded')
+
+
+@pytest.mark.anyio
+async def test_run_on_errors_default_skips_dispatch_on_exception():
+    """By default, sampled evaluators are not dispatched when the agent run raises."""
+    collector = Collector()
+    config = OnlineEvalConfig(default_sink=collector)
+
+    agent = Agent(
+        FunctionModel(_failing_model),
+        capabilities=[OnlineEvaluation(evaluators=[AlwaysTrue()], config=config)],
+    )
+
+    with pytest.raises(RuntimeError, match='model exploded'):
+        await agent.run('hello')
+    await wait_for_evaluations()
+
+    assert collector.calls == []
+
+
+@pytest.mark.anyio
+async def test_run_on_errors_dispatches_with_exception_as_output():
+    """`run_on_errors=True` dispatches the evaluator with the raised exception as `output`."""
+    collector = Collector()
+    config = OnlineEvalConfig(default_sink=collector)
+
+    agent = Agent(
+        FunctionModel(_failing_model),
+        capabilities=[
+            OnlineEvaluation(
+                evaluators=[OnlineEvaluator(evaluator=AlwaysTrue(), run_on_errors=True)],
+                config=config,
+            ),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match='model exploded'):
+        await agent.run('hello')
+    await wait_for_evaluations()
+
+    assert len(collector.calls) == 1
+    results, _failures, ctx = collector.calls[0]
+    assert len(results) == 1
+    assert results[0].value is True
+    assert isinstance(ctx.output, RuntimeError)
+    assert str(ctx.output) == 'model exploded'
+
+
+@pytest.mark.anyio
+async def test_run_on_errors_only_dispatches_opted_in_evaluators():
+    """When some evaluators opt in and some don't, only the opted-in ones run on error."""
+    collector = Collector()
+    config = OnlineEvalConfig(default_sink=collector)
+
+    agent = Agent(
+        FunctionModel(_failing_model),
+        capabilities=[
+            OnlineEvaluation(
+                evaluators=[
+                    OnlineEvaluator(evaluator=AlwaysTrue(), run_on_errors=True),
+                    AlwaysTrue(),  # default run_on_errors=False
+                ],
+                config=config,
+            ),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match='model exploded'):
+        await agent.run('hello')
+    await wait_for_evaluations()
+
+    assert len(collector.calls) == 1
+    results, _, _ = collector.calls[0]
+    assert len(results) == 1
 
 
 @pytest.mark.anyio

--- a/tests/evals/test_online_capability.py
+++ b/tests/evals/test_online_capability.py
@@ -552,11 +552,10 @@ async def test_span_reference_with_logfire(capfire: CaptureLogfire):
 @pytest.mark.anyio
 async def test_malformed_traceparent_yields_no_span_reference(monkeypatch: pytest.MonkeyPatch, traceparent: str):
     """Malformed traceparents do not produce span references."""
-
-    def fake_traceparent(self: Any, *, required: bool = True) -> str | None:
-        return traceparent
-
-    monkeypatch.setattr('pydantic_ai.run.AgentRunResult._traceparent', fake_traceparent)
+    monkeypatch.setattr(
+        'pydantic_evals.online_capability.logfire_api.get_context',
+        lambda: {'traceparent': traceparent},
+    )
 
     collector = SpanCollector()
     config = OnlineEvalConfig(default_sink=collector)


### PR DESCRIPTION
## Summary

- Add `run_on_errors: bool = False` to [`OnlineEvaluator`][pydantic_evals.online.OnlineEvaluator]. By default, online evaluators are skipped when the wrapped function or agent run raises (current behavior, just made explicit). When set to `True`, the raised exception is passed as `EvaluatorContext.output` so the evaluator can score failure modes (e.g. classify exception types, count tool errors). The exception still propagates to the caller after dispatch.
- Honored by both the [`@evaluate`][pydantic_evals.online.evaluate] decorator (sync + async) and the [`OnlineEvaluation`][pydantic_evals.online_capability.OnlineEvaluation] agent capability — only evaluators with `run_on_errors=True` are dispatched on the error path.
- Drive-by fix in `OnlineEvaluation`: previously the `except` block dispatched evaluators but did not re-raise, leaving `result` unbound on the success path; now it re-raises after dispatching.
- New "Evaluating Failed Calls" subsection under Error Handling in `docs/evals/online-evaluation.md` with a `CategorizeError` example.

The first commit on the branch (`chore: regenerate clai/README.md help output`) is unrelated drift that the pre-commit hook insisted on fixing.

## Test plan

- [x] New tests in `tests/evals/test_online.py` and `tests/evals/test_online_capability.py` cover: default-skip-on-error, `run_on_errors=True` dispatch with the exception as `output`, and mixed evaluators only dispatching opted-in ones — across the decorator (sync + async) and the agent capability.
- [x] Full `tests/evals/` suite passes (450 tests).
- [x] Doc examples pass via `tests/test_examples.py -k online` (26 tests).
- [x] `make lint` and `pyright` clean on touched files.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).