### PR TITLE
fix(messages): add InstructionPart to ModelRequestPart discriminated union

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2025,7 +2025,8 @@ ModelRequestPart = Annotated[
     | Annotated[UserPromptPart, pydantic.Tag('user-prompt')]
     | Annotated[ToolSearchReturnPart, pydantic.Tag('tool-search-return')]
     | Annotated[ToolReturnPart, pydantic.Tag('tool-return')]
-    | Annotated[RetryPromptPart, pydantic.Tag('retry-prompt')],
+    | Annotated[RetryPromptPart, pydantic.Tag('retry-prompt')]
+    | Annotated[InstructionPart, pydantic.Tag('instruction')],
     pydantic.Discriminator(_model_request_part_discriminator),
 ]
 """A message part sent by Pydantic AI to a model."""

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1508,6 +1508,44 @@ class TestInstructionParts:
         dynamic_part = InstructionPart(content='world', dynamic=True)
         assert repr(dynamic_part) == "InstructionPart(content='world', dynamic=True)"
 
+    def test_instruction_part_in_parts_roundtrip(self):
+        """InstructionPart inside ModelRequest.parts must survive a dump_json/validate_json round-trip.
+
+        Regression test for https://github.com/pydantic/pydantic-ai/issues/5696 —
+        InstructionPart was missing from the ModelRequestPart discriminated union, so
+        validate_json raised ValidationError for any serialized message history that
+        contained an InstructionPart in its parts list.
+        """
+        request = ModelRequest(
+            parts=[
+                UserPromptPart(content='Hello'),
+                InstructionPart(content='Be concise.', dynamic=False),
+                InstructionPart(content='Always respond in English.', dynamic=True),
+            ]
+        )
+
+        serialized = ModelMessagesTypeAdapter.dump_json([request])
+        deserialized = ModelMessagesTypeAdapter.validate_json(serialized)
+
+        assert len(deserialized) == 1
+        msg = deserialized[0]
+        assert isinstance(msg, ModelRequest)
+        assert len(msg.parts) == 3
+
+        user_part = msg.parts[0]
+        assert isinstance(user_part, UserPromptPart)
+        assert user_part.content == 'Hello'
+
+        static_instr = msg.parts[1]
+        assert isinstance(static_instr, InstructionPart)
+        assert static_instr.content == 'Be concise.'
+        assert static_instr.dynamic is False
+
+        dynamic_instr = msg.parts[2]
+        assert isinstance(dynamic_instr, InstructionPart)
+        assert dynamic_instr.content == 'Always respond in English.'
+        assert dynamic_instr.dynamic is True
+
 
 def test_retry_prompt_strips_input_from_top_level_errors():
     """Top-level validation errors should not include `input` in model_response() since it duplicates the entire generated output."""


### PR DESCRIPTION
## Problem

`InstructionPart` has `part_kind: Literal['instruction'] = 'instruction'` and its
docstring states *"Part type identifier, used as a discriminator for deserialization."*
It can appear in `ModelRequest.parts` during normal agent runs, but it was **not
included** in the `ModelRequestPart` discriminated union.

As a result, any serialized message history containing an `InstructionPart` in its
`parts` list would fail to reload:

```python
from pydantic_ai import InstructionPart, ModelMessagesTypeAdapter, ModelRequest, UserPromptPart

req = ModelRequest(parts=[
    UserPromptPart(content='Hello'),
    InstructionPart(content='Be concise.'),
])

serialized = ModelMessagesTypeAdapter.dump_json([req])  # succeeds with warnings
ModelMessagesTypeAdapter.validate_json(serialized)       # raises ValidationError!
# Input tag 'instruction' found using _model_request_part_discriminator()
# does not match any of the expected tags:
# 'system-prompt', 'user-prompt', 'tool-search-return', 'tool-return', 'retry-prompt'
```

This silently corrupted message histories in Temporal/durable-exec workflows, resumed
runs, and any code that persists history to JSON and reloads it.

## Fix

Add `Annotated[InstructionPart, pydantic.Tag('instruction')]` to the `ModelRequestPart`
union (one line change in `messages.py`).

## Tests

Added `TestInstructionParts::test_instruction_part_in_parts_roundtrip` — a regression
test that round-trips a `ModelRequest` containing both static and dynamic
`InstructionPart` instances alongside a `UserPromptPart` through
`dump_json` → `validate_json` and asserts full fidelity.

Fixes #5696.