### PR TITLE
Forward `top_k` model setting to Bedrock `additionalModelRequestFields`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -723,8 +723,13 @@ class BedrockConverseModel(Model[BaseClient]):
         if (top_k := model_settings.get('top_k')) is not None:
             if profile.bedrock_top_k_variant == 'anthropic' and 'top_k' not in existing:
                 existing['top_k'] = top_k
-            elif profile.bedrock_top_k_variant == 'nova' and 'inferenceConfig' not in existing:
-                existing['inferenceConfig'] = {'topK': top_k}
+            elif profile.bedrock_top_k_variant == 'nova':
+                # Nova nests `topK` under `inferenceConfig`, so check that specific key (not the parent)
+                # and merge into a fresh dict to preserve any other user-supplied `inferenceConfig` fields
+                # without mutating the user's settings in place. A user-supplied `topK` wins.
+                inference_config: Mapping[str, Any] = existing.get('inferenceConfig') or {}
+                if isinstance(inference_config, dict) and 'topK' not in inference_config:
+                    existing['inferenceConfig'] = {**inference_config, 'topK': top_k}
 
         thinking = model_request_parameters.thinking
         if thinking is None:

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -592,7 +592,9 @@ class BedrockConverseModel(Model[BaseClient]):
             converse['toolConfig'] = tool_config
         tools: list[ToolTypeDef] = list(tool_config['tools']) if tool_config else []
         self._limit_cache_points(system_prompt, bedrock_messages, tools)
-        if additional_model_requests_fields := self._translate_thinking(settings, model_request_parameters):
+        if additional_model_requests_fields := self._build_additional_model_request_fields(
+            settings, model_request_parameters
+        ):
             converse['additionalModelRequestFields'] = additional_model_requests_fields
         params: CountTokensRequestTypeDef = {
             'modelId': remove_bedrock_geo_prefix(self.model_name),
@@ -707,18 +709,27 @@ class BedrockConverseModel(Model[BaseClient]):
             provider_details=provider_details,
         )
 
-    def _translate_thinking(
+    def _build_additional_model_request_fields(
         self,
         model_settings: BedrockModelSettings,
         model_request_parameters: ModelRequestParameters,
     ) -> dict[str, Any] | None:
-        """Build thinking-related additionalModelRequestFields, using unified thinking as fallback."""
+        """Build `additionalModelRequestFields` from user-supplied fields plus unified `top_k` and `thinking`."""
         existing = dict(model_settings.get('bedrock_additional_model_requests_fields') or {})
+        profile = BedrockModelProfile.from_profile(self.profile)
+
+        # Bedrock's `inferenceConfig` has no `topK`, so unified `top_k` rides in the model-specific
+        # `additionalModelRequestFields` (shape varies per family). A user-supplied key wins.
+        if (top_k := model_settings.get('top_k')) is not None:
+            if profile.bedrock_top_k_variant == 'anthropic' and 'top_k' not in existing:
+                existing['top_k'] = top_k
+            elif profile.bedrock_top_k_variant == 'nova' and 'inferenceConfig' not in existing:
+                existing['inferenceConfig'] = {'topK': top_k}
+
         thinking = model_request_parameters.thinking
         if thinking is None:
             return existing or None
 
-        profile = BedrockModelProfile.from_profile(self.profile)
         variant = profile.bedrock_thinking_variant
 
         if variant == 'anthropic' and 'thinking' not in existing:
@@ -821,7 +832,9 @@ class BedrockConverseModel(Model[BaseClient]):
             elif (unified_tier := model_settings.get('service_tier')) and unified_tier != 'auto':
                 params['serviceTier'] = {'type': unified_tier}
 
-        if additional_model_requests_fields := self._translate_thinking(settings, model_request_parameters):
+        if additional_model_requests_fields := self._build_additional_model_request_fields(
+            settings, model_request_parameters
+        ):
             params['additionalModelRequestFields'] = additional_model_requests_fields
 
         with _map_api_errors(self.model_name):

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -172,6 +172,19 @@ class BedrockModelProfile(ModelProfile):
     (a sibling of `thinking`, not inside it).
     """
 
+    bedrock_top_k_variant: Literal['anthropic', 'nova'] | None = None
+    """How the unified `top_k` setting is placed in `additionalModelRequestFields`.
+
+    Bedrock's Converse `inferenceConfig` has no `topK` field, so `top_k` must travel in the
+    model-specific `additionalModelRequestFields` blob, where the shape differs per family
+    (and Bedrock 400s on an unrecognized key rather than ignoring it):
+
+    - `'anthropic'`: flat `{'top_k': N}`
+    - `'nova'`: nested `{'inferenceConfig': {'topK': N}}`
+    - `None`: `top_k` is silently dropped (Llama/Mistral/DeepSeek/Jamba don't accept it on
+      Converse; Cohere's `k` and Qwen's key are unverified on Converse, so they stay here too).
+    """
+
 
 def bedrock_anthropic_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for an Anthropic model used via Bedrock."""
@@ -184,7 +197,7 @@ def bedrock_anthropic_model_profile(model_name: str) -> ModelProfile | None:
     # only copies fields that exist on self, so anthropic-prefixed fields would be lost.
     is_anthropic = isinstance(downstream, AnthropicModelProfile)
     supports_adaptive = is_anthropic and downstream.anthropic_supports_adaptive_thinking
-    # Bedrock only honors effort inside the adaptive branch of `_translate_thinking`, so don't claim
+    # Bedrock only honors effort inside the adaptive branch of `_build_additional_model_request_fields`, so don't claim
     # support for non-adaptive models (e.g. Opus 4.5) even when the direct Anthropic API supports it.
     supports_effort = supports_adaptive and is_anthropic and downstream.anthropic_supports_effort
     profile = BedrockModelProfile(
@@ -196,6 +209,7 @@ def bedrock_anthropic_model_profile(model_name: str) -> ModelProfile | None:
         bedrock_thinking_variant='anthropic',
         bedrock_supports_adaptive_thinking=supports_adaptive,
         bedrock_supports_effort=supports_effort,
+        bedrock_top_k_variant='anthropic',
     ).update(_without_builtin_tools(downstream))
     supports_structured_output = profile.supports_json_schema_output and not model_name.startswith(
         bedrock_structured_output_unsupported
@@ -215,6 +229,7 @@ def bedrock_amazon_model_profile(model_name: str) -> ModelProfile | None:
         profile = BedrockModelProfile(
             bedrock_supports_tool_choice=True,
             bedrock_supports_prompt_caching=True,
+            bedrock_top_k_variant='nova',
         ).update(profile)
 
     if 'nova-2' in model_name:

--- a/pydantic_ai_slim/pydantic_ai/settings.py
+++ b/pydantic_ai_slim/pydantic_ai/settings.py
@@ -155,6 +155,7 @@ class ModelSettings(TypedDict, total=False):
     * Gemini
     * Anthropic
     * Cohere
+    * Bedrock (Anthropic and Amazon Nova models only)
     """
 
     timeout: float | Timeout

--- a/tests/models/cassettes/test_bedrock/test_bedrock_top_k_anthropic_variant.yaml
+++ b/tests/models/cassettes/test_bedrock/test_bedrock_top_k_anthropic_variant.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Reply with the single word: ok"}]}], "system": [], "inferenceConfig":
+      {}, "additionalModelRequestFields": {"top_k": 20}}'
+    headers:
+      amz-sdk-invocation-id:
+      - !!binary |
+        NDIxZTQ1MDMtYWQ5OS00ZTRhLWJjMDQtYzc0ODMxZGE5ZTk2
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      content-length:
+      - '173'
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '342'
+      content-type:
+      - application/json
+    parsed_body:
+      metrics:
+        latencyMs: 1033
+      output:
+        message:
+          content:
+          - text: ok
+          role: assistant
+      stopReason: end_turn
+      usage:
+        cacheReadInputTokenCount: 0
+        cacheReadInputTokens: 0
+        cacheWriteInputTokenCount: 0
+        cacheWriteInputTokens: 0
+        inputTokens: 14
+        outputTokens: 4
+        serverToolUsage: {}
+        totalTokens: 18
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_bedrock/test_bedrock_top_k_nova_variant.yaml
+++ b/tests/models/cassettes/test_bedrock/test_bedrock_top_k_nova_variant.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Reply with the single word: ok"}]}], "system": [], "inferenceConfig":
+      {}, "additionalModelRequestFields": {"inferenceConfig": {"topK": 20}}}'
+    headers:
+      amz-sdk-invocation-id:
+      - !!binary |
+        OGMwNTIwZDUtYWE1MS00NWFmLTg2ZWMtMTQ0OGZlZDI3YjZl
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      content-length:
+      - '193'
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-micro-v1%3A0/converse
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '221'
+      content-type:
+      - application/json
+    parsed_body:
+      metrics:
+        latencyMs: 328
+      output:
+        message:
+          content:
+          - text: ok
+          role: assistant
+      stopReason: end_turn
+      usage:
+        inputTokens: 7
+        outputTokens: 2
+        serverToolUsage: {}
+        totalTokens: 9
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -2886,6 +2886,86 @@ async def test_bedrock_thinking_true_qwen_variant(
     assert sent['additionalModelRequestFields'] == {'reasoning_config': 'high'}
 
 
+async def test_bedrock_top_k_anthropic_variant(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, vcr: Cassette
+) -> None:
+    """Unified `top_k` rides in `additionalModelRequestFields` as a flat `top_k` for Anthropic models.
+
+    Bedrock's `inferenceConfig` has no `topK` field, so the setting can only reach Claude here.
+    """
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+    agent = Agent(model, model_settings=ModelSettings(top_k=20))
+    result = await agent.run('Reply with the single word: ok')
+
+    sent = single_request_body(vcr)
+    assert sent['additionalModelRequestFields'] == {'top_k': 20}
+    assert 'topK' not in sent['inferenceConfig']
+    assert result.output == IsStr()
+
+
+async def test_bedrock_top_k_nova_variant(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, vcr: Cassette
+) -> None:
+    """Unified `top_k` rides in `additionalModelRequestFields` nested under `inferenceConfig.topK` for Nova models."""
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    agent = Agent(model, model_settings=ModelSettings(top_k=20))
+    result = await agent.run('Reply with the single word: ok')
+
+    sent = single_request_body(vcr)
+    assert sent['additionalModelRequestFields'] == {'inferenceConfig': {'topK': 20}}
+    assert result.output == IsStr()
+
+
+async def test_bedrock_top_k_user_field_takes_precedence(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+) -> None:
+    """A user-supplied `bedrock_additional_model_requests_fields['top_k']` is never clobbered by unified `top_k`.
+
+    No-network: the assertion is on the outgoing request shape, which a cassette matcher wouldn't pin.
+    """
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+    model_settings = BedrockModelSettings(top_k=20, bedrock_additional_model_requests_fields={'top_k': 5})
+    agent = Agent(model, model_settings=model_settings)
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    await agent.run('What is the capital of France?')
+
+    _, kwargs = mock_converse.call_args
+    assert kwargs['additionalModelRequestFields'] == {'top_k': 5}
+
+
+async def test_bedrock_top_k_unsupported_family_dropped(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+) -> None:
+    """Models without a `bedrock_top_k_variant` (e.g. Mistral) silently drop `top_k`.
+
+    No-network: Bedrock 400s on an unrecognized `additionalModelRequestFields` key, so forwarding `top_k`
+    to a family that doesn't accept it would be a regression — the field must be absent here.
+    """
+    model = BedrockConverseModel('mistral.mistral-large-2402-v1:0', provider=bedrock_provider)
+    agent = Agent(model, model_settings=ModelSettings(top_k=20))
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    await agent.run('What is the capital of France?')
+
+    _, kwargs = mock_converse.call_args
+    assert 'additionalModelRequestFields' not in kwargs
+
+
 async def test_bedrock_model_stream_empty_text_delta(allow_model_requests: None, bedrock_provider: BedrockProvider):
     model = BedrockConverseModel(model_name='openai.gpt-oss-120b-1:0', provider=bedrock_provider)
     agent = Agent(model)

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -2941,6 +2941,65 @@ async def test_bedrock_top_k_user_field_takes_precedence(
     assert kwargs['additionalModelRequestFields'] == {'top_k': 5}
 
 
+async def test_bedrock_top_k_nova_merges_with_user_inference_config(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+) -> None:
+    """For Nova, unified `top_k` merges into a user-supplied `inferenceConfig` without dropping its other fields.
+
+    No-network: the assertion is on the outgoing request shape, which a cassette matcher wouldn't pin. The Nova
+    branch checks the nested `topK` key (not the parent `inferenceConfig`), so an unrelated field doesn't suppress it.
+    A user-supplied `topK` still wins.
+    """
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    user_inference_config = {'maxTokens': 100}
+    model_settings = BedrockModelSettings(
+        top_k=20, bedrock_additional_model_requests_fields={'inferenceConfig': user_inference_config}
+    )
+    agent = Agent(model, model_settings=model_settings)
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    await agent.run('What is the capital of France?')
+
+    _, kwargs = mock_converse.call_args
+    assert kwargs['additionalModelRequestFields'] == {'inferenceConfig': {'maxTokens': 100, 'topK': 20}}
+    # The user's settings dict is not mutated in place.
+    assert user_inference_config == {'maxTokens': 100}
+
+
+async def test_bedrock_top_k_nova_user_top_k_takes_precedence(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+) -> None:
+    """A user-supplied `inferenceConfig['topK']` is never clobbered by unified `top_k` for Nova.
+
+    No-network: the assertion is on the outgoing request shape, which a cassette matcher wouldn't pin.
+    """
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    model_settings = BedrockModelSettings(
+        top_k=20, bedrock_additional_model_requests_fields={'inferenceConfig': {'topK': 5}}
+    )
+    agent = Agent(model, model_settings=model_settings)
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    await agent.run('What is the capital of France?')
+
+    _, kwargs = mock_converse.call_args
+    assert kwargs['additionalModelRequestFields'] == {'inferenceConfig': {'topK': 5}}
+
+
 async def test_bedrock_top_k_unsupported_family_dropped(
     allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
 ) -> None:

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -570,7 +570,7 @@ class TestAnthropicUnifiedThinkingConflict:
 
 @pytest.mark.skipif(not bedrock_imports(), reason='boto3 not installed')
 class TestBedrockThinkingTranslation:
-    """Test Bedrock _translate_thinking translation for each variant."""
+    """Test Bedrock thinking translation in `_build_additional_model_request_fields` for each variant."""
 
     def test_anthropic_variant_thinking_true(self):
         model = BedrockConverseModel.__new__(BedrockConverseModel)
@@ -581,7 +581,7 @@ class TestBedrockThinkingTranslation:
 
         settings = BedrockModelSettings()
         params = ModelRequestParameters(thinking=True)
-        result = model._translate_thinking(settings, params)
+        result = model._build_additional_model_request_fields(settings, params)
         assert result == {'thinking': {'type': 'enabled', 'budget_tokens': 10000}}
 
     def test_anthropic_variant_thinking_false(self):
@@ -593,7 +593,7 @@ class TestBedrockThinkingTranslation:
 
         settings = BedrockModelSettings()
         params = ModelRequestParameters(thinking=False)
-        result = model._translate_thinking(settings, params)
+        result = model._build_additional_model_request_fields(settings, params)
         assert result == {'thinking': {'type': 'disabled'}}
 
     def test_openai_variant_thinking_false(self):
@@ -606,7 +606,7 @@ class TestBedrockThinkingTranslation:
 
         settings = BedrockModelSettings()
         params = ModelRequestParameters(thinking=False)
-        result = model._translate_thinking(settings, params)
+        result = model._build_additional_model_request_fields(settings, params)
         # thinking=False: no reasoning_effort set, returns None
         assert result is None
 
@@ -619,7 +619,7 @@ class TestBedrockThinkingTranslation:
 
         settings = BedrockModelSettings()
         params = ModelRequestParameters(thinking='high')
-        result = model._translate_thinking(settings, params)
+        result = model._build_additional_model_request_fields(settings, params)
         assert result == {'reasoning_effort': 'high'}
 
     def test_qwen_variant_thinking_true(self):
@@ -631,7 +631,7 @@ class TestBedrockThinkingTranslation:
 
         settings = BedrockModelSettings()
         params = ModelRequestParameters(thinking=True)
-        result = model._translate_thinking(settings, params)
+        result = model._build_additional_model_request_fields(settings, params)
         assert result == {'reasoning_config': 'high'}
 
     def test_qwen_variant_thinking_false(self):
@@ -644,7 +644,7 @@ class TestBedrockThinkingTranslation:
 
         settings = BedrockModelSettings()
         params = ModelRequestParameters(thinking=False)
-        result = model._translate_thinking(settings, params)
+        result = model._build_additional_model_request_fields(settings, params)
         # thinking=False on Qwen: no reasoning_config set, returns None (empty dict is falsy)
         assert result is None
 
@@ -655,7 +655,7 @@ class TestBedrockThinkingTranslation:
 
         settings = BedrockModelSettings()
         params = ModelRequestParameters(thinking='high')
-        result = model._translate_thinking(settings, params)
+        result = model._build_additional_model_request_fields(settings, params)
         # No variant set, so no thinking fields are added
         assert result is None
 
@@ -665,7 +665,7 @@ class TestBedrockThinkingTranslation:
 
         settings = BedrockModelSettings()
         params = ModelRequestParameters(thinking=None)
-        result = model._translate_thinking(settings, params)
+        result = model._build_additional_model_request_fields(settings, params)
         assert result is None
 
     def _adaptive_model(self, *, supports_effort: bool = True):
@@ -686,7 +686,9 @@ class TestBedrockThinkingTranslation:
         from pydantic_ai.models.bedrock import BedrockModelSettings
 
         model = self._adaptive_model()
-        result = model._translate_thinking(BedrockModelSettings(), ModelRequestParameters(thinking=True))
+        result = model._build_additional_model_request_fields(
+            BedrockModelSettings(), ModelRequestParameters(thinking=True)
+        )
         assert result == {'thinking': {'type': 'adaptive'}}
 
     def test_anthropic_variant_adaptive_thinking_high_sets_effort(self):
@@ -694,7 +696,9 @@ class TestBedrockThinkingTranslation:
         from pydantic_ai.models.bedrock import BedrockModelSettings
 
         model = self._adaptive_model()
-        result = model._translate_thinking(BedrockModelSettings(), ModelRequestParameters(thinking='high'))
+        result = model._build_additional_model_request_fields(
+            BedrockModelSettings(), ModelRequestParameters(thinking='high')
+        )
         assert result == {'thinking': {'type': 'adaptive'}, 'output_config': {'effort': 'high'}}
 
     @pytest.mark.parametrize(
@@ -706,7 +710,9 @@ class TestBedrockThinkingTranslation:
         from pydantic_ai.models.bedrock import BedrockModelSettings
 
         model = self._adaptive_model()
-        result = model._translate_thinking(BedrockModelSettings(), ModelRequestParameters(thinking=level))
+        result = model._build_additional_model_request_fields(
+            BedrockModelSettings(), ModelRequestParameters(thinking=level)
+        )
         assert result == {'thinking': {'type': 'adaptive'}, 'output_config': {'effort': effort}}
 
     def test_anthropic_variant_adaptive_no_effort_when_unsupported(self):
@@ -714,7 +720,9 @@ class TestBedrockThinkingTranslation:
         from pydantic_ai.models.bedrock import BedrockModelSettings
 
         model = self._adaptive_model(supports_effort=False)
-        result = model._translate_thinking(BedrockModelSettings(), ModelRequestParameters(thinking='high'))
+        result = model._build_additional_model_request_fields(
+            BedrockModelSettings(), ModelRequestParameters(thinking='high')
+        )
         assert result == {'thinking': {'type': 'adaptive'}}
 
     def test_anthropic_variant_adaptive_user_output_config_wins(self):
@@ -723,7 +731,7 @@ class TestBedrockThinkingTranslation:
 
         model = self._adaptive_model()
         settings = BedrockModelSettings(bedrock_additional_model_requests_fields={'output_config': {'effort': 'low'}})
-        result = model._translate_thinking(settings, ModelRequestParameters(thinking='high'))
+        result = model._build_additional_model_request_fields(settings, ModelRequestParameters(thinking='high'))
         assert result == {'thinking': {'type': 'adaptive'}, 'output_config': {'effort': 'low'}}
 
     def test_anthropic_variant_adaptive_thinking_false_omits(self):
@@ -731,7 +739,9 @@ class TestBedrockThinkingTranslation:
         from pydantic_ai.models.bedrock import BedrockModelSettings
 
         model = self._adaptive_model()
-        result = model._translate_thinking(BedrockModelSettings(), ModelRequestParameters(thinking=False))
+        result = model._build_additional_model_request_fields(
+            BedrockModelSettings(), ModelRequestParameters(thinking=False)
+        )
         assert result is None
 
 


### PR DESCRIPTION
- Closes #5916

## Problem

`BedrockConverseModel` silently dropped `ModelSettings(top_k=...)`. `AnthropicModel` forwards it, so the same agent code behaved differently by provider (provider-parity bug).

## Why it wasn't a one-liner

Bedrock's Converse `inferenceConfig` has **no** `topK` field, so `top_k` can only travel in the model-family-specific `additionalModelRequestFields` blob — and Bedrock returns a **400 `ValidationException`** on an unrecognized key rather than ignoring it (verified live against Bedrock `us-east-1`). The key/shape differs per family:

| Family | Shape | Verified |
|---|---|---|
| Anthropic Claude | flat `{'top_k': N}` | live |
| Amazon Nova | nested `{'inferenceConfig': {'topK': N}}` | live |
| Llama / Mistral / DeepSeek / Jamba | no `top_k` (400s on the key) | docs + live |
| Cohere (`k`) / Qwen | Converse key unverified | — |

So forwarding a flat `top_k` unconditionally (as first proposed on the issue) would turn today's harmless silent-drop into a hard 400 regression for every Nova/Llama/Mistral user.

## Change

- New `BedrockModelProfile.bedrock_top_k_variant: Literal['anthropic', 'nova'] | None` gates forwarding per family. Set to `'anthropic'` / `'nova'` for those families; everything else stays `None` and keeps silently dropping `top_k` (the safe behavior, consistent with how unsupported settings are documented and ignored elsewhere).
- `top_k` is merged into `additionalModelRequestFields` (renamed `_translate_thinking` → `_build_additional_model_request_fields`, which already composes user-supplied fields + thinking). A user-supplied `bedrock_additional_model_requests_fields` key is never clobbered. The `count_tokens` path picks it up too, mirroring the request.
- `settings.py` `top_k` docstring notes Bedrock support (Anthropic + Amazon Nova only).

## Tests

- Live VCR cassettes asserting the wire shape for Anthropic (`{'top_k': 20}`) and Nova (`{'inferenceConfig': {'topK': 20}}`).
- No-network: user-field precedence, and silent-drop on an unsupported family (Mistral).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

