### PR TITLE
Add `PromptedOutput` coverage for invalid union `kind` retry

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2410,6 +2410,53 @@ def test_output_type_union_text_fallback_invalid_kind_retries():
     )
 
 
+def test_prompted_output_union_invalid_kind_retries():
+    """`PromptedOutput` is the realistic route to an unknown `kind`: the envelope schema is only
+    advertised in the prompt (no output tools, no provider-enforced `const` discriminator), so a
+    model can plausibly emit a `kind` outside the registered set. The shared `UnionOutputProcessor`
+    must still reject it as a regular `ValidationError` and re-prompt, exactly as the tool-mode text
+    fallback does in `test_output_type_union_text_fallback_invalid_kind_retries`.
+    """
+
+    calls = 0
+
+    def model_fn(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        # Prompted mode, not the tool-mode text fallback: no output tools are offered.
+        assert info.model_request_parameters.output_mode == 'prompted'
+        assert not info.output_tools
+        if calls == 1:
+            # `kind` is not one of the allowed discriminator values (`Apple` / `Banana`).
+            text = '{"result": {"kind": "Cherry", "data": {"color": "red"}}}'
+        else:
+            text = '{"result": {"kind": "Banana", "data": {"length": 6.0}}}'
+        return ModelResponse(parts=[TextPart(content=text)])
+
+    agent = Agent(FunctionModel(model_fn), output_type=PromptedOutput([Apple, Banana]))
+    result = agent.run_sync('What fruit is it?')
+    assert result.output == snapshot(Banana(length=6.0))
+    assert calls == 2
+
+    retry_parts = [p for m in result.all_messages() for p in m.parts if isinstance(p, RetryPromptPart)]
+    assert retry_parts == snapshot(
+        [
+            RetryPromptPart(
+                content=[
+                    {
+                        'type': 'literal_error',
+                        'loc': ('result', 'kind'),
+                        'msg': "Input should be 'Apple' or 'Banana'",
+                        'input': 'Cherry',
+                    }
+                ],
+                tool_call_id=IsStr(),
+                timestamp=IsDatetime(),
+            )
+        ]
+    )
+
+
 def test_output_type_union_text_fallback_invalid_kind_exhausts_retries():
     """When the union envelope text keeps carrying an unknown `kind` past the retry budget, the
     run raises `UnexpectedModelBehavior` — the invalid `kind` is fully absorbed by the retry


### PR DESCRIPTION
Follow-up to #5845 (closed #5844). That PR fixed the unknown union `kind` `KeyError` and, per @adtyavrdhn's review, added a streaming regression test plus a docstring noting that `PromptedOutput` is the realistic route to an invalid `kind` (a real model only sees the envelope schema in prompted mode, never in tool mode).

This adds the test that docstring describes: `test_prompted_output_union_invalid_kind_retries` exercises an invalid `kind` through `PromptedOutput` directly. It asserts inside the `FunctionModel` that `output_mode == 'prompted'` and `not info.output_tools` (so it genuinely hits the prompted path, not the tool-mode fallback), then asserts the re-prompt + recovery and snapshots the same `RetryPromptPart` `literal_error` on `('result', 'kind')` as the tool-mode sibling, confirming both routes flow through the shared `UnionOutputProcessor` `kind` validation.

Test-only; no behavior or public-API change. No separate issue (review-item follow-up to #5845).

### Checklist

- [x] The pull request title is a good summary of the changes
- [ ] I have added tests for the changes (this PR _is_ the test)
- [ ] AI generated code


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

