### PR TITLE
Emit Logfire metrics for CI test durations

### DIFF
--- a/.github/scripts/ci_duration.py
+++ b/.github/scripts/ci_duration.py
@@ -31,6 +31,7 @@ VERY_SLOW_THRESHOLD_MULTIPLIER = 1.5
 
 JsonValue = None | bool | int | float | str | list['JsonValue'] | dict[str, 'JsonValue']
 JsonObject = dict[str, JsonValue]
+MetricAttributes = dict[str, bool | int | float | str]
 
 
 @dataclass(frozen=True)
@@ -623,6 +624,32 @@ def emit_logfire(record: JsonObject) -> None:
     )
     workflow = _expect_object(record['workflow_run'], 'workflow_run')
     jobs = _expect_list(record['jobs'], 'jobs')
+    tracked_test_duration_seconds = sum(
+        _expect_optional_float(_expect_object(job, 'job').get('duration_seconds'), 'duration_seconds') or 0
+        for job in jobs
+    )
+    test_run_duration_metric = logfire.metric_histogram(
+        'ci.test_run.tracked_duration',
+        unit='s',
+        description='Total duration of tracked CI test jobs in one workflow run.',
+    )
+    test_job_duration_metric = logfire.metric_histogram(
+        'ci.test_job.duration',
+        unit='s',
+        description='Duration of one tracked CI test matrix job.',
+    )
+    test_run_duration_metric.record(
+        tracked_test_duration_seconds,
+        metric_attributes(
+            {
+                'repo': workflow.get('repo'),
+                'workflow_name': workflow.get('workflow_name'),
+                'event': workflow.get('event'),
+                'base_branch': workflow.get('base_branch'),
+                'conclusion': workflow.get('conclusion'),
+            }
+        ),
+    )
     with logfire.span(
         'ci.duration.test_run',
         _tags=['ci-duration'],
@@ -639,14 +666,30 @@ def emit_logfire(record: JsonObject) -> None:
         pr_numbers=workflow.get('pr_numbers'),
         duration_seconds=workflow.get('duration_seconds'),
         tracked_test_jobs=len(jobs),
-        tracked_test_duration_seconds=sum(
-            _expect_optional_float(_expect_object(job, 'job').get('duration_seconds'), 'duration_seconds') or 0
-            for job in jobs
-        ),
+        tracked_test_duration_seconds=tracked_test_duration_seconds,
         html_url=workflow.get('html_url'),
     ):
         for job in jobs:
             job_object = _expect_object(job, 'job')
+            duration_seconds = _expect_optional_float(job_object.get('duration_seconds'), 'duration_seconds')
+            if duration_seconds is not None:
+                test_job_duration_metric.record(
+                    duration_seconds,
+                    metric_attributes(
+                        {
+                            'repo': workflow.get('repo'),
+                            'workflow_name': workflow.get('workflow_name'),
+                            'event': workflow.get('event'),
+                            'base_branch': workflow.get('base_branch'),
+                            'job_name': job_object.get('raw_name'),
+                            'job_signature': job_object.get('job_signature'),
+                            'matrix_python': job_object.get('matrix_python'),
+                            'matrix_extra': job_object.get('matrix_extra'),
+                            'runner_class': job_object.get('runner_class'),
+                            'conclusion': job_object.get('conclusion'),
+                        }
+                    ),
+                )
             logfire.info(
                 'ci.duration.test_job',
                 _tags=['ci-duration'],
@@ -681,6 +724,10 @@ def _github_client_from_env() -> GitHubClient:
     if not token:
         raise SystemExit('GITHUB_TOKEN is required')
     return GitHubClient(repo, token)
+
+
+def metric_attributes(attributes: JsonObject) -> MetricAttributes:
+    return {key: value for key, value in attributes.items() if isinstance(value, bool | int | float | str)}
 
 
 def _ssl_context() -> ssl.SSLContext | None:


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #<issue>

Adds native Logfire metrics for the CI duration telemetry added in #5923 and shaped in #5930:

- `ci.test_job.duration` histogram, one observation per tracked `test on ...` matrix job
- `ci.test_run.tracked_duration` histogram, one observation per CI run with the total tracked test-job duration

Metric attributes intentionally stay low-cardinality:

- run metric: `repo`, `workflow_name`, `event`, `base_branch`, `conclusion`
- job metric: run attributes plus `job_name`, `job_signature`, `matrix_python`, `matrix_extra`, `runner_class`

The high-cardinality values (`run_id`, `head_sha`, URLs, job IDs) remain on spans/log records only.

Useful dashboard panels:

- p50/p75/p90/p95 `ci.test_job.duration` by `job_signature`
- latest and p90 `ci.test_job.duration` by `matrix_extra` and `matrix_python`
- `ci.test_run.tracked_duration` trend over time
- failure/cancelled count by `job_signature` using the `conclusion` attribute

Validation:

- `uv run pytest .github/scripts/test_ci_duration.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright .github/scripts/ci_duration.py .github/scripts/test_ci_duration.py`
- `make format`
- `make lint`
- full pre-commit during commit, including pyright

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

