### PR TITLE
fix(openai): ignore post-done tool arg deltas

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3410,6 +3410,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
             # from the `output_item.added` event and merged into the corresponding
             # `TextPart.provider_details` on `output_text.done`.
             _phase_by_item: dict[str, Literal['commentary', 'final_answer']] = {}
+            _done_function_call_item_ids: set[str] = set()
 
             if self._provider_timestamp is not None:  # pragma: no branch
                 self.provider_details = {'timestamp': self._provider_timestamp}
@@ -3447,6 +3448,9 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                     self._usage += self._map_usage(chunk.response)
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDeltaEvent):
+                    if chunk.item_id in _done_function_call_item_ids:
+                        continue
+
                     maybe_event = self._parts_manager.handle_tool_call_delta(
                         vendor_part_id=chunk.item_id,
                         args=chunk.delta,
@@ -3455,7 +3459,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                         yield maybe_event
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDoneEvent):
-                    pass  # there's nothing we need to do here
+                    _done_function_call_item_ids.add(chunk.item_id)
 
                 elif isinstance(chunk, responses.ResponseIncompleteEvent):  # pragma: no cover
                     self._usage += self._map_usage(chunk.response)
@@ -3591,6 +3595,9 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                                 provider_name=self.provider_name,
                             ):
                                 yield event
+                    elif isinstance(chunk.item, responses.ResponseFunctionToolCall):
+                        if chunk.item.id is not None:  # pragma: no branch
+                            _done_function_call_item_ids.add(chunk.item.id)
                     elif isinstance(chunk.item, responses.ResponseCodeInterpreterToolCall):
                         _, return_part, file_parts = _map_code_interpreter_tool_call(chunk.item, self.provider_name)
                         for i, file_part in enumerate(file_parts):

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -11874,6 +11874,169 @@ async def test_openai_responses_phase_streamed(allow_model_requests: None):
     assert text_parts[0].provider_details == snapshot({'phase': 'final_answer'})
 
 
+async def test_openai_responses_ignores_post_done_function_call_delta(allow_model_requests: None):
+    """Malformed Responses-compatible streams can send an arguments delta after the item is done."""
+    from openai.types import responses as resp
+
+    base_response = resp.Response(
+        id='resp_tool',
+        model='gpt-4o',
+        object='response',
+        created_at=1704067200,
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice='auto',
+        tools=[],
+    )
+    tool_call = resp.ResponseFunctionToolCall(
+        id='fc_001',
+        call_id='call_001',
+        name='add',
+        arguments='{"a":1,"b":2}',
+        status='completed',
+        type='function_call',
+    )
+    tool_stream: list[resp.ResponseStreamEvent] = [
+        resp.ResponseCreatedEvent(response=base_response, type='response.created', sequence_number=0),
+        resp.ResponseOutputItemAddedEvent(
+            item=resp.ResponseFunctionToolCall(
+                id='fc_001',
+                call_id='call_001',
+                name='add',
+                arguments='',
+                status='in_progress',
+                type='function_call',
+            ),
+            output_index=0,
+            type='response.output_item.added',
+            sequence_number=1,
+        ),
+        resp.ResponseFunctionCallArgumentsDeltaEvent(
+            delta='{"a":1,"b":2}',
+            item_id='fc_001',
+            output_index=0,
+            type='response.function_call_arguments.delta',
+            sequence_number=2,
+        ),
+        resp.ResponseFunctionCallArgumentsDoneEvent(
+            arguments='{"a":1,"b":2}',
+            item_id='fc_001',
+            name='add',
+            output_index=0,
+            type='response.function_call_arguments.done',
+            sequence_number=3,
+        ),
+        resp.ResponseOutputItemDoneEvent(
+            item=tool_call,
+            output_index=0,
+            type='response.output_item.done',
+            sequence_number=4,
+        ),
+        resp.ResponseFunctionCallArgumentsDeltaEvent(
+            delta='}',
+            item_id='fc_001',
+            output_index=0,
+            type='response.function_call_arguments.delta',
+            sequence_number=5,
+        ),
+        resp.ResponseCompletedEvent(
+            response=base_response.model_copy(update={'status': 'completed', 'output': [tool_call]}),
+            type='response.completed',
+            sequence_number=6,
+        ),
+    ]
+
+    final_response = resp.Response(
+        id='resp_final',
+        model='gpt-4o',
+        object='response',
+        created_at=1704067201,
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice='auto',
+        tools=[],
+    )
+    final_stream: list[resp.ResponseStreamEvent] = [
+        resp.ResponseCreatedEvent(response=final_response, type='response.created', sequence_number=0),
+        resp.ResponseOutputItemAddedEvent(
+            item=ResponseOutputMessage(
+                id='msg_001',
+                content=[],
+                role='assistant',
+                status='in_progress',
+                type='message',
+            ),
+            output_index=0,
+            type='response.output_item.added',
+            sequence_number=1,
+        ),
+        resp.ResponseContentPartAddedEvent(
+            content_index=0,
+            item_id='msg_001',
+            output_index=0,
+            part=resp.ResponseOutputText(text='', type='output_text', annotations=[]),
+            type='response.content_part.added',
+            sequence_number=2,
+        ),
+        resp.ResponseTextDeltaEvent(
+            content_index=0,
+            delta='3',
+            item_id='msg_001',
+            output_index=0,
+            type='response.output_text.delta',
+            sequence_number=3,
+            logprobs=[],
+        ),
+        resp.ResponseTextDoneEvent(
+            content_index=0,
+            item_id='msg_001',
+            output_index=0,
+            text='3',
+            type='response.output_text.done',
+            sequence_number=4,
+            logprobs=[],
+        ),
+        resp.ResponseOutputItemDoneEvent(
+            item=ResponseOutputMessage(
+                id='msg_001',
+                content=cast(list[Content], [ResponseOutputText(text='3', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            ),
+            output_index=0,
+            type='response.output_item.done',
+            sequence_number=5,
+        ),
+        resp.ResponseCompletedEvent(
+            response=final_response.model_copy(update={'status': 'completed'}),
+            type='response.completed',
+            sequence_number=6,
+        ),
+    ]
+
+    mock_client = MockOpenAIResponses.create_mock_stream([tool_stream, final_stream])
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(model=model)
+
+    @agent.tool_plain
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    async with agent.run_stream('Add 1 and 2') as result:
+        output = await result.get_output()
+
+    assert output == snapshot('3')
+    tool_call_parts = [
+        part
+        for message in result.all_messages()
+        if isinstance(message, ModelResponse)
+        for part in message.parts
+        if isinstance(part, ToolCallPart)
+    ]
+    assert tool_call_parts[0].args == '{"a":1,"b":2}'
+
+
 async def test_openai_responses_phase_round_trip(allow_model_requests: None):
     """When the profile supports phase, it's sent back on the assistant ResponseOutputMessageParam."""
     mock_client = MockOpenAIResponses.create_mock(


### PR DESCRIPTION
﻿Fixes #5757.

## Summary

- track completed OpenAI Responses function-call item IDs during streaming
- ignore any later `response.function_call_arguments.delta` for those completed items
- add a synthetic Responses stream regression test where a malformed post-done `}` delta would otherwise corrupt the final tool-call args

The guard is specific to Responses function-call argument deltas. It does not treat "another part started" as completion, so normal interleaved streaming remains handled by the existing parts manager.

## To verify

- `python -m pytest tests/models/test_openai_responses.py::test_openai_responses_ignores_post_done_function_call_delta -q`
- `python -m pytest tests/models/test_openai_responses.py::test_openai_responses_null_text_stream tests/models/test_openai_responses.py::test_openai_responses_ignores_post_done_function_call_delta -q`
- `python -m ruff check pydantic_ai_slim/pydantic_ai/models/openai.py tests/models/test_openai_responses.py`
- `python -m ruff format --check pydantic_ai_slim/pydantic_ai/models/openai.py tests/models/test_openai_responses.py`
- `git diff --check`

Note: local `pyright` could not be run cleanly in this worktree because this machine is reusing a sibling checkout's `.venv`, while pyright resolves the configured venv relative to the current worktree.
