### PR TITLE
Fix CI duration report baseline collection

### DIFF
--- a/.github/scripts/ci_duration.py
+++ b/.github/scripts/ci_duration.py
@@ -22,6 +22,7 @@ REPORT_MARKER = '<!-- ci-duration-report -->'
 REPORT_LABEL = 'trigger:ci-duration-report'
 BASELINE_MAIN_RUN_LIMIT = 30
 BASELINE_PR_RUN_LIMIT = 60
+BASELINE_COLLECTION_MAX_SECONDS = 90
 MIN_BASELINE_SAMPLES = 10
 WARNING_MIN_SECONDS = 60
 SLOW_THRESHOLD_MULTIPLIER = 1.25
@@ -261,23 +262,36 @@ def find_latest_ci_run(client: GitHubClient, head_sha: str) -> JsonObject | None
 
 
 def collect_baselines(client: GitHubClient, current_head_sha: str) -> dict[str, Baseline]:
-    main_runs = client.request_paginated(
-        f'actions/workflows/{CI_WORKFLOW_FILE}/runs?branch=main&event=push&status=success',
-        max_items=BASELINE_MAIN_RUN_LIMIT,
-    )
-    pr_runs = client.request_paginated(
-        f'actions/workflows/{CI_WORKFLOW_FILE}/runs?event=pull_request&status=success',
-        max_items=BASELINE_PR_RUN_LIMIT,
-    )
+    try:
+        main_runs = client.request_paginated(
+            f'actions/workflows/{CI_WORKFLOW_FILE}/runs?branch=main&event=push&status=success',
+            max_items=BASELINE_MAIN_RUN_LIMIT,
+        )
+        pr_runs = client.request_paginated(
+            f'actions/workflows/{CI_WORKFLOW_FILE}/runs?event=pull_request&status=success',
+            max_items=BASELINE_PR_RUN_LIMIT,
+        )
+    except (TimeoutError, urllib.error.URLError) as exc:
+        print(f'Unable to collect baseline CI runs: {exc}', file=sys.stderr)
+        return {}
+
     durations: dict[str, list[float]] = {}
     seen_run_ids: set[int] = set()
+    baseline_deadline = time.monotonic() + BASELINE_COLLECTION_MAX_SECONDS
     for run in [*main_runs, *pr_runs]:
+        if time.monotonic() >= baseline_deadline:
+            print('Baseline collection time budget exhausted; using partial baseline samples', file=sys.stderr)
+            break
         run_id = _expect_int(run.get('id'), 'baseline run id')
         if run_id in seen_run_ids or run.get('head_sha') == current_head_sha:
             continue
         seen_run_ids.add(run_id)
         run_attempt = _expect_int(run.get('run_attempt'), 'baseline run_attempt')
-        jobs = client.request_paginated(f'actions/runs/{run_id}/attempts/{run_attempt}/jobs')
+        try:
+            jobs = client.request_paginated(f'actions/runs/{run_id}/attempts/{run_attempt}/jobs')
+        except (TimeoutError, urllib.error.URLError) as exc:
+            print(f'Unable to collect baseline jobs for run {run_id}: {exc}', file=sys.stderr)
+            continue
         for job_object in jobs:
             job = normalize_job(job_object)
             if job.conclusion == 'success' and job.duration_seconds is not None and is_tracked_test_job(job):

--- a/.github/scripts/test_ci_duration.py
+++ b/.github/scripts/test_ci_duration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import urllib.error
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -106,3 +107,73 @@ def test_render_report_uses_sticky_marker_and_threshold_context():
     assert 'Minimum baseline sample: 10 successful matching jobs' in report
     assert '| test on 3.10 (all-extras) | 10m 00s | 6m 45s | 7m 08s | +3m 15s (+48%) | slow |' in report
     assert 'trigger:ci-duration-report' in report
+
+
+def test_collect_baselines_skips_unavailable_historical_run():
+    class StubGitHubClient(ci_duration.GitHubClient):
+        def request_paginated(self, path: str, *, max_items: int | None = None) -> list[ci_duration.JsonObject]:
+            if path == 'actions/workflows/ci.yml/runs?branch=main&event=push&status=success':
+                return [
+                    {
+                        'id': run_id,
+                        'run_attempt': 1,
+                        'head_sha': f'baseline-{run_id}',
+                    }
+                    for run_id in range(11)
+                ]
+            if path == 'actions/workflows/ci.yml/runs?event=pull_request&status=success':
+                return []
+            if path == 'actions/runs/0/attempts/1/jobs':
+                raise urllib.error.URLError('timed out')
+            if path.startswith('actions/runs/') and path.endswith('/attempts/1/jobs'):
+                return [
+                    {
+                        'id': 123,
+                        'name': 'test on 3.10 (all-extras)',
+                        'status': 'completed',
+                        'conclusion': 'success',
+                        'started_at': '2026-06-13T17:15:03Z',
+                        'completed_at': '2026-06-13T17:24:05Z',
+                        'runner_name': 'GitHub Actions 1001364942',
+                        'runner_group_name': 'GitHub Actions',
+                        'html_url': 'https://github.com/pydantic/pydantic-ai/actions/runs/1/job/123',
+                        'steps': [],
+                    }
+                ]
+            raise RuntimeError(f'Unexpected path: {path}')
+
+    baselines = ci_duration.collect_baselines(StubGitHubClient('pydantic/pydantic-ai', 'token'), 'current-sha')
+
+    assert baselines['job=test / runner=github-hosted / py=3.10 / extra=all-extras'].sample_size == 10
+
+
+def test_collect_baselines_stops_after_time_budget():
+    class StubGitHubClient(ci_duration.GitHubClient):
+        def request_paginated(self, path: str, *, max_items: int | None = None) -> list[ci_duration.JsonObject]:
+            if path == 'actions/workflows/ci.yml/runs?branch=main&event=push&status=success':
+                return [
+                    {
+                        'id': 1,
+                        'run_attempt': 1,
+                        'head_sha': 'baseline-1',
+                    }
+                ]
+            if path == 'actions/workflows/ci.yml/runs?event=pull_request&status=success':
+                return []
+            raise RuntimeError(f'Unexpected path: {path}')
+
+    monotonic_values = [0.0, ci_duration.BASELINE_COLLECTION_MAX_SECONDS]
+    original_monotonic = ci_duration.time.monotonic
+
+    def monotonic() -> float:
+        if monotonic_values:
+            return monotonic_values.pop(0)
+        return ci_duration.BASELINE_COLLECTION_MAX_SECONDS
+
+    ci_duration.time.monotonic = monotonic
+    try:
+        baselines = ci_duration.collect_baselines(StubGitHubClient('pydantic/pydantic-ai', 'token'), 'current-sha')
+    finally:
+        ci_duration.time.monotonic = original_monotonic
+
+    assert baselines == {}


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #<issue>

Fixes the label-triggered CI duration report workflow getting stuck or failing while collecting historical baseline data.

Root cause: report generation fetched up to 90 historical CI workflow runs and then fetched every run's jobs serially. If GitHub Actions metadata was slow or a historical run job request failed, the workflow could fail before posting the PR report.

Changes:

- Make baseline run/job fetching best-effort.
- Add a 90s baseline collection budget so the report still renders with partial or missing baselines.
- Keep current PR CI run collection strict, so the workflow still fails if it cannot read the run it is reporting on.

Validation:

- `uv run pytest .github/scripts/test_ci_duration.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright .github/scripts/ci_duration.py .github/scripts/test_ci_duration.py`
- `make format`
- `make lint`
- pre-commit during commit, including full Pyright after `make install`
- local dry-run for PR #5919 rendered the report body after exhausting the baseline budget

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

