### PR TITLE
Group CI test telemetry in Logfire spans

### DIFF
--- a/.github/scripts/ci_duration.py
+++ b/.github/scripts/ci_duration.py
@@ -439,7 +439,7 @@ def parse_job_family(job_name: str) -> str:
 
 
 def is_tracked_test_job(job: JobRecord) -> bool:
-    return job.job_family in {'test', 'test-examples'}
+    return job.job_family == 'test'
 
 
 def parse_runner_class(runner_group_name: str | None, runner_name: str | None, labels: list[JsonValue] | None) -> str:
@@ -623,7 +623,7 @@ def emit_logfire(record: JsonObject) -> None:
     )
     workflow = _expect_object(record['workflow_run'], 'workflow_run')
     jobs = _expect_list(record['jobs'], 'jobs')
-    logfire.info(
+    with logfire.span(
         'ci.duration.test_run',
         _tags=['ci-duration'],
         schema_version=SCHEMA_VERSION,
@@ -644,32 +644,32 @@ def emit_logfire(record: JsonObject) -> None:
             for job in jobs
         ),
         html_url=workflow.get('html_url'),
-    )
-    for job in jobs:
-        job_object = _expect_object(job, 'job')
-        logfire.info(
-            'ci.duration.test_job',
-            _tags=['ci-duration'],
-            schema_version=SCHEMA_VERSION,
-            repo=workflow.get('repo'),
-            run_id=workflow.get('run_id'),
-            run_attempt=workflow.get('run_attempt'),
-            event=workflow.get('event'),
-            head_branch=workflow.get('head_branch'),
-            base_branch=workflow.get('base_branch'),
-            head_sha=workflow.get('head_sha'),
-            pr_numbers=workflow.get('pr_numbers'),
-            job_id=job_object.get('job_id'),
-            job_name=job_object.get('raw_name'),
-            job_family=job_object.get('job_family'),
-            job_signature=job_object.get('job_signature'),
-            matrix_python=job_object.get('matrix_python'),
-            matrix_extra=job_object.get('matrix_extra'),
-            runner_class=job_object.get('runner_class'),
-            conclusion=job_object.get('conclusion'),
-            duration_seconds=job_object.get('duration_seconds'),
-            html_url=job_object.get('html_url'),
-        )
+    ):
+        for job in jobs:
+            job_object = _expect_object(job, 'job')
+            logfire.info(
+                'ci.duration.test_job',
+                _tags=['ci-duration'],
+                schema_version=SCHEMA_VERSION,
+                repo=workflow.get('repo'),
+                run_id=workflow.get('run_id'),
+                run_attempt=workflow.get('run_attempt'),
+                event=workflow.get('event'),
+                head_branch=workflow.get('head_branch'),
+                base_branch=workflow.get('base_branch'),
+                head_sha=workflow.get('head_sha'),
+                pr_numbers=workflow.get('pr_numbers'),
+                job_id=job_object.get('job_id'),
+                job_name=job_object.get('raw_name'),
+                job_family=job_object.get('job_family'),
+                job_signature=job_object.get('job_signature'),
+                matrix_python=job_object.get('matrix_python'),
+                matrix_extra=job_object.get('matrix_extra'),
+                runner_class=job_object.get('runner_class'),
+                conclusion=job_object.get('conclusion'),
+                duration_seconds=job_object.get('duration_seconds'),
+                html_url=job_object.get('html_url'),
+            )
     logfire.force_flush()
 
 

--- a/.github/scripts/test_ci_duration.py
+++ b/.github/scripts/test_ci_duration.py
@@ -34,22 +34,25 @@ def test_normalize_matrix_job_signature():
 
 
 def test_non_test_jobs_are_not_tracked():
-    job = ci_duration.normalize_job(
-        {
-            'id': 123,
-            'name': 'lint',
-            'status': 'completed',
-            'conclusion': 'success',
-            'started_at': '2026-06-13T17:15:03Z',
-            'completed_at': '2026-06-13T17:16:03Z',
-            'runner_name': 'GitHub Actions 1001364942',
-            'runner_group_name': 'GitHub Actions',
-            'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1/job/123',
-            'steps': [],
-        }
-    )
+    jobs = [
+        ci_duration.normalize_job(
+            {
+                'id': 123,
+                'name': name,
+                'status': 'completed',
+                'conclusion': 'success',
+                'started_at': '2026-06-13T17:15:03Z',
+                'completed_at': '2026-06-13T17:16:03Z',
+                'runner_name': 'GitHub Actions 1001364942',
+                'runner_group_name': 'GitHub Actions',
+                'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1/job/123',
+                'steps': [],
+            }
+        )
+        for name in ['lint', 'test examples on 3.13']
+    ]
 
-    assert not ci_duration.is_tracked_test_job(job)
+    assert [ci_duration.is_tracked_test_job(job) for job in jobs] == [False, False]
 
 
 def test_classify_slow_job_requires_relative_and_absolute_delta():


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #<issue>

Follow-up to #5923:

- stop tracking `test examples on ...` jobs in CI duration telemetry
- emit one `ci.duration.test_run` Logfire span per CI run
- emit `ci.duration.test_job` events inside that span for the tracked `test on ...` jobs

This keeps the telemetry focused on mechanical test matrix jobs, where duration optimization is useful, and avoids treating short example checks as optimization targets.

Validation:

- `uv run pytest .github/scripts/test_ci_duration.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright .github/scripts/ci_duration.py .github/scripts/test_ci_duration.py`
- `make lint`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

