### PR TITLE
feat(groq): forward thinking level as reasoning_effort via extra_body

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -48,7 +48,7 @@ from ..native_tools import AbstractNativeTool, WebSearchTool
 from ..profiles import ModelProfile, ModelProfileSpec
 from ..profiles.groq import GroqModelProfile
 from ..providers import Provider, infer_provider
-from ..settings import ModelSettings
+from ..settings import ModelSettings, ThinkingLevel
 from ..tools import ToolDefinition
 from . import (
     Model,
@@ -127,6 +127,17 @@ _FINISH_REASON_MAP: dict[Literal['stop', 'length', 'tool_calls', 'content_filter
     'function_call': 'tool_call',
 }
 
+GROQ_REASONING_EFFORT_MAP: dict[ThinkingLevel, str] = {
+    True: 'default',
+    False: 'none',
+    'minimal': 'low',
+    'low': 'low',
+    'medium': 'medium',
+    'high': 'high',
+    'xhigh': 'high',
+}
+"""Mapping from pydantic-ai ThinkingLevel to Groq reasoning_effort values."""
+
 
 class GroqModelSettings(ModelSettings, total=False):
     """Settings used for a Groq model request."""
@@ -137,6 +148,15 @@ class GroqModelSettings(ModelSettings, total=False):
     """The format of the reasoning output.
 
     See [the Groq docs](https://console.groq.com/docs/reasoning#reasoning-format) for more details.
+    """
+
+    groq_reasoning_effort: Literal['none', 'default', 'low', 'medium', 'high']
+    """The reasoning effort level for Groq reasoning models.
+
+    Controls how much compute the model uses for reasoning. Takes precedence over the
+    generic `thinking` setting when both are specified.
+
+    See [the Groq docs](https://console.groq.com/docs/reasoning) for more details.
     """
 
 
@@ -344,8 +364,21 @@ class GroqModel(Model[AsyncGroq]):
                 frequency_penalty=model_settings.get('frequency_penalty', NOT_GIVEN),
                 logit_bias=model_settings.get('logit_bias', NOT_GIVEN),
                 extra_headers=extra_headers,
-                extra_body=model_settings.get('extra_body'),
+                extra_body=self._build_extra_body(model_settings, model_request_parameters),
             )
+
+    @staticmethod
+    def _build_extra_body(
+        model_settings: ModelSettings,
+        model_request_parameters: ModelRequestParameters,
+    ) -> dict[str, Any] | None:
+        extra_body: dict[str, Any] = dict(model_settings.get('extra_body') or {})
+        if 'reasoning_effort' not in extra_body:
+            if effort := model_settings.get('groq_reasoning_effort'):
+                extra_body['reasoning_effort'] = effort
+            elif (thinking := model_request_parameters.thinking) is not None:
+                extra_body['reasoning_effort'] = GROQ_REASONING_EFFORT_MAP[thinking]
+        return extra_body or None
 
     def _process_response(self, response: chat.ChatCompletion) -> ModelResponse:
         """Process a non-streamed response, and prepare a message to return."""


### PR DESCRIPTION
## Summary

Fixes #5796.

The Groq API exposes a `reasoning_effort` parameter (distinct from `reasoning_format`) that controls how much compute reasoning models spend on a problem. Previously, pydantic-ai's generic `thinking` / `ModelRequestParameters.thinking` setting had no effect on Groq models.

### Changes

- **`GROQ_REASONING_EFFORT_MAP`** — module-level constant mapping every `ThinkingLevel` value (`True/False/minimal/low/medium/high/xhigh`) to the corresponding Groq effort string (`none/default/low/medium/high`).
- **`GroqModelSettings.groq_reasoning_effort`** — new Groq-specific override field (`Literal['none', 'default', 'low', 'medium', 'high']`) following the existing `groq_` prefix convention.
- **`GroqModel._build_extra_body()`** — new static helper that builds the `extra_body` dict with the following priority:
  1. Explicit `reasoning_effort` key already present in user-supplied `extra_body` → unchanged (preserves existing workarounds).
  2. `groq_reasoning_effort` model setting → used directly.
  3. Generic `thinking` on `ModelRequestParameters` → translated via `GROQ_REASONING_EFFORT_MAP`.
  4. Neither set → `extra_body` returned as-is (or `None` if empty).

### Usage

```python
from pydantic_ai import Agent
from pydantic_ai.models.groq import GroqModel, GroqModelSettings

# via generic thinking setting
agent = Agent(GroqModel('deepseek-r1-distill-llama-70b'), model_settings={'thinking': 'high'})

# via groq-specific setting (takes precedence)
agent = Agent(GroqModel('deepseek-r1-distill-llama-70b'), model_settings=GroqModelSettings(groq_reasoning_effort='high'))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)