### PR TITLE
Handle `UploadedFile` consistently with `FileUrl` in UI adapters

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -37,6 +37,7 @@ from pydantic_ai.messages import (
     ModelResponsePart,
     SystemPromptPart,
     ToolReturnContent,
+    UploadedFile,
     UserContent,
     UserPromptPart,
 )
@@ -209,6 +210,27 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
     `frozenset({True})` or `frozenset({True, 'allow-local'})`.
     """
 
+    preserve_file_data: bool = False
+    """Whether to keep [`UploadedFile`][pydantic_ai.messages.UploadedFile] items from
+    client-submitted messages.
+
+    Defaults to `False`. By default, `UploadedFile` items in client-submitted messages are
+    dropped with a warning before the messages are passed to the agent, mirroring how
+    [`allowed_file_url_schemes`][pydantic_ai.ui.UIAdapter.allowed_file_url_schemes] filters
+    [`FileUrl`][pydantic_ai.messages.FileUrl] parts. This applies both to uploaded files in
+    user content and to those nested in tool return parts.
+
+    Like a non-HTTP `FileUrl`, an `UploadedFile` references an object that the model provider
+    fetches using the server-side IAM role or service account, so a client that can supply
+    arbitrary file references can read anything that identity can reach. Uploaded files should
+    therefore only be accepted from trusted frontends.
+
+    Set to `True` to keep client-submitted uploaded files after auditing your frontend. Some
+    adapters (e.g. AG-UI) additionally use this flag to round-trip agent-generated files and
+    uploaded files through their protocol-specific message representation; see the adapter for
+    details.
+    """
+
     @classmethod
     async def from_request(
         cls,
@@ -218,6 +240,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         manage_system_prompt: Literal['server', 'client'] = 'server',
         allowed_file_url_schemes: frozenset[str] = frozenset({'http', 'https'}),
         allowed_file_url_force_download: frozenset[ForceDownloadMode] = frozenset(),
+        preserve_file_data: bool = False,
         **kwargs: Any,
     ) -> Self:
         """Create an adapter from a request.
@@ -232,6 +255,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             manage_system_prompt=manage_system_prompt,
             allowed_file_url_schemes=allowed_file_url_schemes,
             allowed_file_url_force_download=allowed_file_url_force_download,
+            preserve_file_data=preserve_file_data,
             **kwargs,
         )
 
@@ -342,6 +366,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         stripped_system_prompt = False
         disallowed_url_schemes: set[str] = set()
         reset_force_download_values: set[ForceDownloadMode] = set()
+        dropped_uploaded_file_providers: set[str] = set()
         dangling_tool_call_names: list[str] = []
         last_index = len(messages) - 1
 
@@ -353,6 +378,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                     strip_system_prompt=strip_system_prompt,
                     disallowed_schemes=disallowed_url_schemes,
                     reset_force_download_values=reset_force_download_values,
+                    dropped_uploaded_file_providers=dropped_uploaded_file_providers,
                 )
                 stripped_system_prompt = stripped_system_prompt or request_stripped_system_prompt
                 if new_request_parts:
@@ -366,6 +392,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                     dangling_names=dangling_tool_call_names if index == last_index else None,
                     disallowed_schemes=disallowed_url_schemes,
                     reset_force_download_values=reset_force_download_values,
+                    dropped_uploaded_file_providers=dropped_uploaded_file_providers,
                 )
                 if new_response_parts:
                     sanitized.append(replace(message, parts=new_response_parts))
@@ -408,6 +435,18 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                 stacklevel=2,
             )
 
+        if dropped_uploaded_file_providers:
+            warnings.warn(
+                f'Client-submitted uploaded file(s) for provider(s) {sorted(dropped_uploaded_file_providers)!r} '
+                f'were dropped because `preserve_file_data` is `False` (the default). Like a non-HTTP file URL, '
+                f'an uploaded file references an object the model provider fetches using the server-side IAM role '
+                f'or service account, so it should only be accepted from trusted frontends. To keep uploaded files '
+                f'from the client, set `preserve_file_data=True` on the adapter, or pass them on `message_history` '
+                f'directly to `Agent.run` instead.',
+                UserWarning,
+                stacklevel=2,
+            )
+
         if dangling_tool_call_names:
             warnings.warn(
                 f'Client-submitted history ended with unresolved tool call(s) '
@@ -429,11 +468,13 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         strip_system_prompt: bool,
         disallowed_schemes: set[str],
         reset_force_download_values: set[ForceDownloadMode],
+        dropped_uploaded_file_providers: set[str],
     ) -> tuple[list[ModelRequestPart], bool]:
         """Sanitize the parts of a client-submitted [`ModelRequest`][pydantic_ai.messages.ModelRequest].
 
-        `disallowed_schemes` and `reset_force_download_values` are updated in place with any
-        non-allowlisted file URL schemes and `force_download` values encountered.
+        `disallowed_schemes`, `reset_force_download_values`, and `dropped_uploaded_file_providers` are
+        updated in place with any non-allowlisted file URL schemes, `force_download` values, and dropped
+        uploaded file providers encountered.
         Returns the kept parts and whether any [`SystemPromptPart`][pydantic_ai.messages.SystemPromptPart]s
         were stripped.
         """
@@ -445,7 +486,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                 continue
             if isinstance(part, UserPromptPart) and not isinstance(part.content, str):
                 filtered_content = self._filter_user_content(
-                    part.content, disallowed_schemes, reset_force_download_values
+                    part.content, disallowed_schemes, reset_force_download_values, dropped_uploaded_file_providers
                 )
                 new_parts.append(replace(part, content=filtered_content))
             elif isinstance(part, BaseToolReturnPart) and part.tool_kind is None:
@@ -453,7 +494,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                 # `TypedDict` with required fields, and stripping a `FileUrl`-bearing key
                 # during sanitization would leave it schema-invalid.
                 keep_content, sanitized_content = self._sanitize_tool_return_content(
-                    part.content, disallowed_schemes, reset_force_download_values
+                    part.content, disallowed_schemes, reset_force_download_values, dropped_uploaded_file_providers
                 )
                 new_parts.append(
                     replace(
@@ -470,16 +511,19 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         content: Sequence[UserContent],
         disallowed_schemes: set[str],
         reset_force_download_values: set[ForceDownloadMode],
+        dropped_uploaded_file_providers: set[str],
     ) -> list[UserContent]:
-        """Sanitize [`FileUrl`][pydantic_ai.messages.FileUrl] items in client-submitted user content.
+        """Sanitize client-submitted file references (file URLs and uploaded files) in user content.
 
-        Drops items whose scheme isn't in the allowlist, and resets `force_download` values that
+        Drops file URLs whose scheme isn't in the allowlist, and resets `force_download` values that
         aren't `False` and aren't in
         [`allowed_file_url_force_download`][pydantic_ai.ui.UIAdapter.allowed_file_url_force_download]
-        on kept items to `False`.
+        on kept items to `False`. Drops uploaded files unless
+        [`preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data] is set.
 
-        `disallowed_schemes` and `reset_force_download_values` are updated in place with any
-        disallowed schemes and reset `force_download` values encountered.
+        `disallowed_schemes`, `reset_force_download_values`, and `dropped_uploaded_file_providers` are
+        updated in place with any disallowed schemes, reset `force_download` values, and dropped uploaded
+        file providers encountered.
         """
         filtered: list[UserContent] = []
         for item in content:
@@ -489,6 +533,9 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                     disallowed_schemes.add(scheme)
                     continue
                 item = self._sanitize_file_url(item, reset_force_download_values)
+            elif isinstance(item, UploadedFile) and not self.preserve_file_data:
+                dropped_uploaded_file_providers.add(item.provider_name)
+                continue
             filtered.append(item)
         return filtered
 
@@ -511,15 +558,19 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         content: ToolReturnContent,
         disallowed_schemes: set[str],
         reset_force_download_values: set[ForceDownloadMode],
+        dropped_uploaded_file_providers: set[str],
     ) -> tuple[bool, ToolReturnContent]:
-        """Recursively sanitize [`FileUrl`][pydantic_ai.messages.FileUrl]s nested in tool return content.
+        """Recursively sanitize file references (file URLs and uploaded files) nested in tool return content.
 
         Tool return content is an arbitrarily nested structure of files, sequences, and mappings,
-        so any `FileUrl` it contains — including those introduced by multimodal tool returns — is walked
-        and has its scheme and `force_download` sanitized the same way file URLs in user content are.
+        so any `FileUrl` or `UploadedFile` it contains — including those introduced by multimodal tool
+        returns — is walked and sanitized the same way file references in user content are: file URL
+        schemes and `force_download` are checked, and uploaded files are dropped unless
+        [`preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data] is set.
 
-        `disallowed_schemes` and `reset_force_download_values` are updated in place with any disallowed
-        schemes and reset `force_download` values encountered.
+        `disallowed_schemes`, `reset_force_download_values`, and `dropped_uploaded_file_providers` are
+        updated in place with any disallowed schemes, reset `force_download` values, and dropped uploaded
+        file providers encountered.
         """
         if isinstance(content, FileUrl):
             scheme = urlparse(content.url).scheme.lower()
@@ -527,6 +578,11 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                 disallowed_schemes.add(scheme)
                 return False, content
             return True, self._sanitize_file_url(content, reset_force_download_values)
+        if isinstance(content, UploadedFile):
+            if not self.preserve_file_data:
+                dropped_uploaded_file_providers.add(content.provider_name)
+                return False, content
+            return True, content
         # `ToolReturnContent` is a recursive `TypeAliasType` at runtime (for Pydantic validation)
         # but resolves to `Any` at type-check time, so pyright can't infer the element types.
         if isinstance(content, Mapping):
@@ -534,7 +590,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             sanitized_mapping: dict[str, ToolReturnContent] = {}
             for key, value in mapping.items():
                 keep, sanitized_value = self._sanitize_tool_return_content(
-                    value, disallowed_schemes, reset_force_download_values
+                    value, disallowed_schemes, reset_force_download_values, dropped_uploaded_file_providers
                 )
                 if keep:
                     sanitized_mapping[key] = sanitized_value
@@ -544,7 +600,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             sanitized_sequence: list[ToolReturnContent] = []
             for item in sequence:
                 keep, sanitized_item = self._sanitize_tool_return_content(
-                    item, disallowed_schemes, reset_force_download_values
+                    item, disallowed_schemes, reset_force_download_values, dropped_uploaded_file_providers
                 )
                 if keep:
                     sanitized_sequence.append(sanitized_item)
@@ -559,11 +615,13 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         dangling_names: list[str] | None,
         disallowed_schemes: set[str],
         reset_force_download_values: set[ForceDownloadMode],
+        dropped_uploaded_file_providers: set[str],
     ) -> list[ModelResponsePart]:
         """Sanitize the parts of a client-submitted [`ModelResponse`][pydantic_ai.messages.ModelResponse].
 
         Drops non-allowlisted schemes and resets non-allowlisted `force_download` values on `FileUrl`s
-        nested in tool return parts.
+        nested in tool return parts, and drops `UploadedFile`s nested in tool return parts unless
+        [`preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data] is set.
         When `dangling_names` is not `None` (i.e. this is the trailing response), also drops tool
         calls that aren't resolved by `deferred_tool_results`, appending their names to it.
         """
@@ -581,7 +639,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                 # `TypedDict` with required fields, and stripping a `FileUrl`-bearing key
                 # during sanitization would leave it schema-invalid.
                 keep_content, sanitized_content = self._sanitize_tool_return_content(
-                    part.content, disallowed_schemes, reset_force_download_values
+                    part.content, disallowed_schemes, reset_force_download_values, dropped_uploaded_file_providers
                 )
                 new_parts.append(
                     replace(
@@ -819,6 +877,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         manage_system_prompt: Literal['server', 'client'] = 'server',
         allowed_file_url_schemes: frozenset[str] = frozenset({'http', 'https'}),
         allowed_file_url_force_download: frozenset[ForceDownloadMode] = frozenset(),
+        preserve_file_data: bool = False,
         **kwargs: Any,
     ) -> Response:
         """Handle a protocol-specific HTTP request by running the agent and returning a streaming response of protocol-specific events.
@@ -855,6 +914,8 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             allowed_file_url_force_download: Additional `FileUrl.force_download` values allowed on file URL parts from
                 the client (beyond `False`, which is always allowed). See
                 [`UIAdapter.allowed_file_url_force_download`][pydantic_ai.ui.UIAdapter.allowed_file_url_force_download].
+            preserve_file_data: Whether to keep `UploadedFile` items from client-submitted messages. See
+                [`UIAdapter.preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data].
             **kwargs: Additional keyword arguments forwarded to [`from_request`][pydantic_ai.ui.UIAdapter.from_request].
 
         Returns:
@@ -884,6 +945,7 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
                     manage_system_prompt=manage_system_prompt,
                     allowed_file_url_schemes=allowed_file_url_schemes,
                     allowed_file_url_force_download=allowed_file_url_force_download,
+                    preserve_file_data=preserve_file_data,
                     **kwargs,
                 ),
             )

--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -347,6 +347,12 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
           and `True` makes the server fetch the file itself — neither is safe to honor
           from untrusted client input. This applies to file URLs in user content and
           to those nested in tool return parts.
+        - [`UploadedFile`][pydantic_ai.messages.UploadedFile] items unless
+          [`preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data] is `True`.
+          Like a non-HTTP `FileUrl`, an `UploadedFile` references an object the model
+          provider fetches using the server-side IAM role, so it should only be accepted
+          from trusted frontends. This applies both to uploaded files in user content and
+          to those nested in tool return parts.
         - [`ToolCallPart`][pydantic_ai.messages.ToolCallPart] and
           [`NativeToolCallPart`][pydantic_ai.messages.NativeToolCallPart] entries at
           the end of the history that don't have a matching entry in

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -204,7 +204,16 @@ def _user_content_to_input(
 
 @dataclass
 class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, OutputDataT]):
-    """UI adapter for the Agent-User Interaction (AG-UI) protocol."""
+    """UI adapter for the Agent-User Interaction (AG-UI) protocol.
+
+    When [`preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data] is `True`,
+    agent-generated files and uploaded files are stored as
+    [activity messages](https://docs.ag-ui.com/concepts/activities) during `dump_messages`
+    and restored during `load_messages`, enabling full round-trip fidelity. When `False`
+    (the default), they are dropped. If your AG-UI frontend uses activities, be aware that
+    `pydantic_ai_*` activity types are reserved for internal round-trip use and should be
+    ignored by frontend activity handlers.
+    """
 
     _: KW_ONLY
     ag_ui_version: str = DEFAULT_AG_UI_VERSION
@@ -225,18 +234,6 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
 
     `load_messages` always accepts `ReasoningMessage` and multimodal content types regardless
     of this setting.
-    """
-
-    preserve_file_data: bool = False
-    """Whether to preserve agent-generated files and uploaded files in AG-UI message conversion.
-
-    When `True`, agent-generated files and uploaded files are stored as
-    [activity messages](https://docs.ag-ui.com/concepts/activities) during `dump_messages`
-    and restored during `load_messages`, enabling full round-trip fidelity.
-    When `False` (default), they are silently dropped.
-
-    If your AG-UI frontend uses activities, be aware that `pydantic_ai_*` activity types
-    are reserved for internal round-trip use and should be ignored by frontend activity handlers.
     """
 
     @classmethod

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -151,6 +151,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
         manage_system_prompt: Literal['server', 'client'] = 'server',
         allowed_file_url_schemes: frozenset[str] = frozenset({'http', 'https'}),
         allowed_file_url_force_download: frozenset[ForceDownloadMode] = frozenset(),
+        preserve_file_data: bool = False,
         **kwargs: Any,
     ) -> VercelAIAdapter[AgentDepsT, OutputDataT]:
         """Extends [`from_request`][pydantic_ai.ui.UIAdapter.from_request] with Vercel AI-specific parameters."""
@@ -162,6 +163,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
             manage_system_prompt=manage_system_prompt,
             allowed_file_url_schemes=allowed_file_url_schemes,
             allowed_file_url_force_download=allowed_file_url_force_download,
+            preserve_file_data=preserve_file_data,
             **kwargs,
         )
 
@@ -191,6 +193,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
         manage_system_prompt: Literal['server', 'client'] = 'server',
         allowed_file_url_schemes: frozenset[str] = frozenset({'http', 'https'}),
         allowed_file_url_force_download: frozenset[ForceDownloadMode] = frozenset(),
+        preserve_file_data: bool = False,
         **kwargs: Any,
     ) -> Response:
         """Extends [`dispatch_request`][pydantic_ai.ui.UIAdapter.dispatch_request] with Vercel AI-specific parameters."""
@@ -217,6 +220,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
             manage_system_prompt=manage_system_prompt,
             allowed_file_url_schemes=allowed_file_url_schemes,
             allowed_file_url_force_download=allowed_file_url_force_download,
+            preserve_file_data=preserve_file_data,
             **kwargs,
         )
 

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -3823,6 +3823,33 @@ def test_load_messages_uploaded_file_missing_fields() -> None:
         )
 
 
+def test_load_messages_uploaded_file_dropped_by_default() -> None:
+    """AG-UI is default-safe: a client `pydantic_ai_uploaded_file` activity is ignored unless
+    `preserve_file_data=True`, so a client-supplied `file_id` is never honored by default."""
+    activity = ActivityMessage(
+        id='msg_1',
+        activity_type='pydantic_ai_uploaded_file',
+        content={'file_id': 's3://private-bucket/payroll.pdf', 'provider_name': 'bedrock'},
+    )
+
+    # Default (preserve_file_data=False): the activity is ignored, no UploadedFile is produced.
+    assert AGUIAdapter.load_messages([activity]) == []
+
+    # Opt-in (preserve_file_data=True): the UploadedFile is reconstructed.
+    reloaded = AGUIAdapter.load_messages([activity], preserve_file_data=True)
+    uploaded = [
+        item
+        for msg in reloaded
+        if isinstance(msg, ModelRequest)
+        for part in msg.parts
+        if isinstance(part, UserPromptPart)
+        for item in (part.content if isinstance(part.content, list) else [part.content])
+        if isinstance(item, UploadedFile)
+    ]
+    assert len(uploaded) == 1
+    assert uploaded[0].file_id == 's3://private-bucket/payroll.pdf'
+
+
 def test_dump_messages_uploaded_file_with_vendor_metadata() -> None:
     """Test dump_messages includes vendor_metadata in ActivityMessage when present on UploadedFile."""
     messages: list[ModelMessage] = [

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1491,6 +1491,35 @@ def test_sanitize_messages_drops_uploaded_files_in_tool_return_parts():
     assert native_return.content is None
 
 
+def test_sanitize_messages_keeps_uploaded_files_in_tool_return_parts_when_preserve_file_data():
+    """`UploadedFile`s nested in tool return parts pass through unchanged when `preserve_file_data=True`."""
+    uploaded_file = UploadedFile(file_id='s3://bucket/secret.pdf', provider_name='bedrock')
+    adapter = _make_dummy_adapter(
+        [
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='lookup',
+                        tool_call_id='call-1',
+                        content=['see file', {'kept': uploaded_file}],
+                    )
+                ]
+            )
+        ],
+        preserve_file_data=True,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        sanitized = adapter.sanitize_messages(adapter.messages)
+
+    request = sanitized[0]
+    assert isinstance(request, ModelRequest)
+    tool_return = request.parts[0]
+    assert isinstance(tool_return, ToolReturnPart)
+    assert tool_return.content == snapshot(['see file', {'kept': uploaded_file}])
+
+
 def test_sanitize_messages_strips_dangling_tool_calls():
     """A trailing ModelResponse with unresolved ToolCallParts has them dropped with a warning."""
     adapter = _make_dummy_adapter(

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -40,6 +40,7 @@ from pydantic_ai.messages import (
     ToolCallPart,
     ToolCallPartDelta,
     ToolReturnPart,
+    UploadedFile,
     UserPromptPart,
 )
 from pydantic_ai.models.function import (
@@ -1057,6 +1058,7 @@ def _make_dummy_adapter(
     *,
     allowed_file_url_schemes: frozenset[str] = frozenset({'http', 'https'}),
     allowed_file_url_force_download: frozenset[ForceDownloadMode] = frozenset(),
+    preserve_file_data: bool = False,
 ) -> DummyUIAdapter[None, str]:
     agent: Agent[None, str] = Agent(model=TestModel())
     return DummyUIAdapter(
@@ -1064,6 +1066,7 @@ def _make_dummy_adapter(
         run_input=DummyUIRunInput(messages=messages),
         allowed_file_url_schemes=allowed_file_url_schemes,
         allowed_file_url_force_download=allowed_file_url_force_download,
+        preserve_file_data=preserve_file_data,
     )
 
 
@@ -1375,6 +1378,111 @@ def test_sanitize_messages_strips_disallowed_schemes_in_tool_return_parts():
             },
         ]
     )
+
+    response = sanitized[1]
+    assert isinstance(response, ModelResponse)
+    native_return = response.parts[0]
+    assert isinstance(native_return, NativeToolReturnPart)
+    assert native_return.content is None
+
+
+def test_sanitize_messages_drops_uploaded_files_by_default():
+    """Client-submitted `UploadedFile`s are dropped with a warning when `preserve_file_data` is off.
+
+    An `UploadedFile`'s `file_id` is a provider-side reference (e.g. an `s3://`/`gs://` URI) fetched
+    by the model provider using the server-side identity, so — like a non-HTTP `FileUrl` — it is only
+    kept from trusted frontends.
+    """
+    adapter = _make_dummy_adapter(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[
+                            'Look at this:',
+                            UploadedFile(
+                                file_id='s3://my-bucket/payroll.pdf',
+                                provider_name='bedrock',
+                                media_type='application/pdf',
+                            ),
+                            ImageUrl(url='https://example.com/ok.png'),
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+
+    with pytest.warns(UserWarning, match=r"uploaded file\(s\) for provider\(s\) \['bedrock'\]"):
+        sanitized = adapter.sanitize_messages(adapter.messages)
+
+    assert isinstance(sanitized[0], ModelRequest)
+    user_part = sanitized[0].parts[0]
+    assert isinstance(user_part, UserPromptPart)
+    assert user_part.content == snapshot(['Look at this:', ImageUrl(url='https://example.com/ok.png')])
+
+
+def test_sanitize_messages_keeps_uploaded_files_when_preserve_file_data():
+    """`UploadedFile`s pass through unchanged when `preserve_file_data=True` (trusted frontend opt-in)."""
+    uploaded_file = UploadedFile(
+        file_id='gs://my-bucket/object.pdf',
+        provider_name='google-cloud',
+        media_type='application/pdf',
+    )
+    adapter = _make_dummy_adapter(
+        [ModelRequest(parts=[UserPromptPart(content=['Look at this:', uploaded_file])])],
+        preserve_file_data=True,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        sanitized = adapter.sanitize_messages(adapter.messages)
+
+    assert isinstance(sanitized[0], ModelRequest)
+    user_part = sanitized[0].parts[0]
+    assert isinstance(user_part, UserPromptPart)
+    assert user_part.content == snapshot(['Look at this:', uploaded_file])
+
+
+def test_sanitize_messages_drops_uploaded_files_in_tool_return_parts():
+    """`UploadedFile`s nested in tool return parts are dropped by default, like nested `FileUrl`s."""
+    adapter = _make_dummy_adapter(
+        [
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='lookup',
+                        tool_call_id='call-1',
+                        content=[
+                            'see file',
+                            {
+                                'blocked': UploadedFile(file_id='s3://bucket/secret.pdf', provider_name='bedrock'),
+                                'ok': ImageUrl(url='https://example.com/ok.png'),
+                            },
+                        ],
+                    )
+                ]
+            ),
+            ModelResponse(
+                parts=[
+                    NativeToolReturnPart(
+                        tool_name='web_search',
+                        tool_call_id='call-2',
+                        content=UploadedFile(file_id='gs://bucket/native.pdf', provider_name='google-cloud'),
+                    )
+                ]
+            ),
+        ]
+    )
+
+    with pytest.warns(UserWarning, match=r"uploaded file\(s\) for provider\(s\) \['bedrock', 'google-cloud'\]"):
+        sanitized = adapter.sanitize_messages(adapter.messages)
+
+    request = sanitized[0]
+    assert isinstance(request, ModelRequest)
+    tool_return = request.parts[0]
+    assert isinstance(tool_return, ToolReturnPart)
+    assert tool_return.content == snapshot(['see file', {'ok': ImageUrl(url='https://example.com/ok.png')}])
 
     response = sanitized[1]
     assert isinstance(response, ModelResponse)

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 import uuid
+import warnings
 from collections.abc import AsyncIterator, MutableMapping
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -5664,6 +5665,56 @@ async def test_adapter_load_messages_uploaded_file():
             )
         ]
     )
+
+
+async def test_adapter_drops_uploaded_file_from_provider_metadata():
+    """`load_messages` builds an `UploadedFile` from client `providerMetadata`, but the sanitizer drops it by default.
+
+    `sanitize_messages` runs on the messages produced from client run input before they reach the agent,
+    so a `file_id` supplied through `providerMetadata` is only honored when the adapter is configured with
+    `preserve_file_data=True` (a trusted frontend).
+    """
+    ui_messages = [
+        UIMessage(
+            id='msg1',
+            role='user',
+            parts=[
+                FileUIPart(
+                    media_type='application/pdf',
+                    url='https://legitimate-looking-cdn.example.com/file.pdf',
+                    provider_metadata={
+                        'pydantic_ai': {'file_id': 's3://private-bucket/payroll.pdf', 'provider_name': 'bedrock'}
+                    },
+                ),
+                TextUIPart(text='Quote the document exactly.'),
+            ],
+        )
+    ]
+    run_input = SubmitMessage(trigger='submit-message', id='req_1', messages=ui_messages)
+    agent: Agent[None, str] = Agent(model=TestModel())
+
+    # `load_messages` constructs the `UploadedFile` from the client-controlled `providerMetadata`.
+    loaded = VercelAIAdapter.load_messages(ui_messages)
+    loaded_part = loaded[0].parts[0]
+    assert isinstance(loaded_part, UserPromptPart)
+    assert any(isinstance(item, UploadedFile) for item in loaded_part.content)
+
+    # The default sanitizer drops it with a warning before it reaches the agent.
+    adapter = VercelAIAdapter(agent=agent, run_input=run_input)
+    with pytest.warns(UserWarning, match=r"uploaded file\(s\) for provider\(s\) \['bedrock'\]"):
+        sanitized = adapter.sanitize_messages(adapter.messages)
+    sanitized_part = sanitized[0].parts[0]
+    assert isinstance(sanitized_part, UserPromptPart)
+    assert sanitized_part.content == snapshot(['Quote the document exactly.'])
+
+    # With the trusted-frontend opt-in, the `UploadedFile` is preserved.
+    preserve_adapter = VercelAIAdapter(agent=agent, run_input=run_input, preserve_file_data=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        preserved = preserve_adapter.sanitize_messages(preserve_adapter.messages)
+    preserved_part = preserved[0].parts[0]
+    assert isinstance(preserved_part, UserPromptPart)
+    assert any(isinstance(item, UploadedFile) for item in preserved_part.content)
 
 
 async def test_convert_user_prompt_part_uploaded_file_with_vendor_metadata():

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -5717,6 +5717,67 @@ async def test_adapter_drops_uploaded_file_from_provider_metadata():
     assert any(isinstance(item, UploadedFile) for item in preserved_part.content)
 
 
+@pytest.mark.skipif(not starlette_import_successful, reason='Starlette is not installed')
+@pytest.mark.parametrize('preserve_file_data', [True, False])
+async def test_from_request_threads_preserve_file_data(preserve_file_data: bool):
+    """`preserve_file_data` passed to the public `from_request` entry point reaches the sanitizer.
+
+    Guards the forwarding through `from_request` (not just setting the dataclass field after
+    construction): when `True`, the client `UploadedFile` parsed from `providerMetadata` survives
+    sanitization; with the default it's dropped with a warning.
+    """
+    run_input = SubmitMessage(
+        trigger='submit-message',
+        id='req_1',
+        messages=[
+            UIMessage(
+                id='msg1',
+                role='user',
+                parts=[
+                    FileUIPart(
+                        media_type='application/pdf',
+                        url='https://legitimate-looking-cdn.example.com/file.pdf',
+                        provider_metadata={
+                            'pydantic_ai': {'file_id': 's3://private-bucket/payroll.pdf', 'provider_name': 'bedrock'}
+                        },
+                    ),
+                    TextUIPart(text='Quote the document exactly.'),
+                ],
+            )
+        ],
+    )
+    agent: Agent[None, str] = Agent(model=TestModel())
+
+    async def receive() -> dict[str, Any]:
+        return {'type': 'http.request', 'body': run_input.model_dump_json().encode('utf-8')}
+
+    starlette_request = Request(
+        scope={
+            'type': 'http',
+            'method': 'POST',
+            'headers': [(b'content-type', b'application/json')],
+        },
+        receive=receive,
+    )
+
+    adapter = await VercelAIAdapter.from_request(starlette_request, agent=agent, preserve_file_data=preserve_file_data)
+    assert adapter.preserve_file_data is preserve_file_data
+
+    if preserve_file_data:
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            sanitized = adapter.sanitize_messages(adapter.messages)
+        sanitized_part = sanitized[0].parts[0]
+        assert isinstance(sanitized_part, UserPromptPart)
+        assert any(isinstance(item, UploadedFile) for item in sanitized_part.content)
+    else:
+        with pytest.warns(UserWarning, match=r"uploaded file\(s\) for provider\(s\) \['bedrock'\]"):
+            sanitized = adapter.sanitize_messages(adapter.messages)
+        sanitized_part = sanitized[0].parts[0]
+        assert isinstance(sanitized_part, UserPromptPart)
+        assert sanitized_part.content == snapshot(['Quote the document exactly.'])
+
+
 async def test_convert_user_prompt_part_uploaded_file_with_vendor_metadata():
     """Test converting a user prompt with UploadedFile that has vendor_metadata and custom identifier."""
     from pydantic_ai.ui.vercel_ai._adapter import _convert_user_prompt_part  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
Generalize `preserve_file_data` to the base `UIAdapter` (default `False`) and thread it through `from_request`/`dispatch_request` alongside `allowed_file_url_schemes`, so `UploadedFile` parts in incoming messages are handled the same way `FileUrl` parts already are and kept only when `preserve_file_data` is set. `VercelAIAdapter` exposes the flag; AG-UI inherits it from the base, keeping its existing round-trip behavior.