### PR TITLE
Document testing philosophy and `Case` parametrization pattern in `tests/AGENTS.md`

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,5 +1,13 @@
 # Testing Guidelines
 
+## Testing philosophy
+
+VCR + public-API tests are the default. We test through the public API the way a user would (`Agent(...)`, `agent.run(...)`) against real provider responses recorded as cassettes — provider APIs are the ultimate judge of whether the code is correct when run as intended, and that user-facing correctness is what we care about, not behavior in isolated units.
+
+Unit tests still earn their place — for internal behavior that is definitory and worth pinning against drift. That includes behavior you can't reach or reliably trigger through the public API (pre-request guards, defensive branches no real model produces), but also behavior a VCR test wouldn't actually protect: our cassette matchers aren't always sensitive to the request body, so a changed internal payload can still match an existing recording and pass green — a unit test asserting the internal shape directly is what catches that regression. Each unit test should still say why it isn't (or can't be) a VCR test.
+
+Recording cassettes needs provider API keys and isn't trivial, so contributors routinely under-test the real behavior — writing the VCR test a contributor couldn't is core maintainer work.
+
 ## Test File Structure
 
 ```python
@@ -69,6 +77,53 @@ async def test_feature(model: Model, stream: bool, request: pytest.FixtureReques
 
     assert output == expected
 ```
+
+Use the `EXPECTATIONS` dict only for a pure cartesian output lookup keyed by `(model, stream)`. For feature-centric files where cases are heterogeneous — different inputs, expectations, and xfails per case, all run through one minimal comprehensive test — use a `@dataclass Case` with sensible defaults plus per-case overrides:
+
+```python
+from dataclasses import dataclass, field
+
+import pytest
+from inline_snapshot import snapshot
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage
+
+
+@dataclass(frozen=True)
+class Case:
+    id: str
+    model: str
+    prompt: str = 'hello'
+    instructions: str | None = None
+    expected_messages: list[ModelMessage] = field(default_factory=list[ModelMessage])
+    marks: tuple[pytest.MarkDecorator, ...] = ()
+
+
+CASES = [
+    Case(
+        id='openai',
+        model='openai:gpt-5',
+        expected_messages=snapshot([...]),
+    ),
+    Case(
+        id='anthropic',
+        model='anthropic:claude-sonnet-4-5',
+        instructions='be terse',
+        expected_messages=snapshot([...]),
+        marks=(pytest.mark.skipif(not anthropic_available(), reason='anthropic not installed'),),
+    ),
+]
+
+
+@pytest.mark.parametrize('case', [pytest.param(c, id=c.id, marks=c.marks) for c in CASES])
+async def test_feature(case: Case):
+    agent = Agent(case.model, instructions=case.instructions)
+    result = await agent.run(case.prompt)
+    assert result.all_messages() == case.expected_messages
+```
+
+Each case carries its own snapshot (not the central test body), so a reviewer can read the cases top to bottom and check that every expectation is realistic.
 
 ## VCR Workflow
 


### PR DESCRIPTION
Documentation-only change; no linked issue (trivial CE / doc improvement).

This writes down the VCR-maximalist testing philosophy that the project already enforces in review but whose rationale currently lives only in maintainers' heads and private `CLAUDE.local` notes — not where review agents or contributors can cite it. The new `## Testing philosophy` section makes the default (VCR + public-API tests against real recorded provider responses) and the carve-out for unit tests (definitory internal behavior, including cases VCR can't protect because cassette matchers aren't always body-sensitive) explicit. It also adds the missing worked `@dataclass Case` example to `## Parametrization with Expectations`, disambiguating it from the existing `EXPECTATIONS`-dict pattern: `Case` for heterogeneous feature-centric files run through one comprehensive parametrized test, the dict for a pure cartesian `(model, stream)` output lookup.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
