### PR TITLE
Retain dropped usage fields across `GoogleModel` streaming chunks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -5,7 +5,7 @@ import re
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from datetime import datetime
 from typing import Any, Literal, cast, get_args, overload
 from uuid import uuid4
@@ -1318,7 +1318,7 @@ class GeminiStreamedResponse(StreamedResponse):
             self.provider_details = {'timestamp': self._provider_timestamp}
         try:
             async for chunk in self._response:
-                self._usage = _metadata_as_usage(chunk, self._provider_name, self._provider_url)
+                self._usage = _metadata_as_usage(chunk, self._provider_name, self._provider_url, self._usage)
 
                 if (
                     chunk.sdk_http_response
@@ -1886,10 +1886,15 @@ def _function_declaration_from_tool(tool: ToolDefinition) -> FunctionDeclaration
     return f
 
 
-def _metadata_as_usage(response: GenerateContentResponse, provider: str, provider_url: str) -> usage.RequestUsage:
+def _metadata_as_usage(
+    response: GenerateContentResponse,
+    provider: str,
+    provider_url: str,
+    existing_usage: usage.RequestUsage | None = None,
+) -> usage.RequestUsage:
     metadata = response.usage_metadata
     if metadata is None:
-        return usage.RequestUsage()
+        return existing_usage or usage.RequestUsage()
     details: dict[str, int] = {}
     if cached_content_token_count := metadata.cached_content_token_count:
         details['cached_content_tokens'] = cached_content_token_count
@@ -1914,13 +1919,26 @@ def _metadata_as_usage(response: GenerateContentResponse, provider: str, provide
                 continue
             details[f'{detail.modality.lower()}_{prefix}_tokens'] = detail.token_count
 
-    return usage.RequestUsage.extract(
+    # Gemini streams usage as cumulative snapshots, but a field reported on an earlier chunk can be
+    # absent from a later one (e.g. `cached_content_token_count` when streamed through a gateway, see #5205).
+    # Merge with the usage accumulated so far so those values survive instead of being overwritten with 0.
+    if existing_usage:
+        details = {**existing_usage.details, **details}
+
+    new_usage = usage.RequestUsage.extract(
         response.model_dump(include={'model_version', 'usage_metadata'}, by_alias=True),
         provider=provider,
         provider_url=provider_url,
         provider_fallback='google',
         details=details,
     )
+
+    if existing_usage:
+        for token_field in fields(new_usage):
+            if token_field.name != 'details' and not getattr(new_usage, token_field.name):
+                setattr(new_usage, token_field.name, getattr(existing_usage, token_field.name))
+
+    return new_usage
 
 
 def _map_executable_code(executable_code: ExecutableCode, provider_name: str, tool_call_id: str) -> NativeToolCallPart:

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -1933,6 +1933,12 @@ def _metadata_as_usage(
         details=details,
     )
 
+    # `extract` derives the typed token fields from the raw `usage_metadata`, not from the merged
+    # `details` above, so a typed field that a later cumulative chunk dropped stays zeroed even when
+    # `details` retained it. Backfill those fields from the usage accumulated so far. (Anthropic's
+    # `_map_usage` re-extracts from its merged details instead, because its genai-prices mapping
+    # reads the same keys it stores in `details`; Google's mapping reads the raw API keys, so the
+    # merged `details` cannot reconstruct the typed fields here.)
     if existing_usage:
         for token_field in fields(new_usage):
             if token_field.name != 'details' and not getattr(new_usage, token_field.name):

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -5,7 +5,7 @@ import re
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal, cast, get_args, overload
 from uuid import uuid4
@@ -1934,18 +1934,19 @@ def _metadata_as_usage(
     )
 
     # `extract` derives the typed token fields from the raw `usage_metadata`, not from the merged
-    # `details` above, so a typed field that a later cumulative chunk dropped stays zeroed even when
-    # `details` retained it. Backfill those fields from the usage accumulated so far. (Anthropic's
-    # `_map_usage` re-extracts from its merged details instead, because its genai-prices mapping
-    # reads the same keys it stores in `details`; Google's mapping reads the raw API keys, so the
-    # merged `details` cannot reconstruct the typed fields here.)
-    # A later-chunk 0 is treated as "dropped, restore the earlier value", which is safe only because
-    # Gemini `usage_metadata` is cumulative/monotonic so a real 0 never overwrites a prior non-zero;
-    # a provider whose streamed usage is non-cumulative could not reuse this backfill as-is.
+    # `details`, so a field a later cumulative chunk dropped stays zeroed; backfill it from the usage
+    # so far. A later-chunk 0 means "dropped", safe only because Gemini usage_metadata is cumulative/
+    # monotonic (a real 0 never overwrites a prior non-zero). Unlike Anthropic's `_map_usage`, we can't
+    # re-extract from the merged `details`: Google's genai-prices mapping reads the raw API keys, not
+    # the keys stored in `details`, so `details` alone can't reconstruct the typed fields here.
     if existing_usage:
-        for token_field in fields(new_usage):
-            if token_field.name != 'details' and not getattr(new_usage, token_field.name):
-                setattr(new_usage, token_field.name, getattr(existing_usage, token_field.name))
+        new_usage.input_tokens = new_usage.input_tokens or existing_usage.input_tokens
+        new_usage.cache_write_tokens = new_usage.cache_write_tokens or existing_usage.cache_write_tokens
+        new_usage.cache_read_tokens = new_usage.cache_read_tokens or existing_usage.cache_read_tokens
+        new_usage.output_tokens = new_usage.output_tokens or existing_usage.output_tokens
+        new_usage.input_audio_tokens = new_usage.input_audio_tokens or existing_usage.input_audio_tokens
+        new_usage.cache_audio_read_tokens = new_usage.cache_audio_read_tokens or existing_usage.cache_audio_read_tokens
+        new_usage.output_audio_tokens = new_usage.output_audio_tokens or existing_usage.output_audio_tokens
 
     return new_usage
 

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -1939,6 +1939,9 @@ def _metadata_as_usage(
     # `_map_usage` re-extracts from its merged details instead, because its genai-prices mapping
     # reads the same keys it stores in `details`; Google's mapping reads the raw API keys, so the
     # merged `details` cannot reconstruct the typed fields here.)
+    # A later-chunk 0 is treated as "dropped, restore the earlier value", which is safe only because
+    # Gemini `usage_metadata` is cumulative/monotonic so a real 0 never overwrites a prior non-zero;
+    # a provider whose streamed usage is non-cumulative could not reuse this backfill as-is.
     if existing_usage:
         for token_field in fields(new_usage):
             if token_field.name != 'details' and not getattr(new_usage, token_field.name):

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -4263,31 +4263,30 @@ async def test_gemini_streamed_response_emits_text_events_for_non_empty_parts():
     assert events == snapshot([PartStartEvent(index=0, part=TextPart(content='streamed text'))])
 
 
-async def test_gemini_streamed_response_usage_retains_cached_tokens_across_chunks():
-    """Gemini streams usage as cumulative snapshots, but a gateway/proxy can report
-    `cached_content_token_count` on an earlier chunk and omit it on a later one (#5205).
-
-    This is a deterministic unit test rather than a VCR test because the direct Gemini APIs
-    (GLA and Vertex) always carry `cached_content_token_count` on the final usage chunk, so a
-    real recording would pass even without the cross-chunk merge.
-    """
-
-    def _chunk(*, cached: int | None, candidates: int, text: str) -> GenerateContentResponse:
-        return GenerateContentResponse.model_validate(
-            {
-                'response_id': 'resp-1',
-                'model_version': 'gemini-test',
-                'usage_metadata': GenerateContentResponseUsageMetadata(
-                    prompt_token_count=20025,
-                    candidates_token_count=candidates,
-                    cached_content_token_count=cached,
-                ),
-                'candidates': [{'content': {'role': 'model', 'parts': [{'text': text}]}}],
-            }
+def _usage_chunk(
+    *,
+    candidates: int,
+    text: str,
+    cached: int | None = None,
+    thoughts: int | None = None,
+    with_metadata: bool = True,
+) -> GenerateContentResponse:
+    data: dict[str, Any] = {
+        'response_id': 'resp-1',
+        'model_version': 'gemini-test',
+        'candidates': [{'content': {'role': 'model', 'parts': [{'text': text}]}}],
+    }
+    if with_metadata:
+        data['usage_metadata'] = GenerateContentResponseUsageMetadata(
+            prompt_token_count=20025,
+            candidates_token_count=candidates,
+            cached_content_token_count=cached,
+            thoughts_token_count=thoughts,
         )
+    return GenerateContentResponse.model_validate(data)
 
-    chunks = [_chunk(cached=16365, candidates=5, text='hel'), _chunk(cached=None, candidates=10, text='lo')]
 
+async def _stream_gemini_usage(chunks: list[GenerateContentResponse]) -> RequestUsage:
     async def response_iterator() -> AsyncIterator[GenerateContentResponse]:
         for chunk in chunks:
             yield chunk
@@ -4304,12 +4303,63 @@ async def test_gemini_streamed_response_usage_retains_cached_tokens_across_chunk
     async for _ in streamed_response._get_event_iterator():  # pyright: ignore[reportPrivateUsage]
         pass
 
-    assert streamed_response.usage == snapshot(
+    return streamed_response.usage
+
+
+async def test_gemini_streamed_response_usage_retains_cached_tokens_across_chunks():
+    """Gemini streams usage as cumulative snapshots, but a gateway/proxy can report
+    `cached_content_token_count` on an earlier chunk and omit it on a later one (#5205).
+
+    This is a deterministic unit test rather than a VCR test because the direct Gemini APIs
+    (GLA and Vertex) always carry `cached_content_token_count` on the final usage chunk, so a
+    real recording would pass even without the cross-chunk merge.
+    """
+    chunks = [_usage_chunk(cached=16365, candidates=5, text='hel'), _usage_chunk(cached=None, candidates=10, text='lo')]
+
+    assert await _stream_gemini_usage(chunks) == snapshot(
         RequestUsage(
             input_tokens=20025,
             cache_read_tokens=16365,
             output_tokens=10,
             details={'cached_content_tokens': 16365},
+        )
+    )
+
+
+async def test_gemini_streamed_response_usage_retained_when_later_chunk_drops_metadata():
+    """A Vertex-direct stream delivers `usage_metadata` on an earlier chunk and can omit it entirely
+    on a later one (#5205); the accumulated usage must survive instead of resetting to zero.
+    """
+    chunks = [
+        _usage_chunk(cached=16365, candidates=5, text='hel'),
+        _usage_chunk(candidates=0, text='lo', with_metadata=False),
+    ]
+
+    assert await _stream_gemini_usage(chunks) == snapshot(
+        RequestUsage(
+            input_tokens=20025,
+            cache_read_tokens=16365,
+            output_tokens=5,
+            details={'cached_content_tokens': 16365},
+        )
+    )
+
+
+async def test_gemini_streamed_response_usage_retains_details_only_fields_across_chunks():
+    """`thoughts_tokens` has no typed `RequestUsage` field, so it survives a later chunk dropping it
+    via the `details` union rather than the typed-field backfill (#5205).
+    """
+    chunks = [
+        _usage_chunk(cached=16365, thoughts=100, candidates=5, text='hel'),
+        _usage_chunk(cached=None, thoughts=None, candidates=10, text='lo'),
+    ]
+
+    assert await _stream_gemini_usage(chunks) == snapshot(
+        RequestUsage(
+            input_tokens=20025,
+            cache_read_tokens=16365,
+            output_tokens=10,
+            details={'cached_content_tokens': 16365, 'thoughts_tokens': 100},
         )
     )
 

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -7,6 +7,7 @@ import os
 import random
 import tempfile
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from datetime import date, timezone
 from decimal import Decimal
 from typing import Any, cast
@@ -4306,62 +4307,74 @@ async def _stream_gemini_usage(chunks: list[GenerateContentResponse]) -> Request
     return streamed_response.usage
 
 
-async def test_gemini_streamed_response_usage_retains_cached_tokens_across_chunks():
-    """Gemini streams usage as cumulative snapshots, but a gateway/proxy can report
-    `cached_content_token_count` on an earlier chunk and omit it on a later one (#5205).
+@dataclass
+class _UsageRetentionCase:
+    id: str
+    chunks: list[GenerateContentResponse]
+    expected: RequestUsage
 
-    This is a deterministic unit test rather than a VCR test because the direct Gemini APIs
-    (GLA and Vertex) always carry `cached_content_token_count` on the final usage chunk, so a
-    real recording would pass even without the cross-chunk merge.
+
+_USAGE_RETENTION_CASES = [
+    _UsageRetentionCase(
+        id='cached_tokens_dropped_by_later_chunk',
+        chunks=[
+            _usage_chunk(cached=16365, candidates=5, text='hel'),
+            _usage_chunk(cached=None, candidates=10, text='lo'),
+        ],
+        expected=snapshot(
+            RequestUsage(
+                input_tokens=20025,
+                cache_read_tokens=16365,
+                output_tokens=10,
+                details={'cached_content_tokens': 16365},
+            )
+        ),
+    ),
+    _UsageRetentionCase(
+        id='metadata_dropped_by_later_chunk',
+        chunks=[
+            _usage_chunk(cached=16365, candidates=5, text='hel'),
+            _usage_chunk(candidates=0, text='lo', with_metadata=False),
+        ],
+        expected=snapshot(
+            RequestUsage(
+                input_tokens=20025,
+                cache_read_tokens=16365,
+                output_tokens=5,
+                details={'cached_content_tokens': 16365},
+            )
+        ),
+    ),
+    _UsageRetentionCase(
+        id='details_only_fields_dropped_by_later_chunk',
+        chunks=[
+            _usage_chunk(cached=16365, thoughts=100, candidates=5, text='hel'),
+            _usage_chunk(cached=None, thoughts=None, candidates=10, text='lo'),
+        ],
+        expected=snapshot(
+            RequestUsage(
+                input_tokens=20025,
+                cache_read_tokens=16365,
+                output_tokens=10,
+                details={'cached_content_tokens': 16365, 'thoughts_tokens': 100},
+            )
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize('case', [pytest.param(c, id=c.id) for c in _USAGE_RETENTION_CASES])
+async def test_gemini_streamed_response_usage_retained_across_chunks(case: _UsageRetentionCase):
+    """Gemini streams usage as cumulative snapshots, but a later chunk can drop a field an earlier one
+    carried (#5205): a gateway/proxy omits `cached_content_token_count`, a Vertex-direct stream omits
+    `usage_metadata` entirely, or a `details`-only field like `thoughts_tokens` disappears. The
+    accumulated usage must survive instead of resetting to zero.
+
+    These are deterministic unit tests rather than VCR tests because the direct Gemini APIs (GLA and
+    Vertex) always carry the field on the final usage chunk, so a real recording would pass even
+    without the cross-chunk merge.
     """
-    chunks = [_usage_chunk(cached=16365, candidates=5, text='hel'), _usage_chunk(cached=None, candidates=10, text='lo')]
-
-    assert await _stream_gemini_usage(chunks) == snapshot(
-        RequestUsage(
-            input_tokens=20025,
-            cache_read_tokens=16365,
-            output_tokens=10,
-            details={'cached_content_tokens': 16365},
-        )
-    )
-
-
-async def test_gemini_streamed_response_usage_retained_when_later_chunk_drops_metadata():
-    """A Vertex-direct stream delivers `usage_metadata` on an earlier chunk and can omit it entirely
-    on a later one (#5205); the accumulated usage must survive instead of resetting to zero.
-    """
-    chunks = [
-        _usage_chunk(cached=16365, candidates=5, text='hel'),
-        _usage_chunk(candidates=0, text='lo', with_metadata=False),
-    ]
-
-    assert await _stream_gemini_usage(chunks) == snapshot(
-        RequestUsage(
-            input_tokens=20025,
-            cache_read_tokens=16365,
-            output_tokens=5,
-            details={'cached_content_tokens': 16365},
-        )
-    )
-
-
-async def test_gemini_streamed_response_usage_retains_details_only_fields_across_chunks():
-    """`thoughts_tokens` has no typed `RequestUsage` field, so it survives a later chunk dropping it
-    via the `details` union rather than the typed-field backfill (#5205).
-    """
-    chunks = [
-        _usage_chunk(cached=16365, thoughts=100, candidates=5, text='hel'),
-        _usage_chunk(cached=None, thoughts=None, candidates=10, text='lo'),
-    ]
-
-    assert await _stream_gemini_usage(chunks) == snapshot(
-        RequestUsage(
-            input_tokens=20025,
-            cache_read_tokens=16365,
-            output_tokens=10,
-            details={'cached_content_tokens': 16365, 'thoughts_tokens': 100},
-        )
-    )
+    assert await _stream_gemini_usage(case.chunks) == case.expected
 
 
 async def _cleanup_file_search_store(store: Any, client: Any) -> None:  # pragma: lax no cover

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -6,7 +6,7 @@ import json
 import os
 import random
 import tempfile
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
 from datetime import date, timezone
 from decimal import Decimal
@@ -4310,14 +4310,17 @@ async def _stream_gemini_usage(chunks: list[GenerateContentResponse]) -> Request
 @dataclass
 class _UsageRetentionCase:
     id: str
-    chunks: list[GenerateContentResponse]
+    # A factory rather than a built list: the chunks construct google.genai types, which are only
+    # importable when the `google` extra is installed. Building them at collection time would raise
+    # `NameError` in jobs without the extra (where this test is skipped anyway).
+    make_chunks: Callable[[], list[GenerateContentResponse]]
     expected: RequestUsage
 
 
 _USAGE_RETENTION_CASES = [
     _UsageRetentionCase(
         id='cached_tokens_dropped_by_later_chunk',
-        chunks=[
+        make_chunks=lambda: [
             _usage_chunk(cached=16365, candidates=5, text='hel'),
             _usage_chunk(cached=None, candidates=10, text='lo'),
         ],
@@ -4332,7 +4335,7 @@ _USAGE_RETENTION_CASES = [
     ),
     _UsageRetentionCase(
         id='metadata_dropped_by_later_chunk',
-        chunks=[
+        make_chunks=lambda: [
             _usage_chunk(cached=16365, candidates=5, text='hel'),
             _usage_chunk(candidates=0, text='lo', with_metadata=False),
         ],
@@ -4347,7 +4350,7 @@ _USAGE_RETENTION_CASES = [
     ),
     _UsageRetentionCase(
         id='details_only_fields_dropped_by_later_chunk',
-        chunks=[
+        make_chunks=lambda: [
             _usage_chunk(cached=16365, thoughts=100, candidates=5, text='hel'),
             _usage_chunk(cached=None, thoughts=None, candidates=10, text='lo'),
         ],
@@ -4374,7 +4377,7 @@ async def test_gemini_streamed_response_usage_retained_across_chunks(case: _Usag
     Vertex) always carry the field on the final usage chunk, so a real recording would pass even
     without the cross-chunk merge.
     """
-    assert await _stream_gemini_usage(case.chunks) == case.expected
+    assert await _stream_gemini_usage(case.make_chunks()) == case.expected
 
 
 async def _cleanup_file_search_store(store: Any, client: Any) -> None:  # pragma: lax no cover

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -4263,6 +4263,57 @@ async def test_gemini_streamed_response_emits_text_events_for_non_empty_parts():
     assert events == snapshot([PartStartEvent(index=0, part=TextPart(content='streamed text'))])
 
 
+async def test_gemini_streamed_response_usage_retains_cached_tokens_across_chunks():
+    """Gemini streams usage as cumulative snapshots, but a gateway/proxy can report
+    `cached_content_token_count` on an earlier chunk and omit it on a later one (#5205).
+
+    This is a deterministic unit test rather than a VCR test because the direct Gemini APIs
+    (GLA and Vertex) always carry `cached_content_token_count` on the final usage chunk, so a
+    real recording would pass even without the cross-chunk merge.
+    """
+
+    def _chunk(*, cached: int | None, candidates: int, text: str) -> GenerateContentResponse:
+        return GenerateContentResponse.model_validate(
+            {
+                'response_id': 'resp-1',
+                'model_version': 'gemini-test',
+                'usage_metadata': GenerateContentResponseUsageMetadata(
+                    prompt_token_count=20025,
+                    candidates_token_count=candidates,
+                    cached_content_token_count=cached,
+                ),
+                'candidates': [{'content': {'role': 'model', 'parts': [{'text': text}]}}],
+            }
+        )
+
+    chunks = [_chunk(cached=16365, candidates=5, text='hel'), _chunk(cached=None, candidates=10, text='lo')]
+
+    async def response_iterator() -> AsyncIterator[GenerateContentResponse]:
+        for chunk in chunks:
+            yield chunk
+
+    streamed_response = GeminiStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='gemini-test',
+        _response=cast(Any, PeekableAsyncStream(response_iterator())),
+        _timestamp=IsDatetime(),
+        _provider_name='google',
+        _provider_url='',
+    )
+
+    async for _ in streamed_response._get_event_iterator():  # pyright: ignore[reportPrivateUsage]
+        pass
+
+    assert streamed_response.usage == snapshot(
+        RequestUsage(
+            input_tokens=20025,
+            cache_read_tokens=16365,
+            output_tokens=10,
+            details={'cached_content_tokens': 16365},
+        )
+    )
+
+
 async def _cleanup_file_search_store(store: Any, client: Any) -> None:  # pragma: lax no cover
     """Helper function to clean up a file search store if it exists."""
     if store is not None and store.name is not None:


### PR DESCRIPTION
- Closes #5205

## Problem

When using Google Gemini via streaming (`agent.run_stream()` / `agent.iter()`), `Usage.cache_read_tokens` could come back `0` even when implicit caching was active, causing cost calculations to treat cached input as full-price.

## Root cause

`GeminiStreamedResponse._get_event_iterator` overwrote `self._usage = _metadata_as_usage(chunk, ...)` on **every** chunk with no cross-chunk merge. `_metadata_as_usage` derives the typed `cache_read_tokens` from the **raw chunk** `usage_metadata` via `genai-prices`, so whatever the *last processed* usage chunk reports wins. Gemini streams usage as **cumulative snapshots**; if a later snapshot omits a field that an earlier one carried (e.g. `cached_content_token_count`), the typed usage gets zeroed out.

`AnthropicModel._map_usage` already guards against this by threading `existing_usage` and merging across streaming events. This brings `GoogleModel` to parity.

## Trigger (why this is a defensive retention fix, not a direct-API repro)

The bug only manifests through the **PAIG gateway** (Gemini 3 Flash, Vertex backend, as in the issue report), which emits a trailing usage chunk that drops `cached_content_token_count`. Confirmed empirically against the direct APIs:

- **gemini-2.5-flash (GLA):** `cached_content_token_count` present on every chunk incl. final → not affected.
- **gemini-3-flash-preview (GLA):** present only on the final chunk → not affected.
- **gemini-3-flash-preview (Vertex direct):** intermediate chunks carry no `usage_metadata`; full snapshot incl. cached only on the final chunk → not affected.

So the direct GLA/Vertex APIs keep the field on the final processed chunk and never reproduce the zeroing. This is a defensive cross-chunk **usage retention** fix for cumulative-snapshot streams that drop a field mid-stream.

## Fix

Thread `existing_usage` into `_metadata_as_usage`; merge `details` (union, latest wins) and backfill any numeric token field the latest cumulative snapshot dropped. The non-streaming path and `_metadata_as_usage` callers that pass no `existing_usage` are unchanged.

## Testing

Added a **deterministic** unit test (`test_gemini_streamed_response_usage_retains_cached_tokens_across_chunks`) feeding a cached-on-early / absent-on-later chunk sequence through `GeminiStreamedResponse`. A live VCR test is deliberately not used: it would pass **without** the fix, since the direct APIs don't drop the field. Per `tests/CLAUDE.md`, behavior you can't reliably trigger through the public API gets a targeted unit test.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

