### PR TITLE
fix: tolerate extra kwargs in _make_httpx_client_factory

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -2771,6 +2771,7 @@ def _make_httpx_client_factory(
         headers: dict[str, str] | None = None,
         timeout: httpx.Timeout | None = None,
         auth: httpx.Auth | None = None,
+        **_kwargs: Any,
     ) -> httpx.AsyncClient:
         return http_client
 

--- a/tests/test_mcp_toolset.py
+++ b/tests/test_mcp_toolset.py
@@ -107,6 +107,17 @@ class TestMCPToolsetConstruction:
         assert toolset.client.transport.httpx_client_factory is not None
         assert toolset.client.transport.httpx_client_factory() is client
 
+    def test_http_client_factory_tolerates_extra_kwargs(self):
+        """The factory returned by _make_httpx_client_factory must accept extra
+        kwargs (e.g. ``follow_redirects``) that FastMCP transports may pass."""
+        client = httpx.AsyncClient()
+        toolset = MCPToolset('https://example.com/mcp', http_client=client)
+        factory = toolset.client.transport.httpx_client_factory
+        assert factory is not None
+        # FastMCP's StreamableHttpTransport passes follow_redirects=
+        result = factory(follow_redirects=True)
+        assert result is client
+
     def test_http_kwargs_with_non_url_input_raises(self):
         """HTTP-only kwargs (headers/auth/verify/http_client) must error out when the connection
         target isn't an HTTP URL — otherwise the kwargs are silently dropped on stdio / Path /


### PR DESCRIPTION
## Summary

- Adds `**_kwargs: Any` to the closure returned by `_make_httpx_client_factory` so it tolerates extra keyword arguments (e.g. `follow_redirects`) that FastMCP transports may pass.
- This is a one-line, backwards-compatible fix.

## Root Cause

When `http_client=` is passed to `MCPToolset`, the `_make_httpx_client_factory` function returns a closure with the signature `factory(headers=None, timeout=None, auth=None)` — no `**kwargs`. FastMCP's `StreamableHttpTransport` and `SSETransport` call this factory with `follow_redirects=True`, which raises a `TypeError`.

Fixes #5688

## Test Plan

- [x] Added `test_http_client_factory_tolerates_extra_kwargs` — verifies the factory accepts `follow_redirects=True` and still returns the user-supplied client.
- [x] All 23 existing `TestMCPToolsetConstruction` tests pass.
