### PR TITLE
fix: stream Gemini thought parts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -480,12 +480,18 @@ class GeminiStreamedResponse(StreamedResponse):
             gemini_part: _GeminiPartUnion
             for gemini_part in candidate['content']['parts']:
                 if 'text' in gemini_part:
-                    # Using vendor_part_id=None means we can produce multiple text parts if their deltas are sprinkled
-                    # amongst the tool call deltas
-                    for event in self._parts_manager.handle_text_delta(
-                        vendor_part_id=None, content=gemini_part['text']
-                    ):
-                        yield event
+                    if gemini_part.get('thought'):
+                        for event in self._parts_manager.handle_thinking_delta(
+                            vendor_part_id=None, content=gemini_part['text']
+                        ):
+                            yield event
+                    else:
+                        # Using vendor_part_id=None means we can produce multiple text parts if their deltas are sprinkled
+                        # amongst the tool call deltas
+                        for event in self._parts_manager.handle_text_delta(
+                            vendor_part_id=None, content=gemini_part['text']
+                        ):
+                            yield event
 
                 elif 'function_call' in gemini_part:
                     # Here, we assume all function_call parts are complete and don't have deltas.

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -34,10 +34,12 @@ from pydantic_ai import (
     VideoUrl,
 )
 from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.messages import PartStartEvent
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models.gemini import (
     GeminiModel,
     GeminiModelSettings,
+    GeminiStreamedResponse,
     _content_model_response,
     _gemini_response_ta,
     _gemini_streamed_response_ta,
@@ -830,6 +832,39 @@ async def test_stream_text(get_gemini_client: GetGeminiClient):
         chunks = [chunk async for chunk in result.stream_text(delta=True, debounce_by=None)]
         assert chunks == snapshot(['Hello ', 'world'])
     assert result.usage == snapshot(RunUsage(requests=1, input_tokens=1, output_tokens=2))
+
+
+async def test_stream_thought_text():
+    responses = [
+        gemini_response(
+            _GeminiContent(
+                role='model',
+                parts=[_GeminiTextPart(text='I should think first. ', thought=True)],
+            )
+        ),
+        gemini_response(_content_model_response(ModelResponse(parts=[TextPart('Final answer')]))),
+    ]
+    json_data = _gemini_streamed_response_ta.dump_json(responses, by_alias=True)
+    stream = AsyncByteStreamList([json_data[:100], json_data[100:200], json_data[200:]])
+    response = GeminiStreamedResponse(
+        model_request_parameters=ModelRequestParameters(
+            function_tools=[], output_tools=[], output_mode='text', output_object=None
+        ),
+        _model_name='gemini-1.5-flash',
+        _content=bytearray(),
+        _stream=stream.__aiter__(),
+        _provider_name='google-gla',
+        _provider_url='https://generativelanguage.googleapis.com/v1beta/models/',
+    )
+
+    events = [event async for event in response]
+
+    assert events[0] == PartStartEvent(index=0, part=ThinkingPart(content='I should think first. '))
+    assert response.get().parts == [
+        ThinkingPart(content='I should think first. '),
+        TextPart(content='Final answer'),
+    ]
+    assert response.usage == snapshot(RequestUsage(input_tokens=1, output_tokens=2))
 
 
 async def test_stream_invalid_unicode_text(get_gemini_client: GetGeminiClient):


### PR DESCRIPTION
﻿## Summary

- route Gemini streaming parts marked as `thought` through `handle_thinking_delta`
- add a regression test for streamed Gemini thought text so it becomes a `ThinkingPart`, not a `TextPart`

Fixes #5598

## To verify

- `uv run pytest tests\models\test_gemini.py::test_stream_thought_text -q`
- `uv run ruff check pydantic_ai_slim\pydantic_ai\models\gemini.py tests\models\test_gemini.py`
- `uv run pyright pydantic_ai_slim\pydantic_ai\models\gemini.py tests\models\test_gemini.py`
- `python -m py_compile pydantic_ai_slim\pydantic_ai\models\gemini.py tests\models\test_gemini.py`
- `git diff --check`
