### PR TITLE
Fix `deps` deserialization in non-streaming Temporal model-request activity

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
@@ -81,7 +81,6 @@ class TemporalModel(WrapperModel):
         self._provider_factory = provider_factory
         self._agent = agent
 
-        @activity.defn(name=f'{activity_name_prefix}__model_request')
         async def request_activity(params: _RequestParams, deps: Any | None = None) -> ModelResponse:
             run_context = deserialize_run_context(
                 self.run_context_type, params.serialized_run_context, deps=deps, agent=self._agent
@@ -93,9 +92,11 @@ class TemporalModel(WrapperModel):
                 params.model_request_parameters,
             )
 
-        self.request_activity = request_activity
+        # Set type hint explicitly so that Temporal can take care of serialization and deserialization
         # Union with None for backward compatibility with activity payloads created before deps was added
-        self.request_activity.__annotations__['deps'] = deps_type | None
+        request_activity.__annotations__['deps'] = deps_type | None
+
+        self.request_activity = activity.defn(name=f'{activity_name_prefix}__model_request')(request_activity)
 
         async def request_stream_activity(params: _RequestParams, deps: AgentDepsT) -> ModelResponse:
             # An error is raised in `request_stream` if no `event_stream_handler` is set.

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1583,6 +1583,25 @@ async def test_temporal_agent():
     )
 
 
+def test_temporal_model_request_activities_capture_deps_type():
+    """Both model-request activities must capture the real `deps_type` as the `deps` argument type.
+
+    `temporalio`'s `@activity.defn` freezes a function's type hints into `arg_types` at decoration time for
+    payload conversion, so `deps`'s annotation has to be set before decorating. If it's set afterwards (as the
+    non-streaming activity used to do), the patch is cosmetic and the activity deserializes `deps` as a raw
+    dict instead of the declared deps type.
+    """
+    model = dynamic_toolset_temporal_agent.model
+    assert isinstance(model, TemporalModel)
+
+    # `arg_types[1]` is the `deps` argument's captured type, which drives Temporal's payload conversion.
+    deps_type = DynamicToolsetDeps | None
+    request_arg_types = ActivityDefinition.must_from_callable(model.request_activity).arg_types  # pyright: ignore[reportUnknownMemberType]
+    stream_arg_types = ActivityDefinition.must_from_callable(model.request_stream_activity).arg_types  # pyright: ignore[reportUnknownMemberType]
+    assert request_arg_types is not None and request_arg_types[1] == deps_type
+    assert stream_arg_types is not None and stream_arg_types[1] == deps_type
+
+
 def test_temporal_wrapper_visit_and_replace():
     """Temporal wrapper toolsets should not be replaced by visit_and_replace."""
     from pydantic_ai.durable_exec.temporal._function_toolset import TemporalFunctionToolset


### PR DESCRIPTION
- Closes #5893

## Problem

With `TemporalAgent` and a dataclass `deps_type`, the non-streaming model-request activity received `run_context.deps` as a raw `dict` rather than the declared deps type, raising `AttributeError: 'dict' object has no attribute '...'` inside a `provider_factory` (or anywhere reading `run_context.deps`). Under the default retry policy the activity retries forever, so the workflow hangs instead of failing.

## Root cause

In `durable_exec/temporal/_model.py` the non-streaming `request_activity` patched `__annotations__['deps'] = deps_type | None` *after* `@activity.defn` had already decorated it. `temporalio`'s `@activity.defn` resolves a function's type hints into `arg_types` at decoration time for payload conversion, so the late patch changed `__annotations__` but not the captured `arg_types`. The activity therefore deserialized `deps` against `Any | None` (a raw dict) instead of the real deps type.

The streaming `request_stream_activity` already did it in the correct order (patch annotation, then decorate), and its inline comment documented the ordering requirement.

## Fix

Reorder the non-streaming path to set the `deps` annotation before applying `activity.defn(...)`, exactly mirroring the streaming path. One-line reorder; behavior for the no-deps / `deps_type=None` case is unchanged.

## Tests

Added a deterministic test (no Temporal server required) asserting that `temporalio.activity._Definition.from_callable(...).arg_types` captures the real `deps_type | None` for both the non-streaming and streaming model-request activities. The streaming assertion acts as the control, since that path was already correct.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
