### PR TITLE
fix(groq): pair `NativeToolCallPart` and `NativeToolReturnPart` for streamed `executed_tools`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -826,6 +826,7 @@ def _map_executed_tool(
         else:
             results = tool.output
 
+        has_prior_call_part = tool_call_id is not None
         tool_call_id = tool_call_id or generate_tool_call_id()
         call_part = NativeToolCallPart(
             tool_name=WebSearchTool.kind,
@@ -842,7 +843,7 @@ def _map_executed_tool(
 
         if streaming:
             if results:
-                return None, return_part
+                return None if has_prior_call_part else call_part, return_part
             else:
                 return call_part, None
         else:

--- a/tests/models/cassettes/test_groq/test_groq_model_web_search_tool_stream_single_chunk.yaml
+++ b/tests/models/cassettes/test_groq/test_groq_model_web_search_tool_stream_single_chunk.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.groq.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the weather in San Francisco?
+        role: user
+      model: compound-beta
+      n: 1
+      stream: true
+    uri: https://api.groq.com/openai/v1/chat/completions
+  response:
+    body:
+      string: "data: {\"id\":\"chatcmpl-single-test\",\"object\":\"chat.completion.chunk\"\
+        ,\"created\":1758144046,\"model\":\"groq/compound\",\"system_fingerprint\"\
+        :null,\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\"\
+        :\"\"},\"logprobs\":null,\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-single-test\"\
+        ,\"object\":\"chat.completion.chunk\",\"created\":1758144046,\"model\":\"\
+        groq/compound\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"\
+        delta\":{\"executed_tools\":[{\"index\":0,\"type\":\"search\",\"arguments\"\
+        :\"{\\\"query\\\": \\\"weather in San Francisco\\\"}\",\"search_results\"\
+        :{\"results\":[{\"title\":\"SF Weather\",\"url\":\"https://www.weatherapi.com/\"\
+        ,\"content\":\"San Francisco: Sunny, 62\\u00b0F.\",\"score\":0.98}]}}]},\"\
+        logprobs\":null,\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-single-test\"\
+        ,\"object\":\"chat.completion.chunk\",\"created\":1758144046,\"model\":\"\
+        groq/compound\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"\
+        delta\":{\"content\":\"The weather in San Francisco is sunny and 62\\u00b0F.\"\
+        },\"logprobs\":null,\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-single-test\"\
+        ,\"object\":\"chat.completion.chunk\",\"created\":1758144046,\"model\":\"\
+        groq/compound\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"\
+        delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"x_groq\":{\"id\"\
+        :\"req_test\",\"usage\":{\"queue_time\":0.05,\"prompt_tokens\":100,\"prompt_time\"\
+        :0.02,\"completion_tokens\":20,\"completion_time\":0.01,\"total_tokens\":120,\"\
+        total_time\":0.08}}}\n\ndata: [DONE]\n\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=86400
+      cache-control:
+      - no-cache
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -2050,6 +2050,30 @@ The weather in San Francisco today is partly cloudy with a temperature of 61°F 
     )
 
 
+async def test_groq_model_web_search_tool_stream_single_chunk(allow_model_requests: None, groq_api_key: str):
+    m = GroqModel('compound-beta', provider=GroqProvider(api_key=groq_api_key))
+    agent = Agent(m, capabilities=[NativeTool(WebSearchTool())])
+
+    event_parts: list[Any] = []
+    async with agent.iter(user_prompt='What is the weather in San Francisco?') as agent_run:
+        async for node in agent_run:
+            if Agent.is_model_request_node(node) or Agent.is_call_tools_node(node):
+                async with node.stream(agent_run.ctx) as request_stream:
+                    async for event in request_stream:
+                        event_parts.append(event)
+
+    assert agent_run.result is not None
+
+    # Both call and return parts must be present and correctly paired.
+    call_parts = [e.part for e in event_parts if isinstance(e, PartStartEvent) and isinstance(e.part, NativeToolCallPart)]
+    return_parts = [
+        e.part for e in event_parts if isinstance(e, PartStartEvent) and isinstance(e.part, NativeToolReturnPart)
+    ]
+    assert len(call_parts) == 1, f'Expected 1 NativeToolCallPart, got {len(call_parts)}'
+    assert len(return_parts) == 1, f'Expected 1 NativeToolReturnPart, got {len(return_parts)}'
+    assert call_parts[0].tool_call_id == return_parts[0].tool_call_id, 'tool_call_id must match'
+
+
 async def test_groq_model_thinking_part(allow_model_requests: None, groq_api_key: str):
     m = GroqModel('deepseek-r1-distill-llama-70b', provider=GroqProvider(api_key=groq_api_key))
     settings = GroqModelSettings(groq_reasoning_format='raw')

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -2065,7 +2065,9 @@ async def test_groq_model_web_search_tool_stream_single_chunk(allow_model_reques
     assert agent_run.result is not None
 
     # Both call and return parts must be present and correctly paired.
-    call_parts = [e.part for e in event_parts if isinstance(e, PartStartEvent) and isinstance(e.part, NativeToolCallPart)]
+    call_parts = [
+        e.part for e in event_parts if isinstance(e, PartStartEvent) and isinstance(e.part, NativeToolCallPart)
+    ]
     return_parts = [
         e.part for e in event_parts if isinstance(e, PartStartEvent) and isinstance(e.part, NativeToolReturnPart)
     ]


### PR DESCRIPTION
- Closes #5621

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).