### PR TITLE
fix(anthropic): guard `message=None` Bedrock start events in stream path

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -976,7 +976,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         # On Bedrock the SDK drops SSE event types, so a leading Bedrock-only chunk
         # (e.g. `amazon-bedrock-invocationMetrics`) is non-validating `construct_type`d
         # into `BetaRawMessageStartEvent(message=None)`. Fall back to the configured model
-        # name rather than dereference `first_chunk.message.model` (issue #5774). The
+        # name rather than dereference `first_chunk.message.model` (https://github.com/pydantic/pydantic-ai/issues/5774). The
         # iterator below skips these `message=None` events.
         model_name = first_chunk.message.model if first_chunk.message is not None else self.model_name  # pyright: ignore[reportUnnecessaryComparison]
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2109,6 +2109,8 @@ def _map_usage(
             # On Bedrock the Anthropic SDK drops SSE event types, so Bedrock-only chunks
             # (e.g. `amazon-bedrock-invocationMetrics`) are non-validating `construct_type`d
             # into `BetaRawMessageStartEvent(message=None)`, violating the type annotation.
+            # The metrics chunk's token counts duplicate the canonical `message_start` /
+            # `message_delta` usage, so dropping them here avoids double-counting.
             return existing_usage or usage.RequestUsage()
         response_usage = message.message.usage
     elif isinstance(message, BetaRawMessageDeltaEvent):

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -973,9 +973,16 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
 
         assert isinstance(first_chunk, BetaRawMessageStartEvent)
 
+        # On Bedrock the SDK drops SSE event types, so a leading Bedrock-only chunk
+        # (e.g. `amazon-bedrock-invocationMetrics`) is non-validating `construct_type`d
+        # into `BetaRawMessageStartEvent(message=None)`. Fall back to the configured model
+        # name rather than dereference `first_chunk.message.model` (issue #5774). The
+        # iterator below skips these `message=None` events.
+        model_name = first_chunk.message.model if first_chunk.message is not None else self.model_name  # pyright: ignore[reportUnnecessaryComparison]
+
         return AnthropicStreamedResponse(
             model_request_parameters=model_request_parameters,
-            _model_name=first_chunk.message.model,
+            _model_name=model_name,
             _response=peekable_response,
             _provider_name=self._provider.name,
             _provider_url=self._provider.base_url,
@@ -2098,6 +2105,11 @@ def _map_usage(
     if isinstance(message, BetaMessage):
         response_usage = message.usage
     elif isinstance(message, BetaRawMessageStartEvent):
+        if message.message is None:  # pyright: ignore[reportUnnecessaryComparison]
+            # On Bedrock the Anthropic SDK drops SSE event types, so Bedrock-only chunks
+            # (e.g. `amazon-bedrock-invocationMetrics`) are non-validating `construct_type`d
+            # into `BetaRawMessageStartEvent(message=None)`, violating the type annotation.
+            return existing_usage or usage.RequestUsage()
         response_usage = message.message.usage
     elif isinstance(message, BetaRawMessageDeltaEvent):
         response_usage = message.usage
@@ -2143,6 +2155,11 @@ class AnthropicStreamedResponse(StreamedResponse):
             builtin_tool_calls: dict[str, NativeToolCallPart] = {}
             async for event in self._response:
                 if isinstance(event, BetaRawMessageStartEvent):
+                    if event.message is None:  # pyright: ignore[reportUnnecessaryComparison]
+                        # See `_map_usage`: Bedrock emits type-less chunks the SDK constructs
+                        # as `BetaRawMessageStartEvent(message=None)`. Skip them entirely so we
+                        # don't dereference `event.message.id` / `.container` below.
+                        continue
                     self._usage = _map_usage(event, self._provider_name, self._provider_url, self._model_name)
                     self.provider_response_id = event.message.id
                     if event.message.container:

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -4448,7 +4448,7 @@ def test_streaming_usage():
 def test_map_usage_bedrock_start_event_without_message():
     """On Bedrock the SDK drops SSE event types, so Bedrock-only chunks are non-validating
     `construct_type`d into `BetaRawMessageStartEvent(message=None)`, violating the annotation.
-    `_map_usage` must not dereference `message.message.usage` on such events (issue #5774).
+    `_map_usage` must not dereference `message.message.usage` on such events (https://github.com/pydantic/pydantic-ai/issues/5774).
 
     A unit test rather than VCR: the `message=None` event is an SDK construct artifact, not a
     server response shape, so it can't be elicited from a recorded request.
@@ -4462,7 +4462,7 @@ def test_map_usage_bedrock_start_event_without_message():
 
 
 async def test_streaming_bedrock_start_event_without_message_is_skipped(allow_model_requests: None):
-    """A Bedrock `message=None` start event must be skipped across the whole streaming path (issue #5774).
+    """A Bedrock `message=None` start event must be skipped across the whole streaming path (https://github.com/pydantic/pydantic-ai/issues/5774).
 
     On Bedrock the SDK drops SSE event types, so Bedrock-only chunks (e.g. `amazon-bedrock-invocationMetrics`)
     are non-validating `construct_type`d into `BetaRawMessageStartEvent(message=None)`. Driving `run_stream`

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -4449,6 +4449,9 @@ def test_map_usage_bedrock_start_event_without_message():
     """On Bedrock the SDK drops SSE event types, so Bedrock-only chunks are non-validating
     `construct_type`d into `BetaRawMessageStartEvent(message=None)`, violating the annotation.
     `_map_usage` must not dereference `message.message.usage` on such events (issue #5774).
+
+    A unit test rather than VCR: the `message=None` event is an SDK construct artifact, not a
+    server response shape, so it can't be elicited from a recorded request.
     """
     # `model_construct` skips validation, mirroring the SDK's `construct_type` on Bedrock.
     start = BetaRawMessageStartEvent.model_construct(type='message_start', message=None)
@@ -4459,9 +4462,15 @@ def test_map_usage_bedrock_start_event_without_message():
 
 
 async def test_streaming_bedrock_start_event_without_message_is_skipped(allow_model_requests: None):
-    """The non-streaming Bedrock fallback iterates the stream and previously crashed on
-    `event.message.id` for the type-less `BetaRawMessageStartEvent(message=None)` chunk.
-    The iterator must skip these events entirely (issue #5774).
+    """A Bedrock `message=None` start event must be skipped across the whole streaming path (issue #5774).
+
+    On Bedrock the SDK drops SSE event types, so Bedrock-only chunks (e.g. `amazon-bedrock-invocationMetrics`)
+    are non-validating `construct_type`d into `BetaRawMessageStartEvent(message=None)`. Driving `run_stream`
+    exercises `_process_streamed_response` and `AnthropicStreamedResponse._get_event_iterator`, which
+    previously crashed on `event.message.id`. The malformed chunk is placed first — a constructed worst case
+    (real Bedrock trails the metrics chunk) that also reaches the `_process_streamed_response` model-name
+    fallback: the streamed response then reports the configured model id, while usage and response id come
+    from the real `message_start` that follows.
     """
     stream: list[MockRawMessageStreamEvent] = [
         # Contract-violating Bedrock chunk: the SDK hands out `message=None`.
@@ -4484,9 +4493,18 @@ async def test_streaming_bedrock_start_event_without_message_is_skipped(allow_mo
 
     async with agent.run_stream('hello') as result:
         output = await result.get_output()
-    # The run completes instead of raising `AttributeError: 'NoneType' object has no attribute 'id'`,
-    # and the skipped event contributes no usage / no response id.
     assert output == snapshot('hello')
+
+    # The skipped `message=None` chunk contributes no usage and no response id: usage comes from the
+    # real `message_start` (input) + `message_delta` (output), and the id from the real event. The model
+    # name falls back to the configured id because the peeked-first chunk carried no `message.model`.
+    response = result.all_messages()[-1]
+    assert isinstance(response, ModelResponse)
+    assert response.usage == snapshot(
+        RequestUsage(input_tokens=4, output_tokens=2, details={'input_tokens': 4, 'output_tokens': 2})
+    )
+    assert response.provider_response_id == 'x'
+    assert response.model_name == 'claude-haiku-4-5'
 
 
 def test_streaming_usage_with_compaction():

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -4445,6 +4445,50 @@ def test_streaming_usage():
     )
 
 
+def test_map_usage_bedrock_start_event_without_message():
+    """On Bedrock the SDK drops SSE event types, so Bedrock-only chunks are non-validating
+    `construct_type`d into `BetaRawMessageStartEvent(message=None)`, violating the annotation.
+    `_map_usage` must not dereference `message.message.usage` on such events (issue #5774).
+    """
+    # `model_construct` skips validation, mirroring the SDK's `construct_type` on Bedrock.
+    start = BetaRawMessageStartEvent.model_construct(type='message_start', message=None)
+    assert _map_usage(start, 'anthropic', '', 'unknown') == snapshot(RequestUsage())
+
+    existing = RequestUsage(input_tokens=7, output_tokens=3)
+    assert _map_usage(start, 'anthropic', '', 'unknown', existing_usage=existing) == existing
+
+
+async def test_streaming_bedrock_start_event_without_message_is_skipped(allow_model_requests: None):
+    """The non-streaming Bedrock fallback iterates the stream and previously crashed on
+    `event.message.id` for the type-less `BetaRawMessageStartEvent(message=None)` chunk.
+    The iterator must skip these events entirely (issue #5774).
+    """
+    stream: list[MockRawMessageStreamEvent] = [
+        # Contract-violating Bedrock chunk: the SDK hands out `message=None`.
+        BetaRawMessageStartEvent.model_construct(type='message_start', message=None),
+        BetaRawMessageStartEvent(message=anth_msg(BetaUsage(input_tokens=4, output_tokens=0)), type='message_start'),
+        BetaRawContentBlockStartEvent(
+            content_block=BetaTextBlock(text='hello', type='text'), index=0, type='content_block_start'
+        ),
+        BetaRawContentBlockStopEvent(index=0, type='content_block_stop'),
+        BetaRawMessageDeltaEvent(
+            delta=Delta(stop_reason='end_turn'),
+            usage=BetaMessageDeltaUsage(output_tokens=2),
+            type='message_delta',
+        ),
+        BetaRawMessageStopEvent(type='message_stop'),
+    ]
+    mock_client = MockAnthropic.create_stream_mock(stream)
+    m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('hello') as result:
+        output = await result.get_output()
+    # The run completes instead of raising `AttributeError: 'NoneType' object has no attribute 'id'`,
+    # and the skipped event contributes no usage / no response id.
+    assert output == snapshot('hello')
+
+
 def test_streaming_usage_with_compaction():
     """Delta events don't carry the `iterations` array, so the fixed compaction totals set
     by the start event must survive the merge and still be summed into the final totals."""


### PR DESCRIPTION
## Summary

- Guards the three `BetaRawMessageStartEvent(message=None)` dereference sites that crash Anthropic-on-Bedrock streaming.
- A non-streaming Bedrock call with high `max_tokens` no longer dies with `AttributeError: 'NoneType' object has no attribute ...`.

## Motivation

Closes #5774.

On Bedrock (`AsyncAnthropicBedrock` via `AnthropicProvider`), the Anthropic SDK's stream decoder drops SSE event types, so Bedrock-only chunks like `amazon-bedrock-invocationMetrics` are constructed via non-validating `construct_type` into `BetaRawMessageStartEvent(message=None)` — violating the type annotation. pydantic-ai is the first consumer to dereference them.

This surfaces in a non-obvious way: a *non-streaming* `model.request()` with `max_tokens` above the SDK threshold (~21.3k) trips the SDK's "Streaming is required" guard, which pydantic-ai catches and falls back to internal streaming (the #4491 fix). On Anthropic-direct that's fine; on Bedrock the fallback walks straight into the broken `message=None` events.

## Root cause

The same contract-violating start event is dereferenced at **three** sites in `models/anthropic.py`:

1. `_process_streamed_response` — `first_chunk.message.model` (crashes during stream setup if the *first* chunk is the type-less Bedrock metrics event).
2. `_map_usage` — `message.message.usage`.
3. `AnthropicStreamedResponse._get_event_iterator` — `event.message.id` / `event.message.container`.

## Fix

- `_process_streamed_response`: fall back to the configured `self.model_name` when `first_chunk.message is None` (the leading Bedrock chunk carries no model name; the iterator skips it anyway).
- `_map_usage`: return `existing_usage or RequestUsage()` instead of dereferencing `.usage`.
- `_get_event_iterator`: `continue` past the event before touching `.id` / `.container`.

The SDK violates its own type annotation here (`message` is declared required, non-`None`), so each guard carries `# pyright: ignore[reportUnnecessaryComparison]` with a comment, matching the codebase's existing convention for SDK-contract-violation guards.

## Tests

Two regression tests in `tests/models/test_anthropic.py`, using `BetaRawMessageStartEvent.model_construct(message=None)` to mirror the SDK's `construct_type` on Bedrock:

- `test_map_usage_bedrock_start_event_without_message` — direct `_map_usage` unit assertion (existing + empty usage paths).
- `test_streaming_bedrock_start_event_without_message_is_skipped` — drives the full streaming path via the mock client with a leading `message=None` chunk; the run completes instead of raising.

## Verification

- `uv run pytest tests/models/test_anthropic.py` — 233 passed
- `uv run ruff check` / `ruff format --check` — clean
- `uv run pyright pydantic_ai_slim/pydantic_ai/models/anthropic.py tests/models/test_anthropic.py` — 0 errors
- `uv run mypy` — clean

## Relationship to prior PRs

#5787 (@xlyoung) was identified by the maintainer as the correct two-site approach but was auto-closed as a duplicate of #5786 (@Oxygen56), which was then closed for being incomplete (only `_map_usage` guarded) and bundling unrelated changes. Neither landed; #5774 currently has no open PR.

This PR is scoped to #5774 only, adds the regression test the maintainer asked for, and additionally guards the **third** dereference site (`first_chunk.message.model` in `_process_streamed_response`) — surfaced by the full-streaming-path regression test and not covered by either prior PR.
