### PR TITLE
Replay Cerebras `zai-glm` reasoning in `<think>` tags and bump to `zai-glm-4.7`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cerebras.py
@@ -30,7 +30,7 @@ LatestCerebrasModelNames = Literal[
     'llama3.1-8b',
     'qwen-3-235b-a22b-instruct-2507',
     'qwen-3-32b',
-    'zai-glm-4.6',
+    'zai-glm-4.7',
 ]
 
 CerebrasModelName = str | LatestCerebrasModelNames
@@ -52,7 +52,7 @@ class CerebrasModelSettings(ModelSettings, total=False):
     cerebras_disable_reasoning: bool
     """Disable reasoning for the model.
 
-    This setting is only supported on reasoning models: `zai-glm-4.6` and `gpt-oss-120b`.
+    This setting is only supported on reasoning models: `zai-glm-4.7` and `gpt-oss-120b`.
 
     See [the Cerebras docs](https://inference-docs.cerebras.ai/resources/openai#passing-non-standard-parameters) for more details.
     """

--- a/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/cerebras.py
@@ -71,13 +71,18 @@ class CerebrasProvider(Provider[AsyncOpenAI]):
         )
         is_reasoning = model_name_lower.startswith(reasoning_prefixes)
         # gpt-oss reasons unconditionally on Cerebras: `disable_reasoning=True` is rejected with a 400,
-        # so `thinking=False` must be silently ignored rather than emitted. zai-glm-4.6 can still disable.
+        # so `thinking=False` must be silently ignored rather than emitted. zai-glm-4.7 can still disable.
         is_always_on_reasoning = model_name_lower.startswith('gpt-oss')
+        # GLM requires prior reasoning to be replayed inside `<think>...</think>` tags in the assistant
+        # message content, not in a separate `reasoning` field; gpt-oss follows Harmony rules and keeps `'auto'`.
+        # https://inference-docs.cerebras.ai/capabilities/reasoning
+        send_back_thinking_parts = 'tags' if model_name_lower.startswith('zai') else 'auto'
         return OpenAIModelProfile(
             json_schema_transformer=OpenAIJsonSchemaTransformer,
             openai_unsupported_model_settings=unsupported_model_settings,
             supports_thinking=is_reasoning,
             thinking_always_enabled=is_always_on_reasoning,
+            openai_chat_send_back_thinking_parts=send_back_thinking_parts,
         ).update(profile)
 
     @overload

--- a/tests/models/cassettes/test_cerebras/test_cerebras_zai_reasoning_replayed_as_think_tags.yaml
+++ b/tests/models/cassettes/test_cerebras/test_cerebras_zai_reasoning_replayed_as_think_tags.yaml
@@ -1,0 +1,223 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '124'
+      content-type:
+      - application/json
+      host:
+      - api.cerebras.ai
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is 25 * 4? Think briefly first.
+        role: user
+      model: zai-glm-4.7
+      stream: false
+    uri: https://api.cerebras.ai/v1/chat/completions
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '2151'
+      content-type:
+      - application/json
+      inference-id:
+      - chatcmpl-7a8879bf-5eca-4694-8673-441d7b669f8c
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=15552000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        message:
+          content: 25 * 4 = 100.
+          reasoning: |-
+            The user wants me to solve the multiplication problem: "25 * 4".
+
+            1.  **Analyze the request:**
+                *   Operation: Multiplication.
+                *   Operands: 25 and 4.
+                *   Constraint: "Think briefly first." (This suggests I should perform the calculation mentally or break it down simply before providing the final answer).
+
+            2.  **Mental Calculation:**
+                *   Method 1: Standard multiplication.
+                    *   $5 * 4 = 20$ (write down 0, carry over 2).
+                    *   $2 * 4 = 8$.
+                    *   Add the carried over 2: $8 + 2 = 10$.
+                    *   Result: 100.
+                *   Method 2: Distributive property.
+                    *   $25 = 20 + 5$.
+                    *   $20 * 4 = 80$.
+                    *   $5 * 4 = 20$.
+                    *   $80 + 20 = 100$.
+                *   Method 3: Recognizing the quarter relationship.
+                    *   25 is one-quarter of 100.
+                    *   There are four quarters in a whole.
+                    *   So, $4 * 25$ equals 100.
+
+            3.  **Formulate the output:**
+                *   State the final answer clearly.
+                *   (Optional based on "Think briefly") Should I show the work? The prompt asks *me* to think briefly, not necessarily to show all my thinking, but usually, a simple confirmation or a short breakdown is helpful. However, for such a simple calculation, just the answer is often best. I will provide the answer directly.
+
+            4.  **Final Check:**
+                *   $25 * 4 = 100$. Correct.
+
+            5.  **Construct Response:**
+                *   "25 multiplied by 4 is 100."
+          role: assistant
+      created: 1781208276
+      id: chatcmpl-7a8879bf-5eca-4694-8673-441d7b669f8c
+      model: zai-glm-4.7
+      object: chat.completion
+      system_fingerprint: fp_ba34ecf90156e4888692
+      time_info:
+        completion_time: 0.80132127
+        created: 1781208276.514359
+        prompt_time: 0.004226939
+        queue_time: 0.000162202
+        total_time: 0.8083178997039795
+      usage:
+        completion_tokens: 415
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          reasoning_tokens: 406
+          rejected_prediction_tokens: 0
+        prompt_tokens: 17
+        prompt_tokens_details:
+          cached_tokens: 0
+        total_tokens: 432
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1679'
+      content-type:
+      - application/json
+      host:
+      - api.cerebras.ai
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is 25 * 4? Think briefly first.
+        role: user
+      - content: |-
+          <think>
+          The user wants me to solve the multiplication problem: "25 * 4".
+
+          1.  **Analyze the request:**
+              *   Operation: Multiplication.
+              *   Operands: 25 and 4.
+              *   Constraint: "Think briefly first." (This suggests I should perform the calculation mentally or break it down simply before providing the final answer).
+
+          2.  **Mental Calculation:**
+              *   Method 1: Standard multiplication.
+                  *   $5 * 4 = 20$ (write down 0, carry over 2).
+                  *   $2 * 4 = 8$.
+                  *   Add the carried over 2: $8 + 2 = 10$.
+                  *   Result: 100.
+              *   Method 2: Distributive property.
+                  *   $25 = 20 + 5$.
+                  *   $20 * 4 = 80$.
+                  *   $5 * 4 = 20$.
+                  *   $80 + 20 = 100$.
+              *   Method 3: Recognizing the quarter relationship.
+                  *   25 is one-quarter of 100.
+                  *   There are four quarters in a whole.
+                  *   So, $4 * 25$ equals 100.
+
+          3.  **Formulate the output:**
+              *   State the final answer clearly.
+              *   (Optional based on "Think briefly") Should I show the work? The prompt asks *me* to think briefly, not necessarily to show all my thinking, but usually, a simple confirmation or a short breakdown is helpful. However, for such a simple calculation, just the answer is often best. I will provide the answer directly.
+
+          4.  **Final Check:**
+              *   $25 * 4 = 100$. Correct.
+
+          5.  **Construct Response:**
+              *   "25 multiplied by 4 is 100."
+          </think>
+
+          25 * 4 = 100.
+        role: assistant
+      - content: Now divide that by 2.
+        role: user
+      model: zai-glm-4.7
+      stream: false
+    uri: https://api.cerebras.ai/v1/chat/completions
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '1068'
+      content-type:
+      - application/json
+      inference-id:
+      - chatcmpl-f15f3b64-b343-485f-b3aa-07f6d13d1266
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=15552000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        message:
+          content: 100 / 2 = 50.
+          reasoning: |-
+            1.  **Identify the Core Task:** The user wants me to divide the result of the previous calculation (100) by 2.
+            2.  **Retrieve Previous Context:** The previous question was "25 * 4", which equals 100.
+            3.  **Perform the Operation:** $100 / 2$.
+            4.  **Calculate:** $100 / 2 = 50$.
+            5.  **Formulate Answer:** State the result clearly.
+          role: assistant
+      created: 1781208277
+      id: chatcmpl-f15f3b64-b343-485f-b3aa-07f6d13d1266
+      model: zai-glm-4.7
+      object: chat.completion
+      system_fingerprint: fp_ba34ecf90156e4888692
+      time_info:
+        completion_time: 0.136498275
+        created: 1781208277.7151854
+        prompt_time: 0.006911721999999995
+        queue_time: 0.675865906
+        total_time: 0.8205821514129639
+      usage:
+        completion_tokens: 106
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          reasoning_tokens: 97
+          rejected_prediction_tokens: 0
+        prompt_tokens: 35
+        prompt_tokens_details:
+          cached_tokens: 0
+        total_tokens: 141
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_cerebras.py
+++ b/tests/models/test_cerebras.py
@@ -87,6 +87,35 @@ async def test_cerebras_thinking_part_survives_multiturn(
     assert any(m.get('reasoning') == turn1_thinking[0].content for m in assistant_messages)
 
 
+async def test_cerebras_zai_reasoning_replayed_as_think_tags(
+    allow_model_requests: None, cerebras_api_key: str, vcr: Cassette
+):
+    """GLM replays prior reasoning inside `<think>...</think>` tags in the assistant `content`, not a `reasoning` field.
+
+    Unlike gpt-oss (Harmony, replayed in the `reasoning` field), Cerebras GLM/Qwen require previous reasoning to
+    be wrapped in `<think>` tags inside the assistant message content, so `CerebrasProvider.model_profile()` sets
+    `openai_chat_send_back_thinking_parts='tags'` for `zai`. See https://inference-docs.cerebras.ai/capabilities/reasoning.
+    """
+    provider = CerebrasProvider(api_key=cerebras_api_key)
+    model = CerebrasModel('zai-glm-4.7', provider=provider)
+    agent = Agent(model=model)
+
+    result1 = await agent.run('What is 25 * 4? Think briefly first.')
+    turn1_response = next(m for m in reversed(result1.all_messages()) if isinstance(m, ModelResponse))
+    turn1_thinking = [p for p in turn1_response.parts if isinstance(p, ThinkingPart)]
+    assert turn1_thinking, 'expected a ThinkingPart on turn 1'
+
+    await agent.run('Now divide that by 2.', message_history=result1.all_messages())
+
+    turn2_body = json.loads(vcr.requests[1].body)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    assistant_messages = [m for m in turn2_body['messages'] if m.get('role') == 'assistant']
+    start_tag, end_tag = model.profile.thinking_tags
+    assert any(
+        start_tag in (m.get('content') or '') and end_tag in (m.get('content') or '') for m in assistant_messages
+    ), 'expected prior reasoning wrapped in think tags in the assistant content'
+    assert all('reasoning' not in m for m in assistant_messages), 'reasoning must not be replayed in a separate field'
+
+
 async def test_cerebras_settings_transformation():
     """Test that CerebrasModelSettings are correctly transformed to OpenAIChatModelSettings."""
     from pydantic_ai.models import ModelRequestParameters

--- a/tests/providers/test_cerebras.py
+++ b/tests/providers/test_cerebras.py
@@ -88,13 +88,17 @@ def test_cerebras_provider_model_profile(mocker: MockerFixture):
     assert harmony_profile is not None
     assert isinstance(harmony_profile, OpenAIModelProfile)
     assert harmony_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    # gpt-oss follows Harmony rules: prior reasoning is replayed in the `reasoning` field, not `<think>` tags.
+    assert harmony_profile.openai_chat_send_back_thinking_parts == 'auto'
 
     # Test zai model - uses default OpenAI profile (zai_model_profile returns None)
-    zai_profile = provider.model_profile('zai-glm-4.6')
-    zai_model_profile_mock.assert_called_with('zai-glm-4.6')
+    zai_profile = provider.model_profile('zai-glm-4.7')
+    zai_model_profile_mock.assert_called_with('zai-glm-4.7')
     assert zai_profile is not None
     assert isinstance(zai_profile, OpenAIModelProfile)
     assert zai_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    # GLM requires prior reasoning replayed inside `<think>...</think>` tags in the assistant content.
+    assert zai_profile.openai_chat_send_back_thinking_parts == 'tags'
 
     # Test unknown model - should still return a profile with OpenAIJsonSchemaTransformer
     unknown_profile = provider.model_profile('unknown-model')


### PR DESCRIPTION
Relates to #5606 (items 1 + 4 of 4; the deprecation + `clear_thinking` items 2 + 3 follow in a separate PR).

### What

Cerebras GLM/Qwen require previous reasoning to be replayed inside `<think>...</think>` tags in the assistant message **content**, not in a separate `reasoning` field ([Cerebras docs](https://inference-docs.cerebras.ai/capabilities/reasoning)). Today `CerebrasProvider.model_profile()` marks `zai`/`gpt-oss` as `supports_thinking` but leaves `openai_chat_send_back_thinking_parts` at its `'auto'` default, so on multi-turn runs a GLM `ThinkingPart` (received in the `reasoning` field) is replayed back into that `reasoning` field — which GLM does not consume — and prior thinking is effectively lost across turns.

This PR:

1. **Bug fix:** sets `openai_chat_send_back_thinking_parts='tags'` for `zai` in `CerebrasProvider.model_profile()`, so prior GLM reasoning is replayed inside `<think>...</think>` tags. `gpt-oss` follows Harmony rules and keeps `'auto'` (field replay), unchanged.
2. **Model name:** bumps `LatestCerebrasModelNames` from the retired `zai-glm-4.6` to the current `zai-glm-4.7`.

`qwen` is also documented to use `<think>` tags, but Cerebras `qwen` models aren't currently marked as reasoning-capable here (`qwen` isn't in `reasoning_prefixes`), so wiring `'tags'` for them is a separate change tracked as a follow-up issue (#5892).

### Test

`test_cerebras_zai_reasoning_replayed_as_think_tags` — a VCR-recorded live 2-turn run against `zai-glm-4.7` asserting the 2nd-turn outgoing assistant message carries prior reasoning inside `<think>...</think>` in `content` and has no `reasoning` field. The existing `gpt-oss` multi-turn test is unaffected (still asserts `reasoning`-field replay).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
