### PR TITLE
docs: fix broken A2A protocol link in a2a.md

### DIFF
--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -16,7 +16,7 @@
     app = agent_to_a2a(agent)
     ```
 
-The [Agent2Agent (A2A) Protocol](https://google.github.io/A2A/) is an open standard introduced by Google that enables
+The [Agent2Agent (A2A) Protocol](https://a2a-protocol.org/) is an open standard introduced by Google that enables
 communication and interoperability between AI agents, regardless of the framework or vendor they are built on.
 
 At Pydantic, we built the [FastA2A](#fasta2a) library to make it easier to implement the A2A protocol in Python. It is now maintained at [datalayer/fasta2a](https://github.com/datalayer/fasta2a) and ships a Pydantic AI bridge since [v0.6.1](https://github.com/datalayer/fasta2a/releases/tag/v0.6.1) — install it with the `pydantic-ai` extra and use `agent_to_a2a` to expose a Pydantic AI agent as an A2A server:


### PR DESCRIPTION
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

- Closes #<issue>

The `https://google.github.io/A2A/` link in `docs/a2a.md` returns **404**. The Agent2Agent (A2A) Protocol was donated to the Linux Foundation and now lives at `https://a2a-protocol.org/` (HTTP 200). This PR updates the single occurrence so users following the link from the A2A docs page land on the canonical, currently-maintained home.

```
$ curl -sI https://google.github.io/A2A/ | head -1
HTTP/2 404

$ curl -sI https://a2a-protocol.org/ | head -1
HTTP/2 200
```

Per CONTRIBUTING and the PR template, single-character broken-link fixes don't require a prior issue; happy to open one if preferred.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
