### PR TITLE
ci: constrain `hf-xet` below deprecated API

### DIFF
--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -50,7 +50,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pydantic-ai-slim[openai,vertexai,groq,anthropic,ag-ui]=={{ version }}",
     "pydantic-evals=={{ version }}",
-    "asyncpg>=0.30.0",
+    "asyncpg>=0.31.0",
     "fastapi>=0.117.0",
     "logfire[asyncpg,fastapi,sqlite3,httpx]>=3.14.1",
     "python-multipart>=0.0.17",
@@ -60,9 +60,9 @@ dependencies = [
     "gradio>=6.7.0",
     "mcp[cli]>=1.25.0,<2.0",
     "modal>=1.0.4",
-    "duckdb>=1.3.2",
+    "duckdb>=1.4.2",
     "datasets>=4.0.0",
-    "pandas>=2.2.3",
+    "pandas>=2.3.3",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -79,7 +79,11 @@ openrouter = ["openai>=2.8.0"]
 # `mistralai==2.4.6` was quarantined on PyPI due to a supply-chain attack (see #5382).
 mistral = ["mistralai>=2.0.0,!=2.4.6"]
 bedrock = ["boto3>=1.42.63"]
-huggingface = ["huggingface-hub>=1.3.4,<2.0.0"]
+huggingface = [
+    "huggingface-hub>=1.3.4,<2.0.0",
+    # huggingface_hub 1.3.x still calls the deprecated hf_xet.download_files() API.
+    "hf-xet<1.5.0; platform_machine == 'x86_64' or platform_machine == 'amd64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'aarch64'",
+]
 sentence-transformers = ["sentence-transformers>=5.2.0; python_version < '3.14'"]
 # 3.14 pin removable once voyageai 0.3.8 drops: https://pypi.org/project/voyageai/#history
 voyageai = ["voyageai>=0.3.7; python_version < '3.14'"]

--- a/uv.lock
+++ b/uv.lock
@@ -7186,16 +7186,16 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "devtools", specifier = ">=0.12.2" },
-    { name = "duckdb", specifier = ">=1.3.2" },
+    { name = "duckdb", specifier = ">=1.4.2" },
     { name = "fastapi", specifier = ">=0.117.0" },
     { name = "gradio", specifier = ">=6.7.0" },
     { name = "logfire", extras = ["asyncpg", "fastapi", "httpx", "sqlite3"], specifier = ">=3.14.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.25.0,<2.0" },
     { name = "modal", specifier = ">=1.0.4" },
-    { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pandas", specifier = ">=2.3.3" },
     { name = "pydantic-ai-slim", extras = ["ag-ui", "anthropic", "groq", "openai", "vertexai"], editable = "pydantic_ai_slim" },
     { name = "pydantic-evals", editable = "pydantic_evals" },
     { name = "python-multipart", specifier = ">=0.0.17" },

--- a/uv.lock
+++ b/uv.lock
@@ -7263,6 +7263,7 @@ groq = [
     { name = "groq" },
 ]
 huggingface = [
+    { name = "hf-xet", marker = "platform_machine == 'x86_64' or platform_machine == 'amd64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'aarch64'" },
     { name = "huggingface-hub", version = "1.3.4", source = { registry = "https://pypi.org/simple" } },
 ]
 logfire = [
@@ -7370,6 +7371,7 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.70.0" },
     { name = "griffelib", specifier = ">=2.0" },
     { name = "groq", marker = "extra == 'groq'", specifier = ">=0.25.0" },
+    { name = "hf-xet", marker = "(platform_machine == 'x86_64' or platform_machine == 'amd64' or platform_machine == 'AMD64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and extra == 'huggingface'", specifier = "<1.5.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'web'", specifier = ">=0.27.0" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=1.3.4,<2.0.0" },


### PR DESCRIPTION
Fixes failing main CI run: https://github.com/pydantic/pydantic-ai/actions/runs/26453220808

The lowest-version test matrix resolves `huggingface-hub==1.3.4`. That version still calls `hf_xet.download_files()` while downloading Xet-backed model files, but `hf-xet==1.5.0` deprecates that API. Because the test suite promotes warnings to errors, a clean Hugging Face cache makes `tests/test_embeddings.py::TestSentenceTransformers` fail while loading the fixture model.

Instead of suppressing the warning, this constrains the Hugging Face extra to `hf-xet<1.5.0` on architectures where `huggingface-hub` installs `hf-xet`, keeping the dependency set on the non-deprecated API until `huggingface-hub` switches to the new `hf-xet` API.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).