### PR TITLE
fix(anthropic): cap thinking budget below max tokens

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -657,7 +657,11 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         profile = AnthropicModelProfile.from_profile(self.profile)
         if profile.anthropic_supports_adaptive_thinking:
             return {'type': 'adaptive'}
-        return {'type': 'enabled', 'budget_tokens': ANTHROPIC_THINKING_BUDGET_MAP[thinking]}
+        budget_tokens = ANTHROPIC_THINKING_BUDGET_MAP[thinking]
+        max_tokens = model_settings.get('max_tokens', 4096)
+        if max_tokens is not None and max_tokens > 0:
+            budget_tokens = min(budget_tokens, max_tokens - 1)
+        return {'type': 'enabled', 'budget_tokens': budget_tokens}
 
     @overload
     async def _messages_create(

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -194,18 +194,25 @@ class TestAnthropicThinkingTranslation:
         assert result == snapshot({'type': 'adaptive'})
 
     def test_thinking_true_non_adaptive(self, non_adaptive_model: FunctionModel):
-        """thinking=True with non-adaptive model -> {'type': 'enabled', 'budget_tokens': 10000}."""
+        """thinking=True is capped below the default max_tokens."""
         params = ModelRequestParameters(thinking=True)
         settings: ModelSettings = {}
         result = AnthropicModel._translate_thinking(non_adaptive_model, settings, params)
-        assert result == snapshot({'type': 'enabled', 'budget_tokens': 10000})
+        assert result == snapshot({'type': 'enabled', 'budget_tokens': 4095})
 
     def test_thinking_high_non_adaptive(self, non_adaptive_model: FunctionModel):
-        """thinking='high' with non-adaptive -> budget_tokens=16384."""
+        """thinking='high' is capped below the default max_tokens."""
         params = ModelRequestParameters(thinking='high')
         settings: ModelSettings = {}
         result = AnthropicModel._translate_thinking(non_adaptive_model, settings, params)
-        assert result == snapshot({'type': 'enabled', 'budget_tokens': 16384})
+        assert result == snapshot({'type': 'enabled', 'budget_tokens': 4095})
+
+    def test_non_adaptive_budget_stays_below_max_tokens(self, non_adaptive_model: FunctionModel):
+        """Anthropic rejects budget_tokens >= max_tokens."""
+        params = ModelRequestParameters(thinking='high')
+        settings: ModelSettings = {'max_tokens': 2048}
+        result = AnthropicModel._translate_thinking(non_adaptive_model, settings, params)
+        assert result == snapshot({'type': 'enabled', 'budget_tokens': 2047})
 
     def test_thinking_low_non_adaptive(self, non_adaptive_model: FunctionModel):
         """thinking='low' with non-adaptive -> budget_tokens=2048."""
@@ -234,6 +241,12 @@ class TestAnthropicThinkingTranslation:
         settings = {'anthropic_thinking': {'type': 'disabled'}}
         result = AnthropicModel._translate_thinking(adaptive_model, settings, params)
         assert result == snapshot({'type': 'disabled'})
+
+    def test_provider_specific_thinking_budget_is_not_clamped(self, non_adaptive_model: FunctionModel):
+        params = ModelRequestParameters(thinking=True)
+        settings = {'max_tokens': 2048, 'anthropic_thinking': {'type': 'enabled', 'budget_tokens': 3000}}
+        result = AnthropicModel._translate_thinking(non_adaptive_model, settings, params)
+        assert result == snapshot({'type': 'enabled', 'budget_tokens': 3000})
 
     def test_effort_level_on_output_config(self):
         """thinking='high' sets effort on output_config when model supports it."""


### PR DESCRIPTION
## What changed

- Cap Anthropic unified-thinking `budget_tokens` below the request `max_tokens` for non-adaptive profiles.
- Preserve explicit `anthropic_thinking` unchanged, since that is already provider-specific user intent.
- Update thinking translation tests for the default max-token path and an explicit small `max_tokens` regression case.

This prevents requests like `thinking=True, max_tokens=4096` from emitting `budget_tokens=10000`, which violates Anthropic-style `budget_tokens < max_tokens` validation on Anthropic-compatible endpoints.

Fixes #5445

## To verify

- `$env:PYTHONPATH=(Resolve-Path .\pydantic_ai_slim).Path; python -m pytest tests\test_thinking.py -k "AnthropicThinkingTranslation" -q --basetemp .tmp\pytest`
- `$env:PYTHONPATH=(Resolve-Path .\pydantic_ai_slim).Path; python -m pytest tests\test_thinking.py -q --basetemp .tmp\pytest`
- `$env:PYTHONPATH=(Resolve-Path .\pydantic_ai_slim).Path; python -m py_compile pydantic_ai_slim\pydantic_ai\models\anthropic.py tests\test_thinking.py`
- `python -m ruff check pydantic_ai_slim\pydantic_ai\models\anthropic.py tests\test_thinking.py`
- `git diff --check`
