### PR TITLE
ci(ui-security-review): make non-voting until check-runs land

### DIFF
--- a/.github/workflows/pydantic-ai-ui-security-review.lock.yml
+++ b/.github/workflows/pydantic-ai-ui-security-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e147b7145e20250619ce7aa5722ba74f69f7839832f2be06252c853c2dd4a4ff","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8560231ea4da6bfdd8f6de99872bb6ef1e1796c1e6857d37432e9c0370e92d03","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_READ_EXTERNAL_VARIABLES","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Security review of UI-adapter PRs (Vercel AI + AG-UI): audits the client/server trust boundary for outbound leakage and inbound abuse. Inline comments + a single review verdict. Prompt iterable from a Logfire managed variable; read-only via gh-aw safe-outputs.
+# Security review of UI-adapter PRs (Vercel AI + AG-UI): audits the client/server trust boundary for outbound leakage and inbound abuse. Inline comments + a non-voting COMMENT-type review summary (pydantic-ai-pr-review owns the merge-gate verdict until gh-aw check-runs land). Prompt iterable from a Logfire managed variable; read-only via gh-aw safe-outputs.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -239,20 +239,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_369528e1bec44d8c_EOF'
+          cat << 'GH_AW_PROMPT_96525dcb8e4b2795_EOF'
           <system>
-          GH_AW_PROMPT_369528e1bec44d8c_EOF
+          GH_AW_PROMPT_96525dcb8e4b2795_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_369528e1bec44d8c_EOF'
+          cat << 'GH_AW_PROMPT_96525dcb8e4b2795_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:30), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_369528e1bec44d8c_EOF
+          GH_AW_PROMPT_96525dcb8e4b2795_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_369528e1bec44d8c_EOF'
+          cat << 'GH_AW_PROMPT_96525dcb8e4b2795_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -284,13 +284,13 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_369528e1bec44d8c_EOF
+          GH_AW_PROMPT_96525dcb8e4b2795_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_369528e1bec44d8c_EOF'
+          cat << 'GH_AW_PROMPT_96525dcb8e4b2795_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
           {{#runtime-import .github/workflows/pydantic-ai-ui-security-review.md}}
-          GH_AW_PROMPT_369528e1bec44d8c_EOF
+          GH_AW_PROMPT_96525dcb8e4b2795_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -515,9 +515,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_847d113d2819d996_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3fbf0d18936c58e4_EOF'
           {"create_pull_request_review_comment":{"max":30,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"footer":"none","max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_847d113d2819d996_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_3fbf0d18936c58e4_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -741,7 +741,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_ca925ea05074edbe_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_33afeb8479a77042_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -771,7 +771,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_ca925ea05074edbe_EOF
+          GH_AW_MCP_CONFIG_33afeb8479a77042_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1316,7 +1316,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: "Pydantic AI UI Security Review"
-          WORKFLOW_DESCRIPTION: "Security review of UI-adapter PRs (Vercel AI + AG-UI): audits the client/server trust boundary for outbound leakage and inbound abuse. Inline comments + a single review verdict. Prompt iterable from a Logfire managed variable; read-only via gh-aw safe-outputs."
+          WORKFLOW_DESCRIPTION: "Security review of UI-adapter PRs (Vercel AI + AG-UI): audits the client/server trust boundary for outbound leakage and inbound abuse. Inline comments + a non-voting COMMENT-type review summary (pydantic-ai-pr-review owns the merge-gate verdict until gh-aw check-runs land). Prompt iterable from a Logfire managed variable; read-only via gh-aw safe-outputs."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |

--- a/.github/workflows/pydantic-ai-ui-security-review.md
+++ b/.github/workflows/pydantic-ai-ui-security-review.md
@@ -1,7 +1,7 @@
 ---
 emoji: "🛡️"
 name: "Pydantic AI UI Security Review"
-description: "Security review of UI-adapter PRs (Vercel AI + AG-UI): audits the client/server trust boundary for outbound leakage and inbound abuse. Inline comments + a single review verdict. Prompt iterable from a Logfire managed variable; read-only via gh-aw safe-outputs."
+description: "Security review of UI-adapter PRs (Vercel AI + AG-UI): audits the client/server trust boundary for outbound leakage and inbound abuse. Inline comments + a non-voting COMMENT-type review summary (pydantic-ai-pr-review owns the merge-gate verdict until gh-aw check-runs land). Prompt iterable from a Logfire managed variable; read-only via gh-aw safe-outputs."
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
@@ -88,6 +88,12 @@ safe-outputs:
   noop:
   create-pull-request-review-comment:
     max: 30
+  # Non-voting by design: the prompt restricts the event to COMMENT only,
+  # because both this workflow and pydantic-ai-pr-review submit reviews as
+  # `github-actions[bot]` and GitHub's merge-gate uses the latest verdict
+  # per reviewer login — an APPROVE/REQUEST_CHANGES from here would
+  # overwrite pr-review's. To be reconsidered when gh-aw supports check
+  # runs (https://github.com/githubnext/gh-aw — Bill Easton's WIP).
   submit-pull-request-review:
     max: 1
 timeout-minutes: 30

--- a/.github/workflows/shared/prompts/pydantic-ai-ui-security-review.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-ui-security-review.md
@@ -28,6 +28,14 @@ This PR was selected because it touches the **UI adapters** or the
 the client/server trust boundary. Say nothing about style, naming, typing, or
 test coverage unless it has a concrete security consequence.
 
+This workflow is **non-voting**. GitHub identifies both this bot and the
+general `pydantic-ai-pr-review` bot as `github-actions[bot]`, so submitting
+an `APPROVE` or `REQUEST_CHANGES` verdict here would silently overwrite the
+other bot's verdict on the merge gate. Your review submission is always
+`COMMENT`-type (see Step 5); the security outcome lives in the body header
+and the inline findings. The merge gate stays with `pydantic-ai-pr-review`
+until check-runs support lands in gh-aw.
+
 ## Why this review exists
 
 The UI adapters (`pydantic_ai_slim/pydantic_ai/ui/` — the Vercel AI SDK
@@ -274,12 +282,19 @@ For each surviving finding, call
 
 Then call `mcp__safeoutputs__submit_pull_request_review` with:
 
-- **type:** `REQUEST_CHANGES` if any HIGH or CRITICAL finding survived, else
-  `APPROVE`.
-- **body:** empty for `APPROVE` with no findings. For `REQUEST_CHANGES`,
-  state only the security verdict and any cross-cutting concern that can't
-  be inlined (e.g. "inbound validation added to the Vercel adapter only —
-  AG-UI inherits nothing"). Do not summarize the PR.
+- **type:** **always `COMMENT`** — never `APPROVE` or `REQUEST_CHANGES`.
+  This workflow is informational (see intro); the general
+  `pydantic-ai-pr-review` workflow owns the merge-gate verdict, and both
+  bots post as `github-actions[bot]`, so a verdict from here would
+  overwrite that one.
+- **body:** open with a single-line security-outcome header so a reviewer
+  scanning the PR sees the result at a glance:
+  - no findings → `SECURITY: PASS`
+  - any HIGH or CRITICAL surviving → `SECURITY: REQUEST_CHANGES (N high, M critical)`
+  After the header, include only cross-cutting concerns that can't be
+  inlined (e.g. "inbound validation added to the Vercel adapter only —
+  AG-UI inherits nothing"). Do not summarize the PR or restate inline
+  findings.
 
 **Severity:**
 
@@ -292,15 +307,13 @@ Then call `mcp__safeoutputs__submit_pull_request_review` with:
   a flag whose *default* is the insecure setting).
 - **LOW** — defense-in-depth gap with no concrete attack path.
 
-Both HIGH and CRITICAL map the verdict to `REQUEST_CHANGES`.
+HIGH and CRITICAL drive the `SECURITY: REQUEST_CHANGES` body header. The
+review submission itself is always `COMMENT`-type — see above.
 
-**Skip if redundant:** if you have zero new findings and your verdict
-matches this bot's most recent review (in `review-comments.txt`), call
-`mcp__safeoutputs__noop` with a short reason instead of a redundant review.
-
-**Bot-authored PRs:** GitHub forbids `APPROVE` / `REQUEST_CHANGES` from a bot
-reviewing another bot's PR. If the PR author is a bot, submit a `COMMENT`
-review with the verdict in the body.
+**Skip if redundant:** if you have zero new findings and the most recent
+review from this bot (in `review-comments.txt`) was also `SECURITY: PASS`,
+call `mcp__safeoutputs__noop` with a short reason instead of a redundant
+review.
 
 ## What not to do (recap)
 


### PR DESCRIPTION
<!-- Follow-up to #5591 — addresses Bill Easton's note that two PR-review bots posting as `github-actions[bot]` race for the merge-gate verdict. -->

## Summary

Both `pydantic-ai-pr-review` and the new `pydantic-ai-ui-security-review` (added in #5591) post reviews as `github-actions[bot]`. GitHub's review-decision logic uses the **latest verdict per reviewer login**, so on UI PRs the second workflow to finish overwrites the first — a `REQUEST_CHANGES` from this workflow could be erased by a later `APPROVE` from pr-review, or vice versa.

Bill called this out [in Slack](https://github.com/pydantic/pydantic-ai/pull/5591) and is working on **check-runs** support in gh-aw — once that lands, this workflow will own its own per-workflow Check Run and can carry a real verdict again. Until then, this PR makes the workflow **non-voting**:

- `submit-pull-request-review` is restricted to `event: COMMENT` (prompt-enforced; the workflow's `safe-outputs` block documents the rationale).
- The security outcome moves into the review body header: `SECURITY: PASS` or `SECURITY: REQUEST_CHANGES (N high, M critical)`. Inline findings are unchanged.
- The merge-gate verdict stays with `pydantic-ai-pr-review`.

A reviewer scanning the PR still sees the security verdict at a glance (body header + inline comments). The collision is resolved.

## Files

- `.github/workflows/pydantic-ai-ui-security-review.md` — `safe-outputs` comment documenting non-voting design; frontmatter description updated.
- `.github/workflows/shared/prompts/pydantic-ai-ui-security-review.md` — non-voting note in intro; Step 5 verdict block now always emits `COMMENT`; severity mapping retargeted to the body header; bot-authored clause removed (always-`COMMENT` makes it moot).
- `.github/workflows/pydantic-ai-ui-security-review.lock.yml` — recompiled (`gh aw compile`).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)