### PR TITLE
docs(gateway): refresh "Unable to calculate spend" troubleshooting

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -417,11 +417,13 @@ The first known use of "hello, world" was in a 1974 textbook about the C program
 
 ### Unable to calculate spend
 
-The gateway needs to know the cost of the request in order to provide insights about the spend, and to enforce spending limits.
-If it's unable to calculate the cost, it will return a 400 error with the message "Unable to calculate spend".
+The gateway needs to know the cost of a request in order to provide spend insights and enforce spending limits.
 
-When configuring a provider, you need to decide if you want the gateway to block
-the API key if it's unable to calculate the cost. If you choose to block the API key, any further requests using that API key will fail.
+Each provider has a **Require pricing data** toggle in its settings. When enabled (the default), the gateway rejects requests for models it has no pricing data for before forwarding them upstream. When disabled, those requests are allowed through, but their cost will not be tracked and they will not count toward spending limits.
 
-We are actively working on supporting more providers, and models.
-If you have a specific provider that you would like to see supported, please let us know on [Slack](https://logfire.pydantic.dev/docs/join-slack/) or [open an issue on `genai-prices`](https://github.com/pydantic/genai-prices/issues/new).
+The rejection response depends on the provider type:
+
+- **Built-in providers** (Pydantic-managed): `404` with a message asking you to let us know on Slack so we can add the model.
+- **Custom providers** (your own API keys): `400` indicating that pricing data is required, with a hint to disable the toggle if you want the request through anyway.
+
+We are actively working on supporting more providers and models. If there's a specific provider or model you'd like to see supported, please let us know on [Slack](https://logfire.pydantic.dev/docs/join-slack/) or [open an issue on `genai-prices`](https://github.com/pydantic/genai-prices/issues/new).


### PR DESCRIPTION
## Summary

Updates the gateway docs to reflect the recent gateway changes ("Block on error" → "Require pricing data").

Specifically, the "Troubleshooting → Unable to calculate spend" section is rewritten to:

- Drop the stale `"Unable to calculate spend"` literal error string — the gateway no longer returns that exact message.
- Use the new toggle name **Require pricing data** and explain what enabling/disabling it does (pre-flight reject vs. let through but skip cost tracking).
- Document the split between **built-in providers** (`404` + Slack link) and **custom providers** (`400` + "disable required cost estimates" hint).

A follow-up PR will merge `main` into `v2-main` to carry this through.

## Test plan

- [x] Verified the gateway source still matches the documented behavior (`isBuiltIn` branch in `gateway.ts` and the `Require pricing data` toggle in both provider forms).
- [ ] Docs render preview looks correct.