### PR TITLE
fix: add explicit encoding='utf-8' to scrub_cassette.py file I/O

### DIFF
--- a/scripts/scrub_cassette.py
+++ b/scripts/scrub_cassette.py
@@ -10,14 +10,14 @@ cassette_path = sys.argv[1] if len(sys.argv) > 1 else (
     'test_multimodal_tool_return_matrix[direct-uploaded_file-image-bedrock_nova].yaml'
 )
 
-with open(cassette_path) as f:
+with open(cassette_path, encoding='utf-8') as f:
     content = f.read()
 
 # Round-trip through deserialize/serialize to apply redaction
 cassette_dict = deserialize(content)
 redacted = serialize(cassette_dict)
 
-with open(cassette_path, 'w') as f:
+with open(cassette_path, 'w', encoding='utf-8') as f:
     f.write(redacted)
 
 # Verify


### PR DESCRIPTION
## What

`scripts/scrub_cassette.py` reads and writes YAML VCR cassette files via `open()` in text mode without an explicit `encoding=` argument. Python falls back to `locale.getpreferredencoding()`, which is `cp1252` on Windows and `utf-8` on Linux/macOS.

VCR cassettes in this repo routinely contain non-ASCII payloads — multilingual test inputs, model responses with emoji or accented characters, `SCRUBBED`-marked credential strings — so running the redaction script on Windows or under a non-utf-8 locale can fail with `UnicodeDecodeError` or silently mis-decode cassette content before re-writing it.

## Why

- Reliability when running maintenance scripts on Windows / non-utf-8 locales.
- PEP 597 recommends always specifying `encoding=` for text-mode opens.
- Eliminates `EncodingWarning` under `PYTHONWARNDEFAULTENCODING=1` (Python 3.10+).
- No behavior change on systems where the default is already utf-8.

## Changes

Added `encoding='utf-8'` to both `open()` call sites in `scripts/scrub_cassette.py`:

- the initial read of the cassette
- the post-redaction write-back

Total: 1 file, +2/-2 lines.

## Testing

Pure keyword-argument addition; no logic touched. Verified the file parses cleanly with `python -m py_compile`. The script's downstream consumers (`json_body_serializer.deserialize/serialize`) already operate on `str`, so attaching `encoding='utf-8'` at the open layer just makes explicit what the rest of the pipeline already assumes.