### PR TITLE
fix: guard against null message in BetaRawMessageStartEvent for Bedrock

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2098,6 +2098,8 @@ def _map_usage(
     if isinstance(message, BetaMessage):
         response_usage = message.usage
     elif isinstance(message, BetaRawMessageStartEvent):
+        if message.message is None:
+            return existing_usage or usage.RequestUsage()
         response_usage = message.message.usage
     elif isinstance(message, BetaRawMessageDeltaEvent):
         response_usage = message.usage
@@ -2143,6 +2145,8 @@ class AnthropicStreamedResponse(StreamedResponse):
             builtin_tool_calls: dict[str, NativeToolCallPart] = {}
             async for event in self._response:
                 if isinstance(event, BetaRawMessageStartEvent):
+                    if event.message is None:
+                        continue
                     self._usage = _map_usage(event, self._provider_name, self._provider_url, self._model_name)
                     self.provider_response_id = event.message.id
                     if event.message.container:


### PR DESCRIPTION
## Problem

On Bedrock (`AsyncAnthropicBedrock` via `AnthropicProvider`), the Anthropic SDK's stream decoder drops SSE event types, so Bedrock-only chunks like `amazon-bedrock-invocationMetrics` are constructed (via non-validating `construct_type`) as `BetaRawMessageStartEvent(message=None)`.

This causes `AttributeError: 'NoneType' object has no attribute 'usage'` in `_map_usage` (line 2101) when processing streaming responses.

The bug also affects non-streaming calls: when `max_tokens > ~21.3k`, the SDK raises a "Streaming is required" error, which pydantic-ai catches and falls back to internal streaming — which then walks into the broken Bedrock events.

Fixes #5774

## Changes

Two guards added in `pydantic_ai_slim/pydantic_ai/models/anthropic.py`:

1. **`_map_usage`**: If `message.message is None` for a `BetaRawMessageStartEvent`, return `existing_usage` (or empty `RequestUsage`) instead of dereferencing `.usage`.

2. **`AnthropicStreamedResponse._get_event_iterator`**: If `event.message is None` for a `BetaRawMessageStartEvent`, skip the event entirely (no usage extraction, no response ID extraction).

Both guards handle the case where the SDK's `construct_type` produces objects that violate the type annotations — a known pattern for Bedrock-specific event chunks.