### PR TITLE
Add `gemini-embedding-2` embedding model

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/embeddings/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/__init__.py
@@ -38,10 +38,12 @@ KnownEmbeddingModelName = TypeAliasType(
     Literal[
         'google-cloud:gemini-embedding-001',
         'google-cloud:gemini-embedding-2-preview',
+        'google-cloud:gemini-embedding-2',
         'google-cloud:text-embedding-005',
         'google-cloud:text-multilingual-embedding-002',
         'google:gemini-embedding-001',
         'google:gemini-embedding-2-preview',
+        'google:gemini-embedding-2',
         'openai:text-embedding-ada-002',
         'openai:text-embedding-3-small',
         'openai:text-embedding-3-large',

--- a/pydantic_ai_slim/pydantic_ai/embeddings/google.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/google.py
@@ -20,7 +20,7 @@ except ImportError as _import_error:
     ) from _import_error
 
 
-LatestGoogleGLAEmbeddingModelNames = Literal['gemini-embedding-001', 'gemini-embedding-2-preview']
+LatestGoogleGLAEmbeddingModelNames = Literal['gemini-embedding-001', 'gemini-embedding-2-preview', 'gemini-embedding-2']
 """Latest Gemini API embedding models.
 
 See the [Google Embeddings documentation](https://ai.google.dev/gemini-api/docs/embeddings)
@@ -30,6 +30,7 @@ for available models and their capabilities.
 LatestGoogleVertexEmbeddingModelNames = Literal[
     'gemini-embedding-001',
     'gemini-embedding-2-preview',
+    'gemini-embedding-2',
     'text-embedding-005',
     'text-multilingual-embedding-002',
 ]
@@ -49,6 +50,7 @@ GoogleEmbeddingModelName = str | LatestGoogleEmbeddingModelNames
 _MAX_INPUT_TOKENS: dict[GoogleEmbeddingModelName, int] = {
     'gemini-embedding-001': 2048,
     'gemini-embedding-2-preview': 8192,
+    'gemini-embedding-2': 8192,
     'text-embedding-005': 2048,
     'text-multilingual-embedding-002': 2048,
 }

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1130,6 +1130,7 @@ def mock_infer_embedding_model(model: EmbeddingModel | str) -> EmbeddingModel:
         'lightonai/DenseOn': 768,
         'gemini-embedding-001': 3072,
         'gemini-embedding-2-preview': 3072,
+        'gemini-embedding-2': 3072,
     }
     dimensions = dimensions_map.get(model_name, 8)
     return TestEmbeddingModel(model_name, provider_name=provider_name, dimensions=dimensions)


### PR DESCRIPTION
Adds `gemini-embedding-2` (the GA release of Google's latest embedding model) to the Google embedding model name literals and limits, mirroring the earlier `gemini-embedding-2-preview` add (#4874).

This is a purely additive model registration (no behavior change):

- `LatestGoogleGLAEmbeddingModelNames` + `LatestGoogleVertexEmbeddingModelNames` — add `'gemini-embedding-2'`
- `_MAX_INPUT_TOKENS` — `'gemini-embedding-2': 8192`
- `KnownEmbeddingModelName` — add `'google:gemini-embedding-2'` and `'google-cloud:gemini-embedding-2'`
- `tests/test_examples.py` — add `'gemini-embedding-2': 3072` to the mock dimensions map

Verified live against both the Gemini API (GLA) and Google Cloud (Vertex): the model resolves and returns 3072-dimensional embeddings on both endpoints.

### Known adjacent follow-up (out of scope here): #5888

- Closes #5857

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
