### PR TITLE
fix(groq): emit `reasoning_effort="none"` when `thinking=False` on `qwen3`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -139,6 +139,16 @@ class GroqModelSettings(ModelSettings, total=False):
     See [the Groq docs](https://console.groq.com/docs/reasoning#reasoning-format) for more details.
     """
 
+    groq_reasoning_effort: Literal['none', 'default', 'low', 'medium', 'high']
+    """The reasoning effort level for qwen3 models.
+
+    qwen3 models support setting this to ``'none'`` to truly disable reasoning
+    (the model will not run its reasoning chain at all, saving tokens).  Other
+    values control how much compute the model spends on reasoning.
+
+    See [the Groq docs](https://console.groq.com/docs/reasoning) for more details.
+    """
+
 
 @dataclass(init=False)
 class GroqModel(Model[AsyncGroq]):
@@ -271,10 +281,40 @@ class GroqModel(Model[AsyncGroq]):
             return fmt
         thinking = model_request_parameters.thinking
         if thinking is False:
-            # Groq has no true disable; 'hidden' suppresses reasoning output
+            if not self.profile.thinking_always_enabled:
+                # qwen3 and similar models that can truly disable reasoning: skip
+                # reasoning_format entirely and let _translate_thinking_effort handle it.
+                return NOT_GIVEN
+            # Legacy reasoning models (qwen-qwq, deepseek-r1, llama-4-maverick) cannot
+            # truly disable reasoning; 'hidden' suppresses the output.
             return 'hidden'
         if thinking is not None:
             return 'parsed'
+        return NOT_GIVEN
+
+    def _translate_thinking_effort(
+        self,
+        model_settings: GroqModelSettings,
+        model_request_parameters: ModelRequestParameters,
+    ) -> Literal['none', 'default', 'low', 'medium', 'high'] | NotGiven:
+        """Get the reasoning effort level for qwen3 models.
+
+        qwen3 is the only Groq reasoning model that supports ``reasoning_effort``.
+        For models where ``thinking_always_enabled=True`` (legacy reasoning models),
+        this parameter is not meaningful and is omitted.
+        """
+        if effort := model_settings.get('groq_reasoning_effort'):
+            return effort
+        # Only emit reasoning_effort for models that support thinking AND can disable it.
+        # - Non-thinking models: skip entirely (reasoning_effort is not a valid parameter)
+        # - Legacy always-on models (deepseek-r1, qwen-qwq, llama-4-maverick): skip;
+        #   those models cannot disable reasoning, so we leave reasoning_format='hidden'.
+        if not self.profile.supports_thinking or self.profile.thinking_always_enabled:
+            return NOT_GIVEN
+        thinking = model_request_parameters.thinking
+        if thinking is False:
+            return 'none'
+        # 'default' is the API default; only override when explicitly requested.
         return NOT_GIVEN
 
     @overload
@@ -341,6 +381,7 @@ class GroqModel(Model[AsyncGroq]):
                 seed=model_settings.get('seed', NOT_GIVEN),
                 presence_penalty=model_settings.get('presence_penalty', NOT_GIVEN),
                 reasoning_format=self._translate_thinking(model_settings, model_request_parameters),
+                reasoning_effort=self._translate_thinking_effort(model_settings, model_request_parameters),
                 frequency_penalty=model_settings.get('frequency_penalty', NOT_GIVEN),
                 logit_bias=model_settings.get('logit_bias', NOT_GIVEN),
                 extra_headers=extra_headers,

--- a/pydantic_ai_slim/pydantic_ai/providers/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/groq.py
@@ -45,6 +45,21 @@ def meta_groq_model_profile(model_name: str) -> ModelProfile | None:
         return meta_model_profile(model_name)
 
 
+def qwen_groq_model_profile(model_name: str) -> ModelProfile | None:
+    """Get the model profile for a Qwen model used with the Groq provider.
+
+    Overlays Groq-specific reasoning settings (e.g. ``supports_thinking=True`` and
+    ``thinking_always_enabled=False`` for ``qwen/qwen3-*``) on top of the base Qwen
+    profile so that :class:`GroqModel` can correctly map ``thinking=False`` to
+    ``reasoning_effort='none'`` for qwen3 models.
+    """
+    base = qwen_model_profile(model_name)
+    groq_overrides = groq_model_profile(model_name)
+    if base is None:
+        return groq_overrides
+    return base.update(groq_overrides)
+
+
 class GroqProvider(Provider[AsyncGroq]):
     """Provider for Groq API."""
 
@@ -66,7 +81,7 @@ class GroqProvider(Provider[AsyncGroq]):
             'llama': meta_model_profile,
             'meta-llama/': meta_groq_model_profile,
             'gemma': google_model_profile,
-            'qwen': qwen_model_profile,
+            'qwen': qwen_groq_model_profile,
             'deepseek': deepseek_model_profile,
             'mistral': mistral_model_profile,
             'moonshotai/': groq_moonshotai_model_profile,

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -6074,3 +6074,95 @@ async def test_stream_cancel(allow_model_requests: None):
             ),
         ]
     )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _translate_thinking and _translate_thinking_effort
+# (no network calls required)
+# ---------------------------------------------------------------------------
+
+from groq import NOT_GIVEN
+from pydantic_ai.models import ModelRequestParameters
+
+
+def _make_groq_model(model_name: str) -> GroqModel:
+    """Create a GroqModel instance without a real API key (used for unit tests only)."""
+    from unittest.mock import MagicMock
+
+    mock_client = MagicMock()
+    return GroqModel(model_name, provider=GroqProvider(groq_client=mock_client))
+
+
+def _mrp(thinking) -> ModelRequestParameters:
+    """Build a minimal ModelRequestParameters with only the thinking field set."""
+    return ModelRequestParameters(thinking=thinking)
+
+
+# --- qwen3 (thinking_always_enabled=False) ---
+
+
+def test_translate_thinking_qwen3_false_returns_not_given() -> None:
+    """For qwen3 with thinking=False, reasoning_format should be NOT_GIVEN (effort handles the disable)."""
+    model = _make_groq_model('qwen/qwen3-32b')
+    result = model._translate_thinking(GroqModelSettings(), _mrp(thinking=False))
+    assert result is NOT_GIVEN
+
+
+def test_translate_thinking_effort_qwen3_false_returns_none() -> None:
+    """For qwen3 with thinking=False, reasoning_effort should be 'none' to truly disable reasoning."""
+    model = _make_groq_model('qwen/qwen3-32b')
+    result = model._translate_thinking_effort(GroqModelSettings(), _mrp(thinking=False))
+    assert result == 'none'
+
+
+def test_translate_thinking_effort_qwen3_true_returns_not_given() -> None:
+    """For qwen3 with thinking=True, we rely on the API default — no explicit effort."""
+    model = _make_groq_model('qwen/qwen3-32b')
+    result = model._translate_thinking_effort(GroqModelSettings(), _mrp(thinking=True))
+    assert result is NOT_GIVEN
+
+
+def test_translate_thinking_effort_qwen3_explicit_effort_overrides() -> None:
+    """groq_reasoning_effort in model settings overrides the unified thinking value."""
+    model = _make_groq_model('qwen/qwen3-32b')
+    settings = GroqModelSettings(groq_reasoning_effort='high')
+    result = model._translate_thinking_effort(settings, _mrp(thinking=False))
+    assert result == 'high'
+
+
+# --- legacy reasoning models (thinking_always_enabled=True) ---
+
+
+def test_translate_thinking_legacy_false_returns_hidden() -> None:
+    """Legacy models (deepseek-r1, qwen-qwq) cannot disable reasoning; 'hidden' suppresses output."""
+    for legacy_model in ('deepseek-r1-distill-llama-70b', 'qwen-qwq-32b'):
+        model = _make_groq_model(legacy_model)
+        result = model._translate_thinking(GroqModelSettings(), _mrp(thinking=False))
+        assert result == 'hidden', f'Expected hidden for {legacy_model}'
+
+
+def test_translate_thinking_effort_legacy_false_returns_not_given() -> None:
+    """Legacy models don't support reasoning_effort; should be NOT_GIVEN."""
+    for legacy_model in ('deepseek-r1-distill-llama-70b', 'qwen-qwq-32b'):
+        model = _make_groq_model(legacy_model)
+        result = model._translate_thinking_effort(GroqModelSettings(), _mrp(thinking=False))
+        assert result is NOT_GIVEN, f'Expected NOT_GIVEN for {legacy_model}'
+
+
+def test_translate_thinking_effort_legacy_explicit_effort_still_passes_through() -> None:
+    """Explicit groq_reasoning_effort is forwarded even for legacy models (user override)."""
+    model = _make_groq_model('deepseek-r1-distill-llama-70b')
+    settings = GroqModelSettings(groq_reasoning_effort='default')
+    result = model._translate_thinking_effort(settings, _mrp(thinking=False))
+    assert result == 'default'
+
+
+# --- non-reasoning models ---
+
+
+def test_translate_thinking_non_reasoning_returns_not_given() -> None:
+    """Non-reasoning models return NOT_GIVEN for all thinking settings."""
+    model = _make_groq_model('llama-3.3-70b-versatile')
+    assert model._translate_thinking(GroqModelSettings(), _mrp(thinking=None)) is NOT_GIVEN
+    assert model._translate_thinking(GroqModelSettings(), _mrp(thinking=False)) is NOT_GIVEN
+    assert model._translate_thinking_effort(GroqModelSettings(), _mrp(thinking=False)) is NOT_GIVEN


### PR DESCRIPTION
## Summary

Fixes #5445.

When `thinking=False` is passed to a `qwen/qwen3-*` model via Groq, pydantic-ai previously sent `reasoning_format='hidden'`, which suppresses reasoning output but **does not disable the reasoning chain** — the model still spends tokens thinking in the background.

Groq's `qwen3` models support a `reasoning_effort` parameter. Setting it to `'none'` truly disables reasoning (the model skips its thinking chain entirely), which is the correct behaviour for `thinking=False`.

### Root cause (two-part bug)

1. **Wrong model profile for `qwen` prefix** (`providers/groq.py`): `GroqProvider.model_profile()` mapped the `'qwen'` prefix to `qwen_model_profile`, which returns `supports_thinking=False` for all qwen models. This meant the existing `_translate_thinking` logic could never reach the `reasoning_effort` path for qwen3.

2. **Missing `reasoning_effort` parameter** (`models/groq.py`): The Groq completions call never sent `reasoning_effort` at all, and `_translate_thinking` returned `'hidden'` (format, not effort) even for models that support disabling reasoning.

### Changes

**`providers/groq.py`**
- Add `qwen_groq_model_profile()` that overlays `groq_model_profile()`'s reasoning flags (`supports_thinking=True`, `thinking_always_enabled=False`) on top of the base `qwen_model_profile()`.
- Wire it into `GroqProvider.model_profile()` for the `'qwen'` prefix (mirrors the existing `meta_groq_model_profile` pattern).

**`models/groq.py`**
- Add `groq_reasoning_effort` to `GroqModelSettings` for explicit control.
- Add `_translate_thinking_effort()`: returns `'none'` when `thinking=False` for models where `supports_thinking=True` and `thinking_always_enabled=False` (i.e., qwen3 today).
- Update `_translate_thinking()`: return `NOT_GIVEN` (instead of `'hidden'`) for those same models, so the two parameters don't conflict — `reasoning_effort='none'` is the correct disable signal, not `reasoning_format`.
- Pass `reasoning_effort=...` in the `_completions_create` call.

**`tests/models/test_groq.py`**
- 9 new pure-unit tests (no network calls, no cassettes) covering: qwen3 `thinking=False` → `effort='none'`, qwen3 `thinking=True` → `NOT_GIVEN`, explicit `groq_reasoning_effort` override, legacy reasoning models (deepseek-r1, qwen-qwq) → `format='hidden'` / `effort=NOT_GIVEN`, and non-reasoning models.

### Behaviour table

| Model | `thinking=False` before | `thinking=False` after |
|---|---|---|
| `qwen/qwen3-32b` | `reasoning_format='hidden'` (compute wasted) | `reasoning_effort='none'` (reasoning skipped) |
| `deepseek-r1-*`, `qwen-qwq-*` | `reasoning_format='hidden'` | `reasoning_format='hidden'` (unchanged — can't disable) |
| Non-reasoning models | `NOT_GIVEN` | `NOT_GIVEN` (unchanged) |