### PR TITLE
Accept Vercel dynamic tool provider fields

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py
@@ -246,6 +246,8 @@ class DynamicToolInputStreamingPart(BaseUIPart):
     tool_call_id: str
     state: Literal['input-streaming'] = 'input-streaming'
     input: Any | None = None
+    title: str | None = None
+    provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
     approval: ToolApproval | None = None
 
@@ -258,6 +260,8 @@ class DynamicToolInputAvailablePart(BaseUIPart):
     tool_call_id: str
     state: Literal['input-available'] = 'input-available'
     input: Any
+    title: str | None = None
+    provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
     approval: ToolApproval | None = None
 
@@ -271,6 +275,8 @@ class DynamicToolOutputAvailablePart(BaseUIPart):
     state: Literal['output-available'] = 'output-available'
     input: Any
     output: Any
+    title: str | None = None
+    provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
     preliminary: bool | None = None
     approval: ToolApproval | None = None
@@ -285,6 +291,8 @@ class DynamicToolOutputErrorPart(BaseUIPart):
     state: Literal['output-error'] = 'output-error'
     input: Any
     error_text: str
+    title: str | None = None
+    provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
     approval: ToolApproval | None = None
 
@@ -297,6 +305,8 @@ class DynamicToolApprovalRequestedPart(BaseUIPart):
     tool_call_id: str
     state: Literal['approval-requested'] = 'approval-requested'
     input: Any
+    title: str | None = None
+    provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
     approval: ToolApproval | None = None
 
@@ -309,6 +319,8 @@ class DynamicToolApprovalRespondedPart(BaseUIPart):
     tool_call_id: str
     state: Literal['approval-responded'] = 'approval-responded'
     input: Any
+    title: str | None = None
+    provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
     approval: ToolApproval | None = None
 
@@ -321,6 +333,8 @@ class DynamicToolOutputDeniedPart(BaseUIPart):
     tool_call_id: str
     state: Literal['output-denied'] = 'output-denied'
     input: Any
+    title: str | None = None
+    provider_executed: bool | None = None
     call_provider_metadata: ProviderMetadata | None = None
     approval: ToolApproval | None = None
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -142,6 +142,60 @@ def test_build_run_input_allows_regenerate_without_message_id():
     assert run_input.message_id is None
 
 
+def test_build_run_input_accepts_dynamic_tool_provider_fields():
+    states = (
+        'input-streaming',
+        'input-available',
+        'output-available',
+        'output-error',
+        'approval-requested',
+        'approval-responded',
+        'output-denied',
+    )
+    parts: list[dict[str, Any]] = []
+    for state in states:
+        part: dict[str, Any] = {
+            'type': 'dynamic-tool',
+            'toolName': 'dynamic_search',
+            'toolCallId': f'call_{state.replace("-", "_")}',
+            'state': state,
+            'input': {'query': 'pydantic'},
+            'title': 'Dynamic search',
+            'providerExecuted': True,
+        }
+        if state == 'output-available':
+            part['output'] = {'result': 'ok'}
+        elif state == 'output-error':
+            part['errorText'] = 'tool failed'
+        elif state == 'approval-requested':
+            part['approval'] = {'id': 'approval_requested'}
+        elif state == 'approval-responded':
+            part['approval'] = {'id': 'approval_responded', 'approved': True}
+        parts.append(part)
+
+    data = {
+        'trigger': 'submit-message',
+        'id': 'req_123',
+        'messages': [
+            {
+                'id': 'msg_1',
+                'role': 'assistant',
+                'parts': parts,
+            }
+        ],
+    }
+
+    run_input = VercelAIAdapter.build_run_input(json.dumps(data).encode())
+
+    assert isinstance(run_input, SubmitMessage)
+    dynamic_parts = run_input.messages[0].parts
+    assert len(dynamic_parts) == 7
+    dumped_parts = [part.model_dump(by_alias=True) for part in dynamic_parts]
+    assert {part['state'] for part in dumped_parts} == set(states)
+    assert all(part['providerExecuted'] is True for part in dumped_parts)
+    assert all(part['title'] == 'Dynamic search' for part in dumped_parts)
+
+
 @pytest.mark.skipif(not openai_import_successful(), reason='OpenAI not installed')
 async def test_run(allow_model_requests: None, openai_api_key: str):
     model = OpenAIResponsesModel('gpt-5', provider=OpenAIProvider(api_key=openai_api_key))


### PR DESCRIPTION
## Summary
- add `title` and `providerExecuted` support to every `dynamic-tool` request part state
- keep the change scoped to request parsing/schema compatibility
- add a regression test that parses all dynamic-tool states through `VercelAIAdapter.build_run_input()`

Fixes #5359

## Tests
- PYTHONPATH=. pytest tests/test_vercel_ai.py::test_build_run_input_allows_regenerate_without_message_id tests/test_vercel_ai.py::test_build_run_input_accepts_dynamic_tool_provider_fields tests/test_vercel_ai.py::test_adapter_load_messages_dynamic_tool_input_streaming_part -q
- python -m ruff check pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py tests/test_vercel_ai.py
- python -m compileall pydantic_ai_slim/pydantic_ai/ui/vercel_ai/request_types.py tests/test_vercel_ai.py
- git diff --check