### PR TITLE
Deprecate `pydantic_ai.ext.aci` (`tool_from_aci` and `ACIToolset`) ahead of v2.0 removal

### DIFF
--- a/docs/third-party-tools.md
+++ b/docs/third-party-tools.md
@@ -52,6 +52,9 @@ agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 
 ## ACI.dev Tools {#aci-tools}
 
+!!! warning "Deprecated in 1.x, removed in 2.0"
+    `pydantic_ai.ext.aci` (`tool_from_aci` and `ACIToolset`) is deprecated and will be removed in 2.0 (see [#5467](https://github.com/pydantic/pydantic-ai/pull/5467)). Wrap ACI.dev tools yourself using [`Tool.from_schema`][pydantic_ai.tools.Tool.from_schema] against `aci.ACI().functions.get_definition(...)`, or call the upstream `aci-sdk` integration directly.
+
 If you'd like to use a tool from the [ACI.dev tool library](https://www.aci.dev/tools) with Pydantic AI, you can use the [`tool_from_aci`][pydantic_ai.ext.aci.tool_from_aci] convenience method. Note that Pydantic AI will not validate the arguments in this case -- it's up to the model to provide arguments matching the schema specified by the ACI tool, and up to the ACI tool to raise an error if the arguments are invalid.
 
 You will need to install the `aci-sdk` package, set your ACI API key in the `ACI_API_KEY` environment variable, and pass your ACI "linked account owner ID" to the function.

--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -935,6 +935,9 @@ agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 
 ### ACI.dev Tools {#aci-tools}
 
+!!! warning "Deprecated in 1.x, removed in 2.0"
+    `pydantic_ai.ext.aci` (`tool_from_aci` and `ACIToolset`) is deprecated and will be removed in 2.0 (see [#5467](https://github.com/pydantic/pydantic-ai/pull/5467)). Wrap ACI.dev tools yourself using [`Tool.from_schema`][pydantic_ai.tools.Tool.from_schema] against `aci.ACI().functions.get_definition(...)`, or call the upstream `aci-sdk` integration directly.
+
 If you'd like to use tools from the [ACI.dev tool library](https://www.aci.dev/tools) with Pydantic AI, you can use the [`ACIToolset`][pydantic_ai.ext.aci.ACIToolset] [toolset](toolsets.md) which takes a list of ACI tool names as well as the `linked_account_owner_id`. Note that Pydantic AI will not validate the arguments in this case -- it's up to the model to provide arguments matching the schema specified by the ACI tool, and up to the ACI tool to raise an error if the arguments are invalid.
 
 You will need to install the `aci-sdk` package, set your ACI API key in the `ACI_API_KEY` environment variable, and pass your ACI "linked account owner ID" to the function.

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
@@ -115,10 +115,10 @@ Third-party integrations to reach for:
 
 - `tool_from_langchain`
 - `LangChainToolset`
-- `tool_from_aci`
-- `ACIToolset`
+- `tool_from_aci` (deprecated, removed in 2.0)
+- `ACIToolset` (deprecated, removed in 2.0)
 
-Use these when the user explicitly wants those ecosystems instead of native Pydantic AI tools.
+Use these when the user explicitly wants those ecosystems instead of native Pydantic AI tools. The ACI.dev wrappers are deprecated in 1.x and removed in 2.0; wrap ACI tools yourself with `Tool.from_schema` against `aci.ACI().functions.get_definition(...)`.
 
 ## Systematically Verify Agent Behavior with Evals
 

--- a/pydantic_ai_slim/pydantic_ai/ext/aci.py
+++ b/pydantic_ai_slim/pydantic_ai/ext/aci.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from typing import Any
 
+from typing_extensions import deprecated
+
 from pydantic_ai import FunctionToolset
+from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.tools import Tool
 
 try:
     from aci import ACI
 except ImportError as _import_error:
     raise ImportError('Please install `aci-sdk` to use ACI.dev tools') from _import_error
+
+
+_ACI_DEPRECATION_MESSAGE = (
+    '`pydantic_ai.ext.aci` is deprecated and will be removed in 2.0. '
+    'Wrap ACI.dev tools yourself using `pydantic_ai.tools.Tool.from_schema` against '
+    '`aci.ACI().functions.get_definition(...)`, or use the upstream `aci-sdk` integration directly.'
+)
 
 
 def _clean_schema(schema):
@@ -22,6 +33,7 @@ def _clean_schema(schema):
         return schema
 
 
+@deprecated(_ACI_DEPRECATION_MESSAGE, category=PydanticAIDeprecationWarning)
 def tool_from_aci(aci_function: str, linked_account_owner_id: str) -> Tool:
     """Creates a Pydantic AI tool proxy from an ACI.dev function.
 
@@ -32,6 +44,7 @@ def tool_from_aci(aci_function: str, linked_account_owner_id: str) -> Tool:
     Returns:
         A Pydantic AI tool that corresponds to the ACI.dev tool.
     """
+    warnings.warn(_ACI_DEPRECATION_MESSAGE, PydanticAIDeprecationWarning, stacklevel=2)
     aci = ACI()
     function_definition = aci.functions.get_definition(aci_function)
     function_name = function_definition['function']['name']
@@ -67,10 +80,13 @@ def tool_from_aci(aci_function: str, linked_account_owner_id: str) -> Tool:
     )
 
 
+@deprecated(_ACI_DEPRECATION_MESSAGE, category=PydanticAIDeprecationWarning)
 class ACIToolset(FunctionToolset):
     """A toolset that wraps ACI.dev tools."""
 
     def __init__(self, aci_functions: Sequence[str], linked_account_owner_id: str, *, id: str | None = None):
+        warnings.warn(_ACI_DEPRECATION_MESSAGE, PydanticAIDeprecationWarning, stacklevel=2)
         super().__init__(
-            [tool_from_aci(aci_function, linked_account_owner_id) for aci_function in aci_functions], id=id
+            [tool_from_aci(aci_function, linked_account_owner_id) for aci_function in aci_functions],  # pyright: ignore[reportDeprecated]
+            id=id,
         )

--- a/pydantic_ai_slim/pydantic_ai/ext/aci.py
+++ b/pydantic_ai_slim/pydantic_ai/ext/aci.py
@@ -44,7 +44,6 @@ def tool_from_aci(aci_function: str, linked_account_owner_id: str) -> Tool:
     Returns:
         A Pydantic AI tool that corresponds to the ACI.dev tool.
     """
-    warnings.warn(_ACI_DEPRECATION_MESSAGE, PydanticAIDeprecationWarning, stacklevel=2)
     aci = ACI()
     function_definition = aci.functions.get_definition(aci_function)
     function_name = function_definition['function']['name']
@@ -85,8 +84,9 @@ class ACIToolset(FunctionToolset):
     """A toolset that wraps ACI.dev tools."""
 
     def __init__(self, aci_functions: Sequence[str], linked_account_owner_id: str, *, id: str | None = None):
-        warnings.warn(_ACI_DEPRECATION_MESSAGE, PydanticAIDeprecationWarning, stacklevel=2)
-        super().__init__(
-            [tool_from_aci(aci_function, linked_account_owner_id) for aci_function in aci_functions],  # pyright: ignore[reportDeprecated]
-            id=id,
-        )
+        # `tool_from_aci` is itself `@deprecated`; suppress its warning here so users only see
+        # one warning from `ACIToolset` itself, not a second one per wrapped function.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', PydanticAIDeprecationWarning)
+            tools = [tool_from_aci(aci_function, linked_account_owner_id) for aci_function in aci_functions]  # pyright: ignore[reportDeprecated]
+        super().__init__(tools, id=id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,7 @@ executionEnvironments = [
 exclude = [
     "examples/pydantic_ai_examples/weather_agent_gradio.py",
     "pydantic_ai_slim/pydantic_ai/ext/aci.py",               # aci-sdk is too niche to be added as an (optional) dependency
+    "tests/v2/test_aci_deprecation.py",                      # imports aci-sdk under try_import; SDK not installed in CI lint env
     "pydantic_ai_slim/pydantic_ai/embeddings/voyageai.py",   # voyageai package has no type stubs
 ]
 
@@ -305,6 +306,7 @@ include = [
 omit = [
     "tests/example_modules/*.py",
     "pydantic_ai_slim/pydantic_ai/ext/aci.py",  # aci-sdk is too niche to be added as an (optional) dependency
+    "tests/v2/test_aci_deprecation.py",  # paired with the omit above; aci-sdk isn't installed in the coverage env
     "pydantic_ai_slim/pydantic_ai/common_tools/exa.py",  # exa-py integration with external API calls
     # TODO(Marcelo): Enable prefect coverage again.
     "pydantic_ai_slim/pydantic_ai/durable_exec/prefect/*.py",

--- a/tests/v2/test_aci_deprecation.py
+++ b/tests/v2/test_aci_deprecation.py
@@ -1,0 +1,39 @@
+"""ACI.dev integration 1.x deprecation surfaces.
+
+In 1.x, calling `tool_from_aci(...)` or constructing `ACIToolset(...)` emits a
+`PydanticAIDeprecationWarning` pointing users at wrapping ACI tools directly with
+`Tool.from_schema`. The functions remain functional until the v2 cut, which removes the
+`pydantic_ai.ext.aci` module entirely (see #5467).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pydantic_ai._warnings import PydanticAIDeprecationWarning
+
+from ..conftest import try_import
+
+with try_import() as imports_successful:
+    import aci  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
+    from pydantic_ai.ext.aci import ACIToolset, tool_from_aci  # pyright: ignore[reportDeprecated]
+
+
+pytestmark = pytest.mark.skipif(not imports_successful(), reason='aci-sdk not installed')
+
+
+def test_tool_from_aci_emits_deprecation_warning(monkeypatch: pytest.MonkeyPatch):
+    """`tool_from_aci(...)` emits a `PydanticAIDeprecationWarning` before reaching the SDK."""
+    monkeypatch.setenv('ACI_API_KEY', 'dummy')
+    with pytest.warns(PydanticAIDeprecationWarning, match=r'`pydantic_ai\.ext\.aci` is deprecated'):
+        # The call raises once it tries to hit the network; the warning fires first.
+        with pytest.raises(Exception):
+            tool_from_aci('TAVILY__SEARCH', linked_account_owner_id='dummy')  # pyright: ignore[reportDeprecated]
+
+
+def test_aci_toolset_emits_deprecation_warning(monkeypatch: pytest.MonkeyPatch):
+    """`ACIToolset(...)` emits a `PydanticAIDeprecationWarning` on construction."""
+    monkeypatch.setenv('ACI_API_KEY', 'dummy')
+    with pytest.warns(PydanticAIDeprecationWarning, match=r'`pydantic_ai\.ext\.aci` is deprecated'):
+        ACIToolset([], linked_account_owner_id='dummy')  # pyright: ignore[reportDeprecated]


### PR DESCRIPTION
## Summary

Adds `PydanticAIDeprecationWarning` to `pydantic_ai.ext.aci` so users see the warning on the next 1.x minor before v2.0 removes the module entirely in #5467. The integration's surface is small (two symbols, no `__init__.py` re-export, runtime `ImportError` when `aci-sdk` isn't installed) so the deprecation copy points users at wrapping ACI tools directly with `Tool.from_schema` against `aci.ACI().functions.get_definition(...)` — no upstream replacement path needed.

Card: [`22-non-slim-deps.md`](https://github.com/pydantic/pydantic-ai-notes/blob/main/david/v2-cards/22-non-slim-deps.md). Removal happens in #5467 (`v2:exec`).

## What this PR changes

- `pydantic_ai_slim/pydantic_ai/ext/aci.py` — `@deprecated` decorator + `warnings.warn(PydanticAIDeprecationWarning, ...)` on both `tool_from_aci` and `ACIToolset.__init__`
- `docs/third-party-tools.md` + `docs/toolsets.md` — admonition linking to #5467 with the `Tool.from_schema` migration
- `pydantic_ai_slim/pydantic_ai/.agents/skills/.../ORCHESTRATION-AND-INTEGRATIONS.md` — annotated as deprecated
- `tests/v2/test_aci_deprecation.py` — new, exercises both warnings

No `changelog.md` entry (V2-RULES rule 14 — niche feature, warning copy carries the migration; matches PR #5426 precedent).

## Notes

- Per V2-RULES rule 26: uses `PydanticAIDeprecationWarning` (a `UserWarning` subclass), not stdlib `DeprecationWarning`, so warnings surface by default at runtime.
- `pydantic_ai/ext/aci.py` is already in pyright's `exclude` list (aci-sdk lacks usable stubs), so call sites in the test file need `# pyright: ignore[reportDeprecated]` only because full-project pyright re-includes them via the test file path.

## Test plan

- [ ] `uv run pytest tests/v2/test_aci_deprecation.py -v` passes (requires `aci-sdk` installed; skips otherwise)
- [x] `make format && make lint` clean
- [x] pre-commit typecheck pass

Refs #4299.
