### PR TITLE
fix: preserve request metadata when cleaning history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -2195,7 +2195,8 @@ def _clean_message_history(messages: list[_messages.ModelMessage]) -> list[_mess
                     # Tool return parts always need to be at the start
                     key=lambda x: 0 if isinstance(x, _messages.ToolReturnPart | _messages.RetryPromptPart) else 1
                 )
-                merged_message = _messages.ModelRequest(
+                merged_message = replace(
+                    last_message,
                     parts=parts,
                     instructions=last_message.instructions or message.instructions,
                     timestamp=message.timestamp or last_message.timestamp,

--- a/tests/test_history_processor.py
+++ b/tests/test_history_processor.py
@@ -139,6 +139,8 @@ async def test_history_processor_run_replaces_message_history(
                     ),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             )
         ]
     )
@@ -207,6 +209,8 @@ async def test_history_processor_streaming_replaces_message_history(
                     ),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             )
         ]
     )
@@ -1114,6 +1118,8 @@ async def test_history_processor_reorder_old_new(function_model: FunctionModel, 
                     UserPromptPart(content='Old question', timestamp=IsDatetime()),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             )
         ]
     )

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3690,6 +3690,28 @@ def test_prepare_messages_then_clean_history_merges_consecutive_requests() -> No
     assert isinstance(last.parts[1], UserPromptPart)
 
 
+def test_clean_message_history_preserves_request_metadata_when_merging() -> None:
+    cleaned = _clean_message_history(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='first')],
+                run_id='run-1',
+                conversation_id='conv-1',
+                metadata={'source': 'history'},
+            ),
+            ModelRequest(parts=[UserPromptPart(content='second')]),
+        ]
+    )
+
+    assert len(cleaned) == 1
+    request = cleaned[0]
+    assert isinstance(request, ModelRequest)
+    assert [part.content for part in request.parts] == ['first', 'second']
+    assert request.run_id == 'run-1'
+    assert request.conversation_id == 'conv-1'
+    assert request.metadata == {'source': 'history'}
+
+
 def test_narrow_type_local_return_passthrough_when_already_narrowed() -> None:
     """Narrowing an already-typed `ToolSearchReturnPart` returns the input instance."""
     part = ToolSearchReturnPart(content={'discovered_tools': []}, tool_call_id='c1')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2269,6 +2269,8 @@ def test_parallel_tool_return_with_deferred():
                     ),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             ),
         ]
     )


### PR DESCRIPTION
Fixes #5731.

## Summary

`_clean_message_history()` merged consecutive `ModelRequest` messages by constructing a fresh `ModelRequest`. That preserved the merged parts, instructions, and timestamp, but silently dropped request-level fields such as `run_id`, `conversation_id`, and `metadata`.

This switches the merge path to `dataclasses.replace(last_message, ...)`, matching the existing `ModelResponse` merge pattern so fields not involved in the merge survive the cleanup pass.

## Validation

```console
python -m pip install dirty-equals
$env:PYTHONPATH='C:\dev\GITHUB-clean\pydantic-ai-5731\pydantic_ai_slim'
python -m pytest tests/test_history_processor.py tests/test_tool_search.py tests/test_tools.py -q -k "clean_message_history_preserves_request_metadata_when_merging or history_processor_run_replaces_message_history or history_processor_streaming_replaces_message_history or history_processor_reorder_old_new or parallel_tool_return"
python -m py_compile pydantic_ai_slim\pydantic_ai\_agent_graph.py tests\test_history_processor.py tests\test_tool_search.py tests\test_tools.py
git diff --check origin/main...HEAD
```
