### PR TITLE
Undeprecate `Agent(retries=)`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -327,10 +327,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 Can be a static `ModelSettings` dict or a callable that takes a
                 [`RunContext`][pydantic_ai.tools.RunContext] and returns `ModelSettings`.
                 Callables are called before each model request, allowing dynamic per-step settings.
-            retries: Deprecated alias for `tool_retries`. In 1.x this also still cascades to `output_retries`
-                (when `output_retries` is unset) for backward compatibility, with a `DeprecationWarning`.
-                In v2 it will be removed and the cascade will go away — pass `output_retries` explicitly
-                if you depend on the cascade. For model request retries, see the
+            retries: The default number of retries to allow. Sets both `tool_retries` and
+                `output_retries` (when not provided explicitly). For model request retries, see the
                 [HTTP Request Retries](../retries.md) documentation.
             tool_retries: The default number of retries to allow for tool calls before raising an error. Defaults to 1.
             validation_context: Pydantic [validation context](https://docs.pydantic.dev/latest/concepts/validators/#validation-context) used to validate tool arguments and outputs.
@@ -434,31 +432,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         self._system_prompt_functions = []
         self._system_prompt_dynamic_functions = {}
 
-        # `retries` is deprecated in 1.x and removed in v2. Until then it still cascades to
-        # `_max_output_retries` as a fallback (when `output_retries` isn't explicitly set) so
-        # existing callers keep their original behavior; we only warn so users can migrate.
-        # TODO(v2): drop `retries` entirely; default both `_max_tool_retries` and
-        # `_max_output_retries` to a constant 1 — no cascade.
-        if retries is not None:
-            if tool_retries is not None and output_retries is None:
-                # Combination case: `tool_retries=` already sets the tool budget, so `retries=`
-                # only ends up controlling the output budget via the legacy cascade. Call that out
-                # explicitly — passing `output_retries=` directly is the migration path.
-                warnings.warn(
-                    '`retries` is deprecated and will be removed in v2. You also passed `tool_retries=`, '
-                    'so `retries=` is now only setting `output_retries` via the legacy 1.x cascade — '
-                    'pass `output_retries=` explicitly instead.',
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-            else:
-                warnings.warn(
-                    '`retries` is deprecated and will be removed in v2. Use `tool_retries` instead. '
-                    'Note: in v2, `retries` will no longer also set `output_retries` as a fallback — '
-                    'pass `output_retries` explicitly if you rely on the cascade.',
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+        # `retries` sets the default for both `_max_tool_retries` and `_max_output_retries`,
+        # which can each still be overridden by their dedicated kwargs.
         effective_retries = retries if retries is not None else 1
         self._max_tool_retries = tool_retries if tool_retries is not None else effective_retries
         self._max_output_retries = output_retries if output_retries is not None else effective_retries
@@ -1669,11 +1644,10 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         capabilities = list(_capabilities_from_spec(validated_spec, custom_capability_types, template_context))
         combined = CombinedCapability(capabilities) if capabilities else None
 
-        # Warn for unsupported fields with non-default values. Read via `__dict__` to avoid
-        # triggering the pydantic deprecation warning on the deprecated `retries` field.
+        # Warn for unsupported fields with non-default values.
         for field_name in _UNSUPPORTED_SPEC_FIELDS:
             field_info = type(validated_spec).model_fields[field_name]
-            if validated_spec.__dict__[field_name] != field_info.default:
+            if getattr(validated_spec, field_name) != field_info.default:
                 warnings.warn(
                     f'AgentSpec field {field_name!r} is not supported at run/override time and will be ignored',
                     UserWarning,

--- a/pydantic_ai_slim/pydantic_ai/agent/spec.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/spec.py
@@ -55,14 +55,7 @@ class AgentSpec(BaseModel):
     output_schema: dict[str, Any] | None = None
     model_settings: dict[str, Any] | None = None
     tool_retries: int | None = None
-    retries: int | None = Field(
-        default=None,
-        deprecated=(
-            '`retries` is deprecated. Use `tool_retries` and/or `output_retries` instead. '
-            'In 1.x, setting `retries` on a spec still cascades to `output_retries` '
-            'when the latter is unset, matching `Agent(retries=...)` behavior.'
-        ),
-    )
+    retries: int | None = None
     output_retries: int | None = None
     end_strategy: EndStrategy = 'early'
     tool_timeout: float | None = None
@@ -234,10 +227,7 @@ class AgentSpec(BaseModel):
             output_schema: dict[str, Any] | None = None
             model_settings: ModelSettings | None = None
             tool_retries: int | None = None
-            retries: int | None = Field(
-                default=None,
-                deprecated='`retries` is deprecated. Use `tool_retries` and/or `output_retries` instead.',
-            )
+            retries: int | None = None
             output_retries: int | None = None
             end_strategy: EndStrategy = 'early'
             tool_timeout: float | None = None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -10741,7 +10741,6 @@ class OutputRetryBudgetCase:
     override: dict[str, Any] | None
     run: dict[str, Any]
     expected_budget: int
-    expects_deprecation_warning: bool
 
 
 OUTPUT_RETRY_BUDGET_CASES = [
@@ -10751,7 +10750,6 @@ OUTPUT_RETRY_BUDGET_CASES = [
         override=None,
         run={'output_retries': 2},
         expected_budget=2,
-        expects_deprecation_warning=False,
     ),
     OutputRetryBudgetCase(
         id='run-arg-beats-spec',
@@ -10759,7 +10757,6 @@ OUTPUT_RETRY_BUDGET_CASES = [
         override=None,
         run={'output_retries': 2, 'spec': {'output_retries': 4}},
         expected_budget=2,
-        expects_deprecation_warning=False,
     ),
     OutputRetryBudgetCase(
         id='spec-only-beats-agent-default',
@@ -10767,7 +10764,6 @@ OUTPUT_RETRY_BUDGET_CASES = [
         override=None,
         run={'spec': {'output_retries': 2}},
         expected_budget=2,
-        expects_deprecation_warning=False,
     ),
     OutputRetryBudgetCase(
         id='override-kwarg-caps-agent-default',
@@ -10775,7 +10771,6 @@ OUTPUT_RETRY_BUDGET_CASES = [
         override={'output_retries': 2},
         run={},
         expected_budget=2,
-        expects_deprecation_warning=False,
     ),
     OutputRetryBudgetCase(
         id='override-spec-honored',
@@ -10783,7 +10778,6 @@ OUTPUT_RETRY_BUDGET_CASES = [
         override={'spec': {'output_retries': 2}},
         run={},
         expected_budget=2,
-        expects_deprecation_warning=False,
     ),
     OutputRetryBudgetCase(
         id='override-beats-run-arg',
@@ -10791,15 +10785,13 @@ OUTPUT_RETRY_BUDGET_CASES = [
         override={'output_retries': 1},
         run={'output_retries': 10},
         expected_budget=1,
-        expects_deprecation_warning=False,
     ),
     OutputRetryBudgetCase(
-        id='deprecated-retries-cascades',
+        id='retries-cascades',
         init={'retries': 5},
         override=None,
         run={},
         expected_budget=5,
-        expects_deprecation_warning=True,
     ),
     OutputRetryBudgetCase(
         id='tool-retries-no-cascade',
@@ -10807,7 +10799,6 @@ OUTPUT_RETRY_BUDGET_CASES = [
         override=None,
         run={},
         expected_budget=1,
-        expects_deprecation_warning=False,
     ),
     OutputRetryBudgetCase(
         id='retries-cascades-even-when-tool-retries-set',
@@ -10815,7 +10806,6 @@ OUTPUT_RETRY_BUDGET_CASES = [
         override=None,
         run={},
         expected_budget=5,
-        expects_deprecation_warning=True,
     ),
 ]
 
@@ -10834,16 +10824,9 @@ def test_output_retry_budget_resolution(case: OutputRetryBudgetCase):
         assert info.output_tools is not None
         return ModelResponse(parts=[ToolCallPart(info.output_tools[0].name, '{"a": 1, "b": "foo"}')])
 
-    deprecation_ctx = (
-        pytest.warns(DeprecationWarning, match=r'`retries` is deprecated and will be removed in v2')
-        if case.expects_deprecation_warning
-        else nullcontext()
-    )
     with warnings.catch_warnings():
-        if not case.expects_deprecation_warning:
-            warnings.simplefilter('error', DeprecationWarning)
-        with deprecation_ctx:
-            agent = Agent(FunctionModel(return_model), output_type=ToolOutput(Foo), **case.init)
+        warnings.simplefilter('error', DeprecationWarning)
+        agent = Agent(FunctionModel(return_model), output_type=ToolOutput(Foo), **case.init)
 
     @agent.output_validator
     def always_retry(ctx: RunContext[None], o: Foo) -> Foo:
@@ -10914,45 +10897,6 @@ def test_output_retries_run_override_without_validators():
     assert call_count == 3
     # The shared agent-level toolset's `max_retries` was preserved — confirms the run cloned before mutating.
     assert shared_toolset.max_retries == 10
-
-
-@pytest.mark.parametrize(
-    'kwargs, expected_warning',
-    [
-        ({}, None),
-        ({'tool_retries': 5}, None),
-        ({'output_retries': 5}, None),
-        ({'tool_retries': 5, 'output_retries': 5}, None),
-        ({'retries': 5}, r'`retries` is deprecated.*Use `tool_retries` instead'),
-        ({'retries': 5, 'output_retries': 3}, r'`retries` is deprecated.*Use `tool_retries` instead'),
-        (
-            {'retries': 5, 'tool_retries': 3},
-            r'`retries` is deprecated.*only setting `output_retries` via the legacy 1\.x cascade',
-        ),
-    ],
-    ids=[
-        'no-kwargs',
-        'tool_retries-only',
-        'output_retries-only',
-        'tool_retries-and-output_retries',
-        'retries-only-warns',
-        'retries-and-output_retries-warns-generic',
-        'retries-and-tool_retries-warns-cascade-callout',
-    ],
-)
-def test_agent_init_deprecation_warning(kwargs: dict[str, Any], expected_warning: str | None):
-    """Cover the `Agent.__init__` deprecation warning text for every kwarg combination.
-
-    The both-passed case (`retries=` + `tool_retries=`) gets a sharper message that calls out the
-    silent cascade to `output_retries`; everything else either warns generically or stays silent.
-    """
-    if expected_warning is None:
-        with warnings.catch_warnings():
-            warnings.simplefilter('error', DeprecationWarning)
-            Agent('test', **kwargs)
-    else:
-        with pytest.warns(DeprecationWarning, match=expected_warning):
-            Agent('test', **kwargs)
 
 
 def test_unknown_tool_with_valid_tool_does_not_exhaust_retries():

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -388,33 +388,24 @@ def test_agent_from_spec_model_settings_merged():
 
 
 def test_agent_from_spec_retries():
-    with pytest.warns(DeprecationWarning, match=r'`retries` is deprecated'):
-        agent = Agent.from_spec({'model': 'test', 'retries': 5})
+    agent = Agent.from_spec({'model': 'test', 'retries': 5})
     assert agent._max_tool_retries == 5  # pyright: ignore[reportPrivateUsage]
     assert agent._max_output_retries == 5  # pyright: ignore[reportPrivateUsage]
 
 
 def test_agent_from_spec_retries_override():
-    with pytest.warns(DeprecationWarning, match=r'`retries` is deprecated'):
-        agent = Agent.from_spec({'model': 'test', 'retries': 5}, retries=2)
+    agent = Agent.from_spec({'model': 'test', 'retries': 5}, retries=2)
     assert agent._max_tool_retries == 2  # pyright: ignore[reportPrivateUsage]
     assert agent._max_output_retries == 2  # pyright: ignore[reportPrivateUsage]
 
 
 def test_agent_from_spec_output_retries():
-    with pytest.warns(DeprecationWarning, match=r'`retries` is deprecated'):
-        agent = Agent.from_spec({'model': 'test', 'retries': 3, 'output_retries': 10})
+    agent = Agent.from_spec({'model': 'test', 'retries': 3, 'output_retries': 10})
     assert agent._max_tool_retries == 3  # pyright: ignore[reportPrivateUsage]
     assert agent._max_output_retries == 10  # pyright: ignore[reportPrivateUsage]
 
 
-def test_agent_from_spec_no_retries_does_not_warn():
-    """`from_spec` without an explicit `retries` must not emit the deprecation warning.
-
-    The default for `AgentSpec.retries` is `None` so it can be distinguished from a
-    user-set value; only an explicit value is forwarded to the deprecated
-    `Agent(retries=...)` kwarg.
-    """
+def test_agent_from_spec_no_retries():
     with warnings.catch_warnings():
         warnings.simplefilter('error', DeprecationWarning)
         agent = Agent.from_spec({'model': 'test'})
@@ -423,37 +414,21 @@ def test_agent_from_spec_no_retries_does_not_warn():
     assert agent._max_output_retries == 1  # pyright: ignore[reportPrivateUsage]
 
 
-def test_agent_from_spec_explicit_retries_warns():
-    """An explicit `retries` in the spec still triggers the deprecation warning."""
-    with pytest.warns(DeprecationWarning, match=r'`retries` is deprecated.*Use `tool_retries`'):
-        agent = Agent.from_spec({'model': 'test', 'retries': 5})
-    assert agent._max_tool_retries == 5  # pyright: ignore[reportPrivateUsage]
-    assert agent._max_output_retries == 5  # pyright: ignore[reportPrivateUsage]
-
-
 def test_agent_from_spec_tool_retries():
-    """`tool_retries` on the spec sets the tool budget without cascading to output and without warning."""
-    with warnings.catch_warnings():
-        warnings.simplefilter('error', DeprecationWarning)
-        agent = Agent.from_spec({'model': 'test', 'tool_retries': 5})
-
+    """`tool_retries` on the spec sets the tool budget without cascading to output."""
+    agent = Agent.from_spec({'model': 'test', 'tool_retries': 5})
     assert agent._max_tool_retries == 5  # pyright: ignore[reportPrivateUsage]
     assert agent._max_output_retries == 1  # pyright: ignore[reportPrivateUsage]
 
 
-def test_agent_spec_retries_deprecated_getter():
-    """Reading `AgentSpec.retries` warns; the value is still returned for backward compatibility."""
+def test_agent_spec_retries_getter():
     spec = AgentSpec(model='test', retries=5)
-    with pytest.warns(DeprecationWarning, match=r'`retries` is deprecated'):
-        assert spec.retries == 5
+    assert spec.retries == 5
 
 
 def test_agent_spec_tool_retries_field():
-    """`AgentSpec.tool_retries` is the canonical field and does not warn on access."""
     spec = AgentSpec(model='test', tool_retries=5)
-    with warnings.catch_warnings():
-        warnings.simplefilter('error', DeprecationWarning)
-        assert spec.tool_retries == 5
+    assert spec.tool_retries == 5
 
 
 def test_agent_from_spec_end_strategy():
@@ -1770,7 +1745,6 @@ Supported by:
                 'retries': {
                     'anyOf': [{'type': 'integer'}, {'type': 'null'}],
                     'default': None,
-                    'deprecated': True,
                     'title': 'Retries',
                 },
                 'output_retries': {
@@ -2032,8 +2006,7 @@ def test_agent_from_file_json(tmp_path: str):
 def test_agent_from_file_with_overrides(tmp_path: str):
     spec_path = Path(tmp_path) / 'agent.yaml'
     spec_path.write_text('model: test\nname: spec-name\nretries: 5\n', encoding='utf-8')
-    with pytest.warns(DeprecationWarning, match=r'`retries` is deprecated'):
-        agent = Agent.from_file(spec_path, name='override-name', retries=2)
+    agent = Agent.from_file(spec_path, name='override-name', retries=2)
     assert agent.name == 'override-name'
     assert agent._max_tool_retries == 2  # pyright: ignore[reportPrivateUsage]
 


### PR DESCRIPTION
## Summary

- Remove the `DeprecationWarning` on `Agent(retries=...)` and `AgentSpec.retries`.
- `retries` stays a supported alias that cascades to both `tool_retries` and `output_retries` when they aren't set explicitly.
- `tool_retries` / `output_retries` continue to work as direct, granular overrides.
- Drop the now-obsolete tests that asserted the warning fires and regenerate the affected `AgentSpec` JSON schema snapshot.

## Test plan

- [x] `uv run pytest tests/test_agent.py tests/test_capabilities.py tests/test_streaming.py tests/test_tools.py`
- [x] `uv run ruff check && uv run ruff format --check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.