### PR TITLE
fix(bedrock): map `malformed_model_output` and `malformed_tool_use` to `FinishReason.error`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -226,6 +226,8 @@ _FINISH_REASON_MAP: dict[StopReasonType, FinishReason] = {
     'max_tokens': 'length',
     'model_context_window_exceeded': 'length',
     'stop_sequence': 'stop',
+    'malformed_model_output': 'error',
+    'malformed_tool_use': 'error',
     'tool_use': 'tool_call',
 }
 


### PR DESCRIPTION
## What

Add `'malformed_model_output': 'error'` and `'malformed_tool_use': 'error'` to `_FINISH_REASON_MAP` in `bedrock.py`.

## Why

The Bedrock converse API can return `stopReason: 'malformed_model_output'` or `stopReason: 'malformed_tool_use'`, but these were missing from the map. This caused `finish_reason` to silently become `None` instead of `'error'`, making it impossible for callers to programmatically distinguish malformed-output errors from normal completion.

## Evidence

From the [Bedrock Runtime API spec](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html):

> `stopReason` can be one of: `end_turn`, `tool_use`, `max_tokens`, `stop_sequence`, `guardrail_intervened`, `content_filtered`, `malformed_model_output`, `malformed_tool_use`, `model_context_window_exceeded`

The `_FINISH_REASON_MAP` had 7 entries — the two malformed-* stop reasons were the only unmapped ones. Both map naturally to `'error'`, consistent with how other providers handle `incorrect_output`/`invalid_format`.

Fixes #5635