### PR TITLE
fix(bedrock): recognize `type='adaptive'` in `_is_thinking_enabled`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -1544,7 +1544,7 @@ def _is_thinking_enabled(
         if (
             (additional_fields := model_settings.get('bedrock_additional_model_requests_fields'))
             and (thinking := additional_fields.get('thinking'))
-            and thinking.get('type') == 'enabled'
+            and thinking.get('type') in ('enabled', 'adaptive')
         ):
             return True
     return False

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -2313,19 +2313,27 @@ Mexico City is an important cultural, financial, and political center for the co
     )
 
 
-async def test_bedrock_output_tool_with_thinking_raises(allow_model_requests: None, bedrock_provider: BedrockProvider):
+@pytest.mark.parametrize(
+    'thinking_field',
+    [
+        pytest.param({'type': 'enabled', 'budget_tokens': 1024}, id='enabled'),
+        pytest.param({'type': 'adaptive'}, id='adaptive'),
+    ],
+)
+async def test_bedrock_output_tool_with_thinking_raises(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, thinking_field: dict[str, Any]
+):
     """Bedrock does not support output tools (tool_choice=required) with thinking enabled.
 
     Uses the legacy `bedrock_additional_model_requests_fields` form. See
     `test_bedrock_output_tool_with_unified_thinking_raises` for the unified `thinking` field.
-    Fixes https://github.com/pydantic/pydantic-ai/issues/3092.
+    Fixes https://github.com/pydantic/pydantic-ai/issues/3092 (`enabled`) and
+    https://github.com/pydantic/pydantic-ai/issues/5650 (`adaptive`).
     """
     m = BedrockConverseModel(
         'us.anthropic.claude-sonnet-4-20250514-v1:0',
         provider=bedrock_provider,
-        settings=BedrockModelSettings(
-            bedrock_additional_model_requests_fields={'thinking': {'type': 'enabled', 'budget_tokens': 1024}}
-        ),
+        settings=BedrockModelSettings(bedrock_additional_model_requests_fields={'thinking': thinking_field}),
     )
 
     agent = Agent(m, output_type=ToolOutput(int))


### PR DESCRIPTION
- Closes #5650

`_is_thinking_enabled` previously matched only `{'type': 'enabled'}` in `bedrock_additional_model_requests_fields`, missing the `'adaptive'` variant added in #5304 / #5326. When a user passed the raw adaptive dict (the documented escape hatch for fields the unified API doesn't expose, like `display` and `output_config`), detection silently failed and the downstream tool_choice + thinking guards never fired:

- `prepare_request` didn't switch `output_mode` away from `tool` → structured-output requests failed with Bedrock's "tool_choice + thinking" rejection.
- `_support_tool_forcing` didn't downgrade forced `tool_choice` to `auto`.

The forced workaround was redundantly setting unified `thinking=True` alongside the raw dict, which contradicts the role of `_is_thinking_enabled` as the single source of truth.

The Anthropic adapter already uses the `('enabled', 'adaptive')` membership pattern at `pydantic_ai/models/anthropic.py:593` and `:2728`; this aligns Bedrock with it.

The existing `test_bedrock_output_tool_with_thinking_raises` is parametrized over `enabled` / `adaptive` so the same regression is covered for both variants of #3092 and #5650.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).