### PR TITLE
Deprecate `evaluation_name` / `evaluator_version` attribute pattern in favor of explicit accessor methods

### DIFF
--- a/docs/evals/online-evaluation.md
+++ b/docs/evals/online-evaluation.md
@@ -231,7 +231,7 @@ config = OnlineEvalConfig(emit_otel_events=False)
 
 #### Evaluator Versioning
 
-Set `evaluator_version` as a class attribute on an [`Evaluator`][pydantic_evals.evaluators.Evaluator] subclass to stamp every result it emits with a version string — surfaced as `gen_ai.evaluation.evaluator.version` on emitted events and as `evaluator_version` on each [`EvaluationResult`][pydantic_evals.evaluators.EvaluationResult] and [`EvaluatorFailure`][pydantic_evals.evaluators.EvaluatorFailure]. This lets trend lines and dashboards filter out results produced by retired evaluator versions without deleting historical rows — useful when you change an LLM judge's prompt or rework a heuristic in a way that invalidates prior scores:
+Override [`get_evaluator_version`][pydantic_evals.evaluators.Evaluator.get_evaluator_version] on an [`Evaluator`][pydantic_evals.evaluators.Evaluator] subclass to stamp every result it emits with a version string — surfaced as `gen_ai.evaluation.evaluator.version` on emitted events and as `evaluator_version` on each [`EvaluationResult`][pydantic_evals.evaluators.EvaluationResult] and [`EvaluatorFailure`][pydantic_evals.evaluators.EvaluatorFailure]. This lets trend lines and dashboards filter out results produced by retired evaluator versions without deleting historical rows — useful when you change an LLM judge's prompt or rework a heuristic in a way that invalidates prior scores:
 
 ```python
 from dataclasses import dataclass
@@ -241,10 +241,11 @@ from pydantic_evals.evaluators import Evaluator, EvaluatorContext
 
 @dataclass
 class ToneCheck(Evaluator):
-    evaluator_version = 'v2'  # bumped after prompt rewrite
-
     def evaluate(self, ctx: EvaluatorContext) -> str:
         return 'neutral'
+
+    def get_evaluator_version(self) -> str | None:
+        return 'v2'  # bumped after prompt rewrite
 ```
 
 The version applies to all results the evaluator produces (so one evaluator class maps to one version, even when the evaluator returns a mapping of named results).

--- a/pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py
@@ -59,14 +59,7 @@ async def run_evaluator(
 
         evaluate = tenacity_retry(**retry)(evaluate)
 
-    # Read `evaluator_version` off the subclass if it was declared — an optional
-    # class attribute, fetched via getattr to keep it opt-in without touching the
-    # base signature.
-    # TODO(v2): declare `evaluator_version: ClassVar[str | None] = None` on the
-    # `Evaluator` base (alongside `evaluation_name`) and read it directly.
-    raw_version = getattr(evaluator, 'evaluator_version', None)
-    evaluator_version: str | None = raw_version if isinstance(raw_version, str) else None
-
+    evaluator_version = evaluator.get_evaluator_version()
     evaluator_name = evaluator.get_default_evaluation_name()
     source = evaluator.as_spec()
 

--- a/pydantic_evals/pydantic_evals/evaluators/common.py
+++ b/pydantic_evals/pydantic_evals/evaluators/common.py
@@ -37,6 +37,9 @@ class Equals(Evaluator[object, object, object]):
     def evaluate(self, ctx: EvaluatorContext[object, object, object]) -> bool:
         return ctx.output == self.value
 
+    def get_default_evaluation_name(self) -> str:
+        return self.evaluation_name if isinstance(self.evaluation_name, str) else self.get_serialization_name()
+
 
 @dataclass(repr=False)
 class EqualsExpected(Evaluator[object, object, object]):
@@ -48,6 +51,9 @@ class EqualsExpected(Evaluator[object, object, object]):
         if ctx.expected_output is None:
             return {}  # Only compare if expected output is provided
         return ctx.output == ctx.expected_output
+
+    def get_default_evaluation_name(self) -> str:
+        return self.evaluation_name if isinstance(self.evaluation_name, str) else self.get_serialization_name()
 
 
 # _MAX_REASON_LENGTH = 500
@@ -140,6 +146,9 @@ class Contains(Evaluator[object, object, object]):
 
         return EvaluationReason(value=failure_reason is None, reason=failure_reason)
 
+    def get_default_evaluation_name(self) -> str:
+        return self.evaluation_name if isinstance(self.evaluation_name, str) else self.get_serialization_name()
+
 
 @dataclass(repr=False)
 class IsInstance(Evaluator[object, object, object]):
@@ -158,6 +167,9 @@ class IsInstance(Evaluator[object, object, object]):
         if type(output).__qualname__ != type(output).__name__:
             reason += f' (qualname: {type(output).__qualname__})'
         return EvaluationReason(value=False, reason=reason)
+
+    def get_default_evaluation_name(self) -> str:
+        return self.evaluation_name if isinstance(self.evaluation_name, str) else self.get_serialization_name()
 
 
 @dataclass(repr=False)
@@ -278,6 +290,9 @@ class HasMatchingSpan(Evaluator[object, object, object]):
         ctx: EvaluatorContext[object, object, object],
     ) -> bool:
         return ctx.span_tree.any(self.query)
+
+    def get_default_evaluation_name(self) -> str:
+        return self.evaluation_name if isinstance(self.evaluation_name, str) else self.get_serialization_name()
 
 
 DEFAULT_EVALUATORS: tuple[type[Evaluator[object, object, object]], ...] = (

--- a/pydantic_evals/pydantic_evals/evaluators/evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/evaluator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import warnings
 from abc import abstractmethod
 from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass
@@ -9,7 +10,7 @@ from typing import Any, Generic, cast
 from typing_extensions import TypeVar, deprecated
 
 from .._utils import get_event_loop
-from .._warnings import warn_positional_dataclass_init
+from .._warnings import PydanticEvalsDeprecationWarning, warn_positional_dataclass_init
 from ._base import BaseEvaluator
 from .context import EvaluatorContext
 from .spec import EvaluatorSpec
@@ -73,9 +74,10 @@ class EvaluationResult(Generic[EvaluationScalarT]):
         reason: An optional explanation of the evaluation result.
         source: The spec of the evaluator that produced this result.
         evaluator_version: Optional version tag for the evaluator that produced this result
-            (e.g. `'v2'`). Sourced automatically from the `evaluator_version` class attribute
-            on the `Evaluator` subclass. Lets online-evaluation dashboards filter out results
-            from retired versions without deleting historical rows.
+            (e.g. `'v2'`). Sourced automatically from the evaluator's
+            [`get_evaluator_version`][pydantic_evals.evaluators.Evaluator.get_evaluator_version]
+            method. Lets online-evaluation dashboards filter out results from retired versions
+            without deleting historical rows.
     """
 
     name: str
@@ -118,7 +120,8 @@ class EvaluatorFailure:
     source: EvaluatorSpec
     evaluator_version: str | None = None
     """Optional version tag for the evaluator that raised (e.g. `'v2'`). Sourced automatically
-    from the `evaluator_version` class attribute on the `Evaluator` subclass."""
+    from the evaluator's
+    [`get_evaluator_version`][pydantic_evals.evaluators.Evaluator.get_evaluator_version] method."""
     error_type: str | None = None
     """Class name of the exception that caused the failure (e.g. `'ValueError'`). Populated
     automatically when `EvaluatorFailure` is constructed from a caught exception; surfaced
@@ -157,15 +160,10 @@ class Evaluator(BaseEvaluator, Generic[InputsT, OutputT, MetadataT]):
             return ctx.output == ctx.expected_output
     ```
 
-    Optional class-level attributes:
-
-    - `evaluation_name`: override the default name used in reports for this evaluator's output
-      (only applies when `evaluate` returns a scalar or `EvaluationReason` — mapping outputs
-      always use their own keys).
-    - `evaluator_version`: an optional version tag (e.g. `'v2'`) describing the evaluator's
-      behavior. Propagated to online-evaluation sinks so dashboards can filter out results
-      produced by retired versions without deleting rows. Applies to every result the
-      evaluator emits. Bump whenever behavior changes in a way that invalidates prior scores.
+    Override [`get_default_evaluation_name`][pydantic_evals.evaluators.Evaluator.get_default_evaluation_name]
+    to customize the name used in reports, and
+    [`get_evaluator_version`][pydantic_evals.evaluators.Evaluator.get_evaluator_version] to tag the
+    evaluator with a version that downstream sinks can filter on.
 
     Example:
     ```python
@@ -176,9 +174,10 @@ class Evaluator(BaseEvaluator, Generic[InputsT, OutputT, MetadataT]):
 
     @dataclass
     class LLMJudge(Evaluator):
-        evaluator_version = 'v2'  # bumped after prompt rewrite
-
         def evaluate(self, ctx: EvaluatorContext) -> bool: ...
+
+        def get_evaluator_version(self) -> str | None:
+            return 'v2'  # bumped after prompt rewrite
     ```
     """
 
@@ -191,22 +190,48 @@ class Evaluator(BaseEvaluator, Generic[InputsT, OutputT, MetadataT]):
     def get_default_evaluation_name(self) -> str:
         """Return the default name to use in reports for the output of this evaluator.
 
-        By default, if the evaluator has an attribute called `evaluation_name` of type string, that will be used.
-        Otherwise, the serialization name of the evaluator (which is usually the class name) will be used.
-
-        This can be overridden to get a more descriptive name in evaluation reports, e.g. using instance information.
+        Defaults to the serialization name of the evaluator (which is usually the class name). Override this
+        method to customize the name, e.g. using instance information.
 
         Note that evaluators that return a mapping of results will always use the keys of that mapping as the names
         of the associated evaluation results.
         """
-        # TODO(v2): declare `evaluation_name: ClassVar[str | None] = None` on the
-        # base (alongside `evaluator_version`) and read it directly.
+        # Back-compat: if the subclass set an `evaluation_name` attribute (class or instance), honor it,
+        # but warn — that pattern is being replaced by overriding this method.
+        # TODO(v2): drop this fallback; subclasses must override `get_default_evaluation_name`.
         evaluation_name = getattr(self, 'evaluation_name', None)
         if isinstance(evaluation_name, str):
-            # If the evaluator has an attribute `name` of type string, use that
+            warnings.warn(
+                f'{type(self).__module__}.{type(self).__qualname__} relies on the `evaluation_name` attribute '
+                f'to customize the default evaluation name. This is deprecated; override `get_default_evaluation_name` '
+                f'in your evaluator class to retain this behavior in pydantic-evals v2.',
+                PydanticEvalsDeprecationWarning,
+                stacklevel=2,
+            )
             return evaluation_name
-
         return self.get_serialization_name()
+
+    def get_evaluator_version(self) -> str | None:
+        """Return the version tag for this evaluator, or `None` if it has no version.
+
+        Propagated to online-evaluation sinks so dashboards can filter out results produced by retired
+        versions without deleting historical rows. Applies to every result the evaluator emits; bump
+        whenever behavior changes in a way that invalidates prior scores. Override this method to set
+        a non-`None` version.
+        """
+        # Back-compat: honor an `evaluator_version` attribute (class or instance) but warn.
+        # TODO(v2): drop this fallback; subclasses must override `get_evaluator_version`.
+        evaluator_version = getattr(self, 'evaluator_version', None)
+        if isinstance(evaluator_version, str):
+            warnings.warn(
+                f'{type(self).__module__}.{type(self).__qualname__} relies on the `evaluator_version` attribute '
+                f'to set its version. This is deprecated; override `get_evaluator_version` in your evaluator class '
+                f'to retain this behavior in pydantic-evals v2.',
+                PydanticEvalsDeprecationWarning,
+                stacklevel=2,
+            )
+            return evaluator_version
+        return None
 
     @abstractmethod
     def evaluate(

--- a/pydantic_evals/pydantic_evals/online.py
+++ b/pydantic_evals/pydantic_evals/online.py
@@ -199,9 +199,10 @@ class OnlineEvaluator:
     evaluator: Evaluator
     """The evaluator to run.
 
-    To version an evaluator, set `evaluator_version` as a class attribute on the
-    `Evaluator` subclass itself (see `Evaluator` docstring). The framework reads it
-    via `getattr` at dispatch time and propagates it to sinks alongside each result.
+    To version an evaluator, override
+    [`get_evaluator_version`][pydantic_evals.evaluators.Evaluator.get_evaluator_version] on the
+    `Evaluator` subclass (see `Evaluator` docstring). The framework calls it at dispatch time and
+    propagates the value to sinks alongside each result.
     """
     sample_rate: float | Callable[[SamplingContext], float | bool] | None = None
     """Probability of running this evaluator (0.0–1.0), or a callable returning a float or bool.
@@ -507,8 +508,9 @@ class OnlineEvalConfig:
         `None`, which resolves to the config's `default_sample_rate` at each call — so
         changes to the config after decoration take effect.
 
-        To version an evaluator, set `evaluator_version` on the `Evaluator` subclass
-        itself — the framework reads it at dispatch time and records it on every
+        To version an evaluator, override
+        [`get_evaluator_version`][pydantic_evals.evaluators.Evaluator.get_evaluator_version] on the
+        `Evaluator` subclass — the framework calls it at dispatch time and records the value on every
         [`EvaluationResult`][pydantic_evals.evaluators.EvaluationResult] and
         [`EvaluatorFailure`][pydantic_evals.evaluators.EvaluatorFailure] the evaluator emits:
 
@@ -521,10 +523,11 @@ class OnlineEvalConfig:
 
         @dataclass
         class Tone(Evaluator):
-            evaluator_version = 'v2'
-
             def evaluate(self, ctx: EvaluatorContext) -> str:
                 return 'neutral'
+
+            def get_evaluator_version(self) -> str | None:
+                return 'v2'
 
 
         @evaluate(Tone())

--- a/tests/evals/test_evaluator_base.py
+++ b/tests/evals/test_evaluator_base.py
@@ -254,6 +254,88 @@ async def test_evaluation_name():
     assert evaluator.get_default_evaluation_name() == 'SimpleEvaluator'
 
 
+def test_evaluation_name_attribute_emits_deprecation_warning():
+    """Relying on the `evaluation_name` attribute to customize the default name is deprecated."""
+
+    @dataclass
+    class CustomNameViaAttr(Evaluator[Any, Any, Any]):
+        evaluation_name: str | None = 'custom'
+
+        def evaluate(self, ctx: EvaluatorContext) -> bool:
+            return True
+
+    evaluator = CustomNameViaAttr()
+    with pytest.warns(PydanticEvalsDeprecationWarning, match='evaluation_name'):
+        assert evaluator.get_default_evaluation_name() == 'custom'
+
+
+def test_evaluation_name_method_override_does_not_warn():
+    """Overriding `get_default_evaluation_name` is the supported, warning-free path."""
+
+    @dataclass
+    class CustomNameViaMethod(Evaluator[Any, Any, Any]):
+        def evaluate(self, ctx: EvaluatorContext) -> bool:
+            return True
+
+        def get_default_evaluation_name(self) -> str:
+            return 'overridden'
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', PydanticEvalsDeprecationWarning)
+        assert CustomNameViaMethod().get_default_evaluation_name() == 'overridden'
+
+
+def test_evaluator_version_default_is_none():
+    """The base `get_evaluator_version` returns None when no version is declared."""
+
+    @dataclass
+    class Unversioned(Evaluator[Any, Any, Any]):
+        def evaluate(self, ctx: EvaluatorContext) -> bool:
+            return True
+
+    assert Unversioned().get_evaluator_version() is None
+
+
+def test_evaluator_version_attribute_emits_deprecation_warning():
+    """Relying on the `evaluator_version` attribute is deprecated."""
+
+    @dataclass
+    class VersionedViaAttr(Evaluator[Any, Any, Any]):
+        evaluator_version = 'v2'
+
+        def evaluate(self, ctx: EvaluatorContext) -> bool:
+            return True
+
+    with pytest.warns(PydanticEvalsDeprecationWarning, match='evaluator_version'):
+        assert VersionedViaAttr().get_evaluator_version() == 'v2'
+
+
+def test_evaluator_version_method_override_does_not_warn():
+    """Overriding `get_evaluator_version` is the supported, warning-free path."""
+
+    @dataclass
+    class VersionedViaMethod(Evaluator[Any, Any, Any]):
+        def evaluate(self, ctx: EvaluatorContext) -> bool:
+            return True
+
+        def get_evaluator_version(self) -> str | None:
+            return 'v3'
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', PydanticEvalsDeprecationWarning)
+        assert VersionedViaMethod().get_evaluator_version() == 'v3'
+
+
+def test_builtin_evaluators_with_evaluation_name_do_not_warn():
+    """Built-in evaluators that expose `evaluation_name` as a dataclass field shouldn't self-warn."""
+    from pydantic_evals.evaluators.common import Equals
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', PydanticEvalsDeprecationWarning)
+        assert Equals(value=42, evaluation_name='int_match').get_default_evaluation_name() == 'int_match'
+        assert Equals(value=42).get_default_evaluation_name() == 'Equals'
+
+
 async def test_evaluator_serialization():
     """Test evaluator serialization."""
 

--- a/tests/evals/test_evaluator_base.py
+++ b/tests/evals/test_evaluator_base.py
@@ -262,7 +262,7 @@ def test_evaluation_name_attribute_emits_deprecation_warning():
         evaluation_name: str | None = 'custom'
 
         def evaluate(self, ctx: EvaluatorContext) -> bool:
-            return True
+            raise NotImplementedError
 
     evaluator = CustomNameViaAttr()
     with pytest.warns(PydanticEvalsDeprecationWarning, match='evaluation_name'):
@@ -275,7 +275,7 @@ def test_evaluation_name_method_override_does_not_warn():
     @dataclass
     class CustomNameViaMethod(Evaluator[Any, Any, Any]):
         def evaluate(self, ctx: EvaluatorContext) -> bool:
-            return True
+            raise NotImplementedError
 
         def get_default_evaluation_name(self) -> str:
             return 'overridden'
@@ -291,7 +291,7 @@ def test_evaluator_version_default_is_none():
     @dataclass
     class Unversioned(Evaluator[Any, Any, Any]):
         def evaluate(self, ctx: EvaluatorContext) -> bool:
-            return True
+            raise NotImplementedError
 
     assert Unversioned().get_evaluator_version() is None
 
@@ -304,7 +304,7 @@ def test_evaluator_version_attribute_emits_deprecation_warning():
         evaluator_version = 'v2'
 
         def evaluate(self, ctx: EvaluatorContext) -> bool:
-            return True
+            raise NotImplementedError
 
     with pytest.warns(PydanticEvalsDeprecationWarning, match='evaluator_version'):
         assert VersionedViaAttr().get_evaluator_version() == 'v2'
@@ -316,7 +316,7 @@ def test_evaluator_version_method_override_does_not_warn():
     @dataclass
     class VersionedViaMethod(Evaluator[Any, Any, Any]):
         def evaluate(self, ctx: EvaluatorContext) -> bool:
-            return True
+            raise NotImplementedError
 
         def get_evaluator_version(self) -> str | None:
             return 'v3'

--- a/tests/evals/test_evaluators.py
+++ b/tests/evals/test_evaluators.py
@@ -250,6 +250,9 @@ async def test_custom_evaluator_name(test_context: EvaluatorContext[TaskInput, T
         def evaluate(self, ctx: EvaluatorContext[TaskInput, TaskOutput, TaskMetadata]) -> EvaluatorOutput:
             return self.result
 
+        def get_default_evaluation_name(self) -> str:
+            return self.evaluation_name
+
     evaluator = CustomNameFieldEvaluator(result=123, evaluation_name='abc')
 
     assert to_jsonable_python(await run_evaluator(evaluator, test_context)) == snapshot(
@@ -265,25 +268,24 @@ async def test_custom_evaluator_name(test_context: EvaluatorContext[TaskInput, T
     )
 
     @dataclass
-    class CustomNamePropertyEvaluator(Evaluator[TaskInput, TaskOutput, TaskMetadata]):
+    class CustomNameMethodEvaluator(Evaluator[TaskInput, TaskOutput, TaskMetadata]):
         result: int
         my_name: str
-
-        @property
-        def evaluation_name(self) -> str:
-            return f'hello {self.my_name}'
 
         def evaluate(self, ctx: EvaluatorContext[TaskInput, TaskOutput, TaskMetadata]) -> EvaluatorOutput:
             return self.result
 
-    evaluator = CustomNamePropertyEvaluator(result=123, my_name='marcelo')
+        def get_default_evaluation_name(self) -> str:
+            return f'hello {self.my_name}'
+
+    evaluator = CustomNameMethodEvaluator(result=123, my_name='marcelo')
 
     assert to_jsonable_python(await run_evaluator(evaluator, test_context)) == snapshot(
         [
             {
                 'name': 'hello marcelo',
                 'reason': None,
-                'source': {'arguments': {'my_name': 'marcelo', 'result': 123}, 'name': 'CustomNamePropertyEvaluator'},
+                'source': {'arguments': {'my_name': 'marcelo', 'result': 123}, 'name': 'CustomNameMethodEvaluator'},
                 'value': 123,
                 'evaluator_version': None,
             }

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -166,39 +166,41 @@ if evals_available():
     class UsedSearchTools(Evaluator[str, EvalOutput, EvalMetadata]):
         """Check that the model used search_tools when expected tools exist."""
 
-        evaluation_name: str | None = field(default='used_search_tools')
-
         def evaluate(self, ctx: EvaluatorContext[str, EvalOutput, EvalMetadata]) -> bool:
             if not ctx.metadata or not ctx.metadata.expected_tools:
                 return True
             return 'search_tools' in ctx.output.tool_calls
 
+        def get_default_evaluation_name(self) -> str:
+            return 'used_search_tools'
+
     @dataclass(repr=False)
     class FoundExpectedTools(Evaluator[str, EvalOutput, EvalMetadata]):
         """Check that the model found and called the expected tools."""
-
-        evaluation_name: str | None = field(default='found_expected_tools')
 
         def evaluate(self, ctx: EvaluatorContext[str, EvalOutput, EvalMetadata]) -> bool:
             if not ctx.metadata or not ctx.metadata.expected_tools:
                 return True
             return all(t in ctx.output.tool_calls for t in ctx.metadata.expected_tools)
 
+        def get_default_evaluation_name(self) -> str:
+            return 'found_expected_tools'
+
     @dataclass(repr=False)
     class ReasonableToolUsage(Evaluator[str, EvalOutput, EvalMetadata]):
         """Check that the model didn't use an excessive number of tool calls."""
 
         max_calls: int = 10
-        evaluation_name: str | None = field(default='reasonable_usage')
 
         def evaluate(self, ctx: EvaluatorContext[str, EvalOutput, EvalMetadata]) -> bool:
             return len(ctx.output.tool_calls) <= self.max_calls
 
+        def get_default_evaluation_name(self) -> str:
+            return 'reasonable_usage'
+
     @dataclass(repr=False)
     class KeywordCount(Evaluator[str, EvalOutput, EvalMetadata]):
         """Score the number of keywords used in the search query. Best is <= 3."""
-
-        evaluation_name: str | None = field(default='keyword_count')
 
         def evaluate(self, ctx: EvaluatorContext[str, EvalOutput, EvalMetadata]) -> int | dict[str, int]:
             if not ctx.output.search_args:
@@ -206,6 +208,9 @@ if evals_available():
             raw: Any = ctx.output.search_args[0].get('queries')
             queries = cast('list[str]', raw) if isinstance(raw, list) else ([str(raw)] if raw else [])
             return len(' '.join(queries).split())
+
+        def get_default_evaluation_name(self) -> str:
+            return 'keyword_count'
 
 
 # --- Helpers ---


### PR DESCRIPTION
<!-- Pre-work for the [v2 evals cleanup card](https://github.com/pydantic/pydantic-ai-notes/blob/main/david/v2-cards/for-dmontagu/14-evals-cleanup.md). -->

## Summary

Custom evaluators have so far advertised their default name and version by declaring `evaluation_name` and `evaluator_version` on the class (or as a dataclass field), which `pydantic-evals` then picked up via `getattr`. The implicit, untyped contract is being replaced by typed methods on the `Evaluator` base.

- **`Evaluator.get_default_evaluation_name`** keeps its existing role. The default impl still honors the `evaluation_name` attribute, but emits a `PydanticEvalsDeprecationWarning` when it does — directing custom evaluators to override the method instead.
- **`Evaluator.get_evaluator_version() -> str | None`** is new. Replaces `getattr(evaluator, 'evaluator_version', None)` at the only internal call site (`evaluators/_run_evaluator.py`). Default impl mirrors the same deprecation behavior for the `evaluator_version` attribute.
- The built-in evaluators that expose `evaluation_name` as a dataclass field (`Equals`, `EqualsExpected`, `Contains`, `IsInstance`, `HasMatchingSpan`) override `get_default_evaluation_name` to read the field directly — preserving the constructor-set behavior without self-warning.
- Docs (`docs/evals/online-evaluation.md`) and docstrings now show the method-override pattern; the example `Evaluator` docstring and the `OnlineEvaluator.evaluate` docstring no longer recommend the attribute style.

The v2 follow-up (separate PR) drops the back-compat `getattr` fallback so the methods become the only API.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).