### PR TITLE
Add SQL Mode example and harness docs

### DIFF
--- a/docs/examples/sql-mode.md
+++ b/docs/examples/sql-mode.md
@@ -1,0 +1,20 @@
+Example of [SQL Mode](../harness/sql-mode.md) from the Pydantic AI Harness: the model orchestrates tool calls by writing a single SQL query.
+
+Demonstrates:
+
+- [SQL Mode](../harness/sql-mode.md)
+- [toolsets](../toolsets.md)
+
+The `geocode` and `get_forecast` tools are registered with `SQLModeBuilder` and become DuckDB functions inside a single `run_sql` tool. `geocode` returns a nested object — coordinates, a structured address, and population — and `get_forecast` takes just the coordinates. Asked to build a table across five cities, the model writes one SQL query that fans `geocode` over the list with `unnest`, navigates the JSON it returns (`->`/`->>`) to read the country and population, pipes the nested `coordinates` sub-object straight into `get_forecast`, and aggregates the result — one model round-trip instead of ten tool calls.
+
+## Running the Example
+
+With [dependencies installed and environment variables set](./setup.md#usage), run:
+
+```bash
+python/uv-run -m pydantic_ai_examples.sql_mode
+```
+
+## Example Code
+
+```snippet {path="/examples/pydantic_ai_examples/sql_mode.py"}```

--- a/docs/examples/sql-mode.md
+++ b/docs/examples/sql-mode.md
@@ -3,9 +3,9 @@ Example of [SQL Mode](../harness/sql-mode.md) from the Pydantic AI Harness: the 
 Demonstrates:
 
 - [SQL Mode](../harness/sql-mode.md)
-- [toolsets](../toolsets.md)
+- [capabilities](../capabilities.md)
 
-The `geocode` and `get_forecast` tools are registered with `SQLModeBuilder` and become DuckDB functions inside a single `run_sql` tool. `geocode` returns a nested object — coordinates, a structured address, and population — and `get_forecast` takes just the coordinates. Asked to build a table across five cities, the model writes one SQL query that fans `geocode` over the list with `unnest`, navigates the JSON it returns (`->`/`->>`) to read the country and population, pipes the nested `coordinates` sub-object straight into `get_forecast`, and aggregates the result — one model round-trip instead of ten tool calls.
+The `SQLMode` capability exposes the agent's `geocode` and `get_forecast` tools as DuckDB functions inside a single `run_sql` tool. `geocode` returns a nested object — coordinates as a sub-object, a structured address, and population. Asked to build a table across five cities, the model writes one SQL query that fans `geocode` over the list with `unnest`, navigates the nested JSON it returns (`->`/`->>`) to read the country, population, and coordinates, feeds the coordinates into `get_forecast`, and aggregates the result — one model round-trip instead of ten tool calls.
 
 ## Running the Example
 

--- a/docs/harness/sql-mode.md
+++ b/docs/harness/sql-mode.md
@@ -1,0 +1,66 @@
+# SQL Mode
+
+SQL Mode is one of the capabilities in [**Pydantic AI Harness**](overview.md), the official capability library for Pydantic AI. The full docs live in the [harness repo](https://github.com/pydantic/pydantic-ai-harness) -- this page is a short intro.
+
+[`SQLModeBuilder`](https://github.com/pydantic/pydantic-ai-harness/blob/main/pydantic_ai_harness/sql_mode/README.md) registers your tools as DuckDB functions and exposes a single `run_sql` tool. The model writes one SQL query that calls the tools, navigates the JSON they return, pipes values between them, and joins, filters, and aggregates the results -- all in one tool call, against a locked-down in-memory DuckDB.
+
+Standard tool calling requires one model round-trip per tool call. SQL Mode collapses that into one, and lets the model use SQL -- a contained, well-defined language -- as the orchestration layer.
+
+## Usage
+
+```bash
+uv add "pydantic-ai-harness[sql-mode]"
+```
+
+```python {test="skip" noqa="I001"}
+from pydantic import BaseModel
+from pydantic_ai import Agent
+from pydantic_ai_harness import SQLModeBuilder
+
+
+class Coordinates(BaseModel):
+    lat: float
+    lon: float
+
+
+class Place(BaseModel):
+    coordinates: Coordinates
+    address: dict[str, str]
+    population: int
+
+
+def geocode(city: str) -> Place:
+    """Look up a city's coordinates, address, and population."""
+    ...
+
+
+async def get_forecast(coordinates: Coordinates) -> dict[str, float]:
+    """Get today's forecast for a latitude/longitude pair."""
+    ...
+
+
+sql_mode = SQLModeBuilder().register_tool(geocode).register_tool(get_forecast).build()
+agent = Agent('anthropic:claude-sonnet-4-6', toolsets=[sql_mode])
+
+result = agent.run_sync('How warm is Tokyo today, and what country is it in?')
+print(result.output)
+```
+
+Each tool's pydantic JSON Schema is rendered into the `run_sql` description, so the model knows `geocode` returns a nested object -- and writes one query that drills into it with `->`/`->>`, pipes the `coordinates` sub-object into `get_forecast`, and sorts the result:
+
+```sql
+WITH geocoded AS (
+    SELECT city, geocode(city) AS place
+    FROM (SELECT unnest(['Paris', 'Tokyo']) AS city)
+)
+SELECT
+    city,
+    place->'address'->>'country'                  AS country,
+    get_forecast(place->'coordinates')->>'high_c' AS high_c
+FROM geocoded
+ORDER BY high_c DESC;
+```
+
+## Full documentation
+
+See the [SQL Mode README](https://github.com/pydantic/pydantic-ai-harness/blob/main/pydantic_ai_harness/sql_mode/README.md) in the harness repo for sync and async tools, JSON/pydantic typing, the DuckDB lockdown, result handling, the full API, and limitations.

--- a/docs/harness/sql-mode.md
+++ b/docs/harness/sql-mode.md
@@ -2,7 +2,7 @@
 
 SQL Mode is one of the capabilities in [**Pydantic AI Harness**](overview.md), the official capability library for Pydantic AI. The full docs live in the [harness repo](https://github.com/pydantic/pydantic-ai-harness) -- this page is a short intro.
 
-[`SQLModeBuilder`](https://github.com/pydantic/pydantic-ai-harness/blob/main/pydantic_ai_harness/sql_mode/README.md) registers your tools as DuckDB functions and exposes a single `run_sql` tool. The model writes one SQL query that calls the tools, navigates the JSON they return, pipes values between them, and joins, filters, and aggregates the results -- all in one tool call, against a locked-down in-memory DuckDB.
+[`SQLMode`](https://github.com/pydantic/pydantic-ai-harness/blob/main/pydantic_ai_harness/sql_mode/README.md) is a capability that registers the agent's tools as DuckDB functions and exposes a single `run_sql` tool. The model writes one SQL query that calls the tools, navigates the JSON they return, pipes values between them, and joins, filters, and aggregates the results -- all in one tool call, against a locked-down in-memory DuckDB.
 
 Standard tool calling requires one model round-trip per tool call. SQL Mode collapses that into one, and lets the model use SQL -- a contained, well-defined language -- as the orchestration layer.
 
@@ -15,38 +15,34 @@ uv add "pydantic-ai-harness[sql-mode]"
 ```python {test="skip" noqa="I001"}
 from pydantic import BaseModel
 from pydantic_ai import Agent
-from pydantic_ai_harness import SQLModeBuilder
-
-
-class Coordinates(BaseModel):
-    lat: float
-    lon: float
+from pydantic_ai_harness import SQLMode
 
 
 class Place(BaseModel):
-    coordinates: Coordinates
-    address: dict[str, str]
-    population: int
+    coordinates: dict[str, float]
+    country: str
 
 
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[SQLMode()])
+
+
+@agent.tool_plain
 def geocode(city: str) -> Place:
-    """Look up a city's coordinates, address, and population."""
+    """Look up a city's coordinates and country."""
     ...
 
 
-async def get_forecast(coordinates: Coordinates) -> dict[str, float]:
+@agent.tool_plain
+async def get_forecast(lat: float, lon: float) -> dict[str, float]:
     """Get today's forecast for a latitude/longitude pair."""
     ...
 
-
-sql_mode = SQLModeBuilder().register_tool(geocode).register_tool(get_forecast).build()
-agent = Agent('anthropic:claude-sonnet-4-6', toolsets=[sql_mode])
 
 result = agent.run_sync('How warm is Tokyo today, and what country is it in?')
 print(result.output)
 ```
 
-Each tool's pydantic JSON Schema is rendered into the `run_sql` description, so the model knows `geocode` returns a nested object -- and writes one query that drills into it with `->`/`->>`, pipes the `coordinates` sub-object into `get_forecast`, and sorts the result:
+`SQLMode` removes `geocode` and `get_forecast` from the model's tool list and exposes them as DuckDB functions. Each tool's pydantic JSON Schema is rendered into the `run_sql` description, so the model knows `geocode` returns a nested object -- and writes one query that drills into it with `->`/`->>`, feeds the coordinates into `get_forecast`, and sorts the result:
 
 ```sql
 WITH geocoded AS (
@@ -55,12 +51,12 @@ WITH geocoded AS (
 )
 SELECT
     city,
-    place->'address'->>'country'                  AS country,
-    get_forecast(place->'coordinates')->>'high_c' AS high_c
+    place->>'country' AS country,
+    get_forecast(place->'coordinates'->>'lat', place->'coordinates'->>'lon')->>'high_c' AS high_c
 FROM geocoded
 ORDER BY high_c DESC;
 ```
 
 ## Full documentation
 
-See the [SQL Mode README](https://github.com/pydantic/pydantic-ai-harness/blob/main/pydantic_ai_harness/sql_mode/README.md) in the harness repo for sync and async tools, JSON/pydantic typing, the DuckDB lockdown, result handling, the full API, and limitations.
+See the [SQL Mode README](https://github.com/pydantic/pydantic-ai-harness/blob/main/pydantic_ai_harness/sql_mode/README.md) in the harness repo for tool selection, JSON/pydantic typing, the DuckDB lockdown, result handling, the full API, and limitations.

--- a/examples/pydantic_ai_examples/sql_mode.py
+++ b/examples/pydantic_ai_examples/sql_mode.py
@@ -1,0 +1,105 @@
+"""Example of SQL Mode: letting the model orchestrate tool calls by writing SQL.
+
+SQL Mode (from the [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness))
+registers your tools as DuckDB functions and gives the model a single `run_sql`
+tool. Instead of one model round-trip per tool call, the model writes one SQL
+query that calls the tools, navigates the nested JSON they return, pipes
+sub-objects from one tool into another, and aggregates the results.
+
+Run with:
+
+    uv run -m pydantic_ai_examples.sql_mode
+"""
+
+from pydantic import BaseModel
+from pydantic_ai_harness import SQLModeBuilder
+
+from pydantic_ai import Agent
+
+
+class Coordinates(BaseModel):
+    lat: float
+    lon: float
+
+
+class Address(BaseModel):
+    country: str
+    region: str
+
+
+class Place(BaseModel):
+    coordinates: Coordinates
+    address: Address
+    population: int
+
+
+class Forecast(BaseModel):
+    high_c: float
+    low_c: float
+    summary: str
+
+
+# Canned data keeps the example self-contained; real tools would call an API.
+_PLACES = {
+    'Paris': Place(
+        coordinates=Coordinates(lat=48.85, lon=2.35),
+        address=Address(country='France', region='Ile-de-France'),
+        population=2_103_000,
+    ),
+    'Tokyo': Place(
+        coordinates=Coordinates(lat=35.68, lon=139.69),
+        address=Address(country='Japan', region='Kanto'),
+        population=13_960_000,
+    ),
+    'Lima': Place(
+        coordinates=Coordinates(lat=-12.05, lon=-77.04),
+        address=Address(country='Peru', region='Lima'),
+        population=9_752_000,
+    ),
+    'Cairo': Place(
+        coordinates=Coordinates(lat=30.04, lon=31.24),
+        address=Address(country='Egypt', region='Cairo Governorate'),
+        population=10_100_000,
+    ),
+    'Oslo': Place(
+        coordinates=Coordinates(lat=59.91, lon=10.75),
+        address=Address(country='Norway', region='Ostlandet'),
+        population=709_000,
+    ),
+}
+
+_UNKNOWN = Place(
+    coordinates=Coordinates(lat=0.0, lon=0.0),
+    address=Address(country='Unknown', region='Unknown'),
+    population=0,
+)
+
+
+def geocode(city: str) -> Place:
+    """Look up a city's coordinates, structured address, and population."""
+    return _PLACES.get(city, _UNKNOWN)
+
+
+async def get_forecast(coordinates: Coordinates) -> Forecast:
+    """Get today's forecast for a latitude/longitude pair."""
+    high = round(34.0 - abs(coordinates.lat) * 0.45, 1)
+    return Forecast(high_c=high, low_c=round(high - 8.0, 1), summary='clear skies')
+
+
+# `geocode` returns a nested object: `coordinates` and `address` are sub-objects.
+# `get_forecast` takes only the `Coordinates`, so in SQL the model has to navigate
+# into the geocode result with `->` and pipe the sub-object across:
+#     get_forecast(geocode(city) -> 'coordinates')
+sql_mode = SQLModeBuilder().register_tool(geocode).register_tool(get_forecast).build()
+
+agent = Agent('anthropic:claude-sonnet-4-6', toolsets=[sql_mode])
+
+
+if __name__ == '__main__':
+    result = agent.run_sync(
+        'For Paris, Tokyo, Lima, Cairo and Oslo, show each city with its country, '
+        'population, and forecast high today, sorted warmest first. Which country '
+        'has the warmest city, and what is the combined population of all five? '
+        'Use a single SQL query.'
+    )
+    print(result.output)

--- a/examples/pydantic_ai_examples/sql_mode.py
+++ b/examples/pydantic_ai_examples/sql_mode.py
@@ -1,10 +1,10 @@
 """Example of SQL Mode: letting the model orchestrate tool calls by writing SQL.
 
 SQL Mode (from the [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness))
-registers your tools as DuckDB functions and gives the model a single `run_sql`
-tool. Instead of one model round-trip per tool call, the model writes one SQL
-query that calls the tools, navigates the nested JSON they return, pipes
-sub-objects from one tool into another, and aggregates the results.
+is a capability that registers the agent's tools as DuckDB functions and gives the
+model a single `run_sql` tool. Instead of one model round-trip per tool call, the
+model writes one SQL query that calls the tools, navigates the nested JSON they
+return, and aggregates the results.
 
 Run with:
 
@@ -12,7 +12,7 @@ Run with:
 """
 
 from pydantic import BaseModel
-from pydantic_ai_harness import SQLModeBuilder
+from pydantic_ai_harness import SQLMode
 
 from pydantic_ai import Agent
 
@@ -37,6 +37,11 @@ class Forecast(BaseModel):
     high_c: float
     low_c: float
     summary: str
+
+
+# `SQLMode` wraps the agent's tools: `geocode` and `get_forecast` become DuckDB
+# functions, and the model gets a single `run_sql` tool to orchestrate them.
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[SQLMode()])
 
 
 # Canned data keeps the example self-contained; real tools would call an API.
@@ -75,24 +80,21 @@ _UNKNOWN = Place(
 )
 
 
+@agent.tool_plain
 def geocode(city: str) -> Place:
-    """Look up a city's coordinates, structured address, and population."""
+    """Look up a city's coordinates, structured address, and population.
+
+    The result is a nested object: `coordinates` and `address` are sub-objects,
+    so in SQL the model navigates into it with `->` / `->>`.
+    """
     return _PLACES.get(city, _UNKNOWN)
 
 
-async def get_forecast(coordinates: Coordinates) -> Forecast:
+@agent.tool_plain
+async def get_forecast(lat: float, lon: float) -> Forecast:
     """Get today's forecast for a latitude/longitude pair."""
-    high = round(34.0 - abs(coordinates.lat) * 0.45, 1)
+    high = round(34.0 - abs(lat) * 0.45, 1)
     return Forecast(high_c=high, low_c=round(high - 8.0, 1), summary='clear skies')
-
-
-# `geocode` returns a nested object: `coordinates` and `address` are sub-objects.
-# `get_forecast` takes only the `Coordinates`, so in SQL the model has to navigate
-# into the geocode result with `->` and pipe the sub-object across:
-#     get_forecast(geocode(city) -> 'coordinates')
-sql_mode = SQLModeBuilder().register_tool(geocode).register_tool(get_forecast).build()
-
-agent = Agent('anthropic:claude-sonnet-4-6', toolsets=[sql_mode])
 
 
 if __name__ == '__main__':

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -50,6 +50,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pydantic-ai-slim[openai,vertexai,groq,anthropic,ag-ui]=={{ version }}",
     "pydantic-evals=={{ version }}",
+    "pydantic-ai-harness[sql-mode]",
     "asyncpg>=0.30.0",
     "fastapi>=0.115.4",
     "logfire[asyncpg,fastapi,sqlite3,httpx]>=3.14.1",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
   - Pydantic AI Harness:
       - Overview: harness/overview.md
       - Code Mode: harness/code-mode.md
+      - SQL Mode: harness/sql-mode.md
 
   - Pydantic Evals:
       - Overview: evals.md
@@ -132,6 +133,7 @@ nav:
           - examples/bank-support.md
       - Data & Analytics:
           - examples/sql-gen.md
+          - examples/sql-mode.md
           - examples/data-analyst.md
           - examples/rag.md
       - Streaming:


### PR DESCRIPTION
Adds a runnable example and docs for **SQL Mode** from the [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness) — the harness counterpart to Code Mode. SQL Mode is a capability that registers the agent's tools as DuckDB functions and gives the model a single `run_sql` tool, so the model can orchestrate tool calls by writing one SQL query.

- `examples/pydantic_ai_examples/sql_mode.py` — runnable example: a `geocode` tool that returns a nested object (coordinates as a sub-object, a structured address, population) and a `get_forecast` tool, exposed via `capabilities=[SQLMode()]`.
- `docs/harness/sql-mode.md` — capability intro, parity with `code-mode.md`.
- `docs/examples/sql-mode.md` and the mkdocs nav entries.

## Example run

Asked to compare five cities, the model writes a single `run_sql` query that calls `geocode` once per city, navigates the nested JSON it returns, feeds the coordinates into `get_forecast`, and aggregates:

```sql
WITH cities AS (SELECT unnest(['Paris', 'Tokyo', 'Lima', 'Cairo', 'Oslo']) AS city),
geocoded AS (SELECT city, geocode(city) AS geo FROM cities),
forecasted AS (
    SELECT city,
           geo->>'address'->>'country'   AS country,
           (geo->>'population')::INTEGER  AS population,
           get_forecast((geo->'coordinates'->>'lat')::DOUBLE,
                        (geo->'coordinates'->>'lon')::DOUBLE) AS forecast
    FROM geocoded
)
SELECT city, country, population,
       (forecast->>'high_c')::DOUBLE  AS high_c,
       SUM(population) OVER ()        AS combined_population
FROM forecasted
ORDER BY high_c DESC;
```

Final answer:

| City | Country | Population | High (°C) |
|------|---------|-----------|-----------|
| Lima | Peru | 9,752,000 | 28.6 |
| Cairo | Egypt | 10,100,000 | 20.5 |
| Tokyo | Japan | 13,960,000 | 17.9 |
| Paris | France | 2,103,000 | 12.0 |
| Oslo | Norway | 709,000 | 7.0 |

> Warmest: **Lima, Peru** (28.6 °C). Combined population: **36,624,000**.

## Draft status

The example depends on the `pydantic-ai-harness[sql-mode]` extra, which is not yet on PyPI — SQLMode lands with pydantic/pydantic-ai-harness#244. **CI (pyright and the lockfile check) will fail here until the harness publishes a release with SQLMode.** This is opened as a draft for that reason, and for review alongside the harness PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
