### PR TITLE
Preserve RunUsage in message history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -28,7 +28,7 @@ from ._instrumentation import serialize_any
 from ._utils import generate_tool_call_id as _generate_tool_call_id, now_utc as _now_utc
 from ._warnings import PydanticAIDeprecationWarning
 from .exceptions import UnexpectedModelBehavior
-from .usage import RequestUsage
+from .usage import RequestUsage, RunUsage
 
 if TYPE_CHECKING:
     from .models.instrumented import InstrumentationSettings
@@ -2083,7 +2083,7 @@ class ModelResponse:
 
     _: KW_ONLY
 
-    usage: RequestUsage = field(default_factory=RequestUsage)
+    usage: RequestUsage | RunUsage = field(default_factory=RequestUsage)
     """Usage information for the request.
 
     This has a default to make tests easier, and to support loading old messages where usage will be missing.

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -24,6 +24,7 @@ from pydantic_ai import (
     NativeToolReturnPart,
     RequestUsage,
     RetryPromptPart,
+    RunUsage,
     TextContent,
     TextPart,
     ThinkingPart,
@@ -655,6 +656,43 @@ def test_model_messages_type_adapter_preserves_conversation_id():
     deserialized = ModelMessagesTypeAdapter.validate_python(serialized)
 
     assert [message.conversation_id for message in deserialized] == snapshot(['conv-abc', 'conv-abc'])
+
+
+def test_model_messages_type_adapter_preserves_request_usage():
+    messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[TextPart(content='Hello!')],
+            usage=RequestUsage(input_tokens=10, output_tokens=5),
+        ),
+    ]
+
+    serialized = ModelMessagesTypeAdapter.dump_json(messages)
+    [deserialized] = ModelMessagesTypeAdapter.validate_json(serialized)
+
+    assert isinstance(deserialized, ModelResponse)
+    assert isinstance(deserialized.usage, RequestUsage)
+    assert not isinstance(deserialized.usage, RunUsage)
+    assert deserialized.usage.input_tokens == 10
+    assert deserialized.usage.output_tokens == 5
+
+
+def test_model_messages_type_adapter_preserves_run_usage():
+    messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[TextPart(content='Hello!')],
+            usage=RunUsage(requests=5, tool_calls=3, input_tokens=1000, output_tokens=500),
+        ),
+    ]
+
+    serialized = ModelMessagesTypeAdapter.dump_json(messages)
+    [deserialized] = ModelMessagesTypeAdapter.validate_json(serialized)
+
+    assert isinstance(deserialized, ModelResponse)
+    assert isinstance(deserialized.usage, RunUsage)
+    assert deserialized.usage.requests == 5
+    assert deserialized.usage.tool_calls == 3
+    assert deserialized.usage.input_tokens == 1000
+    assert deserialized.usage.output_tokens == 500
 
 
 def test_model_messages_type_adapter_back_compat_missing_conversation_id():


### PR DESCRIPTION
Fixes #5744.

`ModelResponse.usage` was typed as `RequestUsage`, so serialized message histories containing a `RunUsage` would deserialize as `RequestUsage`. That preserves token counts, but drops run-level fields like `requests` and `tool_calls`.

This accepts both usage types while keeping `RequestUsage` first in the union so existing request-level usage histories continue to deserialize as `RequestUsage`, while payloads with run-level fields deserialize as `RunUsage`.

Tests:
- `PYTHONPATH=/tmp/stubreadline /tmp/pydantic-ai-venv/bin/python -m pytest tests/test_messages.py::test_model_messages_type_adapter_preserves_request_usage tests/test_messages.py::test_model_messages_type_adapter_preserves_run_usage tests/test_messages.py::test_model_messages_type_adapter_preserves_run_id tests/test_messages.py::test_model_messages_type_adapter_preserves_conversation_id`
- `PYTHONPATH=/tmp/stubreadline /tmp/pydantic-ai-venv/bin/python -m pytest tests/test_messages.py`
- `/tmp/pydantic-ai-venv/bin/python -m ruff check --select I pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py`
- `/tmp/pydantic-ai-venv/bin/python -m ruff format --check --diff pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py`
- `/tmp/pydantic-ai-venv/bin/python -m py_compile pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py`
- `git diff --check`