### PR TITLE
fix(mistral): preserve extended usage fields from API response

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -418,7 +418,7 @@ class MistralModel(Model[Mistral]):
 
         return ModelResponse(
             parts=parts,
-            usage=_map_usage(response),
+            usage=_map_usage(response, self._provider.name, self._provider.base_url, response.model),
             model_name=response.model,
             provider_response_id=response.id,
             provider_name=self._provider.name,
@@ -710,7 +710,7 @@ class MistralStreamedResponse(StreamedResponse):
                 self.provider_details = {'timestamp': self._provider_timestamp}
             chunk: MistralCompletionEvent
             async for chunk in self._response:
-                self._usage += _map_usage(chunk.data)
+                self._usage += _map_usage(chunk.data, self._provider_name, self._provider_url, self._model_name)
 
                 if chunk.data.id:  # pragma: no branch
                     self.provider_response_id = chunk.data.id
@@ -845,19 +845,28 @@ SIMPLE_JSON_TYPE_MAPPING = {
 }
 
 
-def _map_usage(response: MistralChatCompletionResponse | MistralCompletionChunk) -> RequestUsage:
+def _map_usage(
+    response: MistralChatCompletionResponse | MistralCompletionChunk,
+    provider: str,
+    provider_url: str,
+    model: str,
+) -> RequestUsage:
     """Maps a Mistral Completion Chunk or Chat Completion Response to a Usage."""
     if response.usage is None:
         return RequestUsage()
     usage_data = response.usage.model_dump(exclude_none=True)
-    known_keys = {'prompt_tokens', 'completion_tokens', 'total_tokens'}
-    details: dict[str, int] | None = {
-        k: v for k, v in usage_data.items() if k not in known_keys and isinstance(v, int)
-    } or None
-    return RequestUsage(
-        input_tokens=usage_data.get('prompt_tokens', 0),
-        output_tokens=usage_data.get('completion_tokens', 0),
-        details=details,
+    details: dict[str, int] = {
+        k: v
+        for k, v in usage_data.items()
+        if k not in {'prompt_tokens', 'completion_tokens', 'total_tokens'}
+        if isinstance(v, int)
+    }
+    return RequestUsage.extract(
+        dict(model=model, usage=usage_data),
+        provider=provider,
+        provider_url=provider_url,
+        provider_fallback='mistral',
+        details=details or None,
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -847,13 +847,18 @@ SIMPLE_JSON_TYPE_MAPPING = {
 
 def _map_usage(response: MistralChatCompletionResponse | MistralCompletionChunk) -> RequestUsage:
     """Maps a Mistral Completion Chunk or Chat Completion Response to a Usage."""
-    if response.usage:
-        return RequestUsage(
-            input_tokens=response.usage.prompt_tokens or 0,
-            output_tokens=response.usage.completion_tokens or 0,
-        )
-    else:
+    if response.usage is None:
         return RequestUsage()
+    usage_data = response.usage.model_dump(exclude_none=True)
+    known_keys = {'prompt_tokens', 'completion_tokens', 'total_tokens'}
+    details: dict[str, int] | None = {
+        k: v for k, v in usage_data.items() if k not in known_keys and isinstance(v, int)
+    } or None
+    return RequestUsage(
+        input_tokens=usage_data.get('prompt_tokens', 0),
+        output_tokens=usage_data.get('completion_tokens', 0),
+        details=details,
+    )
 
 
 def _map_content(content: MistralOptionalNullable[MistralContent]) -> tuple[str | None, list[str]]:

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -34,7 +34,7 @@ from pydantic_ai.agent import Agent
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, ModelRetry
 from pydantic_ai.messages import BinaryImage
 from pydantic_ai.models import ModelRequestParameters
-from pydantic_ai.usage import RequestUsage
+from pydantic_ai.usage import RequestUsage, RunUsage
 
 from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, raise_if_exception, try_import
@@ -387,6 +387,28 @@ async def test_three_completions(allow_model_requests: None):
     )
 
 
+async def test_usage_with_cached_tokens(allow_model_requests: None):
+    # Mistral reports prompt-cache hits nested under `prompt_tokens_details.cached_tokens`,
+    # which genai-prices maps to the first-class `cache_read_tokens` field.
+    # https://docs.mistral.ai/studio-api/conversations/advanced/prompt-caching
+    usage = MistralUsageInfo.model_validate(
+        {
+            'prompt_tokens': 1013,
+            'completion_tokens': 30,
+            'total_tokens': 1043,
+            'prompt_tokens_details': {'cached_tokens': 1008},
+        }
+    )
+    completion = completion_message(MistralAssistantMessage(content='world'), usage=usage)
+    mock_client = MockMistralAI.create_mock(completion)
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
+    agent = Agent(model=model)
+
+    result = await agent.run('hello')
+
+    assert result.usage == snapshot(RunUsage(input_tokens=1013, cache_read_tokens=1008, output_tokens=30, requests=1))
+
+
 #####################
 ## Completion Stream
 #####################
@@ -412,6 +434,44 @@ async def test_stream_text(allow_model_requests: None):
         assert result.is_complete
         assert result.usage.input_tokens == 5
         assert result.usage.output_tokens == 5
+
+
+async def test_stream_usage_with_cached_tokens(allow_model_requests: None):
+    stream = [
+        MistralCompletionEvent(
+            data=MistralCompletionChunk(
+                id='x',
+                choices=[
+                    MistralCompletionResponseStreamChoice(
+                        index=0,
+                        delta=MistralDeltaMessage(content='world', role='assistant'),
+                        finish_reason='stop',
+                    )
+                ],
+                created=1704067200,
+                model='mistral-large-latest',
+                object='chat.completion.chunk',
+                usage=MistralUsageInfo.model_validate(
+                    {
+                        'prompt_tokens': 1013,
+                        'completion_tokens': 30,
+                        'total_tokens': 1043,
+                        'prompt_tokens_details': {'cached_tokens': 1008},
+                    }
+                ),
+            )
+        ),
+    ]
+    mock_client = MockMistralAI.create_stream_mock(stream)
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
+    agent = Agent(model=model)
+
+    async with agent.run_stream('') as result:
+        async for _ in result.stream_text(debounce_by=None):
+            pass
+
+    # `prompt_tokens_details.cached_tokens` is surfaced as first-class `cache_read_tokens`.
+    assert result.usage == snapshot(RunUsage(input_tokens=1013, cache_read_tokens=1008, output_tokens=30, requests=1))
 
 
 async def test_stream_text_finish_reason(allow_model_requests: None):


### PR DESCRIPTION
`_map_usage` only extracted `prompt_tokens` and `completion_tokens`, silently dropping any additional fields the Mistral API returns (e.g. `cached_tokens`, `reasoning_tokens`). It also had a latent bug: `if response.usage:` evaluates truthiness on a Pydantic model instance, which is always `True` even when all token counts are zero.

This matches the pattern used by the Groq provider: call `model_dump(exclude_none=True)` to capture all fields, filter the three known token keys, and forward any remaining integer fields to `RequestUsage.details`.

Works on #4818 for Mistral
