### PR TITLE
fix(groq): return `call_part` in streaming mode when search results are present

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -842,7 +842,11 @@ def _map_executed_tool(
 
         if streaming:
             if results:
-                return None, return_part
+                # The streaming handler yields call_part and return_part as
+                # separate events; return both so the consumer can pair them by
+                # tool_call_id.  Previously this branch returned (None,
+                # return_part), silently dropping the NativeToolCallPart.
+                return call_part, return_part
             else:
                 return call_part, None
         else:

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -6074,3 +6074,92 @@ async def test_stream_cancel(allow_model_requests: None):
             ),
         ]
     )
+
+
+# ── _map_executed_tool regression tests (issue #5626) ────────────────────────
+
+
+@dataclass
+class _FakeSearchResults:
+    results: list[Any]
+    images: list[Any]
+
+    def model_dump(self, *, mode: str = 'python') -> Any:
+        return {'results': self.results, 'images': self.images}
+
+
+@dataclass
+class _FakeExecutedTool:
+    type: str
+    arguments: str
+    output: Any
+    search_results: Any = None
+
+
+def test_map_executed_tool_streaming_with_results_returns_both_parts() -> None:
+    """Regression test for issue #5626.
+
+    When streaming and `results` is truthy, _map_executed_tool must return
+    *both* call_part and return_part (not (None, return_part)).  The (None,
+    return_part) bug silently dropped the NativeToolCallPart so streaming
+    consumers could not pair call and return events.
+    """
+    from pydantic_ai.models.groq import _map_executed_tool
+    from pydantic_ai.messages import NativeToolCallPart, NativeToolReturnPart
+
+    tool = _FakeExecutedTool(
+        type='search',
+        arguments='{"query": "test"}',
+        output={'results': [{'title': 'Test', 'url': 'https://example.com'}]},
+        search_results=_FakeSearchResults(
+            results=[{'title': 'Test', 'url': 'https://example.com'}],
+            images=[],
+        ),
+    )
+
+    call_part, return_part = _map_executed_tool(tool, 'groq', streaming=True)
+
+    assert call_part is not None, "call_part must not be None in streaming+results mode"
+    assert return_part is not None, "return_part must not be None in streaming+results mode"
+    assert isinstance(call_part, NativeToolCallPart)
+    assert isinstance(return_part, NativeToolReturnPart)
+    # Both parts must share the same tool_call_id so consumers can pair them.
+    assert call_part.tool_call_id == return_part.tool_call_id
+
+
+def test_map_executed_tool_streaming_without_results_returns_call_only() -> None:
+    """In streaming mode with no search results, only the call_part is returned."""
+    from pydantic_ai.models.groq import _map_executed_tool
+    from pydantic_ai.messages import NativeToolCallPart
+
+    tool = _FakeExecutedTool(
+        type='search',
+        arguments='{"query": "test"}',
+        output=None,
+    )
+
+    call_part, return_part = _map_executed_tool(tool, 'groq', streaming=True)
+
+    assert call_part is not None
+    assert isinstance(call_part, NativeToolCallPart)
+    assert return_part is None
+
+
+def test_map_executed_tool_non_streaming_returns_both_parts() -> None:
+    """In non-streaming mode, both parts are always returned."""
+    from pydantic_ai.models.groq import _map_executed_tool
+    from pydantic_ai.messages import NativeToolCallPart, NativeToolReturnPart
+
+    tool = _FakeExecutedTool(
+        type='search',
+        arguments='{"query": "test"}',
+        output={'results': [{'title': 'Test', 'url': 'https://example.com'}]},
+    )
+
+    call_part, return_part = _map_executed_tool(tool, 'groq', streaming=False)
+
+    assert call_part is not None
+    assert return_part is not None
+    assert isinstance(call_part, NativeToolCallPart)
+    assert isinstance(return_part, NativeToolReturnPart)
+    assert call_part.tool_call_id == return_part.tool_call_id


### PR DESCRIPTION
## What

Fixes #5626.

`_map_executed_tool` returned `(None, return_part)` when `streaming=True` and `results` was truthy, silently dropping the `NativeToolCallPart`.  Streaming consumers depend on receiving **both** parts — paired by `tool_call_id` — to associate each tool call with its return value.

## Root cause

```python
# Before (groq.py, _map_executed_tool)
if streaming:
    if results:
        return None, return_part   # ← NativeToolCallPart discarded
    else:
        return call_part, None
```

Both `call_part` and `return_part` are constructed (with a matching `tool_call_id`) before this branch, so the fix is straightforward:

```python
# After
if streaming:
    if results:
        return call_part, return_part   # ← both parts returned
    else:
        return call_part, None
```

The streaming handler (which receives and yields these parts) already handles the two-part case correctly; no further changes needed.

## Tests

Added three regression tests to `tests/models/test_groq.py`:

- `test_map_executed_tool_streaming_with_results_returns_both_parts` — reproduces the exact scenario from the issue report
- `test_map_executed_tool_streaming_without_results_returns_call_only` — verifies the no-results branch still returns only `call_part`
- `test_map_executed_tool_non_streaming_returns_both_parts` — ensures non-streaming behaviour is unchanged

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).