### PR TITLE
Add `OrcaRouterProvider` for OrcaRouter

### DIFF
--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -40,6 +40,8 @@
 
 ::: pydantic_ai.providers.openrouter.OpenRouterProvider
 
+::: pydantic_ai.providers.orcarouter.OrcaRouterProvider
+
 ::: pydantic_ai.providers.vercel.VercelProvider
 
 ::: pydantic_ai.providers.huggingface.HuggingFaceProvider

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -579,6 +579,36 @@ agent = Agent(model)
 ...
 ```
 
+### OrcaRouter
+
+To use [OrcaRouter](https://orcarouter.ai), first create an API key in the OrcaRouter dashboard.
+
+You can set the `ORCAROUTER_API_KEY` environment variable and use [`OrcaRouterProvider`][pydantic_ai.providers.orcarouter.OrcaRouterProvider] by name:
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('orcarouter:openai/gpt-4o-mini')
+...
+```
+
+Or initialise the model and provider directly:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.orcarouter import OrcaRouterProvider
+
+model = OpenAIChatModel(
+    'openai/gpt-4o-mini',
+    provider=OrcaRouterProvider(api_key='your-orcarouter-api-key'),
+)
+agent = Agent(model)
+...
+```
+
+You can look up the model identifiers OrcaRouter exposes via `https://api.orcarouter.ai/v1/models`.
+
 ### MoonshotAI
 
 Create an API key in the [Moonshot Console](https://platform.moonshot.ai/console).

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -28,6 +28,7 @@ In addition, many providers are compatible with the OpenAI API, and can be used 
 - [LiteLLM](openai.md#litellm)
 - [Nebius AI Studio](openai.md#nebius-ai-studio)
 - [Ollama](openai.md#ollama)
+- [OrcaRouter](openai.md#orcarouter)
 - [OVHcloud AI Endpoints](openai.md#ovhcloud-ai-endpoints)
 - [Perplexity](openai.md#perplexity)
 - [SambaNova](openai.md#sambanova)

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -563,6 +563,7 @@ OpenAIChatCompatibleProvider = TypeAliasType(
         'nebius',
         'ollama',
         'openrouter',
+        'orcarouter',
         'ovhcloud',
         'sambanova',
         'together',

--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -156,6 +156,10 @@ def infer_provider_class(provider: str) -> type[Provider[Any]]:  # noqa: C901
         from .openrouter import OpenRouterProvider
 
         return OpenRouterProvider
+    elif provider == 'orcarouter':
+        from .orcarouter import OrcaRouterProvider
+
+        return OrcaRouterProvider
     elif provider == 'vercel':
         from .vercel import VercelProvider
 

--- a/pydantic_ai_slim/pydantic_ai/providers/orcarouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/orcarouter.py
@@ -1,0 +1,112 @@
+from __future__ import annotations as _annotations
+
+import os
+from typing import overload
+
+import httpx
+
+from pydantic_ai import ModelProfile
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.models import create_async_http_client
+from pydantic_ai.profiles.anthropic import anthropic_model_profile
+from pydantic_ai.profiles.deepseek import deepseek_model_profile
+from pydantic_ai.profiles.google import google_model_profile
+from pydantic_ai.profiles.grok import grok_model_profile
+from pydantic_ai.profiles.meta import meta_model_profile
+from pydantic_ai.profiles.mistral import mistral_model_profile
+from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
+from pydantic_ai.profiles.qwen import qwen_model_profile
+from pydantic_ai.providers import Provider
+
+try:
+    from openai import AsyncOpenAI
+except ImportError as _import_error:  # pragma: no cover
+    raise ImportError(
+        'Please install the `openai` package to use the OrcaRouter provider, '
+        'you can use the `openai` optional group — `pip install "pydantic-ai-slim[openai]"`'
+    ) from _import_error
+
+
+class OrcaRouterProvider(Provider[AsyncOpenAI]):
+    """Provider for OrcaRouter API."""
+
+    @property
+    def name(self) -> str:
+        return 'orcarouter'
+
+    @property
+    def base_url(self) -> str:
+        return 'https://api.orcarouter.ai/v1'
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        return self._client
+
+    @staticmethod
+    def model_profile(model_name: str) -> ModelProfile | None:
+        provider_to_profile = {
+            'anthropic': anthropic_model_profile,
+            'deepseek': deepseek_model_profile,
+            'google': google_model_profile,
+            'meta-llama': meta_model_profile,
+            'mistral': mistral_model_profile,
+            'mistralai': mistral_model_profile,
+            'moonshotai': moonshotai_model_profile,
+            'openai': openai_model_profile,
+            'qwen': qwen_model_profile,
+            'x-ai': grok_model_profile,
+            'xai': grok_model_profile,
+        }
+
+        profile = None
+
+        if '/' in model_name:
+            vendor, upstream = model_name.split('/', 1)
+            if vendor in provider_to_profile:
+                profile = provider_to_profile[vendor](upstream)
+
+        # As OrcaRouterProvider is always used with OpenAIChatModel, the JSON schema is funneled
+        # through OpenAIJsonSchemaTransformer regardless of the underlying upstream provider.
+        return OpenAIModelProfile(
+            json_schema_transformer=OpenAIJsonSchemaTransformer,
+        ).update(profile)
+
+    @overload
+    def __init__(self, *, openai_client: AsyncOpenAI) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        openai_client: None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        openai_client: AsyncOpenAI | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        api_key = api_key or os.getenv('ORCAROUTER_API_KEY')
+        if not api_key and openai_client is None:
+            raise UserError(
+                'Set the `ORCAROUTER_API_KEY` environment variable or pass it via `OrcaRouterProvider(api_key=...)`'
+                ' to use the OrcaRouter provider.'
+            )
+
+        if openai_client is not None:
+            self._client = openai_client
+        elif http_client is not None:
+            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
+        else:
+            http_client = create_async_http_client()
+            self._own_http_client = http_client
+            self._http_client_factory = create_async_http_client
+            self._client = AsyncOpenAI(base_url=self.base_url, api_key=api_key, http_client=http_client)
+
+    def _set_http_client(self, http_client: httpx.AsyncClient) -> None:
+        self._client._client = http_client  # pyright: ignore[reportPrivateUsage]

--- a/tests/providers/test_orcarouter.py
+++ b/tests/providers/test_orcarouter.py
@@ -1,0 +1,125 @@
+import re
+
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.profiles.anthropic import anthropic_model_profile
+from pydantic_ai.profiles.deepseek import deepseek_model_profile
+from pydantic_ai.profiles.google import google_model_profile
+from pydantic_ai.profiles.grok import grok_model_profile
+from pydantic_ai.profiles.meta import meta_model_profile
+from pydantic_ai.profiles.mistral import mistral_model_profile
+from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, openai_model_profile
+from pydantic_ai.profiles.qwen import qwen_model_profile
+
+from ..conftest import TestEnv, try_import
+
+with try_import() as imports_successful:
+    import openai
+
+    from pydantic_ai.providers.orcarouter import OrcaRouterProvider
+
+
+pytestmark = pytest.mark.skipif(not imports_successful(), reason='openai not installed')
+
+
+def test_orcarouter_provider():
+    provider = OrcaRouterProvider(api_key='api-key')
+    assert provider.name == 'orcarouter'
+    assert provider.base_url == 'https://api.orcarouter.ai/v1'
+    assert isinstance(provider.client, openai.AsyncOpenAI)
+    assert provider.client.api_key == 'api-key'
+
+
+def test_orcarouter_provider_need_api_key(env: TestEnv) -> None:
+    env.remove('ORCAROUTER_API_KEY')
+    with pytest.raises(
+        UserError,
+        match=re.escape(
+            'Set the `ORCAROUTER_API_KEY` environment variable or pass it via `OrcaRouterProvider(api_key=...)`'
+            ' to use the OrcaRouter provider.'
+        ),
+    ):
+        OrcaRouterProvider()
+
+
+def test_orcarouter_pass_openai_client() -> None:
+    openai_client = openai.AsyncOpenAI(api_key='api-key')
+    provider = OrcaRouterProvider(openai_client=openai_client)
+    assert provider.client == openai_client
+
+
+def test_orcarouter_with_http_client():
+    http_client = httpx.AsyncClient()
+    provider = OrcaRouterProvider(api_key='test-key', http_client=http_client)
+    assert provider.client.api_key == 'test-key'
+    assert str(provider.client.base_url) == 'https://api.orcarouter.ai/v1/'
+
+
+def test_orcarouter_provider_model_profile(mocker: MockerFixture):
+    provider = OrcaRouterProvider(api_key='api-key')
+
+    ns = 'pydantic_ai.providers.orcarouter'
+
+    anthropic_mock = mocker.patch(f'{ns}.anthropic_model_profile', wraps=anthropic_model_profile)
+    deepseek_mock = mocker.patch(f'{ns}.deepseek_model_profile', wraps=deepseek_model_profile)
+    google_mock = mocker.patch(f'{ns}.google_model_profile', wraps=google_model_profile)
+    grok_mock = mocker.patch(f'{ns}.grok_model_profile', wraps=grok_model_profile)
+    meta_mock = mocker.patch(f'{ns}.meta_model_profile', wraps=meta_model_profile)
+    mistral_mock = mocker.patch(f'{ns}.mistral_model_profile', wraps=mistral_model_profile)
+    moonshotai_mock = mocker.patch(f'{ns}.moonshotai_model_profile', wraps=moonshotai_model_profile)
+    openai_mock = mocker.patch(f'{ns}.openai_model_profile', wraps=openai_model_profile)
+    qwen_mock = mocker.patch(f'{ns}.qwen_model_profile', wraps=qwen_model_profile)
+
+    profile = provider.model_profile('openai/gpt-4o')
+    openai_mock.assert_called_with('gpt-4o')
+    assert profile is not None
+    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+
+    profile = provider.model_profile('anthropic/claude-sonnet-4-5')
+    anthropic_mock.assert_called_with('claude-sonnet-4-5')
+    assert profile is not None
+    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+
+    profile = provider.model_profile('deepseek/deepseek-chat')
+    deepseek_mock.assert_called_with('deepseek-chat')
+    assert profile is not None
+
+    profile = provider.model_profile('google/gemini-1.5-pro')
+    google_mock.assert_called_with('gemini-1.5-pro')
+    assert profile is not None
+
+    profile = provider.model_profile('meta-llama/llama-3-70b')
+    meta_mock.assert_called_with('llama-3-70b')
+    assert profile is not None
+
+    profile = provider.model_profile('mistralai/mistral-large')
+    mistral_mock.assert_called_with('mistral-large')
+    assert profile is not None
+
+    profile = provider.model_profile('moonshotai/kimi-k2-0711-preview')
+    moonshotai_mock.assert_called_with('kimi-k2-0711-preview')
+    assert profile is not None
+
+    profile = provider.model_profile('qwen/qwen-2.5-72b-instruct')
+    qwen_mock.assert_called_with('qwen-2.5-72b-instruct')
+    assert profile is not None
+
+    profile = provider.model_profile('x-ai/grok-beta')
+    grok_mock.assert_called_with('grok-beta')
+    assert profile is not None
+
+
+def test_orcarouter_provider_model_name_without_slash():
+    profile = OrcaRouterProvider.model_profile('some-direct-model')
+    assert profile is not None
+    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+
+
+def test_orcarouter_provider_unknown_vendor():
+    profile = OrcaRouterProvider.model_profile('unknown/some-model')
+    assert profile is not None
+    assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer

--- a/tests/providers/test_provider_names.py
+++ b/tests/providers/test_provider_names.py
@@ -34,6 +34,7 @@ with try_import() as imports_successful:
     from pydantic_ai.providers.ollama import OllamaProvider
     from pydantic_ai.providers.openai import OpenAIProvider
     from pydantic_ai.providers.openrouter import OpenRouterProvider
+    from pydantic_ai.providers.orcarouter import OrcaRouterProvider
     from pydantic_ai.providers.outlines import OutlinesProvider  # pyright: ignore[reportDeprecated]
     from pydantic_ai.providers.ovhcloud import OVHcloudProvider
     from pydantic_ai.providers.together import TogetherProvider
@@ -45,6 +46,7 @@ with try_import() as imports_successful:
         ('cohere', CohereProvider, 'CO_API_KEY'),
         ('deepseek', DeepSeekProvider, 'DEEPSEEK_API_KEY'),
         ('openrouter', OpenRouterProvider, 'OPENROUTER_API_KEY'),
+        ('orcarouter', OrcaRouterProvider, 'ORCAROUTER_API_KEY'),
         ('vercel', VercelProvider, 'VERCEL_AI_GATEWAY_API_KEY'),
         ('openai', OpenAIProvider, 'OPENAI_API_KEY'),
         ('azure', AzureProvider, 'AZURE_OPENAI'),


### PR DESCRIPTION
<!-- No tracking issue exists for this provider — opening this PR cold to start the conversation. Maintainers, please feel free to close if a built-in provider isn't desired for OrcaRouter and `OpenAIProvider(base_url=...)` is preferred. -->

## Summary

Adds a thin built-in provider for [OrcaRouter](https://orcarouter.ai), which exposes an OpenAI-compatible `/v1/chat/completions` endpoint. The provider is wired through the existing `OpenAIChatModel` path, mirroring the pattern used by `VercelProvider` / `TogetherProvider` / `DeepSeekProvider`.

- new `pydantic_ai.providers.orcarouter.OrcaRouterProvider`
- registered in `infer_provider_class`
- listed in `OpenAIChatCompatibleProvider` so `'orcarouter:<model>'` resolves to `OpenAIChatModel` with the new provider
- profile lookup splits `vendor/model` so upstream profiles (`anthropic`, `deepseek`, `google`, `meta-llama`, `mistral` / `mistralai`, `moonshotai`, `openai`, `qwen`, `x-ai` / `xai`) are picked up and then re-projected through `OpenAIJsonSchemaTransformer`
- reads the API key from `ORCAROUTER_API_KEY`

Usage:

```python
from pydantic_ai import Agent

agent = Agent('orcarouter:openai/gpt-4o-mini')
```

## Why a built-in provider rather than `OpenAIProvider(base_url=...)`

Functionally equivalent today; the built-in version is a convenience that gives users a stable `'orcarouter:'` prefix, env-var contract, and upstream-vendor profile mapping out of the box. Maintainers — if the bar for new built-in providers isn't met here, happy to close and rely on the generic `OpenAIProvider` instead.

## Tests

- new `tests/providers/test_orcarouter.py` (provider init, missing-key error, `model_profile` vendor mapping, fallback for unknown vendor / no slash)
- new parametrization entry in `tests/providers/test_provider_names.py`
- `uv run pytest tests/providers/` — 334 passed locally
- `make lint` / `make typecheck` clean; full pre-commit hook chain passes

## Docs

- `docs/models/overview.md`: OrcaRouter added under "OpenAI-compatible Providers"
- `docs/models/openai.md`: new "OrcaRouter" section with env-var and `OrcaRouterProvider` examples
- `docs/api/providers.md`: mkdocstrings entry for `OrcaRouterProvider`

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).