### PR TITLE
fix(huggingface): forward tool-return file content instead of silently dropping it

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -36,6 +36,7 @@ from ..messages import (
     ToolCallPart,
     ToolReturnPart,
     UploadedFile,
+    UserContent,
     UserPromptPart,
     VideoUrl,
 )
@@ -454,17 +455,20 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
     async def _map_user_message(
         self, message: ModelRequest
     ) -> AsyncIterable[ChatCompletionInputMessage | ChatCompletionOutputMessage]:
+        file_content: list[UserContent] = []
         for part in message.parts:
             if isinstance(part, SystemPromptPart):
                 yield ChatCompletionInputMessage.parse_obj_as_instance({'role': 'system', 'content': part.content})  # type: ignore
             elif isinstance(part, UserPromptPart):
                 yield await self._map_user_prompt(part)
             elif isinstance(part, ToolReturnPart):
+                tool_text, tool_file_content = part.model_response_str_and_user_content()
+                file_content.extend(tool_file_content)
                 yield ChatCompletionOutputMessage.parse_obj_as_instance(  # type: ignore
                     {
                         'role': 'tool',
                         'tool_call_id': _guard_tool_call_id(t=part),
-                        'content': part.model_response_str(),
+                        'content': tool_text,
                     }
                 )
             elif isinstance(part, RetryPromptPart):
@@ -482,6 +486,8 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                     )
             else:
                 assert_never(part)
+        if file_content:
+            yield await self._map_user_prompt(UserPromptPart(content=file_content))
 
     @staticmethod
     async def _map_user_prompt(part: UserPromptPart) -> ChatCompletionInputMessage:

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -1229,3 +1229,41 @@ async def test_huggingface_close_stream_only_suppresses_async_generator_race(err
             await response.close_stream()
     else:
         await response.close_stream()
+
+
+async def test_tool_return_with_uploaded_file_raises() -> None:
+    """UploadedFile in ToolReturnPart must raise NotImplementedError, not be silently dropped."""
+    model = HuggingFaceModel('test-model', provider=HuggingFaceProvider(api_key='x'))
+    message = ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name='my_tool',
+                content=UploadedFile(file_id='file-123', provider_name='anthropic'),
+                tool_call_id='call-1',
+            )
+        ]
+    )
+    with pytest.raises(NotImplementedError, match='UploadedFile is not supported for Hugging Face'):
+        async for _ in model._map_user_message(message):  # pyright: ignore[reportPrivateUsage]
+            pass
+
+
+async def test_tool_return_with_image_url_appends_user_message() -> None:
+    """ImageUrl in ToolReturnPart must be forwarded as a trailing user message, not silently dropped."""
+    model = HuggingFaceModel('test-model', provider=HuggingFaceProvider(api_key='x'))
+    image = ImageUrl(url='https://example.com/img.png')
+    message = ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name='my_tool',
+                content=image,
+                tool_call_id='call-1',
+            )
+        ]
+    )
+    collected = [item async for item in model._map_user_message(message)]  # pyright: ignore[reportPrivateUsage]
+    # First item: tool response with placeholder text; last item: user message carrying the image
+    assert len(collected) == 2
+    tool_msg, user_msg = collected
+    assert tool_msg['role'] == 'tool'  # pyright: ignore[reportIndexIssue]
+    assert user_msg['role'] == 'user'  # pyright: ignore[reportIndexIssue]


### PR DESCRIPTION
Closes #5879

## Problem

`HuggingFaceModel._map_user_message` handled `ToolReturnPart` by calling `model_response_str()`, which only returns the text portion of the tool result. Any `MultiModalContent` in the tool return (e.g. `ImageUrl`, `BinaryContent`, `UploadedFile`) was silently discarded — no error, no warning.

## Fix

Mirror the existing `GroqModel` pattern:

1. Use `model_response_str_and_user_content()` to separate text from file content.
2. Accumulate file content across all `ToolReturnPart`s in the message.
3. After all parts are processed, if any file content was collected, yield a trailing user message via `_map_user_prompt()`.

`_map_user_prompt` already handles the boundary correctly: `ImageUrl` and `BinaryContent` (images) are mapped, while `AudioUrl`, `DocumentUrl`, `VideoUrl`, and `UploadedFile` raise `NotImplementedError`. Users now get a clear signal for unsupported types instead of silent data loss.

## Tests

Two no-network unit tests:
- `test_tool_return_with_uploaded_file_raises` — verifies `UploadedFile` in a tool return now raises `NotImplementedError` (previously silently dropped)
- `test_tool_return_with_image_url_appends_user_message` — verifies `ImageUrl` produces a trailing user message (tool msg + user msg = 2 items from the generator)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

