### PR TITLE
Type `TemporalProviderFactory` against agent deps type (v3)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -61,7 +61,7 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         *,
         name: str | None = None,
         models: Mapping[str, Model] | None = None,
-        provider_factory: TemporalProviderFactory | None = None,
+        provider_factory: TemporalProviderFactory[AgentDepsT] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
         activity_config: ActivityConfig | None = None,
         model_activity_config: ActivityConfig | None = None,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
@@ -53,7 +53,7 @@ class TemporalModel(WrapperModel):
         run_context_type: type[TemporalRunContext[AgentDepsT]] = TemporalRunContext[AgentDepsT],
         event_stream_handler: EventStreamHandler[Any] | None = None,
         models: Mapping[str, Model] | None = None,
-        provider_factory: TemporalProviderFactory | None = None,
+        provider_factory: TemporalProviderFactory[AgentDepsT] | None = None,
         agent: AbstractAgent[Any, Any] | None = None,
     ):
         # Build models_by_id registry from wrapped model and models parameter


### PR DESCRIPTION
### What this does

Threads the agent deps type through `TemporalProviderFactory` so a provider factory can be typed against the agent's real `deps_type`.

The alias is `Callable[[RunContext[AgentDepsT], str], Provider[Any]]`, but both use sites (`TemporalModel.__init__` and `TemporalAgent.__init__`) referenced it bare. Because `AgentDepsT` has `default=None`, the bare form collapses to `RunContext[None]`, so a factory that reads `run_context.deps` (the exact case in #5893) cannot be typed against the declared deps type and users fall back to `RunContext[Any]`.

The fix parameterizes the alias at both use sites as `TemporalProviderFactory[AgentDepsT]`. `AgentDepsT` is already bound in each scope (the class TypeVar on `TemporalAgent`, and `deps_type: type[AgentDepsT]` on `TemporalModel`). Typing-only: no runtime behavior changes, and this does not touch the #5893 runtime fix.

Verified by type-level probe:

- before: `def f(rc: RunContext[MyDeps], name: str)` on a `deps_type=MyDeps` agent does NOT typecheck
- after: it does
- `RunContext[Any]` factories stay assignable both ways (the existing escape hatch is preserved)
- no-deps agents with `RunContext[None]` factories are unchanged

### Status

This is a v3-deferred typing/DX improvement (not a correctness bug), parked in DRAFT to hold the shape and request maintainer direction before it goes further. Refs #5899.

### Open question

The change is strictly-correct variance, but it does flip one edge: a factory annotated `RunContext[None]` passed to a `deps_type=MyDeps` agent typechecks today (bare alias = `RunContext[None]`) and would error after this change (expected `RunContext[MyDeps]`). That annotation is already wrong for a deps-typed agent, and `RunContext[Any]` remains valid, so the practical blast radius looks negligible. Flagging it since `provider_factory` is the type of a public kwarg even though `TemporalProviderFactory` itself is not exported in `__all__`. Worth a maintainer call on whether that edge needs any softening (e.g. an explicit default) before landing.

### Tests

No new tests in this draft. There are no existing temporal `provider_factory` typing tests, and a type-level assertion can be added once the shape is confirmed. Happy to add one (and any docs note) after direction.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).