### PR TITLE
Don't auto-promote `strict=None` tools to strict mode with Bedrock, and skip `strict` field when `botocore` is too old

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import typing
+import warnings
 from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field, replace
@@ -17,6 +18,7 @@ from typing_extensions import ParamSpec, assert_never
 try:
     from botocore.client import BaseClient
     from botocore.exceptions import BotoCoreError, ClientError
+    from botocore.model import StructureShape
 except ImportError as _import_error:
     raise ImportError(
         'Please install `boto3` to use the Bedrock model, '
@@ -493,6 +495,19 @@ class BedrockConverseModel(Model[BaseClient]):
         # Pass unmerged model_settings; base class does its own merge
         return super().prepare_request(model_settings, model_request_parameters)
 
+    @property
+    def _supports_strict_tool_param(self) -> bool:
+        """Whether the installed `botocore` knows the `strict` field on `toolSpec`.
+
+        `botocore` validates request params against its own bundled service model, so a
+        `botocore` older than the one that introduced strict tool calls rejects `strict`
+        with a `ParamValidationError` regardless of what the Bedrock model itself supports.
+        This notably happens on AWS Lambda, where the runtime's bundled `botocore` can
+        shadow a newer one provided via a layer.
+        """
+        tool_spec_shape = self.client.meta.service_model.shape_for('ToolSpecification')
+        return isinstance(tool_spec_shape, StructureShape) and 'strict' in tool_spec_shape.members
+
     def _map_tool_definition(self, f: ToolDefinition) -> ToolTypeDef:
         tool_spec: ToolSpecificationTypeDef = {'name': f.name, 'inputSchema': {'json': f.parameters_json_schema}}
 
@@ -500,7 +515,16 @@ class BedrockConverseModel(Model[BaseClient]):
             tool_spec['description'] = f.description
 
         if f.strict and self.profile.bedrock_supports_strict_tool_definition:
-            tool_spec['strict'] = f.strict
+            if self._supports_strict_tool_param:
+                tool_spec['strict'] = f.strict
+            else:
+                warnings.warn(
+                    'The installed `botocore` is too old to send `strict` tool definitions to Bedrock, '
+                    'so the request is sent without `strict`. Upgrade `boto3`/`botocore` to enable strict '
+                    "tool calls; on AWS Lambda, the runtime's bundled `botocore` may be shadowing a newer "
+                    'one from your layer.',
+                    UserWarning,
+                )
 
         return {'toolSpec': tool_spec}
 

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -496,7 +496,7 @@ class BedrockConverseModel(Model[BaseClient]):
         return super().prepare_request(model_settings, model_request_parameters)
 
     @property
-    def _supports_strict_tool_param(self) -> bool:
+    def _botocore_supports_strict_tool_param(self) -> bool:
         """Whether the installed `botocore` knows the `strict` field on `toolSpec`.
 
         `botocore` validates request params against its own bundled service model, so a
@@ -515,7 +515,7 @@ class BedrockConverseModel(Model[BaseClient]):
             tool_spec['description'] = f.description
 
         if f.strict and self.profile.bedrock_supports_strict_tool_definition:
-            if self._supports_strict_tool_param:
+            if self._botocore_supports_strict_tool_param:
                 tool_spec['strict'] = f.strict
             else:
                 warnings.warn(

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -62,33 +62,45 @@ _BEDROCK_STRICT_UNSUPPORTED_KEYS_BY_TYPE: dict[str, tuple[str, ...]] = {
 class BedrockJsonSchemaTransformer(JsonSchemaTransformer):
     """Transforms schemas to the subset supported by Bedrock structured outputs.
 
-    Transformation is applied when:
-    - `NativeOutput` is used as the `output_type` of the Agent
-    - `strict=True` is set on the `Tool`
+    The transformer is applied to Bedrock tool and output schemas during request
+    customization. Strict-mode rewrites are applied when:
+    - `NativeOutput` is used as the `output_type` of the Agent. `BedrockConverseModel`
+      forces native output schemas to `strict=True` before request customization.
+    - `strict=True` is set explicitly on a Tool.
 
-    When `strict=None` (the default), simple schemas without incompatible constraints are
-    auto-promoted to `strict=True`. Schemas with any key listed in
-    `_BEDROCK_STRICT_UNSUPPORTED_KEYS_BY_TYPE` remain `strict=False`.
+    Like `AnthropicJsonSchemaTransformer`, Bedrock does not infer strict tool mode
+    from `strict=None`. Strict tool definitions are opt-in: callers must set
+    `strict=True` explicitly. This avoids silently changing large toolsets into
+    strict toolsets, which can exceed Anthropic/Bedrock's 20 strict-tools-per-request
+    limit, and avoids applying potentially lossy strict-mode schema rewrites unless
+    requested.
 
-    When `strict=True`, keys Bedrock rejects (see the module-level constant for the
-    empirically-verified list) are popped off the schema and re-emitted into the field's
+    When `strict=True`, `additionalProperties: false` is injected on objects and keys
+    Bedrock rejects are removed from the schema and re-emitted into the field's
     `description` so the model still has the hint.
     """
+
+    def walk(self) -> JsonSchema:
+        schema = super().walk()
+
+        # `_customize_tool_def()` and `_customize_output_object()` use this flag
+        # to resolve `strict=None`. For Bedrock tools, strict mode is opt-in, so
+        # only an explicit `strict=True` should resolve to strict-compatible.
+        self.is_strict_compatible = self.strict is True
+
+        return schema
 
     def transform(self, schema: JsonSchema) -> JsonSchema:
         schema.pop('title', None)
         schema.pop('$schema', None)
 
+        if not self.strict:
+            return schema
+
         schema_type = schema.get('type')
 
         if schema_type == 'object':
-            if self.strict:
-                schema['additionalProperties'] = False
-            elif self.strict is None:
-                if schema.get('additionalProperties', None) not in (None, False):
-                    self.is_strict_compatible = False
-                else:
-                    schema['additionalProperties'] = False
+            schema['additionalProperties'] = False
 
         incompatible: dict[str, object] = {}
         if isinstance(schema_type, str):
@@ -99,16 +111,13 @@ class BedrockJsonSchemaTransformer(JsonSchemaTransformer):
                 incompatible['minItems'] = schema['minItems']
 
         if incompatible:
-            if self.strict:
-                notes: list[str] = []
-                for key, value in incompatible.items():
-                    schema.pop(key)
-                    notes.append(f'{key}={value}')
-                notes_str = ', '.join(notes)
-                desc = schema.get('description')
-                schema['description'] = notes_str if not desc else f'{desc} ({notes_str})'
-            elif self.strict is None:
-                self.is_strict_compatible = False
+            notes: list[str] = []
+            for key, value in incompatible.items():
+                schema.pop(key)
+                notes.append(f'{key}={value}')
+            notes_str = ', '.join(notes)
+            desc = schema.get('description')
+            schema['description'] = notes_str if not desc else f'{desc} ({notes_str})'
 
         return schema
 

--- a/tests/models/bedrock/test_strict_tool_calls.py
+++ b/tests/models/bedrock/test_strict_tool_calls.py
@@ -29,6 +29,8 @@ from ...conftest import IsDatetime, IsStr, try_import
 from .conftest import CityInfo, PersonQuery
 
 with try_import() as imports_successful:
+    from botocore.model import Shape, StructureShape
+
     from pydantic_ai.models.bedrock import BedrockConverseModel
     from pydantic_ai.providers.bedrock import BedrockProvider
 
@@ -113,6 +115,56 @@ def test_bedrock_strict_tool_definition_none(
     )
 
     result = model._map_tool_definition(tool_def)  # pyright: ignore[reportPrivateUsage]
+
+    assert result == snapshot(
+        {
+            'toolSpec': {
+                'name': 'get_weather',
+                'inputSchema': {
+                    'json': {'type': 'object', 'properties': {'city': {'type': 'string'}}, 'required': ['city']}
+                },
+                'description': 'Get the weather for a city',
+            }
+        }
+    )
+
+
+def test_bedrock_strict_dropped_when_botocore_too_old(
+    allow_model_requests: None,
+    bedrock_provider: BedrockProvider,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Old `botocore` (no `strict` on `ToolSpecification`) → `strict` dropped with a warning.
+
+    `botocore` validates params against its own bundled service model, so an explicit
+    `strict=True` crashes with `ParamValidationError` on a `botocore` predating strict tool
+    calls — notably on AWS Lambda, where the runtime's bundled `botocore` can shadow a newer
+    layer-provided one. See https://github.com/pydantic/pydantic-ai/issues/5579.
+    """
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+
+    # `shape_for` builds a fresh `Shape` each call, so drop `strict` from `ToolSpecification`'s
+    # members on every lookup to mimic a `botocore` that predates strict tool calls.
+    service_model = model.client.meta.service_model
+    real_shape_for = service_model.shape_for
+
+    def shape_for_without_strict(name: str) -> Shape:
+        shape = real_shape_for(name)
+        if name == 'ToolSpecification' and isinstance(shape, StructureShape):
+            object.__setattr__(shape, 'members', {k: v for k, v in shape.members.items() if k != 'strict'})
+        return shape
+
+    monkeypatch.setattr(service_model, 'shape_for', shape_for_without_strict)
+
+    tool_def = ToolDefinition(
+        name='get_weather',
+        description='Get the weather for a city',
+        parameters_json_schema={'type': 'object', 'properties': {'city': {'type': 'string'}}, 'required': ['city']},
+        strict=True,
+    )
+
+    with pytest.warns(UserWarning, match='installed `botocore` is too old'):
+        result = model._map_tool_definition(tool_def)  # pyright: ignore[reportPrivateUsage]
 
     assert result == snapshot(
         {

--- a/tests/models/bedrock/test_strict_tool_calls.py
+++ b/tests/models/bedrock/test_strict_tool_calls.py
@@ -145,7 +145,7 @@ def test_bedrock_strict_dropped_when_botocore_too_old(
 
     # `shape_for` builds a fresh `Shape` each call, so drop `strict` from `ToolSpecification`'s
     # members on every lookup to mimic a `botocore` that predates strict tool calls.
-    # `_supports_strict_tool_param` only ever looks up `ToolSpecification`.
+    # `_botocore_supports_strict_tool_param` only ever looks up `ToolSpecification`.
     service_model = model.client.meta.service_model
     real_shape_for = service_model.shape_for
 
@@ -189,7 +189,7 @@ def test_bedrock_strict_none_not_auto_promoted_end_to_end(
     25 simple `strict=None` tools fed through the real `customize_request_parameters`
     entry point must not be auto-promoted to `strict=True`. Bedrock (like Anthropic)
     caps strict tools at 20 per request, so silent promotion breaks any agent with
-    more than 20 tools — pure regression vs. 1.100 behavior.
+    more than 20 tools — a regression introduced in 1.100 by #4237.
     """
     model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
 

--- a/tests/models/bedrock/test_strict_tool_calls.py
+++ b/tests/models/bedrock/test_strict_tool_calls.py
@@ -19,6 +19,7 @@ from pydantic_ai import (
     UserPromptPart,
 )
 from pydantic_ai.agent import Agent
+from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.output import NativeOutput
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage
@@ -124,6 +125,55 @@ def test_bedrock_strict_tool_definition_none(
             }
         }
     )
+
+
+def test_bedrock_strict_none_not_auto_promoted_end_to_end(
+    allow_model_requests: None,
+    bedrock_provider: BedrockProvider,
+):
+    """Regression guard for https://github.com/pydantic/pydantic-ai/issues/5579.
+
+    25 simple `strict=None` tools fed through the real `customize_request_parameters`
+    entry point must not be auto-promoted to `strict=True`. Bedrock (like Anthropic)
+    caps strict tools at 20 per request, so silent promotion breaks any agent with
+    more than 20 tools — pure regression vs. 1.100 behavior.
+    """
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+
+    tools = [
+        ToolDefinition(
+            name=f'tool_{i}',
+            description=f'Tool number {i}',
+            parameters_json_schema={
+                'type': 'object',
+                'properties': {'arg': {'type': 'string'}},
+                'required': ['arg'],
+            },
+            strict=None,
+        )
+        for i in range(25)
+    ]
+    params = model.customize_request_parameters(ModelRequestParameters(function_tools=tools))
+
+    assert all(t.strict is not True for t in params.function_tools)
+
+
+def test_bedrock_strict_true_preserved_end_to_end(
+    allow_model_requests: None,
+    bedrock_provider: BedrockProvider,
+):
+    """Opt-in `strict=True` survives `customize_request_parameters` unchanged."""
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+
+    tool_def = ToolDefinition(
+        name='get_weather',
+        description='Get the weather for a city',
+        parameters_json_schema={'type': 'object', 'properties': {'city': {'type': 'string'}}, 'required': ['city']},
+        strict=True,
+    )
+    params = model.customize_request_parameters(ModelRequestParameters(function_tools=[tool_def]))
+
+    assert params.function_tools[0].strict is True
 
 
 async def test_bedrock_strict_tool_supported_model(

--- a/tests/models/bedrock/test_strict_tool_calls.py
+++ b/tests/models/bedrock/test_strict_tool_calls.py
@@ -29,7 +29,7 @@ from ...conftest import IsDatetime, IsStr, try_import
 from .conftest import CityInfo, PersonQuery
 
 with try_import() as imports_successful:
-    from botocore.model import Shape, StructureShape
+    from botocore.model import StructureShape
 
     from pydantic_ai.models.bedrock import BedrockConverseModel
     from pydantic_ai.providers.bedrock import BedrockProvider
@@ -145,13 +145,14 @@ def test_bedrock_strict_dropped_when_botocore_too_old(
 
     # `shape_for` builds a fresh `Shape` each call, so drop `strict` from `ToolSpecification`'s
     # members on every lookup to mimic a `botocore` that predates strict tool calls.
+    # `_supports_strict_tool_param` only ever looks up `ToolSpecification`.
     service_model = model.client.meta.service_model
     real_shape_for = service_model.shape_for
 
-    def shape_for_without_strict(name: str) -> Shape:
+    def shape_for_without_strict(name: str) -> StructureShape:
         shape = real_shape_for(name)
-        if name == 'ToolSpecification' and isinstance(shape, StructureShape):
-            object.__setattr__(shape, 'members', {k: v for k, v in shape.members.items() if k != 'strict'})
+        assert isinstance(shape, StructureShape)
+        object.__setattr__(shape, 'members', {k: v for k, v in shape.members.items() if k != 'strict'})
         return shape
 
     monkeypatch.setattr(service_model, 'shape_for', shape_for_without_strict)

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -364,7 +364,7 @@ def test_latest_bedrock_model_names_geo_prefixes_are_supported():
 
 
 def test_strict_true_simple_schema():
-    """With strict=True, simple schemas are returned (no-op transform), is_strict_compatible=True."""
+    """With strict=True, simple object schemas get Bedrock-required additionalProperties=false."""
 
     class Person(BaseModel):
         name: str
@@ -480,7 +480,12 @@ def test_strict_false_preserves_schema():
 
 
 def test_strict_none_preserves_schema():
-    """With strict=None (default), schema is preserved, is_strict_compatible=True when compatible."""
+    """With strict=None, strict-mode rewrites are skipped and is_strict_compatible=False.
+
+    Mirrors Anthropic: strict=None never auto-promotes to True — the caller must opt in
+    explicitly. See https://github.com/pydantic/pydantic-ai/issues/5579. `title` and
+    `$schema` are still stripped (always-on transformer behavior).
+    """
 
     class User(BaseModel):
         username: Annotated[str, Field(min_length=3)]
@@ -489,7 +494,7 @@ def test_strict_none_preserves_schema():
     transformer = BedrockJsonSchemaTransformer(User.model_json_schema(), strict=None)
     transformed = transformer.walk()
 
-    assert transformer.is_strict_compatible is True
+    assert transformer.is_strict_compatible is False
     assert transformed == snapshot(
         {
             'type': 'object',
@@ -498,13 +503,12 @@ def test_strict_none_preserves_schema():
                 'age': {'type': 'integer'},
             },
             'required': ['username', 'age'],
-            'additionalProperties': False,
         }
     )
 
 
 def test_strict_none_simple_schema():
-    """With strict=None, simple schemas are strict-compatible."""
+    """With strict=None, even simple schemas are not strict-compatible — opt-in required."""
 
     class Person(BaseModel):
         name: str
@@ -513,22 +517,20 @@ def test_strict_none_simple_schema():
     transformer = BedrockJsonSchemaTransformer(Person.model_json_schema(), strict=None)
     transformed = transformer.walk()
 
-    assert transformer.is_strict_compatible is True
+    assert transformer.is_strict_compatible is False
     assert transformed == snapshot(
         {
             'type': 'object',
             'properties': {'name': {'type': 'string'}, 'age': {'type': 'integer'}},
             'required': ['name', 'age'],
-            'additionalProperties': False,
         }
     )
 
 
-def test_strict_none_incompatible_schema_disables_auto_strict():
-    """With strict=None and constrained fields, is_strict_compatible=False.
+def test_strict_none_never_strict_compatible():
+    """With strict=None and constrained fields, is_strict_compatible=False and constraints survive.
 
-    This ensures strict is NOT auto-enabled for tools with constrained schemas,
-    mirroring the Anthropic test_strict_tools_incompatible_schema_not_auto_enabled.
+    Mirrors the Anthropic transformer's stance — strict=None is never auto-promoted.
     """
 
     class ConstrainedInput(BaseModel):
@@ -548,7 +550,6 @@ def test_strict_none_incompatible_schema_disables_auto_strict():
                 'count': {'minimum': 0, 'type': 'integer'},
             },
             'required': ['username', 'count'],
-            'additionalProperties': False,
         }
     )
 
@@ -875,6 +876,5 @@ def test_strict_none_preserves_numeric_constraints():
                 'score': {'type': 'number', 'minimum': 0.0, 'maximum': 100.0},
             },
             'required': ['score'],
-            'additionalProperties': False,
         }
     )


### PR DESCRIPTION
- Closes #5579

`BedrockJsonSchemaTransformer` (added in 1.100 via #4237) auto-promoted `strict=None` tools to `strict=True` whenever the schema looked compatible, silently breaking agents with more than ~20 tools because Bedrock/Anthropic cap strict tools at 20 per request. Restores 1.99 behavior for the default path; explicit `strict=True` is unchanged, and `NativeOutput` still forces `strict=True` before request customization so structured-output is unaffected.

Additionally, `_map_tool_definition` now gates `toolSpec.strict` on the installed `botocore`: a `botocore` predating strict tool calls validates it out with a `ParamValidationError` regardless of model support (notably on AWS Lambda, where the runtime's bundled `botocore` shadows a newer layer-provided one). When unsupported, `strict` is dropped with a `UserWarning` instead of crashing.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).