### PR TITLE
fix(agent): raise ContentFilterError for non-empty content-filtered responses

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1003,6 +1003,24 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                     isinstance(p, _messages.ThinkingPart) for p in self.model_response.parts
                 )
 
+                # Raise ContentFilterError regardless of whether the response contains parts.
+                # Models can emit a refusal as plain text with finish_reason='content_filter'
+                # rather than as an empty response (e.g. OpenAI's incomplete_details.reason).
+                if self.model_response.finish_reason == 'content_filter':
+                    details = self.model_response.provider_details or {}
+                    body = _messages.ModelMessagesTypeAdapter.dump_json([self.model_response]).decode()
+
+                    if reason := details.get('finish_reason'):
+                        message = f"Content filter triggered. Finish reason: '{reason}'"
+                    elif reason := details.get('block_reason'):
+                        message = f"Content filter triggered. Block reason: '{reason}'"
+                    elif refusal := details.get('refusal'):
+                        message = f'Content filter triggered. Refusal: {refusal!r}'
+                    else:  # pragma: no cover
+                        message = 'Content filter triggered.'
+
+                    raise exceptions.ContentFilterError(message, body=body)
+
                 if is_empty or is_thinking_only:
                     # No actionable output was returned by the model.
 
@@ -1011,22 +1029,6 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                         raise exceptions.UnexpectedModelBehavior(
                             f'Model token limit ({ctx.state.last_max_tokens or "provider default"}) exceeded before any response was generated. Increase the `max_tokens` model setting, or simplify the prompt to result in a shorter response that will fit within the limit.'
                         )
-
-                    # Check for content filter on empty response
-                    if is_empty and self.model_response.finish_reason == 'content_filter':
-                        details = self.model_response.provider_details or {}
-                        body = _messages.ModelMessagesTypeAdapter.dump_json([self.model_response]).decode()
-
-                        if reason := details.get('finish_reason'):
-                            message = f"Content filter triggered. Finish reason: '{reason}'"
-                        elif reason := details.get('block_reason'):
-                            message = f"Content filter triggered. Block reason: '{reason}'"
-                        elif refusal := details.get('refusal'):
-                            message = f'Content filter triggered. Refusal: {refusal!r}'
-                        else:  # pragma: no cover
-                            message = 'Content filter triggered.'
-
-                        raise exceptions.ContentFilterError(message, body=body)
 
                     # If the output type allows None, an empty response is a valid result.
                     if is_empty and output_schema.allows_none:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9219,21 +9219,22 @@ async def test_central_content_filter_handling():
 
 async def test_central_content_filter_with_partial_content():
     """
-    Test that the agent graph returns partial content (does not raise exception)
-    even if finish_reason='content_filter', provided parts are not empty.
+    Test that ContentFilterError is raised even when finish_reason='content_filter'
+    accompanies non-empty parts (e.g. a plain-text refusal from OpenAI/Azure).
     """
 
     async def filtered_response(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         return ModelResponse(
-            parts=[TextPart('Partially generated content...')], model_name='test-model', finish_reason='content_filter'
+            parts=[TextPart("I'm sorry, but I cannot assist with that request.")],
+            model_name='test-model',
+            finish_reason='content_filter',
         )
 
     model = FunctionModel(function=filtered_response, model_name='test-model')
     agent = Agent(model)
 
-    # Should NOT raise ContentFilterError
-    result = await agent.run('Trigger filter')
-    assert result.output == 'Partially generated content...'
+    with pytest.raises(ContentFilterError, match='Content filter triggered.'):
+        await agent.run('Trigger filter')
 
 
 async def test_agent_allows_none_output_empty_response():


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

- Closes #5221

## Summary

`ContentFilterError` was only raised when `finish_reason='content_filter'` **and** the model response had empty parts. OpenAI and Azure models can instead return a plain-text refusal (`TextPart`) with `finish_reason='content_filter'` set via `incomplete_details.reason`, so the `is_empty` guard was never entered and the error was silently swallowed—returning the refusal text as normal agent output.

The fix moves the `content_filter` check to run **before** the `is_empty or is_thinking_only` branch, so `ContentFilterError` is raised unconditionally whenever `finish_reason == 'content_filter'`, regardless of whether parts are empty.

## Issue

#5221 — `ContentFilterError` is not raised when `finish_reason='content_filter'` accompanies a non-empty `TextPart` (e.g. OpenAI/Azure `incomplete_details.reason='content_filter'` with a plain refusal message).

## Local verification

```
$ uv run pytest tests/test_agent.py::test_central_content_filter_handling \
               tests/test_agent.py::test_central_content_filter_with_partial_content \
               -v

============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.2
collecting ... collected 2 items

tests/test_agent.py::test_central_content_filter_handling PASSED         [ 50%]
tests/test_agent.py::test_central_content_filter_with_partial_content PASSED [100%]
Results (2.18s):
         2 passed

=== LOCAL_TEST_PASSED ===
```

Full agent suite (279 tests):

```
$ uv run pytest tests/test_agent.py -x -q

279 passed, 1 skipped in 11.34s
```

## Risk

Low. The change only adds an earlier exit path for `finish_reason='content_filter'`; all other code paths are unaffected. The existing test that previously asserted the opposite (buggy) behavior has been updated to reflect the correct semantics.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
