### PR TITLE
Map `seed` and `top_k` ModelSettings for GeminiModel

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/gemini.py
+++ b/pydantic_ai_slim/pydantic_ai/models/gemini.py
@@ -435,10 +435,14 @@ def _settings_to_generation_config(model_settings: GeminiModelSettings) -> _Gemi
         config['temperature'] = temperature
     if (top_p := model_settings.get('top_p')) is not None:
         config['top_p'] = top_p
+    if (top_k := model_settings.get('top_k')) is not None:
+        config['top_k'] = top_k
     if (presence_penalty := model_settings.get('presence_penalty')) is not None:
         config['presence_penalty'] = presence_penalty
     if (frequency_penalty := model_settings.get('frequency_penalty')) is not None:
         config['frequency_penalty'] = frequency_penalty
+    if (seed := model_settings.get('seed')) is not None:
+        config['seed'] = seed
     if (thinkingConfig := model_settings.get('gemini_thinking_config')) is not None:
         config['thinking_config'] = thinkingConfig
     return config
@@ -636,8 +640,10 @@ class _GeminiGenerationConfig(TypedDict, total=False):
     max_output_tokens: int
     temperature: float
     top_p: float
+    top_k: int
     presence_penalty: float
     frequency_penalty: float
+    seed: int
     stop_sequences: list[str]
     thinking_config: ThinkingConfig
     response_mime_type: str

--- a/tests/models/test_gemini.py
+++ b/tests/models/test_gemini.py
@@ -1138,8 +1138,10 @@ async def test_model_settings(client_with_handler: ClientWithHandler, env: TestE
             'max_output_tokens': 1,
             'temperature': 0.1,
             'top_p': 0.2,
+            'top_k': 5,
             'presence_penalty': 0.3,
             'frequency_penalty': 0.4,
+            'seed': 42,
         }
         return httpx.Response(
             200,
@@ -1160,8 +1162,10 @@ async def test_model_settings(client_with_handler: ClientWithHandler, env: TestE
             'max_tokens': 1,
             'temperature': 0.1,
             'top_p': 0.2,
+            'top_k': 5,
             'presence_penalty': 0.3,
             'frequency_penalty': 0.4,
+            'seed': 42,
         },
     )
     assert result.output == 'world'


### PR DESCRIPTION
## Summary

`GeminiModel` (the Gemini GLA API backend) silently ignores the `seed` and `top_k` model settings. `_settings_to_generation_config` maps `temperature`, `top_p`, `presence_penalty`, `frequency_penalty`, etc., but never `seed` or `top_k` — so a user who sets either on a `GeminiModel` has it dropped without warning.

This is inconsistent with `GoogleModel`, which already forwards both, and with the recent provider-by-provider `seed` support (#2842 added it to `GoogleModel`, #5741 to xAI). The Gemini `generationConfig` supports both `topK` and `seed` ([API docs](https://ai.google.dev/api/generate-content#generationconfig)).

## Change

- Map `top_k` and `seed` in `_settings_to_generation_config`.
- Add the corresponding `top_k` / `seed` fields to `_GeminiGenerationConfig` (whose docstring already notes more fields can be added).
- Extend `test_model_settings` to assert both are forwarded.

No behavior change when the settings are unset (each is only added when present, matching the existing pattern).
