### PR TITLE
fix(output): retry instead of KeyError on unknown union kind

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -1179,7 +1179,15 @@ class UnionOutputProcessor(BaseObjectOutputProcessor[OutputDataT]):
         kind: str = result.kind
         inner_data: dict[str, Any] = result.data
 
-        # Pydantic validation ensures kind is always valid, so KeyError can't happen.
+        # In tool/native output mode the provider enforces the `kind` const from the JSON
+        # schema, but in the text-output fallback nothing constrains it, so the model can
+        # return a `kind` that isn't one of the registered members. Treat that like any
+        # other invalid output and re-prompt the model rather than crashing with a KeyError.
+        if kind not in self._processors:
+            raise ModelRetry(
+                f'Invalid kind {kind!r} for union output, expected one of: '
+                f'{", ".join(map(repr, self._processors))}'
+            )
         inner = self._processors[kind]
         inner_validated = inner.validate(inner_data, allow_partial=allow_partial, validation_context=validation_context)
         # Unwrap to semantic here so the wrapper's `data` is always what hooks / callers

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1540,6 +1540,27 @@ def test_output_type_tool_output_union():
     )
 
 
+def test_output_type_union_text_fallback_invalid_kind():
+    """An unknown `kind` in the text-output union fallback should retry, not raise KeyError."""
+
+    class Apple(BaseModel):
+        color: str
+
+    class Banana(BaseModel):
+        length: float
+
+    def return_invalid_kind(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        # Tool-output mode is active, but the model replies with the union envelope as text,
+        # using a `kind` that isn't one of the registered discriminator values.
+        text = '{"result": {"kind": "Cherry", "data": {"color": "red"}}}'
+        return ModelResponse(parts=[TextPart(content=text)])
+
+    agent = Agent(FunctionModel(return_invalid_kind), output_type=[Apple, Banana])
+
+    with pytest.raises(UnexpectedModelBehavior, match='Exceeded maximum output retries'):
+        agent.run_sync('What fruit is it?')
+
+
 def test_output_type_function():
     class Weather(BaseModel):
         temperature: float


### PR DESCRIPTION
## What's broken

With a union `output_type` (e.g. `output_type=[Apple, Banana]`), if the model returns the union envelope as text and its `kind` discriminator isn't one of the registered members, `UnionOutputProcessor.validate` does `self._processors[kind]` and raises an unhandled `KeyError`, crashing the run. The code even carried a comment claiming this couldn't happen ("Pydantic validation ensures kind is always valid") — but in the text-output fallback nothing constrains `kind`.

```python
def return_invalid_kind(messages, info):
    return ModelResponse(parts=[TextPart(content='{"result": {"kind": "Cherry", "data": {"color": "red"}}}')])
agent = Agent(FunctionModel(return_invalid_kind), output_type=[Apple, Banana])
agent.run_sync('What fruit is it?')   # -> KeyError: 'Cherry'
```

## Why it happens

In text-output mode `kind` is an unvalidated `str`, unlike tool/native mode where the JSON-schema const enforces it.

## Fix

If `kind` isn't a registered processor, raise `ModelRetry` so the model is re-prompted, matching how other invalid output is already handled.

## Test

The run now raises `UnexpectedModelBehavior` (retries exhausted) instead of `KeyError`.

Fixes #5844
