### PR TITLE
Reject conflicting native MCP tool IDs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -56,6 +56,7 @@ from ..capabilities._ordering import has_capability_type
 from ..capabilities._pending_messages import PendingMessageDrainCapability
 from ..capabilities.instrumentation import Instrumentation as InstrumentationCap
 from ..models.instrumented import InstrumentationSettings, InstrumentedModel
+from ..native_tools import AbstractNativeTool
 from ..output import OutputDataT, OutputSpec, StructuredDict
 from ..run import AgentRun, AgentRunResult
 from ..settings import ModelSettings, merge_model_settings
@@ -169,6 +170,27 @@ def _normalize_agent_retry_overrides(
 T = TypeVar('T')
 S = TypeVar('S')
 NoneType = type(None)
+
+
+def _validate_native_tool_id_conflicts(
+    native_tools: Sequence[AgentNativeTool[Any]],
+    *,
+    source: str,
+) -> None:
+    seen: dict[str, AbstractNativeTool] = {}
+    for tool in native_tools:
+        if not isinstance(tool, AbstractNativeTool):
+            continue
+
+        unique_id = tool.unique_id
+        if existing := seen.get(unique_id):
+            if existing != tool:
+                raise exceptions.UserError(
+                    f'Duplicate native tool id {unique_id!r} maps to conflicting definitions in {source}. '
+                    'Pass a unique id for each native tool instance in the same capability layer.'
+                )
+        else:
+            seen[unique_id] = tool
 
 
 @dataclasses.dataclass
@@ -509,6 +531,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         self._validation_context = validation_context
 
         self._cap_native_tools = list(self._root_capability.get_native_tools())
+        _validate_native_tool_id_conflicts(self._cap_native_tools, source='agent capabilities')
 
         self._cap_model_settings = self._root_capability.get_model_settings()
 
@@ -1370,6 +1393,11 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             extra_capabilities.append(resolved.capability)
         extra_capabilities.extend(wrap_capability_funcs(capabilities))
         if extra_capabilities:
+            extra_native_tools: list[AgentNativeTool[AgentDepsT]] = []
+            for cap in extra_capabilities:
+                extra_native_tools.extend(cap.get_native_tools())
+            _validate_native_tool_id_conflicts(extra_native_tools, source='run capabilities')
+        if extra_capabilities:
             effective_capability = CombinedCapability([base_capability, *extra_capabilities])
         else:
             effective_capability = base_capability
@@ -1418,6 +1446,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         # preserving any additional per-run capability-contributed native tools (e.g. from
         # `capabilities=[NativeTool(...)]`) on top.
         if some_native_tools := self._override_builtin_tools.get():
+            _validate_native_tool_id_conflicts(some_native_tools.value, source='override native_tools')
             extra_native_tools: list[AgentNativeTool[AgentDepsT]] = []
             for cap in extra_capabilities:
                 extra_native_tools.extend(cap.get_native_tools())

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -692,6 +692,10 @@ class ModelRequestParameters:
 _utils.install_deprecated_kwarg_alias(ModelRequestParameters, old='builtin_tools', new='native_tools')
 
 
+def _deduplicate_native_tools(native_tools: Sequence[AbstractNativeTool]) -> list[AbstractNativeTool]:
+    return list({tool.unique_id: tool for tool in native_tools}.values())
+
+
 @dataclass(kw_only=True)
 class ModelRequestContext:
     """Context for model request hooks.
@@ -855,11 +859,7 @@ class Model(ABC, Generic[InterfaceClient]):
             model_settings = cast(ModelSettings, stripped) if stripped else None
 
         if native_tools := params.native_tools:
-            # Deduplicate native tools
-            params = replace(
-                params,
-                native_tools=list({tool.unique_id: tool for tool in native_tools}.values()),
-            )
+            params = replace(params, native_tools=_deduplicate_native_tools(native_tools))
 
         params = params.with_default_output_mode(self.profile.default_structured_output_mode)
 

--- a/tests/models/test_model_request_parameters.py
+++ b/tests/models/test_model_request_parameters.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import TypeAdapter
 
 from pydantic_ai.models import ModelRequestParameters, ToolDefinition
+from pydantic_ai.models.test import TestModel
 from pydantic_ai.native_tools import (
     CodeExecutionTool,
     ImageGenerationTool,
@@ -198,3 +199,15 @@ def test_with_default_output_mode_overrides_allow_text():
     resolved = params.with_default_output_mode('native')
     assert resolved.output_mode == 'native'
     assert resolved.allow_text_output is True
+
+
+def test_prepare_request_deduplicates_identical_native_tools():
+    model = TestModel()
+    tool = MCPServerTool(id='deepwiki', url='https://mcp.deepwiki.com/mcp')
+    params = ModelRequestParameters(
+        native_tools=[tool, MCPServerTool(id='deepwiki', url='https://mcp.deepwiki.com/mcp')]
+    )
+
+    _, prepared = model.prepare_request(None, params)
+
+    assert prepared.native_tools == [tool]

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9665,6 +9665,54 @@ def test_agent_native_tools_runtime_vs_agent_level():
     )
 
 
+def test_agent_rejects_conflicting_agent_level_native_tool_ids():
+    with pytest.raises(UserError, match="Duplicate native tool id 'mcp_server:mcp.example.com-api'"):
+        Agent(
+            model=TestModel(),
+            capabilities=[
+                NativeTool(
+                    MCPServerTool(
+                        id='mcp.example.com-api',
+                        url='https://mcp.example.com/tenant-a/api',
+                        authorization_token='Bearer tenant-a',
+                    )
+                ),
+                NativeTool(
+                    MCPServerTool(
+                        id='mcp.example.com-api',
+                        url='https://mcp.example.com/tenant-b/api',
+                        authorization_token='Bearer tenant-b',
+                    )
+                ),
+            ],
+        )
+
+
+def test_agent_rejects_conflicting_run_level_native_tool_ids():
+    agent = Agent(model=TestModel())
+
+    with pytest.raises(UserError, match="Duplicate native tool id 'mcp_server:mcp.example.com-api'"):
+        agent.run_sync(
+            'Hello',
+            capabilities=[
+                NativeTool(
+                    MCPServerTool(
+                        id='mcp.example.com-api',
+                        url='https://mcp.example.com/tenant-a/api',
+                        authorization_token='Bearer tenant-a',
+                    )
+                ),
+                NativeTool(
+                    MCPServerTool(
+                        id='mcp.example.com-api',
+                        url='https://mcp.example.com/tenant-b/api',
+                        authorization_token='Bearer tenant-b',
+                    )
+                ),
+            ],
+        )
+
+
 def test_agent_override_native_tools_empty_runs_with_test_model():
     """Test that agent-level native tools can be removed when overriding the model."""
     model = TestModel()


### PR DESCRIPTION
## Summary

- reject conflicting native tool IDs within the same agent-level or run-level capability layer
- preserve the existing runtime override behavior for agent-level native tools
- add regression coverage for conflicting `MCPServerTool` instances and the existing override path

## Rationale

Native tools are ultimately keyed by `tool.unique_id`. The final merged request parameters intentionally use last-wins behavior so run-level native tools can override agent-level defaults. Within a single capability layer, though, two different native tools with the same ID are ambiguous and can silently bind one stable ID to a different definition.

For native MCP tools, that ambiguity can bind one stable tool ID to an unexpected server URL or authorization token. This PR keeps the existing cross-layer override behavior and fails early only when the duplicate ID is ambiguous within the same layer.

## Tests

- `uv run pytest tests/test_agent.py::test_agent_native_tools_runtime_vs_agent_level tests/test_agent.py::test_agent_rejects_conflicting_agent_level_native_tool_ids tests/test_agent.py::test_agent_rejects_conflicting_run_level_native_tool_ids tests/models/test_model_request_parameters.py -q`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright tests/models/test_model_request_parameters.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/models/__init__.py pydantic_ai_slim/pydantic_ai/agent/__init__.py tests/models/test_model_request_parameters.py tests/test_agent.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/__init__.py pydantic_ai_slim/pydantic_ai/agent/__init__.py tests/models/test_model_request_parameters.py tests/test_agent.py`
- `uv run python -m py_compile pydantic_ai_slim/pydantic_ai/models/__init__.py pydantic_ai_slim/pydantic_ai/agent/__init__.py tests/models/test_model_request_parameters.py tests/test_agent.py`
- `git diff --check`
