### PR TITLE
docs: document `UploadedFile` inbound sanitization in AG-UI adapter docstrings

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ag_ui.py
+++ b/pydantic_ai_slim/pydantic_ai/ag_ui.py
@@ -92,8 +92,11 @@ async def handle_ag_ui_request(
         agent: The agent to run.
         request: The Starlette request (e.g. from FastAPI) containing the AG-UI run input.
         ag_ui_version: AG-UI protocol version controlling thinking/reasoning event format.
-        preserve_file_data: Whether to preserve agent-generated files and uploaded files
-            in AG-UI message conversion. See [`AGUIAdapter.preserve_file_data`][pydantic_ai.ui.ag_ui.AGUIAdapter.preserve_file_data].
+        preserve_file_data: Whether to keep client-submitted `UploadedFile` parts (which the
+            server resolves with its own credentials, so only enable for trusted frontends) and
+            to round-trip agent-generated files and uploaded files through AG-UI message
+            conversion. Defaults to `False`, which drops both. See
+            [`UIAdapter.preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data].
 
         output_type: Custom output type to use for this run, `output_type` may only be used if the agent has no
             output validators since output validators would expect an argument that matches the agent's output type.
@@ -176,8 +179,11 @@ def run_ag_ui(
         run_input: The AG-UI run input containing thread_id, run_id, messages, etc.
         accept: The accept header value for the run.
         ag_ui_version: AG-UI protocol version controlling thinking/reasoning event format.
-        preserve_file_data: Whether to preserve agent-generated files and uploaded files
-            in AG-UI message conversion. See [`AGUIAdapter.preserve_file_data`][pydantic_ai.ui.ag_ui.AGUIAdapter.preserve_file_data].
+        preserve_file_data: Whether to keep client-submitted `UploadedFile` parts (which the
+            server resolves with its own credentials, so only enable for trusted frontends) and
+            to round-trip agent-generated files and uploaded files through AG-UI message
+            conversion. Defaults to `False`, which drops both. See
+            [`UIAdapter.preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data].
 
         output_type: Custom output type to use for this run, `output_type` may only be used if the agent has no
             output validators since output validators would expect an argument that matches the agent's output type.

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -206,11 +206,15 @@ def _user_content_to_input(
 class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, OutputDataT]):
     """UI adapter for the Agent-User Interaction (AG-UI) protocol.
 
-    When [`preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data] is `True`,
-    agent-generated files and uploaded files are stored as
-    [activity messages](https://docs.ag-ui.com/concepts/activities) during `dump_messages`
-    and restored during `load_messages`, enabling full round-trip fidelity. When `False`
-    (the default), they are dropped. If your AG-UI frontend uses activities, be aware that
+    [`preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data] (inherited from
+    `UIAdapter`, default `False`) gates two behaviors. On the way in, client-submitted
+    [`UploadedFile`][pydantic_ai.messages.UploadedFile] parts are dropped during
+    `sanitize_messages` unless it is `True`, since the server resolves them with its own
+    credentials; only set it when the frontend is trusted. On the way out and back in, when
+    `True`, agent-generated files and uploaded files are stored as
+    [activity messages](https://docs.ag-ui.com/concepts/messages) during `dump_messages`
+    and restored during `load_messages`, enabling full round-trip fidelity. When `False`,
+    they are dropped. If your AG-UI frontend uses activities, be aware that
     `pydantic_ai_*` activity types are reserved for internal round-trip use and should be
     ignored by frontend activity handlers.
     """

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/app.py
@@ -95,8 +95,11 @@ class AGUIApp(Generic[AgentDepsT, OutputDataT], Starlette):
         Args:
             agent: The agent to run.
             ag_ui_version: AG-UI protocol version controlling thinking/reasoning event format.
-            preserve_file_data: Whether to preserve agent-generated files and uploaded files
-                in AG-UI message conversion. See [`AGUIAdapter.preserve_file_data`][pydantic_ai.ui.ag_ui.AGUIAdapter.preserve_file_data].
+            preserve_file_data: Whether to keep client-submitted `UploadedFile` parts (which the
+                server resolves with its own credentials, so only enable for trusted frontends) and
+                to round-trip agent-generated files and uploaded files through AG-UI message
+                conversion. Defaults to `False`, which drops both. See
+                [`UIAdapter.preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data].
 
             output_type: Custom output type to use for this run, `output_type` may only be used if the agent has
                 no output validators since output validators would expect an argument that matches the agent's


### PR DESCRIPTION
This is a docs-only follow-up to #5772 ("Handle `UploadedFile` consistently with `FileUrl` in UI adapters"), which is now safe to document publicly as advisory [GHSA-h7p7-w5gc-xj3w](https://github.com/pydantic/pydantic-ai/security/advisories/GHSA-h7p7-w5gc-xj3w) has been published.

#5772 generalized `preserve_file_data` (default `False`) from `AGUIAdapter` up to the base `UIAdapter` and made `sanitize_messages` drop client-submitted `UploadedFile` parts (in user content and nested tool returns) unless the flag is set, mirroring the existing `FileUrl` scheme / `force_download` filtering. The base `UIAdapter.preserve_file_data` attribute docstring and the `sanitize_messages` "Currently strips:" list were updated in that PR, but a few cross-references and the AG-UI forwarder docstrings were left describing the flag only as the old AG-UI round-trip toggle.

This PR:

- Documents the inbound-drop behavior and the credentials caveat (the server resolves `UploadedFile` references with its own identity) on the `AGUIAdapter` class docstring and the `handle_ag_ui_request` / `run_ag_ui` / `AGUIApp` forwarder docstrings.
- Repoints those forwarder cross-references from `AGUIAdapter.preserve_file_data` to `UIAdapter.preserve_file_data`, where the flag now lives.
- Fixes the 404 `https://docs.ag-ui.com/concepts/activities` link in the `AGUIAdapter` docstring to the canonical `https://docs.ag-ui.com/concepts/messages`.

Docstrings only; no logic changes.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
