### PR TITLE
feat: add `anthropic_thinking_display` and `bedrock_thinking_display` settings

### DIFF
--- a/docs/thinking.md
+++ b/docs/thinking.md
@@ -146,6 +146,18 @@ The [`anthropic_effort`][pydantic_ai.models.anthropic.AnthropicModelSettings.ant
 !!! note
     Older models (`claude-sonnet-4-5`, `claude-opus-4-5`, etc.) do not support adaptive thinking and require `{'type': 'enabled', 'budget_tokens': N}` as shown [above](#anthropic).
 
+Anthropic's [`display`](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#summarized-thinking) parameter controls whether the API returns a summary of the model's thinking (`'summarized'`) or only signatures (`'omitted'`). Defaults vary by model — when the model defaults to `'omitted'`, `thinking=True` produces empty thinking content (the model still thinks and is billed). Set [`anthropic_thinking_display`][pydantic_ai.models.anthropic.AnthropicModelSettings.anthropic_thinking_display] to `'summarized'` to receive thinking content:
+
+```python {title="anthropic_thinking_display.py"}
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
+
+model = AnthropicModel('claude-opus-4-7')
+settings = AnthropicModelSettings(thinking=True, anthropic_thinking_display='summarized')
+agent = Agent(model, model_settings=settings)
+...
+```
+
 Thinking tokens count against Anthropic's loop-wide [task budgets](models/anthropic.md#task-budgets-beta), so adaptive thinking naturally scales down as the budget depletes.
 
 ## Google
@@ -181,6 +193,8 @@ agent = Agent(model, model_settings=settings)
 ## Bedrock
 
 For Claude Sonnet 4.6+ and Opus 4.6+, Pydantic AI's unified `thinking` setting translates to AWS's required [adaptive thinking](https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html) shape automatically — set [`ModelSettings.thinking`][pydantic_ai.settings.ModelSettings.thinking] and you're done.
+
+For Bedrock-hosted Claude models whose upstream API defaults to `'omitted'`, set [`bedrock_thinking_display`][pydantic_ai.models.bedrock.BedrockModelSettings.bedrock_thinking_display] to `'summarized'` to receive thinking content — same behavior as the [direct Anthropic API](#adaptive-thinking-effort).
 
 For older Claude models or to pin a specific `budget_tokens`, you can still use [`BedrockModelSettings.bedrock_additional_model_requests_fields`][pydantic_ai.models.bedrock.BedrockModelSettings.bedrock_additional_model_requests_fields] [model setting](agent.md#model-run-settings) to pass provider-specific configuration directly:
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -295,6 +295,19 @@ class AnthropicModelSettings(ModelSettings, total=False):
     See [the Anthropic docs](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking) for more information.
     """
 
+    anthropic_thinking_display: Literal['summarized', 'omitted']
+    """Whether to receive a summary of the model's thinking or only thinking signatures.
+
+    Applied to the thinking block emitted from the unified `thinking` setting;
+    ignored when `anthropic_thinking` is set explicitly (the raw dict wins).
+
+    Defaults vary by model — when the model defaults to `'omitted'`, `thinking=True`
+    produces empty thinking content unless this is set to `'summarized'`. The model
+    still thinks (and is billed for) the same number of tokens regardless.
+
+    See [the Anthropic docs](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#summarized-thinking) for more information.
+    """
+
     anthropic_cache_tool_definitions: bool | Literal['5m', '1h']
     """Whether to add `cache_control` to the last tool definition.
 
@@ -655,9 +668,14 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         if thinking is None or thinking is False:
             return OMIT  # type: ignore[return-value]
         profile = AnthropicModelProfile.from_profile(self.profile)
+        result: BetaThinkingConfigParam
         if profile.anthropic_supports_adaptive_thinking:
-            return {'type': 'adaptive'}
-        return {'type': 'enabled', 'budget_tokens': ANTHROPIC_THINKING_BUDGET_MAP[thinking]}
+            result = {'type': 'adaptive'}
+        else:
+            result = {'type': 'enabled', 'budget_tokens': ANTHROPIC_THINKING_BUDGET_MAP[thinking]}
+        if display := model_settings.get('anthropic_thinking_display'):
+            result['display'] = display
+        return result
 
     @overload
     async def _messages_create(

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -341,6 +341,22 @@ class BedrockModelSettings(ModelSettings, total=False):
     See more about it on <https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html>.
     """
 
+    bedrock_thinking_display: Literal['summarized', 'omitted']
+    """Whether to receive a summary of the model's thinking or only thinking signatures.
+
+    Honored only for models that use the Anthropic thinking variant (Claude on Bedrock).
+    Ignored for OpenAI/Qwen variants — the underlying API has no equivalent knob — matching
+    the precedent of `bedrock_supports_adaptive_thinking`. Applied to the thinking block
+    emitted from the unified `thinking` setting; ignored when a raw `thinking` dict is
+    supplied via `bedrock_additional_model_requests_fields` (the raw dict wins).
+
+    Defaults vary by model — when the model defaults to `'omitted'`, `thinking=True`
+    produces empty thinking content unless this is set to `'summarized'`. The model
+    still thinks (and is billed for) the same number of tokens regardless.
+
+    See [the Anthropic docs](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#summarized-thinking) for more information.
+    """
+
     bedrock_cache_tool_definitions: bool | Literal['5m', '1h']
     """Whether to add a cache point after the last tool definition.
 
@@ -712,9 +728,12 @@ class BedrockConverseModel(Model[BaseClient]):
         variant = profile.bedrock_thinking_variant
 
         if variant == 'anthropic' and 'thinking' not in existing:
+            display = model_settings.get('bedrock_thinking_display')
             if profile.bedrock_supports_adaptive_thinking:
                 if thinking is not False:
                     existing['thinking'] = {'type': 'adaptive'}
+                    if display:
+                        existing['thinking']['display'] = display
                     # Bedrock puts effort in output_config (a sibling of thinking), matching the direct Anthropic API shape.
                     if (
                         profile.bedrock_supports_effort
@@ -726,6 +745,8 @@ class BedrockConverseModel(Model[BaseClient]):
                 existing['thinking'] = {'type': 'disabled'}
             else:
                 existing['thinking'] = {'type': 'enabled', 'budget_tokens': ANTHROPIC_THINKING_BUDGET_MAP[thinking]}
+                if display:
+                    existing['thinking']['display'] = display
         elif variant == 'openai' and 'reasoning_effort' not in existing:
             if thinking is not False:  # Bedrock doesn't accept reasoning_effort='none'
                 existing['reasoning_effort'] = OPENAI_REASONING_EFFORT_MAP[thinking]

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -316,6 +316,49 @@ class TestAnthropicThinkingTranslation:
         result = AnthropicModel._translate_thinking(adaptive_model, settings, params)
         assert result == {'type': 'adaptive'}
 
+    def test_display_summarized_on_adaptive(self, adaptive_model: FunctionModel):
+        params = ModelRequestParameters(thinking=True)
+        settings: AnthropicModelSettings = {'anthropic_thinking_display': 'summarized'}
+        result = AnthropicModel._translate_thinking(adaptive_model, settings, params)
+        assert result == snapshot({'type': 'adaptive', 'display': 'summarized'})
+
+    def test_display_omitted_on_adaptive(self, adaptive_model: FunctionModel):
+        params = ModelRequestParameters(thinking=True)
+        settings: AnthropicModelSettings = {'anthropic_thinking_display': 'omitted'}
+        result = AnthropicModel._translate_thinking(adaptive_model, settings, params)
+        assert result == snapshot({'type': 'adaptive', 'display': 'omitted'})
+
+    def test_display_on_enabled_shape(self, non_adaptive_model: FunctionModel):
+        """display is also emitted on the budget-based 'enabled' shape (pre-adaptive models)."""
+        params = ModelRequestParameters(thinking='high')
+        settings: AnthropicModelSettings = {'anthropic_thinking_display': 'summarized'}
+        result = AnthropicModel._translate_thinking(non_adaptive_model, settings, params)
+        assert result == snapshot({'type': 'enabled', 'budget_tokens': 16384, 'display': 'summarized'})
+
+    def test_display_ignored_when_thinking_false(self, adaptive_model: FunctionModel):
+        """display setting is dropped on the OMIT path — no thinking block to attach to."""
+        params = ModelRequestParameters(thinking=False)
+        settings: AnthropicModelSettings = {'anthropic_thinking_display': 'summarized'}
+        result = AnthropicModel._translate_thinking(adaptive_model, settings, params)
+        assert result is anthropic_omit
+
+    def test_display_ignored_when_thinking_none(self, adaptive_model: FunctionModel):
+        """display setting is dropped on the OMIT path — no thinking block to attach to."""
+        params = ModelRequestParameters(thinking=None)
+        settings: AnthropicModelSettings = {'anthropic_thinking_display': 'summarized'}
+        result = AnthropicModel._translate_thinking(adaptive_model, settings, params)
+        assert result is anthropic_omit
+
+    def test_raw_anthropic_thinking_wins_over_display(self, adaptive_model: FunctionModel):
+        """Raw `anthropic_thinking` dict wins; `anthropic_thinking_display` is not injected on top."""
+        params = ModelRequestParameters(thinking=True)
+        settings: AnthropicModelSettings = {
+            'anthropic_thinking': {'type': 'adaptive'},
+            'anthropic_thinking_display': 'summarized',
+        }
+        result = AnthropicModel._translate_thinking(adaptive_model, settings, params)
+        assert result == snapshot({'type': 'adaptive'})
+
 
 @pytest.mark.skipif(not openai_imports(), reason='openai not installed')
 class TestOpenAIChatThinkingTranslation:
@@ -732,6 +775,85 @@ class TestBedrockThinkingTranslation:
         model = self._adaptive_model()
         result = model._translate_thinking(BedrockModelSettings(), ModelRequestParameters(thinking=False))
         assert result is None
+
+    def test_anthropic_variant_adaptive_display_summarized(self):
+        model = self._adaptive_model()
+        settings = BedrockModelSettings(bedrock_thinking_display='summarized')
+        result = model._translate_thinking(settings, ModelRequestParameters(thinking=True))
+        assert result == snapshot({'thinking': {'type': 'adaptive', 'display': 'summarized'}})
+
+    def test_anthropic_variant_adaptive_display_omitted(self):
+        model = self._adaptive_model()
+        settings = BedrockModelSettings(bedrock_thinking_display='omitted')
+        result = model._translate_thinking(settings, ModelRequestParameters(thinking=True))
+        assert result == snapshot({'thinking': {'type': 'adaptive', 'display': 'omitted'}})
+
+    def test_anthropic_variant_adaptive_display_with_effort(self):
+        """display coexists with output_config.effort on adaptive models."""
+        model = self._adaptive_model()
+        settings = BedrockModelSettings(bedrock_thinking_display='summarized')
+        result = model._translate_thinking(settings, ModelRequestParameters(thinking='high'))
+        assert result == snapshot(
+            {'thinking': {'type': 'adaptive', 'display': 'summarized'}, 'output_config': {'effort': 'high'}}
+        )
+
+    def test_anthropic_variant_enabled_display(self):
+        """display is also attached to the budget-based 'enabled' shape (pre-adaptive Anthropic models)."""
+        model = BedrockConverseModel.__new__(BedrockConverseModel)
+        model._profile = BedrockModelProfile(
+            bedrock_thinking_variant='anthropic',
+            supports_thinking=True,
+        )
+        settings = BedrockModelSettings(bedrock_thinking_display='summarized')
+        result = model._translate_thinking(settings, ModelRequestParameters(thinking='high'))
+        assert result == snapshot({'thinking': {'type': 'enabled', 'budget_tokens': 16384, 'display': 'summarized'}})
+
+    def test_anthropic_variant_display_dropped_when_thinking_false(self):
+        """display is not injected on the 'disabled' shape — Anthropic's API doesn't accept it there."""
+        model = BedrockConverseModel.__new__(BedrockConverseModel)
+        model._profile = BedrockModelProfile(
+            bedrock_thinking_variant='anthropic',
+            supports_thinking=True,
+        )
+        settings = BedrockModelSettings(bedrock_thinking_display='summarized')
+        result = model._translate_thinking(settings, ModelRequestParameters(thinking=False))
+        assert result == snapshot({'thinking': {'type': 'disabled'}})
+
+    def test_anthropic_variant_adaptive_display_dropped_when_thinking_false(self):
+        model = self._adaptive_model()
+        settings = BedrockModelSettings(bedrock_thinking_display='summarized')
+        result = model._translate_thinking(settings, ModelRequestParameters(thinking=False))
+        assert result is None
+
+    def test_openai_variant_ignores_display(self):
+        model = BedrockConverseModel.__new__(BedrockConverseModel)
+        model._profile = BedrockModelProfile(
+            bedrock_thinking_variant='openai',
+            supports_thinking=True,
+        )
+        settings = BedrockModelSettings(bedrock_thinking_display='summarized')
+        result = model._translate_thinking(settings, ModelRequestParameters(thinking='high'))
+        assert result == snapshot({'reasoning_effort': 'high'})
+
+    def test_qwen_variant_ignores_display(self):
+        model = BedrockConverseModel.__new__(BedrockConverseModel)
+        model._profile = BedrockModelProfile(
+            bedrock_thinking_variant='qwen',
+            supports_thinking=True,
+        )
+        settings = BedrockModelSettings(bedrock_thinking_display='summarized')
+        result = model._translate_thinking(settings, ModelRequestParameters(thinking=True))
+        assert result == snapshot({'reasoning_config': 'high'})
+
+    def test_anthropic_variant_raw_thinking_dict_wins_over_display(self):
+        """Raw `thinking` dict in additionalModelRequestFields wins; display is not injected on top."""
+        model = self._adaptive_model()
+        settings = BedrockModelSettings(
+            bedrock_thinking_display='summarized',
+            bedrock_additional_model_requests_fields={'thinking': {'type': 'adaptive'}},
+        )
+        result = model._translate_thinking(settings, ModelRequestParameters(thinking=True))
+        assert result == snapshot({'thinking': {'type': 'adaptive'}})
 
 
 @pytest.mark.skipif(not openai_imports(), reason='openai not installed')


### PR DESCRIPTION
- Closes #5649

Adds a unified-thinking knob for Anthropic's [`display`](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#summarized-thinking) parameter on both the direct Anthropic API and Bedrock, fixing the case where `thinking=True` on newer Claude models (whose API default is `'omitted'`) silently produces empty thinking blocks while still billing for the tokens.

- `AnthropicModelSettings.anthropic_thinking_display: Literal['summarized', 'omitted']` — injected onto the `{'type': 'adaptive'}` or `{'type': 'enabled', ...}` block emitted from unified `thinking`. Skipped on the OMIT path (`thinking is None or thinking is False`) and when `anthropic_thinking` is set explicitly (raw dict wins).
- `BedrockModelSettings.bedrock_thinking_display: Literal['summarized', 'omitted']` — same behavior for the Anthropic Bedrock variant. Silently ignored for OpenAI/Qwen variants (no upstream equivalent) and when a raw `thinking` dict is supplied via `bedrock_additional_model_requests_fields`, matching the precedent of `bedrock_supports_adaptive_thinking`.
- Docs: new sections in `docs/thinking.md` for both Anthropic and Bedrock, with a runnable example.
- Tests: 14 new translation-layer tests in `tests/test_thinking.py` covering adaptive/enabled shapes, the OMIT path, raw-dict precedence, and silent-ignore on non-Anthropic Bedrock variants.

No profile gating is added — `display` is a parameter the upstream API accepts on every Claude thinking config that supports `display` at all, so the existing `*_supports_adaptive_thinking` gating on the surrounding shape is sufficient. Defaults are left to the upstream API (the docstrings note that defaults vary by model and link to Anthropic's docs).

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).