### PR TITLE
fix: set is_complete=True when stream_output/stream_text/stream_response break early

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -553,9 +553,11 @@ class StreamedRunResult(Generic[AgentDepsT, OutputDataT]):
             yield self._run_result.output
             await self._marked_completed()
         elif self._stream_response is not None:
-            async for output in self._stream_response.stream_output(debounce_by=debounce_by):
-                yield output
-            await self._marked_completed(self.response)
+            try:
+                async for output in self._stream_response.stream_output(debounce_by=debounce_by):
+                    yield output
+            finally:
+                await self._marked_completed(self.response)
         else:
             raise ValueError('No stream response or run result provided')  # pragma: no cover
 
@@ -581,9 +583,11 @@ class StreamedRunResult(Generic[AgentDepsT, OutputDataT]):
             yield self._run_result.output
             await self._marked_completed()
         elif self._stream_response is not None:
-            async for text in self._stream_response.stream_text(delta=delta, debounce_by=debounce_by):
-                yield text
-            await self._marked_completed(self.response)
+            try:
+                async for text in self._stream_response.stream_text(delta=delta, debounce_by=debounce_by):
+                    yield text
+            finally:
+                await self._marked_completed(self.response)
         else:
             raise ValueError('No stream response or run result provided')  # pragma: no cover
 
@@ -614,14 +618,15 @@ class StreamedRunResult(Generic[AgentDepsT, OutputDataT]):
             await self._marked_completed()
         elif self._stream_response is not None:
             last_msg: _messages.ModelResponse | None = None
-            async for msg in self._stream_response.stream_response(debounce_by=debounce_by):
-                yield msg
-                last_msg = msg
-            # `AgentStream.stream_response` always yields the final response, so `last_msg` is set.
-            # Pass it to `_marked_completed` so `run_id` and `conversation_id` are stamped onto the
-            # same instance the caller still holds a reference to in their iteration.
-            assert last_msg is not None
-            await self._marked_completed(last_msg)
+            try:
+                async for msg in self._stream_response.stream_response(debounce_by=debounce_by):
+                    yield msg
+                    last_msg = msg
+            finally:
+                # Pass the last yielded response (if any) to stamp run_id / conversation_id onto
+                # the same instance the caller still holds. On early break, last_msg may be None
+                # which is handled gracefully by _marked_completed.
+                await self._marked_completed(last_msg)
         else:
             raise ValueError('No stream response or run result provided')  # pragma: no cover
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -4101,6 +4101,34 @@ async def test_get_output_after_stream_output():
     )
 
 
+@pytest.mark.parametrize('method', ['stream_output', 'stream_text'])
+async def test_stream_is_complete_set_on_early_break(method: str):
+    """Breaking early from stream_output() / stream_text() must still set is_complete=True.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/5615
+
+    Before the fix, `_marked_completed()` was placed *after* the `async for … yield`
+    loop, so a `break` would leave `is_complete=False` and the final response
+    absent from `all_messages()`.  The fix wraps the loop in `try/finally` so
+    `_marked_completed()` always fires, regardless of how iteration ends.
+    """
+
+    async def sf(_: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+        for chunk in ['Hello', ' ', 'world', '!']:
+            yield chunk
+
+    agent = Agent(FunctionModel(stream_function=sf))
+
+    async with agent.run_stream('test') as result:
+        assert not result.is_complete
+
+        stream_iter = result.stream_output() if method == 'stream_output' else result.stream_text()
+        async for _ in stream_iter:  # pragma: no branch
+            break  # break after the very first chunk
+
+    assert result.is_complete, f'{method}(): is_complete must be True after early break'
+
+
 @pytest.mark.parametrize('delta', [True, False])
 @pytest.mark.parametrize('debounce_by', [None, 0.1])
 async def test_stream_text_early_break_cleanup(delta: bool, debounce_by: float | None):


### PR DESCRIPTION
## Summary

Fixes #5615

When a caller breaks out of `stream_output()`, `stream_text()`, or `stream_response()` before the underlying stream is exhausted, `_marked_completed()` was positioned *after* the `async for … yield` loop and therefore never ran. This left `result.is_complete = False` and the final `ModelResponse` absent from `result.all_messages()`.

## Root cause

Python async generators defer cleanup until `aclose()` is awaited. When the caller breaks, the `await self._marked_completed(...)` call that followed the loop is simply skipped.

## Fix

Wrap the streaming loop in `try/finally` in all three affected methods so `_marked_completed()` fires unconditionally:

- `stream_output()`
- `stream_text()`
- `stream_response()` — the `assert last_msg is not None` is also removed since on early break `last_msg` may legitimately be `None`, which `_marked_completed` already handles gracefully.

## Tests

Adds `test_stream_is_complete_set_on_early_break` — a parametrised regression test covering both `stream_output()` and `stream_text()` that verifies `result.is_complete is True` after a single-chunk early break.