### PR TITLE
fix: resolve single-arg unwrap silently dropping wrapped payloads with extra=ignore

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_function_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_function_schema.py
@@ -344,14 +344,13 @@ def _validate_single_arg(
     *,
     name: str,
 ) -> dict[str, Any]:
-    try:
-        return {name: handler(value)}
-    except ValidationError:
-        # Fall back to unwrapping the `{name: value}` shape produced by a previous validation pass
-        # (e.g. after Temporal serialization/deserialization of already-validated args).
-        if isinstance(value, dict) and list(cast(dict[Any, Any], value)) == [name]:
-            return {name: handler(value[name])}
-        raise
+    if isinstance(value, dict) and list(cast(dict[Any, Any], value)) == [name]:
+        # Unwrap the `{name: value}` shape — either from a previous validation pass
+        # or from an LLM that didn't honor the flattened single-arg schema.
+        # Checking shape first avoids the case where pydantic's extra="ignore" (default)
+        # silently drops the wrapper key and the outer handler never raises ValidationError.
+        return {name: handler(value[name])}
+    return {name: handler(value)}
 
 
 def _extract_return_schema_type(return_annotation: Any, function: Callable[..., Any]) -> Any:


### PR DESCRIPTION
This is an independent contribution. This PR was not solicited, commissioned, or paid for by any party.

## Summary

Fixes a bug in `_validate_single_arg` where single-argument tool functions silently receive default-valued models when the LLM sends wrapped `{param_name: {...}}` payloads and the model uses pydantic's default `extra="ignore"`.

## Root Cause

The current validator attempts the unwrapped path first (`handler(value)`), relying on `ValidationError` to trigger the wrapped fallback. With `extra="ignore"` (pydantic default), the outer `{param_name}` key is silently dropped as an extra rather than raising — every field falls back to its default and the fallback path never executes.

## Fix

Move the wrapped-shape check (`{name: dict}`) before the unwrapped attempt. When the value is already wrapped, unwrap it immediately. When it is not, proceed with the direct handler call. This eliminates the race between `extra="ignore"` and the `ValidationError` guard.

```
Before:
    try:
        return {name: handler(value)}
    except ValidationError:
        if isinstance(value, dict) and list(...) == [name]:
            return {name: handler(value[name])}
        raise

After:
    if isinstance(value, dict) and list(...) == [name]:
        return {name: handler(value[name])}
    return {name: handler(value)}
```

## Testing

The reproducer in issue #5550 passes with this change. Existing test suite behavior is preserved: the validator now handles the wrapped case proactively instead of reactively, producing identical results for both `extra="ignore"` and `extra="forbid"` configurations.

Closes #5550