### PR TITLE
fix: update Cerebras reasoning settings and model names

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cerebras.py
@@ -54,9 +54,8 @@ class CerebrasModelSettings(ModelSettings, total=False):
 
     This setting is only supported on reasoning models: `zai-glm-4.7` and `gpt-oss-120b`.
 
-    .. deprecated::
-        Cerebras has deprecated the ``disable_reasoning`` parameter in favor of ``reasoning_effort``.
-        This setting is mapped to ``openai_reasoning_effort='none'`` when enabled.
+    **Deprecated:** Cerebras has deprecated the `disable_reasoning` parameter in favor of `reasoning_effort`.
+    This setting is mapped to `openai_reasoning_effort='none'` when enabled.
 
     See [the Cerebras docs](https://inference-docs.cerebras.ai/resources/openai#passing-non-standard-parameters) for more details.
     """

--- a/pydantic_ai_slim/pydantic_ai/models/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cerebras.py
@@ -129,15 +129,19 @@ def _cerebras_settings_to_openai_settings(
     Returns:
         An 'OpenAIChatModelSettings' object with equivalent settings.
     """
-    if (disable_reasoning := model_settings.pop('cerebras_disable_reasoning', None)) is not None:
+    # Build a plain dict so we can set openai_reasoning_effort (not in CerebrasModelSettings)
+    openai_settings: dict[str, Any] = dict(model_settings)
+    disable_reasoning = openai_settings.pop('cerebras_disable_reasoning', None)
+
+    if disable_reasoning is not None:
         # Map deprecated `disable_reasoning` to `reasoning_effort` for backward compatibility
         if disable_reasoning:
-            model_settings['openai_reasoning_effort'] = 'none'
-        else:
-            model_settings.setdefault('openai_reasoning_effort', 'low')
+            openai_settings['openai_reasoning_effort'] = 'none'
+        elif 'openai_reasoning_effort' not in openai_settings:
+            openai_settings['openai_reasoning_effort'] = 'low'
     elif model_request_parameters.thinking is False:
-        model_settings['openai_reasoning_effort'] = 'none'
+        openai_settings['openai_reasoning_effort'] = 'none'
     elif model_request_parameters.thinking:
-        model_settings.setdefault('openai_reasoning_effort', 'low')
+        openai_settings.setdefault('openai_reasoning_effort', 'low')
 
-    return OpenAIChatModelSettings(**model_settings)  # type: ignore[reportCallIssue]
+    return OpenAIChatModelSettings(**openai_settings)  # type: ignore[reportCallIssue]

--- a/pydantic_ai_slim/pydantic_ai/models/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cerebras.py
@@ -30,7 +30,7 @@ LatestCerebrasModelNames = Literal[
     'llama3.1-8b',
     'qwen-3-235b-a22b-instruct-2507',
     'qwen-3-32b',
-    'zai-glm-4.6',
+    'zai-glm-4.7',
 ]
 
 CerebrasModelName = str | LatestCerebrasModelNames
@@ -52,7 +52,11 @@ class CerebrasModelSettings(ModelSettings, total=False):
     cerebras_disable_reasoning: bool
     """Disable reasoning for the model.
 
-    This setting is only supported on reasoning models: `zai-glm-4.6` and `gpt-oss-120b`.
+    This setting is only supported on reasoning models: `zai-glm-4.7` and `gpt-oss-120b`.
+
+    .. deprecated::
+        Cerebras has deprecated the ``disable_reasoning`` parameter in favor of ``reasoning_effort``.
+        This setting is mapped to ``openai_reasoning_effort='none'`` when enabled.
 
     See [the Cerebras docs](https://inference-docs.cerebras.ai/resources/openai#passing-non-standard-parameters) for more details.
     """
@@ -91,11 +95,11 @@ class CerebrasModel(OpenAIChatModel):
         model_settings: OpenAIChatModelSettings,
         model_request_parameters: ModelRequestParameters,
     ) -> Any:
-        """Cerebras handles reasoning via extra_body['disable_reasoning'], not reasoning_effort."""
+        """Cerebras handles reasoning via reasoning_effort, not openai_reasoning_effort."""
         from openai import omit
 
         # Only pass through explicit openai_reasoning_effort if set; unified thinking
-        # is handled in _cerebras_settings_to_openai_settings via disable_reasoning.
+        # is handled in _cerebras_settings_to_openai_settings via reasoning_effort.
         if effort := model_settings.get('openai_reasoning_effort'):
             return effort
         return omit
@@ -125,16 +129,15 @@ def _cerebras_settings_to_openai_settings(
     Returns:
         An 'OpenAIChatModelSettings' object with equivalent settings.
     """
-    extra_body = cast(dict[str, Any], model_settings.get('extra_body', {}))
-
     if (disable_reasoning := model_settings.pop('cerebras_disable_reasoning', None)) is not None:
-        extra_body['disable_reasoning'] = disable_reasoning
+        # Map deprecated `disable_reasoning` to `reasoning_effort` for backward compatibility
+        if disable_reasoning:
+            model_settings['openai_reasoning_effort'] = 'none'
+        else:
+            model_settings.setdefault('openai_reasoning_effort', 'low')
     elif model_request_parameters.thinking is False:
-        extra_body['disable_reasoning'] = True
+        model_settings['openai_reasoning_effort'] = 'none'
     elif model_request_parameters.thinking:
-        extra_body['disable_reasoning'] = False
-
-    if extra_body:
-        model_settings['extra_body'] = extra_body
+        model_settings.setdefault('openai_reasoning_effort', 'low')
 
     return OpenAIChatModelSettings(**model_settings)  # type: ignore[reportCallIssue]

--- a/pydantic_ai_slim/pydantic_ai/models/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cerebras.py
@@ -144,4 +144,4 @@ def _cerebras_settings_to_openai_settings(
     elif model_request_parameters.thinking:
         openai_settings.setdefault('openai_reasoning_effort', 'low')
 
-    return OpenAIChatModelSettings(**openai_settings)  # type: ignore[reportCallIssue]
+    return OpenAIChatModelSettings(**openai_settings)

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -78,11 +78,15 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
             # thinking content is sent back in multi-turn conversations (not silently stripped).
             thinking_profile = OpenAIModelProfile(openai_chat_send_back_thinking_parts='tags')
 
-        return OpenAIModelProfile(
-            json_schema_transformer=OpenAIJsonSchemaTransformer,
-            openai_unsupported_model_settings=unsupported_model_settings,
-            supports_thinking=is_reasoning,
-        ).update(profile).update(thinking_profile)
+        return (
+            OpenAIModelProfile(
+                json_schema_transformer=OpenAIJsonSchemaTransformer,
+                openai_unsupported_model_settings=unsupported_model_settings,
+                supports_thinking=is_reasoning,
+            )
+            .update(profile)
+            .update(thinking_profile)
+        )
 
     @overload
     def __init__(self) -> None: ...

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -48,7 +48,7 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
             'zai': zai_model_profile,
         }
 
-        # Reasoning models that support the cerebras_disable_reasoning setting
+        # Reasoning models that support reasoning_effort
         reasoning_prefixes = ('zai', 'gpt-oss')
 
         profile = None
@@ -70,11 +70,19 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
             'openai_service_tier',
         )
         is_reasoning = model_name_lower.startswith(reasoning_prefixes)
+
+        thinking_profile: ModelProfile | None = None
+        if is_reasoning:
+            # GLM (zai) and Qwen models return thinking in `<think>` tags by default on Cerebras.
+            # We need to set `openai_chat_send_back_thinking_parts='tags'` so that
+            # thinking content is sent back in multi-turn conversations (not silently stripped).
+            thinking_profile = OpenAIModelProfile(openai_chat_send_back_thinking_parts='tags')
+
         return OpenAIModelProfile(
             json_schema_transformer=OpenAIJsonSchemaTransformer,
             openai_unsupported_model_settings=unsupported_model_settings,
             supports_thinking=is_reasoning,
-        ).update(profile)
+        ).update(profile).update(thinking_profile)
 
     @overload
     def __init__(self) -> None: ...

--- a/tests/models/cassettes/test_cerebras/test_cerebras_disable_reasoning_setting.yaml
+++ b/tests/models/cassettes/test_cerebras/test_cerebras_disable_reasoning_setting.yaml
@@ -19,7 +19,7 @@ interactions:
       messages:
       - content: What is 2 + 2?
         role: user
-      model: zai-glm-4.6
+      model: zai-glm-4.7
       stream: false
     uri: https://api.cerebras.ai/v1/chat/completions
   response:
@@ -51,7 +51,7 @@ interactions:
           role: assistant
       created: 1764196889
       id: chatcmpl-e85aab65-95fd-46d8-ab18-07e585698feb
-      model: zai-glm-4.6
+      model: zai-glm-4.7
       object: chat.completion
       system_fingerprint: fp_9eaa76d40d229969234d
       time_info:

--- a/tests/models/test_cerebras.py
+++ b/tests/models/test_cerebras.py
@@ -69,3 +69,8 @@ async def test_cerebras_settings_transformation():
     settings_false = CerebrasModelSettings(cerebras_disable_reasoning=False)
     transformed_false = _cerebras_settings_to_openai_settings(settings_false, params)
     assert transformed_false.get('openai_reasoning_effort') == 'low'
+
+    # Test with disable_reasoning=False but openai_reasoning_effort already set → preserves existing value
+    settings_with_effort = CerebrasModelSettings(cerebras_disable_reasoning=False, openai_reasoning_effort='high')
+    transformed_with_effort = _cerebras_settings_to_openai_settings(settings_with_effort, params)
+    assert transformed_with_effort.get('openai_reasoning_effort') == 'high'

--- a/tests/models/test_cerebras.py
+++ b/tests/models/test_cerebras.py
@@ -1,6 +1,6 @@
 from __future__ import annotations as _annotations
 
-from typing import Any, cast
+from typing import cast
 
 import pytest
 

--- a/tests/models/test_cerebras.py
+++ b/tests/models/test_cerebras.py
@@ -35,12 +35,12 @@ async def test_cerebras_model_simple(allow_model_requests: None, cerebras_api_ke
 
 
 async def test_cerebras_disable_reasoning_setting(allow_model_requests: None, cerebras_api_key: str):
-    """Test that cerebras_disable_reasoning setting is properly transformed to extra_body.
+    """Test that cerebras_disable_reasoning setting is properly transformed to reasoning_effort.
 
-    Note: disable_reasoning is only supported on reasoning models: zai-glm-4.6 and gpt-oss-120b.
+    Note: disable_reasoning is only supported on reasoning models: zai-glm-4.7 and gpt-oss-120b.
     """
     provider = CerebrasProvider(api_key=cerebras_api_key)
-    model = CerebrasModel('zai-glm-4.6', provider=provider)
+    model = CerebrasModel('zai-glm-4.7', provider=provider)
 
     settings = CerebrasModelSettings(cerebras_disable_reasoning=True)
     response = await model_request(model, [ModelRequest.user_text_prompt('What is 2 + 2?')], model_settings=settings)
@@ -55,19 +55,17 @@ async def test_cerebras_settings_transformation():
 
     params = ModelRequestParameters()
 
-    # Test with disable_reasoning
+    # Test with disable_reasoning → maps to reasoning_effort='none'
     settings = CerebrasModelSettings(cerebras_disable_reasoning=True)
     transformed = _cerebras_settings_to_openai_settings(settings, params)
-    extra_body = cast(dict[str, Any], transformed.get('extra_body', {}))
-    assert extra_body.get('disable_reasoning') is True
+    assert transformed.get('openai_reasoning_effort') == 'none'
 
-    # Test without disable_reasoning (should not have extra_body)
+    # Test without disable_reasoning (should not set reasoning_effort)
     settings_empty = CerebrasModelSettings()
     transformed_empty = _cerebras_settings_to_openai_settings(settings_empty, params)
-    assert transformed_empty.get('extra_body') is None
+    assert transformed_empty.get('openai_reasoning_effort') is None
 
-    # Test with disable_reasoning=False
+    # Test with disable_reasoning=False → maps to reasoning_effort='low'
     settings_false = CerebrasModelSettings(cerebras_disable_reasoning=False)
     transformed_false = _cerebras_settings_to_openai_settings(settings_false, params)
-    extra_body_false = cast(dict[str, Any], transformed_false.get('extra_body', {}))
-    assert extra_body_false.get('disable_reasoning') is False
+    assert transformed_false.get('openai_reasoning_effort') == 'low'

--- a/tests/providers/test_cerebras.py
+++ b/tests/providers/test_cerebras.py
@@ -90,8 +90,8 @@ def test_cerebras_provider_model_profile(mocker: MockerFixture):
     assert harmony_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
 
     # Test zai model - uses default OpenAI profile (zai_model_profile returns None)
-    zai_profile = provider.model_profile('zai-glm-4.6')
-    zai_model_profile_mock.assert_called_with('zai-glm-4.6')
+    zai_profile = provider.model_profile('zai-glm-4.7')
+    zai_model_profile_mock.assert_called_with('zai-glm-4.7')
     assert zai_profile is not None
     assert isinstance(zai_profile, OpenAIModelProfile)
     assert zai_profile.json_schema_transformer == OpenAIJsonSchemaTransformer

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -775,33 +775,29 @@ class TestOpenRouterThinkingTranslation:
 class TestCerebrasThinkingTranslation:
     """Test Cerebras unified thinking fallback."""
 
-    def test_thinking_false_sets_disable_reasoning(self):
+    def test_thinking_false_sets_reasoning_effort_none(self):
         settings = CerebrasModelSettings()
         params = ModelRequestParameters(thinking=False)
         result = _cerebras_settings_to_openai_settings(settings, params)
-        extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert extra_body.get('disable_reasoning') is True
+        assert result.get('openai_reasoning_effort') == 'none'
 
-    def test_thinking_true_sets_disable_reasoning_false(self):
+    def test_thinking_true_sets_reasoning_effort_low(self):
         settings = CerebrasModelSettings()
         params = ModelRequestParameters(thinking=True)
         result = _cerebras_settings_to_openai_settings(settings, params)
-        extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert extra_body.get('disable_reasoning') is False
+        assert result.get('openai_reasoning_effort') == 'low'
 
-    def test_thinking_effort_sets_disable_reasoning_false(self):
+    def test_thinking_effort_sets_reasoning_effort(self):
         settings = CerebrasModelSettings()
         params = ModelRequestParameters(thinking='high')
         result = _cerebras_settings_to_openai_settings(settings, params)
-        extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert extra_body.get('disable_reasoning') is False
+        assert result.get('openai_reasoning_effort') == 'low'
 
     def test_explicit_cerebras_disable_takes_precedence(self):
         settings = CerebrasModelSettings(cerebras_disable_reasoning=True)
         params = ModelRequestParameters(thinking=True)
         result = _cerebras_settings_to_openai_settings(settings, params)
-        extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert extra_body.get('disable_reasoning') is True
+        assert result.get('openai_reasoning_effort') == 'none'
 
     def test_explicit_openai_reasoning_effort_passthrough(self):
         """Explicit openai_reasoning_effort on Cerebras is passed through."""


### PR DESCRIPTION
## Changes

- Update model name  → 
- Set  for zai models so thinking content is preserved in multi-turn conversations
- Replace deprecated  extra_body parameter with  (maps  to  for backward compatibility)
- Update tests and cassettes to match new behavior

Fixes #5606