### PR TITLE
Document Tuning Engines as an OpenAI-compatible endpoint

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -345,6 +345,21 @@ agent = Agent(model)
 ...
 ```
 
+For example, a governed OpenAI-compatible endpoint such as [Tuning Engines](https://www.tuningengines.com/) can be configured without changing your agent code:
+
+```python
+model = OpenAIChatModel(
+    'gpt-4o-mini',
+    provider=OpenAIProvider(
+        base_url='https://api.tuningengines.com/v1',
+        api_key='your-tuning-engines-key',
+    ),
+)
+agent = Agent(model)
+```
+
+This lets Pydantic AI continue to handle agent logic and tool execution while the gateway centralizes model routing, policy controls, audit logs, traces, approvals, and cost visibility.
+
 Various providers also have their own provider classes so that you don't need to specify the base URL yourself and you can use the standard `<PROVIDER>_API_KEY` environment variable to set the API key.
 When a provider has its own provider class, you can use the `Agent("<provider>:<model>")` shorthand, e.g. `Agent("deepseek:deepseek-chat")` or `Agent("moonshotai:kimi-k2-0711-preview")`, instead of building the `OpenAIChatModel` explicitly. Similarly, you can pass the provider name as a string to the `provider` argument on `OpenAIChatModel` instead of instantiating the provider class explicitly.
 

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -348,6 +348,10 @@ agent = Agent(model)
 For example, a governed OpenAI-compatible endpoint such as [Tuning Engines](https://www.tuningengines.com/) can be configured without changing your agent code:
 
 ```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
 model = OpenAIChatModel(
     'gpt-4o-mini',
     provider=OpenAIProvider(


### PR DESCRIPTION
## Summary

- Adds a small documentation example showing how to point this project’s existing OpenAI-compatible configuration at Tuning Engines.
- Keeps this project’s APIs and runtime behavior unchanged: no new dependency, adapter, or code path.
- Shows a path for teams to keep this framework in charge of app, agent, tool, workflow, or retrieval logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI applications.

This project already supports OpenAI-compatible endpoints. The docs change makes that existing capability discoverable for users who want governance and observability without rewriting their application around a separate SDK or changing this project’s runtime behavior.

## Testing

- `git diff --check`
