### PR TITLE
fix(openai): map uploaded image files for responses

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3083,12 +3083,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                             f'UploadedFile with `provider_name={item.provider_name!r}` cannot be used with OpenAIResponsesModel. '
                             f'Expected `provider_name` to be `{self.system!r}`.'
                         )
-                    content.append(
-                        responses.ResponseInputFileParam(
-                            type='input_file',
-                            file_id=item.file_id,
-                        )
-                    )
+                    content.append(OpenAIResponsesModel._map_uploaded_file_to_response_content(item))
                 elif isinstance(item, CachePoint):
                     pass
                 elif is_multi_modal_content(item):
@@ -3096,6 +3091,24 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                 else:
                     raise RuntimeError(f'Unsupported content type: {type(item)}')  # pragma: no cover
         return responses.EasyInputMessageParam(role='user', content=content)
+
+    @staticmethod
+    def _map_uploaded_file_to_response_content(
+        item: UploadedFile,
+    ) -> ResponseInputImageContentParam | ResponseInputFileContentParam:
+        if item.media_type.startswith('image/'):
+            detail: Literal['auto', 'low', 'high'] = 'auto'
+            if metadata := item.vendor_metadata:
+                detail = metadata.get('detail', 'auto')
+            return ResponseInputImageContentParam(
+                type='input_image',
+                file_id=item.file_id,
+                detail=detail,
+            )
+        return ResponseInputFileContentParam(
+            type='input_file',
+            file_id=item.file_id,
+        )
 
     @staticmethod
     async def _map_file_to_response_content(
@@ -3170,12 +3183,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
 
         for item in part.content_items(mode='str'):
             if isinstance(item, UploadedFile):
-                output.append(
-                    ResponseInputFileContentParam(
-                        type='input_file',
-                        file_id=item.file_id,
-                    )
-                )
+                output.append(OpenAIResponsesModel._map_uploaded_file_to_response_content(item))
             elif is_multi_modal_content(item):
                 output.append(await OpenAIResponsesModel._map_file_to_response_content(item, 'tool returns'))  # pyright: ignore[reportArgumentType]
             elif isinstance(item, str):  # pragma: no branch

--- a/tests/models/test_multimodal_tool_returns.py
+++ b/tests/models/test_multimodal_tool_returns.py
@@ -943,6 +943,16 @@ async def test_uploaded_file_validation_error_in_tool_return(
         assert_never(provider)  # pyright: ignore[reportArgumentType]
 
 
+@pytest.mark.skipif(not openai_available(), reason='openai dependencies not installed')
+async def test_openai_responses_uploaded_image_tool_return_maps_input_image() -> None:
+    file = UploadedFile(file_id='file-img123', provider_name='openai', media_type='image/png')
+    part = ToolReturnPart(tool_name='get_image', content=file, tool_call_id='1')
+
+    output = await OpenAIResponsesModel._map_tool_return_output(part)  # pyright: ignore[reportPrivateUsage]
+
+    assert output == [{'detail': 'auto', 'file_id': 'file-img123', 'type': 'input_image'}]
+
+
 @pytest.mark.skipif(not google_available(), reason='google dependencies not installed')
 async def test_uploaded_file_vertex_valid_gcs_uri() -> None:
     """Test that a valid Vertex UploadedFile with gs:// URI maps correctly."""

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -1834,6 +1834,46 @@ async def test_uploaded_file_responses_model(allow_model_requests: None) -> None
     )
 
 
+async def test_uploaded_image_file_responses_model(allow_model_requests: None) -> None:
+    """Test that UploadedFile image references use Responses input_image parts."""
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+    output_item = ResponseOutputMessage(
+        id='msg_123',
+        type='message',
+        role='assistant',
+        status='completed',
+        content=[ResponseOutputText(text='The image shows a chart.', type='output_text', annotations=[])],
+    )
+    r = response_message([output_item])
+    mock_client = MockOpenAIResponses.create_mock(r)
+    m = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    result = await agent.run(
+        [
+            'What does this image show?',
+            UploadedFile(file_id='file-img123', provider_name='openai', media_type='image/png'),
+        ]
+    )
+
+    assert result.output == 'The image shows a chart.'
+
+    responses_kwargs = get_mock_responses_kwargs(mock_client)[0]
+    input_content = responses_kwargs['input']
+    assert input_content == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'What does this image show?', 'type': 'input_text'},
+                    {'detail': 'auto', 'file_id': 'file-img123', 'type': 'input_image'},
+                ],
+            }
+        ]
+    )
+
+
 async def test_uploaded_file_wrong_provider_chat(allow_model_requests: None) -> None:
     """Test that UploadedFile with wrong provider raises an error in OpenAIChatModel."""
     c = completion_message(


### PR DESCRIPTION
## Summary
- map OpenAI Responses `UploadedFile` images to `input_image` instead of `input_file`
- reuse the same mapping for user prompts and tool-return content
- keep non-image uploaded files on the existing `input_file` path

Fixes #5807.

## To verify
- `python -m py_compile pydantic_ai_slim\pydantic_ai\models\openai.py tests\models\test_openai.py tests\models\test_multimodal_tool_returns.py`
- `PYTHONPATH=pydantic_ai_slim python -m pytest tests\models\test_openai.py -k "uploaded_image_file_responses_model or uploaded_file_responses_model" -q`
- `PYTHONPATH=pydantic_ai_slim python -m pytest tests\models\test_multimodal_tool_returns.py -k openai_responses_uploaded_image_tool_return_maps_input_image -q`
