### PR TITLE
fix: `OpenAIJsonSchemaTransformer` mutates top-level `oneOf` object schemas

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -357,7 +357,9 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
             else:
                 self.is_strict_compatible = False
 
-        if schema_type == 'object':
+        has_composition = 'oneOf' in schema or 'anyOf' in schema or 'allOf' in schema
+
+        if schema_type == 'object' and not has_composition:
             # Always ensure 'properties' key exists - OpenAI drops objects without it
             if 'properties' not in schema:
                 schema['properties'] = dict[str, Any]()


### PR DESCRIPTION
## Linked Issue

Closes #5417

## Description

When a JSON schema has `type: "object"` alongside `oneOf`, `anyOf`, or `allOf`, the structural content lives inside the composition branches, not at the outer level. `OpenAIJsonSchemaTransformer.transform` was unconditionally entering the `schema_type == 'object'` block and injecting `properties: {}` + `additionalProperties: false` at the outer level, making the schema reject every key from any composition branch.

The fix skips the object-level mutations when composition keywords are present. The recursive `walk()` handles each branch's inner schemas individually.

**Before:**
```python
{"type": "object", "oneOf": [...], "properties": {}, "additionalProperties": false}
```

**After:**
```python
{"type": "object", "oneOf": [...]}
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I tested manually with the reproducer from #5417
- [ ] Existing integration tests should continue to pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed