### PR TITLE
fix(mistral): forward `presence_penalty` and `frequency_penalty` in non-streaming requests

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -264,6 +264,8 @@ class MistralModel(Model[Mistral]):
                 top_p=model_settings.get('top_p', 1),
                 timeout_ms=self._get_timeout_ms(model_settings.get('timeout')),
                 random_seed=model_settings.get('seed', UNSET),
+                presence_penalty=model_settings.get('presence_penalty'),
+                frequency_penalty=model_settings.get('frequency_penalty'),
                 stop=model_settings.get('stop_sequences', None),
                 http_headers={'User-Agent': get_user_agent()},
             )

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -64,6 +64,7 @@ with try_import() as imports_successful:
 
     from pydantic_ai.models.mistral import (
         MistralModel,
+        MistralModelSettings,
         MistralStreamedResponse,
         _map_content,  # pyright: ignore[reportPrivateUsage]
     )
@@ -379,6 +380,26 @@ async def test_three_completions(allow_model_requests: None):
             ),
         ]
     )
+
+
+async def test_completion_with_penalties(allow_model_requests: None):
+    captured: dict[str, Any] = {}
+
+    class CapturingMockMistralAI(MockMistralAI):
+        async def chat_completions_create(self, *args: Any, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return await super().chat_completions_create(*args, **kwargs)
+
+    mock_client = cast(
+        Mistral, CapturingMockMistralAI(completions=completion_message(MistralAssistantMessage(content='world')))
+    )
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
+    agent = Agent(model=model)
+
+    await agent.run('hello', model_settings=MistralModelSettings(presence_penalty=0.5, frequency_penalty=0.3))
+
+    assert captured['presence_penalty'] == 0.5
+    assert captured['frequency_penalty'] == 0.3
 
 
 #####################


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #5657

`presence_penalty` and `frequency_penalty` model settings were silently dropped in non-streaming Mistral requests: `_completions_create` omitted them from the `complete_async` call, while the streaming path (`_stream_completions_create`) already forwarded both. As a result, users configuring these settings (e.g. to reduce repetition) saw no effect with `agent.run()`, even though the same settings worked with `agent.run_stream()`.

This adds the two missing kwargs to the non-streaming call, mirroring the streaming path.

A regression test (`test_completion_with_penalties`) captures the kwargs passed to `complete_async` and asserts both penalties are forwarded. It's a unit test rather than VCR because our cassette matchers aren't sensitive to these request-body fields, so a recording would replay green even if the settings were dropped.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

