### PR TITLE
fix(instrumentation): Prevent false positive `variable_instructions` span attribute

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -19,8 +19,9 @@ from pydantic_ai._instrumentation import (
     open_model_request_span,
     serialize_any,
 )
+from pydantic_ai._utils import UNSET, Unset
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ToolRetryError
-from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, ToolCallPart, tool_return_ta
+from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart, tool_return_ta
 from pydantic_ai.tools import ToolDefinition
 
 from .abstract import (
@@ -74,6 +75,10 @@ class Instrumentation(AbstractCapability[Any]):
     _new_message_index: int = field(default=0, repr=False, init=False)
     _last_messages: list[ModelMessage] | None = field(default=None, repr=False, init=False)
     _last_model_request_parameters: ModelRequestParameters | None = field(default=None, repr=False, init=False)
+    _last_formatted_instructions: str | None | Unset = field(default=UNSET, repr=False, init=False)
+    """Last formatted instructions sent to the model, or `UNSET` before the first request."""
+    _variable_instructions: bool = field(default=False, repr=False, init=False)
+    """Whether agent-level instructions varied across requests in this run."""
     # Resolved once from `self.settings.version` in `__post_init__` and preserved across
     # `dataclasses.replace` calls in `for_run` (which only touches init=True fields).
     _instrumentation_names: InstrumentationNames = field(
@@ -207,10 +212,7 @@ class Instrumentation(AbstractCapability[Any]):
             if new_message_index > 0:
                 attrs['pydantic_ai.new_message_index'] = new_message_index
 
-            if any(
-                (isinstance(m, ModelRequest) and m.instructions is not None and m.instructions != last_instructions)
-                for m in message_history[new_message_index:]
-            ):
+            if self._variable_instructions:
                 attrs['pydantic_ai.variable_instructions'] = True
 
         if metadata is not None:
@@ -260,6 +262,16 @@ class Instrumentation(AbstractCapability[Any]):
             # (which includes prompted-output template instructions and is properly sorted)
             # instead of falling back to reading `ModelRequest.instructions` from history.
             self._last_model_request_parameters = prepared_request_context.model_request_parameters
+
+            # Track whether the fully formatted instructions (including prompted-output schemas) vary across requests.
+            # This does an apples-to-apples comparison of the final payload sent to the model.
+            current_instructions = get_instructions(
+                request_context.messages, prepared_request_context.model_request_parameters
+            )
+            if not isinstance(self._last_formatted_instructions, Unset):
+                if current_instructions != self._last_formatted_instructions:
+                    self._variable_instructions = True
+            self._last_formatted_instructions = current_instructions
 
             response = await handler(request_context)
             finish(response)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -927,6 +927,101 @@ def test_instructions_with_structured_output_exclude_content(get_logfire_summary
 
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
 @pytest.mark.parametrize('version', [2, 3])
+def test_prompted_output_schema_instructions_do_not_set_variable_instructions(
+    get_logfire_summary: Callable[[], LogfireSummary],
+    version: Literal[2, 3],
+) -> None:
+    class City(BaseModel):
+        name: str
+        population: int
+
+    my_agent = Agent(
+        model=TestModel(custom_output_text='{"name":"Paris","population":2148000}'),
+        instructions='Be helpful',
+        capabilities=[Instrumentation(settings=InstrumentationSettings(version=version))],
+        output_type=PromptedOutput(City, template='Return JSON matching this schema:\n{schema}'),
+    )
+
+    result = my_agent.run_sync('Tell me about Paris')
+    assert result.output == snapshot(City(name='Paris', population=2148000))
+
+    summary = get_logfire_summary()
+    agent_run_attrs = summary.attributes[0]
+    assert 'Be helpful' in agent_run_attrs['gen_ai.system_instructions']
+    assert 'pydantic_ai.variable_instructions' not in agent_run_attrs
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.parametrize('version', [2, 3])
+def test_stable_instructions_across_tool_calls_do_not_set_variable_instructions(
+    get_logfire_summary: Callable[[], LogfireSummary],
+    version: Literal[2, 3],
+) -> None:
+    @dataclass
+    class MyOutput:
+        content: str
+
+    my_agent = Agent(
+        model=TestModel(),
+        instructions='Be helpful',
+        capabilities=[Instrumentation(settings=InstrumentationSettings(version=version))],
+    )
+    instruction_calls = 0
+
+    @my_agent.tool_plain
+    def my_tool() -> str:
+        nonlocal instruction_calls
+        instruction_calls += 1
+        return 'tool result'
+
+    result = my_agent.run_sync('Hello', output_type=MyOutput)
+    assert result.output == MyOutput(content='a')
+    # Ensure multi-step execution occurred so instructions were compared across requests
+    assert instruction_calls >= 1
+
+    summary = get_logfire_summary()
+    assert 'pydantic_ai.variable_instructions' not in summary.attributes[0]
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.parametrize('version', [2, 3])
+def test_dynamic_instructions_toggling_from_none_sets_variable_instructions(
+    get_logfire_summary: Callable[[], LogfireSummary],
+    version: Literal[2, 3],
+) -> None:
+    @dataclass
+    class MyOutput:
+        content: str
+
+    my_agent = Agent(
+        model=TestModel(),
+        capabilities=[Instrumentation(settings=InstrumentationSettings(version=version))],
+    )
+    instruction_calls = 0
+
+    @my_agent.instructions
+    def instructions(_: RunContext[None]) -> str | None:
+        nonlocal instruction_calls
+        instruction_calls += 1
+        if instruction_calls == 1:
+            return None
+        return 'This is a later step'
+
+    @my_agent.tool_plain
+    def my_tool() -> str:
+        return 'This is a tool call'
+
+    result = my_agent.run_sync('Hello', output_type=MyOutput)
+    assert result.output == MyOutput(content='a')
+    # Ensure multi-step execution occurred so instructions actually toggled
+    assert instruction_calls >= 2
+
+    summary = get_logfire_summary()
+    assert summary.attributes[0]['pydantic_ai.variable_instructions'] is True
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.parametrize('version', [2, 3])
 def test_instructions_with_structured_output_exclude_content_v2_v3(
     get_logfire_summary: Callable[[], LogfireSummary],
     version: Literal[2, 3],


### PR DESCRIPTION
Closes #5394

### Summary
Resolves a bug where the `pydantic_ai.variable_instructions` OpenTelemetry span attribute was incorrectly triggering as `True` when using model-injected instructions.

### Root Cause 
When you use `PromptedOutput`, the library automatically appends a JSON schema template to the end of your instructions. The old code was doing a mismatched post-hoc check: it was comparing your original (unformatted) instructions against the final instructions (which included the new schema text). Because they didn't match, it wrongly assumed your instructions were dynamically changing on every request.

### Fix
We moved the check into the `wrap_model_request` hook so that it now compares the fully formatted instructions (including the JSON schema) request-to-request. By caching and evaluating the final payload immediately before it's sent to the model, we achieve a true "like to like" comparison. This guarantees the flag only triggers if the finalized prompt actually changes between steps, completely avoiding re-computation at span-finalization.

*Includes new tests to guarantee this works correctly for both v2 and v3 instrumentation across single and multi-step runs.*

### Checklist

- [X] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [X] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [X] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
