### PR TITLE
fix: serialize callable thinking provider details

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -142,7 +142,17 @@ ForceDownloadMode: TypeAlias = bool | Literal['allow-local']
 - `'allow-local'`: The file is always downloaded, allowing private IPs but still blocking cloud metadata.
 """
 
-ProviderDetailsDelta: TypeAlias = dict[str, Any] | Callable[[dict[str, Any] | None], dict[str, Any]] | None
+
+def _serialize_provider_details_delta(value: Any) -> dict[str, Any] | None:
+    if callable(value):
+        return None
+    return value
+
+
+ProviderDetailsDelta: TypeAlias = Annotated[
+    dict[str, Any] | Callable[[dict[str, Any] | None], dict[str, Any]] | None,
+    pydantic.PlainSerializer(_serialize_provider_details_delta, return_type=dict[str, Any] | None),
+]
 """Type for provider_details input: can be a static dict, a callback to update existing details, or None."""
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -7,6 +7,7 @@ import pytest
 from pydantic import TypeAdapter
 
 from pydantic_ai import (
+    AgentStreamEvent,
     AudioUrl,
     BinaryContent,
     BinaryImage,
@@ -22,6 +23,7 @@ from pydantic_ai import (
     MultiModalContent,
     NativeToolCallPart,
     NativeToolReturnPart,
+    PartDeltaEvent,
     RequestUsage,
     RetryPromptPart,
     TextContent,
@@ -447,6 +449,19 @@ def test_thinking_part_delta_apply_to_thinking_part_delta():
     part = ThinkingPart(content='')
     result_part = chained.apply(part)
     assert result_part.provider_details == {'from_callable': 'yes', 'from_dict': 'also'}
+
+
+def test_thinking_part_delta_callable_provider_details_serializable():
+    delta1 = ThinkingPartDelta(content_delta='first', provider_details=lambda d: {**(d or {}), 'first': True})
+    delta2 = ThinkingPartDelta(content_delta=' second', provider_details=lambda d: {**(d or {}), 'second': True})
+    chained = delta2.apply(delta1)
+    assert isinstance(chained, ThinkingPartDelta)
+    assert callable(chained.provider_details)
+
+    event = PartDeltaEvent(index=0, delta=chained)
+    serialized = TypeAdapter(AgentStreamEvent).dump_json(event)
+
+    assert b'"provider_details":null' in serialized
 
 
 def test_pre_usage_refactor_messages_deserializable():

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -459,9 +459,16 @@ def test_thinking_part_delta_callable_provider_details_serializable():
     assert callable(chained.provider_details)
 
     event = PartDeltaEvent(index=0, delta=chained)
-    serialized = TypeAdapter(AgentStreamEvent).dump_json(event)
+    adapter = cast(TypeAdapter[AgentStreamEvent], TypeAdapter(AgentStreamEvent))
+    serialized = adapter.dump_json(event)
 
     assert b'"provider_details":null' in serialized
+
+    dict_event = PartDeltaEvent(
+        index=0,
+        delta=ThinkingPartDelta(content_delta='dict', provider_details={'provider': 'detail'}),
+    )
+    assert b'"provider_details":{"provider":"detail"}' in adapter.dump_json(dict_event)
 
 
 def test_pre_usage_refactor_messages_deserializable():


### PR DESCRIPTION
## Summary
- make callable `ThinkingPartDelta.provider_details` JSON-serializable by emitting `null`
- keep the existing callable merge behavior for runtime application to `ThinkingPart`
- add a regression test for serializing chained thinking deltas through `AgentStreamEvent`

## To verify
- `uv run pytest tests\test_messages.py::test_thinking_part_delta_callable_provider_details_serializable tests\test_messages.py::test_thinking_part_delta_apply_to_thinking_part_delta -q`
- `python -m py_compile pydantic_ai_slim\pydantic_ai\messages.py tests\test_messages.py`
- `uv run ruff check pydantic_ai_slim\pydantic_ai\messages.py tests\test_messages.py`
- `uv run ruff format --check pydantic_ai_slim\pydantic_ai\messages.py tests\test_messages.py`
- `git diff --check`

Fixes #5612
