### PR TITLE
Deprecate `gateway/gemini:` prefix in favor of `gateway/google-cloud:`

### DIFF
--- a/docs/.hooks/main.py
+++ b/docs/.hooks/main.py
@@ -141,8 +141,8 @@ GATEWAY_MODEL_MAP = {
     'openai-responses': 'openai-responses',
     'openai-chat': 'openai',
     'bedrock': 'bedrock',
-    'google-gla': 'gemini',
-    'google-vertex': 'google-vertex',
+    'google-gla': 'google-cloud',
+    'google-vertex': 'google-cloud',
     'groq': 'groq',
 }
 # Models that should get gateway transformation

--- a/pydantic_ai_slim/pydantic_ai/providers/gateway.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/gateway.py
@@ -253,6 +253,13 @@ def normalize_gateway_provider(provider: str) -> str:
             PydanticAIDeprecationWarning,
             stacklevel=2,
         )
+    elif provider == 'gemini':
+        warnings.warn(
+            "The 'gateway/gemini:' prefix is deprecated and will be removed in v2.0. "
+            "Use 'gateway/google-cloud:' instead.",
+            PydanticAIDeprecationWarning,
+            stacklevel=2,
+        )
 
     if provider in ('openai', 'openai-chat', 'chat'):
         return 'openai'

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -57,12 +57,12 @@ TEST_CASES = [
     ),
     pytest.param(
         {'PYDANTIC_AI_GATEWAY_API_KEY': 'gateway-api-key'},
-        'gateway/gemini:gemini-1.5-flash',
+        'gateway/google-cloud:gemini-1.5-flash',
         'gemini-1.5-flash',
         'google-cloud',
         'google',
         GoogleModel,
-        id='gateway/gemini:gemini-1.5-flash',
+        id='gateway/google-cloud:gemini-1.5-flash',
     ),
     pytest.param(
         {'PYDANTIC_AI_GATEWAY_API_KEY': 'gateway-api-key'},

--- a/tests/providers/test_provider_names.py
+++ b/tests/providers/test_provider_names.py
@@ -66,7 +66,7 @@ with try_import() as imports_successful:
         ('ovhcloud', OVHcloudProvider, 'OVHCLOUD_API_KEY'),
         ('gateway/chat', OpenAIProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),
         ('gateway/groq', GroqProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),
-        ('gateway/gemini', GoogleProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),
+        ('gateway/google-cloud', GoogleCloudProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),
         ('gateway/anthropic', AnthropicProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),
         ('gateway/converse', BedrockProvider, 'PYDANTIC_AI_GATEWAY_API_KEY'),
         ('outlines', OutlinesProvider, None),  # pyright: ignore[reportDeprecated]

--- a/tests/v2/test_google_cloud_split_deprecation.py
+++ b/tests/v2/test_google_cloud_split_deprecation.py
@@ -153,6 +153,18 @@ def test_gateway_google_vertex_prefix_warns_and_routes_to_google_cloud_provider(
     assert isinstance(provider, GoogleCloudProvider)
 
 
+def test_gateway_gemini_prefix_warns_and_routes_to_google_cloud_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`gateway/gemini` is a user-facing alias that warns + routes to the Google Cloud path."""
+    monkeypatch.setenv('PYDANTIC_AI_GATEWAY_API_KEY', 'mock-key')
+    with pytest.warns(PydanticAIDeprecationWarning, match=r"'gateway/gemini.' prefix is deprecated"):
+        assert infer_provider_class('gateway/gemini') is GoogleCloudProvider
+    with pytest.warns(PydanticAIDeprecationWarning, match=r"'gateway/gemini.' prefix is deprecated"):
+        provider = infer_provider('gateway/gemini')
+    assert isinstance(provider, GoogleCloudProvider)
+
+
 def test_gateway_google_cloud_prefix_no_warning(monkeypatch: pytest.MonkeyPatch) -> None:
     """`gateway/google-cloud` is the new canonical user-facing prefix — no deprecation warning."""
     monkeypatch.setenv('PYDANTIC_AI_GATEWAY_API_KEY', 'mock-key')


### PR DESCRIPTION
No issue to close — this is a v2:prep companion PR.

### What

Adds a `PydanticAIDeprecationWarning` on the 1.x line for the `gateway/gemini:` model-name prefix, so the warning ships before v2 removes the prefix.

This is the v2:prep companion to v2:exec PR #5479, which removes the `gateway/gemini:` prefix entirely (makes it raise `UserError`). Per the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md), anything removed in v2.0 must first ship a `PydanticAIDeprecationWarning` in a 1.x release — `gateway/gemini:` never had one.

### Migration target

On `main`, `gateway/gemini:` resolves to `GoogleCloudProvider` (Vertex AI) — not the Gemini Developer API, despite the name. So the migration target is `gateway/google-cloud:`, which preserves the user's current behavior. This exactly mirrors the existing `gateway/google-vertex:` deprecation already on `main`.

### Changes

- `providers/gateway.py`: add the `gemini` branch to `normalize_gateway_provider` (the single chokepoint covering all `infer_*` entry points)
- Migrate general-suite tests (`tests/models/test_model.py`, `tests/providers/test_provider_names.py`) off `gateway/gemini:` to `gateway/google-cloud:` — behavior-preserving, since the suite runs under `filterwarnings = ['error']`
- Add a dedicated deprecation test in `tests/v2/test_google_cloud_split_deprecation.py`
- Point the docs gateway-toggle map (`docs/.hooks/main.py`) at the non-deprecated `gateway/google-cloud:` prefix

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).