### PR TITLE
fix(openai): map `UploadedFile` images as Responses input images

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3083,12 +3083,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                             f'UploadedFile with `provider_name={item.provider_name!r}` cannot be used with OpenAIResponsesModel. '
                             f'Expected `provider_name` to be `{self.system!r}`.'
                         )
-                    content.append(
-                        responses.ResponseInputFileParam(
-                            type='input_file',
-                            file_id=item.file_id,
-                        )
-                    )
+                    content.append(OpenAIResponsesModel._map_uploaded_file_to_response_input(item))
                 elif isinstance(item, CachePoint):
                     pass
                 elif is_multi_modal_content(item):
@@ -3096,6 +3091,30 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                 else:
                     raise RuntimeError(f'Unsupported content type: {type(item)}')  # pragma: no cover
         return responses.EasyInputMessageParam(role='user', content=content)
+
+    @staticmethod
+    def _map_uploaded_file_to_response_input(
+        item: UploadedFile,
+    ) -> responses.ResponseInputImageParam | responses.ResponseInputFileParam:
+        if item.media_type.startswith('image/'):
+            detail: Literal['auto', 'low', 'high'] = 'auto'
+            if metadata := item.vendor_metadata:
+                detail = metadata.get('detail', 'auto')
+            return responses.ResponseInputImageParam(type='input_image', file_id=item.file_id, detail=detail)
+
+        return responses.ResponseInputFileParam(type='input_file', file_id=item.file_id)
+
+    @staticmethod
+    def _map_uploaded_file_to_response_output_content(
+        item: UploadedFile,
+    ) -> ResponseInputImageContentParam | ResponseInputFileContentParam:
+        if item.media_type.startswith('image/'):
+            detail: Literal['auto', 'low', 'high'] = 'auto'
+            if metadata := item.vendor_metadata:
+                detail = metadata.get('detail', 'auto')
+            return ResponseInputImageContentParam(type='input_image', file_id=item.file_id, detail=detail)
+
+        return ResponseInputFileContentParam(type='input_file', file_id=item.file_id)
 
     @staticmethod
     async def _map_file_to_response_content(
@@ -3170,12 +3189,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
 
         for item in part.content_items(mode='str'):
             if isinstance(item, UploadedFile):
-                output.append(
-                    ResponseInputFileContentParam(
-                        type='input_file',
-                        file_id=item.file_id,
-                    )
-                )
+                output.append(OpenAIResponsesModel._map_uploaded_file_to_response_output_content(item))
             elif is_multi_modal_content(item):
                 output.append(await OpenAIResponsesModel._map_file_to_response_content(item, 'tool returns'))  # pyright: ignore[reportArgumentType]
             elif isinstance(item, str):  # pragma: no branch

--- a/tests/models/test_openai_responses_uploaded_file.py
+++ b/tests/models/test_openai_responses_uploaded_file.py
@@ -1,0 +1,68 @@
+import asyncio
+
+import pytest
+
+from pydantic_ai import ToolReturnPart, UserPromptPart
+from pydantic_ai.messages import UploadedFile
+
+from ..conftest import try_import
+
+with try_import() as imports_successful:
+    from pydantic_ai.models.openai import OpenAIResponsesModel
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+from .mock_openai import MockOpenAIResponses, response_message
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='openai not installed'),
+]
+
+
+# Direct mapping tests catch request payload regressions that VCR cassette matching may not.
+def test_openai_responses_uploaded_image_file_input():
+    mock_client = MockOpenAIResponses.create_mock(response_message([]))
+    model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(openai_client=mock_client))
+
+    message = asyncio.run(
+        model._map_user_prompt(  # pyright: ignore[reportPrivateUsage]
+            part=UserPromptPart(
+                content=[
+                    'Describe this image',
+                    UploadedFile(
+                        file_id='file-image-123',
+                        provider_name='openai',
+                        media_type='image/png',
+                        vendor_metadata={'detail': 'high'},
+                    ),
+                ]
+            )
+        )
+    )
+
+    assert message == {
+        'role': 'user',
+        'content': [
+            {'text': 'Describe this image', 'type': 'input_text'},
+            {'type': 'input_image', 'file_id': 'file-image-123', 'detail': 'high'},
+        ],
+    }
+
+
+def test_openai_responses_uploaded_image_file_tool_return():
+    output = asyncio.run(
+        OpenAIResponsesModel._map_tool_return_output(  # pyright: ignore[reportPrivateUsage]
+            ToolReturnPart(
+                tool_name='get_image',
+                content=[
+                    'Tool returned this image',
+                    UploadedFile(file_id='file-image-456', provider_name='openai', media_type='image/webp'),
+                ],
+                tool_call_id='call_123',
+            )
+        )
+    )
+
+    assert output == [
+        {'type': 'input_text', 'text': 'Tool returned this image'},
+        {'type': 'input_image', 'file_id': 'file-image-456', 'detail': 'auto'},
+    ]


### PR DESCRIPTION
Fixes #5807

## Summary
- map OpenAI Responses `UploadedFile` images to `input_image` instead of `input_file`
- reuse the mapping for user prompts and tool returns
- add focused unit coverage for uploaded image files in both paths

## Tests
- `python -m pytest -p no:cacheprovider -o filterwarnings=ignore tests/models/test_openai_responses_uploaded_file.py -q`