### PR TITLE
chore(ai): add testing-skill and refresh agent docs (`AGENTS.md` verify cadence, PR-title rule, `tests/AGENTS.md`)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,8 @@
       "Bash(gh run view:*)",
       "Bash(gh run list:*)",
       "Bash(uv run:*)",
+      "Bash(uv run pyright *)",
+      "Bash(PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright *)",
       "Bash(make:*)"
     ]
   }

--- a/.claude/skills/testing-skill/SKILL.md
+++ b/.claude/skills/testing-skill/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: testing-skill
+description: Record, rewrite, and debug VCR cassettes for HTTP recordings. Use when running tests with --record-mode, verifying cassette playback, or inspecting request/response bodies in YAML cassettes.
+allowed-tools: Bash(uv run pytest *), Bash(uv run python .claude/skills/testing-skill/parse_cassette.py *), Bash(source .env && uv run pytest *), Bash(git diff *)
+---
+
+# Pytest VCR Workflow
+
+Use this skill when recording or re-recording VCR cassettes for tests, or when debugging cassette contents.
+
+## Prerequisites
+
+- Verify `.env` exists: `test -f .env && echo 'ok' || echo 'missing'`
+- Missing API keys will cause clear test errors at runtime
+
+## Important flags
+- `--record-mode=rewrite` : Record cassettes (works for both new and existing)
+- `--lf` : Run only the last failed tests
+- `-vv` : Verbose output
+- `--tb=line` : Short traceback output
+- `-k=""` : Run tests matching the given substring expression
+
+## Recording Cassettes
+
+### Step 1: Record cassettes
+
+```bash
+source .env && uv run pytest path/to/test.py::test_function_name -v --tb=line --record-mode=rewrite
+```
+
+Multiple tests can be specified:
+```bash
+source .env && uv run pytest path/to/test.py::test_one path/to/test.py::test_two -v --tb=line --record-mode=rewrite
+```
+
+### Step 2: Verify recordings
+
+Run the same tests WITHOUT `--record-mode` to verify cassettes play back correctly:
+```bash
+source .env && uv run pytest path/to/test.py::test_function_name -vv --tb=line
+```
+
+### Step 3: Review snapshots
+
+If tests use [`snapshot()`](https://github.com/15r10nk/inline-snapshot) assertions:
+- The test run in Step 2 auto-fills snapshot content
+- Review the generated snapshot files to ensure they match expected output
+- You only review - don't manually write snapshot contents
+- Snapshots capture what the test actually produced, additional to explicit assertions
+
+## Parsing Cassettes
+
+Parse VCR cassette YAML files to inspect request/response bodies without dealing with raw YAML.
+
+### Usage
+
+```bash
+uv run python .claude/skills/testing-skill/parse_cassette.py <cassette_path> [--interaction N]
+```
+
+### Examples
+
+```bash
+# Parse all interactions in a cassette
+uv run python .claude/skills/testing-skill/parse_cassette.py tests/models/cassettes/test_foo/test_bar.yaml
+
+# Parse only interaction 1 (0-indexed)
+uv run python .claude/skills/testing-skill/parse_cassette.py tests/models/cassettes/test_foo/test_bar.yaml --interaction 1
+```
+
+### Output
+
+For each interaction, shows:
+- Request: method, URI, parsed body (truncated base64)
+- Response: status code, parsed body (truncated base64)
+
+Base64 strings longer than 100 chars are truncated for readability.
+
+
+## Full Workflow Example
+
+```bash
+# 1. Record cassette
+source .env && uv run pytest tests/models/test_openai.py::test_chat_completion -v --tb=line --record-mode=rewrite
+
+# 2. Verify playback and fill snapshots
+source .env && uv run pytest tests/models/test_openai.py::test_chat_completion -vv --tb=line
+
+# 3. Review test code diffs (excludes cassettes)
+git diff tests/ -- ':!**/cassettes/**'
+
+# 4. List new/changed cassettes (name only - use parse_cassette.py to inspect)
+git diff --name-only tests/ -- '**/cassettes/**'
+
+# 5. Inspect cassette contents if needed
+uv run python .claude/skills/testing-skill/parse_cassette.py tests/models/cassettes/test_openai/test_chat_completion.yaml
+```

--- a/.claude/skills/testing-skill/parse_cassette.py
+++ b/.claude/skills/testing-skill/parse_cassette.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Parse VCR cassette files and pretty-print request/response bodies."""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def truncate_base64(obj: object, max_len: int = 100) -> object:
+    """Recursively truncate base64-like strings in nested structures."""
+    if isinstance(obj, str):
+        if len(obj) > max_len and re.match(r'^[A-Za-z0-9+/=]+$', obj[:100]):
+            return f'{obj[:50]}...[truncated {len(obj)} chars]...{obj[-20:]}'
+        if obj.startswith('data:') and len(obj) > max_len:
+            return f'{obj[:80]}...[truncated {len(obj)} chars]'
+        return obj
+    elif isinstance(obj, dict):
+        return {k: truncate_base64(v, max_len) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [truncate_base64(item, max_len) for item in obj]
+    return obj
+
+
+def _extract_body(part: dict[str, object]) -> object | None:
+    """Extract body from a request/response, trying parsed_body first, then standard VCR body.string."""
+    if 'parsed_body' in part:
+        return part['parsed_body']
+    body = part.get('body')
+    if isinstance(body, dict):
+        body_str = body.get('string')
+        if isinstance(body_str, str) and body_str:
+            try:
+                return json.loads(body_str)
+            except json.JSONDecodeError:
+                return body_str
+    elif isinstance(body, str) and body:
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return body
+    return None
+
+
+def parse_cassette(path: Path, interaction_idx: int | None = None) -> None:
+    """Parse and print cassette contents."""
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    interactions = data.get('interactions', [])
+    if not interactions:
+        print('No interactions found in cassette')
+        return
+
+    indices = [interaction_idx] if interaction_idx is not None else range(len(interactions))
+
+    for i in indices:
+        if i < 0 or i >= len(interactions):
+            print(f'Interaction {i} not found (only {len(interactions)} interactions)')
+            continue
+
+        interaction = interactions[i]
+        req = interaction.get('request', {})
+        resp = interaction.get('response', {})
+
+        print(f'\n{"="*60}')
+        print(f'INTERACTION {i}')
+        print('='*60)
+
+        print(f'\n--- REQUEST ---')
+        print(f'Method: {req.get("method", "N/A")}')
+        print(f'URI: {req.get("uri", "N/A")}')
+        req_body = _extract_body(req)
+        if req_body is not None:
+            truncated = truncate_base64(req_body)
+            print(f'Body:\n{json.dumps(truncated, indent=2)}')
+
+        print(f'\n--- RESPONSE ---')
+        status = resp.get('status', {})
+        print(f'Status: {status.get("code", "N/A")} {status.get("message", "")}')
+        resp_body = _extract_body(resp)
+        if resp_body is not None:
+            truncated = truncate_base64(resp_body)
+            print(f'Body:\n{json.dumps(truncated, indent=2)}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Parse VCR cassette files')
+    parser.add_argument('cassette', type=Path, help='Path to cassette YAML file')
+    parser.add_argument('--interaction', '-i', type=int, help='Specific interaction index (0-based)')
+    args = parser.parse_args()
+
+    if not args.cassette.exists():
+        print(f'File not found: {args.cassette}', file=sys.stderr)
+        sys.exit(1)
+
+    parse_cassette(args.cassette, args.interaction)
+
+
+if __name__ == '__main__':
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ CLAUDE.local.md
 .claude/skills/*
 !.claude/skills/address-feedback
 !.claude/skills/pre-push-review
+!.claude/skills/testing-skill
 .github/.review-context/
 /.cursor/
 /.devcontainer/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ All changes need to:
 
 When you submit a PR, make sure you include the [PR template](.github/pull_request_template.md) and fill in the issue number that should be closed when the PR is merged. The "AI generated code" checkbox should always be checked manually by the user in the UI, not by the agent.
 
+PR titles feed directly into the release changelog — wrap code identifiers (class names, keyword arguments, module paths, CLI flags, env vars) in backticks, matching the style of recent release notes (e.g. `git log main --oneline -10`).
+
 Never add yourself (Claude) as a co-author on commits. Commits should be authored as the user only, with no `Co-Authored-By` trailer referencing Claude.
 
 ## Repository structure
@@ -98,6 +100,15 @@ The project uses:
     - `tests/test_examples.py` to test all code examples in the docs (including docstrings)
 - [`logfire`](docs/logfire.md) for OTel instrumentation of Pydantic AI and `httpx`
     - If you have access to the Logfire MCP server, you can use it to inspect agent runs, tool calls, and model requests
+
+## When to verify
+
+Pre-commit runs `make lint`, `make format`, and `make typecheck` automatically on every commit; CI additionally runs the full test suite. While iterating, only run targeted checks on the files/tests you have a specific reason to suspect:
+
+- typecheck a single file: `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright path/to/file.py`
+- run a single test: `uv run pytest path/to/test.py::test_name`
+
+Avoid `make typecheck` and `make test` between edits — both are slow and the pre-commit/CI gates cover them at the right time.
 
 # Coding Guidelines
 

--- a/scripts/check_cassettes.py
+++ b/scripts/check_cassettes.py
@@ -5,6 +5,10 @@ This script verifies that every VCR cassette file in the test suite has a
 corresponding test function. Orphaned cassettes (cassettes without tests)
 indicate dead code that should be removed.
 
+The script doesn't handle custom cassette names passed as args
+e.g. `@pytest.mark.vcr('custom_cassette.yaml')`
+Instead, all cassettes _should_ follow the file path set up in conftest.py
+
 Usage:
     python scripts/check_cassettes.py [--verbose]
 """

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,35 +1,167 @@
-<!-- braindump: rules extracted from PR review patterns -->
+# Testing Guidelines
 
-# tests/ Guidelines
+## Test File Structure
 
-## Testing
+```python
+from __future__ import annotations
 
-<!-- rule:177 -->
-- Test through public APIs, not private methods (prefixed with `_`) or helpers — Prevents brittle tests tied to implementation details, reduces maintenance burden when refactoring internals, and validates actual user-facing behavior rather than isolated units
-<!-- rule:173 -->
-- Maintain 1:1 correspondence between test files and source modules (`test_{module}.py`) — consolidate related tests instead of splitting by feature, config, or test type — Prevents test suite fragmentation and makes tests easier to locate by matching source structure; use fixtures/markers to distinguish test types within the file
-<!-- rule:86 -->
-- Use `snapshot()` for complex structured outputs (objects, message sequences, API responses, nested dicts, span attributes) — prevents brittle field-by-field assertions and improves test maintainability — Snapshot testing catches unexpected changes in complex structures more reliably than manual assertions, and `IsStr` matchers handle variable values gracefully
-<!-- rule:318 -->
-- Use `pytest-vcr` cassettes (not mocks) in `tests/models/` — records real HTTP interactions for deterministic replay, captures both success and error cases — Ensures integration tests validate real API behavior without live calls on every run, making tests faster and preventing flakiness from network issues or rate limits
-<!-- rule:334 -->
-- Assert meaningful behavior in tests, not just code execution or type checks — validates correctness and data flow — Prevents false confidence from tests that pass without verifying actual functionality works as intended
-<!-- rule:194 -->
-- In agent/model/stream tests, assert on final output AND snapshot `result.all_messages()` — validates complete execution trace, not just end result — Catches regressions in tool calls, intermediate steps, and message flow that final output assertions miss
-<!-- rule:363 -->
-- Test through real APIs, not mocks — mock only slow/external dependencies outside your control — Improves refactoring safety, documents real usage patterns, and catches integration issues — use lightweight local infrastructure (test servers, in-memory DBs) for systems you control (provider APIs, Temporal workflows, frameworks) in files like `test_{provider}.py`; reserve mocks for third-party HTTP APIs and unreliable external services
-<!-- rule:11 -->
-- Parametrize tests across all providers that support the feature (or at minimum OpenAI, Anthropic, Google) — catches provider-specific regressions and ensures cross-provider compatibility — Prevents breaking unchanged providers when modifying shared model logic, and surfaces integration issues across different provider APIs before they reach production
-<!-- rule:385 -->
-- Ensure test assertions match test names and docstrings — prevents false confidence in test coverage and catches actual regressions — Tests without proper assertions or that verify opposite behavior create false positives and fail to catch bugs they claim to prevent.
-<!-- rule:89 -->
-- Test both positive and negative cases for optional capabilities (model features, server features, streaming) — ensures features work when supported AND fail gracefully when absent — Prevents false confidence from tests that only check unsupported cases, catching both implementation bugs and missing error handling
-<!-- rule:630 -->
-- Test MCP against real `tests.mcp_server` instance, not mocks — extend test server with helper tools to expose runtime context (instructions, client info, session state) — Verifies actual data flow and integration behavior rather than just testing mock interfaces, catching real-world issues that mocks would miss
+import pytest
+from inline_snapshot import snapshot
 
-## General
+from pydantic_ai import Agent
+from pydantic_ai.models import Model
+# ... other imports
 
-<!-- rule:463 -->
-- Remove stale test docstrings, comments, and historical provider bug notes when behavior changes — Outdated test documentation misleads developers about what's actually being tested and why
+pytestmark = [pytest.mark.anyio, pytest.mark.vcr]
 
-<!-- /braindump -->
+
+# fixtures/helpers immediately before their test
+@pytest.fixture
+def my_helper():
+    ...
+
+
+@pytest.mark.parametrize('model', ['openai', 'anthropic', 'google'], indirect=True)
+@pytest.mark.parametrize('stream', [False, True])
+async def test_feature(model: Model, stream: bool):
+    ...
+```
+
+## Parametrization with Expectations
+
+For cartesian product tests, use a dict to map parameter combinations to expected results:
+
+```python
+from vcr.cassette import Cassette
+
+from pydantic_ai.models import Model
+
+# expectation can be a dataclass, for more complex cases
+EXPECTATIONS: dict[tuple[str, bool], str] = {
+    ('openai', False): 'expected output for openai non-streaming',
+    ('openai', True): 'expected output for openai streaming',
+    ('anthropic', False): 'expected output for anthropic non-streaming',
+    ('anthropic', True): 'expected output for anthropic streaming',
+}
+
+
+@pytest.mark.parametrize('model', ['openai', 'anthropic'], indirect=True)
+@pytest.mark.parametrize('stream', [False, True])
+async def test_feature(model: Model, stream: bool, request: pytest.FixtureRequest, vcr: Cassette):
+    """What the test is asserting.
+
+    Use the `request` fixture to access test parameter values.
+
+    Use the `vcr` to make assertions about the HTTP requests if needed.
+    Another creative way of, for instance, asserting headers, is to use a patched httpx client fixture.
+    This spares us the overhead of parsing cassette fields, so it is to be preferred whenever optimal.
+    """
+    model_name = request.node.callspec.params['model']
+    expected = EXPECTATIONS[(model_name, stream)]
+
+    agent = Agent(model)
+    if stream:
+        async with agent.run_stream('hello') as result:
+            output = await result.get_output()
+    else:
+        result = await agent.run('hello')
+        output = result.output
+
+    assert output == expected
+```
+
+## VCR Workflow
+
+Record cassettes with `--record-mode=rewrite`, verify playback without the flag, and review diffs.
+For detailed workflows see `.claude/skills/testing-skill/SKILL.md`.
+
+## Key Fixtures
+
+### From `conftest.py`
+
+#### Model requests
+- `allow_model_requests` - bypasses the default `ALLOW_MODEL_REQUESTS = False`
+
+#### The `model` fixture (use with `indirect=True`)
+
+The `model` fixture takes a string param (e.g. `'openai'`, `'anthropic'`, `'google'`) and returns a configured `Model` instance, using session-scoped API key fixtures that default to `'mock-api-key'` (real keys loaded from env when recording).
+See `tests/conftest.py` for the full list of supported param values.
+
+```python
+@pytest.mark.parametrize('model', ['openai', 'anthropic'], indirect=True)
+async def test_something(model: Model):
+    ...
+```
+
+#### Environment management
+- `env` - `TestEnv` instance for temporary env var changes
+  ```python
+  def test_missing_key(env: TestEnv):
+      env.remove('OPENAI_API_KEY')
+      with pytest.raises(UserError):
+          ...
+  ```
+
+#### Binary content (session-scoped)
+- `assets_path` - `Path` to `tests/assets/`
+- `image_content` - `BinaryImage` (kiwi.jpg)
+- `audio_content` - `BinaryContent` (marcelo.mp3)
+- `video_content` - `BinaryContent` (small_video.mp4)
+- `document_content` - `BinaryContent` (dummy.pdf)
+- `text_document_content` - `BinaryContent` (dummy.txt)
+
+#### SSRF protection for URL downloads
+- `disable_ssrf_protection_for_vcr` - required for VCR tests that download URL content (`ImageUrl`, `AudioUrl`, `DocumentUrl`, `VideoUrl` with `force_download=True`)
+- An autouse guard raises a `RuntimeError` if a VCR test triggers SSRF validation without this fixture
+
+## Assertion Helpers
+
+### From `conftest.py`
+- `IsNow(tz=timezone.utc)` - datetime within 10 seconds of now
+- `IsStr()` - any string, supports `regex=r'...'`
+- `IsDatetime()` - any datetime
+- `IsBytes()` - any bytes
+- `IsInt()` - any int
+- `IsFloat()` - any float
+- `IsList()` - any list
+- `IsInstance(SomeClass)` - instance of class
+
+### Additional helpers
+- `IsSameStr()` - asserts same string value across multiple uses in one assertion
+  ```python
+  assert events == [
+      {'id': (msg_id := IsSameStr())},
+      {'id': msg_id},  # must match first
+  ]
+  ```
+
+## Best Practices
+
+- Test through public APIs, not private methods (prefixed with `_`) or helpers — validates actual user-facing behavior and prevents brittle tests tied to implementation details
+- Prefer feature-centric parametrized test files (e.g. `test_multimodal_tool_returns.py`) over appending to monolithic `test_<provider>.py` files — the legacy per-provider files are large and hard for agents to navigate; new features should get their own test file with a `Case` class and parametrized providers
+- Use `snapshot()` for complex structured outputs (objects, message sequences, API responses, nested dicts) — catches unexpected changes more reliably than field-by-field assertions; use `IsStr` and similar matchers for variable values
+- Assert the core aspect of the change being introduced — use whatever means necessary: patching clients to inspect request payloads, tapping into pydantic-ai internals, snapshot comparisons. Snapshots are valuable for catching structural drift in objects and message arrays, but only use `result.all_messages()` or output assertions when the structure demonstrates behavior you care about keeping consistent
+- Test both positive and negative cases for optional capabilities (model features, server features, streaming) — ensures features work when supported AND fail gracefully when absent
+- Ensure test assertions match test names and docstrings — tests without proper assertions or that verify opposite behavior create false positives
+- Test MCP against real `tests.mcp_server` instance, not mocks — extend test server with helper tools to expose runtime context (instructions, client info, session state)
+- Remove stale test docstrings, comments, and historical provider bug notes when behavior changes
+
+## Directory Structure
+
+```
+tests/
+├── conftest.py              # shared fixtures
+├── json_body_serializer.py  # custom VCR serializer
+├── assets/                  # binary test files
+├── cassettes/               # VCR recordings for root tests
+├── models/
+│   ├── conftest.py          # model-specific fixtures (if needed)
+│   ├── cassettes/           # VCR recordings per test file
+│   │   ├── test_openai/
+│   │   ├── test_anthropic/
+│   │   └── ...
+│   └── test_*.py
+├── providers/
+│   └── test_*.py            # provider initialization tests (unit)
+└── test_*.py                # feature tests (prefer VCR + parametrize)
+```


### PR DESCRIPTION
Splits the testing-related changes out of #4211 so they can land independently of the Vertex / Google-Cloud auth changes (which are being reworked alongside the v2 rename), and adds two small agent-facing workflow nudges to `AGENTS.md`.

### Pre-Review Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **Linting and type checking** pass per `make format` and `make typecheck`.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Pre-Merge Checklist

- [x] New **tests** for any fix or new behavior, maintaining 100% coverage.
- [x] Updated **documentation** for new features and behaviors, including docstrings for API docs.

## Changes Made

- **`AGENTS.md`**: New `## When to verify` section directing agents to lean on pre-commit + CI for the full `make typecheck` / `make test` runs and to iterate with targeted `uv run pyright <file>` / `uv run pytest <test>` instead; plus a one-liner asking PR titles to wrap code identifiers in backticks since titles feed the release changelog.
- **`tests/AGENTS.md`**: Testing guidelines covering test file structure, parametrization patterns, the `model` fixture, VCR cassette workflow, key fixtures (`allow_model_requests`, `env`, binary content, SSRF protection), assertion helpers (`IsNow`, `IsStr`, `IsSameStr`, etc.), directory layout, and best practices distilled from PR review patterns.
- **`.claude/skills/testing-skill/SKILL.md`**: A skill for recording, rewriting, and debugging VCR cassettes, with step-by-step instructions for common workflows.
- **`.claude/skills/testing-skill/parse_cassette.py`**: Helper script to parse and display cassette contents in a readable format (request/response bodies, base64 truncation).
- **`.claude/settings.json`**: Allow `Bash(uv run pyright *)` and `Bash(PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright *)` so contributors don't get permission prompts on the targeted typecheck commands (the existing `:*` form doesn't match multi-word commands).
- **`scripts/check_cassettes.py`**: Documents that the script doesn't handle custom cassette names (`@pytest.mark.vcr('foo.yaml')`).
- **`.gitignore`**: Whitelists the new `.claude/skills/testing-skill/` directory.

The Vertex / Google-Cloud auth changes and the `.agents/` directory restructuring from #4211 are intentionally left out of this PR.