### PR TITLE
fix: preserve `ThinkingPart.id` on AG-UI round-trip when original id is `None`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -430,7 +430,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     builder.add(
                         ThinkingPart(
                             content=reasoning_msg.content,
-                            id=metadata.get('id'),
+                            id=metadata.get('id') or reasoning_msg.id,
                             signature=metadata.get('signature'),
                             provider_name=metadata.get('provider_name'),
                             provider_details=metadata.get('provider_details'),
@@ -619,7 +619,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     encrypted = thinking_encrypted_metadata(part)
                     result.append(
                         ReasoningMessage(
-                            id=_new_message_id(),
+                            id=part.id or _new_message_id(),
                             content=part.content,
                             encrypted_value=json.dumps(encrypted) if encrypted else None,
                         )

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1488,7 +1488,7 @@ def test_reasoning_message_malformed_encrypted_value(encrypted_value: str) -> No
     assert messages == snapshot(
         [
             ModelResponse(
-                parts=[ThinkingPart(content='Thinking...'), TextPart(content='Done')],
+                parts=[ThinkingPart(content='Thinking...', id='r-1'), TextPart(content='Done')],
                 timestamp=IsDatetime(),
             )
         ]
@@ -1571,6 +1571,30 @@ def test_dump_load_roundtrip_thinking() -> None:
     _sync_timestamps(original, reloaded)
 
     assert reloaded == original
+
+
+def test_dump_load_roundtrip_thinking_none_id() -> None:
+    """Test round-trip preserves generated ID when original ThinkingPart.id is None."""
+    original: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Think about this')]),
+        ModelResponse(
+            parts=[
+                ThinkingPart(content='Let me think...'),
+                TextPart(content='Conclusion'),
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original, ag_ui_version='0.1.13')
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    _sync_timestamps(original, reloaded)
+
+    response = reloaded[1]
+    assert isinstance(response, ModelResponse)
+    thinking = response.parts[0]
+    assert isinstance(thinking, ThinkingPart)
+    assert thinking.content == 'Let me think...'
+    assert thinking.id is not None, 'ThinkingPart.id should be preserved from ReasoningMessage.id after round-trip'
 
 
 def test_dump_load_roundtrip_tools() -> None:
@@ -1984,6 +2008,7 @@ async def test_thinking_roundtrip_anthropic(allow_model_requests: None, anthropi
                 parts=[
                     ThinkingPart(
                         content='The user is asking what 1+1 equals and wants a one-word reply. The answer is 2, which is one word.',
+                        id=IsStr(),
                         signature='EooCCkYICxgCKkDYW6Ka+Mo73ZE34HVijmFbdV6QH/iRdv+3WuisH3pR8D5aSFASMBsF1F1bZRQFQXuM0+G4H83czthKvHqdqWriEgwB0eJaWoXZWU18NKoaDMH4nN8ZwJ6W9DnYLyIwrdTWmfc5QTqDr8gye3/yrPpV2YPeZnUBoHBLOGl8MUaC6SuGmxcm8rGqf2s+P+ZtKnJPJJzQiTrvPcEkF3ij22w3bXC9yoyZCyJVPcibR2ZZpLYF/UOoZ+BRBs0FCdm/QFXUUe8W1tcQ/ZQgBaW44LTcdzwOSP5hJb25UrPiGWuTytGMxIr7QyG7INpVbmm8JRBIIEzj3gs2zlxdbl17yZ/yZXcYAQ==',
                         provider_name='anthropic',
                     ),


### PR DESCRIPTION
- Closes #5599

## Summary

When a `ThinkingPart` with `id=None` (the default) is round-tripped through `dump_messages` → `load_messages`, the generated `ReasoningMessage.id` was lost because:

1. **Dump side**: `_new_message_id()` was always called, ignoring any explicit `part.id`
2. **Load side**: `metadata.get('id')` only read from `encrypted_content`, with no fallback to `reasoning_msg.id`

### Fix

- **Dump** (`_adapter.py:622`): `id=part.id or _new_message_id()` — preserves explicit id, generates new one only when needed
- **Load** (`_adapter.py:433`): `id=metadata.get('id') or reasoning_msg.id` — falls back to the ReasoningMessage id when encrypted metadata has no id

### Tests

- Added `test_dump_load_roundtrip_thinking_none_id` covering the `id=None` round-trip case
- Updated `test_reasoning_message_malformed_encrypted_value` snapshot to reflect the fallback behavior
- Updated `test_thinking_roundtrip_anthropic` snapshot to include the preserved id
- All 107 `test_ag_ui.py` tests pass

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).