### PR TITLE
fix: keep capability loader metadata native

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py
@@ -48,7 +48,7 @@ class SetToolMetadata(AbstractCapability[AgentDepsT]):
         async def _set_metadata(ctx: RunContext[AgentDepsT], tool_defs: list[ToolDefinition]) -> list[ToolDefinition]:
             resolved: list[ToolDefinition] = []
             for td in tool_defs:
-                if await matches_tool_selector(selector, ctx, td):
+                if td.tool_kind != 'capability-load' and await matches_tool_selector(selector, ctx, td):
                     td = replace(td, metadata={**(td.metadata or {}), **metadata})
                 resolved.append(td)
             return resolved

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -2852,6 +2852,36 @@ async def test_deferred_capability_partitions_native_tools() -> None:
     assert seen_web_search_tools == snapshot([[], [WebSearchTool()]])
 
 
+async def test_set_tool_metadata_does_not_mark_capability_loader() -> None:
+    seen_metadata: dict[str, dict[str, Any] | None] = {}
+    toolset = FunctionToolset[None]()
+
+    @toolset.tool_plain
+    def demo_tool() -> str:
+        return 'ok'
+
+    deferred = Capability[None](
+        id='demo',
+        description='Demo deferred capability.',
+        toolsets=[toolset],
+        defer_loading=True,
+    )
+
+    def model_fn(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        seen_metadata.update({tool.name: tool.metadata for tool in info.function_tools})
+        return make_text_response('done')
+
+    agent = Agent(FunctionModel(model_fn), capabilities=[deferred, SetToolMetadata(code_mode=True)])
+
+    await agent.run('inspect tools')
+
+    assert seen_metadata[LOAD_CAPABILITY_TOOL_NAME] is None
+    assert seen_metadata['demo_tool'] == {
+        'pydantic_ai_deferred_capability_tool': True,
+        'code_mode': True,
+    }
+
+
 async def test_load_capability_tool_name_conflict_raises() -> None:
     """The framework loader must not be shadowed by a user tool with the same name."""
     toolset = FunctionToolset[None]()


### PR DESCRIPTION
Fixes #5798.

## Summary
- skip framework-managed `capability-load` tools when `SetToolMetadata` applies metadata to selected tools
- add a regression test that keeps `load_capability` native while still marking deferred user tools

## To verify
- `PYTHONPATH=pydantic_ai_slim python -m pytest tests/test_capabilities.py::test_set_tool_metadata_does_not_mark_capability_loader tests/test_capabilities.py::test_load_capability_tool_name_conflict_raises -q`
- `PYTHONPATH=pydantic_ai_slim python -m pytest tests/test_capabilities.py::test_deferred_capability_partitions_native_tools tests/test_capabilities.py::test_deferred_capability_loads_instructions_and_tools_e2e -q`
- `python -m py_compile pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py tests/test_capabilities.py`
- `python -m ruff check pydantic_ai_slim/pydantic_ai/capabilities/set_tool_metadata.py tests/test_capabilities.py`
- `git diff --check`
