### PR TITLE
fix: preserve request metadata when merging history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -2199,6 +2199,7 @@ def _clean_message_history(messages: list[_messages.ModelMessage]) -> list[_mess
                     parts=parts,
                     instructions=last_message.instructions or message.instructions,
                     timestamp=message.timestamp or last_message.timestamp,
+                    metadata=message.metadata if message.metadata is not None else last_message.metadata,
                 )
                 clean_messages[-1] = merged_message
             else:

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3690,6 +3690,45 @@ def test_prepare_messages_then_clean_history_merges_consecutive_requests() -> No
     assert isinstance(last.parts[1], UserPromptPart)
 
 
+def test_clean_message_history_preserves_merged_request_metadata() -> None:
+    history: list[ModelMessage] = [
+        ModelRequest(
+            parts=[ToolReturnPart(tool_name='lookup', content='done', tool_call_id='call-1')],
+            metadata={'source': 'tool-search'},
+        ),
+        ModelRequest(
+            parts=[UserPromptPart(content='follow-up')],
+            metadata={'source': 'app'},
+        ),
+    ]
+
+    cleaned = _clean_message_history(history)
+
+    assert len(cleaned) == 1
+    merged = cleaned[0]
+    assert isinstance(merged, ModelRequest)
+    assert isinstance(merged.parts[0], ToolReturnPart)
+    assert isinstance(merged.parts[1], UserPromptPart)
+    assert merged.metadata == {'source': 'app'}
+
+
+def test_clean_message_history_keeps_existing_request_metadata_when_next_request_has_none() -> None:
+    history: list[ModelMessage] = [
+        ModelRequest(
+            parts=[ToolReturnPart(tool_name='lookup', content='done', tool_call_id='call-1')],
+            metadata={'source': 'tool-search'},
+        ),
+        ModelRequest(parts=[UserPromptPart(content='follow-up')]),
+    ]
+
+    cleaned = _clean_message_history(history)
+
+    assert len(cleaned) == 1
+    merged = cleaned[0]
+    assert isinstance(merged, ModelRequest)
+    assert merged.metadata == {'source': 'tool-search'}
+
+
 def test_narrow_type_local_return_passthrough_when_already_narrowed() -> None:
     """Narrowing an already-typed `ToolSearchReturnPart` returns the input instance."""
     part = ToolSearchReturnPart(content={'discovered_tools': []}, tool_call_id='c1')


### PR DESCRIPTION
﻿Fixes #5629.

This keeps `ModelRequest` application metadata when `_clean_message_history` merges consecutive requests. The merged request now carries the newer request's `run_id`, `conversation_id`, and `metadata` when present, and falls back to the earlier request when the later one has none.

I added direct coverage for both paths so the existing tool-search history cleanup keeps preserving request metadata.

## To verify

- `uv run --no-sync pytest tests/test_tool_search.py::test_prepare_messages_then_clean_history_merges_consecutive_requests tests/test_tool_search.py::test_clean_message_history_preserves_merged_request_metadata tests/test_tool_search.py::test_clean_message_history_keeps_existing_request_metadata_when_next_request_has_none -q`
- `uv run --no-sync pyright pydantic_ai_slim\pydantic_ai\_agent_graph.py tests\test_tool_search.py`
- `uv run --no-sync ruff format --check pydantic_ai_slim\pydantic_ai\_agent_graph.py tests\test_tool_search.py`
- `uv run --no-sync ruff check pydantic_ai_slim\pydantic_ai\_agent_graph.py tests\test_tool_search.py`
- `python -m py_compile pydantic_ai_slim\pydantic_ai\_agent_graph.py`
- `git diff --check`
