### PR TITLE
Change `use_aggregated_usage_attribute_names` default to True

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -62,7 +62,7 @@ class InstrumentationSettings:
     include_binary_content: bool = True
     include_content: bool = True
     version: Literal[2, 3, 4, 5] = DEFAULT_INSTRUMENTATION_VERSION
-    use_aggregated_usage_attribute_names: bool = False
+    use_aggregated_usage_attribute_names: bool = True
 
     def __init__(
         self,
@@ -72,7 +72,7 @@ class InstrumentationSettings:
         include_binary_content: bool = True,
         include_content: bool = True,
         version: Literal[2, 3, 4, 5] = DEFAULT_INSTRUMENTATION_VERSION,
-        use_aggregated_usage_attribute_names: bool = False,
+        use_aggregated_usage_attribute_names: bool = True,
     ):
         """Create instrumentation options.
 
@@ -101,8 +101,8 @@ class InstrumentationSettings:
                     as UNSET, since deferrals are control flow, not errors.
             use_aggregated_usage_attribute_names: Whether to use `gen_ai.aggregated_usage.*` attribute names
                 for token usage on agent run spans instead of the standard `gen_ai.usage.*` names.
-                Enable this to prevent double-counting in observability backends that aggregate span
-                attributes across parent and child spans. Defaults to False.
+                Defaults to True to prevent double-counting in observability backends that aggregate span
+                attributes across parent and child spans.
                 Note: `gen_ai.aggregated_usage.*` is a custom namespace, not part of the OpenTelemetry
                 Semantic Conventions. It may be updated if OTel introduces an official convention.
         """

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -226,8 +226,8 @@ def test_first_failed_instrumented(capfire: CaptureLogfire) -> None:
                     'gen_ai.operation.name': 'invoke_agent',
                     'logfire.msg': 'agent run',
                     'logfire.span_type': 'span',
-                    'gen_ai.usage.input_tokens': 51,
-                    'gen_ai.usage.output_tokens': 1,
+                    'gen_ai.aggregated_usage.input_tokens': 51,
+                    'gen_ai.aggregated_usage.output_tokens': 1,
                     'pydantic_ai.all_messages': [
                         {'role': 'user', 'parts': [{'type': 'text', 'content': 'hello'}]},
                         {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'success'}]},
@@ -350,8 +350,8 @@ async def test_first_failed_instrumented_stream(capfire: CaptureLogfire) -> None
                     'logfire.msg': 'agent run',
                     'logfire.span_type': 'span',
                     'final_result': 'hello world',
-                    'gen_ai.usage.input_tokens': 50,
-                    'gen_ai.usage.output_tokens': 2,
+                    'gen_ai.aggregated_usage.input_tokens': 50,
+                    'gen_ai.aggregated_usage.output_tokens': 2,
                     'pydantic_ai.all_messages': [
                         {'role': 'user', 'parts': [{'type': 'text', 'content': 'input'}]},
                         {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'hello world'}]},
@@ -1032,8 +1032,8 @@ Don't include any text or Markdown fencing before or after.
                     'gen_ai.operation.name': 'invoke_agent',
                     'logfire.msg': 'agent run',
                     'logfire.span_type': 'span',
-                    'gen_ai.usage.input_tokens': 51,
-                    'gen_ai.usage.output_tokens': 4,
+                    'gen_ai.aggregated_usage.input_tokens': 51,
+                    'gen_ai.aggregated_usage.output_tokens': 4,
                     'pydantic_ai.all_messages': [
                         {'role': 'user', 'parts': [{'type': 'text', 'content': 'hello'}]},
                         {'role': 'assistant', 'parts': [{'type': 'text', 'content': '{"bar":"baz"}'}]},

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -250,8 +250,8 @@ def test_logfire(
             'logfire.msg': 'my_agent run',
             'logfire.span_type': 'span',
             'final_result': '{"my_ret":"1"}',
-            'gen_ai.usage.input_tokens': 103,
-            'gen_ai.usage.output_tokens': 12,
+            'gen_ai.aggregated_usage.input_tokens': 103,
+            'gen_ai.aggregated_usage.output_tokens': 12,
             'pydantic_ai.all_messages': IsJson(
                 snapshot(
                     [
@@ -554,8 +554,8 @@ def test_instructions_with_structured_output(
             'logfire.msg': 'my_agent run',
             'logfire.span_type': 'span',
             'final_result': '{"content":"a"}',
-            'gen_ai.usage.input_tokens': 51,
-            'gen_ai.usage.output_tokens': 5,
+            'gen_ai.aggregated_usage.input_tokens': 51,
+            'gen_ai.aggregated_usage.output_tokens': 5,
             'pydantic_ai.all_messages': IsJson(
                 snapshot(
                     [
@@ -649,8 +649,8 @@ def test_instructions_with_structured_output_exclude_content(get_logfire_summary
             'gen_ai.operation.name': 'invoke_agent',
             'logfire.msg': 'my_agent run',
             'logfire.span_type': 'span',
-            'gen_ai.usage.input_tokens': 51,
-            'gen_ai.usage.output_tokens': 5,
+            'gen_ai.aggregated_usage.input_tokens': 51,
+            'gen_ai.aggregated_usage.output_tokens': 5,
             'pydantic_ai.all_messages': IsJson(
                 snapshot(
                     [
@@ -772,8 +772,8 @@ def test_instructions_with_structured_output_exclude_content_v2_v3(
             'gen_ai.operation.name': 'invoke_agent',
             'logfire.msg': 'my_agent run',
             'logfire.span_type': 'span',
-            'gen_ai.usage.input_tokens': 51,
-            'gen_ai.usage.output_tokens': 5,
+            'gen_ai.aggregated_usage.input_tokens': 51,
+            'gen_ai.aggregated_usage.output_tokens': 5,
             'pydantic_ai.all_messages': IsJson(
                 snapshot(
                     [
@@ -1073,8 +1073,8 @@ async def test_feedback(capfire: CaptureLogfire) -> None:
                     'logfire.msg': 'agent run',
                     'logfire.span_type': 'span',
                     'final_result': 'success (no tool calls)',
-                    'gen_ai.usage.input_tokens': 51,
-                    'gen_ai.usage.output_tokens': 4,
+                    'gen_ai.aggregated_usage.input_tokens': 51,
+                    'gen_ai.aggregated_usage.output_tokens': 4,
                     'pydantic_ai.all_messages': [
                         {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]},
                         {'role': 'assistant', 'parts': [{'type': 'text', 'content': 'success (no tool calls)'}]},
@@ -2294,8 +2294,8 @@ def test_static_function_instructions_in_agent_run_span(
             'logfire.msg': 'my_agent run',
             'logfire.span_type': 'span',
             'final_result': '{"content":"a"}',
-            'gen_ai.usage.input_tokens': 51,
-            'gen_ai.usage.output_tokens': 5,
+            'gen_ai.aggregated_usage.input_tokens': 51,
+            'gen_ai.aggregated_usage.output_tokens': 5,
             'pydantic_ai.all_messages': IsJson(
                 snapshot(
                     [
@@ -2464,8 +2464,8 @@ def test_dynamic_function_instructions_in_agent_run_span(
             'logfire.msg': 'my_agent run',
             'logfire.span_type': 'span',
             'final_result': '{"content":"a"}',
-            'gen_ai.usage.input_tokens': 107,
-            'gen_ai.usage.output_tokens': 9,
+            'gen_ai.aggregated_usage.input_tokens': 107,
+            'gen_ai.aggregated_usage.output_tokens': 9,
             'pydantic_ai.all_messages': IsJson(
                 snapshot(
                     [
@@ -2625,8 +2625,8 @@ def test_function_instructions_with_history_in_agent_run_span(
             'logfire.msg': 'my_agent run',
             'logfire.span_type': 'span',
             'final_result': '{"content":"a"}',
-            'gen_ai.usage.input_tokens': 52,
-            'gen_ai.usage.output_tokens': 6,
+            'gen_ai.aggregated_usage.input_tokens': 52,
+            'gen_ai.aggregated_usage.output_tokens': 6,
             'pydantic_ai.all_messages': IsJson(
                 snapshot(
                     [
@@ -2758,8 +2758,8 @@ async def test_run_stream(
             'logfire.msg': 'my_agent run',
             'logfire.span_type': 'span',
             'final_result': 'success (no tool calls)',
-            'gen_ai.usage.input_tokens': 51,
-            'gen_ai.usage.output_tokens': 4,
+            'gen_ai.aggregated_usage.input_tokens': 51,
+            'gen_ai.aggregated_usage.output_tokens': 4,
             'pydantic_ai.all_messages': IsJson(
                 snapshot(
                     [


### PR DESCRIPTION
Similar to https://github.com/pydantic/pydantic-ai/issues/5368. This behaviour is generally preferable to avoid confusion, making the breaking change now in preparation for v2.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it. (there is none)
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md). (there IS a breaking change, preparing for v2)
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
