### PR TITLE
fix: preserve `ThinkingPart.id` in AG-UI round-trips

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -419,18 +419,24 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                         )
 
                 case ReasoningMessage() as reasoning_msg:
+                    invalid_metadata = False
                     try:
                         metadata: dict[str, Any] = (
                             json.loads(reasoning_msg.encrypted_value) if reasoning_msg.encrypted_value else {}
                         )
                         if not isinstance(metadata, dict):
                             metadata = {}
+                            invalid_metadata = True
                     except json.JSONDecodeError:
                         metadata = {}
+                        invalid_metadata = True
+                    thinking_id = metadata.get('id')
+                    if thinking_id is None and not invalid_metadata:
+                        thinking_id = reasoning_msg.id
                     builder.add(
                         ThinkingPart(
                             content=reasoning_msg.content,
-                            id=metadata.get('id') or reasoning_msg.id,
+                            id=thinking_id,
                             signature=metadata.get('signature'),
                             provider_name=metadata.get('provider_name'),
                             provider_details=metadata.get('provider_details'),

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -430,7 +430,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     builder.add(
                         ThinkingPart(
                             content=reasoning_msg.content,
-                            id=metadata.get('id'),
+                            id=metadata.get('id') or reasoning_msg.id,
                             signature=metadata.get('signature'),
                             provider_name=metadata.get('provider_name'),
                             provider_details=metadata.get('provider_details'),
@@ -619,7 +619,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     encrypted = thinking_encrypted_metadata(part)
                     result.append(
                         ReasoningMessage(
-                            id=_new_message_id(),
+                            id=part.id or _new_message_id(),
                             content=part.content,
                             encrypted_value=json.dumps(encrypted) if encrypted else None,
                         )

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1573,6 +1573,38 @@ def test_dump_load_roundtrip_thinking() -> None:
     assert reloaded == original
 
 
+def test_dump_load_roundtrip_thinking_uses_reasoning_message_id() -> None:
+    """Test that a generated ReasoningMessage ID is retained when ThinkingPart.id is unset."""
+    original: list[ModelMessage] = [
+        ModelResponse(parts=[ThinkingPart(content='Let me think...')]),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original, ag_ui_version='0.1.13')
+    reasoning_msg = ag_ui_msgs[0]
+    assert isinstance(reasoning_msg, ReasoningMessage)
+    assert reasoning_msg.id
+    assert reasoning_msg.encrypted_value is None
+
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    response = reloaded[0]
+    assert isinstance(response, ModelResponse)
+    thinking_part = response.parts[0]
+    assert isinstance(thinking_part, ThinkingPart)
+    assert thinking_part.id == reasoning_msg.id
+
+
+def test_dump_load_roundtrip_thinking_sets_reasoning_message_id() -> None:
+    """Test that an explicit ThinkingPart.id is also used as the AG-UI ReasoningMessage ID."""
+    original: list[ModelMessage] = [
+        ModelResponse(parts=[ThinkingPart(content='Let me think...', id='thinking-123')]),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original, ag_ui_version='0.1.13')
+    reasoning_msg = ag_ui_msgs[0]
+    assert isinstance(reasoning_msg, ReasoningMessage)
+    assert reasoning_msg.id == 'thinking-123'
+
+
 def test_dump_load_roundtrip_tools() -> None:
     """Test full round-trip for tool calls and returns."""
     original: list[ModelMessage] = [

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1415,6 +1415,36 @@ def test_reasoning_message_thinking_roundtrip() -> None:
     )
 
 
+def test_reasoning_message_thinking_uses_message_id_when_metadata_id_missing() -> None:
+    """Test that valid metadata without an ID falls back to the ReasoningMessage ID."""
+    messages = AGUIAdapter.load_messages(
+        [
+            ReasoningMessage(
+                id='reasoning-1',
+                content='Let me think about this...',
+                encrypted_value=json.dumps({'signature': 'sig_abc123'}),
+            ),
+            AssistantMessage(id='msg-1', content='Here is my response'),
+        ]
+    )
+
+    assert messages == snapshot(
+        [
+            ModelResponse(
+                parts=[
+                    ThinkingPart(
+                        content='Let me think about this...',
+                        id='reasoning-1',
+                        signature='sig_abc123',
+                    ),
+                    TextPart(content='Here is my response'),
+                ],
+                timestamp=IsDatetime(),
+            )
+        ]
+    )
+
+
 async def test_reasoning_events_with_all_metadata() -> None:
     """Test that REASONING_* events emit encryptedValue with all metadata fields."""
     run_input = create_input(UserMessage(id='msg_1', content='test'))
@@ -2016,6 +2046,7 @@ async def test_thinking_roundtrip_anthropic(allow_model_requests: None, anthropi
                 parts=[
                     ThinkingPart(
                         content='The user is asking what 1+1 equals and wants a one-word reply. The answer is 2, which is one word.',
+                        id=IsStr(),
                         signature='EooCCkYICxgCKkDYW6Ka+Mo73ZE34HVijmFbdV6QH/iRdv+3WuisH3pR8D5aSFASMBsF1F1bZRQFQXuM0+G4H83czthKvHqdqWriEgwB0eJaWoXZWU18NKoaDMH4nN8ZwJ6W9DnYLyIwrdTWmfc5QTqDr8gye3/yrPpV2YPeZnUBoHBLOGl8MUaC6SuGmxcm8rGqf2s+P+ZtKnJPJJzQiTrvPcEkF3ij22w3bXC9yoyZCyJVPcibR2ZZpLYF/UOoZ+BRBs0FCdm/QFXUUe8W1tcQ/ZQgBaW44LTcdzwOSP5hJb25UrPiGWuTytGMxIr7QyG7INpVbmm8JRBIIEzj3gs2zlxdbl17yZ/yZXcYAQ==',
                         provider_name='anthropic',
                     ),


### PR DESCRIPTION
- Closes #5599

### Summary

- Preserve explicit `ThinkingPart.id` values as AG-UI `ReasoningMessage.id` when dumping messages.
- Fall back to `ReasoningMessage.id` when loading reasoning messages without encrypted metadata IDs.
- Add regression coverage for both generated and explicit thinking IDs.

### Tests

- `/tmp/pydantic-ai-pr-venv/bin/python -m pytest --rootdir . -c /dev/null -o cache_dir=/tmp/pydantic-ai-pytest-cache tests/test_ag_ui.py::test_dump_load_roundtrip_thinking tests/test_ag_ui.py::test_dump_load_roundtrip_thinking_uses_reasoning_message_id tests/test_ag_ui.py::test_dump_load_roundtrip_thinking_sets_reasoning_message_id tests/test_ag_ui.py::test_dump_load_roundtrip_multiple_thinking_parts`
- `/tmp/pydantic-ai-pr-venv/bin/python -m py_compile pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`
- `git diff --check`
- `/tmp/pydantic-ai-pr-venv/bin/ruff format --check pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).