### PR TITLE
fix: Preserve property type when using `deprecated_callable_property` (like on `AgentRunResult.usage`)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_deprecated_callable.py
+++ b/pydantic_ai_slim/pydantic_ai/_deprecated_callable.py
@@ -16,11 +16,13 @@ import dataclasses
 import warnings
 from collections.abc import Callable
 from datetime import datetime
-from typing import Any
+from typing import Any, Generic, TypeVar, overload
 
 from ._warnings import PydanticAIDeprecationWarning
 from .messages import ModelResponse
 from .usage import RequestUsage, RunUsage
+
+_T = TypeVar('_T')
 
 
 class _DeprecatedCallableRunUsage(RunUsage):
@@ -150,17 +152,43 @@ def _wrap(value: Any, message: str) -> Any:
     raise TypeError(f'No deprecation wrapper registered for type {type(value).__name__!r}')  # pragma: no cover
 
 
-class _DeprecatedCallableProperty:
+class _DeprecatedCallableProperty(Generic[_T]):
     """Descriptor presenting a method-style accessor as a property.
 
     The accessor returns a wrapper that is `isinstance`-compatible with the
     underlying value type, but calling it emits `PydanticAIDeprecationWarning`.
     """
 
-    def __init__(self, fget: Callable[[Any], Any], message: str) -> None:
+    def __init__(self, fget: Callable[[Any], _T], message: str) -> None:
         self._fget = fget
         self._message = message
         self.__doc__ = fget.__doc__
+
+    @overload
+    def __get__(self, instance: None, owner: type | None = None) -> _DeprecatedCallableProperty[_T]: ...
+
+    @overload
+    def __get__(
+        self: _DeprecatedCallableProperty[RunUsage], instance: Any, owner: type | None = None
+    ) -> _DeprecatedCallableRunUsage: ...
+
+    @overload
+    def __get__(
+        self: _DeprecatedCallableProperty[RequestUsage], instance: Any, owner: type | None = None
+    ) -> _DeprecatedCallableRequestUsage: ...
+
+    @overload
+    def __get__(
+        self: _DeprecatedCallableProperty[ModelResponse], instance: Any, owner: type | None = None
+    ) -> _DeprecatedCallableResponse: ...
+
+    @overload
+    def __get__(
+        self: _DeprecatedCallableProperty[datetime], instance: Any, owner: type | None = None
+    ) -> _DeprecatedCallableDatetime: ...
+
+    @overload
+    def __get__(self, instance: Any, owner: type | None = None) -> _T: ...
 
     def __get__(self, instance: Any, owner: type | None = None) -> Any:
         if instance is None:  # pragma: no cover
@@ -168,7 +196,7 @@ class _DeprecatedCallableProperty:
         return _wrap(self._fget(instance), self._message)
 
 
-def deprecated_callable_property(message: str) -> Callable[[Callable[[Any], Any]], _DeprecatedCallableProperty]:
+def deprecated_callable_property(message: str) -> Callable[[Callable[[Any], _T]], _DeprecatedCallableProperty[_T]]:
     """Decorator for staging a v2 method-to-property migration.
 
     Args:
@@ -179,7 +207,7 @@ def deprecated_callable_property(message: str) -> Callable[[Callable[[Any], Any]
     (or the method is removed entirely, depending on the card).
     """
 
-    def decorator(fget: Callable[[Any], Any]) -> _DeprecatedCallableProperty:
+    def decorator(fget: Callable[[Any], _T]) -> _DeprecatedCallableProperty[_T]:
         return _DeprecatedCallableProperty(fget, message)
 
     return decorator

--- a/tests/typed_agent.py
+++ b/tests/typed_agent.py
@@ -10,7 +10,7 @@ from typing import Any, TypeAlias
 from starlette.requests import Request
 from typing_extensions import assert_type
 
-from pydantic_ai import Agent, ModelRetry, RunContext, Tool
+from pydantic_ai import Agent, ModelRetry, RunContext, RunUsage, Tool
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.capabilities import PrepareTools, Thinking, WebSearch
 from pydantic_ai.output import StructuredDict, TextOutput, ToolOutput
@@ -193,6 +193,9 @@ def run_sync() -> None:
     result = typed_agent.run_sync('testing', deps=MyDeps(foo=1, bar=2))
     assert_type(result, AgentRunResult[str])
     assert_type(result.output, str)
+    # `result.usage` is a callable-property: pyright must see a concrete type, not `Any` (issue #5525)
+    _usage: RunUsage = result.usage
+    assert_type(result.usage(), RunUsage)
 
 
 async def run_stream() -> None:


### PR DESCRIPTION
- Closes #5525

### Summary

`_DeprecatedCallableProperty` (the descriptor backing `AgentRunResult.usage`, `result.timestamp`, `stream.get`, etc.) returned `Any` from `__get__`, so pyright/basedpyright erased the property's type at every access site. Strict configs with `reportAny` enabled errored on snippets like `asdict(result.usage)`.

Made the descriptor `Generic[_T]` over the wrapped function's return type and added `__get__` overloads keyed to each registered wrapper class (`_DeprecatedCallableRunUsage`, `_DeprecatedCallableRequestUsage`, `_DeprecatedCallableResponse`, `_DeprecatedCallableDatetime`) with a `_T` fallback. Pyright now sees the concrete subclass at access sites, and `obj.usage()` (the deprecated call form) still type-checks as `RunUsage`/etc. Runtime behavior is unchanged — the property still wraps the value and the call still emits `PydanticAIDeprecationWarning`.

Based on @grahamcracker1234's [proposed fix](https://github.com/grahamcracker1234/pydantic-ai/tree/gbp/better-deprecated-callable-property-typing) from the issue thread.

### Test plan

- The static-typing test file `tests/typed_agent.py` gains `_usage: RunUsage = result.usage` (assignment) and `assert_type(result.usage(), RunUsage)` (callable form). Verified `make typecheck` and `mypy --strict tests/typed_agent.py` both pass.
- The original repro from the issue (`asdict(result.usage)`) verified clean under `basedpyright --strict` with `reportAny=true`.
- Existing runtime tests in `tests/v2/test_method_to_property_deprecations.py` cover the wrapper behavior and remain unchanged.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
