### PR TITLE
docs: update Ragas repository link

### DIFF
--- a/docs/evals/evaluators/framework-integrations.md
+++ b/docs/evals/evaluators/framework-integrations.md
@@ -1,7 +1,7 @@
 # Third-Party Integrations
 
 Pydantic Evals does not take a hard dependency on any particular metrics framework. When a team
-already uses [Ragas](https://github.com/explodinggradients/ragas),
+already uses [Ragas](https://github.com/vibrantlabsai/ragas),
 [DeepEval](https://github.com/confident-ai/deepeval), or another scoring library, the
 [`Evaluator`][pydantic_evals.evaluators.Evaluator] base class makes it straightforward to wrap the
 upstream metric and run it inside any Pydantic Evals dataset. This page shows worked examples for


### PR DESCRIPTION
### Summary

- Update the Ragas GitHub link in the Pydantic Evals framework integrations docs to the repository's canonical location.

### Verification

- `git diff --check`
- Confirmed `https://github.com/explodinggradients/ragas` redirects to `https://github.com/vibrantlabsai/ragas`
- Confirmed `https://github.com/vibrantlabsai/ragas` returns `200` directly

### Checklist

- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No breaking changes in accordance with the version policy.
- [x] PR title is fit for the release changelog.