### PR TITLE
docs: add governed OpenAI-compatible endpoint example

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -98,6 +98,35 @@ agent = Agent(model)
 ...
 ```
 
+### Governed OpenAI-compatible endpoints
+
+You can also route Pydantic AI through an OpenAI-compatible gateway or control plane when you need centralized model access, policy, audit trails, routing, quota enforcement, or cost controls across multiple applications.
+
+For example, [Tuning Engines](https://www.tuningengines.com/) exposes an OpenAI-compatible endpoint that can be used with the standard `AsyncOpenAI` client:
+
+```python
+import os
+
+from openai import AsyncOpenAI
+
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+client = AsyncOpenAI(
+    api_key=os.environ['TUNING_ENGINES_API_KEY'],
+    base_url='https://api.tuningengines.com/v1',
+)
+
+model = OpenAIChatModel(
+    os.environ.get('TUNING_ENGINES_MODEL', 'your-model-alias'),
+    provider=OpenAIProvider(openai_client=client),
+)
+agent = Agent(model)
+```
+
+This keeps Pydantic AI responsible for agent behavior, tools, structured output, and retries, while the gateway handles organization-wide controls such as tenant or role-based model access, policy enforcement, trace capture, and usage reporting.
+
 ## Model settings
 
 You can customize model behavior using [`OpenAIChatModelSettings`][pydantic_ai.models.openai.OpenAIChatModelSettings]:

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -104,7 +104,7 @@ You can also route Pydantic AI through an OpenAI-compatible gateway or control p
 
 For example, [Tuning Engines](https://www.tuningengines.com/) exposes an OpenAI-compatible endpoint that can be used with the standard `AsyncOpenAI` client:
 
-```python
+```python {test="skip"}
 import os
 
 from openai import AsyncOpenAI


### PR DESCRIPTION
This adds a small example showing how to route Pydantic AI through a governed OpenAI-compatible endpoint using the existing AsyncOpenAI + OpenAIProvider path.\n\nWhy this may be useful:\n- Pydantic AI already supports OpenAI-compatible APIs via custom base_url clients.\n- Teams running agents in production often need centralized model access, policy enforcement, audit trails, usage reporting, quotas, and cost controls across applications.\n- The example keeps Pydantic AI responsible for agent behavior, tools, structured output, and retries while a gateway/control plane handles organization-wide controls.\n\nThe change is docs-only and uses placeholder environment variables.