### PR TITLE
fix: preserve ModelRequest metadata when cleaning history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -2195,10 +2195,14 @@ def _clean_message_history(messages: list[_messages.ModelMessage]) -> list[_mess
                     # Tool return parts always need to be at the start
                     key=lambda x: 0 if isinstance(x, _messages.ToolReturnPart | _messages.RetryPromptPart) else 1
                 )
+                metadata = None
+                if last_message.metadata is not None or message.metadata is not None:
+                    metadata = {**(last_message.metadata or {}), **(message.metadata or {})}
                 merged_message = _messages.ModelRequest(
                     parts=parts,
                     instructions=last_message.instructions or message.instructions,
                     timestamp=message.timestamp or last_message.timestamp,
+                    metadata=metadata,
                 )
                 clean_messages[-1] = merged_message
             else:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -52,6 +52,7 @@ from pydantic_ai import (
     VideoUrl,
     capture_run_messages,
 )
+from pydantic_ai._agent_graph import _clean_message_history  # pyright: ignore[reportPrivateUsage]
 from pydantic_ai._output import (
     NativeOutput,
     NativeOutputSchema,
@@ -3524,6 +3525,26 @@ def test_agent_conversation_id_resolves_from_message_history() -> None:
     assert second.conversation_id == first.conversation_id
     new_conv_ids = [m.conversation_id for m in second.new_messages()]
     assert all(cid == first.conversation_id for cid in new_conv_ids)
+
+
+def test_clean_message_history_preserves_model_request_metadata() -> None:
+    cleaned = _clean_message_history(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='first')],
+                metadata={'session': 'abc123', 'source': 'history'},
+            ),
+            ModelRequest(
+                parts=[UserPromptPart(content='second')],
+                metadata={'session': 'abc123', 'trace_id': 'trace-456'},
+            ),
+        ]
+    )
+
+    assert len(cleaned) == 1
+    request = cleaned[0]
+    assert isinstance(request, ModelRequest)
+    assert request.metadata == {'session': 'abc123', 'source': 'history', 'trace_id': 'trace-456'}
 
 
 def test_agent_conversation_id_explicit_override() -> None:


### PR DESCRIPTION
## Summary

- Preserve `ModelRequest.metadata` when `_clean_message_history()` merges adjacent requests.
- Merge metadata dictionaries instead of dropping them, with later request values taking precedence on duplicate keys.
- Add a regression test covering metadata from both merged requests.

Closes #5629.

## Testing

- `uv run pytest tests/test_agent.py::test_clean_message_history_preserves_model_request_metadata -q`
- `uv run pytest tests/test_agent.py::test_clean_message_history_preserves_model_request_metadata tests/test_tool_search.py::test_prepare_messages_then_clean_history_merges_consecutive_requests -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_agent.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_agent.py`
- `git diff --check`
