### PR TITLE
fix(ui): preserve loaded capability state in `VercelAIAdapter`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -7,7 +7,7 @@ import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import KW_ONLY, dataclass
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 
 from pydantic import TypeAdapter
 from typing_extensions import assert_never
@@ -35,6 +35,7 @@ from ...messages import (
     TextPart,
     ThinkingPart,
     ToolCallPart,
+    ToolPartKind,
     ToolReturnPart,
     UploadedFile,
     UploadedFileProviderName,
@@ -102,6 +103,7 @@ if TYPE_CHECKING:
 __all__ = ['VercelAIAdapter']
 
 request_data_ta: TypeAdapter[RequestData] = TypeAdapter(RequestData)
+_TOOL_PART_KINDS = frozenset(get_args(ToolPartKind))
 
 
 def _generate_message_id(
@@ -384,6 +386,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                         part_id = provider_meta.get('id')
                         provider_name = provider_meta.get('provider_name')
                         provider_details = provider_meta.get('provider_details')
+                        tool_kind = _load_tool_kind(provider_meta)
 
                         if builtin_tool:
                             # For builtin tools, we need to create 2 parts (BuiltinToolCall & BuiltinToolReturn) for a single Vercel ToolOutput
@@ -441,7 +444,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                                     )
                                 )
                         else:
-                            builder.add(
+                            tool_call_part = ToolCallPart.narrow_type(
                                 ToolCallPart(
                                     tool_name=tool_name,
                                     tool_call_id=tool_call_id,
@@ -449,12 +452,21 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                                     id=part_id,
                                     provider_name=provider_name,
                                     provider_details=provider_details,
-                                )
+                                ),
+                                tool_kind=tool_kind,
                             )
+                            builder.add(tool_call_part)
 
                             if part.state == 'output-available':
                                 builder.add(
-                                    ToolReturnPart(tool_name=tool_name, tool_call_id=tool_call_id, content=part.output)
+                                    ToolReturnPart.narrow_type(
+                                        ToolReturnPart(
+                                            tool_name=tool_name,
+                                            tool_call_id=tool_call_id,
+                                            content=part.output,
+                                        ),
+                                        tool_kind=tool_kind,
+                                    )
                                 )
                             elif part.state == 'output-error':
                                 builder.add(
@@ -700,7 +712,10 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
         """Convert a ToolCallPart (with optional result) into UIMessageParts."""
         tool_result = tool_results.get(part.tool_call_id)
         call_provider_metadata = dump_provider_metadata(
-            id=part.id, provider_name=part.provider_name, provider_details=part.provider_details
+            id=part.id,
+            provider_name=part.provider_name,
+            provider_details=part.provider_details,
+            tool_kind=part.tool_kind,
         )
         tool_type = f'tool-{part.tool_name}'
         ui_parts: list[UIMessagePart] = []
@@ -918,6 +933,11 @@ def _denial_reason(part: ToolUIPart | DynamicToolUIPart) -> str:
     if isinstance(part.approval, ToolApprovalResponded) and part.approval.reason:
         return part.approval.reason
     return ToolDenied().message
+
+
+def _load_tool_kind(provider_meta: dict[str, Any]) -> ToolPartKind | None:
+    tool_kind = provider_meta.get('tool_kind')
+    return cast(ToolPartKind, tool_kind) if tool_kind in _TOOL_PART_KINDS else None
 
 
 def _extract_metadata_ui_parts(tool_result: ToolReturnPart) -> list[UIMessagePart]:

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 import pytest
 
 from pydantic_ai import Agent, capture_run_messages
+from pydantic_ai._deferred_capabilities import parse_loaded_capabilities
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._utils import is_str_dict
 from pydantic_ai.capabilities import NativeTool
@@ -25,6 +26,8 @@ from pydantic_ai.messages import (
     FunctionToolCallEvent,
     FunctionToolResultEvent,
     ImageUrl,
+    LoadCapabilityCallPart,
+    LoadCapabilityReturnPart,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -6273,6 +6276,69 @@ async def test_adapter_tool_call_part_with_provider_metadata():
     reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
     _sync_timestamps(messages, reloaded_messages)
     assert reloaded_messages == messages
+
+
+async def test_adapter_preserves_loaded_deferred_capability_state():
+    messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                LoadCapabilityCallPart(
+                    tool_call_id='load-foobar',
+                    args={'id': 'foobar'},
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                LoadCapabilityReturnPart(
+                    tool_call_id='load-foobar',
+                    content={'instructions': '# Foo Bar'},
+                )
+            ]
+        ),
+    ]
+
+    assert parse_loaded_capabilities(messages) == {'foobar'}
+
+    ui_messages = VercelAIAdapter.dump_messages(messages)
+    round_tripped = VercelAIAdapter.load_messages(ui_messages)
+
+    assert parse_loaded_capabilities(round_tripped) == {'foobar'}
+    assert isinstance(round_tripped[0], ModelResponse)
+    assert isinstance(round_tripped[0].parts[0], LoadCapabilityCallPart)
+    assert isinstance(round_tripped[1], ModelRequest)
+    assert isinstance(round_tripped[1].parts[0], LoadCapabilityReturnPart)
+
+
+async def test_adapter_does_not_narrow_failed_loaded_capability_returns():
+    ui_messages = [
+        UIMessage(
+            id='msg1',
+            role='assistant',
+            parts=[
+                ToolOutputErrorPart(
+                    type='tool-load_capability',
+                    tool_call_id='load-foobar',
+                    input={'id': 'foobar'},
+                    error_text='Capability not found',
+                    provider_executed=False,
+                    call_provider_metadata={'pydantic_ai': {'tool_kind': 'capability-load'}},
+                )
+            ],
+        )
+    ]
+
+    messages = VercelAIAdapter.load_messages(ui_messages)
+
+    assert isinstance(messages[0], ModelResponse)
+    assert isinstance(messages[0].parts[0], LoadCapabilityCallPart)
+    assert isinstance(messages[1], ModelRequest)
+    failed_return = messages[1].parts[0]
+    assert isinstance(failed_return, ToolReturnPart)
+    assert not isinstance(failed_return, LoadCapabilityReturnPart)
+    assert failed_return.tool_kind is None
+    assert failed_return.outcome == 'failed'
+    assert parse_loaded_capabilities(messages) == set()
 
 
 async def test_adapter_load_messages_tool_call_with_provider_metadata():


### PR DESCRIPTION
- Closes #5846

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

## Summary

- Preserve typed tool part `tool_kind` in Vercel tool call provider metadata.
- Rehydrate typed tool call and successful tool return parts when loading Vercel UI messages.
- Keep failed or denied tool returns as base `ToolReturnPart` instances so failed capability loads are not treated as loaded capabilities.
- Add regression coverage for deferred capability state across `VercelAIAdapter.dump_messages()` / `load_messages()`.

## Tests

- `uv run --no-sync pytest tests/test_vercel_ai.py::test_adapter_preserves_loaded_deferred_capability_state tests/test_vercel_ai.py::test_adapter_does_not_narrow_failed_loaded_capability_returns tests/test_vercel_ai.py::test_adapter_tool_call_part_with_provider_metadata tests/test_vercel_ai.py::test_adapter_load_messages_tool_call_with_provider_metadata -q`
- `uv run --no-sync ruff check pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py tests/test_vercel_ai.py`
- `uv run --no-sync ruff format --check pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py tests/test_vercel_ai.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py`