### PR TITLE
fix(xai): drop non-native ThinkingParts from history to prevent reasoning leak

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -456,7 +456,8 @@ class XaiModel(Model[AsyncClient]):
         """Map a `ThinkingPart` into a single xAI assistant message.
 
         - Native xAI thinking (with optional signature) is sent via `reasoning_content`/`encrypted_content`
-        - Non-xAI (or non-native) thinking is preserved by wrapping in the model profile's thinking tags
+        - Non-xAI (or unsignatured) thinking is silently dropped by default; set
+          `GrokModelProfile(grok_send_back_thinking_parts=True)` to re-wrap it in thinking tags instead
         """
         if item.provider_name in _XAI_PROVIDER_NAMES and (item.content or item.signature):
             msg = assistant('')

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -465,7 +465,7 @@ class XaiModel(Model[AsyncClient]):
             if item.signature:
                 msg.encrypted_content = item.signature
             return msg
-        elif item.content:
+        elif item.content and self.profile.get('grok_send_back_thinking_parts', False):
             start_tag, end_tag = self.profile.get('thinking_tags', DEFAULT_THINKING_TAGS)
             return assistant('\n'.join([start_tag, item.content, end_tag]))
         else:

--- a/pydantic_ai_slim/pydantic_ai/profiles/grok.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/grok.py
@@ -46,8 +46,8 @@ class GrokModelProfile(ModelProfile, total=False):
     grok_reasoning_efforts: frozenset[GrokReasoningEffort]
     """Native `reasoning_effort` values supported by the Grok model. Default: empty (`frozenset()`)."""
 
-    grok_send_back_thinking_parts: bool = False
-    """Whether to re-render non-native ThinkingParts as thinking tags in history.
+    grok_send_back_thinking_parts: bool
+    """Whether to re-render non-native ThinkingParts as thinking tags in history. Default: `False`.
 
     When False (default), ThinkingParts produced by other providers are dropped from history
     rather than being wrapped in thinking tags — which the model would otherwise repeat

--- a/pydantic_ai_slim/pydantic_ai/profiles/grok.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/grok.py
@@ -46,6 +46,14 @@ class GrokModelProfile(ModelProfile, total=False):
     grok_reasoning_efforts: frozenset[GrokReasoningEffort]
     """Native `reasoning_effort` values supported by the Grok model. Default: empty (`frozenset()`)."""
 
+    grok_send_back_thinking_parts: bool = False
+    """Whether to re-render non-native ThinkingParts as thinking tags in history.
+
+    When False (default), ThinkingParts produced by other providers are dropped from history
+    rather than being wrapped in thinking tags — which the model would otherwise repeat
+    verbatim in subsequent turns (reasoning leak).
+    """
+
 
 def grok_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a Grok model."""

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -3688,7 +3688,11 @@ Fix the errors and try again.\
 
 
 async def test_xai_thinking_part_in_message_history(allow_model_requests: None):
-    """Test that ThinkingPart in message history is properly mapped."""
+    """Test that ThinkingPart in message history is properly mapped.
+
+    Native xAI ThinkingParts WITHOUT a signature (provider_name=None) are dropped from history
+    rather than being re-rendered as <think>…</think> tags (which would leak into model output).
+    """
     # First response with reasoning
     response1 = create_response(
         content='first response',
@@ -3732,18 +3736,7 @@ async def test_xai_thinking_part_in_message_history(allow_model_requests: None):
                 'model': XAI_REASONING_MODEL,
                 'messages': [
                     {'content': [{'text': 'First question'}], 'role': 'ROLE_USER'},
-                    {
-                        'content': [
-                            {
-                                'text': """\
-<think>
-First reasoning
-</think>\
-"""
-                            }
-                        ],
-                        'role': 'ROLE_ASSISTANT',
-                    },
+                    # Unsigned ThinkingPart (provider_name=None) is dropped — not re-rendered as <think> tags.
                     {'content': [{'text': 'first response'}], 'role': 'ROLE_ASSISTANT'},
                     {'content': [{'text': 'Second question <think>user think</think>'}], 'role': 'ROLE_USER'},
                 ],
@@ -5689,6 +5682,86 @@ async def test_xai_legacy_grok_provider_name_in_history(allow_model_requests: No
     for m in assistant_msgs:
         for part in m.get('content', []):
             assert '<think>' not in part.get('text', '')
+
+
+async def test_xai_foreign_thinking_part_dropped_from_history(allow_model_requests: None):
+    """ThinkingPart from a non-xai provider must be silently dropped, not re-rendered as thinking tags.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/5927.
+    Without the fix the elif-branch in _map_thinking_part wraps any ThinkingPart
+    that has content in <think>…</think> tags, which the model then mimics in
+    subsequent turns (reasoning-content leak).
+    """
+    response = create_response(content='Follow-up answer', usage=create_usage(prompt_tokens=10, completion_tokens=5))
+    mock_client = MockXai.create_mock([response])
+    m = XaiModel(XAI_REASONING_MODEL, provider=XaiProvider(xai_client=mock_client))
+    agent = Agent(m)
+
+    # History contains a ThinkingPart produced by *another* provider (e.g. Anthropic).
+    message_history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='First question')]),
+        ModelResponse(
+            parts=[
+                ThinkingPart(content='Foreign reasoning text', provider_name='anthropic'),
+                TextPart(content='First answer'),
+            ],
+            model_name=XAI_REASONING_MODEL,
+        ),
+    ]
+
+    await agent.run('Follow up', message_history=message_history)
+
+    kwargs_list = get_mock_chat_create_kwargs(mock_client)
+    assert len(kwargs_list) == 1
+    messages = kwargs_list[0]['messages']
+
+    # The TextPart from the prior response must still be present.
+    assistant_texts = [
+        m['content'][0]['text']
+        for m in messages
+        if m.get('role') == 'ROLE_ASSISTANT'
+    ]
+    assert 'First answer' in assistant_texts
+
+    # No message must contain the foreign reasoning content.
+    all_text = str(messages)
+    assert 'Foreign reasoning text' not in all_text
+    assert '<think>' not in all_text
+
+
+async def test_xai_foreign_thinking_part_preserved_when_flag_enabled(allow_model_requests: None):
+    """When grok_send_back_thinking_parts=True, non-native ThinkingParts are wrapped in thinking tags.
+
+    Regression test (positive-flag path) for https://github.com/pydantic/pydantic-ai/issues/5927.
+    """
+    response = create_response(content='Follow-up answer', usage=create_usage(prompt_tokens=10, completion_tokens=5))
+    mock_client = MockXai.create_mock([response])
+
+    # Explicit profile that opts-in to re-sending foreign thinking parts.
+    profile = GrokModelProfile(grok_send_back_thinking_parts=True)
+    m = XaiModel(XAI_REASONING_MODEL, provider=XaiProvider(xai_client=mock_client), profile=profile)
+    agent = Agent(m)
+
+    message_history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='First question')]),
+        ModelResponse(
+            parts=[
+                ThinkingPart(content='Foreign reasoning text', provider_name='anthropic'),
+                TextPart(content='First answer'),
+            ],
+            model_name=XAI_REASONING_MODEL,
+        ),
+    ]
+
+    await agent.run('Follow up', message_history=message_history)
+
+    kwargs_list = get_mock_chat_create_kwargs(mock_client)
+    messages = kwargs_list[0]['messages']
+
+    # Foreign ThinkingPart must appear wrapped in thinking tags.
+    all_text = str(messages)
+    assert '<think>' in all_text
+    assert 'Foreign reasoning text' in all_text
 
 
 # End of tests

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -5716,11 +5716,7 @@ async def test_xai_foreign_thinking_part_dropped_from_history(allow_model_reques
     messages = kwargs_list[0]['messages']
 
     # The TextPart from the prior response must still be present.
-    assistant_texts = [
-        m['content'][0]['text']
-        for m in messages
-        if m.get('role') == 'ROLE_ASSISTANT'
-    ]
+    assistant_texts = [m['content'][0]['text'] for m in messages if m.get('role') == 'ROLE_ASSISTANT']
     assert 'First answer' in assistant_texts
 
     # No message must contain the foreign reasoning content.


### PR DESCRIPTION
Fixes #5927.

## Problem

`XaiModel._map_thinking_part` unconditionally re-wrapped any `ThinkingPart` with content in `<think>…</think>` tags when replaying it in multi-turn history — even if the part originated from a different provider (e.g. Anthropic) or was produced by xAI itself without a signature.

The model sees those tags in the request and mimics that format in its next output, leaking reasoning content into user-visible text.

## Fix

Guard the fallback branch (`elif item.content`) with the new `GrokModelProfile.grok_send_back_thinking_parts: bool = False` flag, so unsignatured and foreign `ThinkingPart`s are silently dropped instead of being re-rendered.

The pattern mirrors the existing `bedrock_send_back_thinking_parts` field in `BedrockModelProfile`. Operators who genuinely need the old re-rendering behaviour can opt in by passing a profile with `grok_send_back_thinking_parts=True`.

## Changes

| File | Change |
|------|--------|
| `profiles/grok.py` | Add `grok_send_back_thinking_parts: bool = False` to `GrokModelProfile` |
| `models/xai.py` | Guard `elif item.content` with the flag in `_map_thinking_part` |
| `tests/models/test_xai.py` | Update snapshot for existing test (was asserting the leaky behaviour); add two new regression tests |

## Tests

- `test_xai_foreign_thinking_part_dropped_from_history` — verifies that a `ThinkingPart` with `provider_name='anthropic'` is silently excluded from the API call.
- `test_xai_foreign_thinking_part_preserved_when_flag_enabled` — verifies that the flag opts back in to the old wrapping behaviour when explicitly set.
- All 111 existing xAI model tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

