### PR TITLE
Track CI duration telemetry

### DIFF
--- a/.github/scripts/ci_duration.py
+++ b/.github/scripts/ci_duration.py
@@ -1,0 +1,827 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import ssl
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+SCHEMA_VERSION = 1
+CI_WORKFLOW_FILE = 'ci.yml'
+REPORT_MARKER = '<!-- ci-duration-report -->'
+REPORT_LABEL = 'trigger:ci-duration-report'
+BASELINE_MAIN_RUN_LIMIT = 30
+BASELINE_PR_RUN_LIMIT = 60
+MIN_BASELINE_SAMPLES = 10
+WARNING_MIN_SECONDS = 60
+SLOW_THRESHOLD_MULTIPLIER = 1.25
+FAST_THRESHOLD_MULTIPLIER = 0.75
+VERY_SLOW_MIN_SECONDS = 300
+VERY_SLOW_THRESHOLD_MULTIPLIER = 1.5
+
+JsonValue = None | bool | int | float | str | list['JsonValue'] | dict[str, 'JsonValue']
+JsonObject = dict[str, JsonValue]
+
+
+@dataclass(frozen=True)
+class WorkflowRunRecord:
+    repo: str
+    workflow_id: int
+    workflow_name: str
+    workflow_path: str
+    run_id: int
+    run_attempt: int
+    run_number: int
+    event: str
+    status: str
+    conclusion: str | None
+    head_branch: str | None
+    base_branch: str | None
+    head_sha: str
+    pr_numbers: list[int]
+    run_started_at: str | None
+    updated_at: str | None
+    duration_seconds: float | None
+    html_url: str
+    actor: str | None
+
+
+@dataclass(frozen=True)
+class StepRecord:
+    number: int
+    name: str
+    status: str
+    conclusion: str | None
+    started_at: str | None
+    completed_at: str | None
+    duration_seconds: float | None
+
+
+@dataclass(frozen=True)
+class JobRecord:
+    job_id: int
+    raw_name: str
+    job_family: str
+    job_signature: str
+    matrix_python: str | None
+    matrix_extra: str | None
+    conclusion: str | None
+    status: str
+    started_at: str | None
+    completed_at: str | None
+    duration_seconds: float | None
+    runner_name: str | None
+    runner_group_name: str | None
+    runner_class: str
+    html_url: str
+    steps: list[StepRecord]
+
+
+@dataclass(frozen=True)
+class Baseline:
+    sample_size: int
+    median_seconds: float
+    p75_seconds: float
+    p90_seconds: float
+    mad_seconds: float
+
+
+@dataclass(frozen=True)
+class ReportRow:
+    job_name: str
+    job_signature: str
+    duration_seconds: float | None
+    baseline: Baseline | None
+    delta_seconds: float | None
+    delta_percent: float | None
+    status: Literal['normal', 'fast', 'slow', 'very_slow', 'no_baseline', 'not_completed']
+
+
+class GitHubClient:
+    def __init__(self, repo: str, token: str):
+        self.repo = repo
+        self.token = token
+        self.ssl_context = _ssl_context()
+
+    def request_json(self, path: str, *, method: str = 'GET', body: JsonObject | None = None) -> JsonValue:
+        data = json.dumps(body).encode() if body is not None else None
+        request = urllib.request.Request(
+            self._url(path),
+            data=data,
+            method=method,
+            headers={
+                'Accept': 'application/vnd.github+json',
+                'Authorization': f'Bearer {self.token}',
+                'Content-Type': 'application/json',
+                'X-GitHub-Api-Version': '2022-11-28',
+            },
+        )
+        with urllib.request.urlopen(request, timeout=30, context=self.ssl_context) as response:
+            response_body = response.read()
+        if not response_body:
+            return None
+        return json.loads(response_body)
+
+    def request_paginated(self, path: str, *, max_items: int | None = None) -> list[JsonObject]:
+        parsed = urllib.parse.urlsplit(path)
+        query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+        query = [item for item in query if item[0] not in {'page', 'per_page'}]
+        query.append(('per_page', '100'))
+
+        page = 1
+        results: list[JsonObject] = []
+        while True:
+            page_query = [*query, ('page', str(page))]
+            page_path = urllib.parse.urlunsplit(
+                (parsed.scheme, parsed.netloc, parsed.path, urllib.parse.urlencode(page_query), '')
+            )
+            value = self.request_json(page_path)
+            page_items = _extract_page_items(value)
+            if not page_items:
+                return results
+            results.extend(page_items)
+            if max_items is not None and len(results) >= max_items:
+                return results[:max_items]
+            if len(page_items) < 100:
+                return results
+            page += 1
+
+    def _url(self, path: str) -> str:
+        if path.startswith('http://') or path.startswith('https://'):
+            return path
+        if not path.startswith('/'):
+            path = f'/repos/{self.repo}/{path}'
+        return f'https://api.github.com{path}'
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Collect and report GitHub Actions CI duration telemetry.')
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    collect_parser = subparsers.add_parser('collect', help='Collect one CI workflow run and emit it to Logfire.')
+    collect_parser.add_argument('--run-id', default=os.getenv('CI_RUN_ID') or os.getenv('GITHUB_EVENT_WORKFLOW_RUN_ID'))
+    collect_parser.add_argument(
+        '--run-attempt', default=os.getenv('CI_RUN_ATTEMPT') or os.getenv('GITHUB_EVENT_WORKFLOW_RUN_ATTEMPT')
+    )
+    collect_parser.add_argument('--output', default='ci-duration-record.json')
+    collect_parser.add_argument('--skip-logfire', action='store_true')
+
+    report_parser = subparsers.add_parser('report', help='Post or update a PR CI duration report.')
+    report_parser.add_argument('--pr-number', default=os.getenv('PR_NUMBER'))
+    report_parser.add_argument('--head-sha', default=os.getenv('HEAD_SHA'))
+    report_parser.add_argument('--poll-seconds', type=int, default=0)
+    report_parser.add_argument('--dry-run', action='store_true')
+
+    args = parser.parse_args()
+    client = _github_client_from_env()
+
+    if args.command == 'collect':
+        if args.run_id is None:
+            raise SystemExit('CI_RUN_ID is required')
+        run_attempt = int(args.run_attempt) if args.run_attempt else None
+        record = collect_run(client, int(args.run_id), run_attempt)
+        Path(args.output).write_text(json.dumps(record, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+        print(f'Wrote CI duration record to {args.output}')
+        if not args.skip_logfire:
+            emit_logfire(record)
+    else:
+        if args.pr_number is None:
+            raise SystemExit('PR_NUMBER is required')
+        if args.head_sha is None:
+            raise SystemExit('HEAD_SHA is required')
+        body = build_pr_report(client, int(args.pr_number), args.head_sha, args.poll_seconds)
+        if args.dry_run:
+            print(body)
+        else:
+            upsert_pr_comment(client, int(args.pr_number), body)
+
+
+def collect_run(client: GitHubClient, run_id: int, run_attempt: int | None) -> JsonObject:
+    run = _expect_object(client.request_json(f'actions/runs/{run_id}'), 'workflow run')
+    attempt = run_attempt or _expect_int(run.get('run_attempt'), 'run_attempt')
+    jobs = client.request_paginated(f'actions/runs/{run_id}/attempts/{attempt}/jobs')
+    workflow = normalize_workflow_run(client.repo, run, attempt)
+    job_records = [normalize_job(job) for job in jobs]
+    return {
+        'schema_version': SCHEMA_VERSION,
+        'fetched_at': _now(),
+        'workflow_run': workflow_to_json(workflow),
+        'jobs': [job_to_json(job) for job in job_records],
+    }
+
+
+def build_pr_report(client: GitHubClient, pr_number: int, head_sha: str, poll_seconds: int) -> str:
+    run = wait_for_completed_ci_run(client, head_sha, poll_seconds)
+    if run is None:
+        return render_waiting_report(head_sha)
+
+    run_id = _expect_int(run.get('id'), 'run id')
+    run_attempt = _expect_int(run.get('run_attempt'), 'run_attempt')
+    current_record = collect_run(client, run_id, run_attempt)
+    current_jobs = [_job_from_json(job) for job in _expect_list(current_record['jobs'], 'jobs')]
+    baselines = collect_baselines(client, head_sha)
+    rows = [
+        classify_job(job, baselines.get(job.job_signature)) for job in current_jobs if not _is_ignored_report_job(job)
+    ]
+    workflow = _expect_object(current_record['workflow_run'], 'workflow_run')
+    return render_report(pr_number, head_sha, workflow, rows)
+
+
+def wait_for_completed_ci_run(client: GitHubClient, head_sha: str, poll_seconds: int) -> JsonObject | None:
+    deadline = time.monotonic() + poll_seconds
+    while True:
+        run = find_latest_ci_run(client, head_sha)
+        if run is not None and run.get('status') == 'completed':
+            return run
+        if poll_seconds <= 0 or time.monotonic() >= deadline:
+            return None
+        time.sleep(20)
+
+
+def find_latest_ci_run(client: GitHubClient, head_sha: str) -> JsonObject | None:
+    runs = client.request_paginated(f'actions/workflows/{CI_WORKFLOW_FILE}/runs?head_sha={head_sha}', max_items=10)
+    matching = [run for run in runs if run.get('head_sha') == head_sha]
+    if not matching:
+        return None
+    matching.sort(key=lambda run: str(run.get('created_at') or ''), reverse=True)
+    return matching[0]
+
+
+def collect_baselines(client: GitHubClient, current_head_sha: str) -> dict[str, Baseline]:
+    main_runs = client.request_paginated(
+        f'actions/workflows/{CI_WORKFLOW_FILE}/runs?branch=main&event=push&status=success',
+        max_items=BASELINE_MAIN_RUN_LIMIT,
+    )
+    pr_runs = client.request_paginated(
+        f'actions/workflows/{CI_WORKFLOW_FILE}/runs?event=pull_request&status=success',
+        max_items=BASELINE_PR_RUN_LIMIT,
+    )
+    durations: dict[str, list[float]] = {}
+    seen_run_ids: set[int] = set()
+    for run in [*main_runs, *pr_runs]:
+        run_id = _expect_int(run.get('id'), 'baseline run id')
+        if run_id in seen_run_ids or run.get('head_sha') == current_head_sha:
+            continue
+        seen_run_ids.add(run_id)
+        run_attempt = _expect_int(run.get('run_attempt'), 'baseline run_attempt')
+        jobs = client.request_paginated(f'actions/runs/{run_id}/attempts/{run_attempt}/jobs')
+        for job_object in jobs:
+            job = normalize_job(job_object)
+            if job.conclusion == 'success' and job.duration_seconds is not None and not _is_ignored_report_job(job):
+                durations.setdefault(job.job_signature, []).append(job.duration_seconds)
+    return {
+        signature: compute_baseline(values)
+        for signature, values in durations.items()
+        if len(values) >= MIN_BASELINE_SAMPLES
+    }
+
+
+def normalize_workflow_run(repo: str, run: JsonObject, run_attempt: int) -> WorkflowRunRecord:
+    run_started_at = _expect_optional_str(run.get('run_started_at'), 'run_started_at')
+    updated_at = _expect_optional_str(run.get('updated_at'), 'updated_at')
+    return WorkflowRunRecord(
+        repo=repo,
+        workflow_id=_expect_int(run.get('workflow_id'), 'workflow_id'),
+        workflow_name=_expect_str(run.get('name'), 'workflow name'),
+        workflow_path=_expect_str(run.get('path'), 'workflow path'),
+        run_id=_expect_int(run.get('id'), 'run id'),
+        run_attempt=run_attempt,
+        run_number=_expect_int(run.get('run_number'), 'run_number'),
+        event=_expect_str(run.get('event'), 'event'),
+        status=_expect_str(run.get('status'), 'status'),
+        conclusion=_expect_optional_str(run.get('conclusion'), 'conclusion'),
+        head_branch=_expect_optional_str(run.get('head_branch'), 'head_branch'),
+        base_branch=_expect_optional_str(run.get('base_ref'), 'base_ref'),
+        head_sha=_expect_str(run.get('head_sha'), 'head_sha'),
+        pr_numbers=_pull_request_numbers(run.get('pull_requests')),
+        run_started_at=run_started_at,
+        updated_at=updated_at,
+        duration_seconds=_duration_seconds(run_started_at, updated_at),
+        html_url=_expect_str(run.get('html_url'), 'html_url'),
+        actor=_actor_login(run.get('actor')),
+    )
+
+
+def normalize_job(job: JsonObject) -> JobRecord:
+    raw_name = _expect_str(job.get('name'), 'job name')
+    started_at = _expect_optional_str(job.get('started_at'), 'job started_at')
+    completed_at = _expect_optional_str(job.get('completed_at'), 'job completed_at')
+    matrix_python, matrix_extra = parse_job_matrix(raw_name)
+    job_family = parse_job_family(raw_name)
+    runner_class = parse_runner_class(
+        _expect_optional_str(job.get('runner_group_name'), 'runner_group_name'),
+        _expect_optional_str(job.get('runner_name'), 'runner_name'),
+        _expect_list_or_none(job.get('labels'), 'labels'),
+    )
+    return JobRecord(
+        job_id=_expect_int(job.get('id'), 'job id'),
+        raw_name=raw_name,
+        job_family=job_family,
+        job_signature=job_signature(job_family, matrix_python, matrix_extra, runner_class),
+        matrix_python=matrix_python,
+        matrix_extra=matrix_extra,
+        conclusion=_expect_optional_str(job.get('conclusion'), 'job conclusion'),
+        status=_expect_str(job.get('status'), 'job status'),
+        started_at=started_at,
+        completed_at=completed_at,
+        duration_seconds=_duration_seconds(started_at, completed_at),
+        runner_name=_expect_optional_str(job.get('runner_name'), 'runner_name'),
+        runner_group_name=_expect_optional_str(job.get('runner_group_name'), 'runner_group_name'),
+        runner_class=runner_class,
+        html_url=_expect_str(job.get('html_url'), 'job html_url'),
+        steps=[normalize_step(step) for step in _expect_list_or_none(job.get('steps'), 'steps') or []],
+    )
+
+
+def normalize_step(step: JsonValue) -> StepRecord:
+    step_object = _expect_object(step, 'step')
+    started_at = _expect_optional_str(step_object.get('started_at'), 'step started_at')
+    completed_at = _expect_optional_str(step_object.get('completed_at'), 'step completed_at')
+    return StepRecord(
+        number=_expect_int(step_object.get('number'), 'step number'),
+        name=_expect_str(step_object.get('name'), 'step name'),
+        status=_expect_str(step_object.get('status'), 'step status'),
+        conclusion=_expect_optional_str(step_object.get('conclusion'), 'step conclusion'),
+        started_at=started_at,
+        completed_at=completed_at,
+        duration_seconds=_duration_seconds(started_at, completed_at),
+    )
+
+
+def workflow_to_json(workflow: WorkflowRunRecord) -> JsonObject:
+    pr_numbers: list[JsonValue] = [number for number in workflow.pr_numbers]
+    return {
+        'repo': workflow.repo,
+        'workflow_id': workflow.workflow_id,
+        'workflow_name': workflow.workflow_name,
+        'workflow_path': workflow.workflow_path,
+        'run_id': workflow.run_id,
+        'run_attempt': workflow.run_attempt,
+        'run_number': workflow.run_number,
+        'event': workflow.event,
+        'status': workflow.status,
+        'conclusion': workflow.conclusion,
+        'head_branch': workflow.head_branch,
+        'base_branch': workflow.base_branch,
+        'head_sha': workflow.head_sha,
+        'pr_numbers': pr_numbers,
+        'run_started_at': workflow.run_started_at,
+        'updated_at': workflow.updated_at,
+        'duration_seconds': workflow.duration_seconds,
+        'html_url': workflow.html_url,
+        'actor': workflow.actor,
+    }
+
+
+def job_to_json(job: JobRecord) -> JsonObject:
+    return {
+        'job_id': job.job_id,
+        'raw_name': job.raw_name,
+        'job_family': job.job_family,
+        'job_signature': job.job_signature,
+        'matrix_python': job.matrix_python,
+        'matrix_extra': job.matrix_extra,
+        'conclusion': job.conclusion,
+        'status': job.status,
+        'started_at': job.started_at,
+        'completed_at': job.completed_at,
+        'duration_seconds': job.duration_seconds,
+        'runner_name': job.runner_name,
+        'runner_group_name': job.runner_group_name,
+        'runner_class': job.runner_class,
+        'html_url': job.html_url,
+        'steps': [step_to_json(step) for step in job.steps],
+    }
+
+
+def step_to_json(step: StepRecord) -> JsonObject:
+    return {
+        'number': step.number,
+        'name': step.name,
+        'status': step.status,
+        'conclusion': step.conclusion,
+        'started_at': step.started_at,
+        'completed_at': step.completed_at,
+        'duration_seconds': step.duration_seconds,
+    }
+
+
+def parse_job_matrix(job_name: str) -> tuple[str | None, str | None]:
+    match = re.fullmatch(r'test on (?P<python>[^ ]+) \((?P<extra>[^)]+)\)', job_name)
+    if match:
+        return match.group('python'), match.group('extra')
+    match = re.fullmatch(r'test examples on (?P<python>[^ ]+)', job_name)
+    if match:
+        return match.group('python'), 'examples'
+    return None, None
+
+
+def parse_job_family(job_name: str) -> str:
+    if job_name.startswith('test on '):
+        return 'test'
+    if job_name.startswith('test examples on '):
+        return 'test-examples'
+    if job_name in {'lint', 'mypy', 'docs', 'coverage', 'check'}:
+        return job_name
+    return job_name
+
+
+def parse_runner_class(runner_group_name: str | None, runner_name: str | None, labels: list[JsonValue] | None) -> str:
+    label_values = [value for value in labels or [] if isinstance(value, str)]
+    lower_values = ' '.join([runner_group_name or '', runner_name or '', *label_values]).lower()
+    if 'depot' in lower_values:
+        return 'depot'
+    if 'github actions' in lower_values or 'ubuntu' in lower_values:
+        return 'github-hosted'
+    if 'self-hosted' in lower_values:
+        return 'self-hosted'
+    return 'unknown'
+
+
+def job_signature(job_family: str, matrix_python: str | None, matrix_extra: str | None, runner_class: str) -> str:
+    parts = [f'job={job_family}', f'runner={runner_class}']
+    if matrix_python is not None:
+        parts.append(f'py={matrix_python}')
+    if matrix_extra is not None:
+        parts.append(f'extra={matrix_extra}')
+    return ' / '.join(parts)
+
+
+def compute_baseline(values: list[float]) -> Baseline:
+    sorted_values = sorted(values)
+    median = statistics.median(sorted_values)
+    deviations = [abs(value - median) for value in sorted_values]
+    return Baseline(
+        sample_size=len(sorted_values),
+        median_seconds=median,
+        p75_seconds=percentile(sorted_values, 75),
+        p90_seconds=percentile(sorted_values, 90),
+        mad_seconds=statistics.median(deviations),
+    )
+
+
+def percentile(sorted_values: list[float], percentile_value: int) -> float:
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    index = (len(sorted_values) - 1) * percentile_value / 100
+    lower = int(index)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    fraction = index - lower
+    return sorted_values[lower] * (1 - fraction) + sorted_values[upper] * fraction
+
+
+def classify_job(job: JobRecord, baseline: Baseline | None) -> ReportRow:
+    if job.conclusion != 'success' or job.duration_seconds is None:
+        return ReportRow(job.raw_name, job.job_signature, job.duration_seconds, baseline, None, None, 'not_completed')
+    if baseline is None:
+        return ReportRow(job.raw_name, job.job_signature, job.duration_seconds, None, None, None, 'no_baseline')
+
+    delta = job.duration_seconds - baseline.median_seconds
+    delta_percent = delta / baseline.median_seconds * 100 if baseline.median_seconds else None
+    slow_threshold = max(
+        baseline.p75_seconds * SLOW_THRESHOLD_MULTIPLIER, baseline.median_seconds + 2 * baseline.mad_seconds
+    )
+    very_slow_threshold = max(
+        baseline.p90_seconds * VERY_SLOW_THRESHOLD_MULTIPLIER,
+        baseline.median_seconds + 4 * baseline.mad_seconds,
+    )
+    if job.duration_seconds > very_slow_threshold or delta >= VERY_SLOW_MIN_SECONDS:
+        status: Literal['normal', 'fast', 'slow', 'very_slow', 'no_baseline', 'not_completed'] = 'very_slow'
+    elif job.duration_seconds > slow_threshold and delta >= WARNING_MIN_SECONDS:
+        status = 'slow'
+    elif job.duration_seconds < baseline.median_seconds * FAST_THRESHOLD_MULTIPLIER and delta <= -WARNING_MIN_SECONDS:
+        status = 'fast'
+    else:
+        status = 'normal'
+    return ReportRow(job.raw_name, job.job_signature, job.duration_seconds, baseline, delta, delta_percent, status)
+
+
+def render_report(pr_number: int, head_sha: str, workflow: JsonObject, rows: list[ReportRow]) -> str:
+    slow_rows = [row for row in rows if row.status in {'slow', 'very_slow'}]
+    fast_rows = [row for row in rows if row.status == 'fast']
+    failed_rows = [row for row in rows if row.status == 'not_completed']
+    sorted_rows = sorted(
+        rows,
+        key=lambda row: (
+            row.status not in {'very_slow', 'slow', 'fast', 'not_completed'},
+            -(row.delta_seconds or 0),
+            row.job_name,
+        ),
+    )
+    workflow_duration = _format_seconds(_expect_optional_float(workflow.get('duration_seconds'), 'workflow duration'))
+    run_url = _expect_str(workflow.get('html_url'), 'workflow html_url')
+    sha7 = head_sha[:7]
+    lines = [
+        REPORT_MARKER,
+        '## CI Duration Report',
+        '',
+        f'PR #{pr_number}, commit `{sha7}`: [CI run]({run_url})',
+        '',
+        '**Summary**',
+        f'- Workflow duration: {workflow_duration}',
+        f'- Slow jobs: {len(slow_rows)}',
+        f'- Fast jobs: {len(fast_rows)}',
+        f'- Failed/cancelled jobs: {len(failed_rows)}',
+        f'- Baseline: up to {BASELINE_MAIN_RUN_LIMIT} successful `main` CI runs and {BASELINE_PR_RUN_LIMIT} successful PR CI runs, matched by job signature and runner class',
+        f'- Minimum baseline sample: {MIN_BASELINE_SAMPLES} successful matching jobs',
+        f'- Slow threshold: duration > max(p75 * {SLOW_THRESHOLD_MULTIPLIER}, median + 2 * MAD), with at least {WARNING_MIN_SECONDS}s increase',
+        '',
+        '| Job | Duration | Baseline median | p75 | Delta | Status |',
+        '|---|---:|---:|---:|---:|---|',
+    ]
+    for row in sorted_rows[:20]:
+        lines.append(
+            '| '
+            + ' | '.join(
+                [
+                    row.job_name,
+                    _format_seconds(row.duration_seconds),
+                    _format_seconds(row.baseline.median_seconds if row.baseline else None),
+                    _format_seconds(row.baseline.p75_seconds if row.baseline else None),
+                    _format_delta(row.delta_seconds, row.delta_percent),
+                    row.status.replace('_', ' '),
+                ]
+            )
+            + ' |'
+        )
+    if len(sorted_rows) > 20:
+        lines.append(f'| ... | {len(sorted_rows) - 20} more jobs omitted |  |  |  |  |')
+    lines.extend(
+        [
+            '',
+            '<sub>Re-add the `trigger:ci-duration-report` label to refresh this report.</sub>',
+        ]
+    )
+    return '\n'.join(lines)
+
+
+def render_waiting_report(head_sha: str) -> str:
+    return '\n'.join(
+        [
+            REPORT_MARKER,
+            '## CI Duration Report — waiting for CI',
+            '',
+            f'No completed `CI` run was found for commit `{head_sha[:7]}` yet.',
+            '',
+            '<sub>Re-add the `trigger:ci-duration-report` label after CI completes, or rerun with a longer poll window.</sub>',
+        ]
+    )
+
+
+def upsert_pr_comment(client: GitHubClient, pr_number: int, body: str) -> None:
+    comments = client.request_paginated(f'issues/{pr_number}/comments')
+    existing_url: str | None = None
+    for comment in comments:
+        user = _expect_object(comment.get('user'), 'comment user')
+        if user.get('login') == 'github-actions[bot]' and str(comment.get('body') or '').startswith(REPORT_MARKER):
+            existing_url = _expect_str(comment.get('url'), 'comment url')
+            break
+    if existing_url:
+        client.request_json(existing_url, method='PATCH', body={'body': body})
+        print('Updated existing CI duration report comment')
+    else:
+        client.request_json(f'issues/{pr_number}/comments', method='POST', body={'body': body})
+        print('Created CI duration report comment')
+
+
+def emit_logfire(record: JsonObject) -> None:
+    token = os.getenv('LOGFIRE_WRITE_TOKEN') or os.getenv('LOGFIRE_TOKEN')
+    if not token:
+        print('LOGFIRE_WRITE_TOKEN is not set; skipping Logfire emission')
+        return
+    try:
+        import logfire
+    except ImportError:
+        print('logfire is not installed; skipping Logfire emission')
+        return
+
+    logfire_base_url = os.getenv('LOGFIRE_URL')
+    advanced_options = logfire.AdvancedOptions(base_url=logfire_base_url) if logfire_base_url else None
+    logfire.configure(
+        token=token,
+        service_name='pydantic-ai-ci',
+        environment='github-actions',
+        console=False,
+        advanced=advanced_options,
+    )
+    workflow = _expect_object(record['workflow_run'], 'workflow_run')
+    logfire.info(
+        'ci.duration.workflow',
+        _tags=['ci-duration'],
+        schema_version=SCHEMA_VERSION,
+        repo=workflow.get('repo'),
+        workflow_name=workflow.get('workflow_name'),
+        run_id=workflow.get('run_id'),
+        run_attempt=workflow.get('run_attempt'),
+        event=workflow.get('event'),
+        conclusion=workflow.get('conclusion'),
+        head_branch=workflow.get('head_branch'),
+        base_branch=workflow.get('base_branch'),
+        head_sha=workflow.get('head_sha'),
+        pr_numbers=workflow.get('pr_numbers'),
+        duration_seconds=workflow.get('duration_seconds'),
+        html_url=workflow.get('html_url'),
+    )
+    for job in _expect_list(record['jobs'], 'jobs'):
+        job_object = _expect_object(job, 'job')
+        logfire.info(
+            'ci.duration.job',
+            _tags=['ci-duration'],
+            schema_version=SCHEMA_VERSION,
+            repo=workflow.get('repo'),
+            run_id=workflow.get('run_id'),
+            run_attempt=workflow.get('run_attempt'),
+            event=workflow.get('event'),
+            head_branch=workflow.get('head_branch'),
+            base_branch=workflow.get('base_branch'),
+            head_sha=workflow.get('head_sha'),
+            pr_numbers=workflow.get('pr_numbers'),
+            job_id=job_object.get('job_id'),
+            job_name=job_object.get('raw_name'),
+            job_family=job_object.get('job_family'),
+            job_signature=job_object.get('job_signature'),
+            matrix_python=job_object.get('matrix_python'),
+            matrix_extra=job_object.get('matrix_extra'),
+            runner_class=job_object.get('runner_class'),
+            conclusion=job_object.get('conclusion'),
+            duration_seconds=job_object.get('duration_seconds'),
+            html_url=job_object.get('html_url'),
+        )
+    logfire.force_flush()
+
+
+def _github_client_from_env() -> GitHubClient:
+    repo = os.getenv('GITHUB_REPOSITORY')
+    token = os.getenv('GITHUB_TOKEN')
+    if not repo:
+        raise SystemExit('GITHUB_REPOSITORY is required')
+    if not token:
+        raise SystemExit('GITHUB_TOKEN is required')
+    return GitHubClient(repo, token)
+
+
+def _ssl_context() -> ssl.SSLContext | None:
+    try:
+        import certifi
+    except ImportError:
+        return None
+    return ssl.create_default_context(cafile=certifi.where())
+
+
+def _extract_page_items(value: JsonValue) -> list[JsonObject]:
+    if isinstance(value, list):
+        return [_expect_object(item, 'paginated item') for item in value]
+    if isinstance(value, dict):
+        for key in ('jobs', 'workflow_runs', 'comments'):
+            items = value.get(key)
+            if isinstance(items, list):
+                return [_expect_object(item, key) for item in items]
+    raise RuntimeError(f'Unexpected paginated response shape: {value!r}')
+
+
+def _job_from_json(value: JsonValue) -> JobRecord:
+    job = _expect_object(value, 'job')
+    return JobRecord(
+        job_id=_expect_int(job.get('job_id'), 'job_id'),
+        raw_name=_expect_str(job.get('raw_name'), 'raw_name'),
+        job_family=_expect_str(job.get('job_family'), 'job_family'),
+        job_signature=_expect_str(job.get('job_signature'), 'job_signature'),
+        matrix_python=_expect_optional_str(job.get('matrix_python'), 'matrix_python'),
+        matrix_extra=_expect_optional_str(job.get('matrix_extra'), 'matrix_extra'),
+        conclusion=_expect_optional_str(job.get('conclusion'), 'conclusion'),
+        status=_expect_str(job.get('status'), 'status'),
+        started_at=_expect_optional_str(job.get('started_at'), 'started_at'),
+        completed_at=_expect_optional_str(job.get('completed_at'), 'completed_at'),
+        duration_seconds=_expect_optional_float(job.get('duration_seconds'), 'duration_seconds'),
+        runner_name=_expect_optional_str(job.get('runner_name'), 'runner_name'),
+        runner_group_name=_expect_optional_str(job.get('runner_group_name'), 'runner_group_name'),
+        runner_class=_expect_str(job.get('runner_class'), 'runner_class'),
+        html_url=_expect_str(job.get('html_url'), 'html_url'),
+        steps=[],
+    )
+
+
+def _is_ignored_report_job(job: JobRecord) -> bool:
+    return (
+        job.job_family in {'check'}
+        or job.raw_name.startswith('deploy-')
+        or job.raw_name
+        in {
+            'build release artifacts',
+            'publish to PyPI',
+            'Send tweet',
+        }
+    )
+
+
+def _pull_request_numbers(value: JsonValue) -> list[int]:
+    if not isinstance(value, list):
+        return []
+    numbers: list[int] = []
+    for item in value:
+        if isinstance(item, dict):
+            number = item.get('number')
+            if isinstance(number, int):
+                numbers.append(number)
+    return numbers
+
+
+def _actor_login(value: JsonValue) -> str | None:
+    if isinstance(value, dict):
+        login = value.get('login')
+        if isinstance(login, str):
+            return login
+    return None
+
+
+def _duration_seconds(start: str | None, end: str | None) -> float | None:
+    if start is None or end is None:
+        return None
+    return (_parse_timestamp(end) - _parse_timestamp(start)).total_seconds()
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def _format_seconds(value: float | None) -> str:
+    if value is None:
+        return 'n/a'
+    seconds = int(round(value))
+    minutes, remainder = divmod(seconds, 60)
+    if minutes:
+        return f'{minutes}m {remainder:02d}s'
+    return f'{remainder}s'
+
+
+def _format_delta(delta_seconds: float | None, delta_percent: float | None) -> str:
+    if delta_seconds is None or delta_percent is None:
+        return 'n/a'
+    sign = '+' if delta_seconds >= 0 else '-'
+    return f'{sign}{_format_seconds(abs(delta_seconds))} ({delta_percent:+.0f}%)'
+
+
+def _expect_object(value: JsonValue, label: str) -> JsonObject:
+    if isinstance(value, dict):
+        return value
+    raise RuntimeError(f'Expected {label} to be an object, got {type(value).__name__}')
+
+
+def _expect_list(value: JsonValue, label: str) -> list[JsonValue]:
+    if isinstance(value, list):
+        return value
+    raise RuntimeError(f'Expected {label} to be a list, got {type(value).__name__}')
+
+
+def _expect_list_or_none(value: JsonValue, label: str) -> list[JsonValue] | None:
+    if value is None:
+        return None
+    return _expect_list(value, label)
+
+
+def _expect_str(value: JsonValue, label: str) -> str:
+    if isinstance(value, str):
+        return value
+    raise RuntimeError(f'Expected {label} to be a string, got {type(value).__name__}')
+
+
+def _expect_optional_str(value: JsonValue, label: str) -> str | None:
+    if value is None:
+        return None
+    return _expect_str(value, label)
+
+
+def _expect_int(value: JsonValue, label: str) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    raise RuntimeError(f'Expected {label} to be an integer, got {type(value).__name__}')
+
+
+def _expect_optional_float(value: JsonValue, label: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    raise RuntimeError(f'Expected {label} to be a number, got {type(value).__name__}')
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except urllib.error.HTTPError as exc:
+        print(f'GitHub API request failed: HTTP {exc.code}\n{exc.read().decode()}', file=sys.stderr)
+        raise

--- a/.github/scripts/ci_duration.py
+++ b/.github/scripts/ci_duration.py
@@ -211,7 +211,11 @@ def collect_run(client: GitHubClient, run_id: int, run_attempt: int | None) -> J
     attempt = run_attempt or _expect_int(run.get('run_attempt'), 'run_attempt')
     jobs = client.request_paginated(f'actions/runs/{run_id}/attempts/{attempt}/jobs')
     workflow = normalize_workflow_run(client.repo, run, attempt)
-    job_records = [normalize_job(job) for job in jobs]
+    job_records: list[JobRecord] = []
+    for job_object in jobs:
+        job = normalize_job(job_object)
+        if is_tracked_test_job(job):
+            job_records.append(job)
     return {
         'schema_version': SCHEMA_VERSION,
         'fetched_at': _now(),
@@ -230,9 +234,7 @@ def build_pr_report(client: GitHubClient, pr_number: int, head_sha: str, poll_se
     current_record = collect_run(client, run_id, run_attempt)
     current_jobs = [_job_from_json(job) for job in _expect_list(current_record['jobs'], 'jobs')]
     baselines = collect_baselines(client, head_sha)
-    rows = [
-        classify_job(job, baselines.get(job.job_signature)) for job in current_jobs if not _is_ignored_report_job(job)
-    ]
+    rows = [classify_job(job, baselines.get(job.job_signature)) for job in current_jobs]
     workflow = _expect_object(current_record['workflow_run'], 'workflow_run')
     return render_report(pr_number, head_sha, workflow, rows)
 
@@ -277,7 +279,7 @@ def collect_baselines(client: GitHubClient, current_head_sha: str) -> dict[str, 
         jobs = client.request_paginated(f'actions/runs/{run_id}/attempts/{run_attempt}/jobs')
         for job_object in jobs:
             job = normalize_job(job_object)
-            if job.conclusion == 'success' and job.duration_seconds is not None and not _is_ignored_report_job(job):
+            if job.conclusion == 'success' and job.duration_seconds is not None and is_tracked_test_job(job):
                 durations.setdefault(job.job_signature, []).append(job.duration_seconds)
     return {
         signature: compute_baseline(values)
@@ -436,6 +438,10 @@ def parse_job_family(job_name: str) -> str:
     return job_name
 
 
+def is_tracked_test_job(job: JobRecord) -> bool:
+    return job.job_family in {'test', 'test-examples'}
+
+
 def parse_runner_class(runner_group_name: str | None, runner_name: str | None, labels: list[JsonValue] | None) -> str:
     label_values = [value for value in labels or [] if isinstance(value, str)]
     lower_values = ' '.join([runner_group_name or '', runner_name or '', *label_values]).lower()
@@ -518,7 +524,7 @@ def render_report(pr_number: int, head_sha: str, workflow: JsonObject, rows: lis
             row.job_name,
         ),
     )
-    workflow_duration = _format_seconds(_expect_optional_float(workflow.get('duration_seconds'), 'workflow duration'))
+    tracked_duration = sum(row.duration_seconds or 0 for row in rows)
     run_url = _expect_str(workflow.get('html_url'), 'workflow html_url')
     sha7 = head_sha[:7]
     lines = [
@@ -528,7 +534,8 @@ def render_report(pr_number: int, head_sha: str, workflow: JsonObject, rows: lis
         f'PR #{pr_number}, commit `{sha7}`: [CI run]({run_url})',
         '',
         '**Summary**',
-        f'- Workflow duration: {workflow_duration}',
+        f'- Tracked test jobs: {len(rows)}',
+        f'- Total tracked test job duration: {_format_seconds(tracked_duration)}',
         f'- Slow jobs: {len(slow_rows)}',
         f'- Fast jobs: {len(fast_rows)}',
         f'- Failed/cancelled jobs: {len(failed_rows)}',
@@ -615,8 +622,9 @@ def emit_logfire(record: JsonObject) -> None:
         advanced=advanced_options,
     )
     workflow = _expect_object(record['workflow_run'], 'workflow_run')
+    jobs = _expect_list(record['jobs'], 'jobs')
     logfire.info(
-        'ci.duration.workflow',
+        'ci.duration.test_run',
         _tags=['ci-duration'],
         schema_version=SCHEMA_VERSION,
         repo=workflow.get('repo'),
@@ -630,12 +638,17 @@ def emit_logfire(record: JsonObject) -> None:
         head_sha=workflow.get('head_sha'),
         pr_numbers=workflow.get('pr_numbers'),
         duration_seconds=workflow.get('duration_seconds'),
+        tracked_test_jobs=len(jobs),
+        tracked_test_duration_seconds=sum(
+            _expect_optional_float(_expect_object(job, 'job').get('duration_seconds'), 'duration_seconds') or 0
+            for job in jobs
+        ),
         html_url=workflow.get('html_url'),
     )
-    for job in _expect_list(record['jobs'], 'jobs'):
+    for job in jobs:
         job_object = _expect_object(job, 'job')
         logfire.info(
-            'ci.duration.job',
+            'ci.duration.test_job',
             _tags=['ci-duration'],
             schema_version=SCHEMA_VERSION,
             repo=workflow.get('repo'),
@@ -708,19 +721,6 @@ def _job_from_json(value: JsonValue) -> JobRecord:
         runner_class=_expect_str(job.get('runner_class'), 'runner_class'),
         html_url=_expect_str(job.get('html_url'), 'html_url'),
         steps=[],
-    )
-
-
-def _is_ignored_report_job(job: JobRecord) -> bool:
-    return (
-        job.job_family in {'check'}
-        or job.raw_name.startswith('deploy-')
-        or job.raw_name
-        in {
-            'build release artifacts',
-            'publish to PyPI',
-            'Send tweet',
-        }
     )
 
 

--- a/.github/scripts/test_ci_duration.py
+++ b/.github/scripts/test_ci_duration.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import ci_duration
+
+
+def test_normalize_matrix_job_signature():
+    job = ci_duration.normalize_job(
+        {
+            'id': 123,
+            'name': 'test on 3.10 (all-extras)',
+            'status': 'completed',
+            'conclusion': 'success',
+            'started_at': '2026-06-13T17:15:03Z',
+            'completed_at': '2026-06-13T17:24:05Z',
+            'runner_name': 'GitHub Actions 1001364942',
+            'runner_group_name': 'GitHub Actions',
+            'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1/job/123',
+            'steps': [],
+        }
+    )
+
+    assert job.job_family == 'test'
+    assert job.matrix_python == '3.10'
+    assert job.matrix_extra == 'all-extras'
+    assert job.runner_class == 'github-hosted'
+    assert job.job_signature == 'job=test / runner=github-hosted / py=3.10 / extra=all-extras'
+    assert job.duration_seconds == 542
+
+
+def test_classify_slow_job_requires_relative_and_absolute_delta():
+    baseline = ci_duration.compute_baseline([360, 370, 380, 390, 400, 410, 420, 430, 440, 450])
+    job = ci_duration.JobRecord(
+        job_id=123,
+        raw_name='test on 3.10 (all-extras)',
+        job_family='test',
+        job_signature='job=test / runner=github-hosted / py=3.10 / extra=all-extras',
+        matrix_python='3.10',
+        matrix_extra='all-extras',
+        conclusion='success',
+        status='completed',
+        started_at='2026-06-13T17:15:03Z',
+        completed_at='2026-06-13T17:24:05Z',
+        duration_seconds=600,
+        runner_name='GitHub Actions 1001364942',
+        runner_group_name='GitHub Actions',
+        runner_class='github-hosted',
+        html_url='https://github.com/pydantic/pydantic-ai/actions/runs/1/job/123',
+        steps=[],
+    )
+
+    row = ci_duration.classify_job(job, baseline)
+
+    assert row.status == 'slow'
+    assert row.delta_seconds == 195
+
+
+def test_render_report_uses_sticky_marker_and_threshold_context():
+    workflow: ci_duration.JsonObject = {
+        'duration_seconds': 840,
+        'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1',
+    }
+    row = ci_duration.ReportRow(
+        job_name='test on 3.10 (all-extras)',
+        job_signature='job=test / runner=github-hosted / py=3.10 / extra=all-extras',
+        duration_seconds=600,
+        baseline=ci_duration.compute_baseline([360, 370, 380, 390, 400, 410, 420, 430, 440, 450]),
+        delta_seconds=195,
+        delta_percent=48,
+        status='slow',
+    )
+
+    report = ci_duration.render_report(123, 'abcdef1234567890', workflow, [row])
+
+    assert report.startswith('<!-- ci-duration-report -->\n## CI Duration Report')
+    assert 'Baseline: up to 30 successful `main` CI runs and 60 successful PR CI runs' in report
+    assert 'Minimum baseline sample: 10 successful matching jobs' in report
+    assert '| test on 3.10 (all-extras) | 10m 00s | 6m 45s | 7m 08s | +3m 15s (+48%) | slow |' in report
+    assert 'trigger:ci-duration-report' in report

--- a/.github/scripts/test_ci_duration.py
+++ b/.github/scripts/test_ci_duration.py
@@ -30,6 +30,26 @@ def test_normalize_matrix_job_signature():
     assert job.runner_class == 'github-hosted'
     assert job.job_signature == 'job=test / runner=github-hosted / py=3.10 / extra=all-extras'
     assert job.duration_seconds == 542
+    assert ci_duration.is_tracked_test_job(job)
+
+
+def test_non_test_jobs_are_not_tracked():
+    job = ci_duration.normalize_job(
+        {
+            'id': 123,
+            'name': 'lint',
+            'status': 'completed',
+            'conclusion': 'success',
+            'started_at': '2026-06-13T17:15:03Z',
+            'completed_at': '2026-06-13T17:16:03Z',
+            'runner_name': 'GitHub Actions 1001364942',
+            'runner_group_name': 'GitHub Actions',
+            'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1/job/123',
+            'steps': [],
+        }
+    )
+
+    assert not ci_duration.is_tracked_test_job(job)
 
 
 def test_classify_slow_job_requires_relative_and_absolute_delta():
@@ -77,6 +97,8 @@ def test_render_report_uses_sticky_marker_and_threshold_context():
     report = ci_duration.render_report(123, 'abcdef1234567890', workflow, [row])
 
     assert report.startswith('<!-- ci-duration-report -->\n## CI Duration Report')
+    assert 'Tracked test jobs: 1' in report
+    assert 'Total tracked test job duration: 10m 00s' in report
     assert 'Baseline: up to 30 successful `main` CI runs and 60 successful PR CI runs' in report
     assert 'Minimum baseline sample: 10 successful matching jobs' in report
     assert '| test on 3.10 (all-extras) | 10m 00s | 6m 45s | 7m 08s | +3m 15s (+48%) | slow |' in report

--- a/.github/workflows/after-ci.yml
+++ b/.github/workflows/after-ci.yml
@@ -25,6 +25,7 @@ jobs:
           python-version: "3.12"
 
       - name: Collect CI duration telemetry
+        continue-on-error: true
         run: uv run --no-project --with certifi --with logfire python .github/scripts/ci_duration.py collect --output ci-duration-record.json
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -38,11 +39,12 @@ jobs:
           OTEL_EXPORTER_OTLP_HEADERS: Authorization=${{ secrets.LOGFIRE_TOKEN }}
 
       - name: Store CI duration record
+        if: hashFiles('ci-duration-record.json') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-duration-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
           path: ci-duration-record.json
-          retention-days: 30
+          retention-days: 7
 
   smokeshow:
     runs-on: ubuntu-latest

--- a/.github/workflows/after-ci.yml
+++ b/.github/workflows/after-ci.yml
@@ -9,6 +9,41 @@ on:
 permissions: {}
 
 jobs:
+  ci-duration-collect:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.12"
+
+      - name: Collect CI duration telemetry
+        run: uv run --no-project --with certifi --with logfire python .github/scripts/ci_duration.py collect --output ci-duration-record.json
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          CI_RUN_ID: ${{ github.event.workflow_run.id }}
+          CI_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          LOGFIRE_WRITE_TOKEN: ${{ secrets.LOGFIRE_WRITE_TOKEN }}
+          LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+          LOGFIRE_URL: ${{ vars.LOGFIRE_URL || 'https://logfire-api.pydantic.dev' }}
+          OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.LOGFIRE_URL || 'https://logfire-api.pydantic.dev' }}
+          OTEL_EXPORTER_OTLP_HEADERS: Authorization=${{ secrets.LOGFIRE_TOKEN }}
+
+      - name: Store CI duration record
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-duration-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          path: ci-duration-record.json
+          retention-days: 30
+
   smokeshow:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci-duration-report.yml
+++ b/.github/workflows/ci-duration-report.yml
@@ -1,0 +1,55 @@
+name: CI Duration Report
+
+# Label-triggered CI duration report. Adding `trigger:ci-duration-report` to a
+# PR compares that PR's latest CI run against recent successful `main` and PR
+# runs, then updates one sticky comment on the PR. This workflow never checks
+# out or executes PR head code.
+
+on:
+  # zizmor: ignore[dangerous-triggers] -- pull_request_target is required so fork PRs can
+  # receive comments from a base-repo token. The workflow is gated on a maintainer-applied
+  # label and only reads GitHub Actions metadata.
+  pull_request_target:
+    types: [labeled]
+
+permissions: {}
+
+concurrency:
+  group: ci-duration-report-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    if: github.event.label.name == 'trigger:ci-duration-report'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.12"
+
+      - name: Create or update CI duration report
+        run: uv run --no-project --with certifi python .github/scripts/ci_duration.py report --poll-seconds 600
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Remove trigger label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/trigger:ci-duration-report" || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,8 @@ include = [
     "clai/**/*.py",
     "tests/**/*.py",
     "docs/**/*.py",
+    ".github/scripts/ci_duration.py",
+    ".github/scripts/test_ci_duration.py",
     ".github/scripts/pydantic_ai_gh_aw_shim/**/*.py",
     ".github/scripts/test_pydantic_ai_runner.py",
 ]
@@ -234,6 +236,8 @@ quote-style = "single"
 "examples/**/*.py" = ["D101", "D103"]
 "tests/**/*.py" = ["D"]
 "docs/**/*.py" = ["D"]
+".github/scripts/ci_duration.py" = ["D"]
+".github/scripts/test_ci_duration.py" = ["D"]
 ".github/scripts/test_pydantic_ai_runner.py" = ["D"]
 
 [tool.pyright]
@@ -250,6 +254,8 @@ include = [
     "tests",
     "examples",
     "clai",
+    ".github/scripts/ci_duration.py",
+    ".github/scripts/test_ci_duration.py",
     ".github/scripts/pydantic_ai_gh_aw_shim",
     ".github/scripts/test_pydantic_ai_runner.py",
 ]
@@ -262,6 +268,7 @@ executionEnvironments = [
     # `extraPaths` lets pyright resolve the shim package (which sits next to
     # the test file, not under the project root) the same way the runtime
     # `sys.path.insert(...)` at the top of the test does.
+    { root = ".github/scripts/test_ci_duration.py", extraPaths = [".github/scripts"], reportUnusedFunction = false, reportPrivateImportUsage = false },
     { root = ".github/scripts/test_pydantic_ai_runner.py", extraPaths = [".github/scripts"], reportUnusedFunction = false, reportPrivateImportUsage = false },
 ]
 exclude = [
@@ -276,7 +283,7 @@ files = "tests/typed_agent.py,tests/typed_graph.py"
 strict = true
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "docs/.hooks"]
+testpaths = ["tests", "docs/.hooks", ".github/scripts/test_ci_duration.py"]
 xfail_strict = true
 filterwarnings = [
     "error",


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #<issue>

Adds CI duration telemetry and an on-demand PR report:

- `After CI` now collects completed `CI` workflow/job durations, emits them to Logfire with `ci-duration` tags, and uploads a short JSON artifact for debugging.
- A new `CI Duration Report` workflow runs when `trigger:ci-duration-report` is applied to a PR, waits briefly for the latest CI run, then updates one sticky PR comment.
- The report compares jobs against bounded recent successful `main` and PR CI runs, matched by job signature and runner class, so Depot jobs are not compared against GitHub-hosted jobs.
- The threshold shown in the comment is duration `> max(p75 * 1.25, median + 2 * MAD)` with at least a 60s increase; very slow jobs are flagged at `p90 * 1.5`, `median + 4 * MAD`, or 300s over median.

Validation:

- `uv run pytest .github/scripts/test_ci_duration.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright .github/scripts/ci_duration.py .github/scripts/test_ci_duration.py`
- `make format`
- `make lint`
- `uv run pre-commit run zizmor --files .github/workflows/after-ci.yml .github/workflows/ci-duration-report.yml`
- full pre-commit during commit, including pyright
- `gh api` checks for the exact `head_sha` workflow-run query, recent successful PR-run query, and real Actions job metadata shape

Notes:

- The repo already has `LOGFIRE_TOKEN`, `LOGFIRE_WRITE_TOKEN`, and `LOGFIRE_URL` configured.
- Local Logfire query verification was not possible in this Codex session because no Logfire MCP tool is exposed and `LOGFIRE_READ_TOKEN` is not set locally.
- A local Python collector smoke against GitHub Actions was blocked by this machine's GitHub proxy certificate, while the same endpoints worked via `gh api`; the workflow keeps normal SSL verification intact for GitHub-hosted runners.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

