### PR TITLE
Fix `BinaryContent` tool return round-trips

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -6,7 +6,7 @@ import mimetypes
 import os
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, ItemsView, Mapping, Sequence
 from dataclasses import KW_ONLY, dataclass, field, replace
 from datetime import datetime
 from mimetypes import MimeTypes
@@ -867,6 +867,10 @@ MultiModalContent = Annotated[
 # Explicit tuple for readability; validated against MultiModalContent in tests
 MULTI_MODAL_CONTENT_TYPES: tuple[type, ...] = (ImageUrl, AudioUrl, DocumentUrl, VideoUrl, BinaryContent, UploadedFile)
 
+MULTI_MODAL_CONTENT_KINDS = frozenset(
+    {'image-url', 'audio-url', 'document-url', 'video-url', 'binary', 'uploaded-file'}
+)
+
 
 def is_multi_modal_content(obj: Any) -> TypeGuard[MultiModalContent]:
     """Check if obj is a MultiModalContent type, enabling type narrowing."""
@@ -1094,6 +1098,25 @@ else:
     )
 
 
+multi_modal_content_ta: pydantic.TypeAdapter[MultiModalContent] = pydantic.TypeAdapter(
+    MultiModalContent, config=pydantic.ConfigDict(defer_build=True, ser_json_bytes='base64', val_json_bytes='base64')
+)
+
+
+def _restore_multi_modal_content(content: Any) -> Any:
+    if isinstance(content, Mapping):
+        items = cast(ItemsView[str, Any], content.items())
+        content_dict = dict(items)
+        if content_dict.get('kind') in MULTI_MODAL_CONTENT_KINDS:
+            return multi_modal_content_ta.validate_python(content)
+        return {key: _restore_multi_modal_content(value) for key, value in content_dict.items()}
+    elif isinstance(content, Sequence) and not isinstance(content, str):
+        values = cast(Sequence[Any], content)
+        return [_restore_multi_modal_content(value) for value in values]
+    else:
+        return content
+
+
 ToolPartKind: TypeAlias = Literal['tool-search', 'capability-load']
 """Discriminator value for the typed call/return-part subclass associated with a tool.
 
@@ -1151,6 +1174,11 @@ class BaseToolReturnPart:
     - `'failed'`: The tool raised an error during execution.
     - `'denied'`: The tool call was denied by the approval mechanism.
     """
+
+    @pydantic.field_validator('content', mode='before')
+    @classmethod
+    def _validate_content(cls, content: Any) -> Any:
+        return _restore_multi_modal_content(content)
 
     def _split_content(self) -> tuple[list[Any], list[MultiModalContent], bool]:
         """Split content into non-file and file parts.

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -341,6 +341,38 @@ def test_binary_content_base64():
     assert bc.data_uri == 'data:image/png;base64,SGVsbG8sIHdvcmxkIQ=='
 
 
+def test_tool_return_binary_content_roundtrip():
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name='get_image', content=BinaryContent(data=b'image-data', media_type='image/png'))
+            ]
+        )
+    ]
+
+    payload = ModelMessagesTypeAdapter.dump_python(messages, mode='json')
+    round_tripped = ModelMessagesTypeAdapter.validate_python(payload)
+
+    part = round_tripped[0].parts[0]
+    assert isinstance(part, ToolReturnPart)
+    assert isinstance(part.content, BinaryContent)
+    assert part.content.data == b'image-data'
+    assert part.content.media_type == 'image/png'
+
+
+def test_tool_return_dict_with_kind_roundtrip():
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[ToolReturnPart(tool_name='get_data', content={'kind': 'custom', 'value': 'ok'})])
+    ]
+
+    payload = ModelMessagesTypeAdapter.dump_python(messages, mode='json')
+    round_tripped = ModelMessagesTypeAdapter.validate_python(payload)
+
+    part = round_tripped[0].parts[0]
+    assert isinstance(part, ToolReturnPart)
+    assert part.content == {'kind': 'custom', 'value': 'ok'}
+
+
 def test_from_data_uri_base64():
     bc = BinaryContent.from_data_uri('data:image/png;base64,SGVsbG8sIHdvcmxkIQ==')
     assert bc.data == b'Hello, world!'


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #5811

This fixes `ToolReturnPart.content` JSON-mode round-tripping for multimodal content. `BinaryContent` serialized via `ModelMessagesTypeAdapter.dump_python(..., mode='json')` was validating back as a plain dict because the recursive tool-return content union can accept generic mappings before reconstructing multimodal content.

The change restores serialized multimodal content before normal content validation, including nested lists/dicts, while leaving ordinary user dictionaries with unrelated `kind` values unchanged.

Validation:

```console
uv run pytest tests/test_messages.py::test_tool_return_binary_content_roundtrip tests/test_messages.py::test_tool_return_dict_with_kind_roundtrip -q
uv run ruff check pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py
uv run pyright pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py
```

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
