### PR TITLE
Fix `MCPToolset(http_client=...)` crash on FastMCP's `follow_redirects` kwarg

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -127,7 +127,6 @@ __all__ = (
     'ServerCapabilities',
     'ProcessToolCallback',
     'CallToolFunc',
-    'MCPHTTPClientFactory',
     'ToolResult',
     'Prompt',
     'PromptArgument',
@@ -1942,24 +1941,6 @@ class CallToolFunc(Protocol):
     ) -> ToolResult: ...
 
 
-class MCPHTTPClientFactory(Protocol):
-    """Factory returning the `httpx.AsyncClient` an MCP HTTP transport should use.
-
-    FastMCP's HTTP transports call this with `follow_redirects` and may pass further
-    kwargs in future versions, so the contract names the known arguments and keeps a
-    `**kwargs` catch-all for forward compatibility.
-    """
-
-    def __call__(
-        self,
-        headers: dict[str, str] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
-        follow_redirects: bool = True,
-        **kwargs: object,
-    ) -> httpx.AsyncClient: ...
-
-
 ProcessToolCallback = Callable[
     [
         RunContext[Any],
@@ -2776,15 +2757,16 @@ def _build_transport(
 
 def _make_httpx_client_factory(
     http_client: httpx.AsyncClient,
-) -> MCPHTTPClientFactory:
+) -> Callable[..., httpx.AsyncClient]:
     """Return an `httpx_client_factory` that always returns the user-supplied `http_client`."""
 
     def factory(
         headers: dict[str, str] | None = None,
         timeout: httpx.Timeout | None = None,
         auth: httpx.Auth | None = None,
+        # FastMCP's StreamableHttpTransport calls the factory with `follow_redirects`,
+        # which the mcp SDK's `McpHttpClientFactory` protocol doesn't declare.
         follow_redirects: bool = True,
-        **_kwargs: object,
     ) -> httpx.AsyncClient:
         return http_client
 

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -127,6 +127,7 @@ __all__ = (
     'ServerCapabilities',
     'ProcessToolCallback',
     'CallToolFunc',
+    'MCPHTTPClientFactory',
     'ToolResult',
     'Prompt',
     'PromptArgument',
@@ -1797,14 +1798,7 @@ class MCPServerSSE(_MCPServerHTTP):
             raise ValueError('`http_client` is mutually exclusive with `headers`.')
 
         if self.http_client is not None:
-
-            def httpx_client_factory(
-                headers: dict[str, str] | None = None,
-                timeout: httpx.Timeout | None = None,
-                auth: httpx.Auth | None = None,
-            ) -> httpx.AsyncClient:
-                assert self.http_client is not None
-                return self.http_client
+            httpx_client_factory = _make_httpx_client_factory(self.http_client)
 
             async with sse_client(
                 url=self.url,
@@ -1946,6 +1940,24 @@ class CallToolFunc(Protocol):
         *,
         metadata: dict[str, Any] | None = None,
     ) -> ToolResult: ...
+
+
+class MCPHTTPClientFactory(Protocol):
+    """Factory returning the `httpx.AsyncClient` an MCP HTTP transport should use.
+
+    FastMCP's HTTP transports call this with `follow_redirects` and may pass further
+    kwargs in future versions, so the contract names the known arguments and keeps a
+    `**kwargs` catch-all for forward compatibility.
+    """
+
+    def __call__(
+        self,
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+        follow_redirects: bool = True,
+        **kwargs: object,
+    ) -> httpx.AsyncClient: ...
 
 
 ProcessToolCallback = Callable[
@@ -2764,13 +2776,15 @@ def _build_transport(
 
 def _make_httpx_client_factory(
     http_client: httpx.AsyncClient,
-) -> Callable[..., httpx.AsyncClient]:
+) -> MCPHTTPClientFactory:
     """Return an `httpx_client_factory` that always returns the user-supplied `http_client`."""
 
     def factory(
         headers: dict[str, str] | None = None,
         timeout: httpx.Timeout | None = None,
         auth: httpx.Auth | None = None,
+        follow_redirects: bool = True,
+        **_kwargs: object,
     ) -> httpx.AsyncClient:
         return http_client
 

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -64,6 +64,7 @@ with try_import() as imports_successful:
         ResourceTemplate,
         ServerCapabilities,
         _build_message_handler,  # pyright: ignore[reportPrivateUsage]
+        _make_httpx_client_factory,  # pyright: ignore[reportPrivateUsage]
         load_mcp_toolsets,
     )
     from pydantic_ai.messages import TextContent
@@ -99,6 +100,8 @@ class TestMCPToolsetConstruction:
         assert isinstance(toolset.client.transport, StreamableHttpTransport)
         assert toolset.client.transport.httpx_client_factory is not None
         assert toolset.client.transport.httpx_client_factory() is client
+        factory = _make_httpx_client_factory(client)
+        assert factory(follow_redirects=True) is client
 
     def test_sse_url_with_http_client_uses_factory(self):
         client = httpx.AsyncClient()
@@ -106,6 +109,8 @@ class TestMCPToolsetConstruction:
         assert isinstance(toolset.client.transport, SSETransport)
         assert toolset.client.transport.httpx_client_factory is not None
         assert toolset.client.transport.httpx_client_factory() is client
+        factory = _make_httpx_client_factory(client)
+        assert factory(follow_redirects=True) is client
 
     def test_http_kwargs_with_non_url_input_raises(self):
         """HTTP-only kwargs (headers/auth/verify/http_client) must error out when the connection


### PR DESCRIPTION
## Summary

`MCPToolset(url, http_client=...)` adapts the supplied `httpx.AsyncClient` into FastMCP's `httpx_client_factory` hook. FastMCP's HTTP transports can call that factory with extra runtime kwargs such as `follow_redirects`, so the adapter needs to accept and ignore them while still returning the caller-owned client.

This keeps the existing URL/SSE behavior and only makes the factory tolerant of the extra transport kwargs.

Fixes #5688.

## To verify

- `python -m pytest tests/test_mcp_toolset.py::TestMCPToolsetConstruction -q -p no:cacheprovider --basetemp .tmp/pytest-5688-construction2`
- `ruff format --check pydantic_ai_slim/pydantic_ai/mcp.py tests/test_mcp_toolset.py`
- `ruff check pydantic_ai_slim/pydantic_ai/mcp.py tests/test_mcp_toolset.py`
- `pyright pydantic_ai_slim/pydantic_ai/mcp.py`
- `python -m py_compile pydantic_ai_slim/pydantic_ai/mcp.py tests/test_mcp_toolset.py`
- `git diff --check`