### PR TITLE
fix(core): resolve single-argument tool unwrapping dropping payload fields when extra='ignore'

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_function_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_function_schema.py
@@ -216,7 +216,10 @@ def function_schema(  # noqa: C901
 
     core_config = config_wrapper.core_config(None)
 
-    schema, single_arg_name = _build_schema(fields, var_kwargs_schema, core_config)
+    defs = getattr(gen_schema, 'defs', None)
+    definitions = getattr(defs, '_definitions', {}) if defs is not None else {}
+
+    schema, single_arg_name = _build_schema(fields, var_kwargs_schema, core_config, definitions)
     schema = gen_schema.clean_schema(schema)
     # noinspection PyUnresolvedReferences
     schema_validator = create_schema_validator(
@@ -295,10 +298,47 @@ def _takes_ctx(callable_obj: TargetCallable[P, R]) -> TypeIs[WithCtx[P, R]]:  # 
     return takes_run_context(callable_obj)
 
 
+def _get_schema_fields(schema: Any, defs: dict[str, Any]) -> set[str]:
+    fields: set[str] = set()
+    if isinstance(schema, dict):
+        schema_dict = cast(dict[str, Any], schema)
+        schema_type = schema_dict.get('type')
+        if schema_type == 'definition-ref' and 'schema_ref' in schema_dict:
+            ref = schema_dict['schema_ref']
+            if isinstance(ref, str) and ref in defs:
+                fields.update(_get_schema_fields(defs[ref], defs))
+            return fields
+        elif schema_type in ('model-fields', 'typed-dict') and 'fields' in schema_dict:
+            schema_fields = schema_dict['fields']
+            if isinstance(schema_fields, dict):
+                fields.update(cast(dict[str, Any], schema_fields).keys())
+            return fields
+        elif schema_type == 'dataclass-args' and 'fields' in schema_dict:
+            schema_fields = schema_dict['fields']
+            if isinstance(schema_fields, list):
+                for f in cast(list[Any], schema_fields):
+                    if isinstance(f, dict):
+                        f_dict = cast(dict[str, Any], f)
+                        if 'name' in f_dict:
+                            name = f_dict['name']
+                            if isinstance(name, str):
+                                fields.add(name)
+            return fields
+
+        for v in schema_dict.values():
+            fields.update(_get_schema_fields(v, defs))
+    elif isinstance(schema, list):
+        schema_list = cast(list[Any], schema)
+        for item in schema_list:
+            fields.update(_get_schema_fields(item, defs))
+    return fields
+
+
 def _build_schema(
     fields: dict[str, core_schema.TypedDictField],
     var_kwargs_schema: core_schema.CoreSchema | None,
     core_config: core_schema.CoreConfig,
+    definitions: dict[str, Any],
 ) -> tuple[core_schema.CoreSchema, str | None]:
     """Generate a typed dict schema for function parameters.
 
@@ -306,6 +346,7 @@ def _build_schema(
         fields: The fields to generate a typed dict schema for.
         var_kwargs_schema: The variable keyword arguments schema.
         core_config: The core configuration.
+        definitions: The schema definitions dictionary to resolve definition-refs.
 
     Returns:
         tuple of (generated core schema, single arg name).
@@ -321,9 +362,10 @@ def _build_schema(
             # Use a wrap validator so we also accept the already-wrapped `{name: value}` shape,
             # which is what Temporal (and any other caller) passes when re-validating previously
             # validated args after serialization round-trip.
+            model_fields = _get_schema_fields(td_field['schema'], definitions)
             return (
                 core_schema.no_info_wrap_validator_function(
-                    partial(_validate_single_arg, name=name), td_field['schema']
+                    partial(_validate_single_arg, name=name, model_fields=model_fields), td_field['schema']
                 ),
                 name,
             )
@@ -343,7 +385,15 @@ def _validate_single_arg(
     handler: core_schema.ValidatorFunctionWrapHandler,
     *,
     name: str,
+    model_fields: set[str],
 ) -> dict[str, Any]:
+    if (
+        isinstance(value, dict)
+        and list(cast(dict[Any, Any], value)) == [name]
+        and name not in model_fields
+    ):
+        return {name: handler(value[name])}
+
     try:
         return {name: handler(value)}
     except ValidationError:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3865,6 +3865,70 @@ def test_single_base_model_arg_validator_accepts_wrapped_input():
     assert raw == wrapped == {'argument': Payload(city='Mexico City')}
 
 
+def test_single_base_model_arg_validator_accepts_wrapped_input_extras_ignored():
+    """A single-BaseModel-arg validator correctly unwraps when extra fields are ignored."""
+    from pydantic import ConfigDict
+
+    class Payload(BaseModel):
+        model_config = ConfigDict(extra='ignore')
+        city: str = 'default'
+
+    def my_tool(argument: Payload) -> str:  # pragma: no cover
+        return argument.city
+
+    tool = Tool(my_tool)
+    validator = tool.function_schema.validator
+
+    raw = validator.validate_python({'city': 'Mexico City'})
+    wrapped = validator.validate_python({'argument': {'city': 'Mexico City'}})
+    assert raw == wrapped == {'argument': Payload(city='Mexico City')}
+
+
+def test_single_base_model_arg_validator_overlapping_field():
+    """When the argument name overlaps with a field name, it is treated as unwrapped first, falling back to wrapped if validation fails."""
+
+    class Payload(BaseModel):
+        argument: str = 'default'
+
+    def my_tool(argument: Payload) -> str:  # pragma: no cover
+        return argument.argument
+
+    tool = Tool(my_tool)
+    validator = tool.function_schema.validator
+
+    # Unwrapped shape: input is a dict matching the model fields, e.g. {'argument': 'unwrapped'}
+    # It validates as Payload(argument='unwrapped')
+    raw = validator.validate_python({'argument': 'unwrapped'})
+    assert raw == {'argument': Payload(argument='unwrapped')}
+
+    # Wrapped shape: input is {'argument': {'argument': 'wrapped'}}
+    # Note: validating {'argument': {'argument': 'wrapped'}} against Payload:
+    # 'argument' field expects str, but gets {'argument': 'wrapped'} (a dict), raising ValidationError.
+    # Therefore, the ValidationError is raised, and the fallback block triggers.
+    # The fallback unwraps it to {'argument': 'wrapped'}, which successfully validates.
+    wrapped = validator.validate_python({'argument': {'argument': 'wrapped'}})
+    assert wrapped == {'argument': Payload(argument='wrapped')}
+
+
+def test_single_base_model_arg_validator_extras_forbid():
+    """A single-BaseModel-arg validator with extra='forbid' unwraps wrapped input correctly."""
+    from pydantic import ConfigDict
+
+    class Payload(BaseModel):
+        model_config = ConfigDict(extra='forbid')
+        city: str
+
+    def my_tool(argument: Payload) -> str:  # pragma: no cover
+        return argument.city
+
+    tool = Tool(my_tool)
+    validator = tool.function_schema.validator
+
+    raw = validator.validate_python({'city': 'Mexico City'})
+    wrapped = validator.validate_python({'argument': {'city': 'Mexico City'}})
+    assert raw == wrapped == {'argument': Payload(city='Mexico City')}
+
+
 def test_tool_ctx_agent():
     """ctx.agent gives tools access to the running agent's properties."""
     agent = Agent('test', name='my_agent', output_type=int)


### PR DESCRIPTION
# fix(core): resolve single-argument tool unwrapping dropping payload fields when extra='ignore'

## Description
This pull request fixes an issue in tool argument validation where wrapped payloads for tools accepting a single model-like argument (e.g. `BaseModel`, `dataclass`, or `TypedDict`) could have their field data silently dropped and replaced with defaults if the model configuration ignores extra fields (which is Pydantic's default behavior).

Fixes #5550

### The Problem
When a tool accepts a single model-like argument, the validator schema generated by `pydantic-ai` uses a wrap validator. By default, it runs the validator on the raw input (unwrapped shape). If that fails (raises a `ValidationError`), it falls back to validating the input as a wrapped dictionary: `{argument_name: payload}`.

However, if the model has `extra='ignore'` (Pydantic's default `ConfigDict` configuration), validating the wrapped dictionary `{argument_name: payload}` directly against the unwrapped schema does not raise a `ValidationError`. Instead, Pydantic ignores the outer `{argument_name: ...}` dictionary key as an extra/unknown field, and validates an empty/default instance. This causes the actual payload fields to be silently discarded.

### The Solution
We resolve this by eagerly detecting wrapped shapes:
1. Added a helper `_get_schema_fields(schema, defs)` that resolves the model-like argument schema (recursively dereferencing `$defs` reference schemas) to extract the set of top-level field names defined on the model/dataclass/TypedDict.
2. In `_validate_single_arg`, if the input dictionary has a single key matching the parameter's name (`{name: value}`), and `name` is **not** one of the model's defined field names (which would otherwise imply the input is meant to be unwrapped), we eagerly unwrap the payload.
3. Added robust unit tests in `tests/test_tools.py` ensuring correct unwrapping behavior under `extra='ignore'`, `extra='forbid'`, and checking the behavior of overlapping argument/field names.
