### PR TITLE
mcp: respect audience annotations in tool results

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -708,8 +708,10 @@ class MCPServer(AbstractToolset[Any], ABC):
 
         # Prefer structured content if there are only text parts, which per the docs would contain the JSON-encoded structured content for backward compatibility.
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
-        if (structured := result.structuredContent) and visible_parts and not any(
-            not isinstance(part, mcp_types.TextContent) for part in visible_parts
+        if (
+            (structured := result.structuredContent)
+            and visible_parts
+            and not any(not isinstance(part, mcp_types.TextContent) for part in visible_parts)
         ):
             # The MCP SDK wraps primitives and generic types like list in a `result` key, but we want to use the raw value returned by the tool function.
             # See https://github.com/modelcontextprotocol/python-sdk#structured-output
@@ -2145,8 +2147,10 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
         visible_parts = [part for part in result.content if _is_visible_to_assistant(part)]
 
-        if (structured := result.structured_content) and visible_parts and all(
-            isinstance(part, mcp_types.TextContent) for part in visible_parts
+        if (
+            (structured := result.structured_content)
+            and visible_parts
+            and all(isinstance(part, mcp_types.TextContent) for part in visible_parts)
         ):
             # The MCP SDK wraps primitives and generic types like list in a `result` key, but we want
             # the raw value returned by the tool function.

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -696,18 +696,20 @@ class MCPServer(AbstractToolset[Any], ABC):
             except mcp_exceptions.McpError as e:
                 raise exceptions.ModelRetry(e.error.message)
 
+        visible_parts = [part for part in result.content if _is_visible_to_assistant(part)]
+
         if result.isError:
             message: str | None = None
-            if result.content:  # pragma: no branch
-                text_parts = [part.text for part in result.content if isinstance(part, mcp_types.TextContent)]
+            if visible_parts:  # pragma: no branch
+                text_parts = [part.text for part in visible_parts if isinstance(part, mcp_types.TextContent)]
                 message = '\n'.join(text_parts)
 
             raise exceptions.ModelRetry(message or 'MCP tool call failed')
 
         # Prefer structured content if there are only text parts, which per the docs would contain the JSON-encoded structured content for backward compatibility.
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
-        if (structured := result.structuredContent) and not any(
-            not isinstance(part, mcp_types.TextContent) for part in result.content
+        if (structured := result.structuredContent) and visible_parts and not any(
+            not isinstance(part, mcp_types.TextContent) for part in visible_parts
         ):
             # The MCP SDK wraps primitives and generic types like list in a `result` key, but we want to use the raw value returned by the tool function.
             # See https://github.com/modelcontextprotocol/python-sdk#structured-output
@@ -715,7 +717,7 @@ class MCPServer(AbstractToolset[Any], ABC):
                 return structured['result']
             return structured
 
-        mapped = [await self._map_tool_result_part(part) for part in result.content]
+        mapped = [await self._map_tool_result_part(part) for part in visible_parts]
         return mapped[0] if len(mapped) == 1 else mapped
 
     async def call_tool(
@@ -2141,8 +2143,10 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         # Prefer structured content if all parts are text (per the docs they contain the JSON-encoded
         # structured content for backward compatibility).
         # See https://github.com/modelcontextprotocol/python-sdk#structured-output
-        if (structured := result.structured_content) and all(
-            isinstance(part, mcp_types.TextContent) for part in result.content
+        visible_parts = [part for part in result.content if _is_visible_to_assistant(part)]
+
+        if (structured := result.structured_content) and visible_parts and all(
+            isinstance(part, mcp_types.TextContent) for part in visible_parts
         ):
             # The MCP SDK wraps primitives and generic types like list in a `result` key, but we want
             # the raw value returned by the tool function.
@@ -2150,7 +2154,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 return structured['result']
             return structured
 
-        return _map_mcp_tool_results(result.content)
+        return _map_mcp_tool_results(visible_parts)
 
     async def call_tool(
         self,
@@ -2374,6 +2378,18 @@ def _map_mcp_tool_results(
 ):
     mapped = [_map_mcp_tool_result(part) for part in parts]
     return mapped[0] if len(mapped) == 1 else mapped
+
+
+def _is_visible_to_assistant(part: mcp_types.ContentBlock) -> bool:
+    annotations = getattr(part, 'annotations', None)
+    if annotations is None:
+        return True
+
+    audience = getattr(annotations, 'audience', None)
+    if audience is None:
+        return True
+
+    return 'assistant' in audience
 
 
 def _map_mcp_tool_result(part: mcp_types.ContentBlock) -> str | messages.BinaryContent | dict[str, Any] | list[Any]:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -127,6 +127,45 @@ async def test_stdio_server(run_context: RunContext[int]):
         assert result == snapshot(32.0)
 
 
+async def test_direct_call_tool_filters_user_only_audience_annotations() -> None:
+    from mcp import types as mcp_types
+
+    server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
+    async with server:
+        fake_result = mcp_types.CallToolResult(
+            content=[
+                mcp_types.TextContent(
+                    type='text',
+                    text='visible to user only',
+                    annotations=mcp_types.Annotations(audience=['user']),
+                ),
+                mcp_types.TextContent(
+                    type='text',
+                    text='visible to assistant only',
+                    annotations=mcp_types.Annotations(audience=['assistant']),
+                ),
+                mcp_types.TextContent(
+                    type='text',
+                    text='visible to both',
+                    annotations=mcp_types.Annotations(audience=['assistant', 'user']),
+                ),
+                mcp_types.TextContent(type='text', text='visible when unannotated'),
+            ],
+            isError=False,
+        )
+
+        with patch.object(server._get_client(), 'send_request', AsyncMock(return_value=fake_result)):
+            result = await server.direct_call_tool('ignored_tool_name', {})
+
+    assert result == snapshot(
+        [
+            'visible to assistant only',
+            'visible to both',
+            'visible when unannotated',
+        ]
+    )
+
+
 async def test_reentrant_context_manager():
     server = MCPServerStdio('python', ['-m', 'tests.mcp_server'])
     async with server:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -154,7 +154,11 @@ async def test_direct_call_tool_filters_user_only_audience_annotations() -> None
             isError=False,
         )
 
-        with patch.object(server._get_client(), 'send_request', AsyncMock(return_value=fake_result)):
+        with patch.object(
+            server._get_client(),  # pyright: ignore[reportPrivateUsage]
+            'send_request',
+            AsyncMock(return_value=fake_result),
+        ):
             result = await server.direct_call_tool('ignored_tool_name', {})
 
     assert result == snapshot(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -149,6 +149,11 @@ async def test_direct_call_tool_filters_user_only_audience_annotations() -> None
                     text='visible to both',
                     annotations=mcp_types.Annotations(audience=['assistant', 'user']),
                 ),
+                mcp_types.TextContent(
+                    type='text',
+                    text='visible when audience unset',
+                    annotations=mcp_types.Annotations(),
+                ),
                 mcp_types.TextContent(type='text', text='visible when unannotated'),
             ],
             isError=False,
@@ -165,6 +170,7 @@ async def test_direct_call_tool_filters_user_only_audience_annotations() -> None
         [
             'visible to assistant only',
             'visible to both',
+            'visible when audience unset',
             'visible when unannotated',
         ]
     )


### PR DESCRIPTION
Fixes #4353

## What
- Filter MCP tool result parts by `annotations.audience` before mapping tool output.
- Exclude parts that are `user`-only from assistant-visible tool returns.
- Add a regression test for `direct_call_tool` audience filtering.

## Why
`direct_call_tool` previously returned content blocks regardless of audience annotation, so `user`-only content could leak into model-visible output.

## Scope
- Minimal patch only (no refactor).
- Files changed:
  - `pydantic_ai_slim/pydantic_ai/mcp.py`
  - `tests/test_mcp.py`

## Validation
- Local syntax check passed via `python -m compileall`.
- `pytest` not run in this environment (missing dependency).