### PR TITLE
fix(cerebras): preserve reasoning history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cerebras.py
@@ -30,7 +30,7 @@ LatestCerebrasModelNames = Literal[
     'llama3.1-8b',
     'qwen-3-235b-a22b-instruct-2507',
     'qwen-3-32b',
-    'zai-glm-4.6',
+    'zai-glm-4.7',
 ]
 
 CerebrasModelName = str | LatestCerebrasModelNames
@@ -52,9 +52,15 @@ class CerebrasModelSettings(ModelSettings, total=False):
     cerebras_disable_reasoning: bool
     """Disable reasoning for the model.
 
-    This setting is only supported on reasoning models: `zai-glm-4.6` and `gpt-oss-120b`.
+    This setting is only supported on reasoning models: `zai-glm-4.7` and `gpt-oss-120b`.
 
-    See [the Cerebras docs](https://inference-docs.cerebras.ai/resources/openai#passing-non-standard-parameters) for more details.
+    See [the Cerebras reasoning docs](https://inference-docs.cerebras.ai/capabilities/reasoning) for more details.
+    """
+
+    cerebras_clear_thinking: bool
+    """Controls whether Cerebras clears prior reasoning before a new turn.
+
+    This maps to Cerebras' `clear_thinking` request parameter.
     """
 
 
@@ -91,11 +97,9 @@ class CerebrasModel(OpenAIChatModel):
         model_settings: OpenAIChatModelSettings,
         model_request_parameters: ModelRequestParameters,
     ) -> Any:
-        """Cerebras handles reasoning via extra_body['disable_reasoning'], not reasoning_effort."""
+        """Cerebras uses OpenAI-compatible reasoning effort for thinking control."""
         from openai import omit
 
-        # Only pass through explicit openai_reasoning_effort if set; unified thinking
-        # is handled in _cerebras_settings_to_openai_settings via disable_reasoning.
         if effort := model_settings.get('openai_reasoning_effort'):
             return effort
         return omit
@@ -125,16 +129,19 @@ def _cerebras_settings_to_openai_settings(
     Returns:
         An 'OpenAIChatModelSettings' object with equivalent settings.
     """
-    extra_body = cast(dict[str, Any], model_settings.get('extra_body', {}))
+    openai_settings: dict[str, Any] = dict(model_settings)
+    extra_body = cast(dict[str, Any], openai_settings.get('extra_body', {}))
 
-    if (disable_reasoning := model_settings.pop('cerebras_disable_reasoning', None)) is not None:
-        extra_body['disable_reasoning'] = disable_reasoning
+    if (disable_reasoning := openai_settings.pop('cerebras_disable_reasoning', None)) is not None:
+        if disable_reasoning:
+            openai_settings['openai_reasoning_effort'] = 'none'
     elif model_request_parameters.thinking is False:
-        extra_body['disable_reasoning'] = True
-    elif model_request_parameters.thinking:
-        extra_body['disable_reasoning'] = False
+        openai_settings['openai_reasoning_effort'] = 'none'
+
+    if (clear_thinking := openai_settings.pop('cerebras_clear_thinking', None)) is not None:
+        extra_body['clear_thinking'] = clear_thinking
 
     if extra_body:
-        model_settings['extra_body'] = extra_body
+        openai_settings['extra_body'] = extra_body
 
-    return OpenAIChatModelSettings(**model_settings)  # type: ignore[reportCallIssue]
+    return OpenAIChatModelSettings(**openai_settings)

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -48,8 +48,8 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
             'zai': zai_model_profile,
         }
 
-        # Reasoning models that support the cerebras_disable_reasoning setting
-        reasoning_prefixes = ('zai', 'gpt-oss')
+        reasoning_prefixes = ('zai', 'qwen', 'gpt-oss')
+        tagged_reasoning_prefixes = ('zai', 'qwen')
 
         profile = None
         model_name_lower = model_name.lower()
@@ -70,10 +70,12 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
             'openai_service_tier',
         )
         is_reasoning = model_name_lower.startswith(reasoning_prefixes)
+        send_back_thinking_parts = 'tags' if model_name_lower.startswith(tagged_reasoning_prefixes) else 'auto'
         return OpenAIModelProfile(
             json_schema_transformer=OpenAIJsonSchemaTransformer,
             openai_unsupported_model_settings=unsupported_model_settings,
             supports_thinking=is_reasoning,
+            openai_chat_send_back_thinking_parts=send_back_thinking_parts,
         ).update(profile)
 
     @overload

--- a/tests/models/test_cerebras.py
+++ b/tests/models/test_cerebras.py
@@ -37,10 +37,10 @@ async def test_cerebras_model_simple(allow_model_requests: None, cerebras_api_ke
 async def test_cerebras_disable_reasoning_setting(allow_model_requests: None, cerebras_api_key: str):
     """Test that cerebras_disable_reasoning setting is properly transformed to extra_body.
 
-    Note: disable_reasoning is only supported on reasoning models: zai-glm-4.6 and gpt-oss-120b.
+    Note: disable_reasoning is only supported on reasoning models: zai-glm-4.7 and gpt-oss-120b.
     """
     provider = CerebrasProvider(api_key=cerebras_api_key)
-    model = CerebrasModel('zai-glm-4.6', provider=provider)
+    model = CerebrasModel('zai-glm-4.7', provider=provider)
 
     settings = CerebrasModelSettings(cerebras_disable_reasoning=True)
     response = await model_request(model, [ModelRequest.user_text_prompt('What is 2 + 2?')], model_settings=settings)
@@ -59,7 +59,8 @@ async def test_cerebras_settings_transformation():
     settings = CerebrasModelSettings(cerebras_disable_reasoning=True)
     transformed = _cerebras_settings_to_openai_settings(settings, params)
     extra_body = cast(dict[str, Any], transformed.get('extra_body', {}))
-    assert extra_body.get('disable_reasoning') is True
+    assert extra_body.get('disable_reasoning') is None
+    assert transformed.get('openai_reasoning_effort') == 'none'
 
     # Test without disable_reasoning (should not have extra_body)
     settings_empty = CerebrasModelSettings()
@@ -70,4 +71,10 @@ async def test_cerebras_settings_transformation():
     settings_false = CerebrasModelSettings(cerebras_disable_reasoning=False)
     transformed_false = _cerebras_settings_to_openai_settings(settings_false, params)
     extra_body_false = cast(dict[str, Any], transformed_false.get('extra_body', {}))
-    assert extra_body_false.get('disable_reasoning') is False
+    assert extra_body_false.get('disable_reasoning') is None
+    assert transformed_false.get('openai_reasoning_effort') is None
+
+    settings_clear = CerebrasModelSettings(cerebras_clear_thinking=False)
+    transformed_clear = _cerebras_settings_to_openai_settings(settings_clear, params)
+    extra_body_clear = cast(dict[str, Any], transformed_clear.get('extra_body', {}))
+    assert extra_body_clear.get('clear_thinking') is False

--- a/tests/providers/test_cerebras.py
+++ b/tests/providers/test_cerebras.py
@@ -81,6 +81,8 @@ def test_cerebras_provider_model_profile(mocker: MockerFixture):
     assert qwen_profile is not None
     assert isinstance(qwen_profile, OpenAIModelProfile)
     assert qwen_profile.json_schema_transformer == InlineDefsJsonSchemaTransformer
+    assert qwen_profile.supports_thinking is True
+    assert qwen_profile.openai_chat_send_back_thinking_parts == 'tags'
 
     # Test gpt-oss model (harmony) - uses OpenAIJsonSchemaTransformer
     harmony_profile = provider.model_profile('gpt-oss-120b')
@@ -90,11 +92,13 @@ def test_cerebras_provider_model_profile(mocker: MockerFixture):
     assert harmony_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
 
     # Test zai model - uses default OpenAI profile (zai_model_profile returns None)
-    zai_profile = provider.model_profile('zai-glm-4.6')
-    zai_model_profile_mock.assert_called_with('zai-glm-4.6')
+    zai_profile = provider.model_profile('zai-glm-4.7')
+    zai_model_profile_mock.assert_called_with('zai-glm-4.7')
     assert zai_profile is not None
     assert isinstance(zai_profile, OpenAIModelProfile)
     assert zai_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert zai_profile.supports_thinking is True
+    assert zai_profile.openai_chat_send_back_thinking_parts == 'tags'
 
     # Test unknown model - should still return a profile with OpenAIJsonSchemaTransformer
     unknown_profile = provider.model_profile('unknown-model')

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -808,33 +808,37 @@ class TestOpenRouterThinkingTranslation:
 class TestCerebrasThinkingTranslation:
     """Test Cerebras unified thinking fallback."""
 
-    def test_thinking_false_sets_disable_reasoning(self):
+    def test_thinking_false_sets_reasoning_effort_none(self):
         settings = CerebrasModelSettings()
         params = ModelRequestParameters(thinking=False)
         result = _cerebras_settings_to_openai_settings(settings, params)
         extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert extra_body.get('disable_reasoning') is True
+        assert extra_body.get('disable_reasoning') is None
+        assert result.get('openai_reasoning_effort') == 'none'
 
-    def test_thinking_true_sets_disable_reasoning_false(self):
+    def test_thinking_true_omits_disable_reasoning(self):
         settings = CerebrasModelSettings()
         params = ModelRequestParameters(thinking=True)
         result = _cerebras_settings_to_openai_settings(settings, params)
         extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert extra_body.get('disable_reasoning') is False
+        assert extra_body.get('disable_reasoning') is None
+        assert result.get('openai_reasoning_effort') is None
 
-    def test_thinking_effort_sets_disable_reasoning_false(self):
+    def test_thinking_effort_omits_disable_reasoning(self):
         settings = CerebrasModelSettings()
         params = ModelRequestParameters(thinking='high')
         result = _cerebras_settings_to_openai_settings(settings, params)
         extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert extra_body.get('disable_reasoning') is False
+        assert extra_body.get('disable_reasoning') is None
+        assert result.get('openai_reasoning_effort') is None
 
     def test_explicit_cerebras_disable_takes_precedence(self):
         settings = CerebrasModelSettings(cerebras_disable_reasoning=True)
         params = ModelRequestParameters(thinking=True)
         result = _cerebras_settings_to_openai_settings(settings, params)
         extra_body: dict[str, Any] = result.get('extra_body') or {}  # type: ignore[assignment]
-        assert extra_body.get('disable_reasoning') is True
+        assert extra_body.get('disable_reasoning') is None
+        assert result.get('openai_reasoning_effort') == 'none'
 
     def test_explicit_openai_reasoning_effort_passthrough(self):
         """Explicit openai_reasoning_effort on Cerebras is passed through."""


### PR DESCRIPTION
﻿## What changed

- Mark Cerebras Z.ai GLM and Qwen profiles as tag-based reasoning-history models so previous thinking is sent back as `<think>...</think>` content on later turns.
- Replace `cerebras_disable_reasoning=True` / `thinking=False` translation with `openai_reasoning_effort='none'` instead of the deprecated `extra_body.disable_reasoning` parameter.
- Add `cerebras_clear_thinking` as a first-class model setting mapped to `extra_body.clear_thinking`.
- Update the latest Z.ai GLM Cerebras model name from `zai-glm-4.6` to `zai-glm-4.7`.

The behavior matches Cerebras' current docs:

- https://inference-docs.cerebras.ai/capabilities/reasoning
- https://inference-docs.cerebras.ai/resources/glm-47-migration
- https://inference-docs.cerebras.ai/api-reference/chat-completions

## To verify

- `python -m py_compile pydantic_ai_slim\pydantic_ai\models\cerebras.py pydantic_ai_slim\pydantic_ai\providers\cerebras.py tests\models\test_cerebras.py tests\providers\test_cerebras.py tests\test_thinking.py`
- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run ruff check pydantic_ai_slim\pydantic_ai\models\cerebras.py pydantic_ai_slim\pydantic_ai\providers\cerebras.py tests\models\test_cerebras.py tests\providers\test_cerebras.py tests\test_thinking.py`
- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run ruff format --check pydantic_ai_slim\pydantic_ai\models\cerebras.py pydantic_ai_slim\pydantic_ai\providers\cerebras.py tests\models\test_cerebras.py tests\providers\test_cerebras.py tests\test_thinking.py`
- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run pyright pydantic_ai_slim\pydantic_ai\models\cerebras.py pydantic_ai_slim\pydantic_ai\providers\cerebras.py tests\models\test_cerebras.py tests\providers\test_cerebras.py tests\test_thinking.py`
- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run pytest tests\models\test_cerebras.py tests\providers\test_cerebras.py tests\test_thinking.py -k "cerebras and not simple and not disable_reasoning_setting" -q`

Fixes #5606
