### PR TITLE
fix: preserve `metadata` when merging consecutive `ModelRequest`s in `_clean_message_history`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -2195,10 +2195,12 @@ def _clean_message_history(messages: list[_messages.ModelMessage]) -> list[_mess
                     # Tool return parts always need to be at the start
                     key=lambda x: 0 if isinstance(x, _messages.ToolReturnPart | _messages.RetryPromptPart) else 1
                 )
-                merged_message = _messages.ModelRequest(
+                merged_message = replace(
+                    last_message,
                     parts=parts,
                     instructions=last_message.instructions or message.instructions,
                     timestamp=message.timestamp or last_message.timestamp,
+                    metadata=message.metadata or last_message.metadata,
                 )
                 clean_messages[-1] = merged_message
             else:

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3690,6 +3690,37 @@ def test_prepare_messages_then_clean_history_merges_consecutive_requests() -> No
     assert isinstance(last.parts[1], UserPromptPart)
 
 
+def test_clean_message_history_preserves_metadata_on_merge() -> None:
+    """Regression for #5629: merging consecutive `ModelRequest`s must preserve `metadata`."""
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[UserPromptPart(content='first')],
+            metadata={'trace_id': 'abc'},
+        ),
+        ModelRequest(
+            parts=[UserPromptPart(content='second')],
+        ),
+    ]
+
+    cleaned = _clean_message_history(messages)
+    assert len(cleaned) == 1
+    merged = cleaned[0]
+    assert isinstance(merged, ModelRequest)
+    assert merged.metadata == {'trace_id': 'abc'}
+
+    # When the later request carries metadata and the earlier one doesn't, pick the later one.
+    messages_reversed: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='first')]),
+        ModelRequest(
+            parts=[UserPromptPart(content='second')],
+            metadata={'trace_id': 'xyz'},
+        ),
+    ]
+    cleaned_reversed = _clean_message_history(messages_reversed)
+    assert len(cleaned_reversed) == 1
+    assert cleaned_reversed[0].metadata == {'trace_id': 'xyz'}  # type: ignore[union-attr]
+
+
 def test_narrow_type_local_return_passthrough_when_already_narrowed() -> None:
     """Narrowing an already-typed `ToolSearchReturnPart` returns the input instance."""
     part = ToolSearchReturnPart(content={'discovered_tools': []}, tool_call_id='c1')


### PR DESCRIPTION
## Summary

Closes #5629

`_clean_message_history` constructed a new `ModelRequest` from scratch when merging consecutive requests, which dropped `metadata`, `run_id`, and `conversation_id`. This switches to `replace()` (matching the `ModelResponse` merge path at line 2225) so all dataclass fields are carried over, with explicit handling for `metadata` via `message.metadata or last_message.metadata`.

## Changes

- **`pydantic_ai_slim/pydantic_ai/_agent_graph.py`**: Replace `ModelRequest(parts=..., instructions=..., timestamp=...)` with `replace(last_message, parts=..., instructions=..., timestamp=..., metadata=...)` when merging consecutive requests
- **`tests/test_tool_search.py`**: Add `test_clean_message_history_preserves_metadata_on_merge` — verifies metadata survives merge from either the first or second request