### PR TITLE
Add Bocha web search common tool

### DIFF
--- a/docs/api/common_tools.md
+++ b/docs/api/common_tools.md
@@ -1,5 +1,7 @@
 # `pydantic_ai.common_tools`
 
+::: pydantic_ai.common_tools.bocha
+
 ::: pydantic_ai.common_tools.duckduckgo
 
 ::: pydantic_ai.common_tools.exa

--- a/docs/common-tools.md
+++ b/docs/common-tools.md
@@ -209,6 +209,83 @@ Here are some recent papers about transformer architectures from arxiv.org:
 """
 ```
 
+## Bocha Search Tool
+
+!!! info
+    Bocha is a paid service, but they have free credits to explore their product.
+
+    You need to [sign up for an account](https://open.bochaai.com/) and get an API key to use the Bocha search tool.
+
+The Bocha search tool allows you to search the web for up-to-date information and returns source-linked results.
+
+### Usage
+
+Here's an example of how you can use the Bocha search tool with an agent:
+
+```py {title="bocha_search.py" test="skip"}
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.bocha import bocha_search_tool
+
+api_key = os.getenv('BOCHA_SEARCH_API_KEY')
+assert api_key is not None
+
+agent = Agent(
+    'openai:gpt-5.2',
+    tools=[bocha_search_tool(api_key)],
+    instructions='Search Bocha for the given query and return the results with links.',
+)
+
+result = agent.run_sync('Tell me the top news in the GenAI world, give me links.')
+print(result.output)
+```
+
+### Configuring Parameters
+
+The `bocha_search_tool` factory accepts optional parameters that control search behavior. `count` is developer-controlled and never appears in the LLM tool schema. Other parameters, when provided, are fixed for all searches and hidden from the LLM's tool schema. Parameters left unset remain available for the LLM to set per-call.
+
+For example, you can lock in `count` and `include_domains` at tool creation time while still letting the LLM control `freshness` and `exclude_domains`:
+
+```py {title="bocha_domain_filtering.py" test="skip"}
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.bocha import bocha_search_tool
+
+api_key = os.getenv('BOCHA_SEARCH_API_KEY')
+assert api_key is not None
+
+agent = Agent(
+    'openai:gpt-5.2',
+    tools=[bocha_search_tool(api_key, count=5, include_domains=['arxiv.org'])],
+    instructions='Search for information and return the results.',
+)
+
+result = agent.run_sync('Find recent papers about transformer architectures')
+print(result.output)
+```
+
+!!! tip "Automatic fallback via WebSearch capability"
+    You can also use [`bocha_search_tool`][pydantic_ai.common_tools.bocha.bocha_search_tool] as a local
+    fallback for the [`WebSearch`][pydantic_ai.capabilities.WebSearch] capability:
+
+    ```py {title="bocha_web_search_capability.py" test="skip"}
+    import os
+
+    from pydantic_ai import Agent
+    from pydantic_ai.capabilities import WebSearch
+    from pydantic_ai.common_tools.bocha import bocha_search_tool
+
+    api_key = os.getenv('BOCHA_SEARCH_API_KEY')
+    assert api_key is not None
+
+    agent = Agent(
+        'openai:gpt-5.2',
+        capabilities=[WebSearch(local=bocha_search_tool(api_key))],
+    )
+    ```
+
 ## Exa Search Tool
 
 !!! info

--- a/pydantic_ai_slim/pydantic_ai/common_tools/bocha.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/bocha.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from dataclasses import KW_ONLY, dataclass
+from functools import partial
+from inspect import signature
+from typing import Literal
+
+import httpx
+from pydantic import TypeAdapter
+from typing_extensions import Any, TypedDict
+
+from pydantic_ai.tools import Tool
+
+__all__ = ('BochaSearchTool', 'bocha_search_tool')
+
+_UNSET: Any = object()
+"""Sentinel to distinguish "not provided" from None in factory kwargs."""
+
+DEFAULT_BOCHA_SEARCH_API_URL = 'https://api.bochaai.com/v1/web-search'
+
+
+class BochaSearchResult(TypedDict):
+    """A Bocha web search result."""
+
+    title: str
+    """The title of the search result."""
+    url: str
+    """The URL of the search result."""
+    content: str
+    """A short description or summary of the search result."""
+    site_name: str | None
+    """The source site name, if available."""
+    published_date: str | None
+    """The published or crawled date, if available."""
+
+
+bocha_search_ta = TypeAdapter(list[BochaSearchResult])
+
+
+@dataclass
+class BochaSearchTool:
+    """The Bocha web search tool."""
+
+    client: httpx.AsyncClient
+    """The async HTTP client used to call Bocha."""
+
+    _: KW_ONLY
+
+    api_key: str
+    """The Bocha API key."""
+
+    api_url: str = DEFAULT_BOCHA_SEARCH_API_URL
+    """The Bocha web search API URL."""
+
+    count: int = 5
+    """The maximum number of results to return."""
+
+    async def __call__(
+        self,
+        query: str,
+        freshness: Literal['noLimit', 'oneDay', 'oneWeek', 'oneMonth', 'oneYear'] = 'noLimit',
+        summary: bool = True,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+    ) -> list[BochaSearchResult]:
+        """Searches Bocha for the given query and returns source-linked results.
+
+        Args:
+            query: The search query to execute with Bocha.
+            freshness: The freshness window for search results.
+            summary: Whether to request summarized snippets when supported.
+            include_domains: List of domains to specifically include in the search results.
+            exclude_domains: List of domains to specifically exclude from the search results.
+
+        Returns:
+            A list of search results from Bocha.
+        """
+        request_body: dict[str, Any] = {
+            'query': query,
+            'freshness': freshness,
+            'summary': summary,
+            'count': self.count,
+        }
+        if include_domains:
+            request_body['include'] = '|'.join(include_domains)
+        if exclude_domains:
+            request_body['exclude'] = '|'.join(exclude_domains)
+
+        response = await self.client.post(
+            self.api_url,
+            headers={'Authorization': f'Bearer {self.api_key}'},
+            json=request_body,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        web_pages = payload.get('data', {}).get('webPages', payload.get('webPages', {}))
+        results = web_pages.get('value', [])
+        return bocha_search_ta.validate_python([_map_result(result) for result in results])
+
+
+def _map_result(result: dict[str, Any]) -> BochaSearchResult:
+    return BochaSearchResult(
+        title=result.get('name') or result.get('title') or '',
+        url=result.get('url') or result.get('displayUrl') or '',
+        content=result.get('summary') or result.get('snippet') or result.get('description') or '',
+        site_name=result.get('siteName'),
+        published_date=result.get('datePublished') or result.get('dateLastCrawled'),
+    )
+
+
+def bocha_search_tool(
+    api_key: str | None = None,
+    *,
+    client: httpx.AsyncClient | None = None,
+    api_url: str = DEFAULT_BOCHA_SEARCH_API_URL,
+    count: int = 5,
+    freshness: Literal['noLimit', 'oneDay', 'oneWeek', 'oneMonth', 'oneYear'] = _UNSET,
+    summary: bool = _UNSET,
+    include_domains: list[str] | None = _UNSET,
+    exclude_domains: list[str] | None = _UNSET,
+) -> Tool[Any]:
+    """Creates a Bocha web search tool.
+
+    `count` is developer-controlled and does not appear in the LLM tool schema.
+    Other parameters, when provided, are fixed for all searches and hidden from the LLM's
+    tool schema. Parameters left unset remain available for the LLM to set per-call.
+
+    Args:
+        api_key: The Bocha API key. Required.
+        client: An existing HTTPX async client. This is useful for sharing a client across multiple tool instances.
+        api_url: The Bocha web search API URL.
+        count: The maximum number of results to return.
+        freshness: The freshness window for search results.
+        summary: Whether to request summarized snippets when supported.
+        include_domains: List of domains to specifically include in the search results.
+        exclude_domains: List of domains to specifically exclude from the search results.
+    """
+    if api_key is None:
+        raise ValueError('api_key must be provided')
+    if client is None:
+        client = httpx.AsyncClient()
+    func = BochaSearchTool(client=client, api_key=api_key, api_url=api_url, count=count).__call__
+
+    kwargs: dict[str, Any] = {}
+    if freshness is not _UNSET:
+        kwargs['freshness'] = freshness
+    if summary is not _UNSET:
+        kwargs['summary'] = summary
+    if include_domains is not _UNSET:
+        kwargs['include_domains'] = include_domains
+    if exclude_domains is not _UNSET:
+        kwargs['exclude_domains'] = exclude_domains
+
+    if kwargs:
+        original = func
+        func = partial(func, **kwargs)
+        func.__name__ = original.__name__  # type: ignore[union-attr]
+        func.__qualname__ = original.__qualname__
+        # partial with keyword args only updates defaults, not removes params.
+        # Set __signature__ explicitly to exclude bound params from the tool schema.
+        orig_sig = signature(original)
+        func.__signature__ = orig_sig.replace(  # type: ignore[attr-defined]
+            parameters=[p for name, p in orig_sig.parameters.items() if name not in kwargs]
+        )
+
+    return Tool[Any](
+        func,  # pyright: ignore[reportArgumentType]
+        name='bocha_search',
+        description='Searches Bocha for the given query and returns source-linked web results.',
+    )

--- a/tests/test_common_tools_bocha.py
+++ b/tests/test_common_tools_bocha.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import httpx
+import pytest
+
+from pydantic_ai.common_tools.bocha import BochaSearchTool, bocha_search_tool
+
+from .conftest import ClientWithHandler
+
+
+@pytest.mark.anyio
+async def test_bocha_search_maps_nested_web_pages_response(client_with_handler: ClientWithHandler) -> None:
+    captured_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                'data': {
+                    'webPages': {
+                        'value': [
+                            {
+                                'name': 'Pydantic AI',
+                                'url': 'https://ai.pydantic.dev/',
+                                'summary': 'Agent framework for production AI.',
+                                'siteName': 'Pydantic',
+                                'datePublished': '2026-01-02',
+                            }
+                        ]
+                    }
+                }
+            },
+        )
+
+    client = client_with_handler(handler)
+    search_tool = BochaSearchTool(client=client, api_key='test-key', count=3)
+
+    results = await search_tool(
+        'pydantic ai',
+        freshness='oneWeek',
+        summary=True,
+        include_domains=['ai.pydantic.dev', 'docs.pydantic.dev'],
+        exclude_domains=['example.com'],
+    )
+
+    assert len(captured_requests) == 1
+    request = captured_requests[0]
+    assert request.url == 'https://api.bochaai.com/v1/web-search'
+    assert request.headers['Authorization'] == 'Bearer test-key'
+    assert json.loads(request.content) == {
+        'query': 'pydantic ai',
+        'freshness': 'oneWeek',
+        'summary': True,
+        'count': 3,
+        'include': 'ai.pydantic.dev|docs.pydantic.dev',
+        'exclude': 'example.com',
+    }
+    assert results == [
+        {
+            'title': 'Pydantic AI',
+            'url': 'https://ai.pydantic.dev/',
+            'content': 'Agent framework for production AI.',
+            'site_name': 'Pydantic',
+            'published_date': '2026-01-02',
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_bocha_search_maps_top_level_web_pages_response(client_with_handler: ClientWithHandler) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                'webPages': {
+                    'value': [
+                        {
+                            'title': 'Fallback title',
+                            'displayUrl': 'https://example.com/page',
+                            'snippet': 'Fallback snippet.',
+                            'dateLastCrawled': '2026-02-03',
+                        }
+                    ]
+                }
+            },
+        )
+
+    client = client_with_handler(handler)
+    search_tool = BochaSearchTool(client=client, api_key='test-key')
+
+    assert await search_tool('fallback fields') == [
+        {
+            'title': 'Fallback title',
+            'url': 'https://example.com/page',
+            'content': 'Fallback snippet.',
+            'site_name': None,
+            'published_date': '2026-02-03',
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_bocha_search_raises_for_http_errors(client_with_handler: ClientWithHandler) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, request=request, text='unauthorized')
+
+    client = client_with_handler(handler)
+    search_tool = BochaSearchTool(client=client, api_key='bad-key')
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await search_tool('secret')
+
+
+def test_bocha_search_tool_requires_api_key() -> None:
+    with pytest.raises(ValueError, match='api_key must be provided'):
+        bocha_search_tool()
+
+
+@pytest.mark.anyio
+async def test_bocha_search_tool_hides_fixed_arguments_from_schema(client_with_handler: ClientWithHandler) -> None:
+    captured_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(200, json={'data': {'webPages': {'value': []}}})
+
+    client = client_with_handler(handler)
+
+    tool = bocha_search_tool(
+        'test-key',
+        client=client,
+        count=10,
+        freshness='oneDay',
+        summary=True,
+        include_domains=['ai.pydantic.dev'],
+        exclude_domains=['example.com'],
+    )
+
+    assert tool.name == 'bocha_search'
+    assert set(tool.tool_def.parameters_json_schema['properties']) == {'query'}
+    assert await cast(Any, tool.function)('schema search') == []
+    assert json.loads(captured_requests[0].content) == {
+        'query': 'schema search',
+        'freshness': 'oneDay',
+        'summary': True,
+        'count': 10,
+        'include': 'ai.pydantic.dev',
+        'exclude': 'example.com',
+    }
+
+
+@pytest.mark.anyio
+async def test_bocha_search_tool_creates_default_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    clients: list[httpx.AsyncClient] = []
+    async_client = httpx.AsyncClient
+
+    def async_client_factory() -> httpx.AsyncClient:
+        client = async_client()
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(httpx, 'AsyncClient', async_client_factory)
+
+    tool = bocha_search_tool('test-key')
+
+    assert len(clients) == 1
+    assert cast(Any, tool.function).__self__.client is clients[0]
+    assert set(tool.tool_def.parameters_json_schema['properties']) == {
+        'query',
+        'freshness',
+        'summary',
+        'include_domains',
+        'exclude_domains',
+    }
+    await clients[0].aclose()


### PR DESCRIPTION
## Summary

Adds a Bocha web search common tool, following the existing Tavily/Exa tool factory pattern.

- add `pydantic_ai.common_tools.bocha.bocha_search_tool`
- map Bocha web search responses into source-linked structured results
- document direct tool usage and `WebSearch(local=...)` fallback usage
- add mocked HTTP tests for request shape, response mapping, HTTP errors, and tool schema hiding

## Verification

- `PYTHONUTF8=1 uv run pytest tests/test_common_tools_bocha.py -q` -> `5 passed`
- `PYTHONUTF8=1 uv run ruff check pydantic_ai_slim/pydantic_ai/common_tools/bocha.py tests/test_common_tools_bocha.py docs/common-tools.md docs/api/common_tools.md` -> passed
- `PYTHONUTF8=1 uv run pyright pydantic_ai_slim/pydantic_ai/common_tools/bocha.py tests/test_common_tools_bocha.py` -> `0 errors`
- Live smoke with a temporary `BOCHA_SEARCH_API_KEY`: `BochaSearchTool(..., count=3)` returned 3 web results with titles, URLs, and non-empty content.