### PR TITLE
fix: mark bare list annotations as strict-incompatible in OpenAI profile

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -383,4 +383,12 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                     for k in schema['properties'].keys():
                         if k not in required:
                             self.is_strict_compatible = False
+
+        if schema_type == 'array':
+            # items:{} is produced by bare `list` annotations and is rejected by
+            # OpenAI strict mode ("schema must have a 'type' key")
+            items = schema.get('items')
+            if items == {} or items is None:
+                self.is_strict_compatible = False
+
         return schema


### PR DESCRIPTION
When a tool parameter is typed as a bare `list` (no element type annotation), pydantic emits `{"type": "array", "items": {}}`. Sending this to OpenAI with `strict=True` returns a 400:

```
Invalid schema for function 'my_tool': In context=('properties', 'items', 'items'),
schema must have a 'type' key.
```

`OpenAIJsonSchemaTransformer.transform()` handles `schema_type == 'object'` with full strict-compatibility checks but has no branch for `schema_type == 'array'`. An empty `items` schema is never flagged, so it gets sent with `strict=True` and the API rejects it.

Adding an array branch that sets `is_strict_compatible = False` when `items` is `{}` or absent lets the schema fall back to non-strict mode instead.

Fixes #4425