### PR TITLE
Fix incomplete streamed response when `event_stream_handler` doesn't consume the stream

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -426,9 +426,11 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                             wrapped = agent_run.ctx.deps.root_capability.wrap_run_event_stream(run_ctx, stream=stream)
                             if _handler is not None:
                                 await _handler(run_ctx, wrapped)
-                            else:
-                                async for _ in wrapped:
-                                    pass
+                            # If the handler returns normally, drain whatever it left unconsumed so the
+                            # node can finish through any stream wrappers. Cancellation paths interrupt
+                            # the handler and do not reach this drain.
+                            async for _ in wrapped:
+                                pass
                     return await agent_run._advance_graph(n)  # pyright: ignore[reportPrivateUsage]
 
                 _stream_step = _stream_and_advance
@@ -804,9 +806,11 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                         wrapped = cap.wrap_run_event_stream(run_ctx, stream=stream_to_final(stream))
                         if event_stream_handler is not None:
                             await event_stream_handler(run_ctx, wrapped)
-                        else:
-                            async for _ in wrapped:
-                                pass
+                        # Drain after the handler (same as the `run()` path) so the response is fully
+                        # built and any `wrap_run_event_stream` wrapper finalizes; cancellation/`break`
+                        # interrupt the handler and don't reach here.
+                        async for _ in wrapped:
+                            pass
 
                         if final_result_event is not None:
                             final_result = FinalResult(
@@ -879,9 +883,11 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                         wrapped = cap.wrap_run_event_stream(run_ctx, stream=stream)
                         if event_stream_handler is not None:
                             await event_stream_handler(run_ctx, wrapped)
-                        else:
-                            async for _ in wrapped:
-                                pass
+                        # Drain `wrapped` after the handler, same as the `ModelRequestNode` branch above:
+                        # `CallToolsNode.stream()` self-drains its own events, but `wrapped` is a separate
+                        # `wrap_run_event_stream` layer that must finalize here too, to match the `run()` path.
+                        async for _ in wrapped:
+                            pass
 
                 # Advance graph with remaining hooks (before_node_run already fired above).
                 # Rebuild run_ctx after streaming so hooks see post-streaming state (e.g. run_step).

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3974,6 +3974,32 @@ async def test_run_stream_event_stream_handler_unconsumed_still_executes_tool_ca
     assert tool_calls == [0]
 
 
+async def test_run_event_stream_handler_interrupted_does_not_drain():
+    """A handler interrupted before returning (cancellation/`break`) must not trigger the drain.
+
+    The drain only runs when the handler returns normally; re-running it on an interrupted handler
+    would consume a stream the caller asked to stop, reintroducing the cancellation hang from #5313.
+    `fully_drained` flips only if the stream is iterated to exhaustion, which the drain would do.
+    """
+    fully_drained = False
+
+    async def tracking_stream(_messages: list[ModelMessage], _: AgentInfo) -> AsyncIterator[str]:
+        nonlocal fully_drained
+        for chunk in ('hello', ' ', 'world'):
+            yield chunk
+        fully_drained = True
+
+    agent = Agent(FunctionModel(stream_function=tracking_stream))
+
+    async def event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        raise asyncio.CancelledError  # interrupted before consuming the stream
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run('Hello', event_stream_handler=event_stream_handler)
+
+    assert not fully_drained
+
+
 async def test_stream_tool_returning_user_content():
     m = TestModel()
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3910,6 +3910,70 @@ async def test_run_stream_event_stream_handler():
     )
 
 
+async def test_run_event_stream_handler_does_not_need_to_consume_stream():
+    agent = Agent(TestModel(custom_output_text='hello world this is a long answer'))
+
+    async def event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        return  # never reads the stream
+
+    result = await agent.run('Hello', event_stream_handler=event_stream_handler)
+
+    assert result.output == 'hello world this is a long answer'
+
+
+async def test_run_stream_event_stream_handler_does_not_need_to_consume_stream():
+    agent = Agent(TestModel(custom_output_text='hello world this is a long answer'))
+
+    async def event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        return  # never reads the stream
+
+    async with agent.run_stream('Hello', event_stream_handler=event_stream_handler) as result:
+        output = await result.get_output()
+
+    assert output == 'hello world this is a long answer'
+
+
+async def test_run_event_stream_handler_unconsumed_still_executes_tool_calls():
+    """A handler that ignores the stream must not stop the agent from acting on the model's reply.
+
+    The reply (including tool calls) is built by iterating the stream, so a handler that returns
+    without consuming it used to silently drop the tool call.
+    """
+    tool_calls: list[int] = []
+    agent = Agent(TestModel())
+
+    @agent.tool_plain
+    def record(x: int) -> str:
+        tool_calls.append(x)
+        return 'ok'
+
+    async def event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        return  # never reads the stream
+
+    await agent.run('go', event_stream_handler=event_stream_handler)
+
+    assert tool_calls == [0]
+
+
+async def test_run_stream_event_stream_handler_unconsumed_still_executes_tool_calls():
+    """Same as the `agent.run()` case, but for `agent.run_stream()` (exercises the `CallToolsNode` path)."""
+    tool_calls: list[int] = []
+    agent = Agent(TestModel())
+
+    @agent.tool_plain
+    def record(x: int) -> str:
+        tool_calls.append(x)
+        return 'ok'
+
+    async def event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        return  # never reads the stream
+
+    async with agent.run_stream('go', event_stream_handler=event_stream_handler) as result:
+        await result.get_output()
+
+    assert tool_calls == [0]
+
+
 async def test_stream_tool_returning_user_content():
     m = TestModel()
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3979,17 +3979,17 @@ async def test_run_event_stream_handler_interrupted_does_not_drain():
 
     The drain only runs when the handler returns normally; re-running it on an interrupted handler
     would consume a stream the caller asked to stop, reintroducing the cancellation hang from #5313.
-    `fully_drained` flips only if the stream is iterated to exhaustion, which the drain would do.
+    The stream is unbounded, so a drain that ran after the interrupt would never terminate.
     """
-    fully_drained = False
+    pulled = 0
 
-    async def tracking_stream(_messages: list[ModelMessage], _: AgentInfo) -> AsyncIterator[str]:
-        nonlocal fully_drained
-        for chunk in ('hello', ' ', 'world'):
-            yield chunk
-        fully_drained = True
+    async def counting_stream(_messages: list[ModelMessage], _: AgentInfo) -> AsyncIterator[str]:
+        nonlocal pulled
+        while True:
+            pulled += 1
+            yield 'hello'
 
-    agent = Agent(FunctionModel(stream_function=tracking_stream))
+    agent = Agent(FunctionModel(stream_function=counting_stream))
 
     async def event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:
         raise asyncio.CancelledError  # interrupted before consuming the stream
@@ -3997,7 +3997,9 @@ async def test_run_event_stream_handler_interrupted_does_not_drain():
     with pytest.raises(asyncio.CancelledError):
         await agent.run('Hello', event_stream_handler=event_stream_handler)
 
-    assert not fully_drained
+    # Only the single lookahead the run makes before invoking the handler; the post-handler
+    # drain was skipped (otherwise this unbounded stream would have been pulled forever).
+    assert pulled == 1
 
 
 async def test_stream_tool_returning_user_content():


### PR DESCRIPTION
- Closes #5769

#5313 removed the loop in `ModelRequestNode.stream()` that drained leftover stream events after the consumer finished. It had to go — it also ran after `cancel()`, which broke cancellation. But it was also the only thing making sure the streamed `ModelResponse` was fully built.

The catch: events and the final response come from the same single pass over the model output — iterating an event *is* parsing the next part into the response. So once the drain was gone, any run whose `event_stream_handler` didn't fully consume the stream got an incomplete (often empty) response: truncated output, dropped tool calls, zero usage, and an empty-response retry blowing up as `UnexpectedModelBehavior`.

Fix: drain the leftover events in the run drivers after the handler returns, instead of in the shared node (which is what re-broke cancellation last time). Cancellation/`break` interrupt the handler so the drain never runs then. Only the model-request spots need it — `CallToolsNode.stream()` still self-drains, so its branch is left alone.

Not a Google bug — it's in the provider-agnostic graph. Reproduces the same on Google, Anthropic, and `TestModel`; the reporter just only uses Google. (Their filed repro is a non-streaming `agent.run()`, which doesn't hit this path at all.)

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the version policy.
- [ ] **PR title** is fit for the release changelog.
