### PR TITLE
fix: read cassette test sources as utf-8

### DIFF
--- a/scripts/check_cassettes.py
+++ b/scripts/check_cassettes.py
@@ -56,7 +56,7 @@ def _has_module_vcr_marker(tree: ast.Module) -> bool:
 def _collect_vcr_tests_from_file(path: Path) -> set[str]:
     """Parse a Python test file and return cassette names for VCR-marked tests."""
     try:
-        tree = ast.parse(path.read_text())
+        tree = ast.parse(path.read_text(encoding='utf-8'))
     except SyntaxError:
         return set()
 

--- a/tests/test_check_cassettes.py
+++ b/tests/test_check_cassettes.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from scripts.check_cassettes import _collect_vcr_tests_from_file
+
+
+def test_collect_vcr_tests_reads_utf8_source(tmp_path: Path) -> None:
+    test_file = tmp_path / 'test_unicode_source.py'
+    test_file.write_text(
+        """\
+import pytest
+
+
+@pytest.mark.vcr
+def test_unicode_source_comment():
+    message = 'Olá, 世界'
+    assert message
+""",
+        encoding='utf-8',
+    )
+
+    assert _collect_vcr_tests_from_file(test_file) == {'test_unicode_source_comment'}


### PR DESCRIPTION
## What changed
- Read Python test files in `scripts/check_cassettes.py` with explicit `encoding='utf-8'` before AST parsing.
- Added a focused test that parses a VCR-marked test file containing non-ASCII source text.

## Problem
`Path.read_text()` uses the platform default encoding when no encoding is provided. On non-UTF-8 locales, the cassette checker can fail before AST parsing if a test file contains UTF-8-only text.

## Before/after
Before: the cassette checker depended on the process default encoding when reading test source files.
After: it consistently decodes test source as UTF-8, matching the repository's Python source encoding expectations.

## Verification
- Direct helper verification with a temporary UTF-8 test file containing `Olá, 世界`
- Attempted `python -m pytest tests/test_check_cassettes.py`, but this local lightweight environment is missing optional dependencies needed by the repo-level pytest config (`opentelemetry` import while resolving warning filters), so pytest stopped before collecting the new test.