### PR TITLE
Convert `ModelProfile` to `TypedDict` for easier per-model overrides

### DIFF
--- a/docs/api/profiles.md
+++ b/docs/api/profiles.md
@@ -1,6 +1,14 @@
 # `pydantic_ai.profiles`
 
-::: pydantic_ai.profiles.ModelProfile
+::: pydantic_ai.profiles
+    options:
+      members:
+        - ModelProfile
+        - ModelProfileSpec
+        - merge_profile
+        - DEFAULT_PROFILE
+        - DEFAULT_PROMPTED_OUTPUT_TEMPLATE
+        - DEFAULT_THINKING_TAGS
 
 ::: pydantic_ai.profiles.openai
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,7 +40,7 @@ In v1, `ModelProfile.update()` silently filtered out fields not declared on the 
 
 This means e.g. a Bedrock-hosted Anthropic model's resolved profile now carries the upstream `anthropic_*` fields alongside the `bedrock_*` fields, where v1 dropped them. No in-tree model class reads cross-class fields, so behavior is unchanged in the standard providers; but custom model classes that do `profile.get('anthropic_supports_adaptive_thinking', False)` on a non-Anthropic route will now see the value the upstream Anthropic profile set, where v1 always returned the default.
 
-See [PR #TBD](https://github.com/pydantic/pydantic-ai/pull/0) for the full ModelProfile redesign.
+See [PR #5481](https://github.com/pydantic/pydantic-ai/pull/5481) for the full ModelProfile redesign.
 
 ### v1.0.1 (2025-09-05)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,42 @@ In September 2025, Pydantic AI reached V1, which means we're committed to API st
 
 Here's a filtered list of the breaking changes for each version to help you upgrade Pydantic AI.
 
+### v2.0.0 (unreleased)
+
+#### `ModelProfile` is now a `TypedDict`
+
+`ModelProfile` and all its subclasses (`OpenAIModelProfile`, `AnthropicModelProfile`, `GoogleModelProfile`, `BedrockModelProfile`, etc.) are now `TypedDict(total=False)` instead of `@dataclass`. This unifies the mental model with [`ModelSettings`][pydantic_ai.settings.ModelSettings] (also a `TypedDict`) and enables direct dict-spread for cross-class merging.
+
+`ModelProfile.update()` and `ModelProfile.from_profile()` are removed; use the module-level [`merge_profile`][pydantic_ai.profiles.merge_profile] (later argument wins per key).
+
+Migration recipes:
+
+| v1 (dataclass) | v2 (TypedDict) |
+|---|---|
+| `OpenAIModelProfile(field=value)` | Same syntax; returns a partial `dict` instead of a fully-defaulted instance. |
+| `profile.field` (attribute read) | `profile.get('field', <default>)` |
+| `profile.field = value` (attribute write) | `profile['field'] = value` |
+| `dataclasses.replace(profile, field=value)` | `{**profile, 'field': value}` or `merge_profile(profile, ModelProfile(field=value))` |
+| `profile.update(other)` | `merge_profile(profile, other)` |
+| `OpenAIModelProfile.from_profile(p)` | Just `p` — no upcasting needed |
+| `Model(name, profile=full_profile)` (full replace) | Now merges on top of the provider's default profile — usually what you want. For a hard replace use `Model(name, profile=lambda _default: full_profile)`. |
+| `Model(name, profile=fn)` where `fn: Callable[[str], ModelProfile \| None]` | Removed — the user-passed callable is now `Callable[[ModelProfile], ModelProfile]`, receiving the resolved default and returning the final profile. The `(model_name: str) -> ModelProfile \| None` shape is still accepted internally by `Provider.model_profile`. |
+| `isinstance(profile, OpenAIModelProfile)` | Not supported by `TypedDict` at runtime — raises `TypeError`. Use `isinstance(profile, dict)` or check key presence (`'openai_chat_supports_web_search' in profile`). Pyright still narrows correctly via the TypedDict subclass annotation. |
+
+`Model.profile` is now the single source of truth for the **resolved** profile. It is composed by [`merge_profile`][pydantic_ai.profiles.merge_profile] in this order (later wins):
+
+1. [`DEFAULT_PROFILE`][pydantic_ai.profiles.DEFAULT_PROFILE] — base defaults for every documented key.
+2. `Provider.model_profile(model_name)` — provider/model-specific resolution.
+3. The user's `profile=` argument — either a partial dict (merged on top) or a `Callable[[ModelProfile], ModelProfile]` (full control: receives the resolved default, returns the final profile).
+
+#### Resolved profiles now carry cross-class fields
+
+In v1, `ModelProfile.update()` silently filtered out fields not declared on the target class. In v2, dict-spread preserves every key.
+
+This means e.g. a Bedrock-hosted Anthropic model's resolved profile now carries the upstream `anthropic_*` fields alongside the `bedrock_*` fields, where v1 dropped them. No in-tree model class reads cross-class fields, so behavior is unchanged in the standard providers; but custom model classes that do `profile.get('anthropic_supports_adaptive_thinking', False)` on a non-Anthropic route will now see the value the upstream Anthropic profile set, where v1 always returned the default.
+
+See [PR #TBD](https://github.com/pydantic/pydantic-ai/pull/0) for the full ModelProfile redesign.
+
 ### v1.0.1 (2025-09-05)
 
 The following breaking change was accidentally left out of v1.0.0:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,9 +8,11 @@ Here's a filtered list of the breaking changes for each version to help you upgr
 
 ### v2.0.0 (unreleased)
 
-#### `ModelProfile` is now a `TypedDict`
+#### [`ModelProfile`][pydantic_ai.profiles.ModelProfile] is now a `TypedDict`
 
-`ModelProfile` and all its subclasses (`OpenAIModelProfile`, `AnthropicModelProfile`, `GoogleModelProfile`, `BedrockModelProfile`, etc.) are now `TypedDict(total=False)` instead of `@dataclass`. This unifies the mental model with [`ModelSettings`][pydantic_ai.settings.ModelSettings] (also a `TypedDict`) and enables direct dict-spread for cross-class merging.
+See the [Model Profile guide](models/openai.md#model-profile) for an overview of what a model profile is and how to configure one.
+
+[`ModelProfile`][pydantic_ai.profiles.ModelProfile] and all its subclasses ([`OpenAIModelProfile`][pydantic_ai.profiles.openai.OpenAIModelProfile], [`AnthropicModelProfile`][pydantic_ai.profiles.anthropic.AnthropicModelProfile], [`GoogleModelProfile`][pydantic_ai.profiles.google.GoogleModelProfile], `BedrockModelProfile`, etc.) are now `TypedDict(total=False)` instead of `@dataclass`. This unifies the mental model with [`ModelSettings`][pydantic_ai.settings.ModelSettings] (also a `TypedDict`) and enables direct dict-spread for cross-class merging.
 
 `ModelProfile.update()` and `ModelProfile.from_profile()` are removed; use the module-level [`merge_profile`][pydantic_ai.profiles.merge_profile] (later argument wins per key).
 
@@ -19,7 +21,7 @@ Migration recipes:
 | v1 (dataclass) | v2 (TypedDict) |
 |---|---|
 | `OpenAIModelProfile(field=value)` | Same syntax; returns a partial `dict` instead of a fully-defaulted instance. |
-| `profile.field` (attribute read) | `profile.get('field', <default>)` |
+| `profile.field` (attribute read) | `profile.get('field', <default>)` — non-trivial defaults are exported from [`pydantic_ai.profiles`][pydantic_ai.profiles] (e.g. [`DEFAULT_THINKING_TAGS`][pydantic_ai.profiles.DEFAULT_THINKING_TAGS], [`DEFAULT_PROMPTED_OUTPUT_TEMPLATE`][pydantic_ai.profiles.DEFAULT_PROMPTED_OUTPUT_TEMPLATE]); the fully-merged base is [`DEFAULT_PROFILE`][pydantic_ai.profiles.DEFAULT_PROFILE]. |
 | `profile.field = value` (attribute write) | `profile['field'] = value` |
 | `dataclasses.replace(profile, field=value)` | `{**profile, 'field': value}` or `merge_profile(profile, ModelProfile(field=value))` |
 | `profile.update(other)` | `merge_profile(profile, other)` |

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1014,7 +1014,7 @@ class Model(ABC, Generic[InterfaceClient]):
         """
         # Step 1+2: provider default merged with base default
         provider_profile: ModelProfile = {}
-        if (provider := getattr(self, '_provider', None)) is not None:
+        if (provider := self.provider) is not None:
             provider_profile = provider.model_profile(self.model_name) or {}
         resolved = merge_profile(DEFAULT_PROFILE, provider_profile)
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -674,7 +674,7 @@ class Model(ABC, Generic[InterfaceClient]):
     @property
     def provider(self) -> Provider[InterfaceClient] | None:
         """The provider for this model, if any."""
-        return self._provider
+        return getattr(self, '_provider', None)
 
     async def __aenter__(self) -> Self:
         """Enter the model context, delegating to the provider to manage its HTTP client lifecycle."""

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -49,10 +49,10 @@ from ..messages import (
     ToolCallPart,
     VideoUrl,
 )
-from ..native_tools import AbstractNativeTool
+from ..native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool
 from ..native_tools._tool_search import ToolSearchTool
 from ..output import OutputMode, StructuredOutputMode
-from ..profiles import DEFAULT_PROFILE, ModelProfile, ModelProfileSpec
+from ..profiles import DEFAULT_PROFILE, DEFAULT_PROMPTED_OUTPUT_TEMPLATE, ModelProfile, ModelProfileSpec, merge_profile
 from ..providers import InterfaceClient, Provider, infer_provider, infer_provider_class
 from ..settings import ModelSettings, ThinkingLevel, merge_model_settings
 from ..tools import ToolDefinition
@@ -756,7 +756,7 @@ class Model(ABC, Generic[InterfaceClient]):
         In particular, this method can be used to make modifications to the generated tool JSON schemas if necessary
         for vendor/model-specific reasons.
         """
-        if transformer := self.profile.json_schema_transformer:
+        if transformer := self.profile.get('json_schema_transformer'):
             model_request_parameters = replace(
                 model_request_parameters,
                 function_tools=[_customize_tool_def(transformer, t) for t in model_request_parameters.function_tools],
@@ -791,8 +791,10 @@ class Model(ABC, Generic[InterfaceClient]):
         # Resolve unified thinking setting and strip from model_settings
         if model_settings and 'thinking' in model_settings:
             thinking_value = model_settings['thinking']
-            if self.profile.supports_thinking or self.profile.thinking_always_enabled:
-                if not (thinking_value is False and self.profile.thinking_always_enabled):
+            supports_thinking = self.profile.get('supports_thinking', False)
+            thinking_always_enabled = self.profile.get('thinking_always_enabled', False)
+            if supports_thinking or thinking_always_enabled:
+                if not (thinking_value is False and thinking_always_enabled):
                     params = replace(params, thinking=thinking_value)
             stripped = {k: v for k, v in model_settings.items() if k != 'thinking'}
             model_settings = cast(ModelSettings, stripped) if stripped else None
@@ -804,7 +806,7 @@ class Model(ABC, Generic[InterfaceClient]):
                 native_tools=list({tool.unique_id: tool for tool in native_tools}.values()),
             )
 
-        params = params.with_default_output_mode(self.profile.default_structured_output_mode)
+        params = params.with_default_output_mode(self.profile.get('default_structured_output_mode', 'tool'))
 
         # Reset irrelevant fields
         if params.output_tools and params.output_mode != 'tool':
@@ -817,9 +819,15 @@ class Model(ABC, Generic[InterfaceClient]):
         # Set default prompted output template
         if (
             params.output_mode == 'prompted'
-            or (params.output_mode == 'native' and self.profile.native_output_requires_schema_in_instructions)
+            or (
+                params.output_mode == 'native'
+                and self.profile.get('native_output_requires_schema_in_instructions', False)
+            )
         ) and params.prompted_output_template is None:
-            params = replace(params, prompted_output_template=self.profile.prompted_output_template)
+            params = replace(
+                params,
+                prompted_output_template=self.profile.get('prompted_output_template', DEFAULT_PROMPTED_OUTPUT_TEMPLATE),
+            )
 
         # Append prompted_output_instructions to instruction_parts so models that use structured
         # instruction parts (for per-part system messages or cache placement) also get them.
@@ -829,11 +837,11 @@ class Model(ABC, Generic[InterfaceClient]):
             params = replace(params, instruction_parts=InstructionPart.sorted(parts))
 
         # Check if output mode is supported
-        if params.output_mode == 'native' and not self.profile.supports_json_schema_output:
+        if params.output_mode == 'native' and not self.profile.get('supports_json_schema_output', False):
             raise UserError('Native structured output is not supported by this model.')
-        if params.output_mode == 'tool' and not self.profile.supports_tools:
+        if params.output_mode == 'tool' and not self.profile.get('supports_tools', True):
             raise UserError('Tool output is not supported by this model.')
-        if params.allow_image_output and not self.profile.supports_image_output:
+        if params.allow_image_output and not self.profile.get('supports_image_output', False):
             raise UserError('Image output is not supported by this model.')
 
         # Check native tools and handle fallback swap
@@ -856,7 +864,7 @@ class Model(ABC, Generic[InterfaceClient]):
         agent's behalf in `_agent_graph._make_request` so per-adapter message-prep code
         sees a homogeneous shape regardless of which provider produced the prior turn.
         """
-        if ToolSearchTool not in self.profile.supported_native_tools:
+        if ToolSearchTool not in self.profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS):
             from .._tool_search import synthesize_local_tool_search_messages
 
             return synthesize_local_tool_search_messages(messages)
@@ -889,7 +897,7 @@ class Model(ABC, Generic[InterfaceClient]):
           to this drop, so making `optional` a base-class field doesn't accidentally cause
           e.g. `WebSearchTool(optional=True)` to be dropped here.
         """
-        supported_types = self.profile.supported_native_tools
+        supported_types = self.profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)
 
         supported_natives = [t for t in params.native_tools if isinstance(t, tuple(supported_types))]
         unsupported_natives = [t for t in params.native_tools if not isinstance(t, tuple(supported_types))]
@@ -993,26 +1001,42 @@ class Model(ABC, Generic[InterfaceClient]):
     def profile(self) -> ModelProfile:
         """The model profile.
 
-        We use this to compute the intersection of the profile's supported_native_tools
-        and the model's implemented tools, ensuring model.profile.supported_native_tools
-        is the single source of truth for what native tools are actually usable.
+        Resolution order (later layers override earlier ones):
+          1. `DEFAULT_PROFILE` — base values for every key in `ModelProfile`.
+          2. The provider's `model_profile(model_name)` result — provider-specific defaults
+             for this model.
+          3. The user's `profile=` argument — partial dict merged on top, OR a callable
+             `(default) -> profile` for full control.
+
+        After resolution we compute the intersection of the profile's `supported_native_tools`
+        and the model class's implemented tools, ensuring `model.profile['supported_native_tools']`
+        is the single source of truth for what's actually usable.
         """
-        _profile = self._profile
-        if callable(_profile):
-            _profile = _profile(self.model_name)
+        # Step 1+2: provider default merged with base default
+        provider_profile: ModelProfile = {}
+        if (provider := getattr(self, '_provider', None)) is not None:
+            provider_profile = provider.model_profile(self.model_name) or {}
+        resolved = merge_profile(DEFAULT_PROFILE, provider_profile)
 
-        if _profile is None:
-            _profile = DEFAULT_PROFILE
+        # Step 3: user override
+        user = self._profile
+        if user is None:
+            pass
+        elif callable(user):
+            # New v2 form: (default profile) -> final profile
+            resolved = user(resolved)
+        else:
+            # Partial dict — merge on top
+            resolved = merge_profile(resolved, user)
 
-        # Compute intersection: profile's allowed tools & model's implemented tools
+        # Step 4: native tools intersection — profile's allowed tools & model's implemented tools
         model_supported = self.__class__.supported_native_tools()
-        profile_supported = _profile.supported_native_tools
+        profile_supported = resolved.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)
         effective_tools = profile_supported & model_supported
-
         if effective_tools != profile_supported:
-            _profile = replace(_profile, supported_native_tools=effective_tools)
+            resolved = merge_profile(resolved, ModelProfile(supported_native_tools=effective_tools))
 
-        return _profile
+        return resolved
 
     @property
     @abstractmethod
@@ -1669,7 +1693,7 @@ def _prepare_return_schemas(params: ModelRequestParameters, profile: ModelProfil
     return schemas keep the schema as-is; other models get it injected into the tool description.
     Tools that haven't opted in have their `return_schema` cleared.
     """
-    inject = not profile.supports_tool_return_schema
+    inject = not profile.get('supports_tool_return_schema', False)
     resolved: list[ToolDefinition] = []
     changed = False
     for td in params.function_tools:

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -481,7 +481,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             provider = infer_provider('gateway/anthropic' if provider == 'gateway' else provider)
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile)
+        super().__init__(settings=settings, profile=profile)
 
     @property
     def client(self) -> AsyncAnthropicClient:
@@ -572,11 +572,11 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
     def prepare_request(
         self, model_settings: ModelSettings | None, model_request_parameters: ModelRequestParameters
     ) -> tuple[ModelSettings | None, ModelRequestParameters]:
-        profile = AnthropicModelProfile.from_profile(self.profile)
+        profile = cast(AnthropicModelProfile, self.profile)
         merged = merge_model_settings(self.settings, model_settings) or {}
 
         if (
-            profile.anthropic_disallows_budget_thinking
+            profile.get('anthropic_disallows_budget_thinking', False)
             and (anthropic_thinking := merged.get('anthropic_thinking'))
             and anthropic_thinking.get('type') == 'enabled'
         ):
@@ -593,13 +593,15 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             thinking_enabled = True
 
         if model_request_parameters.output_tools and thinking_enabled:
-            output_mode = 'native' if self.profile.supports_json_schema_output else 'prompted'
+            output_mode = 'native' if self.profile.get('supports_json_schema_output', False) else 'prompted'
             model_request_parameters = model_request_parameters.with_default_output_mode(output_mode)
             if (
                 model_request_parameters.output_mode == 'tool' and not model_request_parameters.allow_text_output
             ):  # pragma: no branch
                 # This would result in `tool_choice=required`, which Anthropic does not support with thinking.
-                suggested_output_type = 'NativeOutput' if self.profile.supports_json_schema_output else 'PromptedOutput'
+                suggested_output_type = (
+                    'NativeOutput' if self.profile.get('supports_json_schema_output', False) else 'PromptedOutput'
+                )
                 raise UserError(
                     f'Anthropic does not support thinking and output tools at the same time. Use `output_type={suggested_output_type}(...)` instead.'
                 )
@@ -615,7 +617,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             )
 
         prepared_settings, model_request_parameters = super().prepare_request(model_settings, model_request_parameters)
-        if profile.anthropic_disallows_sampling_settings and prepared_settings:
+        if profile.get('anthropic_disallows_sampling_settings', False) and prepared_settings:
             filtered: ModelSettings = {**prepared_settings}
             self._drop_unsupported_sampling_settings(filtered)
             prepared_settings = filtered or None
@@ -652,8 +654,8 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         thinking = model_request_parameters.thinking
         if thinking is None or thinking is False:
             return OMIT  # type: ignore[return-value]
-        profile = AnthropicModelProfile.from_profile(self.profile)
-        if profile.anthropic_supports_adaptive_thinking:
+        profile = cast(AnthropicModelProfile, self.profile)
+        if profile.get('anthropic_supports_adaptive_thinking', False):
             return {'type': 'adaptive'}
         return {'type': 'enabled', 'budget_tokens': ANTHROPIC_THINKING_BUDGET_MAP[thinking]}
 
@@ -700,7 +702,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             system_prompt, anthropic_messages, tools, automatic_caching=auto_cache_control is not None
         )
         output_config = self._build_output_config(model_request_parameters, model_settings)
-        anthropic_profile = AnthropicModelProfile.from_profile(self.profile)
+        anthropic_profile = cast(AnthropicModelProfile, self.profile)
         betas, extra_headers = self._get_betas_and_extra_headers(model_settings, anthropic_profile)
         betas.update(native_tool_betas)
         context_management = self._add_compaction_params(messages, betas, model_settings)
@@ -804,7 +806,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
 
     def _client_supports_fast_speed(self, anthropic_profile: AnthropicModelProfile) -> bool:
         """Fast mode is only available on the direct Anthropic API (not Bedrock, Vertex, or Foundry)."""
-        return anthropic_profile.anthropic_supports_fast_speed and not isinstance(
+        return anthropic_profile.get('anthropic_supports_fast_speed', False) and not isinstance(
             self.client, _FAST_MODE_UNSUPPORTED_CLIENTS
         )
 
@@ -859,7 +861,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             system_prompt, anthropic_messages, tools, automatic_caching=auto_cache_control is not None
         )
         output_config = self._build_output_config(model_request_parameters, model_settings)
-        anthropic_profile = AnthropicModelProfile.from_profile(self.profile)
+        anthropic_profile = cast(AnthropicModelProfile, self.profile)
         betas, extra_headers = self._get_betas_and_extra_headers(model_settings, anthropic_profile)
         betas.update(native_tool_betas)
         context_management = self._add_compaction_params(messages, betas, model_settings)
@@ -976,13 +978,13 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         self, model_settings: AnthropicModelSettings
     ) -> AnthropicCodeExecutionToolVersion:
         version = model_settings.get('anthropic_code_execution_tool_version', 'auto')
-        profile = AnthropicModelProfile.from_profile(self.profile)
+        profile = cast(AnthropicModelProfile, self.profile)
         if version == 'auto':
-            return profile.anthropic_default_code_execution_tool_version
-        if version not in profile.anthropic_supported_code_execution_tool_versions:
+            return profile.get('anthropic_default_code_execution_tool_version', '20250825')
+        if version not in profile.get('anthropic_supported_code_execution_tool_versions', ('20250825',)):
             supported_versions = ', '.join(
                 f'{supported_version!r}'
-                for supported_version in profile.anthropic_supported_code_execution_tool_versions
+                for supported_version in profile.get('anthropic_supported_code_execution_tool_versions', ('20250825',))
             )
             raise UserError(
                 f'`anthropic_code_execution_tool_version={version!r}` is not supported by model '
@@ -1325,7 +1327,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                                     )
                                 )
                         elif response_part.content:  # pragma: no branch
-                            start_tag, end_tag = self.profile.thinking_tags
+                            start_tag, end_tag = self.profile.get('thinking_tags', ('<think>', '</think>'))
                             assistant_content_params.append(
                                 BetaTextBlockParam(
                                     text='\n'.join([start_tag, response_part.content, end_tag]), type='text'
@@ -1896,7 +1898,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             'description': f.description or '',
             'input_schema': f.parameters_json_schema,
         }
-        if f.strict and self.profile.supports_json_schema_output:
+        if f.strict and self.profile.get('supports_json_schema_output', False):
             tool_param['strict'] = f.strict
         if model_settings.get('anthropic_eager_input_streaming'):
             tool_param['eager_input_streaming'] = True
@@ -1919,14 +1921,18 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         effort: Literal['low', 'medium', 'high', 'xhigh', 'max'] | None = model_settings.get('anthropic_effort')
         # Fall back to unified thinking effort level when anthropic_effort is not set
         # Only map effort level strings; bare True just enables thinking without a specific effort
-        profile = AnthropicModelProfile.from_profile(self.profile)
-        if effort is None and profile.anthropic_supports_effort and isinstance(model_request_parameters.thinking, str):
+        profile = cast(AnthropicModelProfile, self.profile)
+        if (
+            effort is None
+            and profile.get('anthropic_supports_effort', False)
+            and isinstance(model_request_parameters.thinking, str)
+        ):
             effort_map: dict[ThinkingEffort, Literal['low', 'medium', 'high', 'xhigh', 'max']] = {
                 'minimal': 'low',
                 'low': 'low',
                 'medium': 'medium',
                 'high': 'high',
-                'xhigh': 'xhigh' if profile.anthropic_supports_xhigh_effort else 'max',
+                'xhigh': 'xhigh' if profile.get('anthropic_supports_xhigh_effort', False) else 'max',
             }
             effort = effort_map[model_request_parameters.thinking]
 
@@ -1949,8 +1955,8 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         if task_budget is None:
             return None
 
-        profile = AnthropicModelProfile.from_profile(self.profile)
-        if not profile.anthropic_supports_task_budgets:
+        profile = cast(AnthropicModelProfile, self.profile)
+        if not profile.get('anthropic_supports_task_budgets', False):
             raise UserError(
                 f'Model {self.model_name!r} does not support `anthropic_task_budget`. '
                 'Anthropic task budgets are currently only supported on `claude-opus-4-7`.'

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import datetime
+from functools import cached_property
 from typing import Any, Literal, TypeAlias, cast, overload
 
 import pydantic_core
@@ -501,6 +502,10 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         """The model provider."""
         return self._provider.name
 
+    @cached_property
+    def profile(self) -> AnthropicModelProfile:
+        return cast(AnthropicModelProfile, super().profile)
+
     @classmethod
     def supported_native_tools(cls) -> frozenset[type[AbstractNativeTool]]:
         """The set of builtin tool types this model can handle."""
@@ -572,7 +577,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
     def prepare_request(
         self, model_settings: ModelSettings | None, model_request_parameters: ModelRequestParameters
     ) -> tuple[ModelSettings | None, ModelRequestParameters]:
-        profile = cast(AnthropicModelProfile, self.profile)
+        profile = self.profile
         merged = merge_model_settings(self.settings, model_settings) or {}
 
         if (
@@ -654,7 +659,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         thinking = model_request_parameters.thinking
         if thinking is None or thinking is False:
             return OMIT  # type: ignore[return-value]
-        profile = cast(AnthropicModelProfile, self.profile)
+        profile = self.profile
         if profile.get('anthropic_supports_adaptive_thinking', False):
             return {'type': 'adaptive'}
         return {'type': 'enabled', 'budget_tokens': ANTHROPIC_THINKING_BUDGET_MAP[thinking]}
@@ -702,7 +707,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             system_prompt, anthropic_messages, tools, automatic_caching=auto_cache_control is not None
         )
         output_config = self._build_output_config(model_request_parameters, model_settings)
-        anthropic_profile = cast(AnthropicModelProfile, self.profile)
+        anthropic_profile = self.profile
         betas, extra_headers = self._get_betas_and_extra_headers(model_settings, anthropic_profile)
         betas.update(native_tool_betas)
         context_management = self._add_compaction_params(messages, betas, model_settings)
@@ -861,7 +866,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             system_prompt, anthropic_messages, tools, automatic_caching=auto_cache_control is not None
         )
         output_config = self._build_output_config(model_request_parameters, model_settings)
-        anthropic_profile = cast(AnthropicModelProfile, self.profile)
+        anthropic_profile = self.profile
         betas, extra_headers = self._get_betas_and_extra_headers(model_settings, anthropic_profile)
         betas.update(native_tool_betas)
         context_management = self._add_compaction_params(messages, betas, model_settings)
@@ -978,7 +983,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         self, model_settings: AnthropicModelSettings
     ) -> AnthropicCodeExecutionToolVersion:
         version = model_settings.get('anthropic_code_execution_tool_version', 'auto')
-        profile = cast(AnthropicModelProfile, self.profile)
+        profile = self.profile
         if version == 'auto':
             return profile.get('anthropic_default_code_execution_tool_version', '20250825')
         if version not in profile.get('anthropic_supported_code_execution_tool_versions', ('20250825',)):
@@ -1921,7 +1926,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         effort: Literal['low', 'medium', 'high', 'xhigh', 'max'] | None = model_settings.get('anthropic_effort')
         # Fall back to unified thinking effort level when anthropic_effort is not set
         # Only map effort level strings; bare True just enables thinking without a specific effort
-        profile = cast(AnthropicModelProfile, self.profile)
+        profile = self.profile
         if (
             effort is None
             and profile.get('anthropic_supports_effort', False)
@@ -1955,7 +1960,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         if task_budget is None:
             return None
 
-        profile = cast(AnthropicModelProfile, self.profile)
+        profile = self.profile
         if not profile.get('anthropic_supports_task_budgets', False):
             raise UserError(
                 f'Model {self.model_name!r} does not support `anthropic_task_budget`. '

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -62,7 +62,7 @@ from ..native_tools._tool_search import (
     ToolSearchMatch,
     ToolSearchTool,
 )
-from ..profiles import ModelProfileSpec
+from ..profiles import DEFAULT_THINKING_TAGS, ModelProfileSpec
 from ..profiles.anthropic import (
     ANTHROPIC_THINKING_BUDGET_MAP,
     AnthropicCodeExecutionToolVersion,
@@ -1327,7 +1327,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                                     )
                                 )
                         elif response_part.content:  # pragma: no branch
-                            start_tag, end_tag = self.profile.get('thinking_tags', ('<think>', '</think>'))
+                            start_tag, end_tag = self.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
                             assistant_content_params.append(
                                 BetaTextBlockParam(
                                     text='\n'.join([start_tag, response_part.content, end_tag]), type='text'

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -421,7 +421,7 @@ class BedrockConverseModel(Model[BaseClient]):
             provider = infer_provider('gateway/bedrock' if provider == 'gateway' else provider)
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile)
+        super().__init__(settings=settings, profile=profile)
 
     @property
     def client(self) -> BedrockRuntimeClient:
@@ -475,12 +475,14 @@ class BedrockConverseModel(Model[BaseClient]):
         settings = merge_model_settings(self.settings, model_settings)
         if model_request_parameters.output_tools and _is_thinking_enabled(settings, model_request_parameters):
             if model_request_parameters.output_mode == 'auto':
-                output_mode = 'native' if self.profile.supports_json_schema_output else 'prompted'
+                output_mode = 'native' if self.profile.get('supports_json_schema_output', False) else 'prompted'
                 model_request_parameters = replace(model_request_parameters, output_mode=output_mode)
             elif (
                 model_request_parameters.output_mode == 'tool' and not model_request_parameters.allow_text_output
             ):  # pragma: no branch
-                suggested_output_type = 'NativeOutput' if self.profile.supports_json_schema_output else 'PromptedOutput'
+                suggested_output_type = (
+                    'NativeOutput' if self.profile.get('supports_json_schema_output', False) else 'PromptedOutput'
+                )
                 raise UserError(
                     f'Bedrock does not support thinking and output tools at the same time. Use `output_type={suggested_output_type}(...)` instead.'
                 )
@@ -644,8 +646,8 @@ class BedrockConverseModel(Model[BaseClient]):
         if thinking is None:
             return existing or None
 
-        profile = BedrockModelProfile.from_profile(self.profile)
-        variant = profile.bedrock_thinking_variant
+        profile = cast(BedrockModelProfile, self.profile)
+        variant = profile.get('bedrock_thinking_variant', None)
 
         if variant == 'anthropic' and 'thinking' not in existing:
             if thinking is False:
@@ -772,7 +774,7 @@ class BedrockConverseModel(Model[BaseClient]):
         resolved_tool_choice = resolve_tool_choice(model_settings, model_request_parameters)
         tool_defs = model_request_parameters.tool_defs
 
-        profile = BedrockModelProfile.from_profile(self.profile)
+        profile = cast(BedrockModelProfile, self.profile)
         supports = _support_tool_forcing(
             self.model_name, profile, model_settings, model_request_parameters, resolved_tool_choice
         )
@@ -809,11 +811,11 @@ class BedrockConverseModel(Model[BaseClient]):
             return None
 
         if cache_tool_definitions := (model_settings or {}).get('bedrock_cache_tool_definitions'):
-            if profile.bedrock_supports_tool_caching:
+            if profile.get('bedrock_supports_tool_caching', False):
                 tools.append(cast('ToolTypeDef', self._get_cache_point(cache_tool_definitions)))
 
         tool_config: ToolConfigurationTypeDef = {'tools': tools}
-        if profile.bedrock_supports_tool_choice:
+        if tool_choice and profile.get('bedrock_supports_tool_choice', False):
             tool_config['toolChoice'] = tool_choice
 
         return tool_config
@@ -829,7 +831,7 @@ class BedrockConverseModel(Model[BaseClient]):
         Groups consecutive ToolReturnPart objects into a single user message as required by Bedrock Claude/Nova models.
         """
         settings = model_settings or BedrockModelSettings()
-        profile = BedrockModelProfile.from_profile(self.profile)
+        profile = cast(BedrockModelProfile, self.profile)
         system_prompt: list[SystemContentBlockTypeDef] = []
         bedrock_messages: list[MessageUnionTypeDef] = []
         document_count: Iterator[int] = count(1)
@@ -842,7 +844,9 @@ class BedrockConverseModel(Model[BaseClient]):
                     elif isinstance(part, UserPromptPart):
                         bedrock_messages.extend(
                             await self._map_user_prompt(
-                                part, document_count, supports_prompt_caching=profile.bedrock_supports_prompt_caching
+                                part,
+                                document_count,
+                                supports_prompt_caching=profile.get('bedrock_supports_prompt_caching', False),
                             )
                         )
                     elif isinstance(part, ToolReturnPart):
@@ -851,7 +855,7 @@ class BedrockConverseModel(Model[BaseClient]):
                         sibling_content: list[ContentBlockUnionTypeDef] = []
 
                         content_mode: Literal['str', 'jsonable'] = (
-                            'str' if profile.bedrock_tool_result_format == 'text' else 'jsonable'
+                            'str' if profile.get('bedrock_tool_result_format', 'text') == 'text' else 'jsonable'
                         )
                         for item in part.content_items(mode=content_mode):
                             if isinstance(item, UploadedFile):
@@ -886,7 +890,9 @@ class BedrockConverseModel(Model[BaseClient]):
                                     raise NotImplementedError('AudioUrl is not supported in Bedrock tool returns')
                                 file_block = await self._map_file_to_content_block(item, document_count)  # pyright: ignore[reportArgumentType]
                                 kind = next((k for k in ('image', 'document', 'video') if k in file_block), None)
-                                if kind in profile.bedrock_supported_media_kinds_in_tool_returns:
+                                if kind in profile.get(
+                                    'bedrock_supported_media_kinds_in_tool_returns', frozenset({'image'})
+                                ):
                                     tool_result_content.append(file_block)
                                 else:
                                     tool_result_content.append({'text': f'See file {item.identifier}.'})
@@ -938,7 +944,7 @@ class BedrockConverseModel(Model[BaseClient]):
                         if (
                             item.provider_name == self.system
                             and item.signature
-                            and profile.bedrock_send_back_thinking_parts
+                            and profile.get('bedrock_send_back_thinking_parts', False)
                         ):
                             reasoning_content: ReasoningContentBlockOutputTypeDef
                             if item.id == 'redacted_content':
@@ -954,7 +960,7 @@ class BedrockConverseModel(Model[BaseClient]):
                                 }
                             content.append({'reasoningContent': reasoning_content})
                         else:
-                            start_tag, end_tag = self.profile.thinking_tags
+                            start_tag, end_tag = self.profile.get('thinking_tags', ('<think>', '</think>'))
                             content.append({'text': '\n'.join([start_tag, item.content, end_tag])})
                     elif isinstance(item, NativeToolCallPart):
                         if item.provider_name == self.system:
@@ -1017,7 +1023,7 @@ class BedrockConverseModel(Model[BaseClient]):
         if (
             system_prompt
             and (cache_instructions := settings.get('bedrock_cache_instructions'))
-            and profile.bedrock_supports_prompt_caching
+            and profile.get('bedrock_supports_prompt_caching', False)
         ):
             cache_point = cast('SystemContentBlockTypeDef', self._get_cache_point(cache_instructions))
             if instruction_parts and any(p.dynamic for p in instruction_parts):
@@ -1032,7 +1038,7 @@ class BedrockConverseModel(Model[BaseClient]):
                 system_prompt.append(cache_point)
 
         if processed_messages and (cache_messages := settings.get('bedrock_cache_messages')):
-            if profile.bedrock_supports_prompt_caching:
+            if profile.get('bedrock_supports_prompt_caching', False):
                 last_user_content = self._get_last_user_message_content(processed_messages)
                 if last_user_content is not None:
                     # Note: `_get_last_user_message_content` ensures content doesn't already end with a `cachePoint`.
@@ -1484,7 +1490,7 @@ def _support_tool_forcing(
 
     Also checks for thinking mode compatibility - Bedrock/Anthropic don't support tool forcing with thinking enabled.
     """
-    if not profile.bedrock_supports_tool_choice:
+    if not profile.get('bedrock_supports_tool_choice', False):
         explicit_choice = (model_settings or {}).get('tool_choice')
         if explicit_choice == 'required' or isinstance(explicit_choice, list):
             raise UserError(

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import datetime
+from functools import cached_property
 from itertools import count
 from typing import TYPE_CHECKING, Any, Generic, Literal, cast, overload
 from urllib.parse import parse_qs, urlparse
@@ -456,6 +457,12 @@ class BedrockConverseModel(Model[BaseClient]):
         """The model provider."""
         return self._provider.name
 
+    @cached_property
+    def profile(self) -> BedrockModelProfile:
+        # The resolved profile dict may also carry cross-class fields (e.g. `anthropic_*` for Anthropic-on-Bedrock
+        # models) — read those with `cast` or `.get()`, since the narrowed type only exposes `bedrock_*` keys.
+        return cast(BedrockModelProfile, super().profile)
+
     @classmethod
     def supported_native_tools(cls) -> frozenset[type[AbstractNativeTool]]:
         """The set of builtin tool types this model can handle."""
@@ -647,7 +654,7 @@ class BedrockConverseModel(Model[BaseClient]):
         if thinking is None:
             return existing or None
 
-        profile = cast(BedrockModelProfile, self.profile)
+        profile = self.profile
         variant = profile.get('bedrock_thinking_variant', None)
 
         if variant == 'anthropic' and 'thinking' not in existing:
@@ -775,7 +782,7 @@ class BedrockConverseModel(Model[BaseClient]):
         resolved_tool_choice = resolve_tool_choice(model_settings, model_request_parameters)
         tool_defs = model_request_parameters.tool_defs
 
-        profile = cast(BedrockModelProfile, self.profile)
+        profile = self.profile
         supports = _support_tool_forcing(
             self.model_name, profile, model_settings, model_request_parameters, resolved_tool_choice
         )
@@ -832,7 +839,7 @@ class BedrockConverseModel(Model[BaseClient]):
         Groups consecutive ToolReturnPart objects into a single user message as required by Bedrock Claude/Nova models.
         """
         settings = model_settings or BedrockModelSettings()
-        profile = cast(BedrockModelProfile, self.profile)
+        profile = self.profile
         system_prompt: list[SystemContentBlockTypeDef] = []
         bedrock_messages: list[MessageUnionTypeDef] = []
         document_count: Iterator[int] = count(1)

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -63,6 +63,7 @@ from pydantic_ai.models import (
 )
 from pydantic_ai.models._tool_choice import ResolvedToolChoice, resolve_tool_choice
 from pydantic_ai.native_tools import AbstractNativeTool, CodeExecutionTool
+from pydantic_ai.profiles import DEFAULT_THINKING_TAGS
 from pydantic_ai.profiles.anthropic import ANTHROPIC_THINKING_BUDGET_MAP
 from pydantic_ai.profiles.openai import OPENAI_REASONING_EFFORT_MAP
 from pydantic_ai.providers import Provider, infer_provider
@@ -960,7 +961,7 @@ class BedrockConverseModel(Model[BaseClient]):
                                 }
                             content.append({'reasoningContent': reasoning_content})
                         else:
-                            start_tag, end_tag = self.profile.get('thinking_tags', ('<think>', '</think>'))
+                            start_tag, end_tag = self.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
                             content.append({'text': '\n'.join([start_tag, item.content, end_tag])})
                     elif isinstance(item, NativeToolCallPart):
                         if item.provider_name == self.system:

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -136,7 +136,7 @@ class CohereModel(Model[AsyncClientV2]):
             provider = infer_provider(provider)
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile)
+        super().__init__(settings=settings, profile=profile)
 
     @property
     def client(self) -> AsyncClientV2:

--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -147,7 +147,7 @@ class GeminiModel(Model[httpx.AsyncClient]):
                 provider = GoogleVertexProvider()  # type: ignore[reportDeprecated]
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile)
+        super().__init__(settings=settings, profile=profile)
 
     @property
     def client(self) -> httpx.AsyncClient:

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator, Awaitable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
+from functools import cached_property
 from typing import Any, Literal, cast, overload
 from uuid import uuid4
 
@@ -484,9 +485,9 @@ class GoogleModel(Model[Client]):
             return _GEMINI_API_PROVIDER_NAMES
         return frozenset({self.system})  # pragma: no cover
 
-    @property
-    def _resolved_profile(self) -> GoogleModelProfile:
-        return cast(GoogleModelProfile, self.profile)
+    @cached_property
+    def profile(self) -> GoogleModelProfile:
+        return cast(GoogleModelProfile, super().profile)
 
     @classmethod
     def supported_native_tools(cls) -> frozenset[type[AbstractNativeTool]]:
@@ -503,7 +504,7 @@ class GoogleModel(Model[Client]):
         if (
             user_native_tools
             and model_request_parameters.output_tools
-            and not self._resolved_profile.get('google_supports_tool_combination', False)
+            and not self.profile.get('google_supports_tool_combination', False)
         ):
             # Pre-Gemini-3 models reject `output_tools + native_tools` together. Force prompted
             # output (the only mode that doesn't add a tool to the request); raise if the caller
@@ -663,7 +664,7 @@ class GoogleModel(Model[Client]):
         tools: list[ToolDict] = []
         image_config: ImageConfigDict | None = None
         if model_request_parameters.native_tools:
-            if model_request_parameters.function_tools and not self._resolved_profile.get(
+            if model_request_parameters.function_tools and not self.profile.get(
                 'google_supports_tool_combination', False
             ):
                 raise UserError('This model does not support function tools and built-in tools at the same time.')
@@ -737,9 +738,7 @@ class GoogleModel(Model[Client]):
         emits_tool_call_invocations = any(
             isinstance(t, (WebSearchTool, WebFetchTool, FileSearchTool)) for t in model_request_parameters.native_tools
         )
-        if emits_tool_call_invocations and self._resolved_profile.get(
-            'google_supports_server_side_tool_invocations', False
-        ):
+        if emits_tool_call_invocations and self.profile.get('google_supports_server_side_tool_invocations', False):
             tool_config['include_server_side_tool_invocations'] = True
 
         tools: list[ToolDict] = [
@@ -806,7 +805,7 @@ class GoogleModel(Model[Client]):
         thinking = model_request_parameters.thinking
         if thinking is None:
             return None
-        profile = cast(GoogleModelProfile, self.profile)
+        profile = self.profile
         if thinking is False:
             if profile.get('google_supports_thinking_level', False):
                 return ThinkingConfigDict(thinking_level=cast(Any, 'MINIMAL'))
@@ -847,7 +846,7 @@ class GoogleModel(Model[Client]):
         response_mime_type = None
         response_schema = None
         if model_request_parameters.output_mode == 'native':
-            if model_request_parameters.function_tools and not self._resolved_profile.get(
+            if model_request_parameters.function_tools and not self.profile.get(
                 'google_supports_tool_combination', False
             ):
                 raise UserError(
@@ -1012,7 +1011,7 @@ class GoogleModel(Model[Client]):
         messages: list[ModelMessage],
         model_request_parameters: ModelRequestParameters,
     ) -> tuple[ContentDict | None, list[ContentUnionDict]]:
-        supports_tool_combination = self._resolved_profile.get('google_supports_tool_combination', False)
+        supports_tool_combination = self.profile.get('google_supports_tool_combination', False)
         contents: list[ContentUnionDict] = []
         system_parts: list[PartDict] = []
 
@@ -1094,7 +1093,7 @@ class GoogleModel(Model[Client]):
         parts after the function_response (fallback strategy).
         See: https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#multimodal
         """
-        supported_mime_types = self._resolved_profile.get('google_supported_mime_types_in_tool_returns', ())
+        supported_mime_types = self.profile.get('google_supported_mime_types_in_tool_returns', ())
 
         function_response_parts: list[FunctionResponsePartDict] = []
         fallback_parts: list[PartDict] = []

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -456,7 +456,7 @@ class GoogleModel(Model[Client]):
             provider = infer_provider('gateway/google-cloud' if provider == 'gateway' else provider)
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile)
+        super().__init__(settings=settings, profile=profile)
 
     @property
     def client(self) -> Client:
@@ -486,7 +486,7 @@ class GoogleModel(Model[Client]):
 
     @property
     def _resolved_profile(self) -> GoogleModelProfile:
-        return GoogleModelProfile.from_profile(self.profile)
+        return cast(GoogleModelProfile, self.profile)
 
     @classmethod
     def supported_native_tools(cls) -> frozenset[type[AbstractNativeTool]]:
@@ -503,7 +503,7 @@ class GoogleModel(Model[Client]):
         if (
             user_native_tools
             and model_request_parameters.output_tools
-            and not self._resolved_profile.google_supports_tool_combination
+            and not self._resolved_profile.get('google_supports_tool_combination', False)
         ):
             # Pre-Gemini-3 models reject `output_tools + native_tools` together. Force prompted
             # output (the only mode that doesn't add a tool to the request); raise if the caller
@@ -663,7 +663,9 @@ class GoogleModel(Model[Client]):
         tools: list[ToolDict] = []
         image_config: ImageConfigDict | None = None
         if model_request_parameters.native_tools:
-            if model_request_parameters.function_tools and not self._resolved_profile.google_supports_tool_combination:
+            if model_request_parameters.function_tools and not self._resolved_profile.get(
+                'google_supports_tool_combination', False
+            ):
                 raise UserError('This model does not support function tools and built-in tools at the same time.')
 
             for tool in model_request_parameters.native_tools:
@@ -677,7 +679,7 @@ class GoogleModel(Model[Client]):
                     file_search_config = FileSearchDict(file_search_store_names=list(tool.file_store_ids))
                     tools.append(ToolDict(file_search=file_search_config))
                 elif isinstance(tool, ImageGenerationTool):  # pragma: no branch
-                    if not self.profile.supports_image_output:
+                    if not self.profile.get('supports_image_output', False):
                         raise UserError(
                             "`ImageGenerationTool` is not supported by this model. Use a model with 'image' in the name instead."
                         )
@@ -735,7 +737,9 @@ class GoogleModel(Model[Client]):
         emits_tool_call_invocations = any(
             isinstance(t, (WebSearchTool, WebFetchTool, FileSearchTool)) for t in model_request_parameters.native_tools
         )
-        if emits_tool_call_invocations and self._resolved_profile.google_supports_server_side_tool_invocations:
+        if emits_tool_call_invocations and self._resolved_profile.get(
+            'google_supports_server_side_tool_invocations', False
+        ):
             tool_config['include_server_side_tool_invocations'] = True
 
         tools: list[ToolDict] = [
@@ -802,14 +806,12 @@ class GoogleModel(Model[Client]):
         thinking = model_request_parameters.thinking
         if thinking is None:
             return None
-        # Don't use `self._resolved_profile`: `tests/test_thinking.py` invokes this as an
-        # unbound method with a `FunctionModel` carrying a `GoogleModelProfile`.
-        profile = GoogleModelProfile.from_profile(self.profile)
+        profile = cast(GoogleModelProfile, self.profile)
         if thinking is False:
-            if profile.google_supports_thinking_level:
+            if profile.get('google_supports_thinking_level', False):
                 return ThinkingConfigDict(thinking_level=cast(Any, 'MINIMAL'))
             return ThinkingConfigDict(thinking_budget=0)
-        if profile.google_supports_thinking_level:
+        if profile.get('google_supports_thinking_level', False):
             if thinking is True:
                 return ThinkingConfigDict(include_thoughts=True)
             level_map: dict[ThinkingEffort, str] = {
@@ -839,13 +841,15 @@ class GoogleModel(Model[Client]):
         model_request_parameters: ModelRequestParameters,
     ) -> tuple[list[ContentUnionDict], GenerateContentConfigDict]:
         tools, tool_config, image_config = self._get_tool_config(model_request_parameters, model_settings)
-        if model_request_parameters.function_tools and not self.profile.supports_tools:
+        if model_request_parameters.function_tools and not self.profile.get('supports_tools', True):
             raise UserError('Tools are not supported by this model.')
 
         response_mime_type = None
         response_schema = None
         if model_request_parameters.output_mode == 'native':
-            if model_request_parameters.function_tools and not self._resolved_profile.google_supports_tool_combination:
+            if model_request_parameters.function_tools and not self._resolved_profile.get(
+                'google_supports_tool_combination', False
+            ):
                 raise UserError(
                     'This model does not support `NativeOutput` and function tools at the same time. Use `output_type=ToolOutput(...)` instead.'
                 )
@@ -854,13 +858,13 @@ class GoogleModel(Model[Client]):
             assert output_object is not None
             response_schema = self._map_response_schema(output_object)
         elif model_request_parameters.output_mode == 'prompted' and not tools:
-            if not self.profile.supports_json_object_output:
+            if not self.profile.get('supports_json_object_output', False):
                 raise UserError('JSON output is not supported by this model.')
             response_mime_type = 'application/json'
         system_instruction, contents = await self._map_messages(messages, model_request_parameters)
 
         modalities: list[str] = [Modality.TEXT.value]
-        if self.profile.supports_image_output:
+        if self.profile.get('supports_image_output', False):
             modalities.append(Modality.IMAGE.value)
             if not model_request_parameters.allow_text_output:
                 modalities.remove(Modality.TEXT.value)
@@ -1008,7 +1012,7 @@ class GoogleModel(Model[Client]):
         messages: list[ModelMessage],
         model_request_parameters: ModelRequestParameters,
     ) -> tuple[ContentDict | None, list[ContentUnionDict]]:
-        supports_tool_combination = self._resolved_profile.google_supports_tool_combination
+        supports_tool_combination = self._resolved_profile.get('google_supports_tool_combination', False)
         contents: list[ContentUnionDict] = []
         system_parts: list[PartDict] = []
 
@@ -1090,7 +1094,7 @@ class GoogleModel(Model[Client]):
         parts after the function_response (fallback strategy).
         See: https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#multimodal
         """
-        supported_mime_types = self._resolved_profile.google_supported_mime_types_in_tool_returns
+        supported_mime_types = self._resolved_profile.get('google_supported_mime_types_in_tool_returns', ())
 
         function_response_parts: list[FunctionResponsePartDict] = []
         fallback_parts: list[PartDict] = []

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -46,7 +46,6 @@ from ..messages import (
 )
 from ..native_tools import AbstractNativeTool, WebSearchTool
 from ..profiles import ModelProfile, ModelProfileSpec
-from ..profiles.groq import GroqModelProfile
 from ..providers import Provider, infer_provider
 from ..settings import ModelSettings
 from ..tools import ToolDefinition
@@ -177,7 +176,7 @@ class GroqModel(Model[AsyncGroq]):
             provider = infer_provider('gateway/groq' if provider == 'gateway' else provider)
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile)
+        super().__init__(settings=settings, profile=profile)
 
     @property
     def client(self) -> AsyncGroq:
@@ -317,7 +316,7 @@ class GroqModel(Model[AsyncGroq]):
         elif (
             model_request_parameters.output_mode == 'prompted'
             and not tools
-            and self.profile.supports_json_object_output
+            and self.profile.get('supports_json_object_output', False)
         ):  # pragma: no branch
             response_format = {'type': 'json_object'}
 
@@ -362,7 +361,11 @@ class GroqModel(Model[AsyncGroq]):
                     items.append(return_part)
         if choice.message.content:
             # NOTE: The `<think>` tag is only present if `groq_reasoning_format` is set to `raw`.
-            items.extend(split_content_into_text_and_thinking(choice.message.content, self.profile.thinking_tags))
+            items.extend(
+                split_content_into_text_and_thinking(
+                    choice.message.content, self.profile.get('thinking_tags', ('<think>', '</think>'))
+                )
+            )
         if choice.message.tool_calls is not None:
             for c in choice.message.tool_calls:
                 items.append(ToolCallPart(tool_name=c.function.name, args=c.function.arguments, tool_call_id=c.id))
@@ -449,7 +452,7 @@ class GroqModel(Model[AsyncGroq]):
         tools: list[chat.ChatCompletionToolParam] = []
         for tool in model_request_parameters.native_tools:
             if isinstance(tool, WebSearchTool):
-                if not GroqModelProfile.from_profile(self.profile).groq_always_has_web_search_builtin_tool:
+                if not self.profile.get('groq_always_has_web_search_builtin_tool', False):
                     raise UserError('`WebSearchTool` is not supported by Groq')  # pragma: no cover
             else:  # pragma: no cover
                 raise UserError(
@@ -475,7 +478,7 @@ class GroqModel(Model[AsyncGroq]):
                     elif isinstance(item, ToolCallPart):
                         tool_calls.append(self._map_tool_call(item))
                     elif isinstance(item, ThinkingPart):
-                        start_tag, end_tag = self.profile.thinking_tags
+                        start_tag, end_tag = self.profile.get('thinking_tags', ('<think>', '</think>'))
                         texts.append('\n'.join([start_tag, item.content, end_tag]))
                     elif isinstance(item, NativeToolCallPart | NativeToolReturnPart):  # pragma: no cover
                         # These are not currently sent back
@@ -678,8 +681,10 @@ class GroqStreamedResponse(StreamedResponse):
                         for event in self._parts_manager.handle_text_delta(
                             vendor_part_id='content',
                             content=content,
-                            thinking_tags=self._model_profile.thinking_tags,
-                            ignore_leading_whitespace=self._model_profile.ignore_streamed_leading_whitespace,
+                            thinking_tags=self._model_profile.get('thinking_tags', ('<think>', '</think>')),
+                            ignore_leading_whitespace=self._model_profile.get(
+                                'ignore_streamed_leading_whitespace', False
+                            ),
                         ):
                             yield event
 
@@ -710,8 +715,10 @@ class GroqStreamedResponse(StreamedResponse):
                         for event in self._parts_manager.handle_text_delta(
                             vendor_part_id='tool_use_failed',
                             content=failed_generation,
-                            thinking_tags=self._model_profile.thinking_tags,
-                            ignore_leading_whitespace=self._model_profile.ignore_streamed_leading_whitespace,
+                            thinking_tags=self._model_profile.get('thinking_tags', ('<think>', '</think>')),
+                            ignore_leading_whitespace=self._model_profile.get(
+                                'ignore_streamed_leading_whitespace', False
+                            ),
                         ):
                             yield event
                     return

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -45,7 +45,7 @@ from ..messages import (
     VideoUrl,
 )
 from ..native_tools import AbstractNativeTool, WebSearchTool
-from ..profiles import ModelProfile, ModelProfileSpec
+from ..profiles import DEFAULT_THINKING_TAGS, ModelProfile, ModelProfileSpec
 from ..providers import Provider, infer_provider
 from ..settings import ModelSettings
 from ..tools import ToolDefinition
@@ -363,7 +363,7 @@ class GroqModel(Model[AsyncGroq]):
             # NOTE: The `<think>` tag is only present if `groq_reasoning_format` is set to `raw`.
             items.extend(
                 split_content_into_text_and_thinking(
-                    choice.message.content, self.profile.get('thinking_tags', ('<think>', '</think>'))
+                    choice.message.content, self.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
                 )
             )
         if choice.message.tool_calls is not None:
@@ -478,7 +478,7 @@ class GroqModel(Model[AsyncGroq]):
                     elif isinstance(item, ToolCallPart):
                         tool_calls.append(self._map_tool_call(item))
                     elif isinstance(item, ThinkingPart):
-                        start_tag, end_tag = self.profile.get('thinking_tags', ('<think>', '</think>'))
+                        start_tag, end_tag = self.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
                         texts.append('\n'.join([start_tag, item.content, end_tag]))
                     elif isinstance(item, NativeToolCallPart | NativeToolReturnPart):  # pragma: no cover
                         # These are not currently sent back
@@ -681,7 +681,7 @@ class GroqStreamedResponse(StreamedResponse):
                         for event in self._parts_manager.handle_text_delta(
                             vendor_part_id='content',
                             content=content,
-                            thinking_tags=self._model_profile.get('thinking_tags', ('<think>', '</think>')),
+                            thinking_tags=self._model_profile.get('thinking_tags', DEFAULT_THINKING_TAGS),
                             ignore_leading_whitespace=self._model_profile.get(
                                 'ignore_streamed_leading_whitespace', False
                             ),
@@ -715,7 +715,7 @@ class GroqStreamedResponse(StreamedResponse):
                         for event in self._parts_manager.handle_text_delta(
                             vendor_part_id='tool_use_failed',
                             content=failed_generation,
-                            thinking_tags=self._model_profile.get('thinking_tags', ('<think>', '</think>')),
+                            thinking_tags=self._model_profile.get('thinking_tags', DEFAULT_THINKING_TAGS),
                             ignore_leading_whitespace=self._model_profile.get(
                                 'ignore_streamed_leading_whitespace', False
                             ),

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -166,7 +166,7 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
             provider = infer_provider(provider)
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile)
+        super().__init__(settings=settings, profile=profile)
 
     @property
     def client(self) -> AsyncInferenceClient:
@@ -285,7 +285,11 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
         items: list[ModelResponsePart] = []
 
         if content:
-            items.extend(split_content_into_text_and_thinking(content, self.profile.thinking_tags))
+            items.extend(
+                split_content_into_text_and_thinking(
+                    content, self.profile.get('thinking_tags', ('<think>', '</think>'))
+                )
+            )
         if tool_calls is not None:
             for c in tool_calls:
                 items.append(ToolCallPart(c.function.name, c.function.arguments, tool_call_id=c.id))
@@ -392,7 +396,7 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                     elif isinstance(item, ToolCallPart):
                         tool_calls.append(self._map_tool_call(item))
                     elif isinstance(item, ThinkingPart):
-                        start_tag, end_tag = self.profile.thinking_tags
+                        start_tag, end_tag = self.profile.get('thinking_tags', ('<think>', '</think>'))
                         texts.append('\n'.join([start_tag, item.content, end_tag]))
                     elif isinstance(item, NativeToolCallPart | NativeToolReturnPart):  # pragma: no cover
                         # This is currently never returned from huggingface
@@ -565,8 +569,8 @@ class HuggingFaceStreamedResponse(StreamedResponse):
                     for event in self._parts_manager.handle_text_delta(
                         vendor_part_id='content',
                         content=content,
-                        thinking_tags=self._model_profile.thinking_tags,
-                        ignore_leading_whitespace=self._model_profile.ignore_streamed_leading_whitespace,
+                        thinking_tags=self._model_profile.get('thinking_tags', ('<think>', '</think>')),
+                        ignore_leading_whitespace=self._model_profile.get('ignore_streamed_leading_whitespace', False),
                     ):
                         yield event
 

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -39,7 +39,7 @@ from ..messages import (
     UserPromptPart,
     VideoUrl,
 )
-from ..profiles import ModelProfile, ModelProfileSpec
+from ..profiles import DEFAULT_THINKING_TAGS, ModelProfile, ModelProfileSpec
 from ..providers import Provider, infer_provider
 from ..settings import ModelSettings
 from ..tools import ToolDefinition
@@ -286,9 +286,7 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
 
         if content:
             items.extend(
-                split_content_into_text_and_thinking(
-                    content, self.profile.get('thinking_tags', ('<think>', '</think>'))
-                )
+                split_content_into_text_and_thinking(content, self.profile.get('thinking_tags', DEFAULT_THINKING_TAGS))
             )
         if tool_calls is not None:
             for c in tool_calls:
@@ -396,7 +394,7 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                     elif isinstance(item, ToolCallPart):
                         tool_calls.append(self._map_tool_call(item))
                     elif isinstance(item, ThinkingPart):
-                        start_tag, end_tag = self.profile.get('thinking_tags', ('<think>', '</think>'))
+                        start_tag, end_tag = self.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
                         texts.append('\n'.join([start_tag, item.content, end_tag]))
                     elif isinstance(item, NativeToolCallPart | NativeToolReturnPart):  # pragma: no cover
                         # This is currently never returned from huggingface
@@ -569,7 +567,7 @@ class HuggingFaceStreamedResponse(StreamedResponse):
                     for event in self._parts_manager.handle_text_delta(
                         vendor_part_id='content',
                         content=content,
-                        thinking_tags=self._model_profile.get('thinking_tags', ('<think>', '</think>')),
+                        thinking_tags=self._model_profile.get('thinking_tags', DEFAULT_THINKING_TAGS),
                         ignore_leading_whitespace=self._model_profile.get('ignore_streamed_leading_whitespace', False),
                     ):
                         yield event

--- a/pydantic_ai_slim/pydantic_ai/models/mcp_sampling.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mcp_sampling.py
@@ -87,7 +87,7 @@ class MCPSamplingModel(Model):
 
     @property
     def provider(self) -> None:
-        return None  # pragma: no cover
+        return None
 
     @property
     def model_name(self) -> str:

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -181,7 +181,7 @@ class MistralModel(Model[Mistral]):
             provider = infer_provider(provider)
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile)
+        super().__init__(settings=settings, profile=profile)
 
     @property
     def client(self) -> Mistral:

--- a/pydantic_ai_slim/pydantic_ai/models/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/models/ollama.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations as _annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Literal
 from urllib.parse import urlparse
 
-from ..profiles import ModelProfileSpec
+from ..profiles import ModelProfile, ModelProfileSpec, merge_profile
 from ..providers import Provider, infer_provider
 from ..settings import ModelSettings
 
@@ -90,6 +90,6 @@ class OllamaModel(OpenAIChatModel):
         if profile is None and _routes_to_ollama_cloud(provider, model_name):
             base_profile = provider.model_profile(model_name)
             assert base_profile is not None  # OllamaProvider always returns a profile
-            profile = replace(base_profile, supports_json_schema_output=False)
+            profile = merge_profile(base_profile, ModelProfile(supports_json_schema_output=False))
 
         super().__init__(model_name, provider=provider, profile=profile, settings=settings)

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -80,7 +80,7 @@ from ..native_tools._tool_search import (
     ToolSearchMatch,
     ToolSearchTool,
 )
-from ..profiles import ModelProfile, ModelProfileSpec, merge_profile
+from ..profiles import DEFAULT_THINKING_TAGS, ModelProfile, ModelProfileSpec, merge_profile
 from ..profiles.openai import (
     OPENAI_REASONING_EFFORT_MAP,
     SAMPLING_PARAMS,
@@ -1050,7 +1050,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             items.extend(
                 (replace(part, id='content', provider_name=self.system) if isinstance(part, ThinkingPart) else part)
                 for part in split_content_into_text_and_thinking(
-                    choice.message.content, self.profile.get('thinking_tags', ('<think>', '</think>'))
+                    choice.message.content, self.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
                 )
             )
         if choice.message.tool_calls is not None:
@@ -1331,10 +1331,10 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     self.thinkings.setdefault(item.id, []).append(item.content)
                 else:
                     # Fall back to tags mode
-                    start_tag, end_tag = self._model.profile.get('thinking_tags', ('<think>', '</think>'))
+                    start_tag, end_tag = self._model.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
                     self.texts.append('\n'.join([start_tag, item.content, end_tag]))
             elif include_method == 'tags':
-                start_tag, end_tag = self._model.profile.get('thinking_tags', ('<think>', '</think>'))
+                start_tag, end_tag = self._model.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
                 self.texts.append('\n'.join([start_tag, item.content, end_tag]))
             elif include_method == 'field':
                 field = profile.get('openai_chat_thinking_field', None)
@@ -2869,7 +2869,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                     ReasoningContent(text=text, type='reasoning_text') for text in raw_content
                                 ]
                         else:
-                            start_tag, end_tag = profile.get('thinking_tags', ('<think>', '</think>'))
+                            start_tag, end_tag = profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
                             openai_messages.append(
                                 responses.EasyInputMessageParam(
                                     role='assistant', content='\n'.join([start_tag, item.content, end_tag])
@@ -3162,7 +3162,7 @@ class OpenAIStreamedResponse(StreamedResponse):
             for event in self._parts_manager.handle_text_delta(
                 vendor_part_id='content',
                 content=content,
-                thinking_tags=self._model_profile.get('thinking_tags', ('<think>', '</think>')),
+                thinking_tags=self._model_profile.get('thinking_tags', DEFAULT_THINKING_TAGS),
                 ignore_leading_whitespace=self._model_profile.get('ignore_streamed_leading_whitespace', False),
             ):
                 if isinstance(event, PartStartEvent) and isinstance(event.part, ThinkingPart):

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -778,7 +778,10 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         super().__init__(settings=settings, profile=profile)
 
         if system_prompt_role is not None:
-            self.profile = merge_profile(self.profile, OpenAIModelProfile(openai_system_prompt_role=system_prompt_role))
+            self.profile = cast(
+                OpenAIModelProfile,
+                merge_profile(self.profile, OpenAIModelProfile(openai_system_prompt_role=system_prompt_role)),
+            )
 
         validate_openai_profile(self.profile)
 
@@ -806,7 +809,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         return frozenset({WebSearchTool})
 
     @cached_property
-    def profile(self) -> ModelProfile:
+    def profile(self) -> OpenAIModelProfile:
         """The model profile.
 
         WebSearchTool is only supported if openai_chat_supports_web_search is True.
@@ -815,7 +818,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         if not _profile.get('openai_chat_supports_web_search', False):
             new_tools = _profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) - {WebSearchTool}
             _profile = merge_profile(_profile, ModelProfile(supported_native_tools=new_tools))
-        return _profile
+        return cast(OpenAIModelProfile, _profile)
 
     @property
     @deprecated('Set the `system_prompt_role` in the `OpenAIModelProfile` instead.')
@@ -921,7 +924,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
         tools, tool_choice = self._get_tool_choice(model_settings, model_request_parameters)
         web_search_options = self._get_web_search_options(model_request_parameters)
-        profile = cast(OpenAIModelProfile, self.profile)
+        profile = self.profile
 
         openai_messages = await self._map_messages(messages, model_request_parameters)
 
@@ -1089,7 +1092,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
         This method may be overridden by subclasses of `OpenAIChatModel` to apply custom mappings.
         """
-        profile = cast(OpenAIModelProfile, self.profile)
+        profile = self.profile
         custom_field = profile.get('openai_chat_thinking_field', None)
         items: list[ThinkingPart] = []
 
@@ -1173,7 +1176,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         Returns:
             A tuple of (filtered_tools, tool_choice).
         """
-        openai_profile = cast(OpenAIModelProfile, self.profile)
+        openai_profile = self.profile
 
         resolved_tool_choice = resolve_tool_choice(model_settings, model_request_parameters)
         tool_defs = model_request_parameters.tool_defs
@@ -1311,7 +1314,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             This method serves as a hook that can be overridden by subclasses
             to implement custom logic for handling thinking parts.
             """
-            profile = cast(OpenAIModelProfile, self._model.profile)
+            profile = self._model.profile
             include_method = profile.get('openai_chat_send_back_thinking_parts', 'auto')
 
             # Auto-detect: if thinking came from a custom field and from the same provider, use field mode
@@ -1502,7 +1505,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
     async def _map_binary_content_item(self, item: BinaryContent) -> ChatCompletionContentPartParam:
         """Map a BinaryContent item to a chat completion content part."""
-        profile = cast(OpenAIModelProfile, self.profile)
+        profile = self.profile
         if _is_text_like_media_type(item.media_type):
             # Inline text-like binary content as a text block
             return self._inline_text_file_part(
@@ -1539,7 +1542,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
     async def _map_audio_url_item(self, item: AudioUrl) -> ChatCompletionContentPartInputAudioParam:
         """Map an AudioUrl to a chat completion audio content part."""
-        profile = cast(OpenAIModelProfile, self.profile)
+        profile = self.profile
         data_format = 'base64_uri' if profile.get('openai_chat_audio_input_encoding', 'base64') == 'uri' else 'base64'
         downloaded_item = await download_item(item, data_format=data_format, type_format='extension')
         assert downloaded_item['data_type'] in (
@@ -1551,7 +1554,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
     async def _map_document_url_item(self, item: DocumentUrl) -> ChatCompletionContentPartParam:
         """Map a DocumentUrl to a chat completion content part."""
-        profile = cast(OpenAIModelProfile, self.profile)
+        profile = self.profile
         # OpenAI Chat API's FileFile only supports base64-encoded data, not URLs.
         # Some providers (e.g., OpenRouter) support URLs via the profile flag.
         if not item.force_download and profile.get('openai_chat_supports_file_urls', False):
@@ -1735,6 +1738,10 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
     def system(self) -> str:
         """The model provider."""
         return self._provider.name
+
+    @cached_property
+    def profile(self) -> OpenAIModelProfile:
+        return cast(OpenAIModelProfile, super().profile)
 
     @classmethod
     def supported_native_tools(cls) -> frozenset[type[AbstractNativeTool]]:
@@ -2118,7 +2125,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         )
         if not tools:
             tool_choice = None
-        profile = cast(OpenAIModelProfile, self.profile)
+        profile = self.profile
 
         previous_response_id, conversation_id, messages = self._resolve_server_side_state(model_settings, messages)
 
@@ -2260,7 +2267,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             A tuple of (filtered_function_tools, tool_choice).
             Note: builtin tools are handled separately and should be added to this list.
         """
-        openai_profile = cast(OpenAIModelProfile, self.profile)
+        openai_profile = self.profile
 
         resolved_tool_choice = resolve_tool_choice(model_settings, model_request_parameters)
 
@@ -2554,7 +2561,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
 
         Raw CoT is sent back to improve model performance in multi-turn conversations.
         """
-        profile = cast(OpenAIModelProfile, self.profile)
+        profile = self.profile
         send_item_ids = model_settings.get(
             'openai_send_reasoning_ids', profile.get('openai_supports_encrypted_reasoning_content', False)
         )
@@ -3029,7 +3036,7 @@ class OpenAIStreamedResponse(StreamedResponse):
     """Implementation of `StreamedResponse` for OpenAI models."""
 
     _model_name: OpenAIModelName
-    _model_profile: ModelProfile
+    _model_profile: OpenAIModelProfile
     _response: _utils.PeekableAsyncStream[ChatCompletionChunk, AsyncStream[ChatCompletionChunk]]
     _provider_name: str
     _provider_url: str
@@ -3118,7 +3125,7 @@ class OpenAIStreamedResponse(StreamedResponse):
 
         This method may be overridden by subclasses of `OpenAIStreamResponse` to customize the mapping.
         """
-        profile = cast(OpenAIModelProfile, self._model_profile)
+        profile = self._model_profile
         custom_field = profile.get('openai_chat_thinking_field', None)
 
         # Prefer the configured custom reasoning field, if present in profile.

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2139,7 +2139,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             # > Response input messages must contain the word 'json' in some form to use 'text.format' of type 'json_object'.
             # Apparently they're only checking input messages for "JSON", not instructions.
             assert isinstance(instructions, str)
-            system_prompt_role = profile.openai_system_prompt_role or 'system'
+            system_prompt_role = profile.get('openai_system_prompt_role', None) or 'system'
             system_prompt_count = next(
                 (i for i, m in enumerate(openai_messages) if m.get('role') != system_prompt_role), len(openai_messages)
             )
@@ -2575,7 +2575,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     if isinstance(part, SystemPromptPart):
                         openai_messages.append(
                             responses.EasyInputMessageParam(
-                                role=profile.openai_system_prompt_role or 'system', content=part.content
+                                role=profile.get('openai_system_prompt_role', None) or 'system', content=part.content
                             )
                         )
                     elif isinstance(part, UserPromptPart):

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -65,6 +65,7 @@ from ..messages import (
     is_multi_modal_content,
 )
 from ..native_tools import (
+    SUPPORTED_NATIVE_TOOLS,
     AbstractNativeTool,
     CodeExecutionTool,
     FileSearchTool,
@@ -79,8 +80,14 @@ from ..native_tools._tool_search import (
     ToolSearchMatch,
     ToolSearchTool,
 )
-from ..profiles import ModelProfile, ModelProfileSpec
-from ..profiles.openai import OPENAI_REASONING_EFFORT_MAP, SAMPLING_PARAMS, OpenAIModelProfile, OpenAISystemPromptRole
+from ..profiles import ModelProfile, ModelProfileSpec, merge_profile
+from ..profiles.openai import (
+    OPENAI_REASONING_EFFORT_MAP,
+    SAMPLING_PARAMS,
+    OpenAIModelProfile,
+    OpenAISystemPromptRole,
+    validate_openai_profile,
+)
 from ..providers import Provider, infer_provider
 from ..settings import ModelSettings
 from ..tools import AgentDepsT, ToolDefinition
@@ -426,7 +433,7 @@ def _drop_sampling_params_for_reasoning(
     reasoning is active. For models that support reasoning_effort='none' (GPT-5.1+),
     sampling params are allowed when reasoning is off.
     """
-    if not profile.openai_supports_reasoning:
+    if not profile.get('openai_supports_reasoning', False):
         return
 
     reasoning_effort = model_settings.get('openai_reasoning_effort')
@@ -436,7 +443,7 @@ def _drop_sampling_params_for_reasoning(
         reasoning_effort is None and thinking is not None and thinking is not False
     )
     # On GPT-5.1+ models, sampling params are allowed when reasoning is off
-    if profile.openai_supports_reasoning_effort_none and not reasoning_active:
+    if profile.get('openai_supports_reasoning_effort_none', False) and not reasoning_active:
         return
 
     if dropped := [k for k in SAMPLING_PARAMS if k in model_settings]:
@@ -455,7 +462,7 @@ def _drop_unsupported_params(profile: OpenAIModelProfile, model_settings: OpenAI
 
     Used currently only by Cerebras
     """
-    for setting in profile.openai_unsupported_model_settings:
+    for setting in profile.get('openai_unsupported_model_settings', ()):
         model_settings.pop(setting, None)
 
 
@@ -768,10 +775,12 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             provider = infer_provider('gateway/openai' if provider == 'gateway' else provider)
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile)
+        super().__init__(settings=settings, profile=profile)
 
         if system_prompt_role is not None:
-            self.profile = OpenAIModelProfile(openai_system_prompt_role=system_prompt_role).update(self.profile)
+            self.profile = merge_profile(self.profile, OpenAIModelProfile(openai_system_prompt_role=system_prompt_role))
+
+        validate_openai_profile(self.profile)
 
     @property
     def client(self) -> AsyncOpenAI:
@@ -803,16 +812,15 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         WebSearchTool is only supported if openai_chat_supports_web_search is True.
         """
         _profile = super().profile
-        openai_profile = OpenAIModelProfile.from_profile(_profile)
-        if not openai_profile.openai_chat_supports_web_search:
-            new_tools = _profile.supported_native_tools - {WebSearchTool}
-            _profile = replace(_profile, supported_native_tools=new_tools)
+        if not _profile.get('openai_chat_supports_web_search', False):
+            new_tools = _profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) - {WebSearchTool}
+            _profile = merge_profile(_profile, ModelProfile(supported_native_tools=new_tools))
         return _profile
 
     @property
     @deprecated('Set the `system_prompt_role` in the `OpenAIModelProfile` instead.')
     def system_prompt_role(self) -> OpenAISystemPromptRole | None:
-        return OpenAIModelProfile.from_profile(self.profile).openai_system_prompt_role
+        return self.profile.get('openai_system_prompt_role')
 
     def prepare_request(
         self,
@@ -822,7 +830,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         # Check for WebSearchTool before base validation to provide a helpful error message
         if (
             any(isinstance(tool, WebSearchTool) for tool in model_request_parameters.native_tools)
-            and not OpenAIModelProfile.from_profile(self.profile).openai_chat_supports_web_search
+            and not self.profile.get('openai_chat_supports_web_search', False)
             and not any(t.unless_native == 'web_search' for t in model_request_parameters.function_tools)
         ):
             raise UserError(
@@ -913,7 +921,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
         tools, tool_choice = self._get_tool_choice(model_settings, model_request_parameters)
         web_search_options = self._get_web_search_options(model_request_parameters)
-        profile = OpenAIModelProfile.from_profile(self.profile)
+        profile = cast(OpenAIModelProfile, self.profile)
 
         openai_messages = await self._map_messages(messages, model_request_parameters)
 
@@ -922,8 +930,8 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             output_object = model_request_parameters.output_object
             assert output_object is not None
             response_format = self._map_json_schema(output_object)
-        elif (
-            model_request_parameters.output_mode == 'prompted' and self.profile.supports_json_object_output
+        elif model_request_parameters.output_mode == 'prompted' and self.profile.get(
+            'supports_json_object_output', False
         ):  # pragma: no branch
             response_format = {'type': 'json_object'}
 
@@ -1041,7 +1049,9 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         if choice.message.content:
             items.extend(
                 (replace(part, id='content', provider_name=self.system) if isinstance(part, ThinkingPart) else part)
-                for part in split_content_into_text_and_thinking(choice.message.content, self.profile.thinking_tags)
+                for part in split_content_into_text_and_thinking(
+                    choice.message.content, self.profile.get('thinking_tags', ('<think>', '</think>'))
+                )
             )
         if choice.message.tool_calls is not None:
             for c in choice.message.tool_calls:
@@ -1079,8 +1089,8 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
         This method may be overridden by subclasses of `OpenAIChatModel` to apply custom mappings.
         """
-        profile = OpenAIModelProfile.from_profile(self.profile)
-        custom_field = profile.openai_chat_thinking_field
+        profile = cast(OpenAIModelProfile, self.profile)
+        custom_field = profile.get('openai_chat_thinking_field', None)
         items: list[ThinkingPart] = []
 
         # Prefer the configured custom reasoning field, if present in profile.
@@ -1163,7 +1173,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         Returns:
             A tuple of (filtered_tools, tool_choice).
         """
-        openai_profile = OpenAIModelProfile.from_profile(self.profile)
+        openai_profile = cast(OpenAIModelProfile, self.profile)
 
         resolved_tool_choice = resolve_tool_choice(model_settings, model_request_parameters)
         tool_defs = model_request_parameters.tool_defs
@@ -1301,14 +1311,14 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             This method serves as a hook that can be overridden by subclasses
             to implement custom logic for handling thinking parts.
             """
-            profile = OpenAIModelProfile.from_profile(self._model.profile)
-            include_method = profile.openai_chat_send_back_thinking_parts
+            profile = cast(OpenAIModelProfile, self._model.profile)
+            include_method = profile.get('openai_chat_send_back_thinking_parts', 'auto')
 
             # Auto-detect: if thinking came from a custom field and from the same provider, use field mode
             # id='content' means it came from tags in content, not a custom field
             if include_method == 'auto':
                 # Check if thinking came from a custom field from the same provider
-                custom_field = profile.openai_chat_thinking_field
+                custom_field = profile.get('openai_chat_thinking_field', None)
                 matches_custom_field = (not custom_field) or (item.id == custom_field)
 
                 if (
@@ -1321,13 +1331,13 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     self.thinkings.setdefault(item.id, []).append(item.content)
                 else:
                     # Fall back to tags mode
-                    start_tag, end_tag = self._model.profile.thinking_tags
+                    start_tag, end_tag = self._model.profile.get('thinking_tags', ('<think>', '</think>'))
                     self.texts.append('\n'.join([start_tag, item.content, end_tag]))
             elif include_method == 'tags':
-                start_tag, end_tag = self._model.profile.thinking_tags
+                start_tag, end_tag = self._model.profile.get('thinking_tags', ('<think>', '</think>'))
                 self.texts.append('\n'.join([start_tag, item.content, end_tag]))
             elif include_method == 'field':
-                field = profile.openai_chat_thinking_field
+                field = profile.get('openai_chat_thinking_field', None)
                 if field:  # pragma: no branch
                     self.thinkings.setdefault(field, []).append(item.content)
 
@@ -1389,8 +1399,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     openai_messages.append(mapped)
             else:
                 assert_never(message)
-        profile = OpenAIModelProfile.from_profile(self.profile)
-        system_prompt_role = profile.openai_system_prompt_role or 'system'
+        system_prompt_role = self.profile.get('openai_system_prompt_role', None) or 'system'
         if instruction_parts := self._get_instruction_parts(messages, model_request_parameters):
             system_prompt_count = next(
                 (i for i, m in enumerate(openai_messages) if m.get('role') != system_prompt_role), len(openai_messages)
@@ -1410,7 +1419,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     for part in instruction_parts
                 ]
             openai_messages[system_prompt_count:system_prompt_count] = instruction_messages
-        if not profile.openai_chat_supports_multiple_system_messages:
+        if not self.profile.get('openai_chat_supports_multiple_system_messages', True):
             openai_messages = _merge_leading_system_messages(openai_messages, system_prompt_role)
         return openai_messages
 
@@ -1429,7 +1438,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         }
         if o.description:
             response_format_param['json_schema']['description'] = o.description
-        if OpenAIModelProfile.from_profile(self.profile).openai_supports_strict_tool_definition:  # pragma: no branch
+        if self.profile.get('openai_supports_strict_tool_definition', True):  # pragma: no branch
             response_format_param['json_schema']['strict'] = o.strict
         return response_format_param
 
@@ -1442,7 +1451,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                 'parameters': f.parameters_json_schema,
             },
         }
-        if f.strict and OpenAIModelProfile.from_profile(self.profile).openai_supports_strict_tool_definition:
+        if f.strict and self.profile.get('openai_supports_strict_tool_definition', True):
             tool_param['function']['strict'] = f.strict
         return tool_param
 
@@ -1450,7 +1459,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         file_content: list[UserContent] = []
         for part in message.parts:
             if isinstance(part, SystemPromptPart):
-                system_prompt_role = OpenAIModelProfile.from_profile(self.profile).openai_system_prompt_role
+                system_prompt_role = self.profile.get('openai_system_prompt_role', None)
                 if system_prompt_role == 'developer':
                     yield chat.ChatCompletionDeveloperMessageParam(role='developer', content=part.content)
                 elif system_prompt_role == 'user':
@@ -1493,7 +1502,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
     async def _map_binary_content_item(self, item: BinaryContent) -> ChatCompletionContentPartParam:
         """Map a BinaryContent item to a chat completion content part."""
-        profile = OpenAIModelProfile.from_profile(self.profile)
+        profile = cast(OpenAIModelProfile, self.profile)
         if _is_text_like_media_type(item.media_type):
             # Inline text-like binary content as a text block
             return self._inline_text_file_part(
@@ -1508,13 +1517,13 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             return ChatCompletionContentPartImageParam(image_url=image_url, type='image_url')
         elif item.is_audio:
             assert item.format in ('wav', 'mp3')
-            if profile.openai_chat_audio_input_encoding == 'uri':
+            if profile.get('openai_chat_audio_input_encoding', 'base64') == 'uri':
                 audio = InputAudio(data=item.data_uri, format=item.format)
             else:
                 audio = InputAudio(data=item.base64, format=item.format)
             return ChatCompletionContentPartInputAudioParam(input_audio=audio, type='input_audio')
         elif item.is_document:
-            if not profile.openai_chat_supports_document_input:
+            if not profile.get('openai_chat_supports_document_input', True):
                 self._raise_document_input_not_supported_error()
             return File(
                 file=FileFile(
@@ -1530,8 +1539,8 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
     async def _map_audio_url_item(self, item: AudioUrl) -> ChatCompletionContentPartInputAudioParam:
         """Map an AudioUrl to a chat completion audio content part."""
-        profile = OpenAIModelProfile.from_profile(self.profile)
-        data_format = 'base64_uri' if profile.openai_chat_audio_input_encoding == 'uri' else 'base64'
+        profile = cast(OpenAIModelProfile, self.profile)
+        data_format = 'base64_uri' if profile.get('openai_chat_audio_input_encoding', 'base64') == 'uri' else 'base64'
         downloaded_item = await download_item(item, data_format=data_format, type_format='extension')
         assert downloaded_item['data_type'] in (
             'wav',
@@ -1542,10 +1551,10 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
     async def _map_document_url_item(self, item: DocumentUrl) -> ChatCompletionContentPartParam:
         """Map a DocumentUrl to a chat completion content part."""
-        profile = OpenAIModelProfile.from_profile(self.profile)
+        profile = cast(OpenAIModelProfile, self.profile)
         # OpenAI Chat API's FileFile only supports base64-encoded data, not URLs.
         # Some providers (e.g., OpenRouter) support URLs via the profile flag.
-        if not item.force_download and profile.openai_chat_supports_file_urls:
+        if not item.force_download and profile.get('openai_chat_supports_file_urls', False):
             return File(
                 file=FileFile(
                     file_data=item.url,
@@ -1561,7 +1570,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                 identifier=item.identifier,
             )
         else:
-            if not profile.openai_chat_supports_document_input:
+            if not profile.get('openai_chat_supports_document_input', True):
                 self._raise_document_input_not_supported_error()
             downloaded_item = await download_item(item, data_format='base64_uri', type_format='extension')
             return File(
@@ -1707,7 +1716,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             provider = infer_provider('gateway/openai' if provider == 'gateway' else provider)
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile)
+        super().__init__(settings=settings, profile=profile)
 
     @property
     def client(self) -> AsyncOpenAI:
@@ -2109,7 +2118,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         )
         if not tools:
             tool_choice = None
-        profile = OpenAIModelProfile.from_profile(self.profile)
+        profile = cast(OpenAIModelProfile, self.profile)
 
         previous_response_id, conversation_id, messages = self._resolve_server_side_state(model_settings, messages)
 
@@ -2121,8 +2130,8 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             output_object = model_request_parameters.output_object
             assert output_object is not None
             text = {'format': self._map_json_schema(output_object)}
-        elif (
-            model_request_parameters.output_mode == 'prompted' and self.profile.supports_json_object_output
+        elif model_request_parameters.output_mode == 'prompted' and self.profile.get(
+            'supports_json_object_output', False
         ):  # pragma: no branch
             text = {'format': {'type': 'json_object'}}
 
@@ -2148,7 +2157,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         _drop_unsupported_params(profile, model_settings)
 
         include: list[responses.ResponseIncludable] = []
-        if profile.openai_supports_encrypted_reasoning_content:
+        if profile.get('openai_supports_encrypted_reasoning_content', False):
             include.append('reasoning.encrypted_content')
         if model_settings.get('openai_include_code_execution_outputs'):
             include.append('code_interpreter_call.outputs')
@@ -2251,7 +2260,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             A tuple of (filtered_function_tools, tool_choice).
             Note: builtin tools are handled separately and should be added to this list.
         """
-        openai_profile = OpenAIModelProfile.from_profile(self.profile)
+        openai_profile = cast(OpenAIModelProfile, self.profile)
 
         resolved_tool_choice = resolve_tool_choice(model_settings, model_request_parameters)
 
@@ -2398,9 +2407,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
             'parameters': f.parameters_json_schema,
             'type': 'function',
             'description': f.description,
-            'strict': bool(
-                f.strict and OpenAIModelProfile.from_profile(self.profile).openai_supports_strict_tool_definition
-            ),
+            'strict': bool(f.strict and self.profile.get('openai_supports_strict_tool_definition', True)),
         }
         if f.with_native == ToolSearchTool.kind:
             # `defer_loading` on the wire controls OpenAI's native tool search caching.
@@ -2547,9 +2554,9 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
 
         Raw CoT is sent back to improve model performance in multi-turn conversations.
         """
-        profile = OpenAIModelProfile.from_profile(self.profile)
+        profile = cast(OpenAIModelProfile, self.profile)
         send_item_ids = model_settings.get(
-            'openai_send_reasoning_ids', profile.openai_supports_encrypted_reasoning_content
+            'openai_send_reasoning_ids', profile.get('openai_supports_encrypted_reasoning_content', False)
         )
         # With `execution='client'` tool search, `search_tools` calls/returns need to be
         # replayed as `tool_search_call` / `tool_search_output` items so the provider can
@@ -2624,7 +2631,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     if isinstance(item, TextPart):
                         phase = (item.provider_details or {}).get('phase')
                         send_phase = (
-                            profile.openai_supports_phase
+                            profile.get('openai_supports_phase', False)
                             and item.provider_name == self.system
                             and phase in ('commentary', 'final_answer')
                         )
@@ -2683,7 +2690,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                 call_id=call_id,
                                 type='function_call',
                             )
-                            if profile.openai_responses_requires_function_call_status_none:
+                            if profile.get('openai_responses_requires_function_call_status_none', False):
                                 param['status'] = None  # type: ignore[reportGeneralTypeIssues]
                             if id and should_send_item_id:  # pragma: no branch
                                 param['id'] = id
@@ -2832,7 +2839,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                             if (
                                 item.signature
                                 and item.provider_name == self.system
-                                and profile.openai_supports_encrypted_reasoning_content
+                                and profile.get('openai_supports_encrypted_reasoning_content', False)
                             ):
                                 signature = item.signature
 
@@ -2862,7 +2869,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                     ReasoningContent(text=text, type='reasoning_text') for text in raw_content
                                 ]
                         else:
-                            start_tag, end_tag = profile.thinking_tags
+                            start_tag, end_tag = profile.get('thinking_tags', ('<think>', '</think>'))
                             openai_messages.append(
                                 responses.EasyInputMessageParam(
                                     role='assistant', content='\n'.join([start_tag, item.content, end_tag])
@@ -2896,7 +2903,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         }
         if o.description:
             response_format_param['description'] = o.description
-        if OpenAIModelProfile.from_profile(self.profile).openai_supports_strict_tool_definition:  # pragma: no branch
+        if self.profile.get('openai_supports_strict_tool_definition', True):  # pragma: no branch
             response_format_param['strict'] = o.strict
         return response_format_param
 
@@ -3111,8 +3118,8 @@ class OpenAIStreamedResponse(StreamedResponse):
 
         This method may be overridden by subclasses of `OpenAIStreamResponse` to customize the mapping.
         """
-        profile = OpenAIModelProfile.from_profile(self._model_profile)
-        custom_field = profile.openai_chat_thinking_field
+        profile = cast(OpenAIModelProfile, self._model_profile)
+        custom_field = profile.get('openai_chat_thinking_field', None)
 
         # Prefer the configured custom reasoning field, if present in profile.
         # Fall back to built-in fields if no custom field result was found.
@@ -3155,8 +3162,8 @@ class OpenAIStreamedResponse(StreamedResponse):
             for event in self._parts_manager.handle_text_delta(
                 vendor_part_id='content',
                 content=content,
-                thinking_tags=self._model_profile.thinking_tags,
-                ignore_leading_whitespace=self._model_profile.ignore_streamed_leading_whitespace,
+                thinking_tags=self._model_profile.get('thinking_tags', ('<think>', '</think>')),
+                ignore_leading_whitespace=self._model_profile.get('ignore_streamed_leading_whitespace', False),
             ):
                 if isinstance(event, PartStartEvent) and isinstance(event.part, ThinkingPart):
                     event.part.id = 'content'
@@ -4005,7 +4012,7 @@ def _support_tool_forcing(
     model_settings: ModelSettings | None,
 ) -> bool:
     """Check if the model supports forced tool use, raising UserError if explicitly requested but unsupported."""
-    if not openai_profile.openai_supports_tool_choice_required:
+    if not openai_profile.get('openai_supports_tool_choice_required', True):
         explicit_choice = (model_settings or {}).get('tool_choice')
         if explicit_choice == 'required' or isinstance(explicit_choice, list):
             raise UserError(

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -52,7 +52,7 @@ from ..models import (
     download_item,
 )
 from ..native_tools import CodeExecutionTool, FileSearchTool, MCPServerTool, WebSearchTool, XSearchTool
-from ..profiles import ModelProfileSpec
+from ..profiles import DEFAULT_THINKING_TAGS, ModelProfileSpec
 from ..profiles.grok import GrokModelProfile
 from ..providers import Provider, infer_provider
 from ..settings import ModelSettings, ThinkingLevel
@@ -500,7 +500,7 @@ class XaiModel(Model[AsyncClient]):
                 msg.encrypted_content = item.signature
             return msg
         elif item.content:
-            start_tag, end_tag = self.profile.get('thinking_tags', ('<think>', '</think>'))
+            start_tag, end_tag = self.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
             return assistant('\n'.join([start_tag, item.content, end_tag]))
         else:
             return None

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterat
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from datetime import datetime
+from functools import cached_property
 from typing import Any, Literal, cast
 
 from typing_extensions import assert_never
@@ -338,6 +339,10 @@ class XaiModel(Model[AsyncClient]):
     def system(self) -> str:
         """The model provider."""
         return 'xai'
+
+    @cached_property
+    def profile(self) -> GrokModelProfile:
+        return cast(GrokModelProfile, super().profile)
 
     @classmethod
     def supported_native_tools(cls) -> frozenset[type]:
@@ -682,7 +687,7 @@ class XaiModel(Model[AsyncClient]):
         resolved_tool_choice = resolve_tool_choice(model_settings, model_request_parameters)
         tool_defs = model_request_parameters.tool_defs
 
-        profile = cast(GrokModelProfile, self.profile)
+        profile = self.profile
 
         tool_choice: Literal['none', 'required', 'auto'] | chat_pb2.ToolChoice
         if resolved_tool_choice in ('auto', 'none'):
@@ -748,7 +753,7 @@ class XaiModel(Model[AsyncClient]):
             tool_choice = None
 
         # Set response_format based on the output_mode
-        profile = cast(GrokModelProfile, self.profile)
+        profile = self.profile
         response_format: chat_pb2.ResponseFormat | None = None
         if model_request_parameters.output_mode == 'native':
             output_object = model_request_parameters.output_object

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -323,7 +323,7 @@ class XaiModel(Model[AsyncClient]):
             provider = infer_provider(provider)
         self._provider = provider
 
-        super().__init__(settings=settings, profile=profile or provider.model_profile(model_name))
+        super().__init__(settings=settings, profile=profile)
 
     @property
     def client(self) -> 'AsyncClient':
@@ -500,7 +500,7 @@ class XaiModel(Model[AsyncClient]):
                 msg.encrypted_content = item.signature
             return msg
         elif item.content:
-            start_tag, end_tag = self.profile.thinking_tags
+            start_tag, end_tag = self.profile.get('thinking_tags', ('<think>', '</think>'))
             return assistant('\n'.join([start_tag, item.content, end_tag]))
         else:
             return None
@@ -682,17 +682,17 @@ class XaiModel(Model[AsyncClient]):
         resolved_tool_choice = resolve_tool_choice(model_settings, model_request_parameters)
         tool_defs = model_request_parameters.tool_defs
 
-        profile = GrokModelProfile.from_profile(self.profile)
+        profile = cast(GrokModelProfile, self.profile)
 
         tool_choice: Literal['none', 'required', 'auto'] | chat_pb2.ToolChoice
         if resolved_tool_choice in ('auto', 'none'):
             tool_choice = resolved_tool_choice
         elif resolved_tool_choice == 'required':
-            tool_choice = 'required' if profile.grok_supports_tool_choice_required else 'auto'
+            tool_choice = 'required' if profile.get('grok_supports_tool_choice_required', True) else 'auto'
         elif isinstance(resolved_tool_choice, tuple):
             tool_choice_mode, tool_names = resolved_tool_choice
             if tool_choice_mode == 'required' and len(tool_names) == 1:
-                if profile.grok_supports_tool_choice_required:
+                if profile.get('grok_supports_tool_choice_required', True):
                     tool_choice = required_tool(next(iter(tool_names)))
                 else:
                     # Forcing not supported: filter so the model can only see the requested tool.
@@ -701,7 +701,7 @@ class XaiModel(Model[AsyncClient]):
                     tool_choice = 'auto'
             else:
                 tool_defs = {k: v for k, v in tool_defs.items() if k in tool_names}
-                if tool_choice_mode == 'required' and profile.grok_supports_tool_choice_required:
+                if tool_choice_mode == 'required' and profile.get('grok_supports_tool_choice_required', True):
                     tool_choice = 'required'
                 else:
                     tool_choice = 'auto'
@@ -748,7 +748,7 @@ class XaiModel(Model[AsyncClient]):
             tool_choice = None
 
         # Set response_format based on the output_mode
-        profile = GrokModelProfile.from_profile(self.profile)
+        profile = cast(GrokModelProfile, self.profile)
         response_format: chat_pb2.ResponseFormat | None = None
         if model_request_parameters.output_mode == 'native':
             output_object = model_request_parameters.output_object
@@ -757,7 +757,7 @@ class XaiModel(Model[AsyncClient]):
         elif (
             model_request_parameters.output_mode == 'prompted'
             and not tools_param
-            and profile.supports_json_object_output
+            and profile.get('supports_json_object_output', False)
         ):  # pragma: no branch
             response_format = _map_json_object()
 

--- a/pydantic_ai_slim/pydantic_ai/profiles/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/__init__.py
@@ -1,10 +1,10 @@
 from __future__ import annotations as _annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field, fields, replace
 from textwrap import dedent
+from typing import TypeAlias
 
-from typing_extensions import Self
+from typing_extensions import TypedDict
 
 from .._json_schema import InlineDefsJsonSchemaTransformer, JsonSchemaTransformer
 from ..native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool
@@ -14,72 +14,90 @@ __all__ = [
     'ModelProfile',
     'ModelProfileSpec',
     'DEFAULT_PROFILE',
+    'DEFAULT_PROMPTED_OUTPUT_TEMPLATE',
     'InlineDefsJsonSchemaTransformer',
     'JsonSchemaTransformer',
+    'merge_profile',
 ]
 
 
-@dataclass(kw_only=True)
-class ModelProfile:
-    """Describes how requests to and responses from specific models or families of models need to be constructed and processed to get the best results, independent of the model and provider classes used."""
+DEFAULT_PROMPTED_OUTPUT_TEMPLATE = dedent(
+    """
+    Always respond with a JSON object that's compatible with this schema:
 
-    supports_tools: bool = True
-    """Whether the model supports tools."""
-    supports_tool_return_schema: bool = False
-    """Whether the model natively supports tool return schemas.
+    {schema}
+
+    Don't include any text or Markdown fencing before or after.
+    """
+)
+"""Default instructions template for prompted structured output. The `{schema}` placeholder is replaced with the JSON schema for the output."""
+
+
+class ModelProfile(TypedDict, total=False):
+    """Describes how requests to and responses from specific models or families of models need to be constructed and processed to get the best results, independent of the model and provider classes used.
+
+    All fields are optional; absent keys mean "use the documented default" (defaults are documented per field below and applied at access sites).
+
+    Subclasses (`OpenAIModelProfile`, `AnthropicModelProfile`, ...) add provider-specific keys; cross-class merging via dict-spread is supported.
+    """
+
+    supports_tools: bool
+    """Whether the model supports tools. Default: `True`."""
+
+    supports_tool_return_schema: bool
+    """Whether the model natively supports tool return schemas. Default: `False`.
 
     When True, the model's API accepts a structured return schema alongside each tool definition.
     When False, return schemas are injected as JSON text into tool descriptions as a fallback.
     """
-    supports_json_schema_output: bool = False
-    """Whether the model supports JSON schema output.
+
+    supports_json_schema_output: bool
+    """Whether the model supports JSON schema output. Default: `False`.
 
     This is also referred to as 'native' support for structured output.
     Relates to the `NativeOutput` output type.
     """
-    supports_json_object_output: bool = False
-    """Whether the model supports a dedicated mode to enforce JSON output, without necessarily sending a schema.
+
+    supports_json_object_output: bool
+    """Whether the model supports a dedicated mode to enforce JSON output, without necessarily sending a schema. Default: `False`.
 
     E.g. [OpenAI's JSON mode](https://platform.openai.com/docs/guides/structured-outputs#json-mode)
     Relates to the `PromptedOutput` output type.
     """
-    supports_image_output: bool = False
-    """Whether the model supports image output."""
-    default_structured_output_mode: StructuredOutputMode = 'tool'
-    """The default structured output mode to use for the model."""
-    prompted_output_template: str = dedent(
-        """
-        Always respond with a JSON object that's compatible with this schema:
 
-        {schema}
+    supports_image_output: bool
+    """Whether the model supports image output. Default: `False`."""
 
-        Don't include any text or Markdown fencing before or after.
-        """
-    )
-    """The instructions template to use for prompted structured output. The '{schema}' placeholder will be replaced with the JSON schema for the output."""
-    native_output_requires_schema_in_instructions: bool = False
-    """Whether to add prompted output template in native structured output mode"""
-    json_schema_transformer: type[JsonSchemaTransformer] | None = None
-    """The transformer to use to make JSON schemas for tools and structured output compatible with the model."""
+    default_structured_output_mode: StructuredOutputMode
+    """The default structured output mode to use for the model. Default: `'tool'`."""
 
-    supports_thinking: bool = False
-    """Whether the model supports thinking/reasoning configuration.
+    prompted_output_template: str
+    """The instructions template to use for prompted structured output. The `{schema}` placeholder will be replaced with the JSON schema for the output. Default: `DEFAULT_PROMPTED_OUTPUT_TEMPLATE`."""
+
+    native_output_requires_schema_in_instructions: bool
+    """Whether to add prompted output template in native structured output mode. Default: `False`."""
+
+    json_schema_transformer: type[JsonSchemaTransformer] | None
+    """The transformer to use to make JSON schemas for tools and structured output compatible with the model. Default: `None`."""
+
+    supports_thinking: bool
+    """Whether the model supports thinking/reasoning configuration. Default: `False`.
 
     When False, the unified `thinking` setting in `ModelSettings` is silently ignored.
     """
 
-    thinking_always_enabled: bool = False
-    """Whether the model always uses thinking/reasoning (e.g., OpenAI o-series, DeepSeek R1).
+    thinking_always_enabled: bool
+    """Whether the model always uses thinking/reasoning (e.g., OpenAI o-series, DeepSeek R1). Default: `False`.
 
     When True, `thinking=False` is silently ignored since the model cannot disable thinking.
     Implies `supports_thinking=True`.
     """
 
-    thinking_tags: tuple[str, str] = ('<think>', '</think>')
-    """The tags used to indicate thinking parts in the model's output. Defaults to ('<think>', '</think>')."""
+    thinking_tags: tuple[str, str]
+    """The tags used to indicate thinking parts in the model's output. Default: `('<think>', '</think>')`."""
 
-    ignore_streamed_leading_whitespace: bool = False
-    """Whether to ignore leading whitespace when streaming a response.
+    ignore_streamed_leading_whitespace: bool
+    """Whether to ignore leading whitespace when streaming a response. Default: `False`.
 
     This is a workaround for models that emit `<think>\n</think>\n\n` or an empty text part ahead of tool calls (e.g. Ollama + Qwen3),
     which we don't want to end up treating as a final result when using `run_stream` with `str` a valid `output_type`.
@@ -87,33 +105,48 @@ class ModelProfile:
     This is currently only used by `OpenAIChatModel`, `HuggingFaceModel`, and `GroqModel`.
     """
 
-    supported_native_tools: frozenset[type[AbstractNativeTool]] = field(default_factory=lambda: SUPPORTED_NATIVE_TOOLS)
-    """The set of native tool types that this model/profile supports.
+    supported_native_tools: frozenset[type[AbstractNativeTool]]
+    """The set of native tool types that this model/profile supports. Default: `SUPPORTED_NATIVE_TOOLS` (all)."""
 
-    Defaults to ALL native tools. Profile functions should explicitly
-    restrict this based on model capabilities.
+
+DEFAULT_PROFILE: ModelProfile = {
+    'supports_tools': True,
+    'supports_tool_return_schema': False,
+    'supports_json_schema_output': False,
+    'supports_json_object_output': False,
+    'supports_image_output': False,
+    'default_structured_output_mode': 'tool',
+    'prompted_output_template': DEFAULT_PROMPTED_OUTPUT_TEMPLATE,
+    'native_output_requires_schema_in_instructions': False,
+    'json_schema_transformer': None,
+    'supports_thinking': False,
+    'thinking_always_enabled': False,
+    'thinking_tags': ('<think>', '</think>'),
+    'ignore_streamed_leading_whitespace': False,
+    'supported_native_tools': SUPPORTED_NATIVE_TOOLS,
+}
+"""Fully populated default `ModelProfile`. Used as the base layer when resolving a model's effective profile."""
+
+
+ModelProfileSpec: TypeAlias = ModelProfile | Callable[['ModelProfile'], 'ModelProfile']
+"""Acceptable shapes for the `profile=` argument on a `Model`.
+
+- A `ModelProfile` dict — a partial profile, merged on top of the provider's resolved default.
+- A `Callable[[ModelProfile], ModelProfile]` — receives the provider's resolved default (with `DEFAULT_PROFILE` already merged in) and returns the final profile (full control: replace, derive, ignore the default).
+
+Provider classes still expose `Provider.model_profile(model_name)` (`Callable[[str], ModelProfile | None]`) — that's a separate concept used internally by `Model.profile` to resolve the provider's default for a given model name.
+"""
+
+
+def merge_profile(base: ModelProfile | None, *overrides: ModelProfile | None) -> ModelProfile:
+    """Merge profiles via dict-spread. Later arguments override earlier ones; `None` is treated as empty.
+
+    This is the canonical way to layer profiles in providers and tests; replaces the old `ModelProfile.update()` method.
     """
-
-    @classmethod
-    def from_profile(cls, profile: ModelProfile | None) -> Self:
-        """Build a ModelProfile subclass instance from a ModelProfile instance."""
-        if isinstance(profile, cls):
-            return profile
-        return cls().update(profile)
-
-    def update(self, profile: ModelProfile | None) -> Self:
-        """Update this ModelProfile (subclass) instance with the non-default values from another ModelProfile instance."""
-        if not profile:
-            return self
-        field_names = set(f.name for f in fields(self))
-        non_default_attrs = {
-            f.name: getattr(profile, f.name)
-            for f in fields(profile)
-            if f.name in field_names and getattr(profile, f.name) != f.default
-        }
-        return replace(self, **non_default_attrs)
-
-
-ModelProfileSpec = ModelProfile | Callable[[str], ModelProfile | None]
-
-DEFAULT_PROFILE = ModelProfile()
+    result: ModelProfile = {}
+    if base:
+        result = {**result, **base}
+    for override in overrides:
+        if override:
+            result = {**result, **override}
+    return result

--- a/pydantic_ai_slim/pydantic_ai/profiles/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     'ModelProfileSpec',
     'DEFAULT_PROFILE',
     'DEFAULT_PROMPTED_OUTPUT_TEMPLATE',
+    'DEFAULT_THINKING_TAGS',
     'InlineDefsJsonSchemaTransformer',
     'JsonSchemaTransformer',
     'merge_profile',
@@ -31,6 +32,9 @@ DEFAULT_PROMPTED_OUTPUT_TEMPLATE = dedent(
     """
 )
 """Default instructions template for prompted structured output. The `{schema}` placeholder is replaced with the JSON schema for the output."""
+
+DEFAULT_THINKING_TAGS: tuple[str, str] = ('<think>', '</think>')
+"""Default `(start_tag, end_tag)` pair for parsing thinking content out of text responses."""
 
 
 class ModelProfile(TypedDict, total=False):
@@ -94,7 +98,7 @@ class ModelProfile(TypedDict, total=False):
     """
 
     thinking_tags: tuple[str, str]
-    """The tags used to indicate thinking parts in the model's output. Default: `('<think>', '</think>')`."""
+    """The tags used to indicate thinking parts in the model's output. Default: [`DEFAULT_THINKING_TAGS`][pydantic_ai.profiles.DEFAULT_THINKING_TAGS]."""
 
     ignore_streamed_leading_whitespace: bool
     """Whether to ignore leading whitespace when streaming a response. Default: `False`.
@@ -121,7 +125,7 @@ DEFAULT_PROFILE: ModelProfile = {
     'json_schema_transformer': None,
     'supports_thinking': False,
     'thinking_always_enabled': False,
-    'thinking_tags': ('<think>', '</think>'),
+    'thinking_tags': DEFAULT_THINKING_TAGS,
     'ignore_streamed_leading_whitespace': False,
     'supported_native_tools': SUPPORTED_NATIVE_TOOLS,
 }

--- a/pydantic_ai_slim/pydantic_ai/profiles/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/anthropic.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
 from ..native_tools import (
@@ -31,60 +30,59 @@ _ANTHROPIC_CODE_EXECUTION_20260120_MODEL_PREFIXES = (
 )
 
 
-@dataclass(kw_only=True)
-class AnthropicModelProfile(ModelProfile):
+class AnthropicModelProfile(ModelProfile, total=False):
     """Profile for models used with `AnthropicModel`.
 
     ALL FIELDS MUST BE `anthropic_` PREFIXED SO YOU CAN MERGE THEM WITH OTHER MODELS.
     """
 
-    anthropic_supports_fast_speed: bool = False
-    """Whether the model supports fast inference speed (`anthropic_speed='fast'`).
+    anthropic_supports_fast_speed: bool
+    """Whether the model supports fast inference speed (`anthropic_speed='fast'`). Default: `False`.
 
     Currently only Claude Opus 4.6 supports fast mode. See the Anthropic docs for the latest list.
     """
 
-    anthropic_supports_adaptive_thinking: bool = False
-    """Whether the model supports adaptive thinking (Sonnet 4.6+, Opus 4.6+).
+    anthropic_supports_adaptive_thinking: bool
+    """Whether the model supports adaptive thinking (Sonnet 4.6+, Opus 4.6+). Default: `False`.
 
     When True, unified `thinking` translates to `{'type': 'adaptive'}`.
     When False, it translates to `{'type': 'enabled', 'budget_tokens': N}`.
     """
 
-    anthropic_supports_effort: bool = False
-    """Whether the model supports the `effort` parameter in `output_config` (Opus 4.5+, Sonnet 4.6+).
+    anthropic_supports_effort: bool
+    """Whether the model supports the `effort` parameter in `output_config` (Opus 4.5+, Sonnet 4.6+). Default: `False`.
 
     When True and the unified thinking level is a string (e.g. 'high'), it is also
     mapped to `output_config.effort`.
     """
 
-    anthropic_supports_xhigh_effort: bool = False
-    """Whether the model supports the `xhigh` effort value in `output_config`.
+    anthropic_supports_xhigh_effort: bool
+    """Whether the model supports the `xhigh` effort value in `output_config`. Default: `False`.
 
     Claude Opus 4.7 adds `xhigh`; older Anthropic models should use `max` instead.
     """
 
-    anthropic_disallows_budget_thinking: bool = False
-    """Whether the model rejects budget-based thinking settings.
+    anthropic_disallows_budget_thinking: bool
+    """Whether the model rejects budget-based thinking settings. Default: `False`.
 
     Claude Opus 4.7+ requires adaptive thinking and returns a 400 for
     `{'type': 'enabled', 'budget_tokens': ...}`.
     """
 
-    anthropic_disallows_sampling_settings: bool = False
-    """Whether the model rejects sampling settings like `temperature` and `top_p`.
+    anthropic_disallows_sampling_settings: bool
+    """Whether the model rejects sampling settings like `temperature` and `top_p`. Default: `False`.
 
     Claude Opus 4.7+ requires these settings to be omitted from request payloads.
     """
 
-    anthropic_default_code_execution_tool_version: AnthropicCodeExecutionToolVersion = '20250825'
-    """The Anthropic code execution tool version used when `anthropic_code_execution_tool_version='auto'`."""
+    anthropic_default_code_execution_tool_version: AnthropicCodeExecutionToolVersion
+    """The Anthropic code execution tool version used when `anthropic_code_execution_tool_version='auto'`. Default: `'20250825'`."""
 
-    anthropic_supported_code_execution_tool_versions: tuple[AnthropicCodeExecutionToolVersion, ...] = ('20250825',)
-    """The Anthropic code execution tool versions supported by the model."""
+    anthropic_supported_code_execution_tool_versions: tuple[AnthropicCodeExecutionToolVersion, ...]
+    """The Anthropic code execution tool versions supported by the model. Default: `('20250825',)`."""
 
-    anthropic_supports_task_budgets: bool = False
-    """Whether the model supports `output_config.task_budget`.
+    anthropic_supports_task_budgets: bool
+    """Whether the model supports `output_config.task_budget`. Default: `False`.
 
     Anthropic currently documents task budgets as a Claude Opus 4.7 beta feature.
     """

--- a/pydantic_ai_slim/pydantic_ai/profiles/google.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/google.py
@@ -1,7 +1,5 @@
 from __future__ import annotations as _annotations
 
-from dataclasses import dataclass
-
 from .._json_schema import JsonSchema, JsonSchemaTransformer
 from . import ModelProfile
 
@@ -16,15 +14,14 @@ _GOOGLE_NATIVE_TOOL_RETURN_MIME_TYPES: tuple[str, ...] = (
 )
 
 
-@dataclass(kw_only=True)
-class GoogleModelProfile(ModelProfile):
+class GoogleModelProfile(ModelProfile, total=False):
     """Profile for models used with `GoogleModel`.
 
     ALL FIELDS MUST BE `google_` PREFIXED SO YOU CAN MERGE THEM WITH OTHER MODELS.
     """
 
-    google_supports_tool_combination: bool = False
-    """Whether the model supports combining function declarations with native tools and response_schema.
+    google_supports_tool_combination: bool
+    """Whether the model supports combining function declarations with native tools and response_schema. Default: `False`.
 
     Gemini 3+ supports all tool combinations:
     - function_declarations + native_tools
@@ -33,8 +30,8 @@ class GoogleModelProfile(ModelProfile):
     See https://ai.google.dev/gemini-api/docs/tool-combination
     """
 
-    google_supports_server_side_tool_invocations: bool = False
-    """Whether the model accepts the `include_server_side_tool_invocations` tool-config field.
+    google_supports_server_side_tool_invocations: bool
+    """Whether the model accepts the `include_server_side_tool_invocations` tool-config field. Default: `False`.
 
     When enabled, Gemini emits explicit `tool_call`/`tool_response` parts for server-side
     native tools (Google Search, URL Context, File Search) that we round-trip through
@@ -48,12 +45,12 @@ class GoogleModelProfile(ModelProfile):
     allowed in the same request.
     """
 
-    google_supported_mime_types_in_tool_returns: tuple[str, ...] = ()
-    """MIME types supported in native FunctionResponseDict.parts.
+    google_supported_mime_types_in_tool_returns: tuple[str, ...]
+    """MIME types supported in native FunctionResponseDict.parts. Default: `()`.
     See https://ai.google.dev/gemini-api/docs/function-calling#multimodal-function-responses"""
 
-    google_supports_thinking_level: bool = False
-    """Whether the model uses `thinking_level` (enum: LOW/MEDIUM/HIGH) instead of `thinking_budget` (int).
+    google_supports_thinking_level: bool
+    """Whether the model uses `thinking_level` (enum: LOW/MEDIUM/HIGH) instead of `thinking_budget` (int). Default: `False`.
 
     Gemini 3+ models use `thinking_level`; Gemini 2.5 uses `thinking_budget`.
     """

--- a/pydantic_ai_slim/pydantic_ai/profiles/grok.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/grok.py
@@ -1,23 +1,20 @@
 from __future__ import annotations as _annotations
 
-from dataclasses import dataclass
-
 from ..native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool
 from . import ModelProfile
 
 
-@dataclass(kw_only=True)
-class GrokModelProfile(ModelProfile):
+class GrokModelProfile(ModelProfile, total=False):
     """Profile for Grok models (used with both GrokProvider and XaiProvider).
 
     ALL FIELDS MUST BE `grok_` PREFIXED SO YOU CAN MERGE THEM WITH OTHER MODELS.
     """
 
-    grok_supports_builtin_tools: bool = False
-    """Whether the model supports builtin tools (web_search, x_search, code_execution, mcp)."""
+    grok_supports_builtin_tools: bool
+    """Whether the model supports builtin tools (web_search, x_search, code_execution, mcp). Default: `False`."""
 
-    grok_supports_tool_choice_required: bool = True
-    """Whether the provider accepts the value `tool_choice='required'` in the request payload."""
+    grok_supports_tool_choice_required: bool
+    """Whether the provider accepts the value `tool_choice='required'` in the request payload. Default: `True`."""
 
 
 def grok_model_profile(model_name: str) -> ModelProfile | None:

--- a/pydantic_ai_slim/pydantic_ai/profiles/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/groq.py
@@ -1,19 +1,16 @@
 from __future__ import annotations as _annotations
 
-from dataclasses import dataclass
-
 from . import ModelProfile
 
 
-@dataclass(kw_only=True)
-class GroqModelProfile(ModelProfile):
+class GroqModelProfile(ModelProfile, total=False):
     """Profile for models used with GroqModel.
 
     ALL FIELDS MUST BE `groq_` PREFIXED SO YOU CAN MERGE THEM WITH OTHER MODELS.
     """
 
-    groq_always_has_web_search_builtin_tool: bool = False
-    """Whether the model always has the web search built-in tool available."""
+    groq_always_has_web_search_builtin_tool: bool
+    """Whether the model always has the web search built-in tool available. Default: `False`."""
 
 
 def groq_model_profile(model_name: str) -> ModelProfile:

--- a/pydantic_ai_slim/pydantic_ai/profiles/harmony.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/harmony.py
@@ -1,6 +1,6 @@
 from __future__ import annotations as _annotations
 
-from . import ModelProfile
+from . import ModelProfile, merge_profile
 from .openai import OpenAIModelProfile, openai_model_profile
 
 
@@ -9,7 +9,7 @@ def harmony_model_profile(model_name: str) -> ModelProfile | None:
 
     See <https://cookbook.openai.com/articles/openai-harmony> for more details.
     """
-    profile = openai_model_profile(model_name)
-    return OpenAIModelProfile(
-        openai_supports_tool_choice_required=False, ignore_streamed_leading_whitespace=True
-    ).update(profile)
+    return merge_profile(
+        OpenAIModelProfile(openai_supports_tool_choice_required=False, ignore_streamed_leading_whitespace=True),
+        openai_model_profile(model_name),
+    )

--- a/pydantic_ai_slim/pydantic_ai/profiles/harmony.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/harmony.py
@@ -10,6 +10,6 @@ def harmony_model_profile(model_name: str) -> ModelProfile | None:
     See <https://cookbook.openai.com/articles/openai-harmony> for more details.
     """
     return merge_profile(
-        OpenAIModelProfile(openai_supports_tool_choice_required=False, ignore_streamed_leading_whitespace=True),
         openai_model_profile(model_name),
+        OpenAIModelProfile(openai_supports_tool_choice_required=False, ignore_streamed_leading_whitespace=True),
     )

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -55,15 +55,14 @@ See https://platform.openai.com/docs/guides/reasoning for details.
 OpenAISystemPromptRole = Literal['system', 'developer', 'user']
 
 
-@dataclass(kw_only=True)
-class OpenAIModelProfile(ModelProfile):
+class OpenAIModelProfile(ModelProfile, total=False):
     """Profile for models used with `OpenAIChatModel`.
 
     ALL FIELDS MUST BE `openai_` PREFIXED SO YOU CAN MERGE THEM WITH OTHER MODELS.
     """
 
-    openai_chat_thinking_field: str | None = None
-    """Non-standard field name used by some providers for model thinking content in Chat Completions API responses.
+    openai_chat_thinking_field: str | None
+    """Non-standard field name used by some providers for model thinking content in Chat Completions API responses. Default: `None`.
 
     Plenty of providers use custom field names for thinking content. Ollama and newer versions of vLLM use `reasoning`,
     while DeepSeek, older vLLM and some others use `reasoning_content`.
@@ -72,8 +71,8 @@ class OpenAIModelProfile(ModelProfile):
 
     If `openai_chat_send_back_thinking_parts` is set to `'field'`, this field must be set to a non-None value."""
 
-    openai_chat_send_back_thinking_parts: Literal['auto', 'tags', 'field', False] = 'auto'
-    """Whether the model includes thinking content in requests.
+    openai_chat_send_back_thinking_parts: Literal['auto', 'tags', 'field', False]
+    """Whether the model includes thinking content in requests. Default: `'auto'`.
 
     This can be:
     * `'auto'` (default): Automatically detects how to send thinking content. If thinking was received in a custom field
@@ -88,73 +87,73 @@ class OpenAIModelProfile(ModelProfile):
 
     Defaults to `'auto'` to ensure thinking is sent back in the format expected by the model/provider."""
 
-    openai_supports_strict_tool_definition: bool = True
-    """This can be set by a provider or user if the OpenAI-"compatible" API doesn't support strict tool definitions."""
+    openai_supports_strict_tool_definition: bool
+    """This can be set by a provider or user if the OpenAI-"compatible" API doesn't support strict tool definitions. Default: `True`."""
 
-    openai_supports_sampling_settings: bool = True
-    """Turn off to don't send sampling settings like `temperature` and `top_p` to models that don't support them, like OpenAI's o-series reasoning models."""
+    openai_supports_sampling_settings: bool
+    """Turn off to don't send sampling settings like `temperature` and `top_p` to models that don't support them, like OpenAI's o-series reasoning models. Default: `True`."""
 
-    openai_unsupported_model_settings: Sequence[str] = ()
-    """A list of model settings that are not supported by this model."""
+    openai_unsupported_model_settings: Sequence[str]
+    """A list of model settings that are not supported by this model. Default: `()`."""
 
     # Some OpenAI-compatible providers (e.g. MoonshotAI) currently do **not** accept
     # `tool_choice="required"`.  This flag lets the calling model know whether it's
     # safe to pass that value along.  Default is `True` to preserve existing
     # behaviour for OpenAI itself and most providers.
-    openai_supports_tool_choice_required: bool = True
-    """Whether the provider accepts the value `tool_choice='required'` in the request payload."""
+    openai_supports_tool_choice_required: bool
+    """Whether the provider accepts the value `tool_choice='required'` in the request payload. Default: `True`."""
 
-    openai_system_prompt_role: OpenAISystemPromptRole | None = None
+    openai_system_prompt_role: OpenAISystemPromptRole | None
     """The role to use for the system prompt message. If not provided, defaults to `'system'`."""
 
-    openai_chat_supports_multiple_system_messages: bool = True
-    """Whether the Chat Completions API accepts more than one system-role message at the start of the conversation.
+    openai_chat_supports_multiple_system_messages: bool
+    """Whether the Chat Completions API accepts more than one system-role message at the start of the conversation. Default: `True`.
 
     OpenAI itself and most compatible providers accept multiple system messages, so this defaults to `True`.
     Set to `False` for strict OpenAI-compatible backends (e.g. some LiteLLM/vLLM deployments) that require
     exactly one initial system message; consecutive system messages at the start will be merged into one
     (joined with two newlines) before being sent."""
 
-    openai_chat_supports_web_search: bool = False
-    """Whether the model supports web search in Chat Completions API."""
+    openai_chat_supports_web_search: bool
+    """Whether the model supports web search in Chat Completions API. Default: `False`."""
 
-    openai_chat_audio_input_encoding: Literal['base64', 'uri'] = 'base64'
-    """The encoding to use for audio input in Chat Completions requests.
+    openai_chat_audio_input_encoding: Literal['base64', 'uri']
+    """The encoding to use for audio input in Chat Completions requests. Default: `'base64'`.
 
     - `'base64'`: Raw base64 encoded string. (Default, used by OpenAI)
     - `'uri'`: Data URI (e.g. `data:audio/wav;base64,...`).
     """
 
-    openai_chat_supports_file_urls: bool = False
-    """Whether the Chat API supports file URLs directly in the `file_data` field.
+    openai_chat_supports_file_urls: bool
+    """Whether the Chat API supports file URLs directly in the `file_data` field. Default: `False`.
 
     OpenAI's native Chat API only supports base64-encoded data, but some providers
     like OpenRouter support passing URLs directly.
     """
 
-    openai_supports_encrypted_reasoning_content: bool = False
-    """Whether the model supports including encrypted reasoning content in the response."""
+    openai_supports_encrypted_reasoning_content: bool
+    """Whether the model supports including encrypted reasoning content in the response. Default: `False`."""
 
-    openai_supports_reasoning: bool = False
-    """Whether the model supports reasoning (o-series, GPT-5+).
+    openai_supports_reasoning: bool
+    """Whether the model supports reasoning (o-series, GPT-5+). Default: `False`.
 
     When True, sampling parameters may need to be dropped depending on reasoning_effort setting."""
 
-    openai_supports_reasoning_effort_none: bool = False
-    """Whether the model supports sampling parameters (temperature, top_p, etc.) when reasoning_effort='none'.
+    openai_supports_reasoning_effort_none: bool
+    """Whether the model supports sampling parameters (temperature, top_p, etc.) when reasoning_effort='none'. Default: `False`.
 
     Models like GPT-5.1 and GPT-5.2 default to reasoning_effort='none' and support sampling params in that mode.
     When reasoning is enabled (low/medium/high/xhigh), sampling params are not supported."""
 
-    openai_responses_requires_function_call_status_none: bool = False
-    """Whether the Responses API requires the `status` field on function tool calls to be `None`.
+    openai_responses_requires_function_call_status_none: bool
+    """Whether the Responses API requires the `status` field on function tool calls to be `None`. Default: `False`.
 
     This is required by vLLM Responses API versions before https://github.com/vllm-project/vllm/pull/26706.
     See https://github.com/pydantic/pydantic-ai/issues/3245 for more details.
     """
 
-    openai_supports_phase: bool = False
-    """Whether the Responses API supports the `phase` field on assistant messages.
+    openai_supports_phase: bool
+    """Whether the Responses API supports the `phase` field on assistant messages. Default: `False`.
 
     `phase` labels an assistant message as intermediate `commentary` or the `final_answer`. When the model
     supports it, OpenAI recommends preserving and sending it back unchanged on every assistant message in
@@ -166,25 +165,26 @@ class OpenAIModelProfile(ModelProfile):
     unrecognized field to OpenAI-compatible APIs (vLLM, Bifrost, ...) that haven't been verified to accept it.
     """
 
-    openai_chat_supports_document_input: bool = True
-    """Whether the Chat Completions API supports document content parts (`type='file'`).
+    openai_chat_supports_document_input: bool
+    """Whether the Chat Completions API supports document content parts (`type='file'`). Default: `True`.
 
     Some OpenAI-compatible providers (e.g. Azure) do not support document input via the Chat Completions API.
     """
 
-    def __post_init__(self):  # pragma: no cover
-        if not self.openai_supports_sampling_settings:
-            warnings.warn(
-                'The `openai_supports_sampling_settings` has no effect, and it will be removed in future versions. '
-                'Use `openai_unsupported_model_settings` instead.',
-                DeprecationWarning,
-            )
-        if self.openai_chat_send_back_thinking_parts == 'field' and not self.openai_chat_thinking_field:
-            raise UserError(
-                'If `openai_chat_send_back_thinking_parts` is "field", '
-                '`openai_chat_thinking_field` must be set to a non-None value.'
-            )
-        # Note: 'auto' mode doesn't require openai_chat_thinking_field since it detects dynamically
+
+def validate_openai_profile(profile: ModelProfile) -> None:
+    """Validate an OpenAI-compatible profile after resolution. Called from `OpenAIChatModel.__init__`."""
+    if profile.get('openai_supports_sampling_settings') is False:  # pragma: no cover
+        warnings.warn(
+            'The `openai_supports_sampling_settings` has no effect, and it will be removed in future versions. '
+            'Use `openai_unsupported_model_settings` instead.',
+            DeprecationWarning,
+        )
+    if profile.get('openai_chat_send_back_thinking_parts') == 'field' and not profile.get('openai_chat_thinking_field'):
+        raise UserError(
+            'If `openai_chat_send_back_thinking_parts` is "field", '
+            '`openai_chat_thinking_field` must be set to a non-None value.'
+        )
 
 
 def openai_model_profile(model_name: str) -> ModelProfile:

--- a/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/alibaba.py
@@ -9,6 +9,7 @@ from openai import AsyncOpenAI
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.providers import Provider
@@ -42,11 +43,13 @@ class AlibabaProvider(Provider[AsyncOpenAI]):
         base_profile = qwen_model_profile(model_name)
 
         # Wrap/merge into OpenAIModelProfile
-        openai_profile = OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(base_profile)
+        openai_profile = merge_profile(
+            OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), base_profile
+        )
 
         # For Qwen Omni models, force URI audio input encoding
         if 'omni' in model_name.lower():
-            openai_profile = OpenAIModelProfile(openai_chat_audio_input_encoding='uri').update(openai_profile)
+            openai_profile = merge_profile(openai_profile, OpenAIModelProfile(openai_chat_audio_input_encoding='uri'))
 
         return openai_profile
 

--- a/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
@@ -10,6 +10,7 @@ import httpx
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.anthropic import AnthropicModelProfile, anthropic_model_profile
 from pydantic_ai.providers import Provider
 from pydantic_ai.providers._bedrock_model_names import split_bedrock_model_id
@@ -62,7 +63,7 @@ class AnthropicProvider(Provider[AsyncAnthropicClient]):
         if bedrock_provider == 'anthropic':
             model_name = base_model_name
         profile = anthropic_model_profile(model_name)
-        return AnthropicModelProfile(json_schema_transformer=AnthropicJsonSchemaTransformer).update(profile)
+        return merge_profile(AnthropicModelProfile(json_schema_transformer=AnthropicJsonSchemaTransformer), profile)
 
     @overload
     def __init__(self, *, anthropic_client: AsyncAnthropicClient | None = None) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -10,6 +10,7 @@ from openai import AsyncOpenAI
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.grok import grok_model_profile
@@ -67,17 +68,19 @@ class AzureProvider(Provider[AsyncOpenAI]):
 
                 profile = profile_func(model_name)
 
-                # As AzureProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
-                # we need to maintain that behavior unless json_schema_transformer is set explicitly
-                # Azure Chat Completions API doesn't support document input
-                return OpenAIModelProfile(
-                    json_schema_transformer=OpenAIJsonSchemaTransformer,
-                    openai_chat_supports_document_input=False,
-                ).update(profile)
+                # Three-layer merge: see OpenRouter for the rationale.
+                return merge_profile(
+                    OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
+                    profile,
+                    OpenAIModelProfile(openai_chat_supports_document_input=False),
+                )
 
-        # OpenAI models are unprefixed
-        # Azure Chat Completions API doesn't support document input
-        return OpenAIModelProfile(openai_chat_supports_document_input=False).update(openai_model_profile(model_name))
+        # OpenAI models are unprefixed.
+        # Azure Chat Completions API doesn't support document input — gateway override wins on top of upstream.
+        return merge_profile(
+            openai_model_profile(model_name),
+            OpenAIModelProfile(openai_chat_supports_document_input=False),
+        )
 
     @overload
     def __init__(self, *, openai_client: AsyncAzureOpenAI) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -61,26 +61,23 @@ class AzureProvider(Provider[AsyncOpenAI]):
             'grok': grok_model_profile,
         }
 
+        base: ModelProfile | None = None
         for prefix, profile_func in prefix_to_profile.items():
             if model_name.startswith(prefix):
                 if prefix.endswith('-'):
                     model_name = model_name[len(prefix) :]
-
-                profile = profile_func(model_name)
-
                 # Three-layer merge: see OpenRouter for the rationale.
-                return merge_profile(
+                base = merge_profile(
                     OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
-                    profile,
-                    OpenAIModelProfile(openai_chat_supports_document_input=False),
+                    profile_func(model_name),
                 )
+                break
+        if base is None:
+            # OpenAI models are unprefixed.
+            base = openai_model_profile(model_name)
 
-        # OpenAI models are unprefixed.
-        # Azure Chat Completions API doesn't support document input — gateway override wins on top of upstream.
-        return merge_profile(
-            openai_model_profile(model_name),
-            OpenAIModelProfile(openai_chat_supports_document_input=False),
-        )
+        # Azure Chat Completions API doesn't support document input.
+        return merge_profile(base, OpenAIModelProfile(openai_chat_supports_document_input=False))
 
     @overload
     def __init__(self, *, openai_client: AsyncAzureOpenAI) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -2,12 +2,12 @@ from __future__ import annotations as _annotations
 
 import os
 from collections.abc import Callable
-from dataclasses import dataclass, replace
 from typing import Any, Literal, overload
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.native_tools import CodeExecutionTool
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
@@ -35,41 +35,52 @@ except ImportError as _import_error:
     ) from _import_error
 
 
-@dataclass(kw_only=True)
-class BedrockModelProfile(ModelProfile):
+class BedrockModelProfile(ModelProfile, total=False):
     """Profile for models used with BedrockModel.
 
     ALL FIELDS MUST BE `bedrock_` PREFIXED SO YOU CAN MERGE THEM WITH OTHER MODELS.
     """
 
-    bedrock_supports_tool_choice: bool = False
-    bedrock_tool_result_format: Literal['text', 'json'] = 'text'
-    bedrock_send_back_thinking_parts: bool = False
-    bedrock_supports_prompt_caching: bool = False
-    bedrock_supports_tool_caching: bool = False
-    bedrock_supported_media_kinds_in_tool_returns: frozenset[str] = frozenset({'image'})
+    bedrock_supports_tool_choice: bool
+    """Default: `False`."""
+    bedrock_tool_result_format: Literal['text', 'json']
+    """Default: `'text'`."""
+    bedrock_send_back_thinking_parts: bool
+    """Default: `False`."""
+    bedrock_supports_prompt_caching: bool
+    """Default: `False`."""
+    bedrock_supports_tool_caching: bool
+    """Default: `False`."""
+    bedrock_supported_media_kinds_in_tool_returns: frozenset[str]
+    """Default: `frozenset({'image'})`."""
 
-    bedrock_thinking_variant: Literal['anthropic', 'openai', 'qwen'] | None = None
+    bedrock_thinking_variant: Literal['anthropic', 'openai', 'qwen'] | None
     """Which thinking API shape to use for unified thinking translation.
 
     - `'anthropic'`: Uses `{'thinking': {'type': 'enabled', 'budget_tokens': N}}`
     - `'openai'`: Uses `{'reasoning_effort': 'low'|'medium'|'high'}`
     - `'qwen'`: Uses `{'reasoning_config': 'low'|'high'}`
     - `None`: No unified thinking support.
+
+    Default: `None`.
     """
 
 
 def bedrock_amazon_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for an Amazon model used via Bedrock."""
-    profile = _without_builtin_tools(amazon_model_profile(model_name))
+    profile = _strip_builtin_tools(amazon_model_profile(model_name))
     if 'nova' in model_name:
-        profile = BedrockModelProfile(
-            bedrock_supports_tool_choice=True,
-            bedrock_supports_prompt_caching=True,
-        ).update(profile)
+        # Bedrock-specific overrides apply on top of the upstream Amazon profile.
+        profile = merge_profile(
+            profile,
+            BedrockModelProfile(
+                bedrock_supports_tool_choice=True,
+                bedrock_supports_prompt_caching=True,
+            ),
+        )
 
     if 'nova-2' in model_name:
-        profile.supported_native_tools = frozenset({CodeExecutionTool})
+        profile = merge_profile(profile, ModelProfile(supported_native_tools=frozenset({CodeExecutionTool})))
 
     return profile
 
@@ -78,12 +89,13 @@ def bedrock_deepseek_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a DeepSeek model used via Bedrock."""
     profile = deepseek_model_profile(model_name)
     if 'r1' in model_name:
-        return BedrockModelProfile(bedrock_send_back_thinking_parts=True).update(profile)
+        # Bedrock-specific override applies on top of the upstream DeepSeek profile.
+        return merge_profile(profile, BedrockModelProfile(bedrock_send_back_thinking_parts=True))
     return profile  # pragma: no cover
 
 
-def _without_builtin_tools(profile: ModelProfile | None) -> ModelProfile:
-    return replace(profile or BedrockModelProfile(), supported_native_tools=frozenset())
+def _strip_builtin_tools(profile: ModelProfile | None) -> ModelProfile:
+    return merge_profile(profile, ModelProfile(supported_native_tools=frozenset()))
 
 
 class BedrockProvider(Provider[BaseClient]):
@@ -114,7 +126,8 @@ class BedrockProvider(Provider[BaseClient]):
     @staticmethod
     def model_profile(model_name: str) -> ModelProfile | None:
         provider_to_profile: dict[str, Callable[[str], ModelProfile | None]] = {
-            'anthropic': lambda model_name: replace(
+            'anthropic': lambda model_name: merge_profile(
+                _strip_builtin_tools(anthropic_model_profile(model_name)),
                 BedrockModelProfile(
                     bedrock_supports_tool_choice=True,
                     bedrock_send_back_thinking_parts=True,
@@ -122,18 +135,19 @@ class BedrockProvider(Provider[BaseClient]):
                     bedrock_supports_tool_caching=True,
                     bedrock_supported_media_kinds_in_tool_returns=frozenset({'image', 'document'}),
                     bedrock_thinking_variant='anthropic',
-                ).update(_without_builtin_tools(anthropic_model_profile(model_name))),
-                # We don't currently support native structured output with Bedrock.
-                # See https://github.com/pydantic/pydantic-ai/issues/4209.
-                supports_json_schema_output=False,
+                    # We don't currently support native structured output with Bedrock.
+                    # See https://github.com/pydantic/pydantic-ai/issues/4209.
+                    supports_json_schema_output=False,
+                ),
             ),
-            'mistral': lambda model_name: BedrockModelProfile(bedrock_tool_result_format='json').update(
-                _without_builtin_tools(mistral_model_profile(model_name))
+            'mistral': lambda model_name: merge_profile(
+                _strip_builtin_tools(mistral_model_profile(model_name)),
+                BedrockModelProfile(bedrock_tool_result_format='json'),
             ),
-            'cohere': lambda model_name: _without_builtin_tools(cohere_model_profile(model_name)),
+            'cohere': lambda model_name: _strip_builtin_tools(cohere_model_profile(model_name)),
             'amazon': bedrock_amazon_model_profile,
-            'meta': lambda model_name: _without_builtin_tools(meta_model_profile(model_name)),
-            'deepseek': lambda model_name: _without_builtin_tools(bedrock_deepseek_model_profile(model_name)),
+            'meta': lambda model_name: _strip_builtin_tools(meta_model_profile(model_name)),
+            'deepseek': lambda model_name: _strip_builtin_tools(bedrock_deepseek_model_profile(model_name)),
             'openai': lambda _mn: BedrockModelProfile(
                 bedrock_thinking_variant='openai',
                 supports_thinking=True,

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -8,6 +8,7 @@ import httpx
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.harmony import harmony_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
@@ -70,11 +71,14 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
             'openai_service_tier',
         )
         is_reasoning = model_name_lower.startswith(reasoning_prefixes)
-        return OpenAIModelProfile(
-            json_schema_transformer=OpenAIJsonSchemaTransformer,
-            openai_unsupported_model_settings=unsupported_model_settings,
-            supports_thinking=is_reasoning,
-        ).update(profile)
+        return merge_profile(
+            OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
+            profile,
+            OpenAIModelProfile(
+                openai_unsupported_model_settings=unsupported_model_settings,
+                supports_thinking=is_reasoning,
+            ),
+        )
 
     @overload
     def __init__(self) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/deepseek.py
@@ -9,6 +9,7 @@ from openai import AsyncOpenAI
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.providers import Provider
@@ -48,18 +49,21 @@ class DeepSeekProvider(Provider[AsyncOpenAI]):
         # we need to maintain that behavior unless json_schema_transformer is set explicitly.
         # This was not the case when using a DeepSeek model with another model class (e.g. BedrockConverseModel or GroqModel),
         # so we won't do this in `deepseek_model_profile` unless we learn it's always needed.
-        return OpenAIModelProfile(
-            json_schema_transformer=OpenAIJsonSchemaTransformer,
-            supports_json_object_output=True,
-            openai_chat_thinking_field='reasoning_content',
-            # Starting from DeepSeek v3.2, DeepSeek requires sending thinking parts for optimal agentic performance.
-            openai_chat_send_back_thinking_parts='field',
-            # Reasoning-capable models do not support tool_choice=required; use startswith so
-            # future deepseek-v4-* SKUs are covered automatically without listing each one.
-            openai_supports_tool_choice_required=(
-                model_name != 'deepseek-reasoner' and not model_name.startswith('deepseek-v4-')
+        return merge_profile(
+            OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
+            profile,
+            OpenAIModelProfile(
+                supports_json_object_output=True,
+                openai_chat_thinking_field='reasoning_content',
+                # Starting from DeepSeek v3.2, DeepSeek requires sending thinking parts for optimal agentic performance.
+                openai_chat_send_back_thinking_parts='field',
+                # Reasoning-capable models do not support tool_choice=required; use startswith so
+                # future deepseek-v4-* SKUs are covered automatically without listing each one.
+                openai_supports_tool_choice_required=(
+                    model_name != 'deepseek-reasoner' and not model_name.startswith('deepseek-v4-')
+                ),
             ),
-        ).update(profile)
+        )
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/fireworks.py
@@ -9,6 +9,7 @@ from openai import AsyncOpenAI
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
@@ -63,7 +64,7 @@ class FireworksProvider(Provider[AsyncOpenAI]):
 
         # As the Fireworks API is OpenAI-compatible, let's assume we also need OpenAIJsonSchemaTransformer,
         # unless json_schema_transformer is set explicitly
-        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+        return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)
 
     @overload
     def __init__(self) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/github.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/github.py
@@ -8,6 +8,7 @@ import httpx
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.grok import grok_model_profile
@@ -68,7 +69,7 @@ class GitHubProvider(Provider[AsyncOpenAI]):
 
         # As GitHubProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
         # we need to maintain that behavior unless json_schema_transformer is set explicitly
-        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+        return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)
 
     @overload
     def __init__(self) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/grok.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/grok.py
@@ -10,6 +10,7 @@ from typing_extensions import deprecated
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.providers import Provider
@@ -66,12 +67,14 @@ class GrokProvider(Provider[AsyncOpenAI]):
     def model_profile(model_name: str) -> ModelProfile | None:
         profile = grok_model_profile(model_name)
 
-        # As the Grok API is OpenAI-compatible, let's assume we also need OpenAIJsonSchemaTransformer,
-        # unless json_schema_transformer is set explicitly.
-        # Also, Grok does not support strict tool definitions: https://github.com/pydantic/pydantic-ai/issues/1846
-        return OpenAIModelProfile(
-            json_schema_transformer=OpenAIJsonSchemaTransformer, openai_supports_strict_tool_definition=False
-        ).update(profile)
+        # `json_schema_transformer` is a fallback (upstream wins if it set one).
+        # `openai_supports_strict_tool_definition=False` is a Grok-specific override (Grok does not support strict
+        # tool definitions: https://github.com/pydantic/pydantic-ai/issues/1846), so it goes in the gateway overlay.
+        return merge_profile(
+            OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
+            profile,
+            OpenAIModelProfile(openai_supports_strict_tool_definition=False),
+        )
 
     @overload
     def __init__(self) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/groq.py
@@ -8,6 +8,7 @@ import httpx
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
 from pydantic_ai.profiles.groq import groq_model_profile
@@ -29,16 +30,18 @@ except ImportError as _import_error:
 
 def groq_moonshotai_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for an MoonshotAI model used with the Groq provider."""
-    return ModelProfile(supports_json_object_output=True, supports_json_schema_output=True).update(
-        moonshotai_model_profile(model_name)
+    return merge_profile(
+        ModelProfile(supports_json_object_output=True, supports_json_schema_output=True),
+        moonshotai_model_profile(model_name),
     )
 
 
 def meta_groq_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a Meta model used with the Groq provider."""
     if model_name in {'llama-4-maverick-17b-128e-instruct', 'llama-4-scout-17b-16e-instruct'}:
-        return ModelProfile(supports_json_object_output=True, supports_json_schema_output=True).update(
-            meta_model_profile(model_name)
+        return merge_profile(
+            ModelProfile(supports_json_object_output=True, supports_json_schema_output=True),
+            meta_model_profile(model_name),
         )
     else:
         return meta_model_profile(model_name)

--- a/pydantic_ai_slim/pydantic_ai/providers/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/huggingface.py
@@ -17,7 +17,7 @@ from pydantic_ai.profiles.qwen import qwen_model_profile
 try:
     from huggingface_hub import AsyncInferenceClient
     from huggingface_hub.constants import INFERENCE_PROXY_TEMPLATE
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `huggingface_hub` package to use the HuggingFace provider, '
         "you can use the `huggingface` optional group — `pip install 'pydantic-ai-slim[huggingface]'`"

--- a/pydantic_ai_slim/pydantic_ai/providers/litellm.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/litellm.py
@@ -7,6 +7,7 @@ from openai import AsyncOpenAI
 
 from pydantic_ai import ModelProfile
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
@@ -80,7 +81,7 @@ class LiteLLMProvider(Provider[AsyncOpenAI]):
 
         # As LiteLLMProvider is used with OpenAIModel, which uses OpenAIJsonSchemaTransformer,
         # we maintain that behavior
-        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+        return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)
 
     @overload
     def __init__(

--- a/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/moonshotai.py
@@ -9,6 +9,7 @@ from openai import AsyncOpenAI
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
 from pydantic_ai.profiles.openai import (
     OpenAIJsonSchemaTransformer,
@@ -54,13 +55,16 @@ class MoonshotAIProvider(Provider[AsyncOpenAI]):
         # Also, MoonshotAI does not support strict tool definitions
         # https://platform.moonshot.ai/docs/guide/migrating-from-openai-to-kimi#about-tool_choice
         # "Please note that the current version of Kimi API does not support the tool_choice=required parameter."
-        return OpenAIModelProfile(
-            json_schema_transformer=OpenAIJsonSchemaTransformer,
-            openai_supports_tool_choice_required=False,
-            supports_json_object_output=True,
-            openai_chat_thinking_field='reasoning_content',
-            openai_chat_send_back_thinking_parts='field',
-        ).update(profile)
+        return merge_profile(
+            OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
+            profile,
+            OpenAIModelProfile(
+                openai_supports_tool_choice_required=False,
+                supports_json_object_output=True,
+                openai_chat_thinking_field='reasoning_content',
+                openai_chat_send_back_thinking_parts='field',
+            ),
+        )
 
     @overload
     def __init__(self) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -8,6 +8,7 @@ import httpx
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
 from pydantic_ai.profiles.harmony import harmony_model_profile
@@ -66,7 +67,7 @@ class NebiusProvider(Provider[AsyncOpenAI]):
 
         # As NebiusProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
         # we need to maintain that behavior unless json_schema_transformer is set explicitly
-        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+        return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)
 
     @overload
     def __init__(self) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -7,6 +7,7 @@ import httpx
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
@@ -60,18 +61,19 @@ class OllamaProvider(Provider[AsyncOpenAI]):
             if model_name.startswith(prefix):
                 profile = profile_func(model_name)
 
-        # As OllamaProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
-        # we need to maintain that behavior unless json_schema_transformer is set explicitly.
-        # Ollama's /v1/chat/completions endpoint supports response_format with json_schema natively.
-        # Strict mode is not supported (issue #4116).
-        base = OpenAIModelProfile(
-            json_schema_transformer=OpenAIJsonSchemaTransformer,
-            openai_chat_thinking_field='reasoning',
-            openai_supports_strict_tool_definition=False,
-            supports_json_schema_output=True,
-            supports_json_object_output=True,
-        ).update(profile)
-        return base
+        # `json_schema_transformer` is a fallback (upstream wins if it set one). The other Ollama-specific
+        # overrides win on top of upstream — Ollama's /v1/chat/completions endpoint supports response_format
+        # with json_schema natively, but strict mode is not supported (issue #4116).
+        return merge_profile(
+            OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
+            profile,
+            OpenAIModelProfile(
+                openai_chat_thinking_field='reasoning',
+                openai_supports_strict_tool_definition=False,
+                supports_json_schema_output=True,
+                supports_json_object_output=True,
+            ),
+        )
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import os
-from dataclasses import replace
 from typing import overload
 
 import httpx
@@ -11,6 +10,7 @@ from pydantic_ai import ModelProfile
 from pydantic_ai._json_schema import JsonSchema, JsonSchemaTransformer
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
@@ -88,7 +88,7 @@ def _openrouter_google_model_profile(model_name: str) -> ModelProfile | None:
     profile = google_model_profile(model_name)
     if profile is None:  # pragma: no cover
         return None
-    return replace(profile, json_schema_transformer=_OpenRouterGoogleJsonSchemaTransformer)
+    return merge_profile(profile, ModelProfile(json_schema_transformer=_OpenRouterGoogleJsonSchemaTransformer))
 
 
 class OpenRouterProvider(Provider[AsyncOpenAI]):
@@ -131,15 +131,22 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
                 model_name = model_name.replace('.', '-')
             profile = provider_to_profile[provider](model_name)
 
-        # As OpenRouterProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
-        # we need to maintain that behavior unless json_schema_transformer is set explicitly
-        return OpenAIModelProfile(
-            json_schema_transformer=OpenAIJsonSchemaTransformer,
-            openai_chat_send_back_thinking_parts='field',
-            openai_chat_thinking_field='reasoning',
-            openai_chat_supports_file_urls=True,
-            openai_chat_supports_web_search=True,
-        ).update(profile)
+        # Three-layer merge:
+        # 1. Fallback layer — `OpenAIJsonSchemaTransformer` is the default unless an upstream profile sets one explicitly
+        #    (e.g. `_openrouter_google_model_profile` installs `_OpenRouterGoogleJsonSchemaTransformer`).
+        # 2. Upstream profile — model-specific traits from the lab's profile function.
+        # 3. Gateway-specific overrides — wins on every key it sets, because the upstream profile can't know what
+        #    the OpenRouter gateway adds (web plugin, file URLs, custom thinking field).
+        return merge_profile(
+            OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
+            profile,
+            OpenAIModelProfile(
+                openai_chat_send_back_thinking_parts='field',
+                openai_chat_thinking_field='reasoning',
+                openai_chat_supports_file_urls=True,
+                openai_chat_supports_web_search=True,
+            ),
+        )
 
     @overload
     def __init__(self, *, openai_client: AsyncOpenAI) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ovhcloud.py
@@ -8,6 +8,7 @@ import httpx
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.harmony import harmony_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
@@ -59,7 +60,7 @@ class OVHcloudProvider(Provider[AsyncOpenAI]):
                 profile = profile_func(model_name)
 
         # As the OVHcloud AI Endpoints API is OpenAI-compatible, let's assume we also need OpenAIJsonSchemaTransformer.
-        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+        return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)
 
     @overload
     def __init__(self) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/sambanova.py
@@ -8,6 +8,7 @@ from openai import AsyncOpenAI
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
@@ -72,7 +73,7 @@ class SambaNovaProvider(Provider[AsyncOpenAI]):
                 break
 
         # Wrap into OpenAIModelProfile since SambaNova is OpenAI-compatible
-        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+        return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)
 
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -9,6 +9,7 @@ from openai import AsyncOpenAI
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
@@ -60,7 +61,7 @@ class TogetherProvider(Provider[AsyncOpenAI]):
 
         # As the Together API is OpenAI-compatible, let's assume we also need OpenAIJsonSchemaTransformer,
         # unless json_schema_transformer is set explicitly
-        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+        return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)
 
     @overload
     def __init__(self) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/vercel.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/vercel.py
@@ -8,6 +8,7 @@ import httpx
 from pydantic_ai import ModelProfile
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
@@ -66,9 +67,7 @@ class VercelProvider(Provider[AsyncOpenAI]):
 
         # As VercelProvider is always used with OpenAIChatModel, which used to unconditionally use OpenAIJsonSchemaTransformer,
         # we need to maintain that behavior unless json_schema_transformer is set explicitly
-        return OpenAIModelProfile(
-            json_schema_transformer=OpenAIJsonSchemaTransformer,
-        ).update(profile)
+        return merge_profile(OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer), profile)
 
     @overload
     def __init__(self) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/xai.py
@@ -11,7 +11,7 @@ from pydantic_ai.providers import Provider
 
 try:
     from xai_sdk import AsyncClient
-except ImportError as _import_error:  # pragma: no cover
+except ImportError as _import_error:
     raise ImportError(
         'Please install the `xai-sdk` package to use the xAI provider, '
         'you can use the `xai` optional group — `pip install "pydantic-ai-slim[xai]"`'

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
@@ -13,7 +13,7 @@ from starlette.routing import Route
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import NativeTool
 from pydantic_ai.models import KnownModelName, Model, infer_model
-from pydantic_ai.native_tools import AbstractNativeTool
+from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.ui.vercel_ai import VercelAIAdapter
 
@@ -126,7 +126,7 @@ def create_api_app(
             continue
         seen_model_ids.add(model_id)
         display_name = label or model.label
-        model_supported_tools = model.profile.supported_native_tools
+        model_supported_tools = model.profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)
         supported_tool_ids = [t.unique_id for t in ui_native_tools if type(t) in model_supported_tools]
 
         model_id_to_ref[model_id] = model_ref

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -60,7 +60,14 @@ from pydantic_ai.messages import (
     UploadedFile,
 )
 from pydantic_ai.models import ModelRequestParameters
-from pydantic_ai.native_tools import CodeExecutionTool, MCPServerTool, MemoryTool, WebFetchTool, WebSearchTool
+from pydantic_ai.native_tools import (
+    SUPPORTED_NATIVE_TOOLS,
+    CodeExecutionTool,
+    MCPServerTool,
+    MemoryTool,
+    WebFetchTool,
+    WebSearchTool,
+)
 from pydantic_ai.native_tools._tool_search import ToolSearchTool
 from pydantic_ai.output import NativeOutput, PromptedOutput, TextOutput, ToolOutput
 from pydantic_ai.result import RunUsage
@@ -603,8 +610,8 @@ def test_anthropic_model_resolves_profile_for_bedrock_model_ids(model_name: str,
         model_name, provider=AnthropicProvider(anthropic_client=_mock_anthropic_client(client_cls, base_url))
     )
     assert m.model_name == model_name
-    assert m.profile.supports_json_schema_output is True
-    assert ToolSearchTool in m.profile.supported_native_tools
+    assert m.profile.get('supports_json_schema_output', False) is True
+    assert ToolSearchTool in m.profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)
 
 
 def _tool_search_param(client_cls: Any, base_url: str, tool: ToolSearchTool) -> dict[str, Any]:

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -387,4 +387,4 @@ def test_custom_provider_instance_method_model_profile():
     assert provider.client is None
     # Instance call should still work
     profile = provider.model_profile('some-model')
-    assert isinstance(profile, ModelProfile)
+    assert isinstance(profile, dict)

--- a/tests/models/test_ollama.py
+++ b/tests/models/test_ollama.py
@@ -52,9 +52,7 @@ class Pet(BaseModel):
 
 
 def _get_profile(model: OllamaModel) -> OpenAIModelProfile:
-    from typing import cast as _cast
-
-    return _cast(OpenAIModelProfile, model.profile)
+    return model.profile
 
 
 def test_local_ollama_supports_json_schema_output(ollama_api_key: str) -> None:

--- a/tests/models/test_ollama.py
+++ b/tests/models/test_ollama.py
@@ -52,7 +52,9 @@ class Pet(BaseModel):
 
 
 def _get_profile(model: OllamaModel) -> OpenAIModelProfile:
-    return OpenAIModelProfile.from_profile(model.profile)
+    from typing import cast as _cast
+
+    return _cast(OpenAIModelProfile, model.profile)
 
 
 def test_local_ollama_supports_json_schema_output(ollama_api_key: str) -> None:
@@ -63,9 +65,9 @@ def test_local_ollama_supports_json_schema_output(ollama_api_key: str) -> None:
     model = OllamaModel('qwen3:0.6b', provider=provider)
     profile = _get_profile(model)
 
-    assert model.profile.supports_json_schema_output is True
-    assert model.profile.supports_json_object_output is True
-    assert profile.openai_supports_strict_tool_definition is False
+    assert model.profile.get('supports_json_schema_output', False) is True
+    assert model.profile.get('supports_json_object_output', False) is True
+    assert profile.get('openai_supports_strict_tool_definition', True) is False
 
 
 def test_ollama_cloud_base_url_disables_json_schema_output(ollama_api_key: str) -> None:
@@ -77,9 +79,9 @@ def test_ollama_cloud_base_url_disables_json_schema_output(ollama_api_key: str) 
     model = OllamaModel('gpt-oss:20b', provider=provider)
     profile = _get_profile(model)
 
-    assert model.profile.supports_json_schema_output is False
-    assert model.profile.supports_json_object_output is True
-    assert profile.openai_supports_strict_tool_definition is False
+    assert model.profile.get('supports_json_schema_output', False) is False
+    assert model.profile.get('supports_json_object_output', False) is True
+    assert profile.get('openai_supports_strict_tool_definition', True) is False
 
 
 def test_local_ollama_cloud_suffix_disables_json_schema_output(ollama_api_key: str) -> None:
@@ -88,8 +90,8 @@ def test_local_ollama_cloud_suffix_disables_json_schema_output(ollama_api_key: s
     provider = OllamaProvider(base_url=OLLAMA_LOCAL_BASE_URL, api_key=ollama_api_key)
     model = OllamaModel('gpt-oss:20b-cloud', provider=provider)
 
-    assert model.profile.supports_json_schema_output is False
-    assert model.profile.supports_json_object_output is True
+    assert model.profile.get('supports_json_schema_output', False) is False
+    assert model.profile.get('supports_json_object_output', False) is True
 
 
 def test_ollama_explicit_profile_overrides_cloud_detection(ollama_api_key: str) -> None:
@@ -99,7 +101,7 @@ def test_ollama_explicit_profile_overrides_cloud_detection(ollama_api_key: str) 
     override = OpenAIModelProfile(supports_json_schema_output=True)
     model = OllamaModel('gpt-oss:20b', provider=provider, profile=override)
 
-    assert model.profile.supports_json_schema_output is True
+    assert model.profile.get('supports_json_schema_output', False) is True
 
 
 async def test_ollama_cloud_native_output_raises(allow_model_requests: None, ollama_api_key: str) -> None:
@@ -133,7 +135,7 @@ def test_ollama_provider_name_routes_through_ollama_model(monkeypatch: pytest.Mo
 
     agent = Agent('ollama:gpt-oss:20b')
     assert isinstance(agent.model, OllamaModel)
-    assert agent.model.profile.supports_json_schema_output is False
+    assert agent.model.profile.get('supports_json_schema_output', False) is False
 
 
 # ---------- VCR integration tests against live Ollama ----------

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -52,6 +52,7 @@ from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.native_tools import ImageGenerationTool, WebSearchTool
 from pydantic_ai.output import NativeOutput, PromptedOutput, TextOutput, ToolOutput
+from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
 from pydantic_ai.result import RunUsage
 from pydantic_ai.settings import ModelSettings
@@ -1000,9 +1001,9 @@ async def test_openai_pass_custom_system_prompt_role(allow_model_requests: None,
     model = OpenAIChatModel(  # type: ignore[reportDeprecated]
         'o1-mini', profile=profile, provider=OpenAIProvider(api_key=openai_api_key), system_prompt_role='user'
     )
-    profile = OpenAIModelProfile.from_profile(model.profile)
-    assert profile.openai_system_prompt_role == 'user'
-    assert profile.supports_tools is False
+    profile = model.profile
+    assert profile.get('openai_system_prompt_role', None) == 'user'
+    assert profile.get('supports_tools', True) is False
 
 
 @pytest.mark.parametrize('system_prompt_role', ['system', 'developer'])
@@ -2699,8 +2700,8 @@ async def test_strict_mode_cannot_infer_strict(
     # If the model profile says strict is not supported, we never pass strict
     await assert_strict(
         None,
-        profile=OpenAIModelProfile(openai_supports_strict_tool_definition=False).update(
-            openai_model_profile('test-model')
+        profile=merge_profile(
+            OpenAIModelProfile(openai_supports_strict_tool_definition=False), openai_model_profile('test-model')
         ),
     )
 
@@ -3224,7 +3225,7 @@ async def test_reasoning_model_with_temperature(allow_model_requests: None, open
 
 def test_openai_model_profile():
     m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='foobar'))
-    assert isinstance(m.profile, OpenAIModelProfile)
+    assert isinstance(m.profile, dict)
 
 
 def test_openai_model_profile_custom():
@@ -3233,29 +3234,32 @@ def test_openai_model_profile_custom():
         provider=OpenAIProvider(api_key='foobar'),
         profile=ModelProfile(json_schema_transformer=InlineDefsJsonSchemaTransformer),
     )
-    assert isinstance(m.profile, ModelProfile)
-    assert m.profile.json_schema_transformer is InlineDefsJsonSchemaTransformer
+    assert isinstance(m.profile, dict)
+    assert m.profile.get('json_schema_transformer', None) is InlineDefsJsonSchemaTransformer
 
     m = OpenAIChatModel(
         'gpt-4o',
         provider=OpenAIProvider(api_key='foobar'),
         profile=OpenAIModelProfile(openai_supports_strict_tool_definition=False),
     )
-    assert isinstance(m.profile, OpenAIModelProfile)
-    assert m.profile.openai_supports_strict_tool_definition is False
+    assert isinstance(m.profile, dict)
+    assert m.profile.get('openai_supports_strict_tool_definition', True) is False
 
 
-def test_openai_model_profile_function():
-    def model_profile(model_name: str) -> ModelProfile:
-        return ModelProfile(json_schema_transformer=InlineDefsJsonSchemaTransformer if model_name == 'gpt-4o' else None)
+def test_openai_model_profile_callable():
+    """The user `profile=` kwarg accepts a `Callable[[ModelProfile], ModelProfile]` that receives the resolved default and returns the final profile."""
 
-    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='foobar'), profile=model_profile)
-    assert isinstance(m.profile, ModelProfile)
-    assert m.profile.json_schema_transformer is InlineDefsJsonSchemaTransformer
+    def override(default: ModelProfile) -> ModelProfile:
+        return merge_profile(default, ModelProfile(json_schema_transformer=InlineDefsJsonSchemaTransformer))
 
-    m = OpenAIChatModel('gpt-4o-mini', provider=OpenAIProvider(api_key='foobar'), profile=model_profile)
-    assert isinstance(m.profile, ModelProfile)
-    assert m.profile.json_schema_transformer is None
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='foobar'), profile=override)
+    assert isinstance(m.profile, dict)
+    assert m.profile.get('json_schema_transformer', None) is InlineDefsJsonSchemaTransformer
+
+    # The callable can also fully replace the default.
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='foobar'), profile=lambda _default: ModelProfile())
+    assert isinstance(m.profile, dict)
+    assert m.profile.get('json_schema_transformer', None) is None
 
 
 def test_openai_model_profile_from_provider():
@@ -3267,12 +3271,12 @@ def test_openai_model_profile_from_provider():
             )
 
     m = OpenAIChatModel('gpt-4o', provider=CustomProvider(api_key='foobar'))
-    assert isinstance(m.profile, ModelProfile)
-    assert m.profile.json_schema_transformer is InlineDefsJsonSchemaTransformer
+    assert isinstance(m.profile, dict)
+    assert m.profile.get('json_schema_transformer', None) is InlineDefsJsonSchemaTransformer
 
     m = OpenAIChatModel('gpt-4o-mini', provider=CustomProvider(api_key='foobar'))
-    assert isinstance(m.profile, ModelProfile)
-    assert m.profile.json_schema_transformer is None
+    assert isinstance(m.profile, dict)
+    assert m.profile.get('json_schema_transformer', None) is None
 
 
 def test_model_profile_strict_not_supported():
@@ -3302,7 +3306,7 @@ def test_model_profile_strict_not_supported():
     m = OpenAIChatModel(
         'gpt-4o',
         provider=OpenAIProvider(api_key='foobar'),
-        profile=OpenAIModelProfile(openai_supports_strict_tool_definition=False).update(openai_model_profile('gpt-4o')),
+        profile=OpenAIModelProfile(openai_supports_strict_tool_definition=False),
     )
     tool_param = m._map_tool_definition(my_tool)  # type: ignore[reportPrivateUsage]
 
@@ -4139,7 +4143,9 @@ async def test_service_tier_non_standard_value(allow_model_requests: None):
 
 
 async def test_tool_choice_fallback(allow_model_requests: None) -> None:
-    profile = OpenAIModelProfile(openai_supports_tool_choice_required=False).update(openai_model_profile('stub'))
+    profile = merge_profile(
+        OpenAIModelProfile(openai_supports_tool_choice_required=False), openai_model_profile('stub')
+    )
 
     mock_client = MockOpenAI.create_mock(completion_message(ChatCompletionMessage(content='ok', role='assistant')))
     model = OpenAIChatModel('stub', provider=OpenAIProvider(openai_client=mock_client), profile=profile)
@@ -4158,7 +4164,9 @@ async def test_tool_choice_fallback(allow_model_requests: None) -> None:
 
 async def test_tool_choice_fallback_response_api(allow_model_requests: None) -> None:
     """Ensure tool_choice falls back to 'auto' for Responses API when 'required' unsupported."""
-    profile = OpenAIModelProfile(openai_supports_tool_choice_required=False).update(openai_model_profile('stub'))
+    profile = merge_profile(
+        OpenAIModelProfile(openai_supports_tool_choice_required=False), openai_model_profile('stub')
+    )
 
     mock_client = MockOpenAIResponses.create_mock(response_message([]))
     model = OpenAIResponsesModel('openai/gpt-oss', provider=OpenAIProvider(openai_client=mock_client), profile=profile)
@@ -4315,6 +4323,16 @@ response\
 """,
         }
     )
+
+
+def test_openai_send_back_thinking_field_requires_thinking_field():
+    """`openai_chat_send_back_thinking_parts='field'` requires `openai_chat_thinking_field` to be set."""
+    with pytest.raises(UserError, match='`openai_chat_thinking_field` must be set to a non-None value'):
+        OpenAIChatModel(
+            'foobar',
+            provider=OpenAIProvider(api_key='dummy'),
+            profile=OpenAIModelProfile(openai_chat_send_back_thinking_parts='field'),
+        )
 
 
 async def test_openai_custom_reasoning_field_sending_back_in_custom_field(allow_model_requests: None):

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -2,7 +2,6 @@ import json
 import re
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -53,7 +52,8 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.native_tools import CodeExecutionTool, FileSearchTool, ImageAspectRatio, MCPServerTool, WebSearchTool
 from pydantic_ai.output import NativeOutput, PromptedOutput, TextOutput, ToolOutput
-from pydantic_ai.profiles.openai import OpenAIModelProfile, OpenAISystemPromptRole, openai_model_profile
+from pydantic_ai.profiles import merge_profile
+from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage, RunUsage
 
@@ -1952,7 +1952,9 @@ def test_model_profile_strict_not_supported():
     m = OpenAIResponsesModel(
         'gpt-4o',
         provider=OpenAIProvider(api_key='foobar'),
-        profile=replace(openai_model_profile('gpt-4o'), openai_supports_strict_tool_definition=False),
+        profile=merge_profile(
+            openai_model_profile('gpt-4o'), OpenAIModelProfile(openai_supports_strict_tool_definition=False)
+        ),
     )
     tool_param = m._map_tool_definition(my_tool)  # type: ignore[reportPrivateUsage]
 
@@ -9632,7 +9634,9 @@ async def test_openai_responses_requires_function_call_status_none(allow_model_r
     model = OpenAIResponsesModel(
         'gpt-5',
         provider=OpenAIProvider(api_key=openai_api_key),
-        profile=replace(openai_model_profile('gpt-5'), openai_responses_requires_function_call_status_none=True),
+        profile=merge_profile(
+            openai_model_profile('gpt-5'), OpenAIModelProfile(openai_responses_requires_function_call_status_none=True)
+        ),
     )
     agent = Agent(model)
 
@@ -10868,38 +10872,6 @@ async def test_openai_responses_system_prompts_ordering(allow_model_requests: No
     )
 
 
-@pytest.mark.parametrize('system_prompt_role', ['system', 'developer', 'user', None])
-async def test_openai_responses_system_prompt_role(
-    allow_model_requests: None, system_prompt_role: OpenAISystemPromptRole | None
-) -> None:
-    """`openai_system_prompt_role` profile setting drives the role used for `SystemPromptPart`s on the Responses API."""
-    c = response_message(
-        [
-            ResponseOutputMessage(
-                id='msg_1',
-                content=cast(list[Content], [ResponseOutputText(text='world', type='output_text', annotations=[])]),
-                role='assistant',
-                status='completed',
-                type='message',
-            ),
-        ],
-    )
-    mock_client = MockOpenAIResponses.create_mock(c)
-    profile = OpenAIModelProfile(openai_system_prompt_role=system_prompt_role)
-    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client), profile=profile)
-    agent = Agent(model, system_prompt='some instructions')
-
-    result = await agent.run('hello')
-    assert result.output == 'world'
-
-    expected_role = system_prompt_role or 'system'
-    kwargs = get_mock_responses_kwargs(mock_client)[0]
-    assert kwargs['input'] == [
-        {'content': 'some instructions', 'role': expected_role},
-        {'content': 'hello', 'role': 'user'},
-    ]
-
-
 async def test_reasoning_summary_auto(allow_model_requests: None, openai_api_key: str):
     model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(api_key=openai_api_key))
     agent = Agent(model, instructions='You are a helpful coding assistant.')
@@ -11967,10 +11939,10 @@ async def test_openai_responses_phase_live(allow_model_requests: None, openai_ap
 
 def test_openai_responses_phase_profile_flag():
     """Profile flag tracks the documented set of supporting models."""
-    assert cast(Any, openai_model_profile('gpt-5.5')).openai_supports_phase is True
-    assert cast(Any, openai_model_profile('gpt-5.4')).openai_supports_phase is True
-    assert cast(Any, openai_model_profile('gpt-5.3-codex')).openai_supports_phase is True
-    assert cast(Any, openai_model_profile('gpt-5.3')).openai_supports_phase is False
-    assert cast(Any, openai_model_profile('gpt-5.2')).openai_supports_phase is False
-    assert cast(Any, openai_model_profile('gpt-5')).openai_supports_phase is False
-    assert cast(Any, openai_model_profile('gpt-4o')).openai_supports_phase is False
+    assert openai_model_profile('gpt-5.5').get('openai_supports_phase', False) is True
+    assert openai_model_profile('gpt-5.4').get('openai_supports_phase', False) is True
+    assert openai_model_profile('gpt-5.3-codex').get('openai_supports_phase', False) is True
+    assert openai_model_profile('gpt-5.3').get('openai_supports_phase', False) is False
+    assert openai_model_profile('gpt-5.2').get('openai_supports_phase', False) is False
+    assert openai_model_profile('gpt-5').get('openai_supports_phase', False) is False
+    assert openai_model_profile('gpt-4o').get('openai_supports_phase', False) is False

--- a/tests/models/xai/test_search_tools.py
+++ b/tests/models/xai/test_search_tools.py
@@ -21,7 +21,7 @@ from pydantic_ai import (
 )
 from pydantic_ai.capabilities import NativeTool
 from pydantic_ai.messages import PartStartEvent, RequestUsage
-from pydantic_ai.profiles.grok import GrokModelProfile, grok_model_profile
+from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.usage import RunUsage
 
 from ..._inline_snapshot import snapshot
@@ -91,8 +91,8 @@ XAI_REASONING_MODEL = 'grok-4-fast-reasoning'
 def test_grok_model_profile_thinking(model_name: str, expected_thinking: bool) -> None:
     profile = grok_model_profile(model_name)
     assert profile is not None
-    assert profile.supports_thinking == expected_thinking
-    assert profile.thinking_always_enabled is False
+    assert profile.get('supports_thinking', False) == expected_thinking
+    assert profile.get('thinking_always_enabled', False) is False
 
 
 async def test_grok_4_reasoning_model_does_not_forward_reasoning_effort(allow_model_requests: None) -> None:
@@ -116,13 +116,13 @@ async def test_grok_4_reasoning_model_does_not_forward_reasoning_effort(allow_mo
 def test_grok_model_profile_builtin_tools() -> None:
     grok4_profile = grok_model_profile('grok-4-fast-non-reasoning')
     assert grok4_profile is not None
-    assert isinstance(grok4_profile, GrokModelProfile)
-    assert grok4_profile.grok_supports_builtin_tools is True
+    assert isinstance(grok4_profile, dict)
+    assert grok4_profile.get('grok_supports_builtin_tools', False) is True
 
     grok3_profile = grok_model_profile('grok-3')
     assert grok3_profile is not None
-    assert isinstance(grok3_profile, GrokModelProfile)
-    assert grok3_profile.grok_supports_builtin_tools is False
+    assert isinstance(grok3_profile, dict)
+    assert grok3_profile.get('grok_supports_builtin_tools', False) is False
 
 
 # =============================================================================

--- a/tests/profiles/test_anthropic.py
+++ b/tests/profiles/test_anthropic.py
@@ -278,18 +278,18 @@ def test_model_profile_supported_model():
     """Models that support structured outputs have supports_json_schema_output=True."""
     profile = anthropic_model_profile('claude-sonnet-4-5')
     assert profile is not None
-    assert profile.supports_json_schema_output is True
+    assert profile.get('supports_json_schema_output', False) is True
 
 
 def test_model_profile_unsupported_model():
     """Models that don't support structured outputs have supports_json_schema_output=False."""
     profile = anthropic_model_profile('claude-sonnet-4-0')
     assert profile is not None
-    assert profile.supports_json_schema_output is False
+    assert profile.get('supports_json_schema_output', False) is False
 
 
 def test_model_profile_opus():
     """Opus 4.1 supports structured outputs."""
     profile = anthropic_model_profile('claude-opus-4-1')
     assert profile is not None
-    assert profile.supports_json_schema_output is True
+    assert profile.get('supports_json_schema_output', False) is True

--- a/tests/profiles/test_google.py
+++ b/tests/profiles/test_google.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer, GoogleModelProfile, google_model_profile
+from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer, google_model_profile
 
 from .._inline_snapshot import snapshot
 
@@ -189,8 +189,8 @@ def test_model_profile_gemini_2():
     """Gemini 2.x models should have proper profile settings."""
     profile = google_model_profile('gemini-2.0-flash')
     assert profile is not None
-    assert profile.json_schema_transformer == GoogleJsonSchemaTransformer
-    assert profile.supports_json_schema_output is True
+    assert profile.get('json_schema_transformer', None) == GoogleJsonSchemaTransformer
+    assert profile.get('supports_json_schema_output', False) is True
 
 
 def test_model_profile_gemini_3():
@@ -201,23 +201,21 @@ def test_model_profile_gemini_3():
     """
     profile = google_model_profile('gemini-3.0-pro')
     assert profile is not None
-    assert isinstance(profile, GoogleModelProfile)
-    assert profile.google_supports_tool_combination is True
-    assert profile.google_supports_server_side_tool_invocations is True
+    assert profile.get('google_supports_tool_combination', False) is True
+    assert profile.get('google_supports_server_side_tool_invocations', False) is True
 
 
 def test_model_profile_gemini_2_disables_tool_combination_capabilities():
     profile = google_model_profile('gemini-2.5-flash')
     assert profile is not None
-    assert isinstance(profile, GoogleModelProfile)
-    assert profile.google_supports_tool_combination is False
-    assert profile.google_supports_server_side_tool_invocations is False
+    assert profile.get('google_supports_tool_combination', False) is False
+    assert profile.get('google_supports_server_side_tool_invocations', False) is False
 
 
 def test_model_profile_image_model():
     """Image models should have limited capabilities."""
     profile = google_model_profile('gemini-2.0-flash-image')
     assert profile is not None
-    assert profile.supports_image_output is True
-    assert profile.supports_json_schema_output is False
-    assert profile.supports_tools is False
+    assert profile.get('supports_image_output', False) is True
+    assert profile.get('supports_json_schema_output', False) is False
+    assert profile.get('supports_tools', True) is False

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -14,7 +14,7 @@ import pytest
 from ..conftest import try_import
 
 with try_import() as imports_successful:
-    from pydantic_ai.profiles.openai import OpenAIModelProfile, openai_model_profile
+    from pydantic_ai.profiles.openai import openai_model_profile
 
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='openai not installed'),
@@ -68,9 +68,9 @@ SAMPLING_PARAMS_CASES = [
 def test_sampling_params_support(case: SamplingParamsCase):
     """Test reasoning capability flags for OpenAI models."""
     profile = openai_model_profile(case.model)
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.openai_supports_reasoning is case.supports_reasoning
-    assert profile.openai_supports_reasoning_effort_none is case.supports_reasoning_effort_none
+    assert isinstance(profile, dict)
+    assert profile.get('openai_supports_reasoning', False) is case.supports_reasoning
+    assert profile.get('openai_supports_reasoning_effort_none', False) is case.supports_reasoning_effort_none
 
 
 class TestEncryptedReasoningContent:
@@ -80,12 +80,12 @@ class TestEncryptedReasoningContent:
         """Models with reasoning support encrypted reasoning content."""
         for model in ['o1', 'o3', 'gpt-5', 'gpt-5.1', 'gpt-5.2', 'gpt-5.3-codex', 'gpt-5.4', 'gpt-5.5']:
             profile = openai_model_profile(model)
-            assert isinstance(profile, OpenAIModelProfile)
-            assert profile.openai_supports_encrypted_reasoning_content is True
+            assert isinstance(profile, dict)
+            assert profile.get('openai_supports_encrypted_reasoning_content', False) is True
 
     def test_non_reasoning_models_no_encrypted_content(self):
         """Models without reasoning don't support encrypted reasoning content."""
         for model in ['gpt-4o', 'gpt-4o-mini', 'gpt-5-chat', 'gpt-5.3-chat-latest']:
             profile = openai_model_profile(model)
-            assert isinstance(profile, OpenAIModelProfile)
-            assert profile.openai_supports_encrypted_reasoning_content is False
+            assert isinstance(profile, dict)
+            assert profile.get('openai_supports_encrypted_reasoning_content', False) is False

--- a/tests/profiles/test_resolution_lockin.py
+++ b/tests/profiles/test_resolution_lockin.py
@@ -6,7 +6,7 @@ case (Bedrock-Anthropic, OpenRouter-Google, etc.). The snapshots are the compari
 artifact: any refactor that changes a profile's resolved shape must explicitly update
 these tests.
 
-Used to gate the upcoming `ModelProfile` TypedDict migration (PR #5340 / #TBD): if any
+Used to gate the upcoming `ModelProfile` TypedDict migration (PR #5340 / #5481): if any
 of these snapshots change after the migration without an intentional reason, that's a
 silent semantics regression.
 

--- a/tests/profiles/test_resolution_lockin.py
+++ b/tests/profiles/test_resolution_lockin.py
@@ -1,0 +1,1421 @@
+"""Lock-in snapshots of `Provider.model_profile(model_name)` resolution.
+
+Captures the resolved `ModelProfile` for every interesting (provider, model_name)
+combination — every gateway, every inference provider, every cross-provider routing
+case (Bedrock-Anthropic, OpenRouter-Google, etc.). The snapshots are the comparison
+artifact: any refactor that changes a profile's resolved shape must explicitly update
+these tests.
+
+Used to gate the upcoming `ModelProfile` TypedDict migration (PR #5340 / #TBD): if any
+of these snapshots change after the migration without an intentional reason, that's a
+silent semantics regression.
+
+Provider classes that do `merge_profile(fallback, upstream, override)` (3-layer) have
+the highest risk of silent inversion in the migration — those cases are the densest here.
+
+The `_normalize` helper strips default values, so each snapshot shows only the
+non-default fields of the resolved profile. That keeps snapshots stable across the
+dataclass→TypedDict migration (both representations normalize to the same dict).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from textwrap import dedent
+from typing import Any
+
+import pytest
+
+from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer
+from pydantic_ai.native_tools import (
+    SUPPORTED_NATIVE_TOOLS,
+    CodeExecutionTool,
+    FileSearchTool,
+    ImageGenerationTool,
+    MCPServerTool,
+    MemoryTool,
+    WebFetchTool,
+    WebSearchTool,
+)
+from pydantic_ai.native_tools._tool_search import ToolSearchTool
+from pydantic_ai.profiles import ModelProfile
+from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
+
+from .._inline_snapshot import snapshot
+from ..conftest import try_import
+
+with try_import() as anthropic_imports:
+    from pydantic_ai.providers.anthropic import AnthropicJsonSchemaTransformer, AnthropicProvider
+
+with try_import() as bedrock_imports:
+    from pydantic_ai.providers.bedrock import BedrockProvider
+
+with try_import() as groq_imports:
+    from pydantic_ai.providers.groq import GroqProvider
+
+with try_import() as openrouter_google_imports:
+    # OpenRouter installs its own Google transformer; importable so inline_snapshot can name it.
+    from pydantic_ai.providers.openrouter import (
+        _OpenRouterGoogleJsonSchemaTransformer,  # pyright: ignore[reportPrivateUsage]
+    )
+
+# Canonical defaults — matches `DEFAULT_PROFILE` on both dataclass v1 and TypedDict v2.
+# Defined locally so the test is stable across the migration: anything matching these
+# values gets stripped from the snapshot, leaving only the non-default fields.
+_CANONICAL_DEFAULTS: dict[str, Any] = {
+    # Top-level `ModelProfile` defaults
+    'supports_tools': True,
+    'supports_tool_return_schema': False,
+    'supports_json_schema_output': False,
+    'supports_json_object_output': False,
+    'supports_image_output': False,
+    'default_structured_output_mode': 'tool',
+    'prompted_output_template': dedent(
+        """
+        Always respond with a JSON object that's compatible with this schema:
+
+        {schema}
+
+        Don't include any text or Markdown fencing before or after.
+        """
+    ),
+    'native_output_requires_schema_in_instructions': False,
+    'json_schema_transformer': None,
+    'supports_thinking': False,
+    'thinking_always_enabled': False,
+    'thinking_tags': ('<think>', '</think>'),
+    'ignore_streamed_leading_whitespace': False,
+    'supported_native_tools': SUPPORTED_NATIVE_TOOLS,
+    # OpenAIModelProfile subclass defaults
+    'openai_chat_thinking_field': None,
+    'openai_chat_send_back_thinking_parts': 'auto',
+    'openai_supports_strict_tool_definition': True,
+    'openai_supports_sampling_settings': True,
+    'openai_unsupported_model_settings': (),
+    'openai_supports_tool_choice_required': True,
+    'openai_system_prompt_role': None,
+    'openai_chat_supports_multiple_system_messages': True,
+    'openai_chat_supports_web_search': False,
+    'openai_chat_audio_input_encoding': 'base64',
+    'openai_chat_supports_file_urls': False,
+    'openai_supports_encrypted_reasoning_content': False,
+    'openai_supports_reasoning': False,
+    'openai_supports_reasoning_effort_none': False,
+    'openai_responses_requires_function_call_status_none': False,
+    'openai_supports_phase': False,
+    'openai_chat_supports_document_input': True,
+    # AnthropicModelProfile subclass defaults
+    'anthropic_supports_fast_speed': False,
+    'anthropic_supports_adaptive_thinking': False,
+    'anthropic_supports_effort': False,
+    'anthropic_supports_xhigh_effort': False,
+    'anthropic_disallows_budget_thinking': False,
+    'anthropic_disallows_sampling_settings': False,
+    'anthropic_default_code_execution_tool_version': '20250825',
+    'anthropic_supported_code_execution_tool_versions': ('20250825',),
+    'anthropic_supports_task_budgets': False,
+    # GoogleModelProfile subclass defaults
+    'google_supports_tool_combination': False,
+    'google_supports_server_side_tool_invocations': False,
+    'google_supported_mime_types_in_tool_returns': (),
+    'google_supports_thinking_level': False,
+    # GrokModelProfile subclass defaults
+    'grok_supports_builtin_tools': False,
+    'grok_supports_tool_choice_required': True,
+    # GroqModelProfile subclass defaults
+    'groq_always_has_web_search_builtin_tool': False,
+    # BedrockModelProfile subclass defaults
+    'bedrock_supports_tool_choice': False,
+    'bedrock_tool_result_format': 'text',
+    'bedrock_send_back_thinking_parts': False,
+    'bedrock_supports_prompt_caching': False,
+    'bedrock_supports_tool_caching': False,
+    'bedrock_supported_media_kinds_in_tool_returns': frozenset({'image'}),
+    'bedrock_thinking_variant': None,
+}
+
+
+def _normalize(profile: Any) -> dict[str, Any] | None:
+    """Reduce a `ModelProfile` (dataclass or TypedDict) to a dict of non-default fields.
+
+    - Pre-migration: profile is a `@dataclass` instance; `asdict()` extracts every field.
+    - Post-migration: profile is a `TypedDict` (a dict); already in the right shape.
+
+    Either way, we strip values matching `_CANONICAL_DEFAULTS` so the snapshot focuses
+    on the deltas the provider/gateway actually contributes.
+    """
+    if profile is None:
+        return None
+    if dataclasses.is_dataclass(profile):
+        # Use a shallow extraction (not asdict, which recurses through dataclass-typed
+        # nested values — none expected here, but defensive).
+        raw = {f.name: getattr(profile, f.name) for f in dataclasses.fields(profile)}
+    else:
+        raw = dict(profile)
+    return {k: v for k, v in raw.items() if k not in _CANONICAL_DEFAULTS or v != _CANONICAL_DEFAULTS[k]}
+
+
+# Quiet pyright on the imported tool symbols — they're referenced by name in the
+# generated snapshots below.
+_TOOL_SYMBOLS_REFERENCED_IN_SNAPSHOTS = (
+    CodeExecutionTool,
+    FileSearchTool,
+    ImageGenerationTool,
+    MCPServerTool,
+    MemoryTool,
+    WebFetchTool,
+    WebSearchTool,
+    ToolSearchTool,
+    InlineDefsJsonSchemaTransformer,
+    OpenAIJsonSchemaTransformer,
+    GoogleJsonSchemaTransformer,
+)
+
+
+# =============================================================================
+# Direct labs — single-layer profile functions (no gateway merging)
+# =============================================================================
+
+
+@pytest.mark.skipif(not anthropic_imports(), reason='anthropic not installed')
+def test_anthropic_claude_sonnet_4_6():
+    profile = AnthropicProvider.model_profile('claude-sonnet-4-6')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'json_schema_transformer': AnthropicJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_tags': ('<thinking>', '</thinking>'),
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, MCPServerTool, MemoryTool, ToolSearchTool, WebFetchTool, WebSearchTool}
+            ),
+            'anthropic_supports_adaptive_thinking': True,
+            'anthropic_supports_effort': True,
+            'anthropic_default_code_execution_tool_version': '20260120',
+            'anthropic_supported_code_execution_tool_versions': ('20250825', '20260120'),
+        }
+    )
+
+
+@pytest.mark.skipif(not anthropic_imports(), reason='anthropic not installed')
+def test_anthropic_claude_opus_4_7():
+    profile = AnthropicProvider.model_profile('claude-opus-4-7')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'json_schema_transformer': AnthropicJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_tags': ('<thinking>', '</thinking>'),
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, MCPServerTool, MemoryTool, ToolSearchTool, WebFetchTool, WebSearchTool}
+            ),
+            'anthropic_supports_adaptive_thinking': True,
+            'anthropic_supports_effort': True,
+            'anthropic_supports_xhigh_effort': True,
+            'anthropic_disallows_budget_thinking': True,
+            'anthropic_disallows_sampling_settings': True,
+            'anthropic_default_code_execution_tool_version': '20260120',
+            'anthropic_supported_code_execution_tool_versions': ('20250825', '20260120'),
+            'anthropic_supports_task_budgets': True,
+        }
+    )
+
+
+@pytest.mark.skipif(not anthropic_imports(), reason='anthropic not installed')
+def test_anthropic_claude_haiku_4_5():
+    profile = AnthropicProvider.model_profile('claude-haiku-4-5')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'json_schema_transformer': AnthropicJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_tags': ('<thinking>', '</thinking>'),
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, MCPServerTool, MemoryTool, ToolSearchTool, WebFetchTool, WebSearchTool}
+            ),
+        }
+    )
+
+
+@pytest.mark.skipif(not anthropic_imports(), reason='anthropic not installed')
+def test_anthropic_claude_3_5_sonnet_legacy():
+    """Older model — no structured output, no tool search."""
+    profile = AnthropicProvider.model_profile('claude-3-5-sonnet-20240620')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': AnthropicJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_tags': ('<thinking>', '</thinking>'),
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, MCPServerTool, MemoryTool, WebFetchTool, WebSearchTool}
+            ),
+        }
+    )
+
+
+def test_openai_gpt_5_4():
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    profile = OpenAIProvider.model_profile('gpt-5.4')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'supports_image_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, FileSearchTool, ImageGenerationTool, MCPServerTool, ToolSearchTool, WebSearchTool}
+            ),
+            'openai_supports_encrypted_reasoning_content': True,
+            'openai_supports_reasoning': True,
+            'openai_supports_reasoning_effort_none': True,
+            'openai_supports_phase': True,
+        }
+    )
+
+
+def test_openai_gpt_4o():
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    profile = OpenAIProvider.model_profile('gpt-4o')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'supports_image_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, FileSearchTool, ImageGenerationTool, MCPServerTool, WebSearchTool}
+            ),
+        }
+    )
+
+
+def test_openai_o3_mini():
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    profile = OpenAIProvider.model_profile('o3-mini')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'supports_image_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_always_enabled': True,
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, FileSearchTool, ImageGenerationTool, MCPServerTool, WebSearchTool}
+            ),
+            'openai_supports_encrypted_reasoning_content': True,
+            'openai_supports_reasoning': True,
+        }
+    )
+
+
+def test_google_gemini_3_pro():
+    from pydantic_ai.providers.google import GoogleProvider
+
+    profile = GoogleProvider.model_profile('gemini-3.0-pro')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_tool_return_schema': True,
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': GoogleJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_always_enabled': True,
+            'google_supports_tool_combination': True,
+            'google_supports_server_side_tool_invocations': True,
+            'google_supported_mime_types_in_tool_returns': (
+                'image/png',
+                'image/jpeg',
+                'image/webp',
+                'application/pdf',
+                'text/plain',
+            ),
+            'google_supports_thinking_level': True,
+        }
+    )
+
+
+def test_google_gemini_2_5_flash():
+    from pydantic_ai.providers.google import GoogleProvider
+
+    profile = GoogleProvider.model_profile('gemini-2.5-flash')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_tool_return_schema': True,
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': GoogleJsonSchemaTransformer,
+            'supports_thinking': True,
+        }
+    )
+
+
+def test_xai_grok_4():
+    from pydantic_ai.providers.xai import XaiProvider
+
+    profile = XaiProvider.model_profile('grok-4')
+    assert _normalize(profile) == snapshot(
+        {'supports_json_schema_output': True, 'supports_json_object_output': True, 'grok_supports_builtin_tools': True}
+    )
+
+
+def test_xai_grok_3_mini():
+    from pydantic_ai.providers.xai import XaiProvider
+
+    profile = XaiProvider.model_profile('grok-3-mini')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'supports_thinking': True,
+            'supported_native_tools': frozenset(),
+        }
+    )
+
+
+def test_mistral_mistral_large():
+    from pydantic_ai.providers.mistral import MistralProvider
+
+    profile = MistralProvider.model_profile('mistral-large-latest')
+    assert _normalize(profile) == snapshot(None)
+
+
+def test_cohere_command_r_plus():
+    from pydantic_ai.providers.cohere import CohereProvider
+
+    profile = CohereProvider.model_profile('command-r-plus')
+    assert _normalize(profile) == snapshot(None)
+
+
+def test_deepseek_provider_deepseek_chat():
+    """DeepSeek's own provider (OpenAI-compat) — three-layer merge."""
+    from pydantic_ai.providers.deepseek import DeepSeekProvider
+
+    profile = DeepSeekProvider.model_profile('deepseek-chat')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'openai_chat_thinking_field': 'reasoning_content',
+            'openai_chat_send_back_thinking_parts': 'field',
+        }
+    )
+
+
+def test_deepseek_provider_deepseek_reasoner():
+    """`deepseek-reasoner` overrides `openai_supports_tool_choice_required=False`."""
+    from pydantic_ai.providers.deepseek import DeepSeekProvider
+
+    profile = DeepSeekProvider.model_profile('deepseek-reasoner')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_always_enabled': True,
+            'ignore_streamed_leading_whitespace': True,
+            'openai_chat_thinking_field': 'reasoning_content',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_supports_tool_choice_required': False,
+        }
+    )
+
+
+# =============================================================================
+# Bedrock — cross-provider routing (Anthropic, Mistral, Amazon, Cohere, Meta,
+# DeepSeek, OpenAI, Qwen). Highest-risk migration surface.
+# =============================================================================
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_anthropic_claude_sonnet_4_5():
+    """Anthropic via Bedrock: upstream Anthropic profile + Bedrock overrides (notably `supports_json_schema_output=False`)."""
+    profile = BedrockProvider.model_profile('anthropic.claude-sonnet-4-5-20250929-v1:0')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_thinking': True,
+            'thinking_tags': ('<thinking>', '</thinking>'),
+            'anthropic_default_code_execution_tool_version': '20260120',
+            'anthropic_supported_code_execution_tool_versions': ('20250825', '20260120'),
+            'supported_native_tools': frozenset(),
+            'bedrock_supports_tool_choice': True,
+            'bedrock_send_back_thinking_parts': True,
+            'bedrock_supports_prompt_caching': True,
+            'bedrock_supports_tool_caching': True,
+            'bedrock_supported_media_kinds_in_tool_returns': frozenset({'document', 'image'}),
+            'bedrock_thinking_variant': 'anthropic',
+        }
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_anthropic_with_geo_prefix():
+    profile = BedrockProvider.model_profile('us.anthropic.claude-haiku-4-5-20251001-v1:0')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_thinking': True,
+            'thinking_tags': ('<thinking>', '</thinking>'),
+            'supported_native_tools': frozenset(),
+            'bedrock_supports_tool_choice': True,
+            'bedrock_send_back_thinking_parts': True,
+            'bedrock_supports_prompt_caching': True,
+            'bedrock_supports_tool_caching': True,
+            'bedrock_supported_media_kinds_in_tool_returns': frozenset({'document', 'image'}),
+            'bedrock_thinking_variant': 'anthropic',
+        }
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_anthropic_legacy_claude_3():
+    """Older Claude via Bedrock — should still resolve, no JSON schema."""
+    profile = BedrockProvider.model_profile('anthropic.claude-3-5-sonnet-20240620-v1:0')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_thinking': True,
+            'thinking_tags': ('<thinking>', '</thinking>'),
+            'supported_native_tools': frozenset(),
+            'bedrock_supports_tool_choice': True,
+            'bedrock_send_back_thinking_parts': True,
+            'bedrock_supports_prompt_caching': True,
+            'bedrock_supports_tool_caching': True,
+            'bedrock_supported_media_kinds_in_tool_returns': frozenset({'document', 'image'}),
+            'bedrock_thinking_variant': 'anthropic',
+        }
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_mistral_large():
+    profile = BedrockProvider.model_profile('mistral.mistral-large-2407-v1:0')
+    assert _normalize(profile) == snapshot(
+        {'supported_native_tools': frozenset(), 'bedrock_tool_result_format': 'json'}
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_amazon_nova_pro():
+    profile = BedrockProvider.model_profile('us.amazon.nova-pro-v1:0')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': InlineDefsJsonSchemaTransformer,
+            'supported_native_tools': frozenset(),
+            'bedrock_supports_tool_choice': True,
+            'bedrock_supports_prompt_caching': True,
+        }
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_amazon_nova_2_lite():
+    """Nova 2 adds `CodeExecutionTool` to `supported_native_tools` — verifies the strip-then-restore pattern."""
+    profile = BedrockProvider.model_profile('us.amazon.nova-2-lite-v1:0')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': InlineDefsJsonSchemaTransformer,
+            'supported_native_tools': frozenset({CodeExecutionTool}),
+            'bedrock_supports_tool_choice': True,
+            'bedrock_supports_prompt_caching': True,
+        }
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_amazon_titan():
+    """Titan models — basic Amazon profile, no Nova-specific overrides."""
+    profile = BedrockProvider.model_profile('amazon.titan-text-express-v1')
+    assert _normalize(profile) == snapshot(
+        {'json_schema_transformer': InlineDefsJsonSchemaTransformer, 'supported_native_tools': frozenset()}
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_cohere_command():
+    profile = BedrockProvider.model_profile('cohere.command-r-plus-v1:0')
+    assert _normalize(profile) == snapshot({'supported_native_tools': frozenset()})
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_meta_llama3():
+    profile = BedrockProvider.model_profile('meta.llama3-70b-instruct-v1:0')
+    assert _normalize(profile) == snapshot(
+        {'json_schema_transformer': InlineDefsJsonSchemaTransformer, 'supported_native_tools': frozenset()}
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_deepseek_r1():
+    """`bedrock_send_back_thinking_parts=True` applied for `r1` models via separate function."""
+    profile = BedrockProvider.model_profile('deepseek.deepseek-r1-v1:0')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_thinking': True,
+            'thinking_always_enabled': True,
+            'ignore_streamed_leading_whitespace': True,
+            'supported_native_tools': frozenset(),
+            'bedrock_send_back_thinking_parts': True,
+        }
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_openai():
+    """Bedrock-hosted OpenAI — only has the `openai` thinking variant, no upstream profile."""
+    profile = BedrockProvider.model_profile('openai.gpt-oss-120b-1:0')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_thinking': True,
+            'bedrock_thinking_variant': 'openai',
+        }
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_qwen_qwq():
+    profile = BedrockProvider.model_profile('qwen.qwq-32b-v1:0')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_thinking': True,
+            'bedrock_thinking_variant': 'qwen',
+        }
+    )
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+def test_bedrock_unknown_provider_returns_none():
+    """Bedrock model IDs from an unknown provider prefix → `None`."""
+    assert BedrockProvider.model_profile('unknown.foo-v1:0') is None
+
+
+# =============================================================================
+# OpenRouter — cross-provider routing via the OpenAI-compat surface.
+# Three-layer merge: OpenAI transformer fallback / lab upstream / OpenRouter overrides.
+# =============================================================================
+
+
+def test_openrouter_anthropic_claude_sonnet_4_6():
+    """Anthropic via OpenRouter — relays Anthropic's profile through OpenAI chat."""
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    profile = OpenRouterProvider.model_profile('anthropic/claude-sonnet-4-6')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_tags': ('<thinking>', '</thinking>'),
+            'anthropic_supports_adaptive_thinking': True,
+            'anthropic_supports_effort': True,
+            'anthropic_default_code_execution_tool_version': '20260120',
+            'anthropic_supported_code_execution_tool_versions': ('20250825', '20260120'),
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, MCPServerTool, MemoryTool, ToolSearchTool, WebFetchTool, WebSearchTool}
+            ),
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_chat_supports_web_search': True,
+            'openai_chat_supports_file_urls': True,
+        }
+    )
+
+
+def test_openrouter_openai_gpt_5_4():
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    profile = OpenRouterProvider.model_profile('openai/gpt-5.4')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'supports_image_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, FileSearchTool, ImageGenerationTool, MCPServerTool, ToolSearchTool, WebSearchTool}
+            ),
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_chat_supports_web_search': True,
+            'openai_chat_supports_file_urls': True,
+            'openai_supports_encrypted_reasoning_content': True,
+            'openai_supports_reasoning': True,
+            'openai_supports_reasoning_effort_none': True,
+            'openai_supports_phase': True,
+        }
+    )
+
+
+def test_openrouter_google_gemini_3_pro():
+    """Google via OpenRouter — uses `_OpenRouterGoogleJsonSchemaTransformer` (lab wins over OpenAI fallback)."""
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    profile = OpenRouterProvider.model_profile('google/gemini-3.0-pro')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_tool_return_schema': True,
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': _OpenRouterGoogleJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_always_enabled': True,
+            'google_supports_tool_combination': True,
+            'google_supports_server_side_tool_invocations': True,
+            'google_supported_mime_types_in_tool_returns': (
+                'image/png',
+                'image/jpeg',
+                'image/webp',
+                'application/pdf',
+                'text/plain',
+            ),
+            'google_supports_thinking_level': True,
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_chat_supports_web_search': True,
+            'openai_chat_supports_file_urls': True,
+        }
+    )
+
+
+def test_openrouter_mistral_large():
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    profile = OpenRouterProvider.model_profile('mistralai/mistral-large-latest')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_chat_supports_web_search': True,
+            'openai_chat_supports_file_urls': True,
+        }
+    )
+
+
+def test_openrouter_xai_grok_4():
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    profile = OpenRouterProvider.model_profile('x-ai/grok-4')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'grok_supports_builtin_tools': True,
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_chat_supports_web_search': True,
+            'openai_chat_supports_file_urls': True,
+        }
+    )
+
+
+def test_openrouter_qwen():
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    profile = OpenRouterProvider.model_profile('qwen/qwen3-235b-a22b')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': InlineDefsJsonSchemaTransformer,
+            'ignore_streamed_leading_whitespace': True,
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_chat_supports_web_search': True,
+            'openai_chat_supports_file_urls': True,
+        }
+    )
+
+
+def test_openrouter_deepseek():
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    profile = OpenRouterProvider.model_profile('deepseek/deepseek-chat')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_chat_supports_web_search': True,
+            'openai_chat_supports_file_urls': True,
+        }
+    )
+
+
+def test_openrouter_meta_llama():
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    profile = OpenRouterProvider.model_profile('meta-llama/llama-3.3-70b-instruct')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': InlineDefsJsonSchemaTransformer,
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_chat_supports_web_search': True,
+            'openai_chat_supports_file_urls': True,
+        }
+    )
+
+
+def test_openrouter_moonshotai():
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    profile = OpenRouterProvider.model_profile('moonshotai/kimi-k2-0905')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'ignore_streamed_leading_whitespace': True,
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_chat_supports_web_search': True,
+            'openai_chat_supports_file_urls': True,
+        }
+    )
+
+
+def test_openrouter_unknown_provider_falls_back_to_overlay_only():
+    """Unknown lab → no upstream profile, but OpenRouter overrides still apply."""
+    from pydantic_ai.providers.openrouter import OpenRouterProvider
+
+    profile = OpenRouterProvider.model_profile('unknown-lab/unknown-model')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_chat_supports_web_search': True,
+            'openai_chat_supports_file_urls': True,
+        }
+    )
+
+
+# =============================================================================
+# Azure — three-layer merge, prefix-based lab dispatch
+# =============================================================================
+
+
+def test_azure_openai_gpt_5():
+    """Azure OpenAI — bare model name."""
+    from pydantic_ai.providers.azure import AzureProvider
+
+    profile = AzureProvider.model_profile('gpt-5.4')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'supports_image_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, FileSearchTool, ImageGenerationTool, MCPServerTool, ToolSearchTool, WebSearchTool}
+            ),
+            'openai_supports_encrypted_reasoning_content': True,
+            'openai_supports_reasoning': True,
+            'openai_supports_reasoning_effort_none': True,
+            'openai_supports_phase': True,
+            'openai_chat_supports_document_input': False,
+        }
+    )
+
+
+def test_azure_mistral_prefix():
+    from pydantic_ai.providers.azure import AzureProvider
+
+    profile = AzureProvider.model_profile('mistral-large-latest')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'openai_chat_supports_document_input': False,
+        }
+    )
+
+
+def test_azure_cohere_prefix():
+    from pydantic_ai.providers.azure import AzureProvider
+
+    profile = AzureProvider.model_profile('cohere-command-r-plus')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'openai_chat_supports_document_input': False,
+        }
+    )
+
+
+def test_azure_grok_prefix():
+    from pydantic_ai.providers.azure import AzureProvider
+
+    profile = AzureProvider.model_profile('grok-4')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'grok_supports_builtin_tools': True,
+            'openai_chat_supports_document_input': False,
+        }
+    )
+
+
+# =============================================================================
+# Groq (inference provider — runs models themselves) — three-layer merge
+# =============================================================================
+
+
+@pytest.mark.skipif(not groq_imports(), reason='groq not installed')
+def test_groq_moonshotai_kimi():
+    """Groq's MoonshotAI route — `supports_json_object_output` and `supports_json_schema_output`
+    are pre-set as fallbacks (upstream Moonshot profile wins if it sets them)."""
+    profile = GroqProvider.model_profile('moonshotai/kimi-k2-0905')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'ignore_streamed_leading_whitespace': True,
+        }
+    )
+
+
+@pytest.mark.skipif(not groq_imports(), reason='groq not installed')
+def test_groq_meta_llama4_maverick():
+    """Special-cased Llama 4 Maverick gets `supports_json_object_output=True` overlay."""
+    profile = GroqProvider.model_profile('llama-4-maverick-17b-128e-instruct')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
+
+
+@pytest.mark.skipif(not groq_imports(), reason='groq not installed')
+def test_groq_meta_llama3_no_overlay():
+    """Older Llama models don't get the structured-output overlay."""
+    profile = GroqProvider.model_profile('llama-3.3-70b-versatile')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
+
+
+@pytest.mark.skipif(not groq_imports(), reason='groq not installed')
+def test_groq_deepseek():
+    profile = GroqProvider.model_profile('deepseek-r1-distill-llama-70b')
+    assert _normalize(profile) == snapshot(
+        {'supports_thinking': True, 'thinking_always_enabled': True, 'ignore_streamed_leading_whitespace': True}
+    )
+
+
+# =============================================================================
+# Grok (xAI's OpenAI-compat gateway) — three-layer merge
+# =============================================================================
+
+
+def test_grok_provider_grok_4():
+    """`openai_supports_strict_tool_definition=False` is gateway-level."""
+    from pydantic_ai.providers.grok import GrokProvider  # type: ignore[reportDeprecated]
+
+    profile = GrokProvider.model_profile('grok-4')  # type: ignore[reportDeprecated]
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'grok_supports_builtin_tools': True,
+            'openai_supports_strict_tool_definition': False,
+        }
+    )
+
+
+def test_grok_provider_grok_3_mini():
+    from pydantic_ai.providers.grok import GrokProvider  # type: ignore[reportDeprecated]
+
+    profile = GrokProvider.model_profile('grok-3-mini')  # type: ignore[reportDeprecated]
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'supported_native_tools': frozenset(),
+            'openai_supports_strict_tool_definition': False,
+        }
+    )
+
+
+# =============================================================================
+# Ollama — three-layer merge with strict-mode override
+# =============================================================================
+
+
+def test_ollama_gpt_oss():
+    from pydantic_ai.providers.ollama import OllamaProvider
+
+    profile = OllamaProvider.model_profile('gpt-oss:20b')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'ignore_streamed_leading_whitespace': True,
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, FileSearchTool, ImageGenerationTool, MCPServerTool, WebSearchTool}
+            ),
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_supports_strict_tool_definition': False,
+            'openai_supports_tool_choice_required': False,
+        }
+    )
+
+
+def test_ollama_unknown_falls_back_to_overlay_only():
+    from pydantic_ai.providers.ollama import OllamaProvider
+
+    profile = OllamaProvider.model_profile('some-unknown-model')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'openai_chat_thinking_field': 'reasoning',
+            'openai_supports_strict_tool_definition': False,
+        }
+    )
+
+
+# =============================================================================
+# Cerebras — three-layer merge with reasoning detection
+# =============================================================================
+
+
+def test_cerebras_qwen_reasoning():
+    from pydantic_ai.providers.cerebras import CerebrasProvider
+
+    profile = CerebrasProvider.model_profile('qwen-3-235b-a22b-thinking-2507')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': InlineDefsJsonSchemaTransformer,
+            'ignore_streamed_leading_whitespace': True,
+            'openai_unsupported_model_settings': (
+                'frequency_penalty',
+                'logit_bias',
+                'presence_penalty',
+                'parallel_tool_calls',
+                'service_tier',
+                'openai_service_tier',
+            ),
+        }
+    )
+
+
+def test_cerebras_llama_non_reasoning():
+    from pydantic_ai.providers.cerebras import CerebrasProvider
+
+    profile = CerebrasProvider.model_profile('llama-3.3-70b')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': InlineDefsJsonSchemaTransformer,
+            'openai_unsupported_model_settings': (
+                'frequency_penalty',
+                'logit_bias',
+                'presence_penalty',
+                'parallel_tool_calls',
+                'service_tier',
+                'openai_service_tier',
+            ),
+        }
+    )
+
+
+# =============================================================================
+# OpenAI-compat passthrough gateways — two-layer merge: gateway transformer fallback + upstream wins
+# =============================================================================
+
+
+def test_litellm_openai_gpt():
+    from pydantic_ai.providers.litellm import LiteLLMProvider
+
+    profile = LiteLLMProvider.model_profile('gpt-5.4')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'supports_image_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, FileSearchTool, ImageGenerationTool, MCPServerTool, ToolSearchTool, WebSearchTool}
+            ),
+            'openai_supports_encrypted_reasoning_content': True,
+            'openai_supports_reasoning': True,
+            'openai_supports_reasoning_effort_none': True,
+            'openai_supports_phase': True,
+        }
+    )
+
+
+def test_fireworks_llama():
+    from pydantic_ai.providers.fireworks import FireworksProvider
+
+    profile = FireworksProvider.model_profile('accounts/fireworks/models/llama-v3p3-70b-instruct')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
+
+
+def test_together_qwen():
+    from pydantic_ai.providers.together import TogetherProvider
+
+    profile = TogetherProvider.model_profile('Qwen/Qwen2.5-72B-Instruct-Turbo')
+    assert _normalize(profile) == snapshot(
+        {'json_schema_transformer': InlineDefsJsonSchemaTransformer, 'ignore_streamed_leading_whitespace': True}
+    )
+
+
+def test_sambanova_llama():
+    from pydantic_ai.providers.sambanova import SambaNovaProvider
+
+    profile = SambaNovaProvider.model_profile('Meta-Llama-3.3-70B-Instruct')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
+
+
+def test_ovhcloud_llama():
+    from pydantic_ai.providers.ovhcloud import OVHcloudProvider
+
+    profile = OVHcloudProvider.model_profile('llama-3.3-70b-instruct')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
+
+
+def test_alibaba_qwen():
+    from pydantic_ai.providers.alibaba import AlibabaProvider
+
+    profile = AlibabaProvider.model_profile('qwen3-235b-a22b-thinking-2507')
+    assert _normalize(profile) == snapshot(
+        {'json_schema_transformer': InlineDefsJsonSchemaTransformer, 'ignore_streamed_leading_whitespace': True}
+    )
+
+
+def test_alibaba_qwen_audio():
+    """Alibaba audio models get `openai_chat_audio_input_encoding='uri'`."""
+    from pydantic_ai.providers.alibaba import AlibabaProvider
+
+    profile = AlibabaProvider.model_profile('qwen3-audio-0809-online')
+    assert _normalize(profile) == snapshot(
+        {'json_schema_transformer': InlineDefsJsonSchemaTransformer, 'ignore_streamed_leading_whitespace': True}
+    )
+
+
+# =============================================================================
+# Default-only providers (no per-model variation in the profile function)
+# =============================================================================
+
+
+@pytest.mark.skipif(not anthropic_imports(), reason='anthropic not installed')
+def test_anthropic_unknown_model_returns_some_profile():
+    """Anthropic profile function returns *something* for unknown names — locks the default."""
+    profile = AnthropicProvider.model_profile('some-future-claude')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': AnthropicJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_tags': ('<thinking>', '</thinking>'),
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, MCPServerTool, MemoryTool, WebFetchTool, WebSearchTool}
+            ),
+        }
+    )
+
+
+def test_moonshotai_kimi():
+    from pydantic_ai.providers.moonshotai import MoonshotAIProvider
+
+    profile = MoonshotAIProvider.model_profile('kimi-k2-0905')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'ignore_streamed_leading_whitespace': True,
+            'openai_chat_thinking_field': 'reasoning_content',
+            'openai_chat_send_back_thinking_parts': 'field',
+            'openai_supports_tool_choice_required': False,
+        }
+    )
+
+
+# =============================================================================
+# GitHub Models — multi-lab routing via OpenAIChatModel, 2-layer merge
+# =============================================================================
+
+
+def test_github_openai_bare_name():
+    """Bare model names (no `/` prefix) route to `openai_model_profile`."""
+    from pydantic_ai.providers.github import GitHubProvider
+
+    profile = GitHubProvider.model_profile('gpt-5.4')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'supports_image_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, FileSearchTool, ImageGenerationTool, MCPServerTool, ToolSearchTool, WebSearchTool}
+            ),
+            'openai_supports_encrypted_reasoning_content': True,
+            'openai_supports_reasoning': True,
+            'openai_supports_reasoning_effort_none': True,
+            'openai_supports_phase': True,
+        }
+    )
+
+
+def test_github_xai_grok():
+    from pydantic_ai.providers.github import GitHubProvider
+
+    profile = GitHubProvider.model_profile('xai/grok-4')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'grok_supports_builtin_tools': True,
+        }
+    )
+
+
+def test_github_meta_llama():
+    from pydantic_ai.providers.github import GitHubProvider
+
+    profile = GitHubProvider.model_profile('meta/llama-3.3-70b-instruct')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
+
+
+def test_github_deepseek():
+    from pydantic_ai.providers.github import GitHubProvider
+
+    profile = GitHubProvider.model_profile('deepseek/deepseek-r1')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_always_enabled': True,
+            'ignore_streamed_leading_whitespace': True,
+        }
+    )
+
+
+# =============================================================================
+# Vercel — multi-lab routing via OpenAIChatModel
+# =============================================================================
+
+
+def test_vercel_unknown_bare_name():
+    """Bare names get OpenAI transformer overlay only."""
+    from pydantic_ai.providers.vercel import VercelProvider
+
+    profile = VercelProvider.model_profile('gpt-5.4')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': OpenAIJsonSchemaTransformer})
+
+
+def test_vercel_anthropic_claude_sonnet():
+    from pydantic_ai.providers.vercel import VercelProvider
+
+    profile = VercelProvider.model_profile('anthropic/claude-sonnet-4-6')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_tags': ('<thinking>', '</thinking>'),
+            'anthropic_supports_adaptive_thinking': True,
+            'anthropic_supports_effort': True,
+            'anthropic_default_code_execution_tool_version': '20260120',
+            'anthropic_supported_code_execution_tool_versions': ('20250825', '20260120'),
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, MCPServerTool, MemoryTool, ToolSearchTool, WebFetchTool, WebSearchTool}
+            ),
+        }
+    )
+
+
+def test_vercel_openai_gpt():
+    from pydantic_ai.providers.vercel import VercelProvider
+
+    profile = VercelProvider.model_profile('openai/gpt-5.4')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'supports_image_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'supported_native_tools': frozenset(
+                {CodeExecutionTool, FileSearchTool, ImageGenerationTool, MCPServerTool, ToolSearchTool, WebSearchTool}
+            ),
+            'openai_supports_encrypted_reasoning_content': True,
+            'openai_supports_reasoning': True,
+            'openai_supports_reasoning_effort_none': True,
+            'openai_supports_phase': True,
+        }
+    )
+
+
+def test_vercel_vertex_gemini():
+    """Vercel routes `vertex/...` through `google_model_profile`."""
+    from pydantic_ai.providers.vercel import VercelProvider
+
+    profile = VercelProvider.model_profile('vertex/gemini-3.0-pro')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_tool_return_schema': True,
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': GoogleJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_always_enabled': True,
+            'google_supports_tool_combination': True,
+            'google_supports_server_side_tool_invocations': True,
+            'google_supported_mime_types_in_tool_returns': (
+                'image/png',
+                'image/jpeg',
+                'image/webp',
+                'application/pdf',
+                'text/plain',
+            ),
+            'google_supports_thinking_level': True,
+        }
+    )
+
+
+def test_vercel_xai_grok():
+    from pydantic_ai.providers.vercel import VercelProvider
+
+    profile = VercelProvider.model_profile('xai/grok-4')
+    assert _normalize(profile) == snapshot(
+        {
+            'supports_json_schema_output': True,
+            'supports_json_object_output': True,
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'grok_supports_builtin_tools': True,
+        }
+    )
+
+
+# =============================================================================
+# Heroku — minimal, just sets OpenAI transformer
+# =============================================================================
+
+
+def test_heroku_returns_openai_transformer():
+    """Heroku doesn't vary by model name — always returns OpenAI transformer."""
+    from pydantic_ai.providers.heroku import HerokuProvider
+
+    profile = HerokuProvider.model_profile('claude-sonnet-4-6')  # name is ignored
+    assert _normalize(profile) == snapshot({'json_schema_transformer': OpenAIJsonSchemaTransformer})
+
+
+# =============================================================================
+# Nebius — multi-lab routing
+# =============================================================================
+
+
+def test_nebius_bare_name():
+    from pydantic_ai.providers.nebius import NebiusProvider
+
+    profile = NebiusProvider.model_profile('some-model')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': OpenAIJsonSchemaTransformer})
+
+
+def test_nebius_meta_llama():
+    from pydantic_ai.providers.nebius import NebiusProvider
+
+    profile = NebiusProvider.model_profile('meta-llama/Llama-3.3-70B-Instruct')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
+
+
+def test_nebius_deepseek():
+    from pydantic_ai.providers.nebius import NebiusProvider
+
+    profile = NebiusProvider.model_profile('deepseek-ai/DeepSeek-R1')
+    assert _normalize(profile) == snapshot(
+        {
+            'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'supports_thinking': True,
+            'thinking_always_enabled': True,
+            'ignore_streamed_leading_whitespace': True,
+        }
+    )
+
+
+def test_nebius_qwen():
+    from pydantic_ai.providers.nebius import NebiusProvider
+
+    profile = NebiusProvider.model_profile('Qwen/Qwen3-235B-A22B')
+    assert _normalize(profile) == snapshot(
+        {'json_schema_transformer': InlineDefsJsonSchemaTransformer, 'ignore_streamed_leading_whitespace': True}
+    )
+
+
+def test_nebius_moonshotai():
+    from pydantic_ai.providers.nebius import NebiusProvider
+
+    profile = NebiusProvider.model_profile('moonshotai/Kimi-K2-Instruct-0905')
+    assert _normalize(profile) == snapshot(
+        {'json_schema_transformer': OpenAIJsonSchemaTransformer, 'ignore_streamed_leading_whitespace': True}
+    )
+
+
+# =============================================================================
+# Hugging Face — multi-lab routing, no OpenAI overlay
+# =============================================================================
+
+
+def test_huggingface_bare_name_returns_none():
+    """HF requires `provider/model` form; bare name → `None`."""
+    from pydantic_ai.providers.huggingface import HuggingFaceProvider
+
+    assert HuggingFaceProvider.model_profile('some-model') is None
+
+
+def test_huggingface_meta_llama():
+    from pydantic_ai.providers.huggingface import HuggingFaceProvider
+
+    profile = HuggingFaceProvider.model_profile('meta-llama/Llama-3.3-70B-Instruct')
+    assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
+
+
+def test_huggingface_deepseek():
+    from pydantic_ai.providers.huggingface import HuggingFaceProvider
+
+    profile = HuggingFaceProvider.model_profile('deepseek-ai/DeepSeek-R1')
+    assert _normalize(profile) == snapshot(
+        {'supports_thinking': True, 'thinking_always_enabled': True, 'ignore_streamed_leading_whitespace': True}
+    )
+
+
+def test_huggingface_qwen():
+    from pydantic_ai.providers.huggingface import HuggingFaceProvider
+
+    profile = HuggingFaceProvider.model_profile('Qwen/Qwen3-235B-A22B')
+    assert _normalize(profile) == snapshot(
+        {'json_schema_transformer': InlineDefsJsonSchemaTransformer, 'ignore_streamed_leading_whitespace': True}
+    )
+
+
+def test_huggingface_moonshotai():
+    from pydantic_ai.providers.huggingface import HuggingFaceProvider
+
+    profile = HuggingFaceProvider.model_profile('moonshotai/Kimi-K2-Instruct-0905')
+    assert _normalize(profile) == snapshot({'ignore_streamed_leading_whitespace': True})
+
+
+def test_huggingface_unknown_provider_returns_none():
+    """Unknown provider prefix → `None` (no fallback overlay like other gateways)."""
+    from pydantic_ai.providers.huggingface import HuggingFaceProvider
+
+    assert HuggingFaceProvider.model_profile('unknown/some-model') is None
+
+
+# Ensure the imported symbols above are actually referenced — pyright won't flag them
+# as unused once snapshot generation inserts their names into the snapshot literals.
+def test_imported_tool_symbols_used_in_snapshots():
+    """Snapshots above reference these symbols by name; this test exists to keep the imports alive."""
+    assert all(s is not None for s in _TOOL_SYMBOLS_REFERENCED_IN_SNAPSHOTS)
+    # Also ensure `ModelProfile` and (when available) the OpenRouter Google transformer are imported.
+    assert ModelProfile is not None
+    if openrouter_google_imports():
+        assert _OpenRouterGoogleJsonSchemaTransformer is not None

--- a/tests/profiles/test_resolution_lockin.py
+++ b/tests/profiles/test_resolution_lockin.py
@@ -20,7 +20,6 @@ dataclass→TypedDict migration (both representations normalize to the same dict
 
 from __future__ import annotations
 
-import dataclasses
 from textwrap import dedent
 from typing import Any
 
@@ -38,7 +37,6 @@ from pydantic_ai.native_tools import (
     WebSearchTool,
 )
 from pydantic_ai.native_tools._tool_search import ToolSearchTool
-from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 
@@ -152,40 +150,14 @@ _CANONICAL_DEFAULTS: dict[str, Any] = {
 
 
 def _normalize(profile: Any) -> dict[str, Any] | None:
-    """Reduce a `ModelProfile` (dataclass or TypedDict) to a dict of non-default fields.
+    """Reduce a `ModelProfile` `TypedDict` to a dict of non-default fields.
 
-    - Pre-migration: profile is a `@dataclass` instance; `asdict()` extracts every field.
-    - Post-migration: profile is a `TypedDict` (a dict); already in the right shape.
-
-    Either way, we strip values matching `_CANONICAL_DEFAULTS` so the snapshot focuses
-    on the deltas the provider/gateway actually contributes.
+    Strips keys whose value matches `_CANONICAL_DEFAULTS`, so each snapshot
+    shows only what the provider/gateway actually contributes.
     """
     if profile is None:
         return None
-    if dataclasses.is_dataclass(profile):
-        # Use a shallow extraction (not asdict, which recurses through dataclass-typed
-        # nested values — none expected here, but defensive).
-        raw = {f.name: getattr(profile, f.name) for f in dataclasses.fields(profile)}
-    else:
-        raw = dict(profile)
-    return {k: v for k, v in raw.items() if k not in _CANONICAL_DEFAULTS or v != _CANONICAL_DEFAULTS[k]}
-
-
-# Quiet pyright on the imported tool symbols — they're referenced by name in the
-# generated snapshots below.
-_TOOL_SYMBOLS_REFERENCED_IN_SNAPSHOTS = (
-    CodeExecutionTool,
-    FileSearchTool,
-    ImageGenerationTool,
-    MCPServerTool,
-    MemoryTool,
-    WebFetchTool,
-    WebSearchTool,
-    ToolSearchTool,
-    InlineDefsJsonSchemaTransformer,
-    OpenAIJsonSchemaTransformer,
-    GoogleJsonSchemaTransformer,
-)
+    return {k: v for k, v in profile.items() if k not in _CANONICAL_DEFAULTS or v != _CANONICAL_DEFAULTS[k]}
 
 
 # =============================================================================
@@ -1413,14 +1385,3 @@ def test_huggingface_unknown_provider_returns_none():
     """Unknown provider prefix → `None` (no fallback overlay like other gateways)."""
 
     assert HuggingFaceProvider.model_profile('unknown/some-model') is None
-
-
-# Ensure the imported symbols above are actually referenced — pyright won't flag them
-# as unused once snapshot generation inserts their names into the snapshot literals.
-def test_imported_tool_symbols_used_in_snapshots():
-    """Snapshots above reference these symbols by name; this test exists to keep the imports alive."""
-    assert all(s is not None for s in _TOOL_SYMBOLS_REFERENCED_IN_SNAPSHOTS)
-    # Also ensure `ModelProfile` and (when available) the OpenRouter Google transformer are imported.
-    assert ModelProfile is not None
-    if openrouter_google_imports():
-        assert _OpenRouterGoogleJsonSchemaTransformer is not None

--- a/tests/profiles/test_resolution_lockin.py
+++ b/tests/profiles/test_resolution_lockin.py
@@ -52,22 +52,22 @@ with try_import() as bedrock_imports:
     from pydantic_ai.providers.bedrock import BedrockProvider
 
 with try_import() as cohere_imports:
-    from pydantic_ai.providers.cohere import CohereProvider  # noqa: F401
+    from pydantic_ai.providers.cohere import CohereProvider
 
 with try_import() as google_imports:
-    from pydantic_ai.providers.google import GoogleProvider  # noqa: F401
+    from pydantic_ai.providers.google import GoogleProvider
 
 with try_import() as groq_imports:
     from pydantic_ai.providers.groq import GroqProvider
 
 with try_import() as huggingface_imports:
-    from pydantic_ai.providers.huggingface import HuggingFaceProvider  # noqa: F401
+    from pydantic_ai.providers.huggingface import HuggingFaceProvider
 
 with try_import() as mistral_imports:
-    from pydantic_ai.providers.mistral import MistralProvider  # noqa: F401
+    from pydantic_ai.providers.mistral import MistralProvider
 
 with try_import() as xai_imports:
-    from pydantic_ai.providers.xai import XaiProvider  # noqa: F401
+    from pydantic_ai.providers.xai import XaiProvider
 
 with try_import() as openrouter_google_imports:
     # OpenRouter installs its own Google transformer; importable so inline_snapshot can name it.
@@ -331,8 +331,6 @@ def test_openai_o3_mini():
 
 @pytest.mark.skipif(not google_imports(), reason='google not installed')
 def test_google_gemini_3_pro():
-    from pydantic_ai.providers.google import GoogleProvider
-
     profile = GoogleProvider.model_profile('gemini-3.0-pro')
     assert _normalize(profile) == snapshot(
         {
@@ -358,8 +356,6 @@ def test_google_gemini_3_pro():
 
 @pytest.mark.skipif(not google_imports(), reason='google not installed')
 def test_google_gemini_2_5_flash():
-    from pydantic_ai.providers.google import GoogleProvider
-
     profile = GoogleProvider.model_profile('gemini-2.5-flash')
     assert _normalize(profile) == snapshot(
         {
@@ -374,8 +370,6 @@ def test_google_gemini_2_5_flash():
 
 @pytest.mark.skipif(not xai_imports(), reason='xai not installed')
 def test_xai_grok_4():
-    from pydantic_ai.providers.xai import XaiProvider
-
     profile = XaiProvider.model_profile('grok-4')
     assert _normalize(profile) == snapshot(
         {'supports_json_schema_output': True, 'supports_json_object_output': True, 'grok_supports_builtin_tools': True}
@@ -384,8 +378,6 @@ def test_xai_grok_4():
 
 @pytest.mark.skipif(not xai_imports(), reason='xai not installed')
 def test_xai_grok_3_mini():
-    from pydantic_ai.providers.xai import XaiProvider
-
     profile = XaiProvider.model_profile('grok-3-mini')
     assert _normalize(profile) == snapshot(
         {
@@ -399,16 +391,12 @@ def test_xai_grok_3_mini():
 
 @pytest.mark.skipif(not mistral_imports(), reason='mistral not installed')
 def test_mistral_mistral_large():
-    from pydantic_ai.providers.mistral import MistralProvider
-
     profile = MistralProvider.model_profile('mistral-large-latest')
     assert _normalize(profile) == snapshot(None)
 
 
 @pytest.mark.skipif(not cohere_imports(), reason='cohere not installed')
 def test_cohere_command_r_plus():
-    from pydantic_ai.providers.cohere import CohereProvider
-
     profile = CohereProvider.model_profile('command-r-plus')
     assert _normalize(profile) == snapshot(None)
 
@@ -1388,23 +1376,18 @@ def test_nebius_moonshotai():
 @pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_bare_name_returns_none():
     """HF requires `provider/model` form; bare name → `None`."""
-    from pydantic_ai.providers.huggingface import HuggingFaceProvider
 
     assert HuggingFaceProvider.model_profile('some-model') is None
 
 
 @pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_meta_llama():
-    from pydantic_ai.providers.huggingface import HuggingFaceProvider
-
     profile = HuggingFaceProvider.model_profile('meta-llama/Llama-3.3-70B-Instruct')
     assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
 
 
 @pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_deepseek():
-    from pydantic_ai.providers.huggingface import HuggingFaceProvider
-
     profile = HuggingFaceProvider.model_profile('deepseek-ai/DeepSeek-R1')
     assert _normalize(profile) == snapshot(
         {'supports_thinking': True, 'thinking_always_enabled': True, 'ignore_streamed_leading_whitespace': True}
@@ -1413,8 +1396,6 @@ def test_huggingface_deepseek():
 
 @pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_qwen():
-    from pydantic_ai.providers.huggingface import HuggingFaceProvider
-
     profile = HuggingFaceProvider.model_profile('Qwen/Qwen3-235B-A22B')
     assert _normalize(profile) == snapshot(
         {'json_schema_transformer': InlineDefsJsonSchemaTransformer, 'ignore_streamed_leading_whitespace': True}
@@ -1423,8 +1404,6 @@ def test_huggingface_qwen():
 
 @pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_moonshotai():
-    from pydantic_ai.providers.huggingface import HuggingFaceProvider
-
     profile = HuggingFaceProvider.model_profile('moonshotai/Kimi-K2-Instruct-0905')
     assert _normalize(profile) == snapshot({'ignore_streamed_leading_whitespace': True})
 
@@ -1432,7 +1411,6 @@ def test_huggingface_moonshotai():
 @pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_unknown_provider_returns_none():
     """Unknown provider prefix → `None` (no fallback overlay like other gateways)."""
-    from pydantic_ai.providers.huggingface import HuggingFaceProvider
 
     assert HuggingFaceProvider.model_profile('unknown/some-model') is None
 

--- a/tests/profiles/test_resolution_lockin.py
+++ b/tests/profiles/test_resolution_lockin.py
@@ -51,8 +51,23 @@ with try_import() as anthropic_imports:
 with try_import() as bedrock_imports:
     from pydantic_ai.providers.bedrock import BedrockProvider
 
+with try_import() as cohere_imports:
+    from pydantic_ai.providers.cohere import CohereProvider  # noqa: F401
+
+with try_import() as google_imports:
+    from pydantic_ai.providers.google import GoogleProvider  # noqa: F401
+
 with try_import() as groq_imports:
     from pydantic_ai.providers.groq import GroqProvider
+
+with try_import() as huggingface_imports:
+    from pydantic_ai.providers.huggingface import HuggingFaceProvider  # noqa: F401
+
+with try_import() as mistral_imports:
+    from pydantic_ai.providers.mistral import MistralProvider  # noqa: F401
+
+with try_import() as xai_imports:
+    from pydantic_ai.providers.xai import XaiProvider  # noqa: F401
 
 with try_import() as openrouter_google_imports:
     # OpenRouter installs its own Google transformer; importable so inline_snapshot can name it.
@@ -314,6 +329,7 @@ def test_openai_o3_mini():
     )
 
 
+@pytest.mark.skipif(not google_imports(), reason='google not installed')
 def test_google_gemini_3_pro():
     from pydantic_ai.providers.google import GoogleProvider
 
@@ -340,6 +356,7 @@ def test_google_gemini_3_pro():
     )
 
 
+@pytest.mark.skipif(not google_imports(), reason='google not installed')
 def test_google_gemini_2_5_flash():
     from pydantic_ai.providers.google import GoogleProvider
 
@@ -355,6 +372,7 @@ def test_google_gemini_2_5_flash():
     )
 
 
+@pytest.mark.skipif(not xai_imports(), reason='xai not installed')
 def test_xai_grok_4():
     from pydantic_ai.providers.xai import XaiProvider
 
@@ -364,6 +382,7 @@ def test_xai_grok_4():
     )
 
 
+@pytest.mark.skipif(not xai_imports(), reason='xai not installed')
 def test_xai_grok_3_mini():
     from pydantic_ai.providers.xai import XaiProvider
 
@@ -378,6 +397,7 @@ def test_xai_grok_3_mini():
     )
 
 
+@pytest.mark.skipif(not mistral_imports(), reason='mistral not installed')
 def test_mistral_mistral_large():
     from pydantic_ai.providers.mistral import MistralProvider
 
@@ -385,6 +405,7 @@ def test_mistral_mistral_large():
     assert _normalize(profile) == snapshot(None)
 
 
+@pytest.mark.skipif(not cohere_imports(), reason='cohere not installed')
 def test_cohere_command_r_plus():
     from pydantic_ai.providers.cohere import CohereProvider
 
@@ -1364,6 +1385,7 @@ def test_nebius_moonshotai():
 # =============================================================================
 
 
+@pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_bare_name_returns_none():
     """HF requires `provider/model` form; bare name → `None`."""
     from pydantic_ai.providers.huggingface import HuggingFaceProvider
@@ -1371,6 +1393,7 @@ def test_huggingface_bare_name_returns_none():
     assert HuggingFaceProvider.model_profile('some-model') is None
 
 
+@pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_meta_llama():
     from pydantic_ai.providers.huggingface import HuggingFaceProvider
 
@@ -1378,6 +1401,7 @@ def test_huggingface_meta_llama():
     assert _normalize(profile) == snapshot({'json_schema_transformer': InlineDefsJsonSchemaTransformer})
 
 
+@pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_deepseek():
     from pydantic_ai.providers.huggingface import HuggingFaceProvider
 
@@ -1387,6 +1411,7 @@ def test_huggingface_deepseek():
     )
 
 
+@pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_qwen():
     from pydantic_ai.providers.huggingface import HuggingFaceProvider
 
@@ -1396,6 +1421,7 @@ def test_huggingface_qwen():
     )
 
 
+@pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_moonshotai():
     from pydantic_ai.providers.huggingface import HuggingFaceProvider
 
@@ -1403,6 +1429,7 @@ def test_huggingface_moonshotai():
     assert _normalize(profile) == snapshot({'ignore_streamed_leading_whitespace': True})
 
 
+@pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
 def test_huggingface_unknown_provider_returns_none():
     """Unknown provider prefix → `None` (no fallback overlay like other gateways)."""
     from pydantic_ai.providers.huggingface import HuggingFaceProvider

--- a/tests/providers/test_alibaba_provider.py
+++ b/tests/providers/test_alibaba_provider.py
@@ -2,7 +2,6 @@ import httpx
 import pytest
 
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.profiles.openai import OpenAIModelProfile
 
 from ..conftest import TestEnv, try_import
 
@@ -62,16 +61,16 @@ def test_qwen_omni_profile_audio_uri():
     provider = AlibabaProvider(api_key='key')
     # Omni model -> expect 'uri' encoding
     profile = provider.model_profile('qwen-omni-turbo')
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.openai_chat_audio_input_encoding == 'uri'
+    assert isinstance(profile, dict)
+    assert profile.get('openai_chat_audio_input_encoding', 'base64') == 'uri'
 
 
 def test_qwen_non_omni_profile_default():
     provider = AlibabaProvider(api_key='key')
     # Non-omni model -> expect default (base64)
     profile = provider.model_profile('qwen-max')
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.openai_chat_audio_input_encoding == 'base64'
+    assert isinstance(profile, dict)
+    assert profile.get('openai_chat_audio_input_encoding', 'base64') == 'base64'
 
 
 def test_alibaba_provider_with_openai_client():

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -7,8 +7,8 @@ from ..conftest import try_import
 with try_import() as imports_successful:
     from anthropic import AsyncAnthropic, AsyncAnthropicBedrock
 
+    from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS
     from pydantic_ai.native_tools._tool_search import ToolSearchTool
-    from pydantic_ai.profiles.anthropic import AnthropicModelProfile
     from pydantic_ai.providers.anthropic import AnthropicProvider
 
 
@@ -65,15 +65,15 @@ def test_anthropic_provider_model_profile_normalizes_transport_specific_ids(mode
     """`AnthropicProvider.model_profile` resolves capability flags from the bare `claude-...` name,
     even when the underlying client (Bedrock/Vertex) carries a transport-specific model id."""
     profile = AnthropicProvider.model_profile(model_name)
-    assert isinstance(profile, AnthropicModelProfile)
-    assert profile.supports_json_schema_output is True
-    assert ToolSearchTool in profile.supported_native_tools
+    assert isinstance(profile, dict)
+    assert profile.get('supports_json_schema_output', False) is True
+    assert ToolSearchTool in profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)
 
 
 def test_anthropic_provider_model_profile_older_model_still_resolves():
     """Normalization must not over-strip: an older model without structured-output support
     still resolves to the right (negative) flags."""
     profile = AnthropicProvider.model_profile('anthropic.claude-3-5-sonnet-20240620-v1:0')
-    assert isinstance(profile, AnthropicModelProfile)
-    assert profile.supports_json_schema_output is False
-    assert ToolSearchTool not in profile.supported_native_tools
+    assert isinstance(profile, dict)
+    assert profile.get('supports_json_schema_output', False) is False
+    assert ToolSearchTool not in profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)

--- a/tests/providers/test_azure.py
+++ b/tests/providers/test_azure.py
@@ -114,47 +114,47 @@ def test_azure_provider_model_profile(mocker: MockerFixture):
     meta_profile = provider.model_profile('Llama-4-Scout-17B-16E')
     meta_model_profile_mock.assert_called_with('llama-4-scout-17b-16e')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     meta_profile = provider.model_profile('Meta-Llama-3.1-405B-Instruct')
     meta_model_profile_mock.assert_called_with('llama-3.1-405b-instruct')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     deepseek_profile = provider.model_profile('DeepSeek-R1')
     deepseek_model_profile_mock.assert_called_with('deepseek-r1')
     assert deepseek_profile is not None
-    assert deepseek_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert deepseek_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     mistral_profile = provider.model_profile('mistral-medium-2505')
     mistral_model_profile_mock.assert_called_with('mistral-medium-2505')
     assert mistral_profile is not None
-    assert mistral_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert mistral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     mistral_profile = provider.model_profile('mistralai-Mixtral-8x22B-Instruct-v0-1')
     mistral_model_profile_mock.assert_called_with('mixtral-8x22b-instruct-v0-1')
     assert mistral_profile is not None
-    assert mistral_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert mistral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     cohere_profile = provider.model_profile('cohere-command-a')
     cohere_model_profile_mock.assert_called_with('command-a')
     assert cohere_profile is not None
-    assert cohere_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert cohere_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     grok_profile = provider.model_profile('grok-3')
     grok_model_profile_mock.assert_called_with('grok-3')
     assert grok_profile is not None
-    assert grok_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert grok_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     openai_profile = provider.model_profile('o4-mini')
     openai_model_profile_mock.assert_called_with('o4-mini')
     assert openai_profile is not None
-    assert openai_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert openai_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     unknown_profile = provider.model_profile('unknown-model')
     openai_model_profile_mock.assert_called_with('unknown-model')
     assert unknown_profile is not None
-    assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
 
 async def test_azure_document_input_not_supported(allow_model_requests: None):

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer
-from pydantic_ai.native_tools import CodeExecutionTool
+from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS, CodeExecutionTool
 from pydantic_ai.profiles.amazon import amazon_model_profile
 from pydantic_ai.profiles.anthropic import anthropic_model_profile
 from pydantic_ai.profiles.cohere import cohere_model_profile
@@ -21,7 +21,6 @@ with try_import() as imports_successful:
     from pydantic_ai.models.bedrock import LatestBedrockModelNames
     from pydantic_ai.providers.bedrock import (
         BEDROCK_GEO_PREFIXES,
-        BedrockModelProfile,
         BedrockProvider,
         remove_bedrock_geo_prefix,
     )
@@ -94,72 +93,72 @@ def test_bedrock_provider_model_profile(env: TestEnv, mocker: MockerFixture):
 
     anthropic_profile = provider.model_profile('us.anthropic.claude-3-5-sonnet-20240620-v1:0')
     anthropic_model_profile_mock.assert_called_with('claude-3-5-sonnet-20240620')
-    assert isinstance(anthropic_profile, BedrockModelProfile)
-    assert anthropic_profile.bedrock_supports_tool_choice is True
+    assert isinstance(anthropic_profile, dict)
+    assert anthropic_profile.get('bedrock_supports_tool_choice', False) is True
     # Bedrock does not support native structured output, even for models that support it via direct Anthropic API
-    assert anthropic_profile.supports_json_schema_output is False
-    assert anthropic_profile.json_schema_transformer is None
-    assert anthropic_profile.supported_native_tools == frozenset()
+    assert anthropic_profile.get('supports_json_schema_output', False) is False
+    assert anthropic_profile.get('json_schema_transformer', None) is None
+    assert anthropic_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()
 
     anthropic_profile = provider.model_profile('anthropic.claude-instant-v1')
     anthropic_model_profile_mock.assert_called_with('claude-instant')
-    assert isinstance(anthropic_profile, BedrockModelProfile)
-    assert anthropic_profile.bedrock_supports_tool_choice is True
-    assert anthropic_profile.supports_json_schema_output is False
-    assert anthropic_profile.json_schema_transformer is None
-    assert anthropic_profile.supported_native_tools == frozenset()
+    assert isinstance(anthropic_profile, dict)
+    assert anthropic_profile.get('bedrock_supports_tool_choice', False) is True
+    assert anthropic_profile.get('supports_json_schema_output', False) is False
+    assert anthropic_profile.get('json_schema_transformer', None) is None
+    assert anthropic_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()
 
     anthropic_profile = provider.model_profile('us.anthropic.claude-sonnet-4-5-20250929-v1:0')
     anthropic_model_profile_mock.assert_called_with('claude-sonnet-4-5-20250929')
-    assert isinstance(anthropic_profile, BedrockModelProfile)
+    assert isinstance(anthropic_profile, dict)
     # Anthropic's direct API supports native structured output for this family,
     # but Bedrock support is not implemented yet and must stay disabled.
-    assert anthropic_profile.supports_json_schema_output is False
+    assert anthropic_profile.get('supports_json_schema_output', False) is False
 
     mistral_profile = provider.model_profile('mistral.mistral-large-2407-v1:0')
     mistral_model_profile_mock.assert_called_with('mistral-large-2407')
-    assert isinstance(mistral_profile, BedrockModelProfile)
-    assert mistral_profile.bedrock_tool_result_format == 'json'
-    assert mistral_profile.supported_native_tools == frozenset()
+    assert isinstance(mistral_profile, dict)
+    assert mistral_profile.get('bedrock_tool_result_format', 'text') == 'json'
+    assert mistral_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()
 
     meta_profile = provider.model_profile('meta.llama3-8b-instruct-v1:0')
     meta_model_profile_mock.assert_called_with('llama3-8b-instruct')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
-    assert meta_profile.supported_native_tools == frozenset()
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()
 
     cohere_profile = provider.model_profile('cohere.command-text-v14')
     cohere_model_profile_mock.assert_called_with('command-text')
     assert cohere_profile is not None
-    assert cohere_profile.supported_native_tools == frozenset()
+    assert cohere_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()
 
     deepseek_profile = provider.model_profile('deepseek.deepseek-r1')
     deepseek_model_profile_mock.assert_called_with('deepseek-r1')
     assert deepseek_profile is not None
-    assert deepseek_profile.ignore_streamed_leading_whitespace is True
-    assert deepseek_profile.supported_native_tools == frozenset()
+    assert deepseek_profile.get('ignore_streamed_leading_whitespace', False) is True
+    assert deepseek_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()
 
     amazon_profile = provider.model_profile('us.amazon.nova-pro-v1:0')
     amazon_model_profile_mock.assert_called_with('nova-pro')
-    assert isinstance(amazon_profile, BedrockModelProfile)
-    assert amazon_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
-    assert amazon_profile.bedrock_supports_tool_choice is True
-    assert amazon_profile.bedrock_supports_prompt_caching is True
-    assert amazon_profile.supported_native_tools == frozenset()
+    assert isinstance(amazon_profile, dict)
+    assert amazon_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+    assert amazon_profile.get('bedrock_supports_tool_choice', False) is True
+    assert amazon_profile.get('bedrock_supports_prompt_caching', False) is True
+    assert amazon_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()
 
     amazon_profile = provider.model_profile('us.amazon.nova-2-lite-v1:0')
     amazon_model_profile_mock.assert_called_with('nova-2-lite')
-    assert isinstance(amazon_profile, BedrockModelProfile)
-    assert amazon_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
-    assert amazon_profile.bedrock_supports_tool_choice is True
-    assert amazon_profile.bedrock_supports_prompt_caching is True
-    assert amazon_profile.supported_native_tools == frozenset({CodeExecutionTool})
+    assert isinstance(amazon_profile, dict)
+    assert amazon_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+    assert amazon_profile.get('bedrock_supports_tool_choice', False) is True
+    assert amazon_profile.get('bedrock_supports_prompt_caching', False) is True
+    assert amazon_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset({CodeExecutionTool})
 
     amazon_profile = provider.model_profile('us.amazon.titan-text-express-v1:0')
     amazon_model_profile_mock.assert_called_with('titan-text-express')
     assert amazon_profile is not None
-    assert amazon_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
-    assert amazon_profile.supported_native_tools == frozenset()
+    assert amazon_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+    assert amazon_profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS) == frozenset()
 
     unknown_model = provider.model_profile('unknown-model')
     assert unknown_model is None

--- a/tests/providers/test_cerebras.py
+++ b/tests/providers/test_cerebras.py
@@ -10,7 +10,7 @@ from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.profiles.harmony import harmony_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
 from ..conftest import TestEnv, try_import
@@ -72,45 +72,45 @@ def test_cerebras_provider_model_profile(mocker: MockerFixture):
     meta_profile = provider.model_profile('llama-3.3-70b')
     meta_model_profile_mock.assert_called_with('llama-3.3-70b')
     assert meta_profile is not None
-    assert isinstance(meta_profile, OpenAIModelProfile)
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert isinstance(meta_profile, dict)
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     # Test qwen model - uses qwen profile which has InlineDefsJsonSchemaTransformer
     qwen_profile = provider.model_profile('qwen-3-32b')
     qwen_model_profile_mock.assert_called_with('qwen-3-32b')
     assert qwen_profile is not None
-    assert isinstance(qwen_profile, OpenAIModelProfile)
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert isinstance(qwen_profile, dict)
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     # Test gpt-oss model (harmony) - uses OpenAIJsonSchemaTransformer
     harmony_profile = provider.model_profile('gpt-oss-120b')
     harmony_model_profile_mock.assert_called_with('gpt-oss-120b')
     assert harmony_profile is not None
-    assert isinstance(harmony_profile, OpenAIModelProfile)
-    assert harmony_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert isinstance(harmony_profile, dict)
+    assert harmony_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test zai model - uses default OpenAI profile (zai_model_profile returns None)
     zai_profile = provider.model_profile('zai-glm-4.6')
     zai_model_profile_mock.assert_called_with('zai-glm-4.6')
     assert zai_profile is not None
-    assert isinstance(zai_profile, OpenAIModelProfile)
-    assert zai_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert isinstance(zai_profile, dict)
+    assert zai_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test unknown model - should still return a profile with OpenAIJsonSchemaTransformer
     unknown_profile = provider.model_profile('unknown-model')
     assert unknown_profile is not None
-    assert isinstance(unknown_profile, OpenAIModelProfile)
-    assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert isinstance(unknown_profile, dict)
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Verify unsupported model settings are set for all profiles
     for profile in [meta_profile, qwen_profile, harmony_profile, zai_profile, unknown_profile]:
-        assert isinstance(profile, OpenAIModelProfile)
-        assert 'frequency_penalty' in profile.openai_unsupported_model_settings
-        assert 'logit_bias' in profile.openai_unsupported_model_settings
-        assert 'presence_penalty' in profile.openai_unsupported_model_settings
-        assert 'parallel_tool_calls' in profile.openai_unsupported_model_settings
-        assert 'service_tier' in profile.openai_unsupported_model_settings
-        assert 'openai_service_tier' in profile.openai_unsupported_model_settings
+        assert isinstance(profile, dict)
+        assert 'frequency_penalty' in profile.get('openai_unsupported_model_settings', ())
+        assert 'logit_bias' in profile.get('openai_unsupported_model_settings', ())
+        assert 'presence_penalty' in profile.get('openai_unsupported_model_settings', ())
+        assert 'parallel_tool_calls' in profile.get('openai_unsupported_model_settings', ())
+        assert 'service_tier' in profile.get('openai_unsupported_model_settings', ())
+        assert 'openai_service_tier' in profile.get('openai_unsupported_model_settings', ())
 
 
 def test_infer_cerebras_model(env: TestEnv):

--- a/tests/providers/test_deepseek.py
+++ b/tests/providers/test_deepseek.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 
 from ..conftest import TestEnv, try_import
 
@@ -52,9 +52,9 @@ def test_deep_seek_pass_openai_client() -> None:
 def test_deep_seek_model_profile():
     provider = DeepSeekProvider(api_key='api-key')
     model = OpenAIChatModel('deepseek-r1', provider=provider)
-    assert model.profile.json_schema_transformer == OpenAIJsonSchemaTransformer
-    assert model.profile.supports_thinking is True
-    assert model.profile.thinking_always_enabled is True
+    assert model.profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    assert model.profile.get('supports_thinking', False) is True
+    assert model.profile.get('thinking_always_enabled', False) is True
 
 
 @pytest.mark.parametrize('model_name', ['deepseek-v4-flash', 'deepseek-v4-pro'])
@@ -62,19 +62,19 @@ def test_deep_seek_v4_model_profile(model_name: str):
     provider = DeepSeekProvider(api_key='api-key')
     profile = provider.model_profile(model_name)
     assert profile is not None
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.supports_thinking is True
-    assert profile.thinking_always_enabled is False
-    assert profile.openai_supports_tool_choice_required is False
+    assert isinstance(profile, dict)
+    assert profile.get('supports_thinking', False) is True
+    assert profile.get('thinking_always_enabled', False) is False
+    assert profile.get('openai_supports_tool_choice_required', True) is False
 
 
 def test_deep_seek_chat_model_profile():
     provider = DeepSeekProvider(api_key='api-key')
     profile = provider.model_profile('deepseek-chat')
     assert profile is not None
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.supports_thinking is False
-    assert profile.openai_supports_tool_choice_required is True
+    assert isinstance(profile, dict)
+    assert profile.get('supports_thinking', False) is False
+    assert profile.get('openai_supports_tool_choice_required', True) is True
 
 
 def test_deep_seek_r1_model_profile():
@@ -82,19 +82,19 @@ def test_deep_seek_r1_model_profile():
     provider = DeepSeekProvider(api_key='api-key')
     profile = provider.model_profile('deepseek-r1')
     assert profile is not None
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.supports_thinking is True
-    assert profile.thinking_always_enabled is True
+    assert isinstance(profile, dict)
+    assert profile.get('supports_thinking', False) is True
+    assert profile.get('thinking_always_enabled', False) is True
 
 
 def test_deep_seek_reasoner_model_profile():
     provider = DeepSeekProvider(api_key='api-key')
     profile = provider.model_profile('deepseek-reasoner')
     assert profile is not None
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.supports_thinking is True
-    assert profile.thinking_always_enabled is True
-    assert profile.openai_supports_tool_choice_required is False
+    assert isinstance(profile, dict)
+    assert profile.get('supports_thinking', False) is True
+    assert profile.get('thinking_always_enabled', False) is True
+    assert profile.get('openai_supports_tool_choice_required', True) is False
 
 
 def test_deep_seek_v4_future_sku_inherits_tool_choice_restriction():
@@ -102,5 +102,5 @@ def test_deep_seek_v4_future_sku_inherits_tool_choice_restriction():
     provider = DeepSeekProvider(api_key='api-key')
     profile = provider.model_profile('deepseek-v4-turbo')
     assert profile is not None
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.openai_supports_tool_choice_required is False
+    assert isinstance(profile, dict)
+    assert profile.get('openai_supports_tool_choice_required', True) is False

--- a/tests/providers/test_fireworks.py
+++ b/tests/providers/test_fireworks.py
@@ -73,32 +73,32 @@ def test_fireworks_provider_model_profile(mocker: MockerFixture):
     deepseek_profile = provider.model_profile('accounts/fireworks/models/deepseek-v3')
     deepseek_model_profile_mock.assert_called_with('deepseek-v3')
     assert deepseek_profile is not None
-    assert deepseek_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert deepseek_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     meta_profile = provider.model_profile('accounts/fireworks/models/llama4-maverick-instruct-basic')
     meta_model_profile_mock.assert_called_with('llama4-maverick-instruct-basic')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     qwen_profile = provider.model_profile('accounts/fireworks/models/qwen3-235b-a22b')
     qwen_model_profile_mock.assert_called_with('qwen3-235b-a22b')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     mistral_profile = provider.model_profile('accounts/fireworks/models/mistral-small-24b-instruct-2501')
     mistral_model_profile_mock.assert_called_with('mistral-small-24b-instruct-2501')
     assert mistral_profile is not None
-    assert mistral_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert mistral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     google_profile = provider.model_profile('accounts/fireworks/models/gemma-7b-it')
     google_model_profile_mock.assert_called_with('gemma-7b-it')
     assert google_profile is not None
-    assert google_profile.json_schema_transformer == GoogleJsonSchemaTransformer
+    assert google_profile.get('json_schema_transformer', None) == GoogleJsonSchemaTransformer
 
     unknown_profile = provider.model_profile('accounts/fireworks/models/unknown-model')
     assert unknown_profile is not None
-    assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     unknown_profile = provider.model_profile('unknown-model')
     assert unknown_profile is not None
-    assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer

--- a/tests/providers/test_github.py
+++ b/tests/providers/test_github.py
@@ -69,44 +69,44 @@ def test_github_provider_model_profile(mocker: MockerFixture):
     meta_profile = provider.model_profile('meta/Llama-3.2-11B-Vision-Instruct')
     meta_model_profile_mock.assert_called_with('llama-3.2-11b-vision-instruct')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     meta_profile = provider.model_profile('meta/Llama-3.1-405B-Instruct')
     meta_model_profile_mock.assert_called_with('llama-3.1-405b-instruct')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     deepseek_profile = provider.model_profile('deepseek/deepseek-coder')
     deepseek_model_profile_mock.assert_called_with('deepseek-coder')
     assert deepseek_profile is not None
-    assert deepseek_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert deepseek_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     mistral_profile = provider.model_profile('mistral-ai/mixtral-8x7b-instruct')
     mistral_model_profile_mock.assert_called_with('mixtral-8x7b-instruct')
     assert mistral_profile is not None
-    assert mistral_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert mistral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     cohere_profile = provider.model_profile('cohere/command-r-plus')
     cohere_model_profile_mock.assert_called_with('command-r-plus')
     assert cohere_profile is not None
-    assert cohere_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert cohere_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     grok_profile = provider.model_profile('xai/grok-3-mini')
     grok_model_profile_mock.assert_called_with('grok-3-mini')
     assert grok_profile is not None
-    assert grok_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert grok_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     microsoft_profile = provider.model_profile('microsoft/Phi-3.5-mini-instruct')
     openai_model_profile_mock.assert_called_with('phi-3.5-mini-instruct')
     assert microsoft_profile is not None
-    assert microsoft_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert microsoft_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     unknown_profile = provider.model_profile('some-unknown-model')
     openai_model_profile_mock.assert_called_with('some-unknown-model')
     assert unknown_profile is not None
-    assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     unknown_profile_with_prefix = provider.model_profile('unknown-publisher/some-unknown-model')
     openai_model_profile_mock.assert_called_with('some-unknown-model')
     assert unknown_profile_with_prefix is not None
-    assert unknown_profile_with_prefix.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert unknown_profile_with_prefix.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer

--- a/tests/providers/test_grok.py
+++ b/tests/providers/test_grok.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 
 from ..conftest import TestEnv, try_import
 
@@ -59,9 +59,9 @@ def test_grok_pass_openai_client() -> None:
 def test_grok_model_profile():
     provider = GrokProvider(api_key='api-key')
     model = OpenAIChatModel('grok-3', provider=provider)
-    assert isinstance(model.profile, OpenAIModelProfile)
-    assert model.profile.json_schema_transformer == OpenAIJsonSchemaTransformer
-    assert model.profile.openai_supports_strict_tool_definition is False
+    assert isinstance(model.profile, dict)
+    assert model.profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    assert model.profile.get('openai_supports_strict_tool_definition', True) is False
 
 
 def test_grok_provider_is_deprecated():

--- a/tests/providers/test_groq.py
+++ b/tests/providers/test_groq.py
@@ -10,7 +10,7 @@ from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer, google_model_profile
-from pydantic_ai.profiles.groq import GroqModelProfile, groq_model_profile
+from pydantic_ai.profiles.groq import groq_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
@@ -84,38 +84,38 @@ def test_groq_provider_model_profile(mocker: MockerFixture):
     meta_profile = provider.model_profile('meta-llama/Llama-Guard-4-12B')
     meta_model_profile_mock.assert_called_with('llama-guard-4-12b')
     assert meta_profile is not None
-    assert meta_profile.supports_json_object_output is False
-    assert meta_profile.supports_json_schema_output is False
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('supports_json_object_output', False) is False
+    assert meta_profile.get('supports_json_schema_output', False) is False
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     meta_profile = provider.model_profile('meta-llama/llama-4-maverick-17b-128e-instruct')
     meta_model_profile_mock.assert_called_with('llama-4-maverick-17b-128e-instruct')
     assert meta_profile is not None
-    assert meta_profile.supports_json_object_output is True
-    assert meta_profile.supports_json_schema_output is True
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('supports_json_object_output', False) is True
+    assert meta_profile.get('supports_json_schema_output', False) is True
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     meta_profile = provider.model_profile('meta-llama/llama-4-scout-17b-16e-instruct')
     meta_model_profile_mock.assert_called_with('llama-4-scout-17b-16e-instruct')
     assert meta_profile is not None
-    assert meta_profile.supports_json_object_output is True
-    assert meta_profile.supports_json_schema_output is True
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('supports_json_object_output', False) is True
+    assert meta_profile.get('supports_json_schema_output', False) is True
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     meta_profile = provider.model_profile('llama-3.3-70b-versatile')
     meta_model_profile_mock.assert_called_with('llama-3.3-70b-versatile')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     google_profile = provider.model_profile('gemma2-9b-it')
     google_model_profile_mock.assert_called_with('gemma2-9b-it')
     assert google_profile is not None
-    assert google_profile.json_schema_transformer == GoogleJsonSchemaTransformer
+    assert google_profile.get('json_schema_transformer', None) == GoogleJsonSchemaTransformer
 
     deepseek_profile = provider.model_profile('deepseek-r1-distill-llama-70b')
     deepseek_model_profile_mock.assert_called_with('deepseek-r1-distill-llama-70b')
     assert deepseek_profile is not None
-    assert deepseek_profile.ignore_streamed_leading_whitespace is True
+    assert deepseek_profile.get('ignore_streamed_leading_whitespace', False) is True
 
     mistral_profile = provider.model_profile('mistral-saba-24b')
     mistral_model_profile_mock.assert_called_with('mistral-saba-24b')
@@ -124,32 +124,32 @@ def test_groq_provider_model_profile(mocker: MockerFixture):
     qwen_profile = provider.model_profile('qwen-qwq-32b')
     qwen_model_profile_mock.assert_called_with('qwen-qwq-32b')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     qwen_profile = provider.model_profile('compound-beta')
     groq_model_profile_mock.assert_called_with('compound-beta')
     assert qwen_profile is not None
-    assert isinstance(qwen_profile, GroqModelProfile)
-    assert qwen_profile.groq_always_has_web_search_builtin_tool is True
+    assert isinstance(qwen_profile, dict)
+    assert qwen_profile.get('groq_always_has_web_search_builtin_tool', False) is True
 
     moonshotai_profile = provider.model_profile('moonshotai/kimi-k2-instruct')
     moonshotai_model_profile_mock.assert_called_with('kimi-k2-instruct')
     assert moonshotai_profile is not None
-    assert moonshotai_profile.supports_json_object_output is True
-    assert moonshotai_profile.supports_json_schema_output is True
-    assert moonshotai_profile.ignore_streamed_leading_whitespace is True
+    assert moonshotai_profile.get('supports_json_object_output', False) is True
+    assert moonshotai_profile.get('supports_json_schema_output', False) is True
+    assert moonshotai_profile.get('ignore_streamed_leading_whitespace', False) is True
 
     openai_profile = provider.model_profile('openai/gpt-oss-20b')
     openai_model_profile_mock.assert_called_with('gpt-oss-20b')
     assert openai_profile is not None
-    assert openai_profile.supports_json_object_output is True
-    assert openai_profile.supports_json_schema_output is True
+    assert openai_profile.get('supports_json_object_output', False) is True
+    assert openai_profile.get('supports_json_schema_output', False) is True
 
     openai_profile = provider.model_profile('openai/gpt-oss-120b')
     openai_model_profile_mock.assert_called_with('gpt-oss-120b')
     assert openai_profile is not None
-    assert openai_profile.supports_json_object_output is True
-    assert openai_profile.supports_json_schema_output is True
+    assert openai_profile.get('supports_json_object_output', False) is True
+    assert openai_profile.get('supports_json_schema_output', False) is True
 
     unknown_profile = provider.model_profile('unknown-model')
     assert unknown_profile is None

--- a/tests/providers/test_heroku.py
+++ b/tests/providers/test_heroku.py
@@ -5,7 +5,7 @@ import pytest
 
 from pydantic_ai.agent import Agent
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 
 from .._inline_snapshot import snapshot
 from ..conftest import TestEnv, try_import
@@ -58,8 +58,8 @@ def test_heroku_pass_openai_client() -> None:
 def test_heroku_model_profile():
     provider = HerokuProvider(api_key='api-key')
     model = OpenAIChatModel('claude-3-7-sonnet', provider=provider)
-    assert isinstance(model.profile, OpenAIModelProfile)
-    assert model.profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert isinstance(model.profile, dict)
+    assert model.profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
 
 async def test_heroku_model_provider_claude_3_7_sonnet(allow_model_requests: None, heroku_inference_key: str):

--- a/tests/providers/test_huggingface.py
+++ b/tests/providers/test_huggingface.py
@@ -180,18 +180,18 @@ def test_huggingface_provider_model_profile(mocker: MockerFixture):
     deepseek_profile = provider.model_profile('deepseek-ai/DeepSeek-R1')
     deepseek_model_profile_mock.assert_called_with('deepseek-r1')
     assert deepseek_profile is not None
-    assert deepseek_profile.ignore_streamed_leading_whitespace is True
+    assert deepseek_profile.get('ignore_streamed_leading_whitespace', False) is True
 
     meta_profile = provider.model_profile('meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8')
     meta_model_profile_mock.assert_called_with('llama-4-maverick-17b-128e-instruct-fp8')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     qwen_profile = provider.model_profile('Qwen/QwQ-32B')
     qwen_model_profile_mock.assert_called_with('qwq-32b')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
-    assert qwen_profile.ignore_streamed_leading_whitespace is True
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('ignore_streamed_leading_whitespace', False) is True
 
     mistral_profile = provider.model_profile('mistralai/Devstral-Small-2505')
     mistral_model_profile_mock.assert_called_with('devstral-small-2505')
@@ -200,7 +200,7 @@ def test_huggingface_provider_model_profile(mocker: MockerFixture):
     google_profile = provider.model_profile('google/gemma-3-27b-it')
     google_model_profile_mock.assert_called_with('gemma-3-27b-it')
     assert google_profile is not None
-    assert google_profile.json_schema_transformer == GoogleJsonSchemaTransformer
+    assert google_profile.get('json_schema_transformer', None) == GoogleJsonSchemaTransformer
 
     unknown_profile = provider.model_profile('unknown/model')
     assert unknown_profile is None

--- a/tests/providers/test_litellm.py
+++ b/tests/providers/test_litellm.py
@@ -7,7 +7,7 @@ from ..conftest import try_import
 with try_import() as imports_successful:
     from openai import AsyncOpenAI
 
-    from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
+    from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
     from pydantic_ai.providers.litellm import LiteLLMProvider
 
 pytestmark = [
@@ -38,15 +38,7 @@ def test_init_with_openai_client():
 def test_model_profile_returns_openai_compatible_profile(mocker: MockerFixture):
     provider = LiteLLMProvider(api_key='test-key')
 
-    # Create a proper mock profile object that can be updated
-    from dataclasses import dataclass
-
-    @dataclass
-    class MockProfile:
-        max_tokens: int = 4096
-        supports_streaming: bool = True
-
-    mock_profile = MockProfile()
+    mock_profile: dict[str, object] = {'supports_tools': True}
     mock_openai_profile = mocker.patch('pydantic_ai.providers.litellm.openai_model_profile', return_value=mock_profile)
 
     profile = provider.model_profile('gpt-3.5-turbo')
@@ -55,37 +47,29 @@ def test_model_profile_returns_openai_compatible_profile(mocker: MockerFixture):
     mock_openai_profile.assert_called_once_with('gpt-3.5-turbo')
 
     # Verify the returned profile is an OpenAIModelProfile with OpenAIJsonSchemaTransformer
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert isinstance(profile, dict)
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
 
 def test_model_profile_with_different_models(mocker: MockerFixture):
     provider = LiteLLMProvider(api_key='test-key')
 
-    # Create mocks for all profile functions
-    from dataclasses import dataclass
-
-    @dataclass
-    class MockProfile:
-        max_tokens: int = 4096
-        supports_streaming: bool = True
+    mock_profile: dict[str, object] = {'supports_tools': True}
 
     # Mock all profile functions
     mock_profiles = {
-        'openai': mocker.patch('pydantic_ai.providers.litellm.openai_model_profile', return_value=MockProfile()),
-        'anthropic': mocker.patch('pydantic_ai.providers.litellm.anthropic_model_profile', return_value=MockProfile()),
-        'google': mocker.patch('pydantic_ai.providers.litellm.google_model_profile', return_value=MockProfile()),
-        'meta': mocker.patch('pydantic_ai.providers.litellm.meta_model_profile', return_value=MockProfile()),
-        'mistral': mocker.patch('pydantic_ai.providers.litellm.mistral_model_profile', return_value=MockProfile()),
-        'cohere': mocker.patch('pydantic_ai.providers.litellm.cohere_model_profile', return_value=MockProfile()),
-        'amazon': mocker.patch('pydantic_ai.providers.litellm.amazon_model_profile', return_value=MockProfile()),
-        'deepseek': mocker.patch('pydantic_ai.providers.litellm.deepseek_model_profile', return_value=MockProfile()),
-        'groq': mocker.patch('pydantic_ai.providers.litellm.groq_model_profile', return_value=MockProfile()),
-        'grok': mocker.patch('pydantic_ai.providers.litellm.grok_model_profile', return_value=MockProfile()),
-        'moonshotai': mocker.patch(
-            'pydantic_ai.providers.litellm.moonshotai_model_profile', return_value=MockProfile()
-        ),
-        'qwen': mocker.patch('pydantic_ai.providers.litellm.qwen_model_profile', return_value=MockProfile()),
+        'openai': mocker.patch('pydantic_ai.providers.litellm.openai_model_profile', return_value=mock_profile),
+        'anthropic': mocker.patch('pydantic_ai.providers.litellm.anthropic_model_profile', return_value=mock_profile),
+        'google': mocker.patch('pydantic_ai.providers.litellm.google_model_profile', return_value=mock_profile),
+        'meta': mocker.patch('pydantic_ai.providers.litellm.meta_model_profile', return_value=mock_profile),
+        'mistral': mocker.patch('pydantic_ai.providers.litellm.mistral_model_profile', return_value=mock_profile),
+        'cohere': mocker.patch('pydantic_ai.providers.litellm.cohere_model_profile', return_value=mock_profile),
+        'amazon': mocker.patch('pydantic_ai.providers.litellm.amazon_model_profile', return_value=mock_profile),
+        'deepseek': mocker.patch('pydantic_ai.providers.litellm.deepseek_model_profile', return_value=mock_profile),
+        'groq': mocker.patch('pydantic_ai.providers.litellm.groq_model_profile', return_value=mock_profile),
+        'grok': mocker.patch('pydantic_ai.providers.litellm.grok_model_profile', return_value=mock_profile),
+        'moonshotai': mocker.patch('pydantic_ai.providers.litellm.moonshotai_model_profile', return_value=mock_profile),
+        'qwen': mocker.patch('pydantic_ai.providers.litellm.qwen_model_profile', return_value=mock_profile),
     }
 
     # Test models without provider prefix (should use openai profile)
@@ -93,8 +77,8 @@ def test_model_profile_with_different_models(mocker: MockerFixture):
 
     for model in models_without_prefix:
         profile = provider.model_profile(model)
-        assert isinstance(profile, OpenAIModelProfile)
-        assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+        assert isinstance(profile, dict)
+        assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Verify openai_model_profile was called for each model without prefix
     assert mock_profiles['openai'].call_count == len(models_without_prefix)
@@ -124,8 +108,8 @@ def test_model_profile_with_different_models(mocker: MockerFixture):
 
     for model_name, expected_profile, expected_suffix in test_cases:
         profile = provider.model_profile(model_name)
-        assert isinstance(profile, OpenAIModelProfile)
-        assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+        assert isinstance(profile, dict)
+        assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
         # Verify the correct profile function was called with the correct suffix
         mock_profiles[expected_profile].assert_called_with(expected_suffix)
         mock_profiles[expected_profile].reset_mock()

--- a/tests/providers/test_moonshotai.py
+++ b/tests/providers/test_moonshotai.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 
 from ..conftest import TestEnv, try_import
 
@@ -63,7 +63,7 @@ def test_moonshotai_provider_creates_http_client() -> None:
 def test_moonshotai_model_profile():
     provider = MoonshotAIProvider(api_key='api-key')
     model = OpenAIChatModel('kimi-k2-0711-preview', provider=provider)
-    assert isinstance(model.profile, OpenAIModelProfile)
-    assert model.profile.json_schema_transformer == OpenAIJsonSchemaTransformer
-    assert model.profile.openai_supports_tool_choice_required is False
-    assert model.profile.supports_json_object_output is True
+    assert isinstance(model.profile, dict)
+    assert model.profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    assert model.profile.get('openai_supports_tool_choice_required', True) is False
+    assert model.profile.get('supports_json_object_output', False) is True

--- a/tests/providers/test_nebius.py
+++ b/tests/providers/test_nebius.py
@@ -80,51 +80,51 @@ def test_nebius_provider_model_profile(mocker: MockerFixture):
     meta_profile = provider.model_profile('meta-llama/Llama-3.3-70B-Instruct')
     meta_mock.assert_called_with('llama-3.3-70b-instruct')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     # Test deepseek provider
     profile = provider.model_profile('deepseek-ai/DeepSeek-R1-0528')
     deepseek_mock.assert_called_with('deepseek-r1-0528')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test qwen provider
     qwen_profile = provider.model_profile('Qwen/Qwen3-30B-A3B')
     qwen_mock.assert_called_with('qwen3-30b-a3b')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     # Test google provider
     google_profile = provider.model_profile('google/gemma-2-2b-it')
     google_mock.assert_called_with('gemma-2-2b-it')
     assert google_profile is not None
-    assert google_profile.json_schema_transformer == GoogleJsonSchemaTransformer
+    assert google_profile.get('json_schema_transformer', None) == GoogleJsonSchemaTransformer
 
     # Test harmony (for openai gpt-oss) provider
     profile = provider.model_profile('openai/gpt-oss-120b')
     harmony_mock.assert_called_with('gpt-oss-120b')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test mistral provider
     profile = provider.model_profile('mistralai/Devstral-Small-2505')
     mistral_mock.assert_called_with('devstral-small-2505')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test moonshotai provider
     moonshotai_profile = provider.model_profile('moonshotai/Kimi-K2-Instruct')
     moonshotai_mock.assert_called_with('kimi-k2-instruct')
     assert moonshotai_profile is not None
-    assert moonshotai_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert moonshotai_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test unknown provider
     unknown_profile = provider.model_profile('unknown-provider/unknown-model')
     assert unknown_profile is not None
-    assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
 
 def test_nebius_provider_model_name_without_slash():
     profile = NebiusProvider.model_profile('invalid-model-name')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -12,7 +12,7 @@ from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer, google_mode
 from pydantic_ai.profiles.harmony import harmony_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
 from ..conftest import TestEnv, try_import
@@ -83,72 +83,72 @@ def test_ollama_provider_model_profile(mocker: MockerFixture):
     meta_profile = provider.model_profile('llama3.2')
     meta_model_profile_mock.assert_called_with('llama3.2')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     google_profile = provider.model_profile('gemma3')
     google_model_profile_mock.assert_called_with('gemma3')
     assert google_profile is not None
-    assert google_profile.json_schema_transformer == GoogleJsonSchemaTransformer
+    assert google_profile.get('json_schema_transformer', None) == GoogleJsonSchemaTransformer
 
     deepseek_profile = provider.model_profile('deepseek-r1')
     deepseek_model_profile_mock.assert_called_with('deepseek-r1')
     assert deepseek_profile is not None
-    assert deepseek_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert deepseek_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     mistral_profile = provider.model_profile('mistral-small')
     mistral_model_profile_mock.assert_called_with('mistral-small')
     assert mistral_profile is not None
-    assert mistral_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert mistral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     qwen_profile = provider.model_profile('qwen3')
     qwen_model_profile_mock.assert_called_with('qwen3')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
-    assert qwen_profile.ignore_streamed_leading_whitespace is True
-    assert qwen_profile.supports_json_schema_output is True
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('ignore_streamed_leading_whitespace', False) is True
+    assert qwen_profile.get('supports_json_schema_output', False) is True
 
     qwen_profile = provider.model_profile('qwen3.5')
     qwen_model_profile_mock.assert_called_with('qwen3.5')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
-    assert qwen_profile.ignore_streamed_leading_whitespace is True
-    assert qwen_profile.supports_json_schema_output is True
-    assert qwen_profile.supports_json_object_output is True
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('ignore_streamed_leading_whitespace', False) is True
+    assert qwen_profile.get('supports_json_schema_output', False) is True
+    assert qwen_profile.get('supports_json_object_output', False) is True
 
     qwen_profile = provider.model_profile('qwen3.5:35b')
     qwen_model_profile_mock.assert_called_with('qwen3.5:35b')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
-    assert qwen_profile.ignore_streamed_leading_whitespace is True
-    assert qwen_profile.supports_json_schema_output is True
-    assert qwen_profile.supports_json_object_output is True
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('ignore_streamed_leading_whitespace', False) is True
+    assert qwen_profile.get('supports_json_schema_output', False) is True
+    assert qwen_profile.get('supports_json_object_output', False) is True
 
     qwen_profile = provider.model_profile('qwq')
     qwen_model_profile_mock.assert_called_with('qwq')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
-    assert qwen_profile.ignore_streamed_leading_whitespace is True
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('ignore_streamed_leading_whitespace', False) is True
 
     cohere_profile = provider.model_profile('command-r')
     cohere_model_profile_mock.assert_called_with('command-r')
     assert cohere_profile is not None
-    assert cohere_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert cohere_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     harmony_profile = provider.model_profile('gpt-oss')
     harmony_model_profile_mock.assert_called_with('gpt-oss')
     assert harmony_profile is not None
-    assert harmony_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
-    assert harmony_profile.ignore_streamed_leading_whitespace is True
+    assert harmony_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    assert harmony_profile.get('ignore_streamed_leading_whitespace', False) is True
 
     unknown_profile = provider.model_profile('unknown-model')
     assert unknown_profile is not None
-    assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Ollama does not support strict mode in tool definitions (issue #4116)
     for model in ('llama3.2', 'qwen3', 'unknown-model'):
         profile = provider.model_profile(model)
         assert profile is not None
-        openai_profile = OpenAIModelProfile.from_profile(profile)
-        assert openai_profile.openai_supports_strict_tool_definition is False
-    assert unknown_profile.supports_json_schema_output is True
-    assert unknown_profile.supports_json_object_output is True
+        openai_profile = profile
+        assert openai_profile.get('openai_supports_strict_tool_definition', True) is False
+    assert unknown_profile.get('supports_json_schema_output', False) is True
+    assert unknown_profile.get('supports_json_object_output', False) is True

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -112,77 +112,77 @@ def test_openrouter_provider_model_profile(mocker: MockerFixture):
     google_profile = provider.model_profile('google/gemini-2.5-pro-preview')
     google_model_profile_mock.assert_called_with('gemini-2.5-pro-preview')
     assert google_profile is not None
-    assert google_profile.json_schema_transformer == _OpenRouterGoogleJsonSchemaTransformer
+    assert google_profile.get('json_schema_transformer', None) == _OpenRouterGoogleJsonSchemaTransformer
 
     google_profile = provider.model_profile('google/gemma-3n-e4b-it:free')
     google_model_profile_mock.assert_called_with('gemma-3n-e4b-it')
     assert google_profile is not None
-    assert google_profile.json_schema_transformer == _OpenRouterGoogleJsonSchemaTransformer
+    assert google_profile.get('json_schema_transformer', None) == _OpenRouterGoogleJsonSchemaTransformer
 
     openai_profile = provider.model_profile('openai/o1-mini')
     openai_model_profile_mock.assert_called_with('o1-mini')
     assert openai_profile is not None
-    assert openai_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert openai_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     anthropic_profile = provider.model_profile('anthropic/claude-3.5-sonnet')
     anthropic_model_profile_mock.assert_called_with('claude-3-5-sonnet')
     assert anthropic_profile is not None
-    assert anthropic_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert anthropic_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     anthropic_profile = provider.model_profile('anthropic/claude-sonnet-4.5')
     anthropic_model_profile_mock.assert_called_with('claude-sonnet-4-5')
     assert anthropic_profile is not None
-    assert anthropic_profile.supports_json_schema_output is True
+    assert anthropic_profile.get('supports_json_schema_output', False) is True
 
     anthropic_profile = provider.model_profile('anthropic/claude-haiku-4.5:free')
     anthropic_model_profile_mock.assert_called_with('claude-haiku-4-5')
     assert anthropic_profile is not None
-    assert anthropic_profile.supports_json_schema_output is True
+    assert anthropic_profile.get('supports_json_schema_output', False) is True
 
     mistral_profile = provider.model_profile('mistralai/mistral-large-2407')
     mistral_model_profile_mock.assert_called_with('mistral-large-2407')
     assert mistral_profile is not None
-    assert mistral_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert mistral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     qwen_profile = provider.model_profile('qwen/qwen-2.5-coder-32b')
     qwen_model_profile_mock.assert_called_with('qwen-2.5-coder-32b')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     grok_profile = provider.model_profile('x-ai/grok-3')
     grok_model_profile_mock.assert_called_with('grok-3')
     assert grok_profile is not None
-    assert grok_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert grok_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     cohere_profile = provider.model_profile('cohere/command-a')
     cohere_model_profile_mock.assert_called_with('command-a')
     assert cohere_profile is not None
-    assert cohere_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert cohere_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     amazon_profile = provider.model_profile('amazon/titan-text-express-v1')
     amazon_model_profile_mock.assert_called_with('titan-text-express-v1')
     assert amazon_profile is not None
-    assert amazon_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert amazon_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     deepseek_profile = provider.model_profile('deepseek/deepseek-r1')
     deepseek_model_profile_mock.assert_called_with('deepseek-r1')
     assert deepseek_profile is not None
-    assert deepseek_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert deepseek_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     meta_profile = provider.model_profile('meta-llama/llama-4-maverick')
     meta_model_profile_mock.assert_called_with('llama-4-maverick')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     moonshotai_profile = provider.model_profile('moonshotai/kimi-k2')
     moonshotai_model_profile_mock.assert_called_with('kimi-k2')
     assert moonshotai_profile is not None
-    assert moonshotai_profile.ignore_streamed_leading_whitespace is True
-    assert moonshotai_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert moonshotai_profile.get('ignore_streamed_leading_whitespace', False) is True
+    assert moonshotai_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     unknown_profile = provider.model_profile('unknown/model')
     assert unknown_profile is not None
-    assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
 
 def test_openrouter_google_json_schema_transformer():

--- a/tests/providers/test_ovhcloud.py
+++ b/tests/providers/test_ovhcloud.py
@@ -77,33 +77,33 @@ def test_ovhcloud_model_profile(mocker: MockerFixture):
     profile = provider.model_profile('DeepSeek-R1-Distill-Llama-70B')
     deepseek_mock.assert_called_with('deepseek-r1-distill-llama-70b')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test harmony (for openai gpt-oss) provider
     profile = provider.model_profile('gpt-oss-120b')
     harmony_mock.assert_called_with('gpt-oss-120b')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test meta provider
     meta_profile = provider.model_profile('Llama-3.3-70B-Instruct')
     meta_mock.assert_called_with('llama-3.3-70b-instruct')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     # Test mistral provider
     profile = provider.model_profile('Mistral-Small-3.2-24B-Instruct-2506')
     mistral_mock.assert_called_with('mistral-small-3.2-24b-instruct-2506')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test qwen provider
     qwen_profile = provider.model_profile('Qwen3-32B')
     qwen_mock.assert_called_with('qwen3-32b')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     # Test unknown provider
     unknown_profile = provider.model_profile('unknown-model')
     assert unknown_profile is not None
-    assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer

--- a/tests/providers/test_sambanova_provider.py
+++ b/tests/providers/test_sambanova_provider.py
@@ -2,7 +2,6 @@ import httpx
 import pytest
 
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.profiles.openai import OpenAIModelProfile
 
 from ..conftest import TestEnv, try_import
 
@@ -46,7 +45,7 @@ def test_meta_llama_profile():
     provider = SambaNovaProvider(api_key='key')
     # Meta Llama model -> expect meta profile wrapped in OpenAI compatibility
     profile = provider.model_profile('Meta-Llama-3.1-8B-Instruct')
-    assert isinstance(profile, OpenAIModelProfile)
+    assert isinstance(profile, dict)
     assert profile is not None
 
 
@@ -54,7 +53,7 @@ def test_deepseek_profile():
     provider = SambaNovaProvider(api_key='key')
     # DeepSeek model -> expect deepseek profile wrapped in OpenAI compatibility
     profile = provider.model_profile('DeepSeek-R1-0528')
-    assert isinstance(profile, OpenAIModelProfile)
+    assert isinstance(profile, dict)
     assert profile is not None
 
 
@@ -62,7 +61,7 @@ def test_qwen_profile():
     provider = SambaNovaProvider(api_key='key')
     # Qwen model -> expect qwen profile wrapped in OpenAI compatibility
     profile = provider.model_profile('Qwen3-32B')
-    assert isinstance(profile, OpenAIModelProfile)
+    assert isinstance(profile, dict)
     assert profile is not None
 
 
@@ -70,7 +69,7 @@ def test_llama4_profile():
     provider = SambaNovaProvider(api_key='key')
     # Llama 4 model -> expect meta profile wrapped in OpenAI compatibility
     profile = provider.model_profile('Llama-4-Maverick-17B-128E-Instruct')
-    assert isinstance(profile, OpenAIModelProfile)
+    assert isinstance(profile, dict)
     assert profile is not None
 
 
@@ -78,7 +77,7 @@ def test_mistral_profile():
     provider = SambaNovaProvider(api_key='key')
     # Mistral-based model -> expect mistral profile wrapped in OpenAI compatibility
     profile = provider.model_profile('E5-Mistral-7B-Instruct')
-    assert isinstance(profile, OpenAIModelProfile)
+    assert isinstance(profile, dict)
     assert profile is not None
 
 
@@ -86,7 +85,7 @@ def test_unknown_model_profile():
     provider = SambaNovaProvider(api_key='key')
     # Unknown model -> should return OpenAI compatibility wrapper with None base profile
     profile = provider.model_profile('unknown-model')
-    assert isinstance(profile, OpenAIModelProfile)
+    assert isinstance(profile, dict)
 
 
 def test_sambanova_provider_with_openai_client():

--- a/tests/providers/test_together.py
+++ b/tests/providers/test_together.py
@@ -73,28 +73,28 @@ def test_together_provider_model_profile(mocker: MockerFixture):
     deepseek_profile = provider.model_profile('deepseek-ai/DeepSeek-R1')
     deepseek_model_profile_mock.assert_called_with('deepseek-r1')
     assert deepseek_profile is not None
-    assert deepseek_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert deepseek_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     meta_profile = provider.model_profile('meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8')
     meta_model_profile_mock.assert_called_with('llama-4-maverick-17b-128e-instruct-fp8')
     assert meta_profile is not None
-    assert meta_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert meta_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     qwen_profile = provider.model_profile('Qwen/QwQ-32B')
     qwen_model_profile_mock.assert_called_with('qwq-32b')
     assert qwen_profile is not None
-    assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     mistral_profile = provider.model_profile('mistralai/Devstral-Small-2505')
     mistral_model_profile_mock.assert_called_with('devstral-small-2505')
     assert mistral_profile is not None
-    assert mistral_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert mistral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     google_profile = provider.model_profile('google/gemma-3-27b-it')
     google_model_profile_mock.assert_called_with('gemma-3-27b-it')
     assert google_profile is not None
-    assert google_profile.json_schema_transformer == GoogleJsonSchemaTransformer
+    assert google_profile.get('json_schema_transformer', None) == GoogleJsonSchemaTransformer
 
     unknown_profile = provider.model_profile('unknown/model')
     assert unknown_profile is not None
-    assert unknown_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer

--- a/tests/providers/test_vercel.py
+++ b/tests/providers/test_vercel.py
@@ -76,49 +76,49 @@ def test_vercel_provider_model_profile(mocker: MockerFixture):
     profile = provider.model_profile('openai/gpt-4o')
     openai_mock.assert_called_with('gpt-4o')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test anthropic provider
     profile = provider.model_profile('anthropic/claude-sonnet-4-5')
     anthropic_mock.assert_called_with('claude-sonnet-4-5')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test bedrock provider
     profile = provider.model_profile('bedrock/anthropic.claude-sonnet-4-5')
     amazon_mock.assert_called_with('anthropic.claude-sonnet-4-5')
     assert profile is not None
-    assert profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == InlineDefsJsonSchemaTransformer
 
     # Test cohere provider
     profile = provider.model_profile('cohere/command-r-plus')
     cohere_mock.assert_called_with('command-r-plus')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test deepseek provider
     profile = provider.model_profile('deepseek/deepseek-chat')
     deepseek_mock.assert_called_with('deepseek-chat')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test mistral provider
     profile = provider.model_profile('mistral/mistral-large')
     mistral_mock.assert_called_with('mistral-large')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test vertex provider
     profile = provider.model_profile('vertex/gemini-1.5-pro')
     google_mock.assert_called_with('gemini-1.5-pro')
     assert profile is not None
-    assert profile.json_schema_transformer == GoogleJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == GoogleJsonSchemaTransformer
 
     # Test xai provider
     profile = provider.model_profile('xai/grok-beta')
     grok_mock.assert_called_with('grok-beta')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
 
 def test_vercel_with_http_client():
@@ -131,7 +131,7 @@ def test_vercel_with_http_client():
 def test_vercel_provider_model_name_without_slash():
     profile = VercelProvider.model_profile('invalid-model-name')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
 
 def test_vercel_provider_unknown_provider():
@@ -139,4 +139,4 @@ def test_vercel_provider_unknown_provider():
 
     profile = provider.model_profile('unknown/gpt-4')
     assert profile is not None
-    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer

--- a/tests/providers/test_xai.py
+++ b/tests/providers/test_xai.py
@@ -41,12 +41,10 @@ def test_xai_pass_xai_client() -> None:
 
 
 def test_xai_model_profile():
-    from pydantic_ai.profiles.grok import GrokModelProfile
-
     provider = XaiProvider(api_key='api-key')
     profile = provider.model_profile('grok-4-1-fast-non-reasoning')
-    assert isinstance(profile, GrokModelProfile)
-    assert profile.grok_supports_builtin_tools is True
+    assert isinstance(profile, dict)
+    assert profile.get('grok_supports_builtin_tools', False) is True
 
 
 def test_xai_provider_recreates_client_on_new_loop():

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -61,7 +61,7 @@ from pydantic_ai.models import Model, ModelRequestParameters, create_async_http_
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.native_tools import AbstractNativeTool
+from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool
 from pydantic_ai.profiles import DEFAULT_PROFILE
 from pydantic_ai.run import AgentRunResult
 from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDefinition
@@ -3448,7 +3448,7 @@ class _CodeExecutionOnlyModel(_BuiltinToolModel):
 
 
 def _select_builtin_tool(ctx: RunContext[Any]) -> AbstractNativeTool:
-    if WebSearchTool in ctx.model.profile.supported_native_tools:
+    if WebSearchTool in ctx.model.profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS):
         return WebSearchTool()
     return CodeExecutionTool()
 

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -18,7 +18,7 @@ from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.output import OutputObjectDefinition
 from pydantic_ai.profiles import ModelProfile
-from pydantic_ai.profiles.anthropic import AnthropicModelProfile, anthropic_model_profile
+from pydantic_ai.profiles.anthropic import AnthropicModelProfile
 from pydantic_ai.profiles.cohere import cohere_model_profile
 from pydantic_ai.profiles.google import GoogleModelProfile, google_model_profile
 from pydantic_ai.profiles.groq import groq_model_profile
@@ -1017,73 +1017,75 @@ class TestProfileThinkingCapabilities:
     """Model profiles correctly detect thinking-capable models."""
 
     def test_anthropic_profile_thinking_support(self):
+        from pydantic_ai.profiles.anthropic import anthropic_model_profile
+
         # All Anthropic models support thinking in our implementation
         profile = anthropic_model_profile('claude-3-7-sonnet')
         assert profile is not None
-        assert profile.supports_thinking is True
+        assert profile.get('supports_thinking', False) is True
 
         profile = anthropic_model_profile('claude-sonnet-4-5')
         assert profile is not None
-        assert profile.supports_thinking is True
+        assert profile.get('supports_thinking', False) is True
 
         # Newer models support adaptive thinking
         profile = anthropic_model_profile('claude-sonnet-4-6')
         assert profile is not None
-        assert isinstance(profile, AnthropicModelProfile)
-        assert profile.anthropic_supports_adaptive_thinking is True
+        assert isinstance(profile, dict)
+        assert profile.get('anthropic_supports_adaptive_thinking', False) is True
 
         profile = anthropic_model_profile('claude-opus-4-7')
         assert profile is not None
-        assert isinstance(profile, AnthropicModelProfile)
-        assert profile.anthropic_supports_adaptive_thinking is True
-        assert profile.anthropic_supports_xhigh_effort is True
-        assert profile.anthropic_disallows_budget_thinking is True
-        assert profile.anthropic_supports_task_budgets is True
+        assert isinstance(profile, dict)
+        assert profile.get('anthropic_supports_adaptive_thinking', False) is True
+        assert profile.get('anthropic_supports_xhigh_effort', False) is True
+        assert profile.get('anthropic_disallows_budget_thinking', False) is True
+        assert profile.get('anthropic_supports_task_budgets', False) is True
 
     def test_google_profile_thinking_support(self):
         profile = google_model_profile('gemini-2.5-flash')
         assert profile is not None
-        assert profile.supports_thinking is True
-        assert profile.thinking_always_enabled is False
+        assert profile.get('supports_thinking', False) is True
+        assert profile.get('thinking_always_enabled', False) is False
 
         profile = google_model_profile('gemini-2.5-pro')
         assert profile is not None
-        assert profile.supports_thinking is True
-        assert profile.thinking_always_enabled is True
+        assert profile.get('supports_thinking', False) is True
+        assert profile.get('thinking_always_enabled', False) is True
 
         profile = google_model_profile('gemini-2.0-flash')
         assert profile is not None
-        assert profile.supports_thinking is False
+        assert profile.get('supports_thinking', False) is False
 
     def test_openai_profile_thinking_support(self):
         profile = openai_model_profile('o3')
         assert profile is not None
-        assert profile.supports_thinking is True
-        assert profile.thinking_always_enabled is True
+        assert profile.get('supports_thinking', False) is True
+        assert profile.get('thinking_always_enabled', False) is True
 
         profile = openai_model_profile('gpt-4o')
         assert profile is not None
-        assert profile.supports_thinking is False
+        assert profile.get('supports_thinking', False) is False
 
     def test_groq_profile_thinking_support(self):
         profile = groq_model_profile('deepseek-r1-distill-llama-70b')
         assert profile is not None
-        assert profile.supports_thinking is True
+        assert profile.get('supports_thinking', False) is True
 
         profile = groq_model_profile('llama-3.1-8b-instant')
         assert profile is not None
-        assert profile.supports_thinking is False
+        assert profile.get('supports_thinking', False) is False
 
     def test_cohere_profile_thinking_support(self):
         profile = cohere_model_profile('command-a-reasoning')
         assert profile is not None
-        assert profile.supports_thinking is True
+        assert profile.get('supports_thinking', False) is True
 
     def test_mistral_profile_thinking_support(self):
         profile = mistral_model_profile('magistral-medium')
         assert profile is not None
-        assert profile.supports_thinking is True
-        assert profile.thinking_always_enabled is True
+        assert profile.get('supports_thinking', False) is True
+        assert profile.get('thinking_always_enabled', False) is True
 
 
 class TestCrossProviderPortability:

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import AsyncIterable, AsyncIterator, Sequence
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
@@ -57,8 +57,9 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import ModelRequestParameters, infer_model
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.native_tools import AbstractNativeTool
+from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool
 from pydantic_ai.native_tools._tool_search import ToolSearchMatch, ToolSearchTool
+from pydantic_ai.profiles import ModelProfile, merge_profile
 from pydantic_ai.run import AgentRunResult
 from pydantic_ai.tool_manager import ToolManager
 from pydantic_ai.tools import ToolDefinition
@@ -258,9 +259,12 @@ def _build_agent(model_name: str) -> Agent[None, str]:
     setattr(
         model,
         'profile',
-        replace(
+        merge_profile(
             model.profile,
-            supported_native_tools=model.profile.supported_native_tools - {ToolSearchTool},
+            ModelProfile(
+                supported_native_tools=model.profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)
+                - {ToolSearchTool}
+            ),
         ),
     )
     agent: Agent[None, str] = Agent(model=model)
@@ -3217,7 +3221,7 @@ def test_prepare_messages_translates_on_non_native_model() -> None:
     splits into `ModelResponse(call) + ModelRequest(return)`."""
     # Default `TestModel` excludes `ToolSearchTool` from `supported_native_tools`.
     model = TestModel()
-    assert ToolSearchTool not in model.profile.supported_native_tools
+    assert ToolSearchTool not in model.profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)
 
     history: list[ModelMessage] = [
         ModelRequest(parts=[UserPromptPart(content='Find me a mortgage tool.')]),
@@ -3272,7 +3276,7 @@ def test_prepare_messages_passes_through_on_native_model() -> None:
             return frozenset({ToolSearchTool})
 
     model = NativeToolSearchTestModel()
-    assert ToolSearchTool in model.profile.supported_native_tools
+    assert ToolSearchTool in model.profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)
 
     history: list[ModelMessage] = [
         ModelRequest(parts=[UserPromptPart(content='Find me a mortgage tool.')]),

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -12,7 +12,7 @@ import pytest
 
 from pydantic_ai import Agent, ModelSettings
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.native_tools import AbstractNativeTool, MCPServerTool
+from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool, MCPServerTool
 from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.profiles.google import GoogleModelProfile
 from pydantic_ai.profiles.groq import GroqModelProfile
@@ -316,7 +316,7 @@ def test_model_profile():
 
 @pytest.mark.parametrize('profile_name', ['base', 'openai', 'google', 'groq'])
 def test_supported_native_tools(profile_name: str):
-    """Test profile.supported_native_tools returns proper tool types."""
+    """Test `profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)` returns proper tool types."""
     if profile_name == 'base':
         profile: ModelProfile = ModelProfile()
     elif profile_name == 'openai':
@@ -326,7 +326,7 @@ def test_supported_native_tools(profile_name: str):
     else:
         profile = GroqModelProfile()
 
-    result = profile.supported_native_tools
+    result = profile.get('supported_native_tools', SUPPORTED_NATIVE_TOOLS)
     assert isinstance(result, frozenset)
     assert all(issubclass(t, AbstractNativeTool) for t in result)
 


### PR DESCRIPTION
Re-applies [#5340](https://github.com/pydantic/pydantic-ai/pull/5340) (which was merged then reverted in [#5449](https://github.com/pydantic/pydantic-ai/pull/5449)), rebased onto `v2-main` after the post-revert cleanup commits (drops of `builtin_tools`, Outlines, and the deprecation shim file).

- Closes #3796

### What changed since the reverted PR

1. **Lock-in snapshot test added** (`tests/profiles/test_resolution_lockin.py`) — 83 cases covering every gateway, every cross-provider routing case (Bedrock-Anthropic, OpenRouter-Google, Vercel-Vertex, etc.), and every inference provider. Snapshots use a `_normalize` helper that strips canonical defaults; result is the per-route delta the provider actually contributes. Used to verify the migration produces equivalent resolved profiles.
2. **Migration recipes promoted to `docs/changelog.md`** — v2.0.0 section with literal old→new code samples, designed both for human readers and for an LLM agent grepping the file for breakage patterns.

### Why `TypedDict` (recap from #5340)

`ModelProfile` and its subclasses were `@dataclass(kw_only=True)` while the closely-related `ModelSettings` was already a `TypedDict(total=False)`. That asymmetry produced three structural pain points:

1. **Cross-provider routing forced "downsize then upsize."** Bedrock hosting Anthropic models had to build a `BedrockModelProfile`, call `.update()` with the `AnthropicModelProfile`, then `replace(...)` to override one field. Class identity made mixing awkward.
2. **`ModelProfile.update()` was leaky.** The `f.default == value` heuristic couldn't distinguish "user explicitly set X to its default" from "user didn't pass X."
3. **Two mental models for one concept.** Users had to learn dataclass semantics for `ModelProfile` and TypedDict semantics for `ModelSettings`.

Plus the original issue: overriding a single field on a built-in profile required constructing a full `OpenAIModelProfile(...)` from scratch.

### Lock-in test findings

73 of 83 cases produce identical resolved profiles pre- and post-migration. **10 cases show drift, all from the same root cause:** v1's `ModelProfile.update()` silently filtered out fields not declared on the target class. v2's `merge_profile` (dict-spread) preserves all keys. So e.g. Bedrock-Anthropic profiles now carry `anthropic_*` fields alongside `bedrock_*` fields. Detailed in the changelog entry; no in-tree model class reads cross-class fields, so behavior is unchanged in the standard providers.

The per-field ordering classification (fallback vs upstream-wins vs override) for the 6 three-layer providers (OpenRouter, Azure, Grok, Ollama, DeepSeek, Cerebras) was verified to produce identical resolved profiles for the high-risk fields (`supports_json_schema_output` override on Bedrock-Anthropic, `openai_supports_tool_choice_required` per-model logic on DeepSeek, `json_schema_transformer` fallback in all 3-layer routes).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md). _(v2 PR — breaking changes are allowed and documented in `docs/changelog.md`.)_
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).