### PR TITLE
Fix `gateway/` model construction inside a Temporal workflow by passing provider SDKs through the sandbox

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -80,11 +80,28 @@ def _workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner:
             'anyio',
             'sniffio',
             'httpcore',
+            # `certifi` is imported lazily by `httpx`/`ssl` when a client builds its TLS context. A
+            # model constructed inside the workflow (e.g. a `gateway/` model resolved via
+            # `infer_model`) creates its own HTTP client there, so without passing `certifi` through
+            # alongside the rest of the HTTP stack Temporal warns that it was "imported after initial
+            # workflow load" (a hard error under `filterwarnings=error`).
+            'certifi',
             # `fastmcp` (and the `mcp` SDK it transitively imports) calls `Path.expanduser` at
             # import time when resolving its config directory — restricted by the workflow
             # sandbox. Safe to pass through: the call only happens once at module init.
             'fastmcp',
             'mcp',
+            # The `anthropic` SDK (>=0.99.0) calls `Path.home()` during client construction to
+            # resolve its credentials/profile config directory (`~/.config/anthropic`) — restricted
+            # by the workflow sandbox. This trips when a model is constructed inside the workflow,
+            # e.g. a `gateway/anthropic:` or `anthropic:` model resolved lazily via `infer_model`.
+            # Safe to pass through: a deterministic, read-only config lookup.
+            'anthropic',
+            # The `google-genai` SDK lazily imports `google.auth` submodules (e.g.
+            # `google.auth.aio.credentials`) while constructing its client, which Temporal flags as
+            # "imported after initial workflow load" when a `gateway/google-cloud:` (or `google-*:`)
+            # model is built inside the workflow.
+            'google.auth',
             # Used by fastmcp via py-key-value-aio
             'beartype',
             # Imported inside `logfire._internal.json_encoder` when running `logfire.info` inside an activity with attributes to serialize

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1478,24 +1478,23 @@ async def test_mcptoolset_dynamic_toolset_in_workflow(allow_model_requests: None
 class ConstructModelInWorkflow:
     @workflow.run
     async def run(self, model_name: str) -> str:
-        # Constructing the model also constructs its provider and underlying SDK client, all inside
-        # the workflow sandbox. We only assert this succeeds; no request is made to the model.
+        # Constructs the provider and its SDK client inside the sandbox; we assert only that this
+        # succeeds — no request is made.
         return type(infer_model(model_name)).__name__
 
 
 @pytest.mark.parametrize(
     ('model_name', 'expected_model_class'),
     [
-        # The reported regression: `gateway/anthropic:` resolved in-workflow tripped
-        # `Cannot access pathlib.Path.home.__call__ from inside a workflow`. Uses the latest Sonnet.
+        # The reported regression: `gateway/anthropic:` in-workflow tripped `Path.home` access.
         pytest.param('gateway/anthropic:claude-sonnet-4-6', 'AnthropicModel', id='gateway-anthropic'),
-        # The direct route hits the same `AsyncAnthropic.__init__` path, so it's not gateway-specific.
+        # Same `AsyncAnthropic.__init__` path off the gateway — not gateway-specific.
         pytest.param('anthropic:claude-sonnet-4-6', 'AnthropicModel', id='anthropic'),
-        # OpenAI and Gemini don't touch the home directory at construction *today*, so these pass
-        # without needing their SDKs in the passthrough list. They're canaries: if a future SDK
-        # release starts reading `~/...` (or makes any other restricted call) during client
-        # construction, the corresponding case turns red here instead of in a user's workflow.
+        # Canary: OpenAI needs no passthrough today; turns red here (not in a user's workflow) if a
+        # future SDK release makes a restricted call (e.g. reads `~/...`) during construction.
         pytest.param('gateway/openai-chat:gpt-5', 'OpenAIChatModel', id='gateway-openai'),
+        # Positive coverage of the `google.auth` (+`certifi`) passthrough: `google-genai` lazily
+        # imports `google.auth` during construction, which the sandbox flags without it.
         pytest.param('gateway/google-cloud:gemini-2.5-pro', 'GoogleModel', id='gateway-google'),
     ],
 )
@@ -1505,10 +1504,9 @@ async def test_model_construction_in_workflow_passes_sandbox(
     client: Client,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    # Credentials are read from the environment during construction; dummy values suffice since no
-    # request is made. The gateway key must encode a region (`pylf_v<n>_<region>_...`) so the base
-    # URL can be inferred; the gateway routes all authenticate with it, so no per-provider key is
-    # needed beyond the direct-anthropic case.
+    # Dummy credentials suffice since no request is made. The gateway key must encode a region
+    # (`pylf_v<n>_<region>_...`) so the base URL can be inferred; only the direct-anthropic case
+    # also needs a provider key.
     monkeypatch.setenv('PYDANTIC_AI_GATEWAY_API_KEY', 'pylf_v1_us_0123456789abcdef')
     monkeypatch.setenv('ANTHROPIC_API_KEY', 'mock-anthropic-key')
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1470,16 +1470,14 @@ async def test_mcptoolset_dynamic_toolset_in_workflow(allow_model_requests: None
 # `durable_exec/temporal/__init__.py`). When a model is named by string (e.g. `gateway/anthropic:`
 # or `anthropic:`) it is constructed lazily via `infer_model` *inside* the workflow, so the
 # provider's SDK client `__init__` runs under the `SandboxedWorkflowRunner`. Provider SDKs
-# increasingly touch the filesystem at construction time — e.g. `anthropic>=0.99.0` calls
-# `Path.home()` to resolve `~/.config/anthropic` — which the sandbox forbids unless the SDK module
-# is passed through. Every other test builds its model at module scope (outside the sandbox), so
-# this seam was previously uncovered. Construction-only (no model request) keeps it deterministic.
+# increasingly touch the filesystem at construction time, which the sandbox forbids unless the SDK
+# module is passed through. Every other test builds its model at module scope (outside the sandbox),
+# so this seam was previously uncovered. Construction-only (no model request) keeps it deterministic.
 @workflow.defn
 class ConstructModelInWorkflow:
     @workflow.run
     async def run(self, model_name: str) -> str:
-        # Constructs the provider and its SDK client inside the sandbox; we assert only that this
-        # succeeds — no request is made.
+        # We assert only that construction succeeds — no request is made.
         return type(infer_model(model_name)).__name__
 
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -57,7 +57,13 @@ from pydantic_ai.capabilities import Instrumentation, NativeTool, ProcessHistory
 from pydantic_ai.direct import model_request_stream
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry, UserError
 from pydantic_ai.messages import UploadedFile
-from pydantic_ai.models import Model, ModelRequestParameters, create_async_http_client, infer_model_profile
+from pydantic_ai.models import (
+    Model,
+    ModelRequestParameters,
+    create_async_http_client,
+    infer_model,
+    infer_model_profile,
+)
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
@@ -1458,6 +1464,72 @@ async def test_mcptoolset_dynamic_toolset_in_workflow(allow_model_requests: None
             task_queue=TASK_QUEUE,
         )
         assert 'pydantic' in output.lower() or 'agent' in output.lower()
+
+
+# Regression test for the workflow-sandbox passthrough list (`_workflow_runner` in
+# `durable_exec/temporal/__init__.py`). When a model is named by string (e.g. `gateway/anthropic:`
+# or `anthropic:`) it is constructed lazily via `infer_model` *inside* the workflow, so the
+# provider's SDK client `__init__` runs under the `SandboxedWorkflowRunner`. Provider SDKs
+# increasingly touch the filesystem at construction time — e.g. `anthropic>=0.99.0` calls
+# `Path.home()` to resolve `~/.config/anthropic` — which the sandbox forbids unless the SDK module
+# is passed through. Every other test builds its model at module scope (outside the sandbox), so
+# this seam was previously uncovered. Construction-only (no model request) keeps it deterministic.
+@workflow.defn
+class ConstructModelInWorkflow:
+    @workflow.run
+    async def run(self, model_name: str) -> str:
+        # Constructing the model also constructs its provider and underlying SDK client, all inside
+        # the workflow sandbox. We only assert this succeeds; no request is made to the model.
+        return type(infer_model(model_name)).__name__
+
+
+@pytest.mark.parametrize(
+    ('model_name', 'expected_model_class'),
+    [
+        # The reported regression: `gateway/anthropic:` resolved in-workflow tripped
+        # `Cannot access pathlib.Path.home.__call__ from inside a workflow`. Uses the latest Sonnet.
+        pytest.param('gateway/anthropic:claude-sonnet-4-6', 'AnthropicModel', id='gateway-anthropic'),
+        # The direct route hits the same `AsyncAnthropic.__init__` path, so it's not gateway-specific.
+        pytest.param('anthropic:claude-sonnet-4-6', 'AnthropicModel', id='anthropic'),
+        # OpenAI and Gemini don't touch the home directory at construction *today*, so these pass
+        # without needing their SDKs in the passthrough list. They're canaries: if a future SDK
+        # release starts reading `~/...` (or makes any other restricted call) during client
+        # construction, the corresponding case turns red here instead of in a user's workflow.
+        pytest.param('gateway/openai-chat:gpt-5', 'OpenAIChatModel', id='gateway-openai'),
+        pytest.param('gateway/google-cloud:gemini-2.5-pro', 'GoogleModel', id='gateway-google'),
+    ],
+)
+async def test_model_construction_in_workflow_passes_sandbox(
+    model_name: str,
+    expected_model_class: str,
+    client: Client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Credentials are read from the environment during construction; dummy values suffice since no
+    # request is made. The gateway key must encode a region (`pylf_v<n>_<region>_...`) so the base
+    # URL can be inferred; the gateway routes all authenticate with it, so no per-provider key is
+    # needed beyond the direct-anthropic case.
+    monkeypatch.setenv('PYDANTIC_AI_GATEWAY_API_KEY', 'pylf_v1_us_0123456789abcdef')
+    monkeypatch.setenv('ANTHROPIC_API_KEY', 'mock-anthropic-key')
+
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[ConstructModelInWorkflow],
+        # A sandbox violation surfaces as a workflow *task* failure, which Temporal retries forever
+        # by default — so a regression would hang rather than fail. Promote any in-workflow exception
+        # (e.g. `RestrictedWorkflowAccessError`) to a workflow failure so it surfaces immediately.
+        workflow_failure_exception_types=[Exception],
+    ):
+        # Without the `anthropic` passthrough this fails with a `WorkflowFailureError` caused by a
+        # `RestrictedWorkflowAccessError` for `pathlib.Path.home`.
+        result = await client.execute_workflow(
+            ConstructModelInWorkflow.run,
+            args=[model_name],
+            id=f'construct_model_{re.sub(r"[^a-zA-Z0-9]", "_", model_name)}',
+            task_queue=TASK_QUEUE,
+        )
+    assert result == expected_model_class
 
 
 async def test_temporal_agent():

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1467,12 +1467,12 @@ async def test_mcptoolset_dynamic_toolset_in_workflow(allow_model_requests: None
 
 
 # Regression test for the workflow-sandbox passthrough list (`_workflow_runner` in
-# `durable_exec/temporal/__init__.py`). When a model is named by string (e.g. `gateway/anthropic:`
-# or `anthropic:`) it is constructed lazily via `infer_model` *inside* the workflow, so the
-# provider's SDK client `__init__` runs under the `SandboxedWorkflowRunner`. Provider SDKs
-# increasingly touch the filesystem at construction time, which the sandbox forbids unless the SDK
-# module is passed through. Every other test builds its model at module scope (outside the sandbox),
-# so this seam was previously uncovered. Construction-only (no model request) keeps it deterministic.
+# `durable_exec/temporal/__init__.py`). A `gateway/` model named by string is constructed lazily via
+# `infer_model` *inside* the workflow, so the provider's SDK is imported and its client built under
+# the `SandboxedWorkflowRunner`. Provider SDKs touch the filesystem/env at construction time, which
+# the sandbox forbids unless the SDK module is passed through. Every other test builds its model at
+# module scope (outside the sandbox), so this seam was previously uncovered. Construction-only (no
+# model request) keeps it deterministic.
 @workflow.defn
 class ConstructModelInWorkflow:
     @workflow.run
@@ -1484,10 +1484,14 @@ class ConstructModelInWorkflow:
 @pytest.mark.parametrize(
     ('model_name', 'expected_model_class'),
     [
-        # The reported regression: `gateway/anthropic:` in-workflow tripped `Path.home` access.
+        # Only `gateway/` providers exercise the sandbox: they import their SDK lazily inside
+        # `gateway_provider()`, so the import and client construction run *inside* the workflow. Direct
+        # providers (e.g. `anthropic:`) import their SDK at module level, which rides Temporal's
+        # transitive passthrough of `pydantic_ai` and never trips — so they give no regression coverage.
+        #
+        # The reported regression: `gateway/anthropic:` in-workflow tripped the `anthropic` SDK's
+        # `Path.home()` access.
         pytest.param('gateway/anthropic:claude-sonnet-4-6', 'AnthropicModel', id='gateway-anthropic'),
-        # Same `AsyncAnthropic.__init__` path off the gateway — not gateway-specific.
-        pytest.param('anthropic:claude-sonnet-4-6', 'AnthropicModel', id='anthropic'),
         # Canary: OpenAI needs no passthrough today; turns red here (not in a user's workflow) if a
         # future SDK release makes a restricted call (e.g. reads `~/...`) during construction.
         pytest.param('gateway/openai-chat:gpt-5', 'OpenAIChatModel', id='gateway-openai'),
@@ -1503,10 +1507,8 @@ async def test_model_construction_in_workflow_passes_sandbox(
     monkeypatch: pytest.MonkeyPatch,
 ):
     # Dummy credentials suffice since no request is made. The gateway key must encode a region
-    # (`pylf_v<n>_<region>_...`) so the base URL can be inferred; only the direct-anthropic case
-    # also needs a provider key.
+    # (`pylf_v<n>_<region>_...`) so the base URL can be inferred.
     monkeypatch.setenv('PYDANTIC_AI_GATEWAY_API_KEY', 'pylf_v1_us_0123456789abcdef')
-    monkeypatch.setenv('ANTHROPIC_API_KEY', 'mock-anthropic-key')
 
     async with Worker(
         client,
@@ -1517,8 +1519,9 @@ async def test_model_construction_in_workflow_passes_sandbox(
         # (e.g. `RestrictedWorkflowAccessError`) to a workflow failure so it surfaces immediately.
         workflow_failure_exception_types=[Exception],
     ):
-        # Without the `anthropic` passthrough this fails with a `WorkflowFailureError` caused by a
-        # `RestrictedWorkflowAccessError` for `pathlib.Path.home`.
+        # Without the SDK passed through this fails with a `WorkflowFailureError`: under the suite's
+        # warnings-as-errors, Temporal's "imported after initial workflow load" becomes a hard error;
+        # in production the SDK's restricted `Path.home()`/env access raises `RestrictedWorkflowAccessError`.
         result = await client.execute_workflow(
             ConstructModelInWorkflow.run,
             args=[model_name],


### PR DESCRIPTION
- Closes #5732

Building an Anthropic model inside a Temporal workflow — a `gateway/anthropic:` or `anthropic:` model resolved lazily via `infer_model` — raised `RestrictedWorkflowAccessError: Cannot access pathlib.Path.home.__call__ from inside a workflow`. `anthropic>=0.99.0` reads `~/.config/anthropic` via `Path.home()` during `AsyncAnthropic.__init__` (credential/profile auto-discovery), which the workflow sandbox forbids, and `anthropic` was not in `PydanticAIPlugin`'s passthrough list. Models built at module scope are unaffected, so existing Temporal tests didn't catch it.

Testing in-workflow construction across providers surfaced two adjacent problems on the same path: the gateway builds its own httpx client (lazy `certifi` import) and `google-genai` lazily imports `google.auth` submodules, both tripping the sandbox's "imported after initial workflow load" warning — a hard error under our `filterwarnings=["error"]` policy, and log noise otherwise. (Google's own Gemini + Temporal example documents the same passthrough need.)

This adds `anthropic`, `certifi`, and `google.auth` to the passthrough list. Verified minimal: `google.auth` alone is enough (not the whole `google` namespace, not `google.genai`), and OpenAI/Groq need nothing extra.

Adds a parametrized regression test that constructs `gateway/anthropic`, `anthropic`, `gateway/openai-chat`, and `gateway/google-cloud` models inside a workflow and asserts no sandbox error.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
