### PR TITLE
fix(ui): round-trip file `vendor_metadata` in Vercel AI and AG-UI adapters

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_multimodal.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_multimodal.py
@@ -7,6 +7,7 @@ ag-ui-protocol >= 0.1.15 is installed, so these imports will succeed.
 from __future__ import annotations
 
 from base64 import b64decode
+from typing import Any
 
 from ag_ui.core import (
     AudioInputContent,
@@ -16,6 +17,7 @@ from ag_ui.core import (
     InputContentUrlSource,
     VideoInputContent,
 )
+from pydantic import TypeAdapter
 
 from ...messages import AudioUrl, BinaryContent, DocumentUrl, ImageUrl, VideoUrl
 
@@ -26,13 +28,29 @@ _URL_TYPE_MAP: dict[type, type] = {
     DocumentUrl: DocumentInputContent,
 }
 
+# `vendor_metadata` is carried under a dedicated key inside the input content's generic
+# `metadata` field, mirroring the `vendor_metadata` key the `UploadedFile` round-trip already
+# uses, so we only ever read back our own value and ignore unrelated client metadata.
+_VENDOR_METADATA_KEY = 'vendor_metadata'
+
+# The `metadata` field is typed as `Any`; coerce a client-supplied value to a known `dict` shape
+# (mirroring how the Vercel adapter reads from the typed `load_provider_metadata` result) so the
+# extracted `vendor_metadata` is statically typed rather than `Unknown`.
+_METADATA_ADAPTER: TypeAdapter[dict[str, Any]] = TypeAdapter(dict[str, Any])
+
+
+def _dump_vendor_metadata(
+    item: ImageUrl | AudioUrl | VideoUrl | DocumentUrl | BinaryContent,
+) -> dict[str, object] | None:
+    return {_VENDOR_METADATA_KEY: item.vendor_metadata} if item.vendor_metadata is not None else None
+
 
 def media_url_to_multimodal(
     item: ImageUrl | AudioUrl | VideoUrl | DocumentUrl,
 ) -> ImageInputContent | AudioInputContent | VideoInputContent | DocumentInputContent:
     """Convert a media URL to typed multimodal AG-UI input content."""
     source = InputContentUrlSource(type='url', value=item.url, mime_type=item.media_type or '')
-    return _URL_TYPE_MAP[type(item)](source=source)
+    return _URL_TYPE_MAP[type(item)](source=source, metadata=_dump_vendor_metadata(item))
 
 
 _MEDIA_PREFIX_TO_CONTENT: dict[str, type] = {
@@ -48,7 +66,7 @@ def binary_to_multimodal(
     """Convert BinaryContent to typed multimodal AG-UI input content based on media type prefix."""
     source = InputContentDataSource(type='data', value=item.base64, mime_type=item.media_type)
     content_cls = _MEDIA_PREFIX_TO_CONTENT.get(item.media_type.split('/', 1)[0], DocumentInputContent)
-    return content_cls(source=source)
+    return content_cls(source=source, metadata=_dump_vendor_metadata(item))
 
 
 def multimodal_input_to_content(
@@ -56,15 +74,23 @@ def multimodal_input_to_content(
 ) -> ImageUrl | AudioUrl | VideoUrl | DocumentUrl | BinaryContent:
     """Convert a typed multimodal AG-UI input content back to a Pydantic AI content type."""
     source = part.source
+    # `metadata` is client-controlled and typed as `Any`; the value is passed to the validating
+    # constructors below, so a malformed (non-`dict`) `vendor_metadata` is rejected there, matching
+    # the Vercel adapter. The adapter coerces the `Any` value to a statically-typed `dict` rather
+    # than relying on `isinstance` narrowing.
+    metadata = part.metadata
+    vendor_metadata: dict[str, Any] | None = None
+    if isinstance(metadata, dict):
+        vendor_metadata = _METADATA_ADAPTER.validate_python(metadata).get(_VENDOR_METADATA_KEY)
     if isinstance(source, InputContentUrlSource):
         media_type = source.mime_type or None
         if isinstance(part, ImageInputContent):
-            return ImageUrl(url=source.value, media_type=media_type)
+            return ImageUrl(url=source.value, media_type=media_type, vendor_metadata=vendor_metadata)
         elif isinstance(part, AudioInputContent):
-            return AudioUrl(url=source.value, media_type=media_type)
+            return AudioUrl(url=source.value, media_type=media_type, vendor_metadata=vendor_metadata)
         elif isinstance(part, VideoInputContent):
-            return VideoUrl(url=source.value, media_type=media_type)
+            return VideoUrl(url=source.value, media_type=media_type, vendor_metadata=vendor_metadata)
         else:
-            return DocumentUrl(url=source.value, media_type=media_type)
+            return DocumentUrl(url=source.value, media_type=media_type, vendor_metadata=vendor_metadata)
     else:
-        return BinaryContent(data=b64decode(source.value), media_type=source.mime_type)
+        return BinaryContent(data=b64decode(source.value), media_type=source.mime_type, vendor_metadata=vendor_metadata)

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_multimodal.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_multimodal.py
@@ -17,8 +17,8 @@ from ag_ui.core import (
     InputContentUrlSource,
     VideoInputContent,
 )
-from pydantic import TypeAdapter
 
+from ..._utils import is_str_dict
 from ...messages import AudioUrl, BinaryContent, DocumentUrl, ImageUrl, VideoUrl
 
 _URL_TYPE_MAP: dict[type, type] = {
@@ -32,11 +32,6 @@ _URL_TYPE_MAP: dict[type, type] = {
 # `metadata` field, mirroring the `vendor_metadata` key the `UploadedFile` round-trip already
 # uses, so we only ever read back our own value and ignore unrelated client metadata.
 _VENDOR_METADATA_KEY = 'vendor_metadata'
-
-# The `metadata` field is typed as `Any`; coerce a client-supplied value to a known `dict` shape
-# (mirroring how the Vercel adapter reads from the typed `load_provider_metadata` result) so the
-# extracted `vendor_metadata` is statically typed rather than `Unknown`.
-_METADATA_ADAPTER: TypeAdapter[dict[str, Any]] = TypeAdapter(dict[str, Any])
 
 
 def _dump_vendor_metadata(
@@ -74,14 +69,13 @@ def multimodal_input_to_content(
 ) -> ImageUrl | AudioUrl | VideoUrl | DocumentUrl | BinaryContent:
     """Convert a typed multimodal AG-UI input content back to a Pydantic AI content type."""
     source = part.source
-    # `metadata` is client-controlled and typed as `Any`; the value is passed to the validating
-    # constructors below, so a malformed (non-`dict`) `vendor_metadata` is rejected there, matching
-    # the Vercel adapter. The adapter coerces the `Any` value to a statically-typed `dict` rather
-    # than relying on `isinstance` narrowing.
+    # `metadata` is client-controlled and typed as `Any`; a non-`dict` value is ignored, and a
+    # malformed (non-`dict`) `vendor_metadata` inside it is rejected by the validating constructors
+    # below, matching the Vercel adapter.
     metadata = part.metadata
     vendor_metadata: dict[str, Any] | None = None
-    if isinstance(metadata, dict):
-        vendor_metadata = _METADATA_ADAPTER.validate_python(metadata).get(_VENDOR_METADATA_KEY)
+    if is_str_dict(metadata):
+        vendor_metadata = metadata.get(_VENDOR_METADATA_KEY)
     if isinstance(source, InputContentUrlSource):
         media_type = source.mime_type or None
         if isinstance(part, ImageInputContent):

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -278,11 +278,12 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                     if isinstance(part, TextUIPart):
                         user_prompt_content.append(part.text)
                     elif isinstance(part, FileUIPart):
+                        provider_meta = load_provider_metadata(part.provider_metadata)
+                        vendor_metadata = provider_meta.get('vendor_metadata')
                         try:
                             file = BinaryContent.from_data_uri(part.url)
                         except ValueError:
                             # Check provider_metadata for UploadedFile data
-                            provider_meta = load_provider_metadata(part.provider_metadata)
                             uploaded_file_id = provider_meta.get('file_id')
                             uploaded_file_provider = provider_meta.get('provider_name')
                             if uploaded_file_id and uploaded_file_provider:
@@ -290,20 +291,32 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                                     file_id=uploaded_file_id,
                                     provider_name=cast(UploadedFileProviderName, uploaded_file_provider),
                                     media_type=part.media_type,
-                                    vendor_metadata=provider_meta.get('vendor_metadata'),
+                                    vendor_metadata=vendor_metadata,
                                     identifier=provider_meta.get('identifier'),
                                 )
                             else:
                                 media_type_prefix = part.media_type.split('/', 1)[0]
                                 match media_type_prefix:
                                     case 'image':
-                                        file = ImageUrl(url=part.url, media_type=part.media_type)
+                                        file = ImageUrl(
+                                            url=part.url, media_type=part.media_type, vendor_metadata=vendor_metadata
+                                        )
                                     case 'video':
-                                        file = VideoUrl(url=part.url, media_type=part.media_type)
+                                        file = VideoUrl(
+                                            url=part.url, media_type=part.media_type, vendor_metadata=vendor_metadata
+                                        )
                                     case 'audio':
-                                        file = AudioUrl(url=part.url, media_type=part.media_type)
+                                        file = AudioUrl(
+                                            url=part.url, media_type=part.media_type, vendor_metadata=vendor_metadata
+                                        )
                                     case _:
-                                        file = DocumentUrl(url=part.url, media_type=part.media_type)
+                                        file = DocumentUrl(
+                                            url=part.url, media_type=part.media_type, vendor_metadata=vendor_metadata
+                                        )
+                        else:
+                            # `from_data_uri` succeeded: restore vendor_metadata onto the BinaryContent.
+                            if vendor_metadata is not None:
+                                file.vendor_metadata = vendor_metadata
                         user_prompt_content.append(file)
                     elif isinstance(part, DataUIPart):
                         # Contains custom data that shouldn't be sent to the model
@@ -890,9 +903,25 @@ def _convert_user_prompt_part(part: UserPromptPart) -> list[UIMessagePart]:
             elif isinstance(item, TextContent):
                 ui_parts.append(TextUIPart(text=item.content, state='done'))
             elif isinstance(item, BinaryContent):
-                ui_parts.append(FileUIPart(url=item.data_uri, media_type=item.media_type))
+                ui_parts.append(
+                    FileUIPart(
+                        url=item.data_uri,
+                        media_type=item.media_type,
+                        # Round-trip vendor_metadata (e.g. OpenAI/xAI image `detail`,
+                        # Google `video_metadata`); see `BinaryContent.vendor_metadata`.
+                        provider_metadata=dump_provider_metadata(vendor_metadata=item.vendor_metadata),
+                    )
+                )
             elif isinstance(item, ImageUrl | AudioUrl | VideoUrl | DocumentUrl):
-                ui_parts.append(FileUIPart(url=item.url, media_type=item.media_type))
+                ui_parts.append(
+                    FileUIPart(
+                        url=item.url,
+                        media_type=item.media_type,
+                        # Round-trip vendor_metadata (e.g. OpenAI/xAI image `detail`,
+                        # Google `video_metadata`); see `FileUrl.vendor_metadata`.
+                        provider_metadata=dump_provider_metadata(vendor_metadata=item.vendor_metadata),
+                    )
+                )
             elif isinstance(item, UploadedFile):
                 # Store uploaded file info in provider_metadata for round-trip support
                 provider_metadata = dump_provider_metadata(

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -279,6 +279,9 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                         user_prompt_content.append(part.text)
                     elif isinstance(part, FileUIPart):
                         provider_meta = load_provider_metadata(part.provider_metadata)
+                        # Restoring client-supplied `vendor_metadata` is intentional (as the `UploadedFile` branch
+                        # already does, #5571/#5772): it carries only the requester's own request params and is
+                        # dict-validated by the constructors below.
                         vendor_metadata = provider_meta.get('vendor_metadata')
                         try:
                             file = BinaryContent.from_data_uri(part.url)

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -317,13 +317,17 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                             # `from_data_uri` succeeded: restore vendor_metadata onto the BinaryContent.
                             # Reconstruct through the constructor so a malformed client value is rejected
                             # here (matching the URL constructor path) instead of being stored unvalidated
-                            # and crashing a provider model later.
+                            # and crashing a provider model later. Re-narrow afterwards so an image
+                            # round-trips back to `BinaryImage` (as `from_data_uri` returned it), not
+                            # plain `BinaryContent`.
                             if vendor_metadata is not None:
-                                file = BinaryContent(
-                                    data=file.data,
-                                    media_type=file.media_type,
-                                    identifier=file.identifier,
-                                    vendor_metadata=vendor_metadata,
+                                file = BinaryContent.narrow_type(
+                                    BinaryContent(
+                                        data=file.data,
+                                        media_type=file.media_type,
+                                        identifier=file.identifier,
+                                        vendor_metadata=vendor_metadata,
+                                    )
                                 )
                         user_prompt_content.append(file)
                     elif isinstance(part, DataUIPart):

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -315,8 +315,16 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                                         )
                         else:
                             # `from_data_uri` succeeded: restore vendor_metadata onto the BinaryContent.
+                            # Reconstruct through the constructor so a malformed client value is rejected
+                            # here (matching the URL constructor path) instead of being stored unvalidated
+                            # and crashing a provider model later.
                             if vendor_metadata is not None:
-                                file.vendor_metadata = vendor_metadata
+                                file = BinaryContent(
+                                    data=file.data,
+                                    media_type=file.media_type,
+                                    identifier=file.identifier,
+                                    vendor_metadata=vendor_metadata,
+                                )
                         user_prompt_content.append(file)
                     elif isinstance(part, DataUIPart):
                         # Contains custom data that shouldn't be sent to the model

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -4121,6 +4121,209 @@ def test_dump_messages_legacy_binary_content() -> None:
     )
 
 
+def test_multimodal_roundtrip_preserves_file_vendor_metadata() -> None:
+    """`vendor_metadata` on `FileUrl`/`BinaryContent` survives a dump -> load round-trip (ag-ui >= 0.1.15).
+
+    Regression test for #5764: the AG-UI adapter dropped `vendor_metadata`
+    (e.g. OpenAI/xAI image `detail`, Google `video_metadata`) for every
+    `ImageUrl`/`AudioUrl`/`VideoUrl`/`DocumentUrl`/`BinaryContent`, even though the adjacent
+    `UploadedFile` branch already round-tripped it. Multimodal input content carries it under
+    a `vendor_metadata` key in the typed part's `metadata` field.
+    """
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        ImageUrl(
+                            url='https://example.com/image.png',
+                            media_type='image/png',
+                            vendor_metadata={'detail': 'high'},
+                        ),
+                        AudioUrl(
+                            url='https://example.com/audio.mp3',
+                            media_type='audio/mpeg',
+                            vendor_metadata={'foo': 'bar'},
+                        ),
+                        VideoUrl(
+                            url='https://example.com/video.mp4',
+                            media_type='video/mp4',
+                            vendor_metadata={'fps': 5},
+                        ),
+                        DocumentUrl(
+                            url='https://example.com/doc.pdf',
+                            media_type='application/pdf',
+                            vendor_metadata={'foo': 'baz'},
+                        ),
+                        BinaryContent(
+                            data=b'fake_doc',
+                            media_type='application/pdf',
+                            vendor_metadata={'detail': 'low'},
+                        ),
+                    ]
+                )
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(messages, ag_ui_version='0.1.15')
+    # The dumped `metadata` is the external contract a frontend persists and re-sends.
+    assert [m.model_dump(exclude={'id'}, exclude_none=True) for m in ag_ui_msgs] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'type': 'image',
+                        'source': {'type': 'url', 'value': 'https://example.com/image.png', 'mime_type': 'image/png'},
+                        'metadata': {'vendor_metadata': {'detail': 'high'}},
+                    },
+                    {
+                        'type': 'audio',
+                        'source': {'type': 'url', 'value': 'https://example.com/audio.mp3', 'mime_type': 'audio/mpeg'},
+                        'metadata': {'vendor_metadata': {'foo': 'bar'}},
+                    },
+                    {
+                        'type': 'video',
+                        'source': {'type': 'url', 'value': 'https://example.com/video.mp4', 'mime_type': 'video/mp4'},
+                        'metadata': {'vendor_metadata': {'fps': 5}},
+                    },
+                    {
+                        'type': 'document',
+                        'source': {
+                            'type': 'url',
+                            'value': 'https://example.com/doc.pdf',
+                            'mime_type': 'application/pdf',
+                        },
+                        'metadata': {'vendor_metadata': {'foo': 'baz'}},
+                    },
+                    {
+                        'type': 'document',
+                        'source': {'type': 'data', 'value': 'ZmFrZV9kb2M=', 'mime_type': 'application/pdf'},
+                        'metadata': {'vendor_metadata': {'detail': 'low'}},
+                    },
+                ],
+            }
+        ]
+    )
+
+    loaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    assert loaded == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[
+                            ImageUrl(
+                                url='https://example.com/image.png',
+                                media_type='image/png',
+                                identifier='01a7df',
+                                vendor_metadata={'detail': 'high'},
+                            ),
+                            AudioUrl(
+                                url='https://example.com/audio.mp3',
+                                vendor_metadata={'foo': 'bar'},
+                                _media_type='audio/mpeg',
+                            ),
+                            VideoUrl(
+                                url='https://example.com/video.mp4',
+                                media_type='video/mp4',
+                                identifier='8cb95e',
+                                vendor_metadata={'fps': 5},
+                            ),
+                            DocumentUrl(
+                                url='https://example.com/doc.pdf',
+                                media_type='application/pdf',
+                                identifier='e3337d',
+                                vendor_metadata={'foo': 'baz'},
+                            ),
+                            BinaryContent(
+                                data=b'fake_doc',
+                                media_type='application/pdf',
+                                identifier='42a9bb',
+                                vendor_metadata={'detail': 'low'},
+                            ),
+                        ],
+                        timestamp=IsDatetime(),
+                    )
+                ]
+            )
+        ]
+    )
+
+
+def test_multimodal_roundtrip_file_without_vendor_metadata_stays_none() -> None:
+    """A file with no `vendor_metadata` round-trips to `None` (no spurious `metadata`)."""
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        ImageUrl(url='https://example.com/image.png', media_type='image/png'),
+                        BinaryContent(data=b'fake_image', media_type='image/png'),
+                    ]
+                )
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(messages, ag_ui_version='0.1.15')
+    # `exclude_none` drops the `metadata` key entirely when no vendor_metadata is present.
+    assert [m.model_dump(exclude={'id'}, exclude_none=True) for m in ag_ui_msgs] == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {
+                        'type': 'image',
+                        'source': {'type': 'url', 'value': 'https://example.com/image.png', 'mime_type': 'image/png'},
+                    },
+                    {
+                        'type': 'image',
+                        'source': {'type': 'data', 'value': 'ZmFrZV9pbWFnZQ==', 'mime_type': 'image/png'},
+                    },
+                ],
+            }
+        ]
+    )
+
+    loaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    request = loaded[0]
+    assert isinstance(request, ModelRequest)
+    user_part = request.parts[0]
+    assert isinstance(user_part, UserPromptPart)
+    assert isinstance(user_part.content, list)
+    for item in user_part.content:
+        assert getattr(item, 'vendor_metadata', None) is None
+
+
+def test_load_multimodal_rejects_invalid_vendor_metadata() -> None:
+    """A malformed `vendor_metadata` on multimodal input content is rejected on load.
+
+    The `metadata` field is typed as `Any`, so a non-`dict` client value is passed to the file
+    constructor which raises `ValidationError` here (matching the Vercel adapter), instead of
+    being stored unvalidated and crashing a provider model later.
+    """
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AGUIAdapter.load_messages(
+            [
+                UserMessage(
+                    id='msg-1',
+                    content=[
+                        ImageInputContent(
+                            source=InputContentUrlSource(
+                                type='url', value='https://example.com/image.png', mime_type='image/png'
+                            ),
+                            metadata={'vendor_metadata': 'not-a-dict'},
+                        )
+                    ],
+                )
+            ]
+        )
+
+
 def test_load_messages_unknown_type_warns() -> None:
     """Test that an unknown AG-UI message type emits a warning and is skipped."""
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -8745,6 +8745,13 @@ async def test_adapter_roundtrip_preserves_file_vendor_metadata():
                             media_type='application/pdf',
                             vendor_metadata={'detail': 'low'},
                         ),
+                        # Image data-URI: must round-trip back to `BinaryImage` (the narrowed type
+                        # `from_data_uri` produces), not plain `BinaryContent`.
+                        BinaryContent(
+                            data=b'fake_image',
+                            media_type='image/png',
+                            vendor_metadata={'detail': 'auto'},
+                        ),
                     ]
                 )
             ]
@@ -8764,31 +8771,58 @@ async def test_adapter_roundtrip_preserves_file_vendor_metadata():
         {'pydantic_ai': {'vendor_metadata': {'fps': 5}}},
         {'pydantic_ai': {'vendor_metadata': {'foo': 'baz'}}},
         {'pydantic_ai': {'vendor_metadata': {'detail': 'low'}}},
+        {'pydantic_ai': {'vendor_metadata': {'detail': 'auto'}}},
     ]
 
     loaded = VercelAIAdapter.load_messages(ui_messages)
-
-    assert len(loaded) == 1
-    request = loaded[0]
-    assert isinstance(request, ModelRequest)
-    user_part = request.parts[0]
-    assert isinstance(user_part, UserPromptPart)
-    assert isinstance(user_part.content, list)
-
-    image = next(item for item in user_part.content if isinstance(item, ImageUrl))
-    assert image.vendor_metadata == {'detail': 'high'}
-
-    audio = next(item for item in user_part.content if isinstance(item, AudioUrl))
-    assert audio.vendor_metadata == {'foo': 'bar'}
-
-    video = next(item for item in user_part.content if isinstance(item, VideoUrl))
-    assert video.vendor_metadata == {'fps': 5}
-
-    document = next(item for item in user_part.content if isinstance(item, DocumentUrl))
-    assert document.vendor_metadata == {'foo': 'baz'}
-
-    binary = next(item for item in user_part.content if isinstance(item, BinaryContent))
-    assert binary.vendor_metadata == {'detail': 'low'}
+    assert loaded == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[
+                            ImageUrl(
+                                url='https://example.com/image.png',
+                                media_type='image/png',
+                                identifier='01a7df',
+                                vendor_metadata={'detail': 'high'},
+                            ),
+                            AudioUrl(
+                                url='https://example.com/audio.mp3',
+                                vendor_metadata={'foo': 'bar'},
+                                _media_type='audio/mpeg',
+                            ),
+                            VideoUrl(
+                                url='https://example.com/video.mp4',
+                                media_type='video/mp4',
+                                identifier='8cb95e',
+                                vendor_metadata={'fps': 5},
+                            ),
+                            DocumentUrl(
+                                url='https://example.com/doc.pdf',
+                                media_type='application/pdf',
+                                identifier='e3337d',
+                                vendor_metadata={'foo': 'baz'},
+                            ),
+                            BinaryContent(
+                                data=b'fake_doc',
+                                media_type='application/pdf',
+                                identifier='42a9bb',
+                                vendor_metadata={'detail': 'low'},
+                            ),
+                            BinaryImage(
+                                data=b'fake_image',
+                                media_type='image/png',
+                                identifier='3d738c',
+                                vendor_metadata={'detail': 'auto'},
+                            ),
+                        ],
+                        timestamp=IsDatetime(),
+                    )
+                ]
+            )
+        ]
+    )
 
 
 async def test_adapter_roundtrip_file_without_vendor_metadata_stays_none():

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -8704,3 +8704,105 @@ async def test_denied_builtin_tool_round_trip():
             )
         ]
     )
+
+
+async def test_adapter_roundtrip_preserves_file_vendor_metadata():
+    """`vendor_metadata` on `FileUrl`/`BinaryContent` survives a dump -> load round-trip.
+
+    Regression test for #5764: the Vercel AI adapter dropped `vendor_metadata`
+    (e.g. OpenAI/xAI image `detail`, Google `video_metadata`) for every
+    `ImageUrl`/`AudioUrl`/`VideoUrl`/`DocumentUrl`/`BinaryContent` because the
+    `FileUIPart` was built without `provider_metadata`, even though the adjacent
+    `UploadedFile` branch already round-tripped it.
+    """
+    messages = [
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        ImageUrl(
+                            url='https://example.com/image.png',
+                            media_type='image/png',
+                            vendor_metadata={'detail': 'high'},
+                        ),
+                        AudioUrl(
+                            url='https://example.com/audio.mp3',
+                            media_type='audio/mpeg',
+                            vendor_metadata={'foo': 'bar'},
+                        ),
+                        VideoUrl(
+                            url='https://example.com/video.mp4',
+                            media_type='video/mp4',
+                            vendor_metadata={'fps': 5},
+                        ),
+                        DocumentUrl(
+                            url='https://example.com/doc.pdf',
+                            media_type='application/pdf',
+                            vendor_metadata={'foo': 'baz'},
+                        ),
+                        BinaryContent(
+                            data=b'fake_doc',
+                            media_type='application/pdf',
+                            vendor_metadata={'detail': 'low'},
+                        ),
+                    ]
+                )
+            ]
+        ),
+    ]
+
+    ui_messages = VercelAIAdapter.dump_messages(messages)
+    loaded = VercelAIAdapter.load_messages(ui_messages)
+
+    assert len(loaded) == 1
+    request = loaded[0]
+    assert isinstance(request, ModelRequest)
+    user_part = request.parts[0]
+    assert isinstance(user_part, UserPromptPart)
+    assert isinstance(user_part.content, list)
+
+    image = next(item for item in user_part.content if isinstance(item, ImageUrl))
+    assert image.vendor_metadata == {'detail': 'high'}
+
+    audio = next(item for item in user_part.content if isinstance(item, AudioUrl))
+    assert audio.vendor_metadata == {'foo': 'bar'}
+
+    video = next(item for item in user_part.content if isinstance(item, VideoUrl))
+    assert video.vendor_metadata == {'fps': 5}
+
+    document = next(item for item in user_part.content if isinstance(item, DocumentUrl))
+    assert document.vendor_metadata == {'foo': 'baz'}
+
+    binary = next(item for item in user_part.content if isinstance(item, BinaryContent))
+    assert binary.vendor_metadata == {'detail': 'low'}
+
+
+async def test_adapter_roundtrip_file_without_vendor_metadata_stays_none():
+    """A file with no `vendor_metadata` round-trips to `None` (no spurious metadata)."""
+    messages = [
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        ImageUrl(url='https://example.com/image.png', media_type='image/png'),
+                        BinaryContent(data=b'fake_image', media_type='image/png'),
+                    ]
+                )
+            ]
+        ),
+    ]
+
+    ui_messages = VercelAIAdapter.dump_messages(messages)
+    # No vendor_metadata -> no provider_metadata emitted on the file part.
+    file_parts = [part for msg in ui_messages for part in msg.parts if isinstance(part, FileUIPart)]
+    assert len(file_parts) == 2
+    assert all(part.provider_metadata is None for part in file_parts)
+
+    loaded = VercelAIAdapter.load_messages(ui_messages)
+    request = loaded[0]
+    assert isinstance(request, ModelRequest)
+    user_part = request.parts[0]
+    assert isinstance(user_part, UserPromptPart)
+    assert isinstance(user_part.content, list)
+    for item in user_part.content:
+        assert getattr(item, 'vendor_metadata', None) is None

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -8752,6 +8752,20 @@ async def test_adapter_roundtrip_preserves_file_vendor_metadata():
     ]
 
     ui_messages = VercelAIAdapter.dump_messages(messages)
+
+    # Pin the dumped external contract: each file part carries vendor_metadata under
+    # provider_metadata['pydantic_ai'] (the shape the symmetric dump -> load relies on).
+    dumped_metadata = [
+        part.provider_metadata for message in ui_messages for part in message.parts if isinstance(part, FileUIPart)
+    ]
+    assert dumped_metadata == [
+        {'pydantic_ai': {'vendor_metadata': {'detail': 'high'}}},
+        {'pydantic_ai': {'vendor_metadata': {'foo': 'bar'}}},
+        {'pydantic_ai': {'vendor_metadata': {'fps': 5}}},
+        {'pydantic_ai': {'vendor_metadata': {'foo': 'baz'}}},
+        {'pydantic_ai': {'vendor_metadata': {'detail': 'low'}}},
+    ]
+
     loaded = VercelAIAdapter.load_messages(ui_messages)
 
     assert len(loaded) == 1
@@ -8806,3 +8820,30 @@ async def test_adapter_roundtrip_file_without_vendor_metadata_stays_none():
     assert isinstance(user_part.content, list)
     for item in user_part.content:
         assert getattr(item, 'vendor_metadata', None) is None
+
+
+async def test_adapter_load_binary_content_rejects_invalid_vendor_metadata():
+    """A malformed `vendor_metadata` on a data-URI `BinaryContent` is rejected on load.
+
+    The restore path reconstructs `BinaryContent` through its constructor so a non-dict
+    client value raises `ValidationError` here (matching the URL constructor path),
+    instead of being stored unvalidated and crashing a provider model later.
+    """
+    from pydantic import ValidationError
+
+    ui_messages = [
+        UIMessage(
+            id='msg-1',
+            role='user',
+            parts=[
+                FileUIPart(
+                    media_type='application/pdf',
+                    url='data:application/pdf;base64,ZGF0YQ==',
+                    provider_metadata={'pydantic_ai': {'vendor_metadata': 'not-a-dict'}},
+                ),
+            ],
+        )
+    ]
+
+    with pytest.raises(ValidationError):
+        VercelAIAdapter.load_messages(ui_messages)


### PR DESCRIPTION
## Summary

- Round-trips `vendor_metadata` for `ImageUrl`, `AudioUrl`, `VideoUrl`, `DocumentUrl`, and `BinaryContent` through both the Vercel AI and AG-UI adapters.
- Preserves load-bearing provider hints such as OpenAI/xAI image `detail` and Google `video_metadata` when UI clients persist messages and feed them back as history.

## Fix

- Vercel AI: stores file `vendor_metadata` in `provider_metadata` on dump and restores it on load, including `BinaryContent` reconstructed from data URIs.
- AG-UI: for `ag_ui_version >= 0.1.15`, stores file `vendor_metadata` under the typed multimodal input content `metadata` field and restores it on load.
- Keeps files without `vendor_metadata` dumping without spurious metadata, and rejects malformed client-supplied `vendor_metadata` during load.

## Verification

- Added Vercel AI round-trip regression tests for all affected file content types.
- Added AG-UI round-trip regression tests for all affected file content types, plus no-metadata and invalid-metadata cases.
- `uv run --all-extras --no-extra outlines-vllm-offline pytest tests/test_vercel_ai.py`
- `uv run --all-extras --no-extra outlines-vllm-offline pytest tests/test_ag_ui.py`
- `uv run ruff format --check`, `uv run ruff check`, `uv run pyright <adapter> <test>`, and `uv run mypy`

Refs #5764.
