### PR TITLE
Make `FunctionToolset.tool()` raise on non-`RunContext` callables

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -270,7 +270,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 raise UserError(
                     f'`FunctionToolset.tool()` requires a function whose first parameter is annotated with `RunContext`. '
                     f'For tools that do not need run context, use `FunctionToolset.tool_plain()` instead. '
-                    f'Got: {func_.__qualname__}'
+                    f'Got: {func_.__qualname__!r}'
                 )
             self.add_function(
                 func=func_,

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -9,7 +9,6 @@ from pydantic.json_schema import GenerateJsonSchema
 
 from .._run_context import AgentDepsT, RunContext
 from .._system_prompt import SystemPromptRunner
-from .._utils import takes_run_context
 from ..exceptions import ModelRetry, UserError
 from ..messages import InstructionPart
 from ..tools import (
@@ -266,12 +265,6 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         def tool_decorator(
             func_: ToolFuncContext[AgentDepsT, ToolParams],
         ) -> ToolFuncContext[AgentDepsT, ToolParams]:
-            if not takes_run_context(func_):
-                raise UserError(
-                    f'`FunctionToolset.tool()` requires a function whose first parameter is annotated with `RunContext`. '
-                    f'For tools that do not need run context, use `FunctionToolset.tool_plain()` instead. '
-                    f'Got: {func_.__qualname__!r}'
-                )
             self.add_function(
                 func=func_,
                 takes_ctx=True,

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
 from typing import Any, overload
@@ -10,6 +9,7 @@ from pydantic.json_schema import GenerateJsonSchema
 
 from .._run_context import AgentDepsT, RunContext
 from .._system_prompt import SystemPromptRunner
+from .._utils import takes_run_context
 from ..exceptions import ModelRetry, UserError
 from ..messages import InstructionPart
 from ..tools import (
@@ -266,15 +266,15 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         def tool_decorator(
             func_: ToolFuncContext[AgentDepsT, ToolParams],
         ) -> ToolFuncContext[AgentDepsT, ToolParams]:
-            # TODO(v2): Remove this deprecation fallback
-            #  and let takes_ctx=True propagate, which will raise a runtime error
-            #  in function_schema if the function doesn't accept RunContext.
-
-            # Is the func actually taking RunContext or is it a plain function in disguise?
-
-            tool = self.add_function(
+            if not takes_run_context(func_):
+                raise UserError(
+                    f'`FunctionToolset.tool()` requires a function whose first parameter is annotated with `RunContext`. '
+                    f'For tools that do not need run context, use `FunctionToolset.tool_plain()` instead. '
+                    f'Got: {func_.__qualname__}'
+                )
+            self.add_function(
                 func=func_,
-                takes_ctx=None,
+                takes_ctx=True,
                 name=name,
                 description=description,
                 retries=retries,
@@ -291,13 +291,6 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
                 defer_loading=defer_loading,
                 include_return_schema=include_return_schema,
             )
-            if not tool.function_schema.takes_ctx:
-                warnings.warn(
-                    'Passing a function without `RunContext` to `FunctionToolset.tool()` is deprecated, use `tool_plain()` instead.',
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
             return func_
 
         return tool_decorator if func is None else tool_decorator(func)

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -2010,22 +2010,28 @@ async def test_no_input_raises_without_toolset_instructions():
         await agent.run()
 
 
-def test_tool_without_runctx_raises_warning():
+def test_tool_without_runctx_raises():
     toolset = FunctionToolset()
-    with pytest.warns(
-        DeprecationWarning, match='Passing a function without `RunContext` to `FunctionToolset.tool\\(\\)`'
+    with pytest.raises(
+        UserError,
+        match=r'`FunctionToolset\.tool\(\)` requires a function whose first parameter is annotated with `RunContext`',
     ):
 
-        @toolset.tool  # type: ignore[arg-type]  # pragma: no cover
-        def add(x: int):
+        @toolset.tool  # type: ignore[arg-type]
+        def add(x: int):  # pragma: no cover
             return x + 1
 
-        @toolset.tool(retries=2)  # type: ignore[arg-type]  # pragma: no cover
-        def sub(x: int):
+    with pytest.raises(
+        UserError,
+        match=r'`FunctionToolset\.tool\(\)` requires a function whose first parameter is annotated with `RunContext`',
+    ):
+
+        @toolset.tool(retries=2)  # type: ignore[arg-type]
+        def sub(x: int):  # pragma: no cover
             return x - 1
 
-    assert 'add' in toolset.tools
-    assert 'sub' in toolset.tools
+    assert 'add' not in toolset.tools
+    assert 'sub' not in toolset.tools
 
 
 class StatefulToolset(AbstractToolset[None]):

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -2010,30 +2010,6 @@ async def test_no_input_raises_without_toolset_instructions():
         await agent.run()
 
 
-def test_tool_without_runctx_raises():
-    toolset = FunctionToolset()
-    with pytest.raises(
-        UserError,
-        match=r'`FunctionToolset\.tool\(\)` requires a function whose first parameter is annotated with `RunContext`',
-    ):
-
-        @toolset.tool  # type: ignore[arg-type]
-        def add(x: int):  # pragma: no cover
-            return x + 1
-
-    with pytest.raises(
-        UserError,
-        match=r'`FunctionToolset\.tool\(\)` requires a function whose first parameter is annotated with `RunContext`',
-    ):
-
-        @toolset.tool(retries=2)  # type: ignore[arg-type]
-        def sub(x: int):  # pragma: no cover
-            return x - 1
-
-    assert 'add' not in toolset.tools
-    assert 'sub' not in toolset.tools
-
-
 class StatefulToolset(AbstractToolset[None]):
     """A custom stateful toolset for testing for_run/for_run_step."""
 


### PR DESCRIPTION
### Description

`FunctionToolset.tool()` is intended for tools that take a `RunContext`. `FunctionToolset.tool_plain()` is the explicit form for tools that don't. The fallback that allowed a no-`RunContext` callable on `.tool()` (shipped with a `DeprecationWarning` in 1.x) is removed in v2.

`FunctionToolset.tool()` now raises a `UserError` directing users to `FunctionToolset.tool_plain()` if the registered callable's first parameter is not annotated with `RunContext`.

### Migration

```python
# Before (v1.x emitted DeprecationWarning, now raises)
@toolset.tool
async def my_tool(query: str) -> str:
    return f'searched: {query}'

# After: add RunContext to the signature...
@toolset.tool
async def my_tool(ctx: RunContext, query: str) -> str:
    return f'searched: {query}'

# ... or switch to tool_plain
@toolset.tool_plain
async def my_tool(query: str) -> str:
    return f'searched: {query}'
```