### PR TITLE
fix: skip framework tools in SetToolMetadata wrapper

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py
@@ -48,6 +48,13 @@ class SetToolMetadata(AbstractCapability[AgentDepsT]):
         async def _set_metadata(ctx: RunContext[AgentDepsT], tool_defs: list[ToolDefinition]) -> list[ToolDefinition]:
             resolved: list[ToolDefinition] = []
             for td in tool_defs:
+                # Framework-managed tools (tool_kind is not None, e.g. 'capability-load')
+                # must not receive code_mode or other per-user-tool metadata — wrapping
+                # them hides them from the model and breaks framework behavior such as
+                # deferred capability loading.
+                if td.tool_kind is not None:
+                    resolved.append(td)
+                    continue
                 if await matches_tool_selector(selector, ctx, td):
                     td = replace(td, metadata={**(td.metadata or {}), **metadata})
                 resolved.append(td)

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -2627,6 +2627,64 @@ def test_set_tool_metadata_capability_with_dict_selector():
     assert 'audited' not in td_b.metadata
 
 
+async def test_set_tool_metadata_skips_framework_tools():
+    """SetToolMetadata must not apply metadata to framework-managed tools (tool_kind is not None).
+
+    Framework tools like `load_capability` (tool_kind='capability-load') are
+    managed by the framework and must remain callable by the model. Applying
+    code_mode or other per-user-tool metadata would hide them from the model
+    and break deferred capability loading.
+    """
+    from pydantic_ai.capabilities import SetToolMetadata
+    from pydantic_ai.tools import ToolDefinition
+    from pydantic_ai.toolsets.abstract import ToolsetTool
+    from pydantic_ai.toolsets.function import FunctionToolset
+
+    def tool_a(x: int) -> int:
+        return x
+
+    ts = FunctionToolset()
+    ts.add_function(tool_a)
+
+    # Simulate a framework tool with tool_kind set
+    framework_def = ToolDefinition(
+        name='load_capability',
+        description='Load a capability',
+        parameters_json_schema={},
+        tool_kind='capability-load',
+    )
+    framework_tool = ToolsetTool(
+        toolset=ts,
+        tool_def=framework_def,
+        max_retries=1,
+        args_validator=None,
+    )
+
+    class ToolsetWithFrameworkTool(FunctionToolset[None]):
+        async def get_tools(self, ctx):
+            tools = await super().get_tools(ctx)
+            tools['load_capability'] = framework_tool
+            return tools
+
+    test_model = TestModel()
+    cap = SetToolMetadata(tools='all', code_mode=True)
+    wrapped = cap.get_wrapper_toolset(ToolsetWithFrameworkTool())
+    agent = Agent(test_model, toolsets=[wrapped])
+    agent.run_sync('test')
+
+    params = test_model.last_model_request_parameters
+    assert params is not None
+
+    # Framework tool must NOT receive code_mode metadata
+    td_load = next(td for td in params.function_tools if td.name == 'load_capability')
+    assert td_load.metadata is None or td_load.metadata.get('code_mode') is None
+
+    # User tool SHOULD receive code_mode metadata
+    td_a = next(td for td in params.function_tools if td.name == 'tool_a')
+    assert td_a.metadata is not None
+    assert td_a.metadata['code_mode'] is True
+
+
 async def test_custom_toolset_returning_plain_str_instructions():
     """A custom AbstractToolset returning a plain str from get_instructions is treated as dynamic."""
     from pydantic_ai import Agent

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -2628,12 +2628,13 @@ def test_set_tool_metadata_capability_with_dict_selector():
 
 
 async def test_set_tool_metadata_skips_framework_tools():
-    """SetToolMetadata must not apply metadata to framework-managed tools (tool_kind is not None).
+    """SetToolMetadata must not apply metadata to framework-managed tools.
 
-    Framework tools like `load_capability` (tool_kind='capability-load') are
-    managed by the framework and must remain callable by the model. Applying
-    code_mode or other per-user-tool metadata would hide them from the model
-    and break deferred capability loading.
+    A tool whose `ToolDefinition` carries a `tool_kind` (e.g. the framework-managed
+    tool-search tool) is owned by the framework. Merging `code_mode` or other
+    per-user-tool metadata onto it would change how it is surfaced to the model and
+    break framework behavior such as deferred capability loading, so the wrapper must
+    leave those definitions untouched while still tagging ordinary user tools.
     """
     from pydantic_ai.capabilities import SetToolMetadata
     from pydantic_ai.tools import ToolDefinition
@@ -2643,49 +2644,46 @@ async def test_set_tool_metadata_skips_framework_tools():
     def tool_a(x: int) -> int:
         return x
 
-    ts = FunctionToolset()
-    ts.add_function(tool_a)
-
-    # Simulate a framework tool with tool_kind set
     framework_def = ToolDefinition(
         name='load_capability',
         description='Load a capability',
-        parameters_json_schema={},
-        tool_kind='capability-load',
-    )
-    framework_tool = ToolsetTool(
-        toolset=ts,
-        tool_def=framework_def,
-        max_retries=1,
-        args_validator=None,  # type: ignore[arg-type]
+        parameters_json_schema={'type': 'object', 'properties': {}},
+        tool_kind='tool-search',
     )
 
     class ToolsetWithFrameworkTool(FunctionToolset[None]):
-        async def get_tools(self, ctx: RunContext[None]):
+        async def get_tools(self, ctx: RunContext[None]) -> dict[str, ToolsetTool[None]]:
             tools = await super().get_tools(ctx)
-            tools['load_capability'] = framework_tool
+            # Reuse the user tool's validator so the simulated framework tool is a
+            # fully-formed ToolsetTool; only its `tool_kind` marks it framework-managed.
+            base = tools['tool_a']
+            tools['load_capability'] = ToolsetTool(
+                toolset=self,
+                tool_def=framework_def,
+                max_retries=base.max_retries,
+                args_validator=base.args_validator,
+            )
             return tools
 
-    # Use `call_tools=[]` so TestModel inspects the tool definitions without
-    # invoking them. The simulated framework tool has `args_validator=None`,
-    # which would raise during argument validation if it were actually called.
-    test_model = TestModel(call_tools=[])
+    ts = ToolsetWithFrameworkTool()
+    ts.add_function(tool_a)
+
     cap = SetToolMetadata(tools='all', code_mode=True)
-    wrapped = cap.get_wrapper_toolset(ToolsetWithFrameworkTool())
-    agent = Agent(test_model, toolsets=[wrapped])
-    await agent.run('test')
+    wrapped = cap.get_wrapper_toolset(ts)
 
-    params = test_model.last_model_request_parameters
-    assert params is not None
+    # Inspect the prepared tool definitions directly: the wrapper's prepare function
+    # is where framework tools are skipped, so we don't need a full model round-trip.
+    tools = await wrapped.get_tools(build_run_context(None))
 
-    # Framework tool must NOT receive code_mode metadata
-    td_load = next(td for td in params.function_tools if td.name == 'load_capability')
-    assert td_load.metadata is None or td_load.metadata.get('code_mode') is None
-
-    # User tool SHOULD receive code_mode metadata
-    td_a = next(td for td in params.function_tools if td.name == 'tool_a')
+    # User tool should receive code_mode metadata.
+    td_a = tools['tool_a'].tool_def
     assert td_a.metadata is not None
     assert td_a.metadata['code_mode'] is True
+
+    # Framework tool (tool_kind set) must be left untouched.
+    td_load = tools['load_capability'].tool_def
+    assert td_load.metadata is None or 'code_mode' not in td_load.metadata
+    assert td_load.tool_kind == 'tool-search'
 
 
 async def test_custom_toolset_returning_plain_str_instructions():

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -2657,11 +2657,11 @@ async def test_set_tool_metadata_skips_framework_tools():
         toolset=ts,
         tool_def=framework_def,
         max_retries=1,
-        args_validator=None,
+        args_validator=None,  # type: ignore[arg-type]
     )
 
     class ToolsetWithFrameworkTool(FunctionToolset[None]):
-        async def get_tools(self, ctx):
+        async def get_tools(self, ctx: RunContext[None]):
             tools = await super().get_tools(ctx)
             tools['load_capability'] = framework_tool
             return tools
@@ -2670,7 +2670,7 @@ async def test_set_tool_metadata_skips_framework_tools():
     cap = SetToolMetadata(tools='all', code_mode=True)
     wrapped = cap.get_wrapper_toolset(ToolsetWithFrameworkTool())
     agent = Agent(test_model, toolsets=[wrapped])
-    agent.run_sync('test')
+    await agent.run('test')
 
     params = test_model.last_model_request_parameters
     assert params is not None

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -2666,7 +2666,10 @@ async def test_set_tool_metadata_skips_framework_tools():
             tools['load_capability'] = framework_tool
             return tools
 
-    test_model = TestModel()
+    # Use `call_tools=[]` so TestModel inspects the tool definitions without
+    # invoking them. The simulated framework tool has `args_validator=None`,
+    # which would raise during argument validation if it were actually called.
+    test_model = TestModel(call_tools=[])
     cap = SetToolMetadata(tools='all', code_mode=True)
     wrapped = cap.get_wrapper_toolset(ToolsetWithFrameworkTool())
     agent = Agent(test_model, toolsets=[wrapped])

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -2644,6 +2644,9 @@ async def test_set_tool_metadata_skips_framework_tools():
     def tool_a(x: int) -> int:
         return x
 
+    # Sanity-check the user tool is a normal, callable function.
+    assert tool_a(1) == 1
+
     framework_def = ToolDefinition(
         name='load_capability',
         description='Load a capability',


### PR DESCRIPTION
## Problem

`SetToolMetadata(code_mode=True)` applies metadata to ALL tools matching the selector, including the framework-managed `load_capability` (which has `tool_kind='capability-load'`). This hides `load_capability` from the model — it gets wrapped into code mode and the model can no longer call it directly, breaking deferred capability loading.

Fixes #5798.

## Root Cause

The `_set_metadata` prepare function in `SetToolMetadata.get_wrapper_toolset()` iterates over all tool definitions and applies metadata to any that match the selector. With `tools='all'`, this includes framework tools like `load_capability`.

## Fix

Add a guard to skip framework-managed tools (where `tool_kind is not None`) before applying user-facing metadata. This protects `load_capability` and any future framework-owned tools from being inadvertently wrapped.

The `tool_kind` discriminator already exists precisely to distinguish framework-owned tools from user tools — `'capability-load'` for `load_capability`, `'tool-search'` for tool-search tools, and potentially more in the future.

## Change

- **`capabilities/set_tool_metadata.py`**: Skip tools with `tool_kind is not None` in `_set_metadata`
- **`tests/test_toolsets.py`**: Add `test_set_tool_metadata_skips_framework_tools` verifying that framework tools are not modified while user tools still receive metadata