### PR TITLE
fix(openrouter): map `thinking=False` to `reasoning_effort="none"`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -558,19 +558,19 @@ def _openrouter_settings_to_openai_settings(
     # Fall back to unified thinking when openrouter_reasoning is not set
     if 'openrouter_reasoning' not in model_settings and model_request_parameters.thinking is not None:
         thinking = model_request_parameters.thinking
-        if thinking is not False:
-            unified_reasoning: OpenRouterReasoning = {}
-            # OpenRouter only supports low/medium/high; map others to closest
-            effort_map: dict[ThinkingLevel, str] = {
-                True: 'medium',
-                'minimal': 'low',
-                'low': 'low',
-                'medium': 'medium',
-                'high': 'high',
-                'xhigh': 'high',
-            }
-            unified_reasoning['effort'] = effort_map[thinking]  # type: ignore[typeddict-item]
-            model_settings['openrouter_reasoning'] = unified_reasoning
+        unified_reasoning: OpenRouterReasoning = {}
+        # OpenRouter only supports low/medium/high; map others to closest
+        effort_map: dict[ThinkingLevel, str] = {
+            True: 'medium',
+            False: 'none',
+            'minimal': 'low',
+            'low': 'low',
+            'medium': 'medium',
+            'high': 'high',
+            'xhigh': 'high',
+        }
+        unified_reasoning['effort'] = effort_map[thinking]  # type: ignore[typeddict-item]
+        model_settings['openrouter_reasoning'] = unified_reasoning
 
     if reasoning := model_settings.pop('openrouter_reasoning', None):
         extra_body['reasoning'] = reasoning

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -757,7 +757,7 @@ class TestOpenRouterThinkingTranslation:
         params = ModelRequestParameters(thinking=False)
         result = _openrouter_settings_to_openai_settings(settings, params)
         extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert 'reasoning' not in extra_body
+        assert extra_body.get('reasoning') == {'effort': 'none'}
 
     def test_openai_reasoning_effort_passthrough(self):
         """Explicit openai_reasoning_effort on OpenRouter is passed through."""


### PR DESCRIPTION
## Summary

Fixes #5587

When `thinking=False` is set on `OpenRouterModel`, it should disable reasoning by mapping to `effort="none"`. Instead, it was silently ignored because the inner guard `if thinking is not False` filtered out the `False` value, making it behave identically to `thinking=None`.

## Changes

- **Removed** the redundant `if thinking is not False:` guard
- **Added** `False: 'none'` to the effort map so `thinking=False` maps to `effort="none"`

## Verification

Unit test confirms the fix:
- `thinking=False` → `extra_body["reasoning"] = {"effort": "none"}`
- `thinking=None` → no reasoning config set
- `thinking=True` → `effort="medium"` (unchanged)