### PR TITLE
docs(openai): add Auxen as OpenAI-compatible provider example

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -375,6 +375,29 @@ model = OpenAIChatModel(
 agent = Agent(model)
 ```
 
+### Auxen
+
+[Auxen](https://auxen.ai) hosts per-customer **dedicated** LLM endpoints (Llama 3.1/3.2, Qwen 2.5, Mistral, Gemma 2, Mixtral, Phi-3, Command R) with an OpenAI-compatible `/v1/chat/completions` API. Each instance is a dedicated GPU billed per-minute of runtime — no token charges, no monthly minimums.
+
+Because every Auxen instance has its own per-instance base URL of the form `https://api.auxen.ai/v1/inst_xxx/v1` (issued by the Auxen dashboard), there is no shared default endpoint, so the integration uses [`OpenAIProvider`][pydantic_ai.providers.openai.OpenAIProvider] with explicit `base_url` and `api_key`:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+model = OpenAIChatModel(
+    'llama-3.1-8b',  # the model your instance is provisioned to serve
+    provider=OpenAIProvider(
+        base_url='https://api.auxen.ai/v1/inst_xxx/v1',  # from the Auxen dashboard
+        api_key='auxk_...',                              # from the Auxen dashboard
+    ),
+)
+agent = Agent(model)
+```
+
+Auxen-hosted models include: `llama-3.1-8b`, `llama-3.1-70b`, `llama-3.2-3b`, `qwen2.5-7b`, `qwen2.5-14b`, `qwen2.5-32b`, `mistral-7b`, `mistral-nemo-12b`, `mixtral-8x7b`, `gemma2-9b`, `phi-3-mini`, `command-r-7b`. Each instance is provisioned with one model at creation time. See [auxen.ai/pricing](https://auxen.ai/pricing) for per-minute hourly rates.
+
 ### DeepSeek
 
 To use the [DeepSeek](https://deepseek.com) provider, first create an API key by following the [Quick Start guide](https://api-docs.deepseek.com/).


### PR DESCRIPTION
Adds an Auxen section to \`docs/models/openai.md\` under "OpenAI-compatible Models", positioned before the existing DeepSeek entry.

[Auxen](https://auxen.ai) hosts per-customer **dedicated** LLM endpoints (Llama 3.1/3.2, Qwen 2.5, Mistral, Gemma 2, Mixtral, Phi-3, Command R) with an OpenAI-compatible \`/v1/chat/completions\` API. Each instance is a dedicated GPU billed per-minute of runtime.

## Docs-only on purpose

Unlike the existing named providers (Fireworks, Together, DeepSeek, etc.) which have fixed shared base URLs, **every Auxen instance has its own per-instance base URL** of the form \`https://api.auxen.ai/v1/inst_xxx/v1\`. There is no shared default endpoint to encode in a dedicated provider class, so the docs use the generic \`OpenAIProvider\` with explicit \`base_url\` and \`api_key\` — same shape the docs already recommend for arbitrary OpenAI-compatible endpoints.

Happy to also add a dedicated \`AuxenProvider\` class (that takes \`base_url\` and \`api_key\` as required arguments) if the team would prefer that shape — let me know.

## Companion PRs (Auxen distribution series)

- [BerriAI/litellm#28532](https://github.com/BerriAI/litellm/pull/28532) — LiteLLM provider
- [vercel/ai#15536](https://github.com/vercel/ai/pull/15536) — Vercel AI SDK community provider
- [langchain-ai/docs#4146](https://github.com/langchain-ai/docs/pull/4146) — LangChain docs (Python + JS)
- [run-llama/llama_index#21764](https://github.com/run-llama/llama_index/pull/21764) — LlamaIndex Python
- [continuedev/continue#12473](https://github.com/continuedev/continue/pull/12473) — Continue.dev provider
- [cline/cline#10988](https://github.com/cline/cline/pull/10988) — Cline OpenAI-compatible quickstart
- [crewAIInc/crewAI#5911](https://github.com/crewAIInc/crewAI/pull/5911) — CrewAI provider config
- [Helicone/helicone#5685](https://github.com/Helicone/helicone/pull/5685) — Helicone gateway
- [langfuse/langfuse-docs#2990](https://github.com/langfuse/langfuse-docs/pull/2990) — Langfuse provider page
- npm: [\`@auxen/ai-sdk-provider\`](https://www.npmjs.com/package/@auxen/ai-sdk-provider) (live)

AI agent (Claude) assisted in drafting this PR.