### PR TITLE
fix: handle list content in Google model code execution result replay

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -1671,7 +1671,7 @@ def _native_tool_return_part_dict(
 ) -> PartDict | None:
     if item.provider_name not in accepted_provider_names:
         return None
-    if item.tool_name == CodeExecutionTool.kind and isinstance(item.content, dict):
+    if item.tool_name == CodeExecutionTool.kind and isinstance(item.content, (dict, list)):
         return _attach_signature(
             {'code_execution_result': cast(CodeExecutionResultDict, item.content)},  # pyright: ignore[reportUnknownMemberType]
             signature,


### PR DESCRIPTION
## Summary

Fix `_native_tool_return_part_dict` in the Google model adapter to accept `list` content for `code_execution_result` parts, not just `dict`.

Previously, when replaying a conversation history containing `NativeToolReturnPart` with code execution tool results where the `content` field is a `list` (rather than a `dict`), the function raised `UnexpectedModelBehavior('Unknown native tool name: code_execution')` instead of properly serializing the result.

This happens because the `isinstance` check at `google.py:1674` only accepted `dict`:

```python
if item.tool_name == CodeExecutionTool.kind and isinstance(item.content, dict):
```

When content is a list (e.g., `[{'return_code': 0, 'stdout': 'hello\n', 'type': 'bash_code_execution_result'}]`), this check fails and the code falls through to raise the error.

## Fix

Extend the `isinstance` check to accept both `dict` and `list`:

```python
if item.tool_name == CodeExecutionTool.kind and isinstance(item.content, (dict, list)):
```

This is a 1-line change that preserves the existing behavior for dict content while correctly handling list content during message replay.

## Testing

Verified that:
1. Dict content still produces the correct `code_execution_result` dict
2. List content now produces the correct `code_execution_result` list (previously raised `UnexpectedModelBehavior`)

Closes #5614