### PR TITLE
fix(anthropic): ensure count_tokens preserves replay history and drops native tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -850,12 +850,15 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         if isinstance(self.client, AsyncAnthropicBedrock):
             raise UserError('AsyncAnthropicBedrock client does not support `count_tokens` api.')
 
-        # standalone function to make it easier to override
-        tools, tool_choice = self._prepare_tools_and_tool_choice(model_settings, model_request_parameters)
-        tools, mcp_servers, native_tool_betas = self._add_native_tools(tools, model_request_parameters, model_settings)
-
         auto_cache_control, resolved_cache_ttl = self._build_automatic_cache_control(model_settings)
         system_prompt, anthropic_messages = await self._map_message(messages, model_request_parameters, model_settings)
+
+        # Omit native/server tools from count_tokens payload to avoid API 400 errors,
+        # but only after mapping messages so that history replay formatting is preserved.
+        count_params = replace(model_request_parameters, native_tools=[])
+        tools, tool_choice = self._prepare_tools_and_tool_choice(model_settings, count_params)
+        tools, mcp_servers, native_tool_betas = self._add_native_tools(tools, count_params, model_settings)
+
         self._apply_per_block_caching_fallback(resolved_cache_ttl, anthropic_messages)
         self._apply_explicit_message_caching(model_settings, anthropic_messages)
         self._limit_cache_points(

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -10630,9 +10630,10 @@ async def test_anthropic_count_tokens_omits_native_tools(allow_model_requests: N
             parts=[
                 ToolSearchReturnPart(
                     tool_name='search_tools',
-                    content=[{'name': 'my_tool'}],
-                    discovered_tools=[{'name': 'my_tool', 'description': ''}],
-                    message='Found 1 tool',
+                    content={
+                        'discovered_tools': [{'name': 'my_tool', 'description': ''}],
+                        'message': 'Found 1 tool',
+                    },
                 )
             ]
         ),

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -10625,33 +10625,40 @@ async def test_anthropic_count_tokens_omits_native_tools(allow_model_requests: N
     )
 
     messages = [
-        ModelResponse(parts=[TextPart(content="Hello")]),
-        ModelRequest(parts=[
-            ToolSearchReturnPart(
-                tool_name='search_tools',
-                content=[{'name': 'my_tool'}],
-                discovered_tools=[{'name': 'my_tool', 'description': ''}],
-                message='Found 1 tool',
-            )
-        ])
+        ModelResponse(parts=[TextPart(content='Hello')]),
+        ModelRequest(
+            parts=[
+                ToolSearchReturnPart(
+                    tool_name='search_tools',
+                    content=[{'name': 'my_tool'}],
+                    discovered_tools=[{'name': 'my_tool', 'description': ''}],
+                    message='Found 1 tool',
+                )
+            ]
+        ),
     ]
 
     await m.count_tokens(messages, None, params)
 
-    assert len(mock_client.chat_completion_kwargs) == 1  # type: ignore
-    req = mock_client.chat_completion_kwargs[0]  # type: ignore
+    assert len(mock_client.chat_completion_kwargs) == 1  # pyright: ignore
+    req = cast('dict[str, Any]', mock_client.chat_completion_kwargs[0])  # pyright: ignore
 
     # Server tools should be omitted
     assert 'tools' in req
-    assert len(req['tools']) == 1
-    assert req['tools'][0]['name'] == 'my_tool'
+    tools_payload = cast('list[dict[str, Any]]', req['tools'])
+    assert len(tools_payload) == 1
+    assert tools_payload[0]['name'] == 'my_tool'
 
     # Messages array should preserve the tool_reference block serialization
     assert 'messages' in req
-    assert len(req['messages']) == 2
-    tool_result_content = req['messages'][1]['content'][0]
+    messages_payload = cast('list[dict[str, Any]]', req['messages'])
+    assert len(messages_payload) == 2
+    
+    content_payload = cast('list[dict[str, Any]]', messages_payload[1]['content'])
+    tool_result_content = content_payload[0]
     assert tool_result_content['type'] == 'tool_reference'
     assert tool_result_content['tool_name'] == 'my_tool'
+
 
 @pytest.mark.vcr()
 async def test_anthropic_count_tokens_error(allow_model_requests: None, anthropic_api_key: str):

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -10609,6 +10609,50 @@ async def test_anthropic_count_tokens_with_no_messages(allow_model_requests: Non
     assert result.input_tokens == 10
 
 
+async def test_anthropic_count_tokens_omits_native_tools(allow_model_requests: None):
+    """Test that count_tokens omits native tools but preserves tool_reference block."""
+    from pydantic_ai.messages import ToolSearchReturnPart
+    from pydantic_ai.tools import ToolDefinition
+    from pydantic_ai.native_tools import CodeExecutionTool
+    from pydantic_ai.native_tools._tool_search import ToolSearchTool
+
+    mock_client = cast(AsyncAnthropic, MockAnthropic())
+    m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    params = ModelRequestParameters(
+        function_tools=[ToolDefinition(name='my_tool', description='', parameters_json_schema={})],
+        native_tools=[CodeExecutionTool(), ToolSearchTool()],
+    )
+
+    messages = [
+        ModelResponse(parts=[TextPart(content="Hello")]),
+        ModelRequest(parts=[
+            ToolSearchReturnPart(
+                tool_name='search_tools',
+                content=[{'name': 'my_tool'}],
+                discovered_tools=[{'name': 'my_tool', 'description': ''}],
+                message='Found 1 tool',
+            )
+        ])
+    ]
+
+    await m.count_tokens(messages, None, params)
+
+    assert len(mock_client.chat_completion_kwargs) == 1  # type: ignore
+    req = mock_client.chat_completion_kwargs[0]  # type: ignore
+
+    # Server tools should be omitted
+    assert 'tools' in req
+    assert len(req['tools']) == 1
+    assert req['tools'][0]['name'] == 'my_tool'
+
+    # Messages array should preserve the tool_reference block serialization
+    assert 'messages' in req
+    assert len(req['messages']) == 2
+    tool_result_content = req['messages'][1]['content'][0]
+    assert tool_result_content['type'] == 'tool_reference'
+    assert tool_result_content['tool_name'] == 'my_tool'
+
 @pytest.mark.vcr()
 async def test_anthropic_count_tokens_error(allow_model_requests: None, anthropic_api_key: str):
     """Test that errors convert to ModelHTTPError."""


### PR DESCRIPTION
- Addresses #5702 (Replaces inactive PR #5704 which introduces the #5780 regression)
- Closes #5780

### Summary

- Fixes the Anthropic token counting payload to omit native/server tools (which fixes API 400 errors).
- Defers native tool removal until after message mapping completes, which fixes an issue where the \ToolSearch\ replay history was diverging from the real execution payload by incorrectly serializing as plain text.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).