### PR TITLE
Fix AG-UI `ThinkingPart` ID round-trip

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -430,7 +430,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     builder.add(
                         ThinkingPart(
                             content=reasoning_msg.content,
-                            id=metadata.get('id'),
+                            id=metadata.get('id') or reasoning_msg.id,
                             signature=metadata.get('signature'),
                             provider_name=metadata.get('provider_name'),
                             provider_details=metadata.get('provider_details'),
@@ -619,7 +619,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     encrypted = thinking_encrypted_metadata(part)
                     result.append(
                         ReasoningMessage(
-                            id=_new_message_id(),
+                            id=part.id or _new_message_id(),
                             content=part.content,
                             encrypted_value=json.dumps(encrypted) if encrypted else None,
                         )

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1415,6 +1415,35 @@ def test_reasoning_message_thinking_roundtrip() -> None:
     )
 
 
+def test_dump_load_messages_preserves_generated_thinking_id() -> None:
+    """Test that dumped ReasoningMessage ids survive a load round-trip."""
+    messages: list[ModelMessage] = [
+        ModelResponse(parts=[ThinkingPart(content='Let me think...')]),
+    ]
+
+    ag_ui_messages = AGUIAdapter.dump_messages(messages, ag_ui_version='0.1.13')
+    reasoning_message = next(m for m in ag_ui_messages if isinstance(m, ReasoningMessage))
+    reloaded_messages = AGUIAdapter.load_messages(ag_ui_messages)
+
+    response = reloaded_messages[0]
+    assert isinstance(response, ModelResponse)
+    thinking_part = response.parts[0]
+    assert isinstance(thinking_part, ThinkingPart)
+    assert thinking_part.id == reasoning_message.id
+
+
+def test_dump_messages_preserves_explicit_thinking_id() -> None:
+    """Test that explicit ThinkingPart ids are used as ReasoningMessage ids."""
+    messages: list[ModelMessage] = [
+        ModelResponse(parts=[ThinkingPart(content='Let me think...', id='thinking-1')]),
+    ]
+
+    ag_ui_messages = AGUIAdapter.dump_messages(messages, ag_ui_version='0.1.13')
+    reasoning_message = next(m for m in ag_ui_messages if isinstance(m, ReasoningMessage))
+
+    assert reasoning_message.id == 'thinking-1'
+
+
 async def test_reasoning_events_with_all_metadata() -> None:
     """Test that REASONING_* events emit encryptedValue with all metadata fields."""
     run_input = create_input(UserMessage(id='msg_1', content='test'))


### PR DESCRIPTION
- Closes #5599

### Summary

- preserve explicit `ThinkingPart.id` values when dumping AG-UI `ReasoningMessage`s
- restore generated `ReasoningMessage.id` values when loading reasoning messages without encrypted id metadata
- add regression coverage for both generated and explicit thinking ids

### Tests

- `uv run pytest tests/test_ag_ui.py::test_reasoning_message_thinking_roundtrip tests/test_ag_ui.py::test_dump_load_messages_preserves_generated_thinking_id tests/test_ag_ui.py::test_dump_messages_preserves_explicit_thinking_id tests/test_ag_ui.py::test_dump_messages_thinking_version_gated -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
