### PR TITLE
Reject duplicate deferred tool call IDs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -243,6 +243,17 @@ def is_agent_node(
     return isinstance(node, AgentNode)
 
 
+def _duplicate_tool_call_ids(calls: Sequence[_messages.ToolCallPart]) -> list[str]:
+    """Return duplicate tool call ids while preserving first duplicate order."""
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for call in calls:
+        if call.tool_call_id in seen and call.tool_call_id not in duplicates:
+            duplicates.append(call.tool_call_id)
+        seen.add(call.tool_call_id)
+    return duplicates
+
+
 @dataclasses.dataclass
 class UserPromptNode(AgentNode[DepsT, NodeRunEndT]):
     """The node that handles the user prompt and instructions."""
@@ -1684,6 +1695,12 @@ async def process_tool_calls(  # noqa: C901
         calls_to_run.extend(tool_calls_by_kind['external'])
         calls_to_run.extend(tool_calls_by_kind['unapproved'])
 
+        if duplicate_ids := _duplicate_tool_call_ids(calls_to_run):
+            raise exceptions.UserError(
+                'Tool call results cannot be matched unambiguously because the model response contains duplicate '
+                f'tool_call_id values: {duplicate_ids}'
+            )
+
         result_tool_call_ids = set(tool_call_results.keys())
         tool_call_ids_to_run = {call.tool_call_id for call in calls_to_run}
         if tool_call_ids_to_run != result_tool_call_ids:
@@ -1783,6 +1800,12 @@ async def process_tool_calls(  # noqa: C901
                         yield _messages.FunctionToolResultEvent(e.tool_retry)
 
     if not final_result and deferred_calls:
+        duplicate_deferred_ids = _duplicate_tool_call_ids([*deferred_calls['external'], *deferred_calls['unapproved']])
+        if duplicate_deferred_ids:
+            raise exceptions.UnexpectedModelBehavior(
+                f'Deferred tool calls must have unique tool_call_id values; duplicate ids: {duplicate_deferred_ids}'
+            )
+
         deferred_tool_requests: _output.DeferredToolRequests | None = _output.DeferredToolRequests(
             calls=deferred_calls['external'],
             approvals=deferred_calls['unapproved'],

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9012,6 +9012,62 @@ async def test_run_with_deferred_tool_results_errors():
         )
 
 
+async def test_deferred_tool_requests_reject_duplicate_tool_call_ids():
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(tool_name='safe_tool', args={'item': 'visible-safe'}, tool_call_id='duplicate-id'),
+                ToolCallPart(tool_name='danger_tool', args={'item': 'hidden-danger'}, tool_call_id='duplicate-id'),
+            ]
+        )
+
+    agent = Agent(FunctionModel(model_function), output_type=[str, DeferredToolRequests])
+
+    def safe_tool(item: str) -> str:
+        return f'safe:{item}'  # pragma: no cover
+
+    def danger_tool(item: str) -> str:
+        return f'danger:{item}'  # pragma: no cover
+
+    agent.tool_plain(requires_approval=True)(safe_tool)
+    agent.tool_plain(requires_approval=True)(danger_tool)
+
+    with pytest.raises(UnexpectedModelBehavior, match='duplicate ids'):
+        await agent.run('approve the safe operation')
+
+
+async def test_deferred_tool_results_reject_duplicate_tool_call_ids_in_history():
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart('done')])  # pragma: no cover
+
+    agent = Agent(FunctionModel(model_function), output_type=[str, DeferredToolRequests])
+
+    def safe_tool(item: str) -> str:
+        return f'safe:{item}'  # pragma: no cover
+
+    def danger_tool(item: str) -> str:
+        return f'danger:{item}'  # pragma: no cover
+
+    agent.tool_plain(requires_approval=True)(safe_tool)
+    agent.tool_plain(requires_approval=True)(danger_tool)
+
+    message_history = [
+        ModelRequest(parts=[UserPromptPart(content='approve the safe operation')]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(tool_name='safe_tool', args={'item': 'visible-safe'}, tool_call_id='duplicate-id'),
+                ToolCallPart(tool_name='danger_tool', args={'item': 'hidden-danger'}, tool_call_id='duplicate-id'),
+            ]
+        ),
+    ]
+
+    with pytest.raises(UserError, match='duplicate tool_call_id'):
+        await agent.run(
+            message_history=message_history,
+            deferred_tool_results=DeferredToolResults(approvals={'duplicate-id': True}),
+        )
+
+
 async def test_user_prompt_with_deferred_tool_results():
     """Test that user_prompt can be provided alongside deferred_tool_results."""
     from pydantic_ai.exceptions import ApprovalRequired


### PR DESCRIPTION
## Summary

- reject duplicate `tool_call_id` values before returning deferred tool requests
- reject duplicate pending IDs when resuming from message history with deferred tool results
- add regressions for ambiguous approval/result matching

## Why

Deferred tool resume matches results back to pending calls by `tool_call_id`. If a model response or imported message history contains duplicate pending IDs, the resume state is ambiguous: one approval/result can no longer be bound to exactly one pending tool call. This change fails closed before downstream resume handling consumes that ambiguous state.

## Tests

- `uv run ruff check pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_agent.py`
- `uv run pytest -q tests/test_agent.py::test_deferred_tool_requests_reject_duplicate_tool_call_ids tests/test_agent.py::test_deferred_tool_results_reject_duplicate_tool_call_ids_in_history`
- `uv run pytest -q tests/test_agent.py`
- `git diff --check`
