### PR TITLE
Reframe profile-resolution snapshots as ongoing regression matrix

### DIFF
--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -1,21 +1,26 @@
-"""Lock-in snapshots of `Provider.model_profile(model_name)` resolution.
+"""Regression matrix for resolved `ModelProfile` flags across providers, gateways, and routing.
 
-Captures the resolved `ModelProfile` for every interesting (provider, model_name)
-combination — every gateway, every inference provider, every cross-provider routing
-case (Bedrock-Anthropic, OpenRouter-Google, etc.). The snapshots are the comparison
-artifact: any refactor that changes a profile's resolved shape must explicitly update
-these tests.
+Captures the resolved `Provider.model_profile(model_name)` output for every interesting
+(provider, model_name) combination — every gateway (OpenRouter, Azure, Vertex), every
+inference provider (Cerebras, Groq, Together, etc.), and every cross-provider routing case
+(Bedrock-Anthropic, OpenRouter-Google, etc.).
 
-Used to gate the upcoming `ModelProfile` TypedDict migration (PR #5340 / #5481): if any
-of these snapshots change after the migration without an intentional reason, that's a
-silent semantics regression.
+The snapshots are the comparison artifact: any change to a provider profile, an upstream
+profile, or `merge_profile()` semantics that affects a resolved flag must show up as a
+diff here. The PR author then has to confront the diff and decide whether each delta is
+intentional. Without this matrix, a one-line tweak to an upstream profile can silently
+change behavior on a downstream routing case (e.g. an OpenAI profile change quietly
+flipping a flag for the Azure-OpenAI route), and nobody on the PR is thinking about that.
 
-Provider classes that do `merge_profile(fallback, upstream, override)` (3-layer) have
-the highest risk of silent inversion in the migration — those cases are the densest here.
+Provider classes that do `merge_profile(fallback, upstream, override)` (3-layer) are the
+densest here, because they have the most layers where an ordering change can silently
+invert a flag.
 
-The `_normalize` helper strips default values, so each snapshot shows only the
-non-default fields of the resolved profile. That keeps snapshots stable across the
-dataclass→TypedDict migration (both representations normalize to the same dict).
+The `_normalize` helper strips canonical default values (everything in `DEFAULT_PROFILE`
+plus the subclass defaults), so each snapshot shows only the deltas the provider/gateway
+is opinionating about. Snapshots stay scannable — a real diff stands out.
+
+To regenerate after an intentional change: `pytest tests/profiles/test_resolution_lockin.py --inline-snapshot=fix`.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Follow-up to #5481.

The 82-snapshot file under `tests/profiles/test_resolution_lockin.py` was originally a migration-specific safety net for the v2 ModelProfile TypedDict change. Now that v2 has shipped, the snapshots have an ongoing role as a regression gate: any change to a provider profile, an upstream profile, or `merge_profile()` semantics that affects a resolved flag shows up as a diff here, forcing the PR author to confront each delta.

The value is exactly the "have to update the snapshots" friction. Without this matrix, a one-line tweak to e.g. an OpenAI profile can silently change behavior on a downstream routing case (Azure-OpenAI, OpenRouter-OpenAI) and nobody on the PR is thinking about it. With it, the diff makes the change visible.

This PR:
- Renames `test_resolution_lockin.py` → `test_resolution_matrix.py` to remove the "lock-in = one-time" connotation
- Rewrites the file-level docstring to explain the ongoing motivation (cross-provider routing surprises) and how to regenerate after an intentional change
- Drops migration-specific framing (PR #5340 / #5481 references, "3-layer providers have the highest risk of silent inversion in the migration" language, dataclass→TypedDict normalization notes)

No behavioral or snapshot changes — same 82 tests, same `_normalize` helper, same assertions.

### Test plan

- [x] `pytest tests/profiles/test_resolution_matrix.py` — 82 passed locally