### PR TITLE
fix: gate Bedrock Anthropic structured output behind an explicit allowlist

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -175,9 +175,17 @@ class BedrockModelProfile(ModelProfile):
 
 def bedrock_anthropic_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for an Anthropic model used via Bedrock."""
-    # Opus 4.1 supports structured output on the direct Anthropic API but is not listed
-    # in the Bedrock docs: https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
-    bedrock_structured_output_unsupported = ('claude-opus-4-1',)
+    # Anthropic models confirmed for structured output on the Bedrock Runtime Converse path
+    # (`outputConfig.textFormat`), per https://platform.claude.com/docs/en/build-with-claude/structured-outputs.
+    # Closed-by-default so a newly-added Anthropic model doesn't inherit Bedrock structured-output
+    # support before AWS confirms it (e.g. Opus 4.7 is listed there as Messages-API-only).
+    bedrock_structured_output_supported = (
+        'claude-haiku-4-5',
+        'claude-sonnet-4-5',
+        'claude-sonnet-4-6',
+        'claude-opus-4-5',
+        'claude-opus-4-6',
+    )
     downstream = anthropic_model_profile(model_name)
     # Read anthropic_* capability flags before update() strips them: ModelProfile.update()
     # only copies fields that exist on self, so anthropic-prefixed fields would be lost.
@@ -196,8 +204,8 @@ def bedrock_anthropic_model_profile(model_name: str) -> ModelProfile | None:
         bedrock_supports_adaptive_thinking=supports_adaptive,
         bedrock_supports_effort=supports_effort,
     ).update(_without_builtin_tools(downstream))
-    supports_structured_output = profile.supports_json_schema_output and not model_name.startswith(
-        bedrock_structured_output_unsupported
+    supports_structured_output = profile.supports_json_schema_output and model_name.startswith(
+        bedrock_structured_output_supported
     )
     return replace(
         profile,

--- a/tests/providers/test_bedrock.py
+++ b/tests/providers/test_bedrock.py
@@ -136,6 +136,20 @@ def test_bedrock_provider_model_profile(env: TestEnv, mocker: MockerFixture):
     assert anthropic_profile.bedrock_supports_adaptive_thinking is False
     assert anthropic_profile.bedrock_supports_effort is False
 
+    # Opus 4.7 supports structured output on the direct Anthropic API but Bedrock lists it as
+    # Messages-API-only, so it stays off the closed-by-default allowlist.
+    anthropic_profile = provider.model_profile('us.anthropic.claude-opus-4-7-20251101-v1:0')
+    anthropic_model_profile_mock.assert_called_with('claude-opus-4-7-20251101')
+    assert isinstance(anthropic_profile, BedrockModelProfile)
+    assert anthropic_profile.supports_json_schema_output is False
+    assert anthropic_profile.bedrock_supports_strict_tool_definition is False
+
+    anthropic_profile = provider.model_profile('us.anthropic.claude-haiku-4-5-20251001-v1:0')
+    anthropic_model_profile_mock.assert_called_with('claude-haiku-4-5-20251001')
+    assert isinstance(anthropic_profile, BedrockModelProfile)
+    assert anthropic_profile.supports_json_schema_output is True
+    assert anthropic_profile.bedrock_supports_strict_tool_definition is True
+
     anthropic_profile = provider.model_profile('us.anthropic.claude-sonnet-4-5-20250929-v1:0')
     anthropic_model_profile_mock.assert_called_with('claude-sonnet-4-5-20250929')
     assert isinstance(anthropic_profile, BedrockModelProfile)
@@ -147,6 +161,8 @@ def test_bedrock_provider_model_profile(env: TestEnv, mocker: MockerFixture):
     anthropic_profile = provider.model_profile('us.anthropic.claude-opus-4-5-20251101-v1:0')
     anthropic_model_profile_mock.assert_called_with('claude-opus-4-5-20251101')
     assert isinstance(anthropic_profile, BedrockModelProfile)
+    assert anthropic_profile.supports_json_schema_output is True
+    assert anthropic_profile.bedrock_supports_strict_tool_definition is True
     # Opus 4.5 supports `effort` on the direct Anthropic API but Bedrock only honors it
     # alongside adaptive thinking, so the Bedrock flag must stay False here.
     assert anthropic_profile.bedrock_supports_adaptive_thinking is False
@@ -162,6 +178,8 @@ def test_bedrock_provider_model_profile(env: TestEnv, mocker: MockerFixture):
     anthropic_profile = provider.model_profile('us.anthropic.claude-opus-4-6-20251015-v1:0')
     anthropic_model_profile_mock.assert_called_with('claude-opus-4-6-20251015')
     assert isinstance(anthropic_profile, BedrockModelProfile)
+    assert anthropic_profile.supports_json_schema_output is True
+    assert anthropic_profile.bedrock_supports_strict_tool_definition is True
     assert anthropic_profile.bedrock_supports_adaptive_thinking is True
     assert anthropic_profile.bedrock_supports_effort is True
 


### PR DESCRIPTION
- Closes #5581

`bedrock_anthropic_model_profile` derived Bedrock structured-output support from the direct Anthropic model profile minus a one-entry denylist (`claude-opus-4-1`). That open-by-default approach let any newly-added structured-output-capable Anthropic model inherit `supports_json_schema_output=True` (and `bedrock_supports_strict_tool_definition=True`) for Bedrock before AWS confirmed support on the Bedrock Runtime Converse path.

Claude Opus 4.7 hit this: it is structured-output-capable on the direct Anthropic API, but [Anthropic's docs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs) list it as available only through the Messages-API Bedrock endpoint — not the Bedrock Runtime `outputConfig.textFormat` path `BedrockConverseModel` uses. So Bedrock Opus 4.7 reported `supports_json_schema_output=True`, `NativeOutput` was selected, and `outputConfig` was sent on a path AWS rejects.

This replaces the denylist with a closed-by-default allowlist of the Anthropic models AWS confirms for Bedrock Runtime structured output (Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6), matching the pattern already used by every other Bedrock model family (`mistral`, `qwen`, `google`). The result is **identical to the previous behavior for every model except Opus 4.7**, which now correctly falls back to prompted output — the direct Anthropic profile only marks 7 models structured-output-capable, and the allowlist is exactly those minus `claude-opus-4-1` (already excluded) and `claude-opus-4-7` (the bug).

**Alternative considered:** a minimal one-line denylist addition (`claude-opus-4-7`). The allowlist was chosen because the denylist has now needed manual patching twice for the same bug class (Opus 4.1, Opus 4.7) and leaves the next new model exposed. Happy to switch to the minimal fix if maintainers prefer narrower scope.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).