### PR TITLE
Fix typo in `SystemPromptFunc` docstring

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -56,7 +56,7 @@ SystemPromptFunc: TypeAlias = (
     | Callable[[], str | None]
     | Callable[[], Awaitable[str | None]]
 )
-"""A function that may or maybe not take `RunContext` as an argument, and may or may not be async.
+"""A function that may or may not take `RunContext` as an argument, and may or may not be async.
 
 Functions which return None are excluded from model requests.
 


### PR DESCRIPTION
The docstring for `SystemPromptFunc` in `pydantic_ai_slim/pydantic_ai/tools.py` reads "may or maybe not take \`RunContext\`". This is a small typo — the second clause on the same line correctly says "may or may not be async". Fixed to match.

```diff
-"""A function that may or maybe not take `RunContext` as an argument, and may or may not be async.
+"""A function that may or may not take `RunContext` as an argument, and may or may not be async.
```