### PR TITLE
Uninstrument httpx between tests so doc-example instrumentation can't leak across the suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -413,12 +413,20 @@ def no_instrumentation_by_default():
 
 try:
     import logfire
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
     logfire.DEFAULT_LOGFIRE_INSTANCE.config.ignore_no_config = True
+
+    _httpx_instrumentor = HTTPXClientInstrumentor()
 
     @pytest.fixture(autouse=True)
     def fresh_logfire():
         logfire.shutdown(flush=False)
+        # `test_examples.py` runs doc snippets that call the process-global `logfire.instrument_httpx()`,
+        # which patches httpx via OTel and is never torn down. Reset it so it can't leak request spans
+        # into other tests sharing the xdist worker (e.g. stray `POST` spans in `test_temporal` snapshots).
+        if _httpx_instrumentor._is_instrumented_by_opentelemetry:  # pyright: ignore[reportPrivateUsage]
+            _httpx_instrumentor.uninstrument()
 
 except ImportError:
     pass


### PR DESCRIPTION
Fixes a test-isolation flake (no issue — test-infra fix).

### Problem

`test_complex_agent_run_in_workflow` (and potentially other tests) intermittently fails on CI — most recently on the `test on 3.10 (lowest-versions)` shard — with a stray span breaking its snapshot:

```
BasicSpan(content='RunActivity:agent__complex_agent__model_request_stream', children=[
    BasicSpan(content='POST api.openai.com/v1/chat/completions'),   # ← not in the snapshot
    BasicSpan(content='ctx.run_step=1'),
    ...
```

### Root cause

`docs/logfire.md`'s `with_logfire_instrument_httpx.py` example calls the **process-global** `logfire.instrument_httpx(capture_all=True)`. `tests/test_examples.py` executes that snippet, which patches httpx's transport via OTel's `HTTPXClientInstrumentor` — and **nothing tears it down**. The autouse `fresh_logfire` fixture only called `logfire.shutdown(flush=False)`, which does *not* reset the httpx instrumentor (the `_is_instrumented_by_opentelemetry` flag survives shutdown).

Under `-n auto --dist=loadgroup`, when that example test and a later test land on the **same xdist worker**, the later test's real httpx client inherits the global instrumentation and emits an extra `POST` request span. It is **not** version-specific (reproduced on the exact CI dependency versions) — purely xdist co-scheduling luck, which is why it never reproduces in isolation but reproduces 100% when the example is forced to run before the temporal test in one process (running the `logfire` doc examples and `test_complex_agent_run_in_workflow` together, selected via `-k`, fails before this change and passes after).

### Fix

The autouse `fresh_logfire` fixture now uninstruments httpx when it was left instrumented, so doc examples (or any test) can't leak global httpx instrumentation into other tests on the same worker.

Per-test overhead is a single bool read in the common (not-instrumented) case — measured at ~15 ns/test, ~125 µs total across the ~8.3k-test suite; the actual `uninstrument()` only runs the handful of times an example leaves httpx instrumented.

Verified: the repro above flips to passing; the `logfire` doc examples (15 passed) and the full `tests/test_temporal.py` (94 passed) show no regression.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
