### PR TITLE
Add regression test for Google thinking-model `max_tokens` empty response

### DIFF
--- a/tests/models/cassettes/test_google/test_google_model_max_tokens.yaml
+++ b/tests/models/cassettes/test_google/test_google_model_max_tokens.yaml
@@ -4,11 +4,11 @@ interactions:
       accept:
       - '*/*'
       accept-encoding:
-      - gzip, deflate
+      - gzip, deflate, br, zstd
       connection:
       - keep-alive
       content-length:
-      - '221'
+      - '295'
       content-type:
       - application/json
       host:
@@ -21,21 +21,25 @@ interactions:
         role: user
       generationConfig:
         maxOutputTokens: 5
+        responseModalities:
+        - TEXT
+        thinkingConfig:
+          thinking_budget: 0
       systemInstruction:
         parts:
         - text: You are a helpful chatbot.
         role: user
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
   response:
     headers:
       alt-svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       content-length:
-      - '677'
+      - '401'
       content-type:
       - application/json; charset=UTF-8
       server-timing:
-      - gfet4t7; dur=703
+      - gfet4t7; dur=713
       transfer-encoding:
       - chunked
       vary:
@@ -44,24 +48,22 @@ interactions:
       - Referer
     parsed_body:
       candidates:
-      - avgLogprobs: -8.130469359457493e-05
-        content:
+      - content:
           parts:
           - text: The capital of France is
           role: model
         finishReason: MAX_TOKENS
-      modelVersion: gemini-1.5-flash
-      responseId: zlpeaNKFIZW1nvgP-O3vwQY
+        index: 0
+      modelVersion: gemini-2.5-flash
+      responseId: R5MoavWNNp_8qtsP2fWD2A0
       usageMetadata:
         candidatesTokenCount: 5
-        candidatesTokensDetails:
-        - modality: TEXT
-          tokenCount: 5
-        promptTokenCount: 13
+        promptTokenCount: 15
         promptTokensDetails:
         - modality: TEXT
-          tokenCount: 13
-        totalTokenCount: 18
+          tokenCount: 15
+        serviceTier: standard
+        totalTokenCount: 20
     status:
       code: 200
       message: OK

--- a/tests/models/cassettes/test_google/test_google_model_max_tokens_thinking_model_empty_response.yaml
+++ b/tests/models/cassettes/test_google/test_google_model_max_tokens_thinking_model_empty_response.yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '253'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: What is the capital of France?
+        role: user
+      generationConfig:
+        maxOutputTokens: 5
+        responseModalities:
+        - TEXT
+      systemInstruction:
+        parts:
+        - text: You are a helpful chatbot.
+        role: user
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '348'
+      content-type:
+      - application/json; charset=UTF-8
+      server-timing:
+      - gfet4t7; dur=1606
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    parsed_body:
+      candidates:
+      - content:
+          role: model
+        finishReason: MAX_TOKENS
+        index: 0
+      modelVersion: gemini-2.5-pro
+      responseId: fH8oaunbEbr9qtsPjYGX4A0
+      usageMetadata:
+        promptTokenCount: 15
+        promptTokensDetails:
+        - modality: TEXT
+          tokenCount: 15
+        serviceTier: standard
+        thoughtsTokenCount: 2
+        totalTokenCount: 17
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -538,8 +538,11 @@ async def test_google_model_retry(allow_model_requests: None, google_provider: G
 
 
 async def test_google_model_max_tokens(allow_model_requests: None, google_provider: GoogleProvider):
-    model = GoogleModel('gemini-1.5-flash', provider=google_provider)
-    agent = Agent(model=model, instructions='You are a helpful chatbot.', model_settings={'max_tokens': 5})
+    # With thinking disabled, the model spends its tiny budget on visible output, so it returns the partial
+    # text generated before the `max_tokens` limit is hit, with `finish_reason=MAX_TOKENS` and no error.
+    model = GoogleModel('gemini-2.5-flash', provider=google_provider)
+    settings = GoogleModelSettings(max_tokens=5, google_thinking_config={'thinking_budget': 0})
+    agent = Agent(model=model, instructions='You are a helpful chatbot.', model_settings=settings)
     result = await agent.run('What is the capital of France?')
     assert result.output == snapshot('The capital of France is')
 
@@ -547,9 +550,9 @@ async def test_google_model_max_tokens(allow_model_requests: None, google_provid
 async def test_google_model_max_tokens_thinking_model_empty_response(
     allow_model_requests: None, google_provider: GoogleProvider
 ):
-    # Unlike the non-thinking `gemini-1.5-flash` above, which returns the partial text it generated before
-    # truncation, a thinking model spends the tiny token budget on hidden reasoning and returns no content
-    # parts with `finish_reason=MAX_TOKENS`, which the agent graph surfaces as a clear `UnexpectedModelBehavior`.
+    # Unlike the non-thinking case above, a thinking model spends the tiny token budget on hidden reasoning
+    # and returns no content parts with `finish_reason=MAX_TOKENS`, which the agent graph surfaces as a clear
+    # `UnexpectedModelBehavior`.
     model = GoogleModel('gemini-2.5-pro', provider=google_provider)
     agent = Agent(model=model, instructions='You are a helpful chatbot.', model_settings={'max_tokens': 5})
     with pytest.raises(

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -59,6 +59,7 @@ from pydantic_ai.exceptions import (
     ModelAPIError,
     ModelHTTPError,
     ModelRetry,
+    UnexpectedModelBehavior,
     UserError,
 )
 from pydantic_ai.messages import (
@@ -541,6 +542,20 @@ async def test_google_model_max_tokens(allow_model_requests: None, google_provid
     agent = Agent(model=model, instructions='You are a helpful chatbot.', model_settings={'max_tokens': 5})
     result = await agent.run('What is the capital of France?')
     assert result.output == snapshot('The capital of France is')
+
+
+async def test_google_model_max_tokens_thinking_model_empty_response(
+    allow_model_requests: None, google_provider: GoogleProvider
+):
+    # Unlike the non-thinking `gemini-1.5-flash` above, which returns the partial text it generated before
+    # truncation, a thinking model spends the tiny token budget on hidden reasoning and returns no content
+    # parts with `finish_reason=MAX_TOKENS`, which the agent graph surfaces as a clear `UnexpectedModelBehavior`.
+    model = GoogleModel('gemini-2.5-pro', provider=google_provider)
+    agent = Agent(model=model, instructions='You are a helpful chatbot.', model_settings={'max_tokens': 5})
+    with pytest.raises(
+        UnexpectedModelBehavior, match=r'Model token limit \(\d+\) exceeded before any response was generated'
+    ):
+        await agent.run('What is the capital of France?')
 
 
 async def test_google_model_top_p(allow_model_requests: None, google_provider: GoogleProvider):


### PR DESCRIPTION
- Closes #2021

The bug — Gemini thinking models raising a cryptic `UnexpectedModelBehavior: Content field missing from Gemini response` when `max_tokens` is too low — was already fixed centrally by #3512, which raises a clear, actionable `UnexpectedModelBehavior` ("Model token limit (N) exceeded before any response was generated…") for any provider that returns an empty/thinking-only response with `finish_reason='length'`.

This PR adds the missing **real-provider regression coverage**: a Google VCR test proving a live `gemini-2.5-pro` request with a tiny `max_tokens` actually emits empty content parts + `finish_reason=MAX_TOKENS`, which the agent graph surfaces as the clear error. It's co-located right after the existing non-thinking `gemini-1.5-flash` `max_tokens` test, so the contrast the reporter asked about ("why isn't this an issue with `gemini-1.5-flash`?") is legible: the non-thinking model returns the partial text it generated before truncation, while the thinking model burns the whole budget on hidden reasoning and returns no content.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
