### PR TITLE
fix: preserve binary data in instrumentation serialization

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import warnings
+from base64 import b64encode
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
@@ -85,9 +86,28 @@ def serialize_any(value: Any) -> str:
         return ANY_ADAPTER.dump_python(value, mode='json')
     except Exception:
         try:
+            return ANY_ADAPTER.dump_python(_json_safe_bytes(value), mode='json')
+        except Exception:
+            pass
+        try:
             return str(value)
         except Exception as e:
             return f'Unable to serialize: {e}'
+
+
+def _json_safe_bytes(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return b64encode(value).decode()
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[Any, Any], value)
+        return {k: _json_safe_bytes(v) for k, v in mapping.items()}
+    if isinstance(value, tuple):
+        tuple_value = cast(tuple[Any, ...], value)
+        return tuple(_json_safe_bytes(v) for v in tuple_value)
+    if isinstance(value, list):
+        list_value = cast(list[Any], value)
+        return [_json_safe_bytes(v) for v in list_value]
+    return value
 
 
 def model_attributes(model: Model) -> dict[str, AttributeValue]:

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -37,7 +37,7 @@ from pydantic_ai import (
     UserPromptPart,
     VideoUrl,
 )
-from pydantic_ai._instrumentation import event_to_dict
+from pydantic_ai._instrumentation import event_to_dict, serialize_any
 from pydantic_ai._run_context import RunContext
 from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
 from pydantic_ai.models.instrumented import InstrumentationSettings, InstrumentedModel
@@ -1038,6 +1038,14 @@ def test_messages_to_otel_events_serialization_errors():
             },
         ]
     )
+
+
+def test_serialize_any_preserves_binary_data():
+    assert serialize_any(b'\xff') == '/w=='
+    assert serialize_any({'image_data': b'\x89PNG\r\n\x1a\nbinary content'}) == {
+        'image_data': 'iVBORw0KGgpiaW5hcnkgY29udGVudA=='
+    }
+    assert serialize_any((b'\xff', [b'\x00'])) == ['/w==', ['AA==']]
 
 
 def test_messages_to_otel_events_instructions():


### PR DESCRIPTION
## Summary

Fixes #5666.

When serialize_any hits non-UTF-8 bytes, Pydantic JSON-mode serialization raises and the fallback converts bytes to their Python repr string. For nested values, that can turn the whole object into a string instead of preserving structured data.

This adds a fallback pass that converts bytes to base64 strings before the final str fallback, including bytes nested in mappings, lists, and tuples.

## Tests

- uv run pytest tests/models/test_instrumented.py -q -k "serialize_any_preserves_binary_data or messages_to_otel_events_serialization_errors"
- uv run pytest tests/models/test_instrumented.py -q
- uv run ruff format --check pydantic_ai_slim/pydantic_ai/_instrumentation.py tests/models/test_instrumented.py
- uv run ruff check pydantic_ai_slim/pydantic_ai/_instrumentation.py tests/models/test_instrumented.py