### PR TITLE
fix(xai): merge ToolCallPart onto preceding assistant message regardless of existing tool_calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -397,11 +397,15 @@ class XaiModel(Model[AsyncClient]):
 
     @staticmethod
     def _append_tool_call(messages: list[chat_types.chat_pb2.Message], tool_call: chat_types.chat_pb2.ToolCall) -> None:
-        """Append a tool call to the most recent tool-call assistant message, or create a new one.
+        """Append a tool call to the most recent assistant message, or create a new one.
 
-        We keep tool calls grouped to avoid generating one assistant message per tool call.
+        Tool calls are merged onto the preceding assistant message regardless of whether that
+        message already has tool calls, reasoning content, or text content.  This matches
+        xAI's own convention: a single response turn (reasoning + tool calls) must be
+        represented as one assistant message so that encrypted reasoning content stays
+        paired with the tool calls it produced.
         """
-        if messages and messages[-1].tool_calls:
+        if messages and messages[-1].role == chat_types.chat_pb2.MessageRole.ROLE_ASSISTANT:
             messages[-1].tool_calls.append(tool_call)
         else:
             msg = assistant('')

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -388,6 +388,58 @@ async def test_xai_multiple_tool_calls_in_history_are_grouped(allow_model_reques
     )
 
 
+async def test_xai_tool_call_attaches_to_preceding_reasoning_message(allow_model_requests: None):
+    """ToolCallPart after ThinkingPart must land on the same assistant message, not a new one.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/5329.
+    Before the fix, _append_tool_call only merged onto messages[-1] when
+    messages[-1].tool_calls was truthy.  A reasoning message has an empty
+    tool_calls list, so the condition evaluated to False and a brand-new
+    assistant message was created for the tool call — orphaning the
+    reasoning_content from the tool calls it produced.
+    """
+    response1 = create_response(
+        reasoning_content='let me think',
+        tool_calls=[create_tool_call('call_a', 'tool_a', {})],
+        finish_reason='tool_call',
+        usage=create_usage(prompt_tokens=10, completion_tokens=5),
+    )
+    response2 = create_response(
+        content='done',
+        usage=create_usage(prompt_tokens=20, completion_tokens=5),
+    )
+    mock_client = MockXai.create_mock([response1, response2])
+    m = XaiModel(XAI_REASONING_MODEL, provider=XaiProvider(xai_client=mock_client))
+    agent = Agent(m)
+
+    @agent.tool_plain
+    async def tool_a() -> str:
+        return 'a'
+
+    result = await agent.run('Run tool')
+    assert result.output == 'done'
+
+    kwargs = get_mock_chat_create_kwargs(mock_client)
+    assert len(kwargs) == 2
+    second_messages = kwargs[1]['messages']
+
+    # There must be exactly ONE assistant message that carries both
+    # reasoning_content and tool_calls (not two separate messages).
+    assistant_msgs = [m for m in second_messages if m.get('role') == 'ROLE_ASSISTANT']
+    reasoning_msgs = [m for m in assistant_msgs if m.get('reasoning_content')]
+    tool_call_msgs = [m for m in assistant_msgs if m.get('tool_calls')]
+
+    assert len(reasoning_msgs) == 1, (
+        f'Expected 1 assistant message with reasoning, got {len(reasoning_msgs)}'
+    )
+    assert len(tool_call_msgs) == 1, (
+        f'Expected 1 assistant message with tool calls, got {len(tool_call_msgs)}'
+    )
+    assert reasoning_msgs[0] is tool_call_msgs[0], (
+        'reasoning_content and tool_calls must be on the same assistant message'
+    )
+
+
 async def test_xai_reorders_tool_return_parts_by_tool_call_id(allow_model_requests: None):
     response = create_response(
         content='done',


### PR DESCRIPTION
## Problem

When a `ModelResponse` from Grok contains a `ThinkingPart` followed by one or more `ToolCallPart`s — the normal shape for any reasoning + tool-use turn — `_append_tool_call` creates a **second** assistant message for the tool calls instead of attaching them to the reasoning message.

Root cause: the merge guard in `_append_tool_call` checks `messages[-1].tool_calls` (truthy only when tool calls already exist on the previous message). A reasoning message has `reasoning_content`/`encrypted_content` but an empty `tool_calls` list, so the condition is `False` and a fresh assistant message is created.

This leaves encrypted reasoning content orphaned from the tool calls it produced. It also diverges from xAI's own convention: `xai_sdk.chat.Chat.append(response)` packs all parts of one output turn onto a single assistant message, and that is the shape xAI's reasoning models expect when round-tripping encrypted traces.

Closes #5329.

## Fix

Relax the merge condition to check the message role instead of the tool_calls list:

```python
# Before
if messages and messages[-1].tool_calls:

# After
if messages and messages[-1].role == chat_types.chat_pb2.MessageRole.ROLE_ASSISTANT:
```

Any preceding assistant message (reasoning, text, or with existing tool calls) now absorbs the tool call — matching xAI's own SDK behavior.

## Changes

- `pydantic_ai_slim/pydantic_ai/models/xai.py`: relax `_append_tool_call` merge guard from `tool_calls` truthiness to role check
- `tests/models/test_xai.py`: add `test_xai_tool_call_attaches_to_preceding_reasoning_message` which exercises a response with both `reasoning_content` and `tool_calls` and asserts they land on one message