### PR TITLE
Fix `AnthropicModel` dropping code execution tool results when continuing a conversation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1450,7 +1450,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                                 'code_execution_tool_result',  # Backward compatibility
                                 'bash_code_execution',
                                 'text_editor_code_execution',
-                            ) and isinstance(response_part.content, dict):
+                            ) and isinstance(response_part.content, dict | list):
                                 match _get_anthropic_code_execution_tool_name(response_part):
                                     case 'code_execution':
                                         assistant_content_params.append(

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -9181,6 +9181,124 @@ async def test_anthropic_bash_code_execution_tool_message_replay(allow_model_req
     )
 
 
+async def test_anthropic_code_execution_tool_message_replay_with_list_results(allow_model_requests: None):
+    """Serialize Anthropic code execution result lists instead of dropping them."""
+    c = completion_message(
+        [BetaTextBlock(text='ok', type='text')],
+        BetaUsage(input_tokens=5, output_tokens=10),
+    )
+    mock_client = MockAnthropic.create_mock(c)
+    m = AnthropicModel('claude-sonnet-4-6', provider=AnthropicProvider(anthropic_client=mock_client))
+    agent = Agent(m, capabilities=[NativeTool(CodeExecutionTool())])
+
+    bash_result = [
+        {
+            'return_code': 0,
+            'stderr': '',
+            'stdout': 'hello\n',
+            'type': 'bash_code_execution_result',
+        }
+    ]
+    text_editor_result = [
+        {
+            'content': 'Hello, world!',
+            'file_type': 'text',
+            'num_lines': 1,
+            'start_line': 1,
+            'total_lines': 1,
+            'type': 'text_editor_code_execution_view_result',
+        }
+    ]
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Replay code execution history.')], timestamp=IsDatetime()),
+        ModelResponse(
+            parts=[
+                NativeToolCallPart(
+                    provider_name=m.system,
+                    tool_name='code_execution',
+                    args={'command': 'echo hello'},
+                    tool_call_id='srvtoolu_bash_list',
+                    provider_details={'anthropic_tool_name': 'bash_code_execution'},
+                ),
+                NativeToolReturnPart(
+                    provider_name=m.system,
+                    tool_name='code_execution',
+                    content=bash_result,
+                    tool_call_id='srvtoolu_bash_list',
+                    provider_details={'anthropic_tool_name': 'bash_code_execution'},
+                ),
+                NativeToolCallPart(
+                    provider_name=m.system,
+                    tool_name='code_execution',
+                    args={'command': 'view', 'path': '/tmp/hello.txt'},
+                    tool_call_id='srvtoolu_text_editor_list',
+                    provider_details={'anthropic_tool_name': 'text_editor_code_execution'},
+                ),
+                NativeToolReturnPart(
+                    provider_name=m.system,
+                    tool_name='code_execution',
+                    content=text_editor_result,
+                    tool_call_id='srvtoolu_text_editor_list',
+                    provider_details={'anthropic_tool_name': 'text_editor_code_execution'},
+                ),
+            ],
+            model_name='claude-sonnet-4-6',
+        ),
+    ]
+
+    await agent.run('Continue.', message_history=messages)
+
+    assert get_mock_chat_completion_kwargs(mock_client)[0]['messages'] == snapshot(
+        [
+            {'role': 'user', 'content': [{'type': 'text', 'text': 'Replay code execution history.'}]},
+            {
+                'role': 'assistant',
+                'content': [
+                    {
+                        'type': 'server_tool_use',
+                        'id': 'srvtoolu_bash_list',
+                        'name': 'bash_code_execution',
+                        'input': {'command': 'echo hello'},
+                    },
+                    {
+                        'type': 'bash_code_execution_tool_result',
+                        'tool_use_id': 'srvtoolu_bash_list',
+                        'content': [
+                            {
+                                'return_code': 0,
+                                'stderr': '',
+                                'stdout': 'hello\n',
+                                'type': 'bash_code_execution_result',
+                            }
+                        ],
+                    },
+                    {
+                        'type': 'server_tool_use',
+                        'id': 'srvtoolu_text_editor_list',
+                        'name': 'text_editor_code_execution',
+                        'input': {'command': 'view', 'path': '/tmp/hello.txt'},
+                    },
+                    {
+                        'type': 'text_editor_code_execution_tool_result',
+                        'tool_use_id': 'srvtoolu_text_editor_list',
+                        'content': [
+                            {
+                                'content': 'Hello, world!',
+                                'file_type': 'text',
+                                'num_lines': 1,
+                                'start_line': 1,
+                                'total_lines': 1,
+                                'type': 'text_editor_code_execution_view_result',
+                            }
+                        ],
+                    },
+                ],
+            },
+            {'role': 'user', 'content': [{'type': 'text', 'text': 'Continue.'}]},
+        ]
+    )
+
+
 async def test_anthropic_code_execution_tool_message_replay_infers_anthropic_tool_name(
     allow_model_requests: None,
 ):


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #5567

### Summary

- Preserve Anthropic `bash_code_execution` and `text_editor_code_execution` tool result blocks when replayed history stores list-shaped result content.
- Add a regression test covering both Anthropic code execution variants so same-provider replay does not emit a `server_tool_use` without the matching `*_code_execution_tool_result` block.

### Validation

- `PYTHONPATH=... .venv\Scripts\python.exe -m pytest tests/models/test_anthropic.py::test_anthropic_code_execution_tool_message_replay_with_list_results`
- `PYTHONPATH=... .venv\Scripts\python.exe -m pytest tests/models/test_anthropic.py::test_anthropic_text_editor_code_execution_tool_message_replay tests/models/test_anthropic.py::test_anthropic_bash_code_execution_tool_message_replay tests/models/test_anthropic.py::test_anthropic_code_execution_tool_message_replay_with_list_results tests/models/test_anthropic.py::test_anthropic_code_execution_tool_message_replay_infers_anthropic_tool_name`
- `.venv\Scripts\python.exe -m ruff check pydantic_ai_slim/pydantic_ai/models/anthropic.py tests/models/test_anthropic.py`
- `uv run --no-project --with pyright pyright pydantic_ai_slim/pydantic_ai/models/anthropic.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).