### PR TITLE
fix(bedrock): send `toolConfig` when history carries tool blocks but request defines no tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -588,6 +588,9 @@ class BedrockConverseModel(Model[BaseClient]):
         # count-tokens-capable models (Claude) don't support native tools, and native-tool-capable models
         # (Nova-2) don't support count_tokens, so a `systemTool` can never reach this request.
         tool_config = self._map_tool_config(model_request_parameters, settings)
+        if not tool_config:
+            # Bedrock requires `toolConfig` whenever the history carries tool blocks.
+            tool_config = self._map_history_tool_config(bedrock_messages)
         if tool_config:
             converse['toolConfig'] = tool_config
         tools: list[ToolTypeDef] = list(tool_config['tools']) if tool_config else []
@@ -793,6 +796,9 @@ class BedrockConverseModel(Model[BaseClient]):
         }
 
         tool_config = self._map_tool_config(model_request_parameters, settings)
+        if not tool_config:
+            # Bedrock requires `toolConfig` whenever the history carries tool blocks.
+            tool_config = self._map_history_tool_config(bedrock_messages)
         if tool_config:
             params['toolConfig'] = tool_config
 
@@ -910,6 +916,32 @@ class BedrockConverseModel(Model[BaseClient]):
             tool_config['toolChoice'] = tool_choice
 
         return tool_config
+
+    def _map_history_tool_config(self, bedrock_messages: list[MessageUnionTypeDef]) -> ToolConfigurationTypeDef | None:
+        """Reconstruct a minimal `toolConfig` from the tools referenced in message history.
+
+        Bedrock's Converse API rejects a request whose `messages` contain `toolUse`/`toolResult`
+        content blocks unless `toolConfig` is also defined. This happens when conversation history
+        produced by a tool-using agent is replayed against a request that defines no tools of its own
+        (e.g. continuing the conversation with an agent that has no tools, or `output_type=str`).
+
+        To keep the request valid, we rebuild minimal tool specs for the tool names that already
+        appear in the mapped history. `toolChoice` is omitted so it defaults to `auto`, leaving the
+        model free to respond with text rather than being forced to call a tool.
+        """
+        tool_names: list[str] = []
+        seen: set[str] = set()
+        for message in bedrock_messages:
+            for block in message.get('content', []):
+                if (tool_use := block.get('toolUse')) and (name := tool_use.get('name')) and name not in seen:
+                    seen.add(name)
+                    tool_names.append(name)
+        if not tool_names:
+            return None
+        tools: list[ToolTypeDef] = [
+            {'toolSpec': {'name': name, 'inputSchema': {'json': {'type': 'object'}}}} for name in tool_names
+        ]
+        return {'tools': tools}
 
     async def _map_messages(  # noqa: C901
         self,

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -845,6 +845,103 @@ async def test_bedrock_unified_service_tier_auto_omits(
     assert 'serviceTier' not in kwargs
 
 
+async def test_bedrock_tool_config_reconstructed_from_history_without_tools(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+):
+    """Replaying tool-using history against a tool-less request still sends `toolConfig`.
+
+    Bedrock rejects a request whose `messages` carry `toolUse`/`toolResult` content blocks unless
+    `toolConfig` is also defined (`The toolConfig field must be defined when using toolUse and
+    toolResult content blocks.`). Regression test for #1966.
+    """
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    agent = Agent(model=model)
+
+    message_history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Are you a LLM?')]),
+        ModelResponse(parts=[TextPart(content='Yes, I am.')]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name='final_result', args={'response': True}, tool_call_id='tooluse_abc')]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name='final_result', content='Final result processed.', tool_call_id='tooluse_abc')
+            ]
+        ),
+    ]
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'A poem.'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    await agent.run('Create a poem', message_history=message_history)
+
+    _, kwargs = mock_converse.call_args
+    # The mapped history carries tool blocks, so `toolConfig` must be present even though the
+    # current request defines no tools. The tool spec is reconstructed from the history tool name,
+    # and `toolChoice` is omitted so it defaults to `auto`, leaving the model free to answer text.
+    assert kwargs['toolConfig'] == snapshot(
+        {'tools': [{'toolSpec': {'name': 'final_result', 'inputSchema': {'json': {'type': 'object'}}}}]}
+    )
+
+
+async def test_bedrock_no_tool_config_without_history_tools(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+):
+    """A tool-less request with no tool blocks in history omits `toolConfig` entirely."""
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    agent = Agent(model=model)
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 1, 'outputTokens': 1},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    await agent.run('Hello')
+
+    _, kwargs = mock_converse.call_args
+    assert 'toolConfig' not in kwargs
+
+
+async def test_bedrock_count_tokens_tool_config_reconstructed_from_history(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+):
+    """`count_tokens` also reconstructs `toolConfig` when history carries tool blocks but no tools are defined.
+
+    Mirrors the request path so token counts stay consistent. Regression test for #1966.
+    """
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-20250514-v1:0', provider=bedrock_provider)
+
+    message_history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Are you a LLM?')]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name='final_result', args={'response': True}, tool_call_id='tooluse_abc')]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name='final_result', content='Final result processed.', tool_call_id='tooluse_abc')
+            ]
+        ),
+    ]
+
+    mock_count_tokens = mocker.patch.object(model.client, 'count_tokens')
+    mock_count_tokens.return_value = {'inputTokens': 5}
+
+    await model.count_tokens(message_history, None, ModelRequestParameters())
+
+    _, kwargs = mock_count_tokens.call_args
+    assert kwargs['input']['converse']['toolConfig'] == snapshot(
+        {'tools': [{'toolSpec': {'name': 'final_result', 'inputSchema': {'json': {'type': 'object'}}}}]}
+    )
+
+
 async def test_bedrock_model_service_tier(allow_model_requests: None, bedrock_provider: BedrockProvider):
     model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
     model_settings = BedrockModelSettings(bedrock_service_tier={'type': 'flex'})


### PR DESCRIPTION
## Summary

- Bedrock requests now include `toolConfig` whenever the message history carries `toolUse`/`toolResult` content blocks, even if the current request defines no tools.
- Fixes the `ValidationException: The toolConfig field must be defined when using toolUse and toolResult content blocks.` error when replaying tool-using history against a tool-less agent.

## Motivation

Closes #1966.

When messages from a tool-using agent are passed as `message_history` to an agent that defines no tools (e.g. `output_type=str`, or simply no tools), the second Bedrock call fails:

```
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the Converse operation: The toolConfig field must be defined when using toolUse and toolResult content blocks.
```

As confirmed in the issue thread (root-caused by @leandrodamascena), the mapped `messages` still contain the historical `toolUse`/`toolResult` blocks, but `_map_tool_config` returns `None` because the current request has no tool definitions, so `toolConfig` is omitted and Bedrock rejects the request. OpenAI does not have this requirement, which is why the same flow works there. The reporter's own workaround was to add a dummy tool — confirming Bedrock only needs `toolConfig` to be present.

## Fix

When `_map_tool_config` yields nothing, fall back to a new `_map_history_tool_config` that reconstructs minimal tool specs from the tool names already referenced in the mapped history (`toolUse` blocks). `toolChoice` is omitted so it defaults to `auto`, leaving the model free to respond with plain text rather than being forced to call a tool. If the history contains no tool blocks, it returns `None` and nothing changes.

Applied to both request paths that send `messages` with tool blocks:
- `_messages_create` (the reproduced converse/stream path)
- `count_tokens` — I reproduced the identical defect there before extending the fix, rather than assuming it (per the narrowest-fix guidance in `AGENTS.md`).

## Verification

- `uv run pytest tests/models/test_bedrock.py` — 134 passed
- New regression tests:
  - `test_bedrock_tool_config_reconstructed_from_history_without_tools` — tool-less request + tool-using history → `toolConfig` present
  - `test_bedrock_no_tool_config_without_history_tools` — tool-less request + no tool blocks → `toolConfig` omitted (no behavior change)
  - `test_bedrock_count_tokens_tool_config_reconstructed_from_history` — same for `count_tokens`
- `uv run ruff format` / `uv run ruff check` — clean
- `uv run pyright pydantic_ai_slim/pydantic_ai/models/bedrock.py` — 0 errors
- `uv run mypy` — Success, no issues
- The tests patch the Bedrock client's `converse`/`count_tokens` (no live AWS), asserting on the request kwargs.

## Scope

Narrowly scoped: no change when a request already sends `toolConfig`, and no change when history has no tool blocks. `toolChoice` is intentionally left to default (`auto`) so the model is never coerced into calling a tool that may no longer be available.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

