### PR TITLE
Route `max_tokens` to `max_completion_tokens` or `max_tokens` via `OpenAIModelProfile` flag

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -370,6 +370,7 @@ model = OpenAIChatModel(
         json_schema_transformer=InlineDefsJsonSchemaTransformer,  # Supported by any model class via the base ModelProfile
         openai_supports_strict_tool_definition=False,  # Supported by OpenAIChatModel and OpenAIResponsesModel
         openai_chat_supports_multiple_system_messages=False,  # Supported by OpenAIChatModel only — for strict providers (e.g. some vLLM/LiteLLM setups) that require exactly one initial system message
+        openai_chat_supports_max_completion_tokens=False,  # Supported by OpenAIChatModel only — for providers (e.g. OpenRouter) that only accept the older `max_tokens` field instead of `max_completion_tokens`
     )
 )
 agent = Agent(model)

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1003,6 +1003,10 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
                 # OpenAI SDK type stubs incorrectly use 'in-memory' but API requires 'in_memory', so we have to use `Any` to not hit type errors
                 prompt_cache_retention: Any = model_settings.get('openai_prompt_cache_retention', OMIT)
+                # Most providers only accept one of `max_completion_tokens` (OpenAI, incl. o-series) or
+                # `max_tokens` (e.g. OpenRouter), so the profile decides which field the `max_tokens` setting maps to.
+                max_tokens = model_settings.get('max_tokens', OMIT)
+                supports_max_completion_tokens = profile.openai_chat_supports_max_completion_tokens
                 return await self.client.chat.completions.create(
                     model=self.model_name,
                     messages=openai_messages,
@@ -1012,7 +1016,8 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     stream=stream,
                     stream_options=self._get_stream_options(model_settings) if stream else OMIT,
                     stop=model_settings.get('stop_sequences', OMIT),
-                    max_completion_tokens=model_settings.get('max_tokens', OMIT),
+                    max_completion_tokens=max_tokens if supports_max_completion_tokens else OMIT,
+                    max_tokens=OMIT if supports_max_completion_tokens else max_tokens,
                     timeout=model_settings.get('timeout', NOT_GIVEN),
                     response_format=response_format or OMIT,
                     seed=model_settings.get('seed', OMIT),

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -175,6 +175,15 @@ class OpenAIModelProfile(ModelProfile):
     Some OpenAI-compatible providers (e.g. Azure) do not support document input via the Chat Completions API.
     """
 
+    openai_chat_supports_max_completion_tokens: bool = True
+    """Whether the Chat Completions API accepts the `max_completion_tokens` field for the `max_tokens` setting.
+
+    OpenAI itself (including the o-series reasoning models) uses `max_completion_tokens`, the field that caps
+    visible output plus reasoning tokens, so this defaults to `True`. Many OpenAI-compatible providers (e.g.
+    OpenRouter) only accept the older `max_tokens` field; set this to `False` for those so the `max_tokens`
+    setting is sent as `max_tokens` instead.
+    """
+
     def __post_init__(self):  # pragma: no cover
         if not self.openai_supports_sampling_settings:
             warnings.warn(

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -172,6 +172,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
             openai_chat_thinking_field='reasoning',
             openai_chat_supports_file_urls=True,
             openai_chat_supports_web_search=True,
+            openai_chat_supports_max_completion_tokens=False,
             supports_thinking=True,
             openrouter_supports_cache_control=supports_cache_control,
             openrouter_supports_cache_ttl=supports_anthropic_cache,

--- a/tests/models/cassettes/test_openai/test_max_completion_tokens[gpt-4o-mini].yaml
+++ b/tests/models/cassettes/test_openai/test_max_completion_tokens[gpt-4o-mini].yaml
@@ -4,11 +4,11 @@ interactions:
       accept:
       - application/json
       accept-encoding:
-      - gzip, deflate
+      - gzip, deflate, br, zstd
       connection:
       - keep-alive
       content-length:
-      - '119'
+      - '123'
       content-type:
       - application/json
       host:
@@ -20,25 +20,22 @@ interactions:
       - content: hello
         role: user
       model: gpt-4o-mini
-      n: 1
       stream: false
     uri: https://api.openai.com/v1/chat/completions
   response:
     headers:
       access-control-expose-headers:
-      - X-Request-ID
+      - CF-Ray
       alt-svc:
       - h3=":443"; ma=86400
       connection:
       - keep-alive
       content-length:
-      - '840'
+      - '670'
       content-type:
       - application/json
-      openai-organization:
-      - pydantic-28gund
       openai-processing-ms:
-      - '278'
+      - '462'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -55,14 +52,14 @@ interactions:
           content: Hello! How can I assist you today?
           refusal: null
           role: assistant
-      created: 1742636224
-      id: chatcmpl-BDpZoxw4i90ZesN8iyrwLmGWRJ5lz
+      created: 1781536548
+      id: chatcmpl-Dr3KONlJHqM2OKkn7IPxwgC3ZIEZw
       model: gpt-4o-mini-2024-07-18
       object: chat.completion
       service_tier: default
-      system_fingerprint: fp_b8bc95a0ac
+      system_fingerprint: fp_4f5f0b399a
       usage:
-        completion_tokens: 10
+        completion_tokens: 9
         completion_tokens_details:
           accepted_prediction_tokens: 0
           audio_tokens: 0
@@ -72,7 +69,7 @@ interactions:
         prompt_tokens_details:
           audio_tokens: 0
           cached_tokens: 0
-        total_tokens: 18
+        total_tokens: 17
     status:
       code: 200
       message: OK

--- a/tests/models/cassettes/test_openai/test_max_completion_tokens[o3-mini].yaml
+++ b/tests/models/cassettes/test_openai/test_max_completion_tokens[o3-mini].yaml
@@ -4,11 +4,11 @@ interactions:
       accept:
       - application/json
       accept-encoding:
-      - gzip, deflate
+      - gzip, deflate, br, zstd
       connection:
       - keep-alive
       content-length:
-      - '115'
+      - '119'
       content-type:
       - application/json
       host:
@@ -20,25 +20,22 @@ interactions:
       - content: hello
         role: user
       model: o3-mini
-      n: 1
       stream: false
     uri: https://api.openai.com/v1/chat/completions
   response:
     headers:
       access-control-expose-headers:
-      - X-Request-ID
+      - CF-Ray
       alt-svc:
       - h3=":443"; ma=86400
       connection:
       - keep-alive
       content-length:
-      - '817'
+      - '654'
       content-type:
       - application/json
-      openai-organization:
-      - pydantic-28gund
       openai-processing-ms:
-      - '1895'
+      - '1045'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -54,14 +51,14 @@ interactions:
           content: Hello there! How can I help you today?
           refusal: null
           role: assistant
-      created: 1742636222
-      id: chatcmpl-BDpZm1SiItIXIcDA0xRV9QGZhD97e
+      created: 1781536547
+      id: chatcmpl-Dr3KNfXKBS1oDOrhqYDuLYdjX9PM4
       model: o3-mini-2025-01-31
       object: chat.completion
       service_tier: default
-      system_fingerprint: fp_617f206dd9
+      system_fingerprint: fp_e89900d9f6
       usage:
-        completion_tokens: 85
+        completion_tokens: 87
         completion_tokens_details:
           accepted_prediction_tokens: 0
           audio_tokens: 0
@@ -71,7 +68,7 @@ interactions:
         prompt_tokens_details:
           audio_tokens: 0
           cached_tokens: 0
-        total_tokens: 92
+        total_tokens: 94
     status:
       code: 200
       message: OK

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -1931,6 +1931,41 @@ async def test_max_completion_tokens(allow_model_requests: None, model_name: str
     assert result.output == IsStr()
 
 
+@pytest.mark.parametrize(
+    'supports_max_completion_tokens,sent_field,omitted_field',
+    [
+        (True, 'max_completion_tokens', 'max_tokens'),
+        (False, 'max_tokens', 'max_completion_tokens'),
+    ],
+)
+async def test_max_tokens_field_routed_by_profile(
+    allow_model_requests: None,
+    supports_max_completion_tokens: bool,
+    sent_field: str,
+    omitted_field: str,
+) -> None:
+    """The `max_tokens` setting maps to whichever API field the profile selects.
+
+    OpenAI (and o-series) use `max_completion_tokens`; many compatible providers (e.g. OpenRouter)
+    only accept `max_tokens`. This is a unit test rather than VCR because our cassette matchers ignore
+    the request body, so a VCR test would still pass green if `max_tokens` were routed to the wrong key.
+    """
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel(
+        'gpt-4o',
+        provider=OpenAIProvider(openai_client=mock_client),
+        profile=OpenAIModelProfile(openai_chat_supports_max_completion_tokens=supports_max_completion_tokens),
+    )
+    agent = Agent(m, model_settings=ModelSettings(max_tokens=100))
+
+    await agent.run('Hello')
+
+    kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert kwargs[sent_field] == 100
+    assert omitted_field not in kwargs
+
+
 async def test_multiple_agent_tool_calls(allow_model_requests: None, gemini_api_key: str, openai_api_key: str):
     gemini_model = GoogleModel('gemini-2.0-flash-exp', provider=GoogleProvider(api_key=gemini_api_key))
     openai_model = OpenAIChatModel('gpt-4o-mini', provider=OpenAIProvider(api_key=openai_api_key))

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -16,7 +16,7 @@ from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
-from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, openai_model_profile
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
 from .._inline_snapshot import snapshot
@@ -124,6 +124,9 @@ def test_openrouter_provider_model_profile(mocker: MockerFixture):
     openai_model_profile_mock.assert_called_with('o1-mini')
     assert openai_profile is not None
     assert openai_profile.json_schema_transformer == OpenAIJsonSchemaTransformer
+    # OpenRouter only accepts the older `max_tokens` field, never `max_completion_tokens` — even for OpenAI
+    # models, whose own profile defaults the flag to `True`; the merge must not clobber OpenRouter's `False`.
+    assert OpenAIModelProfile.from_profile(openai_profile).openai_chat_supports_max_completion_tokens is False
 
     anthropic_profile = provider.model_profile('anthropic/claude-3.5-sonnet')
     anthropic_model_profile_mock.assert_called_with('claude-3-5-sonnet')


### PR DESCRIPTION
- Closes #5186

### Problem

`OpenAIChatModel._completions_create` unconditionally mapped the generic `max_tokens` setting to OpenAI's newer `max_completion_tokens` API field. Many OpenAI-compatible providers (OpenRouter and others) only accept the older `max_tokens` field, so the field they understand was never sent:

- on OpenRouter with `provider.require_parameters: true` → HTTP 404 ("No endpoints found that can handle the requested parameters")
- otherwise → the field is silently dropped and the token cap is ignored

Reproduced live on OpenRouter `meta-llama/llama-3.1-8b-instruct`: `max_completion_tokens` → 404, `max_tokens` → 200.

### Fix

Per-model routing via the model profile (a 1.x, backward-compatible change — no default flip, no public API break):

- New `OpenAIModelProfile.openai_chat_supports_max_completion_tokens` flag, default `True`.
- `_completions_create` routes the `max_tokens` setting on the flag: `True` → `max_completion_tokens` (unchanged for OpenAI, incl. o-series reasoning models); `False` → plain `max_tokens`. Never dual-sends.
- The OpenRouter profile sets the flag `False`. `ModelProfile.update()` copies only non-default values, so a downstream `openai` profile's default-`True` does not clobber OpenRouter's `False`.

The default preserves today's exact behavior for everyone on OpenAI; only providers that are broken today change behavior, where the current behavior is itself the bug.

### Why not the earlier attempt (#5187)

#5187 tried three variations of a **global static remap**: mapping `max_tokens`→`max_tokens` for everyone breaks o-series; adding a fallback dual-sends both fields (OpenAI rejects them as mutually exclusive); the final global split forces every reasoning-model user to migrate their settings. The author closed it noting *"No single static mapping works for all cases. This needs model/provider-aware routing."* This PR is that per-model routing.

### Tests

- `test_max_tokens_field_routed_by_profile` — asserts the outbound request kwargs: flag `True` sends `max_completion_tokens` (omits `max_tokens`), flag `False` sends `max_tokens` (omits `max_completion_tokens`). A unit test rather than VCR because our cassette matchers ignore the request body, so a VCR test would pass green even if the field were routed to the wrong key.
- Existing `test_max_completion_tokens[o3-mini|gpt-4o-mini|gpt-4.5-preview]` stay green (OpenAI path unchanged).
- `test_openrouter_provider_model_profile` now also asserts the flag is `False` on an OpenAI-via-OpenRouter model (verifying it survives the profile merge).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

