### PR TITLE
docs: add pydantic-ai-ejentum to Third-Party Toolsets

### DIFF
--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -958,3 +958,20 @@ toolset = ACIToolset(
 
 agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 ```
+
+### pydantic-ai-ejentum {#ejentum-tools}
+
+[`pydantic-ai-ejentum`](https://pypi.org/project/pydantic-ai-ejentum/) wraps the [Ejentum Reasoning Harness](https://ejentum.com) as a `FunctionToolset` subclass. `EjentumToolset` registers four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). The agent calls one before generating; each call returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) that the model reads internally to shape its next response.
+
+You will need to install the `pydantic-ai-ejentum` package and set your Ejentum API key in the `EJENTUM_API_KEY` environment variable (free and paid tiers at <https://ejentum.com/pricing>), or pass `api_key=` to the constructor.
+
+```python {test="skip" lint="skip"}
+from pydantic_ai import Agent
+from pydantic_ai_ejentum import EjentumToolset
+
+toolset = EjentumToolset()
+
+agent = Agent('openai:gpt-5.2', toolsets=[toolset])
+```
+
+The toolset emits PydanticAI `instructions` that nudge the agent to call the matching `harness_*` tool before generating. Pass `add_instructions=False` to suppress and supply routing guidance from your own system prompt.


### PR DESCRIPTION
## Summary

Per maintainer guidance on #5593 ([pydanty bot status update](https://github.com/pydantic/pydantic-ai/issues/5593)), this PR adds an entry for `pydantic-ai-ejentum` under the **Third-Party Toolsets** section of `docs/toolsets.md`.

The entry follows the format set by **LangChain Tools** and **ACI.dev Tools**:

- Level 3 heading: `### pydantic-ai-ejentum {#ejentum-tools}`
- Concise functional summary (no marketing language)
- Install pointer with `EJENTUM_API_KEY` env-var guidance and the pricing-page link for the API key
- Code example wrapped in `{test="skip" lint="skip"}` so CI passes without external API keys
- Trailing paragraph documenting the `add_instructions=False` knob

## What the package does

`EjentumToolset` subclasses `FunctionToolset` and registers four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). The agent calls one before generating; each call returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) that the model reads internally before producing its user-facing answer.

## Test plan

- [x] No code changes; doc-only PR
- [x] `{test="skip" lint="skip"}` metadata on the code block per maintainer guidance
- [x] Voice scrub: no em dashes, no \"powerful\", \"best-in-class\", or other marketing language
- [x] Format matches the existing `LangChain Tools` and `ACI.dev Tools` subsections in the same file

## Links

- Issue: #5593
- Package: https://pypi.org/project/pydantic-ai-ejentum/
- Source: https://github.com/ejentum/pydantic-ai-ejentum
- Free and paid tiers: https://ejentum.com/pricing

## Note on the Capabilities abstraction

The maintainer status update on #5593 noted the newer `Capabilities` abstraction (`AbstractCapability`) is the preferred pattern for integrations that bundle tools with instructions or hooks. This PR keeps the docs entry pointed at the current `FunctionToolset`-based release (`0.1.0`) so users land on a runnable example today. Happy to follow up with a `Capabilities`-based 0.2.0 once the upstream API surface stabilizes; will mirror the docs change at that point.

Closes #5593 (if maintainers consider docs-listing the resolution).