### PR TITLE
Pin `aiohttp` below 3.14 for vcrpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ constraint-dependencies = [
     "python-dotenv>=1.2.2",
     "pygments>=2.20.0",
     "xgrammar>=0.1.32",
+    # TODO: Remove or loosen once vcrpy includes https://github.com/kevin1024/vcrpy/pull/996.
+    "aiohttp<3.14",
     "langchain-core>=1.3.3",
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -32,6 +32,7 @@ members = [
     "pydantic-graph",
 ]
 constraints = [
+    { name = "aiohttp", specifier = "<3.14" },
     { name = "authlib", specifier = ">=1.6.7" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "idna", specifier = ">=3.15" },


### PR DESCRIPTION
## Summary

- Constrain `aiohttp` to `<3.14` while vcrpy's aiohttp stub is incompatible with aiohttp 3.14.
- Add a TODO pointing at https://github.com/kevin1024/vcrpy/pull/996 so the pin can be removed or loosened once vcrpy includes the upstream fix.
- Regenerate `uv.lock` with the new resolver constraint.

- Closes none.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

## Verification

- `UV_FROZEN=0 uv --config-file /dev/null lock --check`
- `UV_FROZEN=1 uv --config-file /dev/null run python -c "import aiohttp; import vcr.stubs.aiohttp_stubs; print(aiohttp.__version__)"`
- `make format`
- `make lint`
