### PR TITLE
Fix flaky `test_tool_cancelled_when_agent_cancelled` under CI load

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3049,7 +3049,10 @@ async def test_tool_cancelled_when_agent_cancelled(is_stream: bool):
         is_called.set()
 
         try:
-            await asyncio.sleep(1.0)
+            # Block until cancelled instead of sleeping a fixed duration: a sleep that races the
+            # `wait_for` timeouts below is flaky under CI load — if the loop is starved past the
+            # sleep, the tool returns normally and `is_cancelled` is never set.
+            await asyncio.Event().wait()
 
         except asyncio.CancelledError:
             is_cancelled.set()
@@ -3064,9 +3067,9 @@ async def test_tool_cancelled_when_agent_cancelled(is_stream: bool):
                 pass
 
     task = asyncio.create_task(run_agent())
-    await asyncio.wait_for(is_called.wait(), timeout=1.0)
+    await asyncio.wait_for(is_called.wait(), timeout=10)
     task.cancel()
-    await asyncio.wait_for(is_cancelled.wait(), timeout=1.0)
+    await asyncio.wait_for(is_cancelled.wait(), timeout=10)
 
 
 def test_tool_approved_with_metadata():


### PR DESCRIPTION
Fixes a flaky test (no issue — trivial test-only fix).

### Problem

`test_tool_cancelled_when_agent_cancelled` intermittently fails on CI with `TimeoutError`, most visibly on the most-loaded matrix shard (recently `test on 3.14 (all-extras)`, but it is **not** Python-version-specific).

The tool slept for a fixed `1.0s` — the same value as the two `asyncio.wait_for(..., timeout=1.0)` calls that drive the test:

```python
async def tool() -> None:
    is_called.set()
    try:
        await asyncio.sleep(1.0)          # same duration as the timeouts below
    except asyncio.CancelledError:
        is_cancelled.set()
        raise
...
await asyncio.wait_for(is_called.wait(), timeout=1.0)
task.cancel()
await asyncio.wait_for(is_cancelled.wait(), timeout=1.0)
```

CI runs `pytest -n auto`; when the worker processes saturate the CPU, the event loop's timer callbacks can slip past `1.0s`. If that slip lands between the tool starting and `task.cancel()` taking effect, the tool's `sleep(1.0)` completes **normally** → the `except CancelledError` branch never runs → `is_cancelled` stays unset → the second `wait_for` raises `TimeoutError`.

### Root-cause proof

Reproduced deterministically with a faithful standalone harness (real `Agent` + `TestModel`), injecting a 1.2s scheduler slip before the cancel:

| scenario | Python 3.13 | Python 3.14 |
|---|---|---|
| current logic + 1.2s slip | FAIL ×5 (`TimeoutError`) | FAIL ×5 (`TimeoutError`) |
| this fix + 1.2s slip | pass ×5 | pass ×5 |

So the defect is the coupling of the tool's sleep duration to the timeout, not anything version-specific.

### Fix

The tool now blocks until cancelled (`await asyncio.Event().wait()`) — there is no fixed duration left to race the timeout — and the `wait_for` safety timeouts are widened to 10s. With a tool that only ends via cancellation, a starved loop can no longer let it finish early.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
