### PR TITLE
fix: keep capability loader outside tool metadata wrappers

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py
@@ -48,7 +48,7 @@ class SetToolMetadata(AbstractCapability[AgentDepsT]):
         async def _set_metadata(ctx: RunContext[AgentDepsT], tool_defs: list[ToolDefinition]) -> list[ToolDefinition]:
             resolved: list[ToolDefinition] = []
             for td in tool_defs:
-                if await matches_tool_selector(selector, ctx, td):
+                if td.tool_kind is None and await matches_tool_selector(selector, ctx, td):
                     td = replace(td, metadata={**(td.metadata or {}), **metadata})
                 resolved.append(td)
             return resolved

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -2465,6 +2465,43 @@ def test_set_tool_metadata_capability():
     assert td_b.metadata is None or 'code_mode' not in td_b.metadata
 
 
+def test_set_tool_metadata_capability_skips_framework_tools():
+    """Framework-managed tools should not be wrapped by code-mode metadata."""
+    from pydantic_ai.capabilities import Capability, SetToolMetadata
+
+    def visible_tool() -> str:
+        return 'visible'
+
+    hidden_toolset = FunctionToolset[None]()
+
+    @hidden_toolset.tool_plain
+    def hidden_tool() -> str:
+        return 'hidden'
+
+    deferred = Capability[None](
+        id='hidden',
+        description='Hidden tool access.',
+        toolsets=[hidden_toolset],
+        defer_loading=True,
+    )
+    test_model = TestModel(call_tools=[])
+    agent = Agent(
+        test_model,
+        tools=[visible_tool],
+        capabilities=[deferred, SetToolMetadata(code_mode=True)],
+    )
+    agent.run_sync('test')
+
+    params = test_model.last_model_request_parameters
+    assert params is not None
+    tools = {td.name: td for td in params.function_tools}
+
+    assert tools['visible_tool'].metadata is not None
+    assert tools['visible_tool'].metadata['code_mode'] is True
+    assert tools['load_capability'].tool_kind == 'capability-load'
+    assert tools['load_capability'].metadata is None or 'code_mode' not in tools['load_capability'].metadata
+
+
 def test_set_tool_metadata_capability_with_async_selector():
     """SetToolMetadata with async callable selector."""
     from pydantic_ai.capabilities import SetToolMetadata


### PR DESCRIPTION
## Summary

- skip framework-managed tools when applying `SetToolMetadata`
- keep deferred capability loader tools native, even when capability metadata selects all ordinary tools for code mode
- add a regression test proving `load_capability` remains unwrapped while user tools still receive code-mode metadata

Fixes #5798.

## To verify

- `PYTHONPATH=pydantic_ai_slim python -m pytest tests/test_toolsets.py -q -k "set_tool_metadata_capability"`
- `python -m py_compile pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py tests/test_toolsets.py`
- `python -m ruff check pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py tests/test_toolsets.py`
- `python -m ruff format --check pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py tests/test_toolsets.py`
- `git diff --check origin/main..HEAD`
