### PR TITLE
fix(gemini): emit `ThinkingPartDelta` for thought parts in streaming mode

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -480,12 +480,18 @@ class GeminiStreamedResponse(StreamedResponse):
             gemini_part: _GeminiPartUnion
             for gemini_part in candidate['content']['parts']:
                 if 'text' in gemini_part:
-                    # Using vendor_part_id=None means we can produce multiple text parts if their deltas are sprinkled
-                    # amongst the tool call deltas
-                    for event in self._parts_manager.handle_text_delta(
-                        vendor_part_id=None, content=gemini_part['text']
-                    ):
-                        yield event
+                    if gemini_part.get('thought'):
+                        for event in self._parts_manager.handle_thinking_delta(
+                            vendor_part_id=None, content=gemini_part['text']
+                        ):
+                            yield event
+                    else:
+                        # Using vendor_part_id=None means we can produce multiple text parts if their deltas are sprinkled
+                        # amongst the tool call deltas
+                        for event in self._parts_manager.handle_text_delta(
+                            vendor_part_id=None, content=gemini_part['text']
+                        ):
+                            yield event
 
                 elif 'function_call' in gemini_part:
                     # Here, we assume all function_call parts are complete and don't have deltas.

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -2152,3 +2152,37 @@ def test_map_empty_usage():
     del response['usage_metadata']
 
     assert _metadata_as_usage(response) == RequestUsage()
+
+
+async def test_stream_thinking_parts(get_gemini_client: GetGeminiClient):
+    """Test that thought parts (text with thought=True) are emitted as ThinkingPartDelta in streaming."""
+    responses = [
+        gemini_response(
+            _GeminiContent(
+                role='model',
+                parts=[
+                    {'text': 'Let me think about this...', 'thought': True},
+                    {'text': 'Here is the answer.'},
+                ],
+            )
+        ),
+    ]
+    json_data = _gemini_streamed_response_ta.dump_json(responses, by_alias=True)
+    stream = AsyncByteStreamList([json_data[:80], json_data[80:]])
+    gemini_client = get_gemini_client(stream)
+    m = GeminiModel('gemini-2.5-flash', provider=GoogleGLAProvider(http_client=gemini_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('Hello') as result:
+        data = await result.get_output()
+
+    assert data == 'Here is the answer.'
+    messages = result.all_messages()
+    response_msg = messages[1]
+    assert isinstance(response_msg, ModelResponse)
+    # The thinking part should be present in the response
+    assert any(isinstance(part, ThinkingPart) for part in response_msg.parts)
+    thinking_parts = [p for p in response_msg.parts if isinstance(p, ThinkingPart)]
+    assert thinking_parts[0].content == 'Let me think about this...'
+    text_parts = [p for p in response_msg.parts if isinstance(p, TextPart)]
+    assert text_parts[0].content == 'Here is the answer.'


### PR DESCRIPTION
## Summary

Fix the Gemini REST API streaming path to correctly emit `ThinkingPartDelta` events for thought parts, instead of misclassifying them as text deltas.

## Issue

Closes #5598

## Changes

- In `GeminiStreamedResponse._get_event_iterator`, check `gemini_part.get('thought')` within the `'text' in gemini_part` branch to distinguish thinking text from regular text
- Added a test verifying that thought parts produce `ThinkingPart` in the final response during streaming

## Context

The Gemini REST API sends thought parts as `{'text': '...', 'thought': true}`. The streaming iterator checked for `'text'` first, so these were emitted as `TextPartDelta` instead of `ThinkingPartDelta`. The non-streaming path already handled this correctly.

This means users calling `agent.run_stream()` with a thinking-enabled Gemini model (via `GeminiModel` / REST API path) saw no thinking content in the response, while `agent.run()` worked correctly.

The Google SDK path (`GoogleModel`) was already correct.

## Related

#5625 — `thoughtSignature` is also silently dropped from thinking parts in the REST path (both streaming and non-streaming). That's a follow-up issue; fixing it is a prerequisite for safely sending `ThinkingPart`s back to the model in multi-turn conversations.

- [ ] AI generated code