### PR TITLE
Add Kitaru durable execution docs

### DIFF
--- a/docs/durable_execution/kitaru.md
+++ b/docs/durable_execution/kitaru.md
@@ -10,6 +10,8 @@ For example, imagine an agent calls a model, gets a useful response, starts a to
 
 This is useful for long-running agents, human-in-the-loop workflows, and applications where a repeated model request or external API call would cost money, take time, or duplicate a side effect.
 
+When you call a `KitaruAgent`, your application still calls the underlying Pydantic AI agent. Kitaru starts or resumes a flow for that call. With the default `"calls"` checkpoint strategy, it records completed model requests, tool calls, MCP invocations, and human waits in Kitaru's checkpoint storage. On recovery, Kitaru runs the Python function again until it reaches an operation that already has a checkpoint, returns the saved result for that operation, and then continues from the first operation that has not completed.
+
 ## Durable Agent
 
 You can make a normal [`Agent`][pydantic_ai.agent.Agent] durable by wrapping it with `KitaruAgent` from `kitaru.adapters.pydantic_ai`. Install Kitaru separately from Pydantic AI:
@@ -45,7 +47,14 @@ result = durable_agent.run_sync('Summarize quantum error correction.')
 print(result.output)
 ```
 
-`KitaruAgent` exposes the usual run methods, including [`Agent.run`][pydantic_ai.agent.Agent.run] and [`Agent.run_sync`][pydantic_ai.agent.Agent.run_sync], while Kitaru persists recoverable work around the agent run.
+`KitaruAgent` does not replace the original agent object. With the default call-level checkpoint strategy, it delegates to that agent for the actual Pydantic AI run and records recoverable operations while the run is executing:
+
+* model requests;
+* Pydantic AI tool calls;
+* MCP tool calls;
+* `@hitl_tool` human waits.
+
+It exposes the usual run methods, including [`Agent.run`][pydantic_ai.agent.Agent.run] and [`Agent.run_sync`][pydantic_ai.agent.Agent.run_sync]. The original [`Agent`][pydantic_ai.agent.Agent] can still be used normally outside Kitaru.
 
 ## Production Flows
 

--- a/docs/durable_execution/kitaru.md
+++ b/docs/durable_execution/kitaru.md
@@ -1,0 +1,118 @@
+# Durable Execution with Kitaru
+
+[Kitaru](https://docs.zenml.io/kitaru) is a durable execution layer for AI agents. Its Pydantic AI adapter is provided by the `kitaru` package through `kitaru.adapters.pydantic_ai`, rather than by `pydantic_ai.durable_exec`.
+
+## Durable Execution
+
+Kitaru records agent progress as **flows** and **checkpoints**. A flow is the durable run you can resume later. A checkpoint is a completed model request, tool call, MCP invocation, or human wait that Kitaru can reuse during recovery.
+
+For example, imagine an agent calls a model, gets a useful response, starts a tool call, and then the process crashes. Without durable execution, restarting the program usually repeats the model request and may repeat later side effects too. With Kitaru, the restarted flow can replay the run, reuse the completed checkpoint for the model request, and continue from the first incomplete point.
+
+This is useful for long-running agents, human-in-the-loop workflows, and applications where a repeated model request or external API call would cost money, take time, or duplicate a side effect.
+
+## Durable Agent
+
+You can make a normal [`Agent`][pydantic_ai.agent.Agent] durable by wrapping it with `KitaruAgent` from `kitaru.adapters.pydantic_ai`. Install Kitaru separately from Pydantic AI:
+
+```bash
+uv add "kitaru[pydantic-ai]"
+```
+
+For local development with Kitaru's local server, install the `local` extra too:
+
+```bash
+uv add "kitaru[pydantic-ai,local]"
+```
+
+Initialize the project and check your connection before running the examples:
+
+```bash
+kitaru init
+kitaru login
+kitaru status
+```
+
+Here is the smallest durable Pydantic AI agent using Kitaru:
+
+```python {title="kitaru_agent.py" test="skip" lint="skip"}
+from pydantic_ai import Agent
+from kitaru.adapters.pydantic_ai import KitaruAgent
+
+agent = Agent('openai:gpt-5-nano', name='researcher')
+durable_agent = KitaruAgent(agent)
+
+result = durable_agent.run_sync('Summarize quantum error correction.')
+print(result.output)
+```
+
+`KitaruAgent` exposes the usual run methods, including [`Agent.run`][pydantic_ai.agent.Agent.run] and [`Agent.run_sync`][pydantic_ai.agent.Agent.run_sync], while Kitaru persists recoverable work around the agent run.
+
+## Production Flows
+
+!!! warning
+
+    The minimal wrapper above uses Kitaru's automatic flow creation, which is intended for local development. For remote stacks or production services, put the durable agent call inside an explicit `@kitaru.flow` so Kitaru has a stable flow entry point to submit, replay, and inspect.
+
+```python {title="kitaru_flow.py" test="skip" lint="skip"}
+import kitaru
+from pydantic_ai import Agent
+from kitaru.adapters.pydantic_ai import KitaruAgent
+
+agent = Agent('openai:gpt-5-nano', name='researcher')
+durable_agent = KitaruAgent(agent)
+
+
+@kitaru.flow
+def research_topic(topic: str) -> str:
+    result = durable_agent.run_sync(f'Summarize {topic}.')
+    return result.output
+```
+
+Use the short wrapper for first experiments. Use an explicit flow when the run needs to move beyond your local process.
+
+## Checkpoint Strategy
+
+`KitaruAgent` supports two checkpoint strategies:
+
+| Strategy | Default? | What gets persisted | Best for |
+| --- | --- | --- | --- |
+| `"calls"` | Yes | Replay-safe model requests, tool calls, MCP invocations, and human waits are persisted as separate checkpoints. | Most agents, especially when individual calls are expensive or have side effects. |
+| `"turn"` | No | One checkpoint wraps the full agent run. | Simpler runs where per-call checkpoints are unnecessary, or cases where streaming constraints require a full-turn checkpoint. |
+
+With the default `"calls"` strategy, Kitaru cannot create nested checkpoints inside a user-defined `@kitaru.checkpoint` body. If `durable_agent.run_sync(...)` runs inside a user `@kitaru.checkpoint`, Kitaru records the whole agent turn under that outer checkpoint instead of creating separate model, tool, or MCP checkpoint rows.
+
+See the [Kitaru Pydantic AI adapter guide](https://docs.zenml.io/kitaru/adapters/pydantic-ai) for advanced checkpoint configuration.
+
+## Human-in-the-loop
+
+For pure human approval or data-entry gates, prefer Kitaru's `@hitl_tool`. It turns the wait into a durable tool call: the process can stop while waiting for a human response, and recovery can continue after the response is available.
+
+```python {test="skip" lint="skip"}
+from kitaru.adapters.pydantic_ai import hitl_tool
+
+
+@hitl_tool(question='Approve publishing this answer?', schema=bool)
+def approve_publish(summary: str) -> bool: ...
+```
+
+!!! warning "Regular tool-body waits need extra configuration"
+
+    Regular Pydantic AI tool bodies can also wait for human input, but sync tool-body waits need extra Kitaru configuration. If you need that pattern, follow the human-in-the-loop section of the [Kitaru Pydantic AI adapter guide](https://docs.zenml.io/kitaru/adapters/pydantic-ai#human-in-the-loop).
+
+For Pydantic AI's own deferred tool patterns, see [deferred tools](../deferred-tools.md).
+
+## Streaming
+
+Kitaru supports Pydantic AI streaming with some constraints. For event streaming, prefer the [`event_stream_handler`](../agent.md#streaming-all-events) argument on [`Agent.run`][pydantic_ai.agent.Agent.run]. When a run uses `event_stream_handler`, Kitaru falls back to a turn checkpoint for that call.
+
+If you use [`run_stream()`][pydantic_ai.agent.AbstractAgent.run_stream] or [`iter()`][pydantic_ai.agent.AbstractAgent.iter], wrap the streaming call in an explicit `@kitaru.checkpoint`. This gives Kitaru one durable operation to replay instead of trying to persist each streamed event separately.
+
+## Requirements and Constraints
+
+When using Kitaru with Pydantic AI:
+
+* Define the agent with a concrete model at construction time, such as `Agent('openai:gpt-5-nano', ...)`.
+* Give each durable agent a stable `name`; Kitaru uses it to identify persisted work across runs.
+* Do not override the model per run with `model=` when using `KitaruAgent`.
+* Use an explicit `@kitaru.flow` for remote stacks and production services; automatic flow creation is local-only.
+* Avoid nested Kitaru checkpoints inside user-defined `@kitaru.checkpoint` bodies.

--- a/docs/durable_execution/overview.md
+++ b/docs/durable_execution/overview.md
@@ -10,3 +10,7 @@ Pydantic AI officially supports four durable execution solutions:
 - [Restate](./restate.md)
 
 These integrations are co-maintained by the Pydantic and vendor teams and only use Pydantic AI's public interface, so they also serve as a reference for integrating with other durable systems.
+
+Additional external SDK integrations:
+
+- [Kitaru](./kitaru.md)

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -298,6 +298,10 @@
           {
             "label": "Restate",
             "slug": "durable_execution/restate"
+          },
+          {
+            "label": "Kitaru",
+            "slug": "durable_execution/kitaru"
           }
         ]
       },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
           - DBOS: durable_execution/dbos.md
           - Prefect: durable_execution/prefect.md
           - Restate: durable_execution/restate.md
+          - Kitaru: durable_execution/kitaru.md
       - UI Event Streams:
           - Overview: ui/overview.md
           - AG-UI: ui/ag-ui.md


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes: N/A — small documentation addition.

## Reviewer Notes

This adds [Kitaru](https://kitaru.ai) to the durable execution documentation as an external SDK integration. The page introduces `KitaruAgent` from `kitaru.adapters.pydantic_ai`, shows the minimal wrapper pattern, and explains when users should move from automatic local flow creation to an explicit `@kitaru.flow`.

The main thing to review is the positioning: Kitaru is listed separately from the four officially supported durable execution integrations, and the page avoids implying that Kitaru lives under `pydantic_ai.durable_exec`. The examples use a concrete model name and skip execution because they require the external `kitaru` package plus a configured Kitaru environment. (I wasn't sure whether to reclassify Restate as the same, since it's also an external SDK, but for the sake of not touching too many files I left that as it currently is).

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

