### PR TITLE
Preserve deferred capability state in UI adapters

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -39,6 +39,7 @@ from ...messages import (
     TextPart,
     ThinkingPart,
     ToolCallPart,
+    ToolPartKind,
     ToolReturnPart,
     UploadedFile,
     UserContent,
@@ -307,7 +308,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
     def load_messages(cls, messages: Sequence[Message], *, preserve_file_data: bool = False) -> list[ModelMessage]:  # noqa: C901
         """Transform AG-UI messages into Pydantic AI messages."""
         builder = MessagesBuilder()
-        tool_calls: dict[str, str] = {}  # Tool call ID to tool name mapping.
+        tool_calls: dict[str, tuple[str, ToolPartKind | None]] = {}
         for msg in messages:
             match msg:
                 case UserMessage(content=content):
@@ -371,7 +372,8 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                         for tool_call in tool_calls_list:
                             tool_call_id = tool_call.id
                             tool_name = tool_call.function.name
-                            tool_calls[tool_call_id] = tool_name
+                            tool_kind = _load_tool_kind(tool_call.encrypted_value)
+                            tool_calls[tool_call_id] = (tool_name, tool_kind)
 
                             if tool_call_id.startswith(BUILTIN_TOOL_CALL_ID_PREFIX):
                                 _, provider_name, original_id = tool_call_id.split('|', 2)
@@ -385,17 +387,21 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 )
                             else:
                                 builder.add(
-                                    ToolCallPart(
-                                        tool_name=tool_name,
-                                        tool_call_id=tool_call_id,
-                                        args=tool_call.function.arguments,
+                                    _narrow_tool_call(
+                                        ToolCallPart(
+                                            tool_name=tool_name,
+                                            tool_call_id=tool_call_id,
+                                            args=tool_call.function.arguments,
+                                        ),
+                                        tool_kind,
                                     )
                                 )
                 case ToolMessage() as tool_msg:
                     tool_call_id = tool_msg.tool_call_id
-                    tool_name = tool_calls.get(tool_call_id)
-                    if tool_name is None:  # pragma: no cover
+                    tool_call_info = tool_calls.get(tool_call_id)
+                    if tool_call_info is None:  # pragma: no cover
                         raise ValueError(f'Tool call with ID {tool_call_id} not found in the history.')
+                    tool_name, tool_kind = tool_call_info
 
                     if tool_call_id.startswith(BUILTIN_TOOL_CALL_ID_PREFIX):
                         _, provider_name, original_id = tool_call_id.split('|', 2)
@@ -414,11 +420,20 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             )
                         )
                     else:
+                        content: Any = tool_msg.content
+                        if tool_kind is not None:
+                            try:
+                                content = json.loads(content)
+                            except json.JSONDecodeError:
+                                pass
                         builder.add(
-                            ToolReturnPart(
-                                tool_name=tool_name,
-                                content=tool_msg.content,
-                                tool_call_id=tool_call_id,
+                            _narrow_tool_return(
+                                ToolReturnPart(
+                                    tool_name=tool_name,
+                                    content=content,
+                                    tool_call_id=tool_call_id,
+                                ),
+                                tool_kind,
                             )
                         )
 
@@ -633,6 +648,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     ToolCall(
                         id=part.tool_call_id,
                         function=FunctionCall(name=part.tool_name, arguments=part.args_as_json_str()),
+                        encrypted_value=_dump_tool_kind(part.tool_kind),
                     )
                 )
             elif isinstance(part, NativeToolCallPart):
@@ -734,3 +750,39 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                 assert_never(msg)
 
         return result
+
+
+def _dump_tool_kind(tool_kind: ToolPartKind | None) -> str | None:
+    if tool_kind is None:
+        return None
+    return json.dumps({'tool_kind': tool_kind})
+
+
+def _load_tool_kind(encrypted_value: str | None) -> ToolPartKind | None:
+    if encrypted_value is None:
+        return None
+    try:
+        value = json.loads(encrypted_value)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(value, dict):
+        return None
+    metadata = cast(dict[str, Any], value)
+    tool_kind = metadata.get('tool_kind')
+    if tool_kind in ('tool-search', 'capability-load'):
+        return tool_kind
+    return None
+
+
+def _narrow_tool_call(part: ToolCallPart, tool_kind: ToolPartKind | None) -> ToolCallPart:
+    try:
+        return ToolCallPart.narrow_type(part, tool_kind=tool_kind)
+    except ValueError:
+        return part
+
+
+def _narrow_tool_return(part: ToolReturnPart, tool_kind: ToolPartKind | None) -> ToolReturnPart:
+    try:
+        return ToolReturnPart.narrow_type(part, tool_kind=tool_kind)
+    except ValueError:
+        return part

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -35,6 +35,7 @@ from ...messages import (
     TextPart,
     ThinkingPart,
     ToolCallPart,
+    ToolPartKind,
     ToolReturnPart,
     UploadedFile,
     UploadedFileProviderName,
@@ -384,6 +385,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                         part_id = provider_meta.get('id')
                         provider_name = provider_meta.get('provider_name')
                         provider_details = provider_meta.get('provider_details')
+                        tool_kind = _load_tool_kind(provider_meta)
 
                         if builtin_tool:
                             # For builtin tools, we need to create 2 parts (BuiltinToolCall & BuiltinToolReturn) for a single Vercel ToolOutput
@@ -442,19 +444,29 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                                 )
                         else:
                             builder.add(
-                                ToolCallPart(
-                                    tool_name=tool_name,
-                                    tool_call_id=tool_call_id,
-                                    args=args,
-                                    id=part_id,
-                                    provider_name=provider_name,
-                                    provider_details=provider_details,
+                                _narrow_tool_call(
+                                    ToolCallPart(
+                                        tool_name=tool_name,
+                                        tool_call_id=tool_call_id,
+                                        args=args,
+                                        id=part_id,
+                                        provider_name=provider_name,
+                                        provider_details=provider_details,
+                                    ),
+                                    tool_kind,
                                 )
                             )
 
                             if part.state == 'output-available':
                                 builder.add(
-                                    ToolReturnPart(tool_name=tool_name, tool_call_id=tool_call_id, content=part.output)
+                                    _narrow_tool_return(
+                                        ToolReturnPart(
+                                            tool_name=tool_name,
+                                            tool_call_id=tool_call_id,
+                                            content=part.output,
+                                        ),
+                                        tool_kind,
+                                    )
                                 )
                             elif part.state == 'output-error':
                                 builder.add(
@@ -700,7 +712,10 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
         """Convert a ToolCallPart (with optional result) into UIMessageParts."""
         tool_result = tool_results.get(part.tool_call_id)
         call_provider_metadata = dump_provider_metadata(
-            id=part.id, provider_name=part.provider_name, provider_details=part.provider_details
+            id=part.id,
+            provider_name=part.provider_name,
+            provider_details=part.provider_details,
+            tool_kind=part.tool_kind,
         )
         tool_type = f'tool-{part.tool_name}'
         ui_parts: list[UIMessagePart] = []
@@ -918,6 +933,27 @@ def _denial_reason(part: ToolUIPart | DynamicToolUIPart) -> str:
     if isinstance(part.approval, ToolApprovalResponded) and part.approval.reason:
         return part.approval.reason
     return ToolDenied().message
+
+
+def _load_tool_kind(provider_meta: dict[str, Any]) -> ToolPartKind | None:
+    tool_kind = provider_meta.get('tool_kind')
+    if tool_kind in ('tool-search', 'capability-load'):
+        return tool_kind
+    return None
+
+
+def _narrow_tool_call(part: ToolCallPart, tool_kind: ToolPartKind | None) -> ToolCallPart:
+    try:
+        return ToolCallPart.narrow_type(part, tool_kind=tool_kind)
+    except ValueError:
+        return part
+
+
+def _narrow_tool_return(part: ToolReturnPart, tool_kind: ToolPartKind | None) -> ToolReturnPart:
+    try:
+        return ToolReturnPart.narrow_type(part, tool_kind=tool_kind)
+    except ValueError:
+        return part
 
 
 def _extract_metadata_ui_parts(tool_result: ToolReturnPart) -> list[UIMessagePart]:

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -54,11 +54,13 @@ from pydantic_ai import (
     VideoUrl,
     capture_run_messages,
 )
+from pydantic_ai._deferred_capabilities import parse_loaded_capabilities
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.agent import Agent, AgentRunResult
 from pydantic_ai.capabilities import PrepareTools
 from pydantic_ai.exceptions import UserError
+from pydantic_ai.messages import LoadCapabilityCallPart, LoadCapabilityReturnPart
 from pydantic_ai.models.function import (
     AgentInfo,
     BuiltinToolCallsReturns,
@@ -1597,6 +1599,72 @@ def test_dump_load_roundtrip_tools() -> None:
     _sync_timestamps(original, reloaded)
 
     assert reloaded == original
+
+
+def test_dump_load_roundtrip_preserves_loaded_capabilities() -> None:
+    original: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                LoadCapabilityCallPart(
+                    tool_call_id='load-foobar',
+                    args={'id': 'foobar'},
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                LoadCapabilityReturnPart(
+                    tool_call_id='load-foobar',
+                    content={'instructions': '# Foo Bar'},
+                )
+            ]
+        ),
+    ]
+
+    assert parse_loaded_capabilities(original) == {'foobar'}
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+
+    assert parse_loaded_capabilities(reloaded) == {'foobar'}
+    assert isinstance(reloaded[0], ModelResponse)
+    assert isinstance(reloaded[0].parts[0], LoadCapabilityCallPart)
+    assert isinstance(reloaded[1], ModelRequest)
+    assert isinstance(reloaded[1].parts[0], LoadCapabilityReturnPart)
+
+
+def test_dump_load_roundtrip_preserves_user_load_capability_tool() -> None:
+    original: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name='load_capability',
+                    tool_call_id='user-load',
+                    args={'id': 'not-a-framework-capability'},
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='load_capability',
+                    tool_call_id='user-load',
+                    content={'instructions': '# Not Framework Managed'},
+                )
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+
+    assert parse_loaded_capabilities(reloaded) == set()
+    assert isinstance(reloaded[0], ModelResponse)
+    assert isinstance(reloaded[0].parts[0], ToolCallPart)
+    assert not isinstance(reloaded[0].parts[0], LoadCapabilityCallPart)
+    assert isinstance(reloaded[1], ModelRequest)
+    assert isinstance(reloaded[1].parts[0], ToolReturnPart)
+    assert not isinstance(reloaded[1].parts[0], LoadCapabilityReturnPart)
 
 
 def test_dump_load_roundtrip_multiple_thinking_parts() -> None:

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 import pytest
 
 from pydantic_ai import Agent, capture_run_messages
+from pydantic_ai._deferred_capabilities import parse_loaded_capabilities
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._utils import is_str_dict
 from pydantic_ai.capabilities import NativeTool
@@ -25,6 +26,8 @@ from pydantic_ai.messages import (
     FunctionToolCallEvent,
     FunctionToolResultEvent,
     ImageUrl,
+    LoadCapabilityCallPart,
+    LoadCapabilityReturnPart,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -4790,6 +4793,66 @@ async def test_adapter_dump_load_roundtrip():
     reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
     _sync_timestamps(original_messages, reloaded_messages)
 
+    assert reloaded_messages == original_messages
+
+
+async def test_adapter_dump_load_roundtrip_preserves_loaded_capabilities():
+    original_messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                LoadCapabilityCallPart(
+                    tool_call_id='load-foobar',
+                    args={'id': 'foobar'},
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                LoadCapabilityReturnPart(
+                    tool_call_id='load-foobar',
+                    content={'instructions': '# Foo Bar'},
+                )
+            ]
+        ),
+    ]
+
+    assert parse_loaded_capabilities(original_messages) == {'foobar'}
+
+    ui_messages = VercelAIAdapter.dump_messages(original_messages)
+    reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
+    _sync_timestamps(original_messages, reloaded_messages)
+
+    assert parse_loaded_capabilities(reloaded_messages) == {'foobar'}
+    assert reloaded_messages == original_messages
+
+
+async def test_adapter_dump_load_roundtrip_preserves_user_load_capability_tool():
+    original_messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name='load_capability',
+                    tool_call_id='user-load',
+                    args={'id': 'not-a-framework-capability'},
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='load_capability',
+                    tool_call_id='user-load',
+                    content={'instructions': '# Not Framework Managed'},
+                )
+            ]
+        ),
+    ]
+
+    ui_messages = VercelAIAdapter.dump_messages(original_messages)
+    reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
+    _sync_timestamps(original_messages, reloaded_messages)
+
+    assert parse_loaded_capabilities(reloaded_messages) == set()
     assert reloaded_messages == original_messages
 
 


### PR DESCRIPTION
Fixes #5846.

`LoadCapabilityCallPart` and `LoadCapabilityReturnPart` rely on `tool_kind='capability-load'` to survive message-history replay. The UI adapters were dumping the visible `load_capability` tool call and return, but not the typed discriminator, so `load_messages(dump_messages(...))` reconstructed generic `ToolCallPart` / `ToolReturnPart` values and `parse_loaded_capabilities()` returned an empty set.

This PR preserves that discriminator only through adapter-owned metadata:

- Vercel AI stores `tool_kind` in `callProviderMetadata.pydantic_ai` and narrows calls/available returns during `load_messages()`.
- AG-UI stores `tool_kind` in `ToolCall.encrypted_value`, matching the existing JSON metadata pattern used for thinking parts, and narrows the paired `ToolMessage` return when present.
- Both adapters keep ordinary user tools named `load_capability` generic unless they were dumped with the framework discriminator.

Local checks:

```bash
PYTHONUTF8=1 uv run pytest tests/test_vercel_ai.py tests/test_ag_ui.py -k "loaded_capabilities or user_load_capability_tool or test_adapter_dump_load_roundtrip"
PYTHONUTF8=1 uv run pytest tests/test_ag_ui.py -k "dump_load_roundtrip_tools or loaded_capabilities or user_load_capability_tool"
PYTHONUTF8=1 uv run ruff check pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_vercel_ai.py tests/test_ag_ui.py
PYTHONUTF8=1 uv run pyright pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_vercel_ai.py tests/test_ag_ui.py
```
