### PR TITLE
fix(mistral): preserve SDK import errors

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -93,11 +93,13 @@ try:
     from mistralai.client.types import UNSET, OptionalNullable as MistralOptionalNullable
     from mistralai.client.types.basemodel import Unset as MistralUnset
     from mistralai.client.utils.eventstreaming import EventStreamAsync as MistralEventStreamAsync
-except ImportError as e:  # pragma: lax no cover
-    raise ImportError(
-        'Please install `mistral` to use the Mistral model, '
-        'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
-    ) from e
+except ModuleNotFoundError as e:  # pragma: lax no cover
+    if e.name == 'mistralai':
+        raise ImportError(
+            'Please install `mistral` to use the Mistral model, '
+            'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
+        ) from e
+    raise
 
 
 @contextmanager

--- a/pydantic_ai_slim/pydantic_ai/providers/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/mistral.py
@@ -13,11 +13,13 @@ from pydantic_ai.providers import Provider
 
 try:
     from mistralai.client import Mistral
-except ImportError as e:
-    raise ImportError(
-        'Please install the `mistral` package to use the Mistral provider, '
-        'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
-    ) from e
+except ModuleNotFoundError as e:
+    if e.name == 'mistralai':
+        raise ImportError(
+            'Please install the `mistral` package to use the Mistral provider, '
+            'you can use the `mistral` optional group — `pip install "pydantic-ai-slim[mistral]"`'
+        ) from e
+    raise
 
 
 class MistralProvider(Provider[Mistral]):

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -1,6 +1,9 @@
 from __future__ import annotations as _annotations
 
+import builtins
+import importlib
 import json
+import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -136,6 +139,31 @@ class MockMistralAI:
                 response = cast(MistralChatCompletionResponse, self.completions)
         self.index += 1
         return response
+
+
+def test_mistral_model_preserves_sdk_import_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def import_with_broken_mistral_types(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == 'mistralai.client.types' and 'UNSET' in fromlist:
+            raise ImportError("cannot import name 'UNSET' from 'mistralai.client.types'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with monkeypatch.context() as m:
+        m.setattr(builtins, '__import__', import_with_broken_mistral_types)
+        sys.modules.pop('pydantic_ai.models.mistral', None)
+
+        with pytest.raises(ImportError, match="cannot import name 'UNSET'"):
+            importlib.import_module('pydantic_ai.models.mistral')
+
+    sys.modules.pop('pydantic_ai.models.mistral', None)
+    importlib.import_module('pydantic_ai.models.mistral')
 
 
 def completion_message(

--- a/tests/providers/test_mistral.py
+++ b/tests/providers/test_mistral.py
@@ -1,6 +1,9 @@
 from __future__ import annotations as _annotations
 
+import builtins
+import importlib
 import re
+import sys
 
 import httpx
 import pytest
@@ -56,3 +59,28 @@ def test_mistral_provider_with_base_url() -> None:
         mistral_client=Mistral(api_key='test-api-key', server_url='https://custom.mistral.com/v1'),
     )
     assert provider.base_url == 'https://custom.mistral.com/v1'
+
+
+def test_mistral_provider_preserves_sdk_import_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def import_with_broken_mistral_client(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == 'mistralai.client' and 'Mistral' in fromlist:
+            raise ImportError("cannot import name 'Mistral' from 'mistralai.client'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with monkeypatch.context() as m:
+        m.setattr(builtins, '__import__', import_with_broken_mistral_client)
+        sys.modules.pop('pydantic_ai.providers.mistral', None)
+
+        with pytest.raises(ImportError, match="cannot import name 'Mistral'"):
+            importlib.import_module('pydantic_ai.providers.mistral')
+
+    sys.modules.pop('pydantic_ai.providers.mistral', None)
+    importlib.import_module('pydantic_ai.providers.mistral')


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #4927

### Root Cause

The Mistral model and provider import guards caught every `ImportError` from the SDK imports and replaced it with the optional dependency installation message. When `mistralai` was installed but incompatible, for example missing `UNSET` or `Mistral`, users saw the same message as if the package were absent.

### Change

Only convert `ModuleNotFoundError` for the top-level `mistralai` package into the optional dependency message. Other SDK import errors now propagate with their original message and traceback context.

Added focused regression tests for the provider and model import paths.

### Validation

- `uv run pytest tests/providers/test_mistral.py::test_mistral_provider_preserves_sdk_import_errors tests/models/test_mistral.py::test_mistral_model_preserves_sdk_import_errors -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/providers/mistral.py pydantic_ai_slim/pydantic_ai/models/mistral.py tests/providers/test_mistral.py tests/models/test_mistral.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
