### PR TITLE
fix: keep streaming state as 'complete' if cancelled after finish

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1367,10 +1367,10 @@ class StreamedResponse(ABC):
 
     def get(self) -> ModelResponse:
         """Build a [`ModelResponse`][pydantic_ai.messages.ModelResponse] from the data received from the stream so far."""
-        if self._cancelled:
-            state: ModelResponseState = 'interrupted'
-        elif self._finished:
-            state = 'complete'
+        if self._finished:
+            state: ModelResponseState = 'complete'
+        elif self._cancelled:
+            state = 'interrupted'
         else:
             state = 'incomplete'
         return ModelResponse(


### PR DESCRIPTION
Resilience Sweep:
      > Swapped logic in StreamedResponse.get() to prioritize _finished over _cancelled. This ensures state remains 'complete' if
  cancel() is called after a successful finish, as noted in the streaming-resilience-sweep (#5782).