### PR TITLE
Fix `AnthropicModel.count_tokens` divergence on `ToolSearchTool` replay history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -852,21 +852,24 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
 
         # Anthropic docs: https://platform.claude.com/docs/en/api/messages-count-tokens
         # The `count_tokens` endpoint rejects server-side tools (`web_search`, `code_execution`,
-        # `web_fetch`, `tool_search`) and the `mcp_servers` param with a 400, so omit them. This
-        # undercounts the prompt by those tools' definitions, but it's the only way to get a count
-        # until Anthropic supports them. Client-side tools like `MemoryTool` are accepted and
-        # contribute real tokens, so keep them for an accurate count.
+        # `web_fetch`, `tool_search`) and the `mcp_servers` param with a 400, so restrict the wire
+        # `tools` list to client-side tools like `MemoryTool`, which are accepted and contribute
+        # real tokens. This undercounts the prompt by the server tools' definitions, but it's the
+        # only way to get a count until Anthropic supports them.
         # TODO: Remove this workaround if Anthropic starts accepting server tools on `count_tokens`.
-        model_request_parameters = replace(
+        count_tokens_parameters = replace(
             model_request_parameters,
             native_tools=[tool for tool in model_request_parameters.native_tools if isinstance(tool, MemoryTool)],
         )
 
         # standalone function to make it easier to override
-        tools, tool_choice = self._prepare_tools_and_tool_choice(model_settings, model_request_parameters)
-        tools, mcp_servers, native_tool_betas = self._add_native_tools(tools, model_request_parameters, model_settings)
+        tools, tool_choice = self._prepare_tools_and_tool_choice(model_settings, count_tokens_parameters)
+        tools, mcp_servers, native_tool_betas = self._add_native_tools(tools, count_tokens_parameters, model_settings)
 
         auto_cache_control, resolved_cache_ttl = self._build_automatic_cache_control(model_settings)
+        # Map messages with the UNMODIFIED params so `tool_search_active` stays True and tool-search
+        # replay history renders the same `tool_reference` wire shape as `/v1/messages`; those
+        # references point at `function_tools`, which aren't stripped here, so they stay valid.
         system_prompt, anthropic_messages = await self._map_message(messages, model_request_parameters, model_settings)
         self._apply_per_block_caching_fallback(resolved_cache_ttl, anthropic_messages)
         self._apply_explicit_message_caching(model_settings, anthropic_messages)

--- a/tests/models/cassettes/test_anthropic/test_anthropic_count_tokens_with_tool_search_replay.yaml
+++ b/tests/models/cassettes/test_anthropic/test_anthropic_count_tokens_with_tool_search_replay.yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '581'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      messages:
+      - content:
+        - text: What is the USD to EUR rate?
+          type: text
+        role: user
+      - content:
+        - id: search-1
+          input:
+            queries:
+            - exchange rate
+          name: search_tools
+          type: tool_use
+        role: assistant
+      - content:
+        - content:
+          - tool_name: get_exchange_rate
+            type: tool_reference
+          is_error: false
+          tool_use_id: search-1
+          type: tool_result
+        role: user
+      model: claude-sonnet-4-5
+      tool_choice:
+        type: auto
+      tools:
+      - description: ''
+        input_schema:
+          type: object
+        name: get_exchange_rate
+    uri: https://api.anthropic.com/v1/messages/count_tokens?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '21'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      server-timing:
+      - x-originResponse;dur=808
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+    parsed_body:
+      input_tokens: 641
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -58,6 +58,8 @@ from pydantic_ai.messages import (
     BuiltinToolResultEvent,  # pyright: ignore[reportDeprecated]
     CompactionPart,
     InstructionPart,
+    ToolSearchCallPart,
+    ToolSearchReturnPart,
     UploadedFile,
 )
 from pydantic_ai.models import ModelRequestParameters
@@ -10716,6 +10718,67 @@ async def test_anthropic_count_tokens_omits_native_tools(allow_model_requests: N
     assert create_kwargs['betas'] == ['context-management-2025-06-27', 'web-fetch-2025-09-10']
 
 
+async def test_anthropic_count_tokens_preserves_tool_search_replay(allow_model_requests: None):
+    """`count_tokens` renders a tool-search replay turn with the same `tool_reference` wire shape
+    as the real `/v1/messages` request, while still omitting the server-side `tool_search_tool_*`
+    entry that the endpoint rejects.
+
+    The count path strips server tools from the wire `tools` list, but `_map_message` also derives
+    `tool_search_active` from `native_tools`: clearing `ToolSearchTool` there would silently
+    re-serialize the history turn as plain text and diverge from the real request. A VCR test
+    wouldn't catch this — the cassette matcher isn't sensitive to the `messages` body.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/5780
+    """
+    c = completion_message([BetaTextBlock(text='done', type='text')], BetaUsage(input_tokens=5, output_tokens=10))
+    mock_client = MockAnthropic.create_mock(c)
+    m = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    params = ModelRequestParameters(
+        function_tools=[
+            ToolDefinition(name='get_exchange_rate', description='', parameters_json_schema={'type': 'object'})
+        ],
+        native_tools=[ToolSearchTool()],
+    )
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='What is the USD to EUR rate?')]),
+        ModelResponse(parts=[ToolSearchCallPart(args={'queries': ['exchange rate']}, tool_call_id='search-1')]),
+        ModelRequest(
+            parts=[
+                ToolSearchReturnPart(
+                    content={
+                        'discovered_tools': [{'name': 'get_exchange_rate', 'description': ''}],
+                        'message': 'Found 1 tool',
+                    },
+                    tool_call_id='search-1',
+                )
+            ]
+        ),
+    ]
+
+    await m.count_tokens(messages, None, params)
+    await m.request(messages, None, params)
+
+    count_tokens_kwargs, create_kwargs = get_mock_chat_completion_kwargs(mock_client)
+
+    # The tool-search replay turn renders identically on both paths: a `tool_result` whose content
+    # is a `tool_reference` array pointing at the discovered function tool.
+    assert count_tokens_kwargs['messages'] == create_kwargs['messages']
+    assert count_tokens_kwargs['messages'][-1]['content'][0] == snapshot(
+        {
+            'tool_use_id': 'search-1',
+            'type': 'tool_result',
+            'content': [{'tool_name': 'get_exchange_rate', 'type': 'tool_reference'}],
+            'is_error': False,
+        }
+    )
+
+    # The server-side `tool_search_tool_*` entry is rejected by `count_tokens`, so it's omitted there
+    # but present on the real request.
+    assert not any(str(tool.get('type', '')).startswith('tool_search_tool_') for tool in count_tokens_kwargs['tools'])
+    assert any(str(tool.get('type', '')).startswith('tool_search_tool_') for tool in create_kwargs['tools'])
+
+
 @pytest.mark.vcr()
 async def test_anthropic_count_tokens_with_native_tools(allow_model_requests: None, anthropic_api_key: str):
     """`count_tokens` succeeds against the live API when a native/server tool is configured.
@@ -10736,6 +10799,52 @@ async def test_anthropic_count_tokens_with_native_tools(allow_model_requests: No
     )
 
     assert usage.input_tokens > 0
+
+
+@pytest.mark.vcr()
+async def test_anthropic_count_tokens_with_tool_search_replay(
+    allow_model_requests: None, anthropic_api_key: str, vcr: Any
+):
+    """`count_tokens` succeeds against the live API with a `ToolSearchTool` and a tool-search replay history.
+
+    The endpoint rejects the server-side `tool_search_tool_*` entry, so it's omitted from the wire `tools`
+    list, but the replay turn must still serialize as a `tool_reference` block (pointing at a `function_tools`
+    entry, which is not stripped) — exactly as the real `/v1/messages` request does. A successful token count
+    proves the endpoint accepts that payload; the recorded request is the regression guard.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/5780
+    """
+    m = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key=anthropic_api_key))
+
+    params = ModelRequestParameters(
+        function_tools=[
+            ToolDefinition(name='get_exchange_rate', description='', parameters_json_schema={'type': 'object'})
+        ],
+        native_tools=[ToolSearchTool()],
+    )
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='What is the USD to EUR rate?')]),
+        ModelResponse(parts=[ToolSearchCallPart(args={'queries': ['exchange rate']}, tool_call_id='search-1')]),
+        ModelRequest(
+            parts=[
+                ToolSearchReturnPart(
+                    content={
+                        'discovered_tools': [{'name': 'get_exchange_rate', 'description': ''}],
+                        'message': 'Found 1 tool',
+                    },
+                    tool_call_id='search-1',
+                )
+            ]
+        ),
+    ]
+
+    usage = await m.count_tokens(messages, None, params)
+
+    assert usage.input_tokens > 0
+    request_body = json.loads(vcr.requests[0].body)
+    assert not any(str(tool.get('type', '')).startswith('tool_search_tool_') for tool in request_body['tools'])
+    tool_result = request_body['messages'][-1]['content'][0]
+    assert tool_result['content'] == [{'tool_name': 'get_exchange_rate', 'type': 'tool_reference'}]
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
- Closes #5780
- Supersedes the stalled AI PR #5827 (its `count_tokens` fix dropped the client-side `MemoryTool` too, regressing #5704, its CI never completed, and its body has escaped-backtick artifacts).

### Summary

After #5704, `AnthropicModel._messages_count_tokens` filters server-side native tools out of `native_tools` before mapping messages (the `count_tokens` endpoint 400s on server tools). But `native_tools` has a second consumer: `_map_message` derives `tool_search_active = any(isinstance(t, ToolSearchTool) for t in native_tools)`. Stripping `ToolSearchTool` there forced `tool_search_active = False` in the count path, so a tool-search replay turn (`ToolSearchReturnPart` in history) re-serialized as a plain-text `tool_result` instead of the `tool_reference` array the real `/v1/messages` request emits — the count estimate diverged from the actual request body.

### Fix

Build a count-only copy of the params (native tools restricted to client-side `MemoryTool`) and feed **that** only to `_prepare_tools_and_tool_choice` + `_add_native_tools` (the wire `tools` list). Pass the **unmodified** params to `_map_message`, so `tool_search_active` stays correct. The replay `tool_reference` blocks point at `function_tools`, which the count path does not strip, so they remain valid; the server-side `tool_search_tool_*` entry that `count_tokens` rejects stays omitted.

### Tests

- `test_anthropic_count_tokens_preserves_tool_search_replay` — mock-client wire-shape guard: asserts the count-path `messages` equal the create-path `messages` for the tool-search turn (a `tool_reference` block), and that the server-side `tool_search_tool_*` entry is omitted from the count `tools` while present on the real request. This pins the internal `messages` body, which the VCR cassette matcher isn't sensitive to.
- `test_anthropic_count_tokens_with_tool_search_replay` — live VCR test (`tests/models/cassettes/test_anthropic/test_anthropic_count_tokens_with_tool_search_replay.yaml`): real `count_tokens` with a `ToolSearchTool` + replay history returns 200, proving the endpoint accepts the `tool_reference` payload with the server tool omitted.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)