### PR TITLE
docs: fix GitHub capitalization in Algolia hook comment

### DIFF
--- a/docs/.hooks/algolia.py
+++ b/docs/.hooks/algolia.py
@@ -57,7 +57,7 @@ def on_page_content(html: str, page: Page, config: Config, files: Files) -> str:
     for element in soup.find_all(['autoref']):
         element.decompose()
 
-    # this removes the large source code embeds from Github
+    # this removes the large source code embeds from GitHub
     for element in soup.find_all('details'):
         element.decompose()
 


### PR DESCRIPTION
Small focused maintenance fix. No functional change.