### PR TITLE
Strip stale `# TODO (v2)` markers surfaced in #5544 review

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_json_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_json_schema.py
@@ -29,7 +29,7 @@ class JsonSchemaTransformer(ABC):
         *,
         strict: bool | None = None,
         prefer_inlined_defs: bool = False,
-        simplify_nullable_unions: bool = False,  # TODO (v2): Remove this, no longer used
+        simplify_nullable_unions: bool = False,
     ):
         self.schema = schema
 
@@ -161,7 +161,6 @@ class JsonSchemaTransformer(ABC):
 
         handled = [self._handle(member) for member in members]
 
-        # TODO (v2): Remove this feature, no longer used
         if self.simplify_nullable_unions:
             handled = self._simplify_nullable_union(handled)
         if len(handled) == 1:
@@ -177,7 +176,6 @@ class JsonSchemaTransformer(ABC):
 
     @staticmethod
     def _simplify_nullable_union(cases: list[_JsonSchemaNode]) -> list[_JsonSchemaNode]:
-        # TODO (v2): Remove this method, no longer used
         if len(cases) == 2 and {'type': 'null'} in cases:
             # Find the non-null schema
             non_null_schema = next(

--- a/pydantic_ai_slim/pydantic_ai/capabilities/reinject_system_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/reinject_system_prompt.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from pydantic_ai.models import ModelRequestContext
 
 
-# TODO (v2): consider making this the default behavior by adding `ReinjectSystemPrompt()` to
+# TODO: consider making this the default behavior by adding `ReinjectSystemPrompt()` to
 # every `Agent`'s default capabilities. Issue #1646 has been open since 2025-05 with community
 # users repeatedly asking for this. Deferred to v2 because it changes the documented contract
 # of `agent.run(message_history=[...])` — callers who deliberately omit the agent's system

--- a/pydantic_ai_slim/pydantic_ai/capabilities/reinject_system_prompt.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/reinject_system_prompt.py
@@ -12,14 +12,6 @@ if TYPE_CHECKING:
     from pydantic_ai.models import ModelRequestContext
 
 
-# TODO: consider making this the default behavior by adding `ReinjectSystemPrompt()` to
-# every `Agent`'s default capabilities. Issue #1646 has been open since 2025-05 with community
-# users repeatedly asking for this. Deferred to v2 because it changes the documented contract
-# of `agent.run(message_history=[...])` — callers who deliberately omit the agent's system
-# prompt (compaction pipelines, replay harnesses, OpenAI Responses with `previous_response_id`
-# server-side memory) would see new content added to their requests.
-
-
 @dataclass
 class ReinjectSystemPrompt(AbstractCapability[AgentDepsT]):
     """Capability that reinjects the agent's configured `system_prompt` when missing from history.

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1242,7 +1242,7 @@ class StreamedResponse(ABC):
             'This model class must override `close_stream()` to support streaming cancellation.'
         )
 
-    # TODO: (v2) We should not have public private methods which need to be overwritten.
+    # TODO: We should not have public private methods which need to be overwritten.
     @abstractmethod
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         """Return an async iterator of [`ModelResponseStreamEvent`][pydantic_ai.messages.ModelResponseStreamEvent]s.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,9 +264,6 @@ filterwarnings = [
     # uvicorn (mcp server)
     "ignore:websockets.legacy is deprecated.*:DeprecationWarning:websockets.legacy",
     "ignore:websockets.server.WebSocketServerProtocol is deprecated:DeprecationWarning",
-    # Provider.__del__ emits ResourceWarning when GC'd with an open HTTP client.
-    # Most tests create providers without async context managers, so this is expected.
-    "ignore:.*was garbage collected with an open HTTP client:ResourceWarning",
     # random resource warnings; I suspect these are coming from vendor SDKs when running examples..
     "ignore:unclosed <socket:ResourceWarning",
     "ignore:unclosed <ssl.SSLSocket:ResourceWarning",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -7166,23 +7166,6 @@ async def test_provider_aexit_without_aenter_then_async_with():
     assert provider._own_http_client.is_closed  # pyright: ignore[reportPrivateUsage]
 
 
-# TODO(v2): uncomment when we re-enable the ResourceWarning in Provider.__del__
-# @requires_openai
-# async def test_provider_del_warns_on_unclosed_client():
-#     """Provider.__del__ warns if the HTTP client was never closed.
-#
-#     Regression test for PR #4421 (provider lifecycle management).
-#     https://github.com/pydantic/pydantic-ai/pull/4421
-#     """
-#     provider = OpenAIProvider(api_key='test-key')
-#     assert provider._own_http_client is not None
-#     assert not provider._own_http_client.is_closed
-#     with pytest.warns(ResourceWarning, match='was garbage collected with an open HTTP client'):
-#         provider.__del__()
-#     # Clean up
-#     await provider._own_http_client.aclose()
-
-
 @requires_openai
 async def test_provider_reentry_after_close():
     """Provider can be re-entered after exit by recreating the HTTP client."""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -143,10 +143,6 @@ def _check_python_version(min_version: str | None, max_version: str | None) -> N
 
 
 @pytest.mark.xdist_group(name='doc_tests')
-@pytest.mark.filterwarnings(  # TODO (v2): Remove this once we drop the deprecated events
-    # Docs intentionally keep the bare `'openai:'` prefix to surface the v2 default flip to readers.
-    'ignore:.*will resolve to the OpenAI Responses API.*:pydantic_ai._warnings.PydanticAIDeprecationWarning',
-)
 @pytest.mark.parametrize('example', find_filter_examples())
 def test_docs_examples(
     example: CodeExample,


### PR DESCRIPTION
Follow-up to #5544 — stale `# TODO (v2)` markers and dead v2 scaffolding surfaced during its review.

Per @DouweM's review of the `# TODO (v2)` markers:

- **`_json_schema.py`** — `simplify_nullable_unions` ×3 markers removed. The feature is **kept** (still used by `OpenRouterProvider`); the "remove, no longer used" markers were simply wrong.
- **`models/__init__.py`** `_get_event_iterator` — kept the note, dropped the `(v2)` scoping (still agreed with, but not v2-gated).
- **`capabilities/reinject_system_prompt.py`** — dropped the `(v2)` scoping; making `ReinjectSystemPrompt` a default was decided against for v2.

Plus two pieces of dead v2 scaffolding found while auditing the remaining markers:

- **`tests/test_agent.py` + `pyproject.toml`** — removed the commented-out `test_provider_del_warns_on_unclosed_client` (it carried a `# TODO(v2)` marker) and its `filterwarnings` ignore. `Provider.__del__` no longer exists: the provider HTTP-client lifecycle was reworked to `__aenter__`/`__aexit__` with `_http_client_factory` re-creation (it no longer relies on a GC-time `__del__` to close the client). So the test can never be "re-enabled", and nothing emits the `was garbage collected with an open HTTP client` `ResourceWarning` anymore — its `filterwarnings` entry suppressed a warning that can't fire.
- **`tests/test_examples.py`** — removed the `@pytest.mark.filterwarnings` on `test_docs_examples` (also `# TODO (v2)`-marked). #5469 flipped `openai:` to the Responses API on `v2-main` and deleted the `'... will resolve to the OpenAI Responses API ...'` `PydanticAIDeprecationWarning`, so the filter no longer suppresses anything.

Comment / dead-code only; no behavior or API change.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)