### PR TITLE
fix: preserve request metadata when cleaning history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -2195,7 +2195,8 @@ def _clean_message_history(messages: list[_messages.ModelMessage]) -> list[_mess
                     # Tool return parts always need to be at the start
                     key=lambda x: 0 if isinstance(x, _messages.ToolReturnPart | _messages.RetryPromptPart) else 1
                 )
-                merged_message = _messages.ModelRequest(
+                merged_message = replace(
+                    last_message,
                     parts=parts,
                     instructions=last_message.instructions or message.instructions,
                     timestamp=message.timestamp or last_message.timestamp,

--- a/tests/test_history_processor.py
+++ b/tests/test_history_processor.py
@@ -139,6 +139,8 @@ async def test_history_processor_run_replaces_message_history(
                     ),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             )
         ]
     )
@@ -207,6 +209,8 @@ async def test_history_processor_streaming_replaces_message_history(
                     ),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             )
         ]
     )
@@ -1114,6 +1118,8 @@ async def test_history_processor_reorder_old_new(function_model: FunctionModel, 
                     UserPromptPart(content='Old question', timestamp=IsDatetime()),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             )
         ]
     )

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3690,6 +3690,28 @@ def test_prepare_messages_then_clean_history_merges_consecutive_requests() -> No
     assert isinstance(last.parts[1], UserPromptPart)
 
 
+def test_clean_message_history_preserves_request_metadata_when_merging() -> None:
+    cleaned = _clean_message_history(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='first')],
+                run_id='run-1',
+                conversation_id='conv-1',
+                metadata={'source': 'history'},
+            ),
+            ModelRequest(parts=[UserPromptPart(content='second')]),
+        ]
+    )
+
+    assert len(cleaned) == 1
+    request = cleaned[0]
+    assert isinstance(request, ModelRequest)
+    assert [part.content for part in request.parts] == ['first', 'second']
+    assert request.run_id == 'run-1'
+    assert request.conversation_id == 'conv-1'
+    assert request.metadata == {'source': 'history'}
+
+
 def test_narrow_type_local_return_passthrough_when_already_narrowed() -> None:
     """Narrowing an already-typed `ToolSearchReturnPart` returns the input instance."""
     part = ToolSearchReturnPart(content={'discovered_tools': []}, tool_call_id='c1')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2269,6 +2269,8 @@ def test_parallel_tool_return_with_deferred():
                     ),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             ),
         ]
     )


### PR DESCRIPTION
﻿## Summary
- Fixes #5731
- Preserve `ModelRequest` fields such as `run_id`, `conversation_id`, and `metadata` when `_clean_message_history()` merges consecutive requests
- Use `dataclasses.replace()` for request merging, matching the existing response merge pattern
- Add a regression test for request metadata preservation during cleanup

## To verify
- `python -m pytest -q tests/test_tool_search.py::test_prepare_messages_then_clean_history_merges_consecutive_requests tests/test_tool_search.py::test_clean_message_history_preserves_request_metadata_when_merging`
- `python -m ruff check --select=F401,F821 pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_tool_search.py`
- `python -m ruff format --check pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_tool_search.py`
- `python -m py_compile pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_tool_search.py`
- `git diff --check`

Note: in the local Windows venv I had to set `PYTHONUTF8=1` while installing editable packages because the isolated hatch/uv-dynamic-versioning build otherwise tried to read `pyproject.toml` with the Windows default code page.
