### PR TITLE
docs: fix broken temporalio API reference links

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -265,7 +265,7 @@ class MultiModelWorkflow:
 
 ## Activity Configuration
 
-Temporal activity configuration, like timeouts and retry policies, can be customized by passing [`temporalio.workflow.ActivityConfig`](https://python.temporal.io/temporalio.workflow.ActivityConfig.html) objects to the `TemporalAgent` constructor:
+Temporal activity configuration, like timeouts and retry policies, can be customized by passing [`temporalio.workflow.ActivityConfig`](https://python.temporal.io/temporalio.workflow._activities.ActivityConfig.html) objects to the `TemporalAgent` constructor:
 
 - `activity_config`: The base Temporal activity config to use for all activities. If no config is provided, a `start_to_close_timeout` of 60 seconds is used.
 - `model_activity_config`: The Temporal activity config to use for model request activities. This is merged with the base activity config.
@@ -314,7 +314,7 @@ When `logfire.info` is used inside an activity and the `pandas` package is among
 AttributeError: partially initialized module 'pandas' has no attribute '_pandas_parser_CAPI' (most likely due to a circular import)
 ```
 
-To fix this, you can use the [`temporalio.workflow.unsafe.imports_passed_through()`](https://python.temporal.io/temporalio.workflow.unsafe.html#imports_passed_through) context manager to proactively import the package and not have it be reloaded in the workflow sandbox:
+To fix this, you can use the [`temporalio.workflow.unsafe.imports_passed_through()`](https://python.temporal.io/temporalio.workflow._sandbox.unsafe.html#imports_passed_through) context manager to proactively import the package and not have it be reloaded in the workflow sandbox:
 
 ```python {title="temporal_activity.py" test="skip" noqa="F401"}
 from temporalio import workflow


### PR DESCRIPTION
<!-- Trivial doc fix — broken external API links (no issue needed per CONTRIBUTING). -->

The Temporal Python SDK's hosted API docs moved `ActivityConfig` and `unsafe.imports_passed_through` into private submodule pages, so the URLs in `docs/durable_execution/temporal.md` return 404. Updated to the current canonical URLs.

- `temporalio.workflow.ActivityConfig.html` → `temporalio.workflow._activities.ActivityConfig.html`
- `temporalio.workflow.unsafe.html#imports_passed_through` → `temporalio.workflow._sandbox.unsafe.html#imports_passed_through`

Both replacement URLs return HTTP 200 and the `imports_passed_through` anchor still resolves on the new page. Verified via the docs index at https://python.temporal.io/temporalio.workflow.html.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
