### PR TITLE
Validate `UploadedFile` `provider_name` in `OpenAIResponsesModel` tool-return path

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3177,8 +3177,8 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         else:
             raise NotImplementedError(f'VideoUrl is not supported in OpenAI Responses {context}')
 
-    @staticmethod
     async def _map_tool_return_output(
+        self,
         part: ToolReturnPart,
     ) -> str | list[ResponseInputTextContentParam | ResponseInputImageContentParam | ResponseInputFileContentParam]:
         """Map a `ToolReturnPart` to OpenAI Responses API output format, supporting multimodal content.
@@ -3194,6 +3194,11 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
 
         for item in part.content_items(mode='str'):
             if isinstance(item, UploadedFile):
+                if item.provider_name != self.system:
+                    raise UserError(
+                        f'UploadedFile with `provider_name={item.provider_name!r}` cannot be used with OpenAIResponsesModel. '
+                        f'Expected `provider_name` to be `{self.system!r}`.'
+                    )
                 output.append(
                     ResponseInputFileContentParam(
                         type='input_file',

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -1867,6 +1867,22 @@ async def test_uploaded_file_wrong_provider_responses(allow_model_requests: None
         await agent.run(['Analyze this file', UploadedFile(file_id='file-xyz789', provider_name='anthropic')])
 
 
+async def test_uploaded_file_wrong_provider_responses_tool_return(allow_model_requests: None) -> None:
+    """An `UploadedFile` from another provider in a tool return must raise the same error as in a user prompt.
+
+    Unit test rather than VCR: this is a pre-request guard that raises while mapping the tool return, before any
+    HTTP request, and reaching it through the public API would require mocking a full tool-call round-trip.
+    """
+    m = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(api_key='test-key'))
+    part = ToolReturnPart(
+        tool_name='get_file',
+        content=[UploadedFile(file_id='file-xyz789', provider_name='anthropic')],
+        tool_call_id='call_1',
+    )
+    with pytest.raises(UserError, match="provider_name='anthropic'.*cannot be used with OpenAIResponsesModel"):
+        await m._map_tool_return_output(part)  # pyright: ignore[reportPrivateUsage]
+
+
 async def test_text_content_input(allow_model_requests: None):
     m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='test-key'))
     res = await m._map_user_prompt(  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
- Closes #5859

The user-prompt path raises a `UserError` when an `UploadedFile` carries a `provider_name` from another provider, but the tool-return path mapped it straight to a `ResponseInputFileContentParam` with no such check: `_map_tool_return_output` was a `@staticmethod` and couldn't see `self.system`. This makes it an instance method (its only caller already invokes it via `self`) and applies the same validation, so a foreign-provider file is rejected consistently in both paths.

The regression test is a unit test on the mapping method rather than a VCR test, because the guard raises before any HTTP request and reaching it through the public API would need a full tool-call round-trip.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
