### PR TITLE
Document snapshot matcher-vs-concrete-value guidance in `tests/AGENTS.md`

### DIFF
--- a/.claude/skills/testing-skill/SKILL.md
+++ b/.claude/skills/testing-skill/SKILL.md
@@ -48,6 +48,15 @@ If tests use [`snapshot()`](https://github.com/15r10nk/inline-snapshot) assertio
 - You only review - don't manually write snapshot contents
 - Snapshots capture what the test actually produced, additional to explicit assertions
 
+## Snapshots: prefer a concrete value over a dirty-equals matcher
+
+When an existing concrete snapshot value changes (re-record, dependency bump, code change), don't reach for a dirty-equals matcher (`IsInt()`, `IsFloat()`, `IsStr()`, `IsDatetime()`, ...) just to make the test green. First ask: **did the concrete value provide stability?** -- would an *unintended* future change to it be a bug this snapshot should catch?
+
+- **Yes -> keep it concrete.** Root-cause the change, then update to the new value with `--inline-snapshot=fix`. Small scalars (token counts, costs, lengths, ids) are the *reason* the snapshot exists -- concreteness is what catches drift; a matcher silently discards that signal. A small value going to `IsInt()` is almost always wrong.
+- **No -> a matcher is fine.** Reserve matchers for genuinely non-deterministic values (timestamps, random request ids, durations) or large opaque noise with no drift signal (a long static base64 blob, an opaque token), where concreteness only adds review burden.
+
+If a value differs only because CI runs two dependency versions (e.g. a lowest-versions shard vs the lock), align the versions and pin the concrete value rather than masking the split with a matcher -- the matcher disables drift detection on that dependency for good.
+
 ## Parsing Cassettes
 
 Parse VCR cassette YAML files to inspect request/response bodies without dealing with raw YAML.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -190,6 +190,15 @@ async def test_something(model: Model):
   ]
   ```
 
+### Matcher vs concrete value
+
+When an existing snapshot value *changes* (re-record, dependency bump, refactor), don't swap the concrete value for a matcher (`IsInt()`, `IsFloat()`, `IsStr()`, ...) just to make the test pass. First ask: did the concrete value provide stability — would an unintended future change to it be a bug this snapshot should catch?
+
+- Yes — keep it concrete. Root-cause the change, then update to the new value with `--inline-snapshot=fix`. Small scalars (token counts, costs, ids) are the *reason* the snapshot exists; concreteness is what catches drift, and a matcher silently discards that signal. A small value becoming `IsInt()` is almost always wrong.
+- No — a matcher is fine. Reserve matchers for genuinely non-deterministic values (timestamps, random request ids, durations) or large opaque noise with no drift signal (a static base64 blob, an opaque token).
+
+If a value differs only because CI runs two dependency versions (a lowest-versions shard vs the lock), align the versions and pin the concrete value rather than masking the split with a matcher — the matcher disables drift detection on that dependency for good.
+
 ## Best Practices
 
 - Test through public APIs, not private methods (prefixed with `_`) or helpers — validates actual user-facing behavior and prevents brittle tests tied to implementation details


### PR DESCRIPTION
<!-- Trivial doc improvement — no issue per the PR template. -->

Adds a decision rule for when a snapshot value should stay a concrete number vs. become a dirty-equals matcher (`IsInt()`, `IsFloat()`, `IsStr()`, ...).

Motivation: when an existing concrete snapshot value changes (after a re-record, dependency bump, or refactor), swapping it for a matcher to make the test pass silently discards the drift-detection signal the snapshot existed to provide. The new guidance frames the call as one question — *did the concrete value provide stability?* — keep small, meaningful scalars (token counts, costs, ids) concrete and root-cause why they changed; reserve matchers for genuinely non-deterministic values (timestamps, random ids) or large opaque noise (a static base64 blob). It also notes that a value differing only because CI runs two dependency versions should be fixed by aligning the versions, not by masking the split with a matcher.

Lands in `tests/AGENTS.md` (the canonical testing-philosophy doc, loaded for every test-writing agent) and the VCR `testing-skill` snapshot-review step.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).