### PR TITLE
ci(at-claude): gate `at-claude-fork` job behind `claude-fork-review` environment

### DIFF
--- a/.github/workflows/at-claude.yml
+++ b/.github/workflows/at-claude.yml
@@ -91,6 +91,12 @@ jobs:
     if: needs.get-pr-info.outputs.is_fork == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Required-reviewer environment gates execution of fork PR code in this
+    # privileged context. Mitigates CodeQL `actions/untrusted-checkout/high` +
+    # `actions/untrusted-checkout-toctou/high`: a maintainer must approve each
+    # run before the fork's `pr_head_sha` is checked out and exposed to the
+    # `claude-code-action` step.
+    environment: claude-fork-review
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

Closes the two open CodeQL alerts on `.github/workflows/at-claude.yml`:

- [`actions/untrusted-checkout/high`](https://github.com/pydantic/pydantic-ai/security/code-scanning/12) — privileged workflow checks out fork PR code
- [`actions/untrusted-checkout-toctou/high`](https://github.com/pydantic/pydantic-ai/security/code-scanning/11) — TOCTOU on the PR diff check

Adds `environment: claude-fork-review` to the `at-claude-fork` job. With required reviewers configured on that environment, a maintainer must click **approve** before the fork's `pr_head_sha` is checked out and exposed to `claude-code-action`. This is the canonical CodeQL-accepted mitigation for the "untrusted checkout in privileged context" pattern.

## Existing defenses (kept)

The workflow already had several mitigations layered on; this PR adds the human-approval gate on top:

- Author-association gate (`OWNER|MEMBER|COLLABORATOR` only, lines 29-32)
- SHA-pinned checkout (`pr_head_sha` captured in `get-pr-info`, used as `ref:` at line 105)
- Config-file modification block (`AGENTS.md` / `CLAUDE.md` / `.claude/`, line 113)
- Restricted `allowedTools` for the fork job (no `git push`, no `make`, no `uv run`, line 129)
- `bubblewrap` sandbox (line 121)

## Required follow-up (UI, by maintainer)

This PR is a no-op until the environment is configured on the upstream repo:

1. `Settings → Environments → New environment`
2. Name: `claude-fork-review`
3. Add maintainers (or a team) as **required reviewers**
4. Recommended: also restrict to the `main` branch under "Deployment branches"

Without the required-reviewer config, the environment exists but doesn't gate anything — the alert mitigation effectively requires both this PR and the UI step.

## Out of scope (also from code-scanning, handled separately)

- Two `py/clear-text-logging-sensitive-data` alerts (#9, #10) on `examples/pydantic_ai_examples/medical_agent_delegation.py` were **dismissed as false positives** via `gh api` — the script uses hardcoded fake patient IDs (`P003`); CodeQL flags the variable name heuristically.

## Test plan

- [ ] CI green
- [ ] Maintainer configures `claude-fork-review` environment with required reviewers
- [ ] Next external @claude on a fork PR shows "waiting for approval" before running the privileged steps
- [ ] CodeQL rescan closes alerts #11 and #12 (may need manual mark-as-fixed if the rule's pattern-match doesn't auto-clear)