### PR TITLE
Normalize trailing dot and case in `WebFetchTool` domain matching

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_ssrf.py
+++ b/pydantic_ai_slim/pydantic_ai/_ssrf.py
@@ -206,6 +206,12 @@ def extract_host_and_port(url: str) -> tuple[str, str, int, bool]:
     parsed = urlparse(url)
     hostname = parsed.hostname
 
+    # Strip the trailing-dot (FQDN root label): DNS treats `host.` and `host` as the same,
+    # so leaving it in would bypass exact-match domain allow/blocklists and skip the
+    # IP-literal fast path (e.g. `169.254.169.254.`). urlparse already lowercases the host.
+    if hostname:
+        hostname = hostname.rstrip('.')
+
     if not hostname:
         raise ValueError(f'Invalid URL: no hostname found in "{url}"')
 

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -787,6 +787,13 @@ class TestSafeDownload:
         with pytest.raises(ValueError, match='is blocked'):
             await safe_download('https://evil.com/page', blocked_domains=['evil.com'])
 
+    @pytest.mark.parametrize('url', ['https://evil.com./page', 'https://EVIL.com/page', 'https://Evil.Com./page'])
+    async def test_blocked_domains_normalizes_host(self, url: str, mock_dns: AsyncMock) -> None:
+        """A trailing FQDN dot or uppercasing must not bypass the blocked-domains list."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        with pytest.raises(ValueError, match='is blocked'):
+            await safe_download(url, blocked_domains=['evil.com'])
+
     async def test_blocked_domains_permits(self, mock_dns: AsyncMock, mock_ssrf_client: MagicMock) -> None:
         """Test that non-blocked domain passes validation."""
         mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -781,6 +781,23 @@ class TestSafeDownload:
         with pytest.raises(ValueError, match='not in the allowed domains'):
             await safe_download('https://evil.com/page', allowed_domains=['example.com'])
 
+    @pytest.mark.parametrize(
+        'url', ['https://example.com./page', 'https://EXAMPLE.com/page', 'https://Example.Com./page']
+    )
+    async def test_allowed_domains_normalizes_host(
+        self, url: str, mock_dns: AsyncMock, mock_ssrf_client: MagicMock
+    ) -> None:
+        """A trailing FQDN dot or uppercasing must not cause false rejection by the allowed-domains list."""
+        mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]
+        mock_response = AsyncMock()
+        mock_response.is_redirect = False
+        mock_response.raise_for_status = lambda: None
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_ssrf_client.return_value = mock_client
+
+        await safe_download(url, allowed_domains=['example.com'])
+
     async def test_blocked_domains_blocks(self, mock_dns: AsyncMock) -> None:
         """Test that blocked domain is rejected."""
         mock_dns.return_value = [(2, 1, 6, '', ('93.184.215.14', 0))]


### PR DESCRIPTION
`pydantic_ai/_ssrf.py` exposes `safe_download(..., allowed_domains=, blocked_domains=)`, used by the local `WebFetchTool` / `WebFetchLocalTool` for exact-match hostname filtering. `urlparse()` lowercases the host but does not strip a trailing FQDN-root dot, so:

- `blocked_domains=['evil.com']` was bypassed by a URL host `evil.com.` (DNS treats `evil.com.` == `evil.com`, but the exact-string match did not).
- `allowed_domains=['example.com']` wrongly rejected `example.com.` (fail-closed correctness bug).

This normalizes the hostname (strips the trailing root dot) at the single choke point `extract_host_and_port()` that all callers go through, so every downstream check (IP-literal detection, `_check_domain`, the `Host` header, SNI) reads the normalized hostname.

This is a low-severity hardening of an optional policy filter, not a security advisory: the trailing-dot host has to be emitted by the model/agent itself, and the IP-level SSRF guards (private ranges + cloud-metadata) are unaffected since they canonicalize via DNS resolution.

<!-- No issue: trivial low-severity hardening of an optional filter. -->

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
