### PR TITLE
fix: prevent cancel() from flipping complete state and guard against stray post-done tool-call deltas

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1321,8 +1321,13 @@ class StreamedResponse(ABC):
         so the flag is visible to any iterator that observes the transport error
         raised when the underlying connection is torn down, even if
         `close_stream()` itself raises.
+
+        Does nothing if the stream was already fully consumed
+        (`self._finished` is ``True``) — a redundant defensive `cancel()` after
+        a successful run must not flip `response.state` from `'complete'` to
+        `'interrupted'` (fixes #5782).
         """
-        if self.cancelled:
+        if self.cancelled or self._finished:
             return
         self._cancelled = True
         await self.close_stream()

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3406,6 +3406,11 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
         with _map_api_errors(self._model_name):
             # Track annotations by item_id and content_index
             _annotations_by_item: dict[str, list[Any]] = {}
+            # Track function-call item_ids that have already received a
+            # "done" signal. Stray arguments deltas arriving after the item
+            # is done (non-conforming endpoints) are silently dropped to
+            # prevent corrupting the final tool-call args (#5757).
+            _done_function_call_ids: set[str] = set()
             # Track `phase` (commentary | final_answer) on assistant message items, captured
             # from the `output_item.added` event and merged into the corresponding
             # `TextPart.provider_details` on `output_text.done`.
@@ -3447,15 +3452,18 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                     self._usage += self._map_usage(chunk.response)
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDeltaEvent):
-                    maybe_event = self._parts_manager.handle_tool_call_delta(
-                        vendor_part_id=chunk.item_id,
-                        args=chunk.delta,
-                    )
-                    if maybe_event is not None:  # pragma: no branch
-                        yield maybe_event
+                    # Drop stray deltas arriving after the item is done (#5757).
+                    if chunk.item_id not in _done_function_call_ids:
+                        maybe_event = self._parts_manager.handle_tool_call_delta(
+                            vendor_part_id=chunk.item_id,
+                            args=chunk.delta,
+                        )
+                        if maybe_event is not None:  # pragma: no branch
+                            yield maybe_event
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDoneEvent):
-                    pass  # there's nothing we need to do here
+                    # Mark item done so post-done deltas are silently dropped (#5757).
+                    _done_function_call_ids.add(chunk.item_id)
 
                 elif isinstance(chunk, responses.ResponseIncompleteEvent):  # pragma: no cover
                     self._usage += self._map_usage(chunk.response)
@@ -3581,6 +3589,10 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                         )
 
                 elif isinstance(chunk, responses.ResponseOutputItemDoneEvent):
+                    # Mark function-call items done so post-done deltas are
+                    # silently dropped (#5757).
+                    if isinstance(chunk.item, responses.ResponseFunctionToolCall):
+                        _done_function_call_ids.add(chunk.item.id)
                     if isinstance(chunk.item, responses.ResponseReasoningItem):
                         if signature := chunk.item.encrypted_content:  # pragma: no branch
                             # Add the signature to the part corresponding to the first summary/raw CoT


### PR DESCRIPTION
## Summary

Two streaming bug fixes:

### 1. cancel() no-op on finished stream (closes #5782)

**Problem**: A defensive `await result.cancel()` in a `finally`-style cleanup path after a fully consumed stream would flip `response.state` from `'complete'` to `'interrupted'`.

**Root cause**: `StreamedResponse.cancel()` always set `_cancelled=True`, and `StreamedResponse.get()` checked `_cancelled` before `_finished` — so any prior `cancel()` downgraded a successful run.

**Fix**: `cancel()` now returns immediately (no-op) when the stream is already `_finished`, guarding against redundant defensive cancel calls.

### 2. Drop stray post-done arguments deltas (closes #5757)

**Problem**: Non-conforming OpenAI Responses-compatible endpoints may emit a `ResponseFunctionCallArgumentsDeltaEvent` **after** `ResponseOutputItemDoneEvent` / `ResponseFunctionCallArgumentsDoneEvent`. The stray delta was applied to the part, corrupting the final tool-call args (e.g., `'{...}' + '}'` → invalid JSON).

**Root cause**: While #5027 fixed the AG-UI **protocol** layer (suppressing the stray event from stream consumers), the delta had already mutated the underlying part via `handle_tool_call_delta`, corrupting the `ModelResponse.tool_calls` args.

**Fix**: Track done function-call `item_id`s in `_done_function_call_ids`, and skip `ResponseFunctionCallArgumentsDeltaEvent` for already-done items:
- `ResponseFunctionCallArgumentsDoneEvent` → add to done set
- `ResponseOutputItemDoneEvent` (for `ResponseFunctionToolCall` items) → add to done set
- `ResponseFunctionCallArgumentsDeltaEvent` → skip if item_id is in done set

### Files changed
| File | Change |
|------|--------|
| `models/__init__.py` | +6/-1 (cancel guard) |
| `models/openai.py` | +19/-7 (done tracking + delta guard) |