### PR TITLE
fix: pass provider modules through Temporal sandbox

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -80,6 +80,9 @@ def _workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner:
             'anyio',
             'sniffio',
             'httpcore',
+            'anthropic',
+            'certifi',
+            'google.auth',
             # `fastmcp` (and the `mcp` SDK it transitively imports) calls `Path.expanduser` at
             # import time when resolving its config directory — restricted by the workflow
             # sandbox. Safe to pass through: the call only happens once at module init.

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -83,6 +83,7 @@ try:
     from temporalio.exceptions import ApplicationError
     from temporalio.testing import WorkflowEnvironment
     from temporalio.worker import Worker
+    from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
     from temporalio.workflow import ActivityConfig
 
     from pydantic_ai.durable_exec.temporal import (
@@ -91,6 +92,7 @@ try:
         PydanticAIPlugin,
         PydanticAIWorkflow,
         TemporalAgent,
+        _workflow_runner,  # pyright: ignore[reportPrivateUsage]
     )
     from pydantic_ai.durable_exec.temporal._function_toolset import TemporalFunctionToolset
     from pydantic_ai.durable_exec.temporal._mcp_server import TemporalMCPServer
@@ -4008,6 +4010,12 @@ def test_pydantic_ai_plugin_with_non_pydantic_converter_preserves_codec() -> Non
         result = plugin.configure_client(config)  # type: ignore[arg-type]
     assert result['data_converter'].payload_converter_class is PydanticPayloadConverter
     assert result['data_converter'].payload_codec is codec
+
+
+def test_pydantic_ai_plugin_provider_passthrough_modules() -> None:
+    runner = _workflow_runner(SandboxedWorkflowRunner())
+    assert isinstance(runner, SandboxedWorkflowRunner)
+    assert {'anthropic', 'certifi', 'google.auth'} <= runner.restrictions.passthrough_modules
 
 
 def test_temporal_model_profile_with_no_provider_prefix() -> None:


### PR DESCRIPTION
﻿Fixes #5732.

## Summary
- add `anthropic`, `certifi`, and `google.auth` to the Temporal sandbox passthrough list
- cover the plugin runner configuration with a small regression test

## To verify
- `PYTHONUTF8=1 uv run pytest tests/test_temporal.py::test_pydantic_ai_plugin_provider_passthrough_modules -q`
- `PYTHONUTF8=1 uv run ruff check pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py tests/test_temporal.py`
- `PYTHONUTF8=1 uv run ruff format --check pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py tests/test_temporal.py`
- `PYTHONUTF8=1 uv run python -m py_compile pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py tests/test_temporal.py`
- `PYTHONUTF8=1 uv run pyright pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py tests/test_temporal.py`
- `git diff --check`
