### PR TITLE
Read provider `created` timestamp from any chunk in OpenAI streaming responses

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1280,6 +1280,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         # When using Azure OpenAI and a content filter is enabled, the first chunk will contain a `''` model name,
         # so we set it from a later chunk in `OpenAIChatStreamedResponse`.
         model_name = first_chunk.model or self.model_name
+        timestamp = _now_utc()
 
         return self._streamed_response_cls(
             model_request_parameters=model_request_parameters,
@@ -1288,7 +1289,8 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             _response=peekable_response,
             _provider_name=self._provider.name,
             _provider_url=self._provider.base_url,
-            _provider_timestamp=number_to_datetime(first_chunk.created) if first_chunk.created else None,
+            _provider_timestamp=number_to_datetime(first_chunk.created) if first_chunk.created else timestamp,
+            _timestamp=timestamp,
             _model_settings=model_settings,
         )
 
@@ -3612,6 +3614,8 @@ class OpenAIStreamedResponse(StreamedResponse):
             if self._provider_timestamp is not None:  # pragma: no branch
                 self.provider_details = {'timestamp': self._provider_timestamp}
             async for chunk in self._validate_response():
+                self._update_provider_timestamp(chunk)
+
                 chunk_usage = self._map_usage(chunk)
                 if self._model_settings and self._model_settings.get('openai_continuous_usage_stats'):
                     # When continuous_usage_stats is enabled, each chunk contains cumulative usage,
@@ -3665,6 +3669,13 @@ class OpenAIStreamedResponse(StreamedResponse):
 
             if self._refusal_text:
                 self.provider_details = {**(self.provider_details or {}), 'refusal': self._refusal_text}
+
+    def _update_provider_timestamp(self, chunk: ChatCompletionChunk) -> None:
+        if chunk.created:
+            self.provider_details = {
+                **(self.provider_details or {}),
+                'timestamp': number_to_datetime(chunk.created),
+            }
 
     def _validate_response(self) -> AsyncIterable[ChatCompletionChunk]:
         """Hook that validates incoming chunks.

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1287,9 +1287,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             _response=peekable_response,
             _provider_name=self._provider.name,
             _provider_url=self._provider.base_url,
-            _provider_timestamp=number_to_datetime(first_chunk.created)
-            if first_chunk.created is not None  # pyright: ignore[reportUnnecessaryComparison]
-            else None,
+            _provider_timestamp=number_to_datetime(first_chunk.created) if first_chunk.created else None,
             _model_settings=model_settings,
         )
 
@@ -3610,7 +3608,7 @@ class OpenAIStreamedResponse(StreamedResponse):
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         with _map_api_errors(self._model_name):
-            if self._provider_timestamp is not None:  # pragma: no branch
+            if self._provider_timestamp is not None:
                 self.provider_details = {'timestamp': self._provider_timestamp}
             async for chunk in self._validate_response():
                 self._update_provider_timestamp(chunk)
@@ -3670,7 +3668,7 @@ class OpenAIStreamedResponse(StreamedResponse):
                 self.provider_details = {**(self.provider_details or {}), 'refusal': self._refusal_text}
 
     def _update_provider_timestamp(self, chunk: ChatCompletionChunk) -> None:
-        if self._provider_timestamp is None and chunk.created is not None:  # pyright: ignore[reportUnnecessaryComparison]
+        if self._provider_timestamp is None and chunk.created:
             self._provider_timestamp = number_to_datetime(chunk.created)
             self.provider_details = {
                 **(self.provider_details or {}),

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1280,6 +1280,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         # When using Azure OpenAI and a content filter is enabled, the first chunk will contain a `''` model name,
         # so we set it from a later chunk in `OpenAIChatStreamedResponse`.
         model_name = first_chunk.model or self.model_name
+
         return self._streamed_response_cls(
             model_request_parameters=model_request_parameters,
             _model_name=model_name,
@@ -3608,7 +3609,12 @@ class OpenAIStreamedResponse(StreamedResponse):
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         with _map_api_errors(self._model_name):
             async for chunk in self._validate_response():
-                self._update_provider_timestamp(chunk)
+                if self._provider_timestamp is None and chunk.created:
+                    self._provider_timestamp = number_to_datetime(chunk.created)
+                    self.provider_details = {
+                        **(self.provider_details or {}),
+                        'timestamp': self._provider_timestamp,
+                    }
 
                 chunk_usage = self._map_usage(chunk)
                 if self._model_settings and self._model_settings.get('openai_continuous_usage_stats'):
@@ -3663,14 +3669,6 @@ class OpenAIStreamedResponse(StreamedResponse):
 
             if self._refusal_text:
                 self.provider_details = {**(self.provider_details or {}), 'refusal': self._refusal_text}
-
-    def _update_provider_timestamp(self, chunk: ChatCompletionChunk) -> None:
-        if self._provider_timestamp is None and chunk.created:
-            self._provider_timestamp = number_to_datetime(chunk.created)
-            self.provider_details = {
-                **(self.provider_details or {}),
-                'timestamp': self._provider_timestamp,
-            }
 
     def _validate_response(self) -> AsyncIterable[ChatCompletionChunk]:
         """Hook that validates incoming chunks.

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1289,7 +1289,9 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             _response=peekable_response,
             _provider_name=self._provider.name,
             _provider_url=self._provider.base_url,
-            _provider_timestamp=number_to_datetime(first_chunk.created) if first_chunk.created else timestamp,
+            _provider_timestamp=number_to_datetime(first_chunk.created)
+            if first_chunk.created is not None  # pyright: ignore[reportUnnecessaryComparison]
+            else timestamp,
             _timestamp=timestamp,
             _model_settings=model_settings,
         )
@@ -3671,7 +3673,7 @@ class OpenAIStreamedResponse(StreamedResponse):
                 self.provider_details = {**(self.provider_details or {}), 'refusal': self._refusal_text}
 
     def _update_provider_timestamp(self, chunk: ChatCompletionChunk) -> None:
-        if chunk.created:
+        if chunk.created is not None:  # pyright: ignore[reportUnnecessaryComparison]
             self.provider_details = {
                 **(self.provider_details or {}),
                 'timestamp': number_to_datetime(chunk.created),

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1280,8 +1280,6 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
         # When using Azure OpenAI and a content filter is enabled, the first chunk will contain a `''` model name,
         # so we set it from a later chunk in `OpenAIChatStreamedResponse`.
         model_name = first_chunk.model or self.model_name
-        timestamp = _now_utc()
-
         return self._streamed_response_cls(
             model_request_parameters=model_request_parameters,
             _model_name=model_name,
@@ -1291,8 +1289,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             _provider_url=self._provider.base_url,
             _provider_timestamp=number_to_datetime(first_chunk.created)
             if first_chunk.created is not None  # pyright: ignore[reportUnnecessaryComparison]
-            else timestamp,
-            _timestamp=timestamp,
+            else None,
             _model_settings=model_settings,
         )
 
@@ -3673,10 +3670,11 @@ class OpenAIStreamedResponse(StreamedResponse):
                 self.provider_details = {**(self.provider_details or {}), 'refusal': self._refusal_text}
 
     def _update_provider_timestamp(self, chunk: ChatCompletionChunk) -> None:
-        if chunk.created is not None:  # pyright: ignore[reportUnnecessaryComparison]
+        if self._provider_timestamp is None and chunk.created is not None:  # pyright: ignore[reportUnnecessaryComparison]
+            self._provider_timestamp = number_to_datetime(chunk.created)
             self.provider_details = {
                 **(self.provider_details or {}),
-                'timestamp': number_to_datetime(chunk.created),
+                'timestamp': self._provider_timestamp,
             }
 
     def _validate_response(self) -> AsyncIterable[ChatCompletionChunk]:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1287,7 +1287,6 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
             _response=peekable_response,
             _provider_name=self._provider.name,
             _provider_url=self._provider.base_url,
-            _provider_timestamp=number_to_datetime(first_chunk.created) if first_chunk.created else None,
             _model_settings=model_settings,
         )
 
@@ -3608,8 +3607,6 @@ class OpenAIStreamedResponse(StreamedResponse):
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         with _map_api_errors(self._model_name):
-            if self._provider_timestamp is not None:
-                self.provider_details = {'timestamp': self._provider_timestamp}
             async for chunk in self._validate_response():
                 self._update_provider_timestamp(chunk)
 

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -474,7 +474,7 @@ class StreamedRunResult(Generic[AgentDepsT, OutputDataT]):
             raise NotImplementedError('Setting output tool return content is not supported for this result type.')
         return self._all_messages
 
-    def all_messages_json(self, *, output_tool_return_content: str | None = None) -> bytes:  # pragma: no cover
+    def all_messages_json(self, *, output_tool_return_content: str | None = None) -> bytes:
         """Return all messages from [`all_messages`][pydantic_ai.result.StreamedRunResult.all_messages] as JSON bytes.
 
         Args:

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -717,6 +717,25 @@ async def test_stream_text_ignores_zero_created_timestamp(allow_model_requests: 
         assert b'1970-01-01T00:00:00Z' not in result.all_messages_json()
 
 
+async def test_stream_text_uses_created_timestamp_from_usage_chunk(allow_model_requests: None):
+    stream = [
+        text_chunk('hello ').model_copy(update={'created': None}),
+        text_chunk('world', finish_reason='stop').model_copy(update={'created': None}),
+        chunk([]),
+    ]
+
+    mock_client = MockOpenAI.create_mock_stream(stream)
+    model = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    async with Agent(model).run_stream('') as result:
+        assert await result.get_output() == 'hello world'
+        response = cast(ModelResponse, result.all_messages()[-1])
+        assert response.provider_details == {
+            'timestamp': datetime(2024, 1, 1, tzinfo=timezone.utc),
+            'finish_reason': 'stop',
+        }
+
+
 @pytest.mark.parametrize(
     ('created_values', 'expected'),
     [

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -689,7 +689,6 @@ async def test_stream_text_no_created_timestamp(allow_model_requests: None):
                 provider_name='openai',
                 provider_url='https://api.openai.com/v1',
                 provider_details={
-                    'timestamp': IsNow(tz=timezone.utc),
                     'finish_reason': 'stop',
                 },
                 provider_response_id='123',
@@ -739,7 +738,7 @@ async def test_stream_text_uses_created_timestamp_from_later_chunk(allow_model_r
         assert response.timestamp == IsNow(tz=timezone.utc)
         assert response.provider_details == snapshot(
             {
-                'timestamp': datetime(1970, 1, 1, tzinfo=timezone.utc),
+                'timestamp': datetime(2024, 1, 2, tzinfo=timezone.utc),
                 'finish_reason': 'stop',
             }
         )

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -700,7 +700,7 @@ async def test_stream_text_no_created_timestamp(allow_model_requests: None):
         assert b'1970-01-01T00:00:00Z' not in result.all_messages_json()
 
 
-async def test_stream_text_uses_epoch_created_timestamp(allow_model_requests: None):
+async def test_stream_text_ignores_zero_created_timestamp(allow_model_requests: None):
     stream = [
         text_chunk('hello ').model_copy(update={'created': 0}),
         text_chunk('world').model_copy(update={'created': None}),
@@ -713,27 +713,27 @@ async def test_stream_text_uses_epoch_created_timestamp(allow_model_requests: No
         await result.get_output()
         response = cast(ModelResponse, result.all_messages()[-1])
         assert response.timestamp == IsNow(tz=timezone.utc)
-        assert response.provider_details == {'timestamp': datetime(1970, 1, 1, tzinfo=timezone.utc)}
+        assert response.provider_details is None
+        assert b'1970-01-01T00:00:00Z' not in result.all_messages_json()
 
 
 @pytest.mark.parametrize(
-    ('created', 'last_created', 'expected'),
+    'created_values',
     [
-        (1704153600, 0, datetime(2024, 1, 2, tzinfo=timezone.utc)),
-        (0, 1704153600, datetime(1970, 1, 1, tzinfo=timezone.utc)),
+        [None, 1704153600, 1704240000],
+        [0, 1704153600, 1704240000],
+        [None, 0, 1704153600],
     ],
 )
 async def test_stream_text_uses_created_timestamp_from_later_chunk(
-    allow_model_requests: None, created: int, last_created: int, expected: datetime
+    allow_model_requests: None, created_values: list[int | None]
 ):
     stream = [
         text_chunk('hello '),
         text_chunk('world'),
         text_chunk('.', finish_reason='stop'),
     ]
-    stream[0] = stream[0].model_copy(update={'created': None})
-    stream[1].created = created
-    stream[2].created = last_created
+    stream = [chunk.model_copy(update={'created': created}) for chunk, created in zip(stream, created_values)]
 
     mock_client = MockOpenAI.create_mock_stream(stream)
     m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
@@ -745,7 +745,10 @@ async def test_stream_text_uses_created_timestamp_from_later_chunk(
         )
         response = cast(ModelResponse, result.all_messages()[-1])
         assert response.timestamp == IsNow(tz=timezone.utc)
-        assert response.provider_details == {'timestamp': expected, 'finish_reason': 'stop'}
+        assert response.provider_details == {
+            'timestamp': datetime(2024, 1, 2, tzinfo=timezone.utc),
+            'finish_reason': 'stop',
+        }
 
 
 def struc_chunk(

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -701,6 +701,22 @@ async def test_stream_text_no_created_timestamp(allow_model_requests: None):
         assert b'1970-01-01T00:00:00Z' not in result.all_messages_json()
 
 
+async def test_stream_text_uses_epoch_created_timestamp(allow_model_requests: None):
+    stream = [
+        text_chunk('hello ').model_copy(update={'created': 0}),
+        text_chunk('world').model_copy(update={'created': None}),
+    ]
+
+    mock_client = MockOpenAI.create_mock_stream(stream)
+    model = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    async with Agent(model).run_stream('') as result:
+        await result.get_output()
+        response = cast(ModelResponse, result.all_messages()[-1])
+        assert response.timestamp == IsNow(tz=timezone.utc)
+        assert response.provider_details == {'timestamp': datetime(1970, 1, 1, tzinfo=timezone.utc)}
+
+
 async def test_stream_text_uses_created_timestamp_from_later_chunk(allow_model_requests: None):
     stream = [
         text_chunk('hello '),
@@ -709,7 +725,7 @@ async def test_stream_text_uses_created_timestamp_from_later_chunk(allow_model_r
     ]
     stream[0] = stream[0].model_copy(update={'created': None})
     stream[1].created = 1704153600  # 2024-01-02
-    stream[2].created = 1704240000  # 2024-01-03
+    stream[2].created = 0
 
     mock_client = MockOpenAI.create_mock_stream(stream)
     m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
@@ -723,7 +739,7 @@ async def test_stream_text_uses_created_timestamp_from_later_chunk(allow_model_r
         assert response.timestamp == IsNow(tz=timezone.utc)
         assert response.provider_details == snapshot(
             {
-                'timestamp': datetime(2024, 1, 3, 0, 0, tzinfo=timezone.utc),
+                'timestamp': datetime(1970, 1, 1, tzinfo=timezone.utc),
                 'finish_reason': 'stop',
             }
         )

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -718,15 +718,16 @@ async def test_stream_text_ignores_zero_created_timestamp(allow_model_requests: 
 
 
 @pytest.mark.parametrize(
-    'created_values',
+    ('created_values', 'expected'),
     [
-        [None, 1704153600, 1704240000],
-        [0, 1704153600, 1704240000],
-        [None, 0, 1704153600],
+        ([1704067200, 1704153600, 1704240000], datetime(2024, 1, 1, tzinfo=timezone.utc)),
+        ([None, 1704153600, 1704240000], datetime(2024, 1, 2, tzinfo=timezone.utc)),
+        ([0, 1704153600, 1704240000], datetime(2024, 1, 2, tzinfo=timezone.utc)),
+        ([None, 0, 1704153600], datetime(2024, 1, 2, tzinfo=timezone.utc)),
     ],
 )
 async def test_stream_text_uses_created_timestamp_from_later_chunk(
-    allow_model_requests: None, created_values: list[int | None]
+    allow_model_requests: None, created_values: list[int | None], expected: datetime
 ):
     stream = [
         text_chunk('hello '),
@@ -746,7 +747,7 @@ async def test_stream_text_uses_created_timestamp_from_later_chunk(
         response = cast(ModelResponse, result.all_messages()[-1])
         assert response.timestamp == IsNow(tz=timezone.utc)
         assert response.provider_details == {
-            'timestamp': datetime(2024, 1, 2, tzinfo=timezone.utc),
+            'timestamp': expected,
             'finish_reason': 'stop',
         }
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -716,15 +716,24 @@ async def test_stream_text_uses_epoch_created_timestamp(allow_model_requests: No
         assert response.provider_details == {'timestamp': datetime(1970, 1, 1, tzinfo=timezone.utc)}
 
 
-async def test_stream_text_uses_created_timestamp_from_later_chunk(allow_model_requests: None):
+@pytest.mark.parametrize(
+    ('created', 'last_created', 'expected'),
+    [
+        (1704153600, 0, datetime(2024, 1, 2, tzinfo=timezone.utc)),
+        (0, 1704153600, datetime(1970, 1, 1, tzinfo=timezone.utc)),
+    ],
+)
+async def test_stream_text_uses_created_timestamp_from_later_chunk(
+    allow_model_requests: None, created: int, last_created: int, expected: datetime
+):
     stream = [
         text_chunk('hello '),
         text_chunk('world'),
         text_chunk('.', finish_reason='stop'),
     ]
     stream[0] = stream[0].model_copy(update={'created': None})
-    stream[1].created = 1704153600  # 2024-01-02
-    stream[2].created = 0
+    stream[1].created = created
+    stream[2].created = last_created
 
     mock_client = MockOpenAI.create_mock_stream(stream)
     m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
@@ -736,12 +745,7 @@ async def test_stream_text_uses_created_timestamp_from_later_chunk(allow_model_r
         )
         response = cast(ModelResponse, result.all_messages()[-1])
         assert response.timestamp == IsNow(tz=timezone.utc)
-        assert response.provider_details == snapshot(
-            {
-                'timestamp': datetime(2024, 1, 2, tzinfo=timezone.utc),
-                'finish_reason': 'stop',
-            }
-        )
+        assert response.provider_details == {'timestamp': expected, 'finish_reason': 'stop'}
 
 
 def struc_chunk(

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -663,6 +663,72 @@ async def test_stream_text_finish_reason(allow_model_requests: None):
             )
 
 
+async def test_stream_text_no_created_timestamp(allow_model_requests: None):
+    stream = [
+        text_chunk('hello ').model_copy(update={'created': None}),
+        text_chunk('world').model_copy(update={'created': None}),
+        text_chunk('.', finish_reason='stop').model_copy(update={'created': None}),
+    ]
+
+    mock_client = MockOpenAI.create_mock_stream(stream)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(
+            ['hello ', 'hello world', 'hello world.']
+        )
+        assert result.timestamp == IsNow(tz=timezone.utc)
+        response = cast(ModelResponse, result.all_messages()[-1])
+        assert response == snapshot(
+            ModelResponse(
+                parts=[TextPart(content='hello world.')],
+                usage=RequestUsage(input_tokens=6, output_tokens=3),
+                model_name='gpt-4o-123',
+                timestamp=IsNow(tz=timezone.utc),
+                provider_name='openai',
+                provider_url='https://api.openai.com/v1',
+                provider_details={
+                    'timestamp': IsNow(tz=timezone.utc),
+                    'finish_reason': 'stop',
+                },
+                provider_response_id='123',
+                finish_reason='stop',
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            )
+        )
+        assert b'1970-01-01T00:00:00Z' not in result.all_messages_json()
+
+
+async def test_stream_text_uses_created_timestamp_from_later_chunk(allow_model_requests: None):
+    stream = [
+        text_chunk('hello '),
+        text_chunk('world'),
+        text_chunk('.', finish_reason='stop'),
+    ]
+    stream[0] = stream[0].model_copy(update={'created': None})
+    stream[1].created = 1704153600  # 2024-01-02
+    stream[2].created = 1704240000  # 2024-01-03
+
+    mock_client = MockOpenAI.create_mock_stream(stream)
+    m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(
+            ['hello ', 'hello world', 'hello world.']
+        )
+        response = cast(ModelResponse, result.all_messages()[-1])
+        assert response.timestamp == IsNow(tz=timezone.utc)
+        assert response.provider_details == snapshot(
+            {
+                'timestamp': datetime(2024, 1, 3, 0, 0, tzinfo=timezone.utc),
+                'finish_reason': 'stop',
+            }
+        )
+
+
 def struc_chunk(
     tool_name: str | None, tool_arguments: str | None, finish_reason: FinishReason | None = None
 ) -> chat.ChatCompletionChunk:


### PR DESCRIPTION
Fixes #2997.

## Summary

OpenAI-compatible streaming endpoints (e.g. GitHub Models) may omit `created`, send `0`, or only provide a usable value on a later chunk. `OpenAIStreamedResponse` reads `created` exclusively from the first chunk, so in these cases the provider timestamp is silently dropped from `provider_details['timestamp']` for the whole stream.

This PR moves the check into the per-chunk loop of `OpenAIStreamedResponse._get_event_iterator`:

- inspect every chunk, including the final usage-only chunk that has empty `choices`
- store the first non-zero `created` value in `provider_details['timestamp']`
- never overwrite it with values from later chunks
- treat `0` as missing, matching the existing first-chunk truthy check — affected endpoints send it when no provider timestamp is available

`ModelResponse.timestamp` is unchanged: it remains the locally captured response time.

Also removes a `# pragma: no cover` on `StreamedRunResult.all_messages_json`, which the new tests now exercise.

## Validation

- `uv run pytest tests/models/test_openai.py -q` (229 passed)
- targeted Pyright and Ruff checks
- pre-commit hooks

Tests cover omitted timestamps, zero timestamps, later timestamps, first-value stability, and a final usage-only chunk carrying the only usable timestamp.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
