### PR TITLE
fix(anthropic): skip Bedrock `message_start` events with `message=None`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2098,6 +2098,12 @@ def _map_usage(
     if isinstance(message, BetaMessage):
         response_usage = message.usage
     elif isinstance(message, BetaRawMessageStartEvent):
+        # On Bedrock the Anthropic SDK drops SSE event types, so Bedrock-only chunks (e.g.
+        # `amazon-bedrock-invocationMetrics`) are non-validatingly constructed as a
+        # `BetaRawMessageStartEvent` with `message=None`. Treat those as carrying no usage.
+        # The SDK types `message` as non-optional, but the Bedrock events violate that contract.
+        if message.message is None:  # pyright: ignore[reportUnnecessaryComparison]
+            return existing_usage or usage.RequestUsage()
         response_usage = message.message.usage
     elif isinstance(message, BetaRawMessageDeltaEvent):
         response_usage = message.usage
@@ -2143,6 +2149,10 @@ class AnthropicStreamedResponse(StreamedResponse):
             builtin_tool_calls: dict[str, NativeToolCallPart] = {}
             async for event in self._response:
                 if isinstance(event, BetaRawMessageStartEvent):
+                    # See `_map_usage`: Bedrock emits message_start events with `message=None`,
+                    # which carry no usage or response id to extract.
+                    if event.message is None:  # pyright: ignore[reportUnnecessaryComparison]
+                        continue
                     self._usage = _map_usage(event, self._provider_name, self._provider_url, self._model_name)
                     self.provider_response_id = event.message.id
                     if event.message.container:

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -86,6 +86,7 @@ with try_import() as imports_successful:
         AsyncStream,
         omit as OMIT,
     )
+    from anthropic._models import construct_type
     from anthropic.lib.tools import BetaAbstractMemoryTool
     from anthropic.resources.beta import AsyncBeta
     from anthropic.types.beta import (
@@ -10953,6 +10954,95 @@ async def test_anthropic_container_id_from_stream_response(allow_model_requests:
     assert model_response.provider_details is not None
     assert model_response.provider_details.get('container_id') == 'container_from_stream'
     assert model_response.provider_details.get('finish_reason') == 'end_turn'
+
+
+async def test_anthropic_bedrock_message_start_without_message(allow_model_requests: None):
+    """Bedrock emits `message_start` events with `message=None` and PAI must not crash on them.
+
+    The Anthropic SDK's stream decoder drops SSE event types on Bedrock, so Bedrock-only chunks
+    (e.g. `amazon-bedrock-invocationMetrics`) are built via non-validating `construct_type` into a
+    `BetaRawMessageStartEvent` whose `message` is `None` — violating the type. This can't be a VCR
+    test because no recorded Anthropic-direct stream produces the malformed event; we construct it
+    the same way the SDK does. The empty event (here trailing the stream, as Bedrock emits it) must
+    be skipped without crashing or contributing usage, while the real `message_start` still drives
+    the output, usage, and response id.
+    """
+    empty_metric_event = construct_type(
+        value={'amazon-bedrock-invocationMetrics': {'inputTokenCount': 1}},
+        type_=BetaRawMessageStreamEvent,
+    )
+    assert isinstance(empty_metric_event, BetaRawMessageStartEvent)
+    assert empty_metric_event.message is None
+
+    # The Bedrock metric event arrives at the end of the stream, after a normal `message_start`.
+    stream_events: list[BetaRawMessageStreamEvent] = [
+        BetaRawMessageStartEvent(
+            type='message_start',
+            message=BetaMessage(
+                id='msg_123',
+                content=[],
+                model='claude-3-5-haiku-123',
+                role='assistant',
+                stop_reason=None,
+                type='message',
+                usage=BetaUsage(input_tokens=5, output_tokens=0),
+            ),
+        ),
+        BetaRawContentBlockStartEvent(
+            type='content_block_start',
+            index=0,
+            content_block=BetaTextBlock(text='', type='text'),
+        ),
+        BetaRawContentBlockDeltaEvent(
+            type='content_block_delta',
+            index=0,
+            delta=BetaTextDelta(type='text_delta', text='hello'),
+        ),
+        BetaRawContentBlockStopEvent(type='content_block_stop', index=0),
+        BetaRawMessageDeltaEvent(
+            type='message_delta',
+            delta=Delta(stop_reason='end_turn', stop_sequence=None),
+            usage=BetaMessageDeltaUsage(output_tokens=5),
+        ),
+        BetaRawMessageStopEvent(type='message_stop'),
+        empty_metric_event,
+    ]
+
+    mock_client = MockAnthropic.create_stream_mock(stream_events)
+    m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('hello') as result:
+        assert await result.get_output() == 'hello'
+
+    model_response = result.all_messages()[-1]
+    assert isinstance(model_response, ModelResponse)
+    assert model_response.provider_response_id == 'msg_123'
+    assert model_response.usage == snapshot(
+        RequestUsage(input_tokens=5, output_tokens=5, details={'input_tokens': 5, 'output_tokens': 5})
+    )
+
+
+def test_map_usage_ignores_bedrock_message_start_without_message():
+    """`_map_usage` defends against the Bedrock `message=None` start event directly.
+
+    The streaming iterator skips these events before `_map_usage` sees them, so this branch isn't
+    reachable through the public API — but `_map_usage` still guards its own contract against the
+    SDK's non-validating `construct_type` output (#5774), returning the existing usage (or an empty
+    one) rather than dereferencing the missing message.
+    """
+    empty_metric_event = construct_type(
+        value={'amazon-bedrock-invocationMetrics': {'inputTokenCount': 1}},
+        type_=BetaRawMessageStreamEvent,
+    )
+    assert isinstance(empty_metric_event, BetaRawMessageStartEvent)
+
+    assert _map_usage(empty_metric_event, 'anthropic', 'https://example.invalid', 'claude-haiku-4-5') == RequestUsage()
+
+    existing = RequestUsage(input_tokens=7, output_tokens=3)
+    assert (
+        _map_usage(empty_metric_event, 'anthropic', 'https://example.invalid', 'claude-haiku-4-5', existing) == existing
+    )
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
- Closes #5774

## Problem

On Bedrock (`AsyncAnthropicBedrock` via `AnthropicProvider`), the Anthropic SDK's stream decoder drops SSE event types, so Bedrock-only chunks like `amazon-bedrock-invocationMetrics` are built via non-validating `construct_type` as `BetaRawMessageStartEvent(message=None)` — violating the SDK's own type, which declares `message` non-optional.

`AnthropicStreamedResponse._get_event_iterator` then crashed with `AttributeError: 'NoneType' object has no attribute 'id'` when dereferencing `event.message.id` / `event.message.container`. This also bites **non-streaming** calls: a high `max_tokens` trips the SDK's "Streaming is required" guard, which `AnthropicModel.request` catches and transparently falls back to internal streaming (#4491) — walking straight into the malformed events.

## Fix

- Skip `BetaRawMessageStartEvent`s with `message is None` in `_get_event_iterator` before extracting usage / response id — the load-bearing guard for the real Bedrock path.
- Guard `_map_usage` against the missing message too, so the helper defends its own contract against the SDK's contract-violating output.

Both `is None` checks carry a scoped `# pyright: ignore[reportUnnecessaryComparison]` because the SDK stubs type `message` as non-optional — that's precisely the contract Bedrock violates at runtime.

## Tests

- `test_anthropic_bedrock_message_start_without_message` — drives `agent.run_stream` through a mock Bedrock stream with a trailing `message=None` metric event (constructed the same way the SDK does), asserting no crash and correct output / usage / response id.
- `test_map_usage_ignores_bedrock_message_start_without_message` — unit test for the `_map_usage` guard branch, which the iterator skips before reaching (so it isn't reachable via the public API).

## Credit

The complete two-site diagnosis and fix came from @xlyoung in #5787, which our automated dedup bot closed in favor of an incomplete PR. Credited as co-author.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)