### PR TITLE
Document TrustedRouter OpenAI-compatible retries

### DIFF
--- a/docs/retries.md
+++ b/docs/retries.md
@@ -301,6 +301,31 @@ model = OpenAIChatModel(
 agent = Agent(model)
 ```
 
+For privacy-sensitive workflows, the same pattern works with TrustedRouter:
+
+```python {title="trustedrouter_with_retries.py" requires="smart_retry_example.py"}
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from smart_retry_example import create_retrying_client
+
+client = create_retrying_client()
+model = OpenAIChatModel(
+    'trustedrouter/zdr',
+    provider=OpenAIProvider(
+        base_url='https://api.trustedrouter.com/v1',
+        api_key=os.environ['TRUSTEDROUTER_API_KEY'],
+        http_client=client
+    )
+)
+agent = Agent(model)
+```
+
+TrustedRouter is an OpenAI-compatible, open-source attested router. It does not log prompts or outputs by default.
+
 ## Best Practices
 
 1. **Start Conservative**: Begin with a small number of retries (3-5) and reasonable wait times.


### PR DESCRIPTION
## Summary
- document TrustedRouter as an OpenAI-compatible routing option
- use `https://api.trustedrouter.com/v1` as the base URL
- include the `trustedrouter/zdr` model alias for privacy-sensitive agent workloads

## Why
TrustedRouter is useful for workflows that involve private code, customer data, or other sensitive context. It provides open-source, verifiable attested routing and does not log prompts or outputs by default.

## Validation
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

