### PR TITLE
Deprecate positional construction of evals classes ahead of v2 kw-only flip

### DIFF
--- a/pydantic_evals/pydantic_evals/_warnings.py
+++ b/pydantic_evals/pydantic_evals/_warnings.py
@@ -15,6 +15,9 @@ class PydanticEvalsDeprecationWarning(UserWarning):
     """
 
 
+# TODO(v2): drop this helper alongside the matching `@warn_positional_dataclass_init`
+# wrappers in `evaluators/evaluator.py` — `EvaluationResult` / `EvaluatorFailure` become
+# `@dataclass(kw_only=True)` in v2 and the warning is no longer needed.
 def warn_positional_dataclass_init(cls: _T) -> _T:
     """Wrap a dataclass `__init__` so positional construction emits a deprecation warning.
 

--- a/pydantic_evals/pydantic_evals/_warnings.py
+++ b/pydantic_evals/pydantic_evals/_warnings.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import warnings
+from typing import TypeVar
+
+_T = TypeVar('_T', bound=type)
+
 
 class PydanticEvalsDeprecationWarning(UserWarning):
     """Warning emitted when a deprecated Pydantic Evals API is used.
@@ -8,3 +13,29 @@ class PydanticEvalsDeprecationWarning(UserWarning):
     deprecations are visible by default at runtime, following the approach
     described in https://sethmlarson.dev/deprecations-via-warnings-dont-work-for-python-libraries.
     """
+
+
+def warn_positional_dataclass_init(cls: _T) -> _T:
+    """Wrap a dataclass `__init__` so positional construction emits a deprecation warning.
+
+    The typed `__init__` signature pyright infers from `@dataclass` is unchanged, so existing
+    positional callers still type-check; only the runtime check is new. Intended as a
+    stepping-stone to `@dataclass(kw_only=True)` in pydantic-evals v2.
+    """
+    original_init = cls.__init__
+    cls_name = cls.__name__
+
+    def __init__(self: object, *args: object, **kwargs: object) -> None:
+        if args:
+            warnings.warn(
+                f'Constructing `{cls_name}` with positional arguments is deprecated; '
+                f'use keyword arguments instead. Positional construction will be removed in pydantic-evals v2.',
+                PydanticEvalsDeprecationWarning,
+                stacklevel=2,
+            )
+        original_init(self, *args, **kwargs)
+
+    __init__.__qualname__ = f'{cls_name}.__init__'
+    __init__.__doc__ = original_init.__doc__
+    cls.__init__ = __init__
+    return cls

--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -606,7 +606,7 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
             metadata = getattr(c, '__pydantic_generic_metadata__', {})
             if len(args := (metadata.get('args', ()) or getattr(c, '__args__', ()))) == 3:  # pragma: no branch
                 return args
-        else:  # pragma: no cover
+        else:  # pragma: lax no cover
             warnings.warn(
                 f'Could not determine the generic parameters for {cls}; using `Any` for each.'
                 f' You should explicitly set the generic parameters via `Dataset[MyInputs, MyOutput, MyMetadata]`'

--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -87,6 +87,51 @@ _REPORT_CASE_FAILURES_ADAPTER = TypeAdapter(list[ReportCaseFailure])
 _REPORT_CASE_AGGREGATE_ADAPTER = TypeAdapter(ReportCaseAggregate)
 
 
+# TODO(v2): drop this helper and the `*_deprecated_positional` parameter on
+# `Dataset.evaluate` / `Dataset.evaluate_sync`; the remaining params will become keyword-only.
+_LEGACY_POSITIONAL_EVALUATE_NAMES = (
+    'name',
+    'max_concurrency',
+    'progress',
+    'retry_task',
+    'retry_evaluators',
+)
+
+
+def _resolve_positional_evaluate_args(
+    positional: tuple[Any, ...],
+    *,
+    name: str | None,
+    max_concurrency: int | None,
+    progress: bool,
+    retry_task: RetryConfig | None,
+    retry_evaluators: RetryConfig | None,
+) -> tuple[str | None, int | None, bool, RetryConfig | None, RetryConfig | None]:
+    """Fold deprecated positional args back onto their named slots, warning if any were passed."""
+    if not positional:
+        return name, max_concurrency, progress, retry_task, retry_evaluators
+    if len(positional) > len(_LEGACY_POSITIONAL_EVALUATE_NAMES):
+        raise TypeError(
+            f'evaluate() takes at most {1 + len(_LEGACY_POSITIONAL_EVALUATE_NAMES)} positional '
+            f'arguments but {1 + len(positional)} were given'
+        )
+    warnings.warn(
+        'Passing `name`, `max_concurrency`, `progress`, `retry_task`, or `retry_evaluators` '
+        'positionally to `Dataset.evaluate` / `Dataset.evaluate_sync` is deprecated; pass them '
+        'as keyword arguments. Positional support will be removed in pydantic-evals v2.',
+        PydanticEvalsDeprecationWarning,
+        stacklevel=3,
+    )
+    overrides = dict(zip(_LEGACY_POSITIONAL_EVALUATE_NAMES, positional))
+    return (
+        overrides.get('name', name),
+        overrides.get('max_concurrency', max_concurrency),
+        overrides.get('progress', progress),
+        overrides.get('retry_task', retry_task),
+        overrides.get('retry_evaluators', retry_evaluators),
+    )
+
+
 class _CaseModel(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid'):
     """Internal model for a case, used for serialization/deserialization."""
 
@@ -286,16 +331,17 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
         else:
             return [(case, case.name or f'Case {i}', None) for i, case in enumerate(self.cases, 1)]
 
-    # TODO in v2: Make everything not required keyword-only
+    # TODO(v2): drop `*_deprecated_positional` and the `_resolve_positional_evaluate_args` call;
+    # `name`, `max_concurrency`, `progress`, `retry_task`, `retry_evaluators` will be keyword-only.
     async def evaluate(
         self,
         task: Callable[[InputsT], Awaitable[OutputT]] | Callable[[InputsT], OutputT],
+        *_deprecated_positional: Any,
         name: str | None = None,
         max_concurrency: int | None = None,
         progress: bool = True,
         retry_task: RetryConfig | None = None,
         retry_evaluators: RetryConfig | None = None,
-        *,
         task_name: str | None = None,
         metadata: dict[str, Any] | None = None,
         repeat: int = 1,
@@ -327,6 +373,14 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
         Returns:
             A report containing the results of the evaluation.
         """
+        name, max_concurrency, progress, retry_task, retry_evaluators = _resolve_positional_evaluate_args(
+            _deprecated_positional,
+            name=name,
+            max_concurrency=max_concurrency,
+            progress=progress,
+            retry_task=retry_task,
+            retry_evaluators=retry_evaluators,
+        )
         if repeat < 1:
             raise ValueError(f'repeat must be >= 1, got {repeat}')
 
@@ -417,15 +471,16 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
             _set_experiment_span_attributes(eval_span, report, metadata, len(self.cases), repeat)
         return report
 
+    # TODO(v2): drop `*_deprecated_positional`; see the matching note on `Dataset.evaluate`.
     def evaluate_sync(
         self,
         task: Callable[[InputsT], Awaitable[OutputT]] | Callable[[InputsT], OutputT],
+        *_deprecated_positional: Any,
         name: str | None = None,
         max_concurrency: int | None = None,
         progress: bool = True,
         retry_task: RetryConfig | None = None,
         retry_evaluators: RetryConfig | None = None,
-        *,
         task_name: str | None = None,
         metadata: dict[str, Any] | None = None,
         repeat: int = 1,
@@ -456,6 +511,14 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
         Returns:
             A report containing the results of the evaluation.
         """
+        name, max_concurrency, progress, retry_task, retry_evaluators = _resolve_positional_evaluate_args(
+            _deprecated_positional,
+            name=name,
+            max_concurrency=max_concurrency,
+            progress=progress,
+            retry_task=retry_task,
+            retry_evaluators=retry_evaluators,
+        )
         return get_event_loop().run_until_complete(
             self.evaluate(
                 task,

--- a/pydantic_evals/pydantic_evals/evaluators/evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/evaluator.py
@@ -9,6 +9,7 @@ from typing import Any, Generic, cast
 from typing_extensions import TypeVar, deprecated
 
 from .._utils import get_event_loop
+from .._warnings import warn_positional_dataclass_init
 from ._base import BaseEvaluator
 from .context import EvaluatorContext
 from .spec import EvaluatorSpec
@@ -56,10 +57,10 @@ EvaluationScalarT = TypeVar('EvaluationScalarT', default=EvaluationScalar, covar
 T = TypeVar('T')
 
 
-# TODO(v2): switch to `@dataclass(kw_only=True)` so new fields can be inserted anywhere
-# without shifting positional-argument bindings, and consider reordering the existing
-# fields into a more logical grouping (e.g. identity → value → source metadata) while
-# we're free to rearrange.
+# TODO(v2): switch to `@dataclass(kw_only=True)`, drop the `warn_positional_dataclass_init`
+# wrapper, and consider reordering the existing fields into a more logical grouping (e.g.
+# identity → value → source metadata) while we're free to rearrange.
+@warn_positional_dataclass_init
 @dataclass
 class EvaluationResult(Generic[EvaluationScalarT]):
     """The details of an individual evaluation result.
@@ -103,10 +104,10 @@ class EvaluationResult(Generic[EvaluationScalarT]):
         return None
 
 
-# TODO(v2): switch to `@dataclass(kw_only=True)` so new fields can be inserted anywhere
-# without shifting positional-argument bindings, and consider reordering the existing
-# fields into a more logical grouping (e.g. identity → error detail → source metadata)
-# while we're free to rearrange.
+# TODO(v2): switch to `@dataclass(kw_only=True)`, drop the `warn_positional_dataclass_init`
+# wrapper, and consider reordering the existing fields into a more logical grouping (e.g.
+# identity → error detail → source metadata) while we're free to rearrange.
+@warn_positional_dataclass_init
 @dataclass
 class EvaluatorFailure:
     """Represents a failure raised during the execution of an evaluator."""

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -147,6 +147,44 @@ def test_dataset_name_deprecation_warning(
         Dataset(cases=example_cases)
 
 
+async def test_evaluate_positional_args_deprecation_warning(
+    example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata],
+):
+    """Passing positional args to `Dataset.evaluate` warns and still binds correctly ahead of v2 kw-only."""
+
+    async def task(inputs: TaskInput) -> TaskOutput:
+        return TaskOutput(answer=inputs.query)
+
+    with pytest.warns(PydanticEvalsDeprecationWarning, match='positionally to `Dataset.evaluate`'):
+        report = await example_dataset.evaluate(task, 'custom_experiment_name')
+    assert report.name == 'custom_experiment_name'
+
+
+def test_evaluate_sync_positional_args_deprecation_warning(
+    example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata],
+):
+    """`Dataset.evaluate_sync` mirrors the same positional deprecation."""
+
+    def task(inputs: TaskInput) -> TaskOutput:
+        return TaskOutput(answer=inputs.query)
+
+    with pytest.warns(PydanticEvalsDeprecationWarning, match='positionally to `Dataset.evaluate`'):
+        report = example_dataset.evaluate_sync(task, 'custom_experiment_name')
+    assert report.name == 'custom_experiment_name'
+
+
+async def test_evaluate_too_many_positional_args_raises(
+    example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata],
+):
+    """More positionals than legacy slots should still be a TypeError."""
+
+    async def task(inputs: TaskInput) -> TaskOutput:
+        return TaskOutput(answer=inputs.query)
+
+    with pytest.raises(TypeError, match='takes at most'):
+        await example_dataset.evaluate(task, 'n', None, True, None, None, 'extra')
+
+
 def test_from_file_uses_filename_as_default_name(tmp_path: Path):
     """Test that from_file uses filename stem as name and does not emit a deprecation warning."""
     yaml_content = 'cases:\n- name: test\n  inputs:\n    query: hello\n'

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -178,8 +178,8 @@ async def test_evaluate_too_many_positional_args_raises(
 ):
     """More positionals than legacy slots should still be a TypeError."""
 
-    async def task(inputs: TaskInput) -> TaskOutput:
-        return TaskOutput(answer=inputs.query)
+    async def task(inputs: TaskInput) -> TaskOutput:  # pragma: no cover
+        raise AssertionError('task should not be called when evaluate() rejects bad positional args')
 
     with pytest.raises(TypeError, match='takes at most'):
         await example_dataset.evaluate(task, 'n', None, True, None, None, 'extra')

--- a/tests/evals/test_evaluator_base.py
+++ b/tests/evals/test_evaluator_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import asyncio
+import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -12,6 +13,7 @@ from .._inline_snapshot import snapshot
 from ..conftest import try_import
 
 with try_import() as imports_successful:
+    from pydantic_evals import PydanticEvalsDeprecationWarning
     from pydantic_evals.evaluators._run_evaluator import run_evaluator
     from pydantic_evals.evaluators.context import EvaluatorContext
     from pydantic_evals.evaluators.evaluator import (
@@ -73,6 +75,55 @@ def test_evaluation_result():
     downcast = result.downcast(int, bool)
     assert downcast is not None
     assert downcast.value is True
+
+
+def test_evaluation_result_positional_construction_warns():
+    """Positional construction of `EvaluationResult` is deprecated ahead of v2 making it kw-only."""
+
+    @dataclass
+    class DummyEvaluator(Evaluator[Any, Any, Any]):
+        def evaluate(self, ctx: EvaluatorContext) -> bool:
+            raise NotImplementedError
+
+    source = DummyEvaluator().as_spec()
+    with pytest.warns(PydanticEvalsDeprecationWarning, match='positional arguments is deprecated'):
+        result = EvaluationResult('test', True, 'Success', source)
+    assert result.name == 'test'
+    assert result.value is True
+    assert result.reason == 'Success'
+    assert result.source == source
+
+
+def test_evaluator_failure_positional_construction_warns():
+    """Positional construction of `EvaluatorFailure` is deprecated ahead of v2 making it kw-only."""
+
+    @dataclass
+    class DummyEvaluator(Evaluator[Any, Any, Any]):
+        def evaluate(self, ctx: EvaluatorContext) -> bool:
+            raise NotImplementedError
+
+    source = DummyEvaluator().as_spec()
+    with pytest.warns(PydanticEvalsDeprecationWarning, match='positional arguments is deprecated'):
+        failure = EvaluatorFailure('test', 'boom', 'traceback...', source)
+    assert failure.name == 'test'
+    assert failure.error_message == 'boom'
+    assert failure.error_stacktrace == 'traceback...'
+    assert failure.source == source
+
+
+def test_evaluation_result_kwargs_does_not_warn():
+    """Keyword construction should not emit a deprecation warning."""
+
+    @dataclass
+    class DummyEvaluator(Evaluator[Any, Any, Any]):
+        def evaluate(self, ctx: EvaluatorContext) -> bool:
+            raise NotImplementedError
+
+    source = DummyEvaluator().as_spec()
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', PydanticEvalsDeprecationWarning)
+        EvaluationResult(name='test', value=True, reason='Success', source=source)
+        EvaluatorFailure(name='test', error_message='boom', error_stacktrace='tb', source=source)
 
 
 def test_strict_abc_meta():


### PR DESCRIPTION
<!-- Pre-work for the [v2 evals cleanup card](https://github.com/pydantic/pydantic-ai-notes/blob/main/david/v2-cards/for-dmontagu/14-evals-cleanup.md) — not tied to a public issue. -->

## Summary

Adds runtime `PydanticEvalsDeprecationWarning`s for the three sites that v2 will flip to keyword-only, so the eventual breaking change has a migration path on v1.

- `EvaluationResult(...)` / `EvaluatorFailure(...)` — wrapped via a new `warn_positional_dataclass_init` helper that monkey-patches the generated `__init__`. Pyright's dataclass-inferred signature is unchanged, so existing positional callers still type-check; only the runtime check is new.
- `Dataset.evaluate` / `Dataset.evaluate_sync` — `name`, `max_concurrency`, `progress`, `retry_task`, `retry_evaluators` now go through `*_deprecated_positional`; a shared `_resolve_positional_evaluate_args` helper folds them back to the named slots and emits the warning (or `TypeError` if too many positionals are passed).
- `TODO(v2)` markers updated to point at the removal sites.

The matching v2 follow-up (apply `kw_only=True` on the dataclasses, drop `*_deprecated_positional` from `Dataset.evaluate(_sync)?`, remove the helpers) lives in the v2 cleanup card and will land on `v2-main`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).