### PR TITLE
docs: fix inaccurate `_metadata_panel` docstring in `pydantic_evals` reporting

### DIFF
--- a/pydantic_evals/pydantic_evals/reporting/__init__.py
+++ b/pydantic_evals/pydantic_evals/reporting/__init__.py
@@ -569,14 +569,13 @@ class EvaluationReport(Generic[InputsT, OutputT, MetadataT]):
     def _metadata_panel(
         self, baseline: EvaluationReport[InputsT, OutputT, MetadataT] | None = None
     ) -> RenderableType | None:
-        """Wrap a table with an experiment metadata panel if metadata exists.
+        """Build an experiment metadata panel if metadata exists.
 
         Args:
-            table: The table to wrap
-            baseline: Optional baseline report for diff metadata
+            baseline: Optional baseline report for diff metadata.
 
         Returns:
-            Either the table unchanged or a Group with Panel and Table
+            A `Panel` with the experiment (or diff) metadata, or `None` if there is no metadata to show.
         """
         if baseline is None:
             # Single report - show metadata if present


### PR DESCRIPTION
The docstring for `EvaluationReport._metadata_panel` in `pydantic_evals/pydantic_evals/reporting/__init__.py` does not match the method. It documents a `table` parameter that the signature does not have (`_metadata_panel(self, baseline=None)`), states that it "wraps a table", and describes the return as "the table unchanged or a Group with Panel and Table". In reality the method takes only `baseline` and returns a `rich` `Panel` (single report or diff) or `None` when there is no metadata; the `Group` wrapping is done by the caller. This corrects the summary, drops the nonexistent `table` arg, and fixes the Returns description to match the actual behavior. Docstring-only change, no functional impact.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

