### PR TITLE
Preserve `run_id`, `conversation_id`, and `metadata` when merging consecutive `ModelRequest`s

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -2239,7 +2239,8 @@ def _clean_message_history(messages: list[_messages.ModelMessage]) -> list[_mess
                     # Tool return parts always need to be at the start
                     key=lambda x: 0 if isinstance(x, _messages.ToolReturnPart | _messages.RetryPromptPart) else 1
                 )
-                merged_message = _messages.ModelRequest(
+                merged_message = replace(
+                    last_message,
                     parts=parts,
                     instructions=last_message.instructions or message.instructions,
                     timestamp=message.timestamp or last_message.timestamp,

--- a/tests/test_clean_message_history.py
+++ b/tests/test_clean_message_history.py
@@ -1,0 +1,36 @@
+"""Unit tests for `_clean_message_history`'s `ModelRequest` merge.
+
+These are unit tests rather than VCR/public-API tests because the fields they
+guard (`run_id`, `conversation_id`, `metadata`) are internal bookkeeping that is
+never sent to the model — `metadata` is explicitly off the wire — so a recorded
+request wouldn't exercise the regression. The merge is a pure internal transform,
+so it's asserted directly.
+"""
+
+from __future__ import annotations
+
+from pydantic_ai import ModelRequest, UserPromptPart
+from pydantic_ai._agent_graph import _clean_message_history  # pyright: ignore[reportPrivateUsage]
+
+
+def test_clean_message_history_preserves_request_fields_on_merge() -> None:
+    """Merging consecutive `ModelRequest`s must carry over `run_id`, `conversation_id`,
+    and `metadata`, not silently drop them to `None`.
+    """
+    first = ModelRequest(
+        parts=[UserPromptPart(content='first')],
+        run_id='run-1',
+        conversation_id='conv-1',
+        metadata={'key': 'value'},
+    )
+    second = ModelRequest(parts=[UserPromptPart(content='second')])
+
+    cleaned = _clean_message_history([first, second])
+
+    assert len(cleaned) == 1
+    merged = cleaned[0]
+    assert isinstance(merged, ModelRequest)
+    assert [p.content for p in merged.parts if isinstance(p, UserPromptPart)] == ['first', 'second']
+    assert merged.run_id == 'run-1'
+    assert merged.conversation_id == 'conv-1'
+    assert merged.metadata == {'key': 'value'}

--- a/tests/test_history_processor.py
+++ b/tests/test_history_processor.py
@@ -139,6 +139,8 @@ async def test_history_processor_run_replaces_message_history(
                     ),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             )
         ]
     )
@@ -207,6 +209,8 @@ async def test_history_processor_streaming_replaces_message_history(
                     ),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             )
         ]
     )
@@ -1114,6 +1118,8 @@ async def test_history_processor_reorder_old_new(function_model: FunctionModel, 
                     UserPromptPart(content='Old question', timestamp=IsDatetime()),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             )
         ]
     )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2286,6 +2286,8 @@ def test_parallel_tool_return_with_deferred():
                     ),
                 ],
                 timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
             ),
         ]
     )


### PR DESCRIPTION
- Closes #5731

`_clean_message_history` merges consecutive `ModelRequest`s by rebuilding them with a bare `ModelRequest(...)` that only passed `parts`, `instructions`, and `timestamp`, so `run_id`, `conversation_id`, and `metadata` (added to `ModelRequest` after this merge logic was written) were silently dropped to `None`. Since the merge also mutates `ctx.state.message_history` in place, the persisted history lost these fields — breaking cross-run correlation for durable execution.

The fix swaps the constructor for `dataclasses.replace(last_message, ...)`, which carries the previously-dropped fields through while keeping the existing `instructions`/`timestamp` precedence — matching the `ModelResponse` branch just below that already uses `replace`. Added a unit test for the preservation, and updated the `test_history_processor` snapshots where merged requests now retain `run_id`/`conversation_id`.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).