### PR TITLE
fix(openai): merge LiteLLM leading system prompts

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -748,6 +748,9 @@ To use [LiteLLM](https://www.litellm.ai/), set the configs as outlined in the [d
 
 To use custom LLMs, use `custom/` prefix in the model name.
 
+`LiteLLMProvider` merges consecutive leading system messages by default, which is required by stricter
+OpenAI-compatible backends such as some vLLM deployments.
+
 Once you have the configs, use the [`LiteLLMProvider`][pydantic_ai.providers.litellm.LiteLLMProvider] as follows:
 
 ```python

--- a/pydantic_ai_slim/pydantic_ai/providers/litellm.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/litellm.py
@@ -78,9 +78,15 @@ class LiteLLMProvider(Provider[AsyncOpenAI]):
         if profile is None:
             profile = openai_model_profile(model_name)
 
-        # As LiteLLMProvider is used with OpenAIModel, which uses OpenAIJsonSchemaTransformer,
-        # we maintain that behavior
-        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+        # LiteLLM often fronts strict OpenAI-compatible backends such as vLLM,
+        # which reject multiple leading system messages.
+        profile = OpenAIModelProfile.from_profile(profile)
+        return profile.update(
+            OpenAIModelProfile(
+                json_schema_transformer=OpenAIJsonSchemaTransformer,
+                openai_chat_supports_multiple_system_messages=False,
+            )
+        )
 
     @overload
     def __init__(

--- a/tests/providers/test_litellm.py
+++ b/tests/providers/test_litellm.py
@@ -57,6 +57,7 @@ def test_model_profile_returns_openai_compatible_profile(mocker: MockerFixture):
     # Verify the returned profile is an OpenAIModelProfile with OpenAIJsonSchemaTransformer
     assert isinstance(profile, OpenAIModelProfile)
     assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    assert profile.openai_chat_supports_multiple_system_messages is False
 
 
 def test_model_profile_with_different_models(mocker: MockerFixture):
@@ -95,6 +96,7 @@ def test_model_profile_with_different_models(mocker: MockerFixture):
         profile = provider.model_profile(model)
         assert isinstance(profile, OpenAIModelProfile)
         assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+        assert profile.openai_chat_supports_multiple_system_messages is False
 
     # Verify openai_model_profile was called for each model without prefix
     assert mock_profiles['openai'].call_count == len(models_without_prefix)
@@ -126,6 +128,7 @@ def test_model_profile_with_different_models(mocker: MockerFixture):
         profile = provider.model_profile(model_name)
         assert isinstance(profile, OpenAIModelProfile)
         assert profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+        assert profile.openai_chat_supports_multiple_system_messages is False
         # Verify the correct profile function was called with the correct suffix
         mock_profiles[expected_profile].assert_called_with(expected_suffix)
         mock_profiles[expected_profile].reset_mock()


### PR DESCRIPTION
## Summary

Fixes #5812.

`LiteLLMProvider` is commonly used in front of strict OpenAI-compatible servers such as vLLM. Those servers can reject requests that start with more than one `system` message, which happens when ordinary agent instructions are combined with extra `PromptedOutput` instructions.

The OpenAI model already has the correct compatibility path via `openai_chat_supports_multiple_system_messages=False`; this changes the LiteLLM provider profile to use that path by default and documents the behavior in the LiteLLM section.

## Validation

```text
PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run pytest tests/providers/test_litellm.py -q
PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run ruff check pydantic_ai_slim/pydantic_ai/providers/litellm.py tests/providers/test_litellm.py
PYTHONUTF8=1 PYTHONIOENCODING=utf-8 uv run ruff format --check pydantic_ai_slim/pydantic_ai/providers/litellm.py tests/providers/test_litellm.py
python -m py_compile pydantic_ai_slim/pydantic_ai/providers/litellm.py tests/providers/test_litellm.py
git diff --check
```

Note: `PYTHONUTF8=1` is needed in my Windows shell because dependency metadata generation otherwise reads `pyproject.toml` with the local GBK default encoding.
