### PR TITLE
Add agent guideline: avoid `getattr`/`setattr` over our own statically-known fields

### DIFF
--- a/agent_docs/index.md
+++ b/agent_docs/index.md
@@ -35,6 +35,7 @@
 
 <!-- rule:0 -->
 - Use `isinstance()` for type checking, not `hasattr()`, `getattr()`, `type(obj).__name__`, or discriminator field checks like `part_kind` — Enables proper type narrowing for static analysis and prevents fragile string-based comparisons that break during refactoring
+- Don't use `getattr()`/`setattr()` with a non-literal field name to read or copy fields of our own statically-known types (dataclasses, `BaseModel`s, message/part classes), e.g. looping over `fields()` and copying by name — use explicit attribute access (`merged.foo = merged.foo or other.foo`) — Reflecting over known fields by name defeats Pyright's field-existence and type checks and breaks silently on rename; this does not apply to `getattr(obj, 'name', default)` for genuinely optional or duck-typed attributes whose shape isn't statically known
 <!-- rule:142 -->
 - Use `Literal` types instead of plain `str` for fixed string value sets in parameters, fields, and return types — Makes valid values explicit in type signatures, enabling static type checkers to catch invalid strings at compile time and improving IDE autocomplete
 <!-- rule:809 -->


### PR DESCRIPTION
Adds one agent-guideline bullet under `## Type System` in `agent_docs/index.md`: avoid `getattr()`/`setattr()` with a non-literal field name to read or copy fields of our own statically-known types (dataclasses, `BaseModel`s, message/part classes). Use explicit attribute access instead, since reflecting over known fields by name defeats Pyright's field and type checks and breaks silently on rename.

The bullet explicitly carves out the legitimate `getattr(obj, 'name', default)` duck-typing form, which is idiomatic and common in the tree, so the rule targets only known-shape reflection.

It sits next to the existing `isinstance()`-over-`getattr()` rule (rule:0), which covers type discrimination; this one covers field copying, an adjacent but distinct concern. Surfaced from the review on #5886, where a streaming-usage backfill used a `fields()` + `getattr`/`setattr` loop over `RequestUsage`.

Note: these guideline files are normally produced by the braindump pipeline; this bullet is added manually (no `rule:N` marker) and can be reconciled on the next run.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
