### PR TITLE
docs(agents): instruct agents to not always `make typecheck` and `make test` with incremental changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,15 @@ The project uses:
 - [`logfire`](docs/logfire.md) for OTel instrumentation of Pydantic AI and `httpx`
     - If you have access to the Logfire MCP server, you can use it to inspect agent runs, tool calls, and model requests
 
+### Running checks efficiently
+
+`make typecheck` and `make test` run against the whole repo and take several minutes each; running them after every individual file edit turns a 10-minute refactor into a multi-hour session. Don't.
+
+- For mechanical/sweeping changes (import renames, symbol moves, deprecation shims, type-only refactors): finish the whole change first, then run `make typecheck` and `make test` once at the end. Editing 20 files and running checks once is the right shape, not editing 1 file and running checks 20 times.
+- For semantic/behavioral changes: iterate with scoped commands, not the Makefile targets. Use `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright <changed_path>` for type checking and `uv run pytest tests/path/test_foo.py::test_bar` (or a single test file) for tests. Save the full `make typecheck` / `make test` for one final pass before declaring the task done.
+- If you need to verify cross-file impact, escalate scope incrementally (e.g. `uv run pyright pydantic_ai_slim/pydantic_ai/models/`) rather than jumping straight to the whole repo.
+- After a failure, fix and re-run only the failing target; don't re-run the full suite to "confirm green" between fixes — that's what the final pass is for.
+
 # Coding Guidelines
 
 When generating or reviewing code anywhere in this repo, always read [agent_docs/index.md](agent_docs/index.md) and follow/enforce those guidelines. Don't forget to read the linked "topic guides" when appropriate.


### PR DESCRIPTION
`make typecheck` and `make test` take several minutes each; agents re-running them after every file edit can stretch a 10-minute refactor into a multi-hour session. Add explicit guidance under "Development workflow" to batch full Makefile runs, and use scoped `uv run pyright <path>` / `uv run pytest <node-id>` commands during iteration.

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
