### PR TITLE
Forward `additionalModelRequestFields` in Bedrock `count_tokens`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -584,6 +584,11 @@ class BedrockConverseModel(Model[BaseClient]):
             'messages': bedrock_messages,
             'system': system_prompt,
         }
+        tool_config = self._map_tool_config(model_request_parameters, settings)
+        if tool_config:
+            converse['toolConfig'] = tool_config
+        tools: list[ToolTypeDef] = list(tool_config['tools']) if tool_config else []
+        self._limit_cache_points(system_prompt, bedrock_messages, tools)
         if additional_model_requests_fields := self._translate_thinking(settings, model_request_parameters):
             converse['additionalModelRequestFields'] = additional_model_requests_fields
         params: CountTokensRequestTypeDef = {

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -584,6 +584,9 @@ class BedrockConverseModel(Model[BaseClient]):
             'messages': bedrock_messages,
             'system': system_prompt,
         }
+        # No native-tool strip is needed here (unlike Anthropic's count_tokens, which must drop server tools):
+        # count-tokens-capable models (Claude) don't support native tools, and native-tool-capable models
+        # (Nova-2) don't support count_tokens, so a `systemTool` can never reach this request.
         tool_config = self._map_tool_config(model_request_parameters, settings)
         if tool_config:
             converse['toolConfig'] = tool_config

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -89,6 +89,7 @@ if TYPE_CHECKING:
         ConverseStreamMetadataEventTypeDef,
         ConverseStreamOutputTypeDef,
         ConverseStreamResponseTypeDef,
+        ConverseTokensRequestTypeDef,
         CountTokensRequestTypeDef,
         DocumentSourceTypeDef,
         GuardrailConfigurationTypeDef,
@@ -579,14 +580,15 @@ class BedrockConverseModel(Model[BaseClient]):
         model_settings, model_request_parameters = self.prepare_request(model_settings, model_request_parameters)
         settings = cast(BedrockModelSettings, model_settings or {})
         system_prompt, bedrock_messages = await self._map_messages(messages, model_request_parameters, settings)
+        converse: ConverseTokensRequestTypeDef = {
+            'messages': bedrock_messages,
+            'system': system_prompt,
+        }
+        if additional_model_requests_fields := self._translate_thinking(settings, model_request_parameters):
+            converse['additionalModelRequestFields'] = additional_model_requests_fields
         params: CountTokensRequestTypeDef = {
             'modelId': remove_bedrock_geo_prefix(self.model_name),
-            'input': {
-                'converse': {
-                    'messages': bedrock_messages,
-                    'system': system_prompt,
-                },
-            },
+            'input': {'converse': converse},
         }
         with _map_api_errors(self.model_name):
             response = await anyio.to_thread.run_sync(functools.partial(self.client.count_tokens, **params))

--- a/tests/models/cassettes/test_bedrock/test_bedrock_count_tokens_additional_model_requests_fields.yaml
+++ b/tests/models/cassettes/test_bedrock/test_bedrock_count_tokens_additional_model_requests_fields.yaml
@@ -1,0 +1,32 @@
+interactions:
+- request:
+    body: '{"input": {"converse": {"messages": [{"role": "user", "content": [{"text": "Hello, world!"}]}], "system": [], "additionalModelRequestFields":
+      {"anthropic_beta": ["context-1m-2025-08-07"]}}}}'
+    headers:
+      amz-sdk-invocation-id:
+      - !!binary |
+        YTEzNTA0MmQtYzgwMS00OWZkLTljOTctZWU1OGZlNzU0YmRi
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      content-length:
+      - '190'
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-sonnet-4-20250514-v1%3A0/count-tokens
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '19'
+      content-type:
+      - application/json
+    parsed_body:
+      inputTokens: 11
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_bedrock/test_bedrock_count_tokens_tool_config.yaml
+++ b/tests/models/cassettes/test_bedrock/test_bedrock_count_tokens_tool_config.yaml
@@ -1,0 +1,34 @@
+interactions:
+- request:
+    body: '{"input": {"converse": {"messages": [{"role": "user", "content": [{"text": "What is the weather in Paris?"}]}],
+      "system": [], "toolConfig": {"tools": [{"toolSpec": {"name": "get_weather", "inputSchema": {"json": {"type": "object",
+      "properties": {"location": {"type": "string"}}}}, "description": "Get the weather for a location"}}], "toolChoice":
+      {"auto": {}}}}}}'
+    headers:
+      amz-sdk-invocation-id:
+      - !!binary |
+        MTVkNjk4OWYtNGFmMS00NmZkLTkzZDAtZDdiMDc0NWEwNzhl
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      content-length:
+      - '363'
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-sonnet-4-20250514-v1%3A0/count-tokens
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '20'
+      content-type:
+      - application/json
+    parsed_body:
+      inputTokens: 375
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -348,6 +348,29 @@ async def test_bedrock_inference_profile_count_tokens(
     assert model.model_name == 'us.anthropic.claude-sonnet-4-20250514-v1:0'
 
 
+async def test_bedrock_count_tokens_additional_model_requests_fields(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, vcr: Cassette
+):
+    """`count_tokens` forwards `bedrock_additional_model_requests_fields` to `input.converse`.
+
+    The `anthropic_beta: ['context-1m-2025-08-07']` header enables Claude's 1M context window;
+    without it, `count_tokens` rejects prompts over 200K tokens even though inference accepts them.
+    """
+    settings: BedrockModelSettings = {
+        'bedrock_additional_model_requests_fields': {'anthropic_beta': ['context-1m-2025-08-07']}
+    }
+    model = BedrockConverseModel(
+        'us.anthropic.claude-sonnet-4-20250514-v1:0', provider=bedrock_provider, settings=settings
+    )
+    params = ModelRequestParameters()
+
+    result = await model.count_tokens([ModelRequest.user_text_prompt('Hello, world!')], settings, params)
+    assert result.input_tokens > 0
+
+    sent = json.loads(vcr.requests[0].body)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    assert sent['input']['converse']['additionalModelRequestFields'] == {'anthropic_beta': ['context-1m-2025-08-07']}
+
+
 async def test_bedrock_stream_non_http_error():
     error = ClientError({'Error': {'Code': 'TestException', 'Message': 'broken connection'}}, 'converse_stream')
     model = _bedrock_model_with_client_error(error)

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -367,7 +367,7 @@ async def test_bedrock_count_tokens_additional_model_requests_fields(
     result = await model.count_tokens([ModelRequest.user_text_prompt('Hello, world!')], settings, params)
     assert result.input_tokens > 0
 
-    sent = json.loads(vcr.requests[0].body)  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
+    sent = single_request_body(vcr)
     assert sent['input']['converse']['additionalModelRequestFields'] == {'anthropic_beta': ['context-1m-2025-08-07']}
 
 

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -351,10 +351,9 @@ async def test_bedrock_inference_profile_count_tokens(
 async def test_bedrock_count_tokens_additional_model_requests_fields(
     allow_model_requests: None, bedrock_provider: BedrockProvider, vcr: Cassette
 ):
-    """`count_tokens` forwards `bedrock_additional_model_requests_fields` to `input.converse`.
+    """`count_tokens` forwards `bedrock_additional_model_requests_fields` to `input.converse` and Bedrock accepts it.
 
-    The `anthropic_beta: ['context-1m-2025-08-07']` header enables Claude's 1M context window;
-    without it, `count_tokens` rejects prompts over 200K tokens even though inference accepts them.
+    Here it carries `anthropic_beta: ['context-1m-2025-08-07']`, the header used to opt into Claude's 1M context window.
     """
     settings: BedrockModelSettings = {
         'bedrock_additional_model_requests_fields': {'anthropic_beta': ['context-1m-2025-08-07']}
@@ -369,6 +368,38 @@ async def test_bedrock_count_tokens_additional_model_requests_fields(
 
     sent = single_request_body(vcr)
     assert sent['input']['converse']['additionalModelRequestFields'] == {'anthropic_beta': ['context-1m-2025-08-07']}
+
+
+async def test_bedrock_count_tokens_tool_config(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, vcr: Cassette
+):
+    """`count_tokens` forwards `toolConfig` to `input.converse`, mirroring the real request so tool schemas are counted."""
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-20250514-v1:0', provider=bedrock_provider)
+    tool_def = ToolDefinition(
+        name='get_weather',
+        description='Get the weather for a location',
+        parameters_json_schema={'type': 'object', 'properties': {'location': {'type': 'string'}}},
+    )
+    params = ModelRequestParameters(function_tools=[tool_def], allow_text_output=True)
+
+    result = await model.count_tokens([ModelRequest.user_text_prompt('What is the weather in Paris?')], None, params)
+    assert result.input_tokens > 0
+
+    sent = single_request_body(vcr)
+    assert sent['input']['converse']['toolConfig'] == snapshot(
+        {
+            'tools': [
+                {
+                    'toolSpec': {
+                        'name': 'get_weather',
+                        'inputSchema': {'json': {'type': 'object', 'properties': {'location': {'type': 'string'}}}},
+                        'description': 'Get the weather for a location',
+                    }
+                }
+            ],
+            'toolChoice': {'auto': {}},
+        }
+    )
 
 
 async def test_bedrock_stream_non_http_error():


### PR DESCRIPTION
- Fixes #5497

`BedrockConverseModel.count_tokens()` never forwarded `additionalModelRequestFields` to the Bedrock CountTokens API, even though `_messages_create()` does for inference calls. Any field set via `bedrock_additional_model_requests_fields` — most notably the `anthropic_beta: ['context-1m-2025-08-07']` header required for Claude's 1M context window — was silently dropped during token counting, so pre-flight counting failed on prompts over 200K tokens (`ValidationException: prompt is too long`) while the actual inference call succeeded.

The fix mirrors the inference path: run `_translate_thinking()` and, when it returns fields, nest them at `input.converse.additionalModelRequestFields`. That key belongs to boto3's `ConverseTokensRequestTypeDef` (the `converse` sub-dict), not the top-level `CountTokensRequestTypeDef`, so it's placed and typed accordingly — fully type-safe, no `Any`/`cast`.

A live-recorded VCR test (`test_bedrock_count_tokens_additional_model_requests_fields`) sets the 1M-context beta field and asserts it reaches `input.converse.additionalModelRequestFields` on the wire.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

