### PR TITLE
fix: avoid wall-clock retry test flake

### DIFF
--- a/tests/test_tenacity.py
+++ b/tests/test_tenacity.py
@@ -651,26 +651,22 @@ class TestIntegration:
             if response.status_code == 429:
                 raise httpx.HTTPStatusError('Rate limited', request=request, response=response)
 
+        sleep_calls: list[int | float] = []
         config = RetryConfig(
             retry=retry_if_exception_type(httpx.HTTPStatusError),
             wait=wait_retry_after(max_wait=0.1),  # Cap at 0.1 seconds for tests
             stop=stop_after_attempt(3),
+            sleep=sleep_calls.append,
             reraise=True,
         )
         transport = TenacityTransport(config, mock_transport, validate_response)
 
         request = httpx.Request('GET', 'https://example.com')
-
-        # Time the request to ensure max_wait was respected
-        start_time = time.time()
         result = transport.handle_request(request)
-        end_time = time.time()
 
         assert result is mock_response_success
         assert mock_transport.handle_request.call_count == 2
-        # Should have waited approximately 0.2 seconds (capped by max_wait)
-        duration = end_time - start_time
-        assert 0.1 <= duration <= 0.2
+        assert sleep_calls == [0.1]
 
 
 class TestConnectionPool:


### PR DESCRIPTION
﻿## Summary

This removes a wall-clock upper bound from `test_sync_transport_with_wait_retry_after`.

The behavior under test is that `Retry-After: 30` is capped to `0.1` by `wait_retry_after(max_wait=0.1)`. The old assertion measured real elapsed time and required it to stay below `0.2s`, which can fail under coverage, xdist, or a busy CI runner even when tenacity asked for the correct sleep duration.

The test now passes a fake `sleep` callable through `RetryConfig`, records the requested sleep duration, and asserts that tenacity asked to sleep for `0.1` seconds.

Refs #5399.

## To verify

- `python -m pytest tests/test_tenacity.py::TestIntegration::test_sync_transport_with_wait_retry_after -q`
- `python -m pytest tests/test_tenacity.py::TestWaitRetryAfter tests/test_tenacity.py::TestIntegration::test_sync_transport_with_wait_retry_after -q`
- `python -m pytest tests/test_tenacity.py -q`
- `python -m ruff check tests/test_tenacity.py`
- `python -m ruff format --check tests/test_tenacity.py`
- `python -m py_compile tests/test_tenacity.py`
