### PR TITLE
Disallow non-finite `Evaluator` outputs

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py
@@ -107,6 +107,8 @@ async def run_evaluator(
     return details
 
 
+# `EvaluationReason` is a plain dataclass, so pydantic would otherwise trust
+# existing instances and skip validating `value` against the finite-float constraint.
 _EVALUATOR_OUTPUT_ADAPTER = TypeAdapter[EvaluatorOutput](
     EvaluatorOutput, config=ConfigDict(revalidate_instances='always')
 )

--- a/pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from pydantic import (
+    ConfigDict,
     TypeAdapter,
     ValidationError,
 )
@@ -106,7 +107,9 @@ async def run_evaluator(
     return details
 
 
-_EVALUATOR_OUTPUT_ADAPTER = TypeAdapter[EvaluatorOutput](EvaluatorOutput)
+_EVALUATOR_OUTPUT_ADAPTER = TypeAdapter[EvaluatorOutput](
+    EvaluatorOutput, config=ConfigDict(revalidate_instances='always')
+)
 
 
 def _convert_to_mapping(

--- a/pydantic_evals/pydantic_evals/evaluators/evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/evaluator.py
@@ -5,8 +5,9 @@ import warnings
 from abc import abstractmethod
 from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass
-from typing import Any, Generic, cast
+from typing import Annotated, Any, Generic, cast
 
+from pydantic import Field
 from typing_extensions import TypeVar, deprecated
 
 from .._utils import get_event_loop
@@ -25,10 +26,10 @@ __all__ = (
     'EvaluatorSpec',
 )
 
-EvaluationScalar = bool | int | float | str
+EvaluationScalar = bool | int | Annotated[float, Field(allow_inf_nan=False)] | str
 """The most primitive output allowed as an output from an Evaluator.
 
-`int` and `float` are treated as scores, `str` as labels, and `bool` as assertions.
+`int` and finite `float` are treated as scores, `str` as labels, and `bool` as assertions.
 """
 
 

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import json
+import math
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1399,6 +1400,42 @@ async def test_dataset_evaluate_with_invalid_evaluator_result(
         ]
     )
     assert report.failures == snapshot([])
+
+
+@pytest.mark.parametrize(
+    'output',
+    [
+        pytest.param(math.nan, id='nan'),
+        pytest.param(math.inf, id='inf'),
+        pytest.param(-math.inf, id='negative-inf'),
+    ],
+)
+async def test_dataset_evaluate_with_non_finite_evaluator_result(
+    example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata], output: float
+):
+    """Non-finite evaluator scores should be reported as evaluator failures."""
+
+    class NonFiniteEvaluator(Evaluator[TaskInput, TaskOutput, TaskMetadata]):
+        def evaluate(self, ctx: EvaluatorContext[TaskInput, TaskOutput, TaskMetadata]) -> float:
+            return output
+
+    example_dataset.add_evaluator(NonFiniteEvaluator())
+
+    async def task(inputs: TaskInput) -> TaskOutput:
+        return TaskOutput(answer=inputs.query.upper())
+
+    report = await example_dataset.evaluate(task)
+
+    assert report.failures == []
+    assert len(report.cases) == 2
+    for case in report.cases:
+        assert case.scores == {}
+        assert len(case.evaluator_failures) == 1
+        failure = case.evaluator_failures[0]
+        assert failure.name == 'NonFiniteEvaluator'
+        assert failure.error_type == 'ValueError'
+        assert 'returned a value of an invalid type' in failure.error_message
+        assert repr(output) in failure.error_message
 
 
 async def test_dataset_evaluate_with_custom_name(example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata]):

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -3,6 +3,7 @@ from __future__ import annotations as _annotations
 import json
 import math
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -20,6 +21,7 @@ with try_import() as imports_successful:
     from pydantic_evals import Case, Dataset, PydanticEvalsDeprecationWarning
     from pydantic_evals.dataset import increment_eval_metric, set_eval_attribute
     from pydantic_evals.evaluators import (
+        EvaluationReason,
         EvaluationResult,
         Evaluator,
         EvaluatorFailure,
@@ -1403,20 +1405,24 @@ async def test_dataset_evaluate_with_invalid_evaluator_result(
 
 
 @pytest.mark.parametrize(
-    'output',
+    'output_factory',
     [
-        pytest.param(math.nan, id='nan'),
-        pytest.param(math.inf, id='inf'),
-        pytest.param(-math.inf, id='negative-inf'),
+        pytest.param(lambda: math.nan, id='nan-scalar'),
+        pytest.param(lambda: math.inf, id='inf-scalar'),
+        pytest.param(lambda: -math.inf, id='negative-inf-scalar'),
+        pytest.param(lambda: {'score': math.nan}, id='nan-mapping'),
+        pytest.param(lambda: EvaluationReason(value=math.nan, reason='not finite'), id='nan-reason'),
+        pytest.param(lambda: {'score': EvaluationReason(value=math.inf, reason='not finite')}, id='inf-mapped-reason'),
     ],
 )
 async def test_dataset_evaluate_with_non_finite_evaluator_result(
-    example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata], output: float
+    example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata], output_factory: Callable[[], Any]
 ):
     """Non-finite evaluator scores should be reported as evaluator failures."""
+    output = output_factory()
 
     class NonFiniteEvaluator(Evaluator[TaskInput, TaskOutput, TaskMetadata]):
-        def evaluate(self, ctx: EvaluatorContext[TaskInput, TaskOutput, TaskMetadata]) -> float:
+        def evaluate(self, ctx: EvaluatorContext[TaskInput, TaskOutput, TaskMetadata]) -> Any:
             return output
 
     example_dataset.add_evaluator(NonFiniteEvaluator())

--- a/tests/evals/test_evaluator_base.py
+++ b/tests/evals/test_evaluator_base.py
@@ -1,9 +1,8 @@
 from __future__ import annotations as _annotations
 
 import asyncio
-import math
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -473,42 +472,3 @@ async def test_run_evaluator():
             }
         ]
     )
-
-
-@pytest.mark.parametrize(
-    'output_factory',
-    [
-        pytest.param(lambda: math.nan, id='nan-scalar'),
-        pytest.param(lambda: math.inf, id='inf-scalar'),
-        pytest.param(lambda: -math.inf, id='negative-inf-scalar'),
-        pytest.param(lambda: {'score': math.nan}, id='nan-mapping'),
-        pytest.param(lambda: EvaluationReason(value=math.nan, reason='not finite'), id='nan-reason'),
-        pytest.param(lambda: {'score': EvaluationReason(value=math.inf, reason='not finite')}, id='inf-mapped-reason'),
-    ],
-)
-async def test_run_evaluator_rejects_non_finite_numbers(output_factory: Callable[[], Any]):
-    """Adapter validation should reject non-finite numbers before report conversion."""
-    output = output_factory()
-    ctx = EvaluatorContext(
-        name='test',
-        inputs={},
-        metadata=None,
-        expected_output=None,
-        output={},
-        duration=0.0,
-        _span_tree=SpanTreeRecordingError('did not record spans'),
-        attributes={},
-        metrics={},
-    )
-
-    @dataclass
-    class NonFiniteEvaluator(Evaluator[Any, Any, Any]):
-        def evaluate(self, ctx: EvaluatorContext) -> Any:
-            return output
-
-    results = await run_evaluator(NonFiniteEvaluator(), ctx)
-
-    assert isinstance(results, EvaluatorFailure)
-    assert results.name == 'NonFiniteEvaluator'
-    assert results.error_type == 'ValueError'
-    assert 'returned a value of an invalid type' in results.error_message

--- a/tests/evals/test_evaluator_base.py
+++ b/tests/evals/test_evaluator_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import asyncio
+import math
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -472,3 +473,41 @@ async def test_run_evaluator():
             }
         ]
     )
+
+
+@pytest.mark.parametrize(
+    'output',
+    [
+        pytest.param(math.nan, id='nan-scalar'),
+        pytest.param(math.inf, id='inf-scalar'),
+        pytest.param(-math.inf, id='negative-inf-scalar'),
+        pytest.param({'score': math.nan}, id='nan-mapping'),
+        pytest.param(EvaluationReason(value=math.nan, reason='not finite'), id='nan-reason'),
+        pytest.param({'score': EvaluationReason(value=math.inf, reason='not finite')}, id='inf-mapped-reason'),
+    ],
+)
+async def test_run_evaluator_rejects_non_finite_numbers(output: Any):
+    """Adapter validation should reject non-finite numbers before report conversion."""
+    ctx = EvaluatorContext(
+        name='test',
+        inputs={},
+        metadata=None,
+        expected_output=None,
+        output={},
+        duration=0.0,
+        _span_tree=SpanTreeRecordingError('did not record spans'),
+        attributes={},
+        metrics={},
+    )
+
+    @dataclass
+    class NonFiniteEvaluator(Evaluator[Any, Any, Any]):
+        def evaluate(self, ctx: EvaluatorContext) -> Any:
+            return output
+
+    results = await run_evaluator(NonFiniteEvaluator(), ctx)
+
+    assert isinstance(results, EvaluatorFailure)
+    assert results.name == 'NonFiniteEvaluator'
+    assert results.error_type == 'ValueError'
+    assert 'returned a value of an invalid type' in results.error_message

--- a/tests/evals/test_evaluator_base.py
+++ b/tests/evals/test_evaluator_base.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 import asyncio
 import math
 import warnings
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -476,18 +476,19 @@ async def test_run_evaluator():
 
 
 @pytest.mark.parametrize(
-    'output',
+    'output_factory',
     [
-        pytest.param(math.nan, id='nan-scalar'),
-        pytest.param(math.inf, id='inf-scalar'),
-        pytest.param(-math.inf, id='negative-inf-scalar'),
-        pytest.param({'score': math.nan}, id='nan-mapping'),
-        pytest.param(EvaluationReason(value=math.nan, reason='not finite'), id='nan-reason'),
-        pytest.param({'score': EvaluationReason(value=math.inf, reason='not finite')}, id='inf-mapped-reason'),
+        pytest.param(lambda: math.nan, id='nan-scalar'),
+        pytest.param(lambda: math.inf, id='inf-scalar'),
+        pytest.param(lambda: -math.inf, id='negative-inf-scalar'),
+        pytest.param(lambda: {'score': math.nan}, id='nan-mapping'),
+        pytest.param(lambda: EvaluationReason(value=math.nan, reason='not finite'), id='nan-reason'),
+        pytest.param(lambda: {'score': EvaluationReason(value=math.inf, reason='not finite')}, id='inf-mapped-reason'),
     ],
 )
-async def test_run_evaluator_rejects_non_finite_numbers(output: Any):
+async def test_run_evaluator_rejects_non_finite_numbers(output_factory: Callable[[], Any]):
     """Adapter validation should reject non-finite numbers before report conversion."""
+    output = output_factory()
     ctx = EvaluatorContext(
         name='test',
         inputs={},


### PR DESCRIPTION
- Closes: N/A

### Summary

- Reject `NaN` and infinite floats from evaluator outputs via the shared output adapter.
- Revalidate `EvaluationReason` instances so wrapped non-finite values are rejected too.
- Add coverage for scalar, mapping, and reason-wrapped evaluator outputs.

### Tests

- `uv run pytest tests/evals/test_evaluator_base.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_evals/pydantic_evals/evaluators/evaluator.py pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py`
- `uv run ruff check pydantic_evals/pydantic_evals/evaluators/evaluator.py pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py tests/evals/test_evaluator_base.py`
- `gcap pydantic_evals/pydantic_evals/evaluators/evaluator.py pydantic_evals/pydantic_evals/evaluators/_run_evaluator.py tests/evals/test_evaluator_base.py -m "Disallow non-finite evaluator outputs"`

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
