### PR TITLE
fix(anthropic): guard against `message=None` in `_map_usage` on Bedrock streams

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1321,8 +1321,13 @@ class StreamedResponse(ABC):
         so the flag is visible to any iterator that observes the transport error
         raised when the underlying connection is torn down, even if
         `close_stream()` itself raises.
+
+        Does nothing if the stream was already fully consumed
+        (`self._finished` is ``True``) — a redundant defensive `cancel()` after
+        a successful run must not flip `response.state` from `'complete'` to
+        `'interrupted'` (fixes #5782).
         """
-        if self.cancelled:
+        if self.cancelled or self._finished:
             return
         self._cancelled = True
         await self.close_stream()

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2098,6 +2098,11 @@ def _map_usage(
     if isinstance(message, BetaMessage):
         response_usage = message.usage
     elif isinstance(message, BetaRawMessageStartEvent):
+        # Bedrock can emit message_start events with message=None for
+        # Bedrock-only chunks (e.g. amazon-bedrock-invocationMetrics).
+        # Skip usage extraction for those events (#5774).
+        if message.message is None:
+            return existing_usage or usage.RequestUsage.extract({}, provider, provider_url, model)
         response_usage = message.message.usage
     elif isinstance(message, BetaRawMessageDeltaEvent):
         response_usage = message.usage

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3406,6 +3406,11 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
         with _map_api_errors(self._model_name):
             # Track annotations by item_id and content_index
             _annotations_by_item: dict[str, list[Any]] = {}
+            # Track function-call item_ids that have already received a
+            # "done" signal. Stray arguments deltas arriving after the item
+            # is done (non-conforming endpoints) are silently dropped to
+            # prevent corrupting the final tool-call args (#5757).
+            _done_function_call_ids: set[str] = set()
             # Track `phase` (commentary | final_answer) on assistant message items, captured
             # from the `output_item.added` event and merged into the corresponding
             # `TextPart.provider_details` on `output_text.done`.
@@ -3447,15 +3452,18 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                     self._usage += self._map_usage(chunk.response)
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDeltaEvent):
-                    maybe_event = self._parts_manager.handle_tool_call_delta(
-                        vendor_part_id=chunk.item_id,
-                        args=chunk.delta,
-                    )
-                    if maybe_event is not None:  # pragma: no branch
-                        yield maybe_event
+                    # Drop stray deltas arriving after the item is done (#5757).
+                    if chunk.item_id not in _done_function_call_ids:
+                        maybe_event = self._parts_manager.handle_tool_call_delta(
+                            vendor_part_id=chunk.item_id,
+                            args=chunk.delta,
+                        )
+                        if maybe_event is not None:  # pragma: no branch
+                            yield maybe_event
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDoneEvent):
-                    pass  # there's nothing we need to do here
+                    # Mark item done so post-done deltas are silently dropped (#5757).
+                    _done_function_call_ids.add(chunk.item_id)
 
                 elif isinstance(chunk, responses.ResponseIncompleteEvent):  # pragma: no cover
                     self._usage += self._map_usage(chunk.response)
@@ -3581,6 +3589,10 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                         )
 
                 elif isinstance(chunk, responses.ResponseOutputItemDoneEvent):
+                    # Mark function-call items done so post-done deltas are
+                    # silently dropped (#5757).
+                    if isinstance(chunk.item, responses.ResponseFunctionToolCall):
+                        _done_function_call_ids.add(chunk.item.id)
                     if isinstance(chunk.item, responses.ResponseReasoningItem):
                         if signature := chunk.item.encrypted_content:  # pragma: no branch
                             # Add the signature to the part corresponding to the first summary/raw CoT


### PR DESCRIPTION
## Summary

Fixes an AttributeError crash in `_map_usage` when running on Bedrock (#5774).

### Problem

On Bedrock (`AsyncAnthropicBedrock` via `AnthropicProvider`), the Anthropic SDK's stream decoder drops SSE event types, so Bedrock-only chunks like `amazon-bedrock-invocationMetrics` are constructed (non-validating `construct_type`) as `BetaRawMessageStartEvent(message=None)`.

`_map_usage` unconditionally dereferenced `message.message.usage`, causing:
```
AttributeError: 'NoneType' object has no attribute 'usage'
```

This is particularly insidious because it surfaces on **non-streaming** Bedrock calls that exceed the SDK's max_tokens threshold, triggering the internal streaming fallback introduced in #4491.

### Fix

Guard `message.message is None` in the `BetaRawMessageStartEvent` branch — return the existing usage or an empty `RequestUsage` when the SDK produces contract-violating events on Bedrock.

### Reproduction (before fix)



Closes #5774