### PR TITLE
Cover `GoogleModel.count_tokens` Vertex native-tool path and document the intentional `AnthropicModel` divergence

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -592,7 +592,11 @@ class GoogleModel(Model[Client]):
         )
         if self._provider.name not in _GEMINI_API_PROVIDER_NAMES:
             # The fields are not supported by the Gemini API per https://github.com/googleapis/python-genai/blob/7e4ec284dc6e521949626f3ed54028163ef9121d/google/genai/models.py#L1195-L1214
-            config.update(  # pragma: lax no cover
+            # The Vertex `countTokens` endpoint accepts native/server-side tools (e.g. Google Search grounding), so we
+            # forward `tools` as-is to mirror the real request for an accurate count. This intentionally differs from
+            # `AnthropicModel.count_tokens`, which strips native tools because Anthropic's endpoint rejects them (#5704);
+            # don't copy that strip here.
+            config.update(
                 system_instruction=generation_config.get('system_instruction'),
                 tools=cast(list[ToolDict], generation_config.get('tools')),
                 # Annoyingly, GenerationConfigDict has fewer fields than GenerateContentConfigDict, and no extra fields are allowed.

--- a/tests/models/cassettes/test_google/test_google_vertexai_count_tokens_forwards_native_tools.yaml
+++ b/tests/models/cassettes/test_google/test_google_vertexai_count_tokens_forwards_native_tools.yaml
@@ -1,0 +1,123 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '234'
+      content-type:
+      - application/json
+      host:
+      - aiplatform.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: What is the capital of France?
+        role: user
+      generationConfig: {}
+      systemInstruction:
+        parts:
+        - text: You are a helpful chatbot.
+        role: user
+      tools:
+      - googleSearch: {}
+    uri: https://aiplatform.googleapis.com/v1beta1/projects/pydantic-ai/locations/global/publishers/google/models/gemini-2.5-flash:countTokens
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '115'
+      content-type:
+      - application/json; charset=UTF-8
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    parsed_body:
+      promptTokensDetails:
+      - modality: TEXT
+        tokenCount: 13
+      totalBillableCharacters: 47
+      totalTokens: 13
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '264'
+      content-type:
+      - application/json
+      host:
+      - aiplatform.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: What is the capital of France?
+        role: user
+      generationConfig:
+        responseModalities:
+        - TEXT
+      systemInstruction:
+        parts:
+        - text: You are a helpful chatbot.
+        role: user
+      tools:
+      - googleSearch: {}
+    uri: https://aiplatform.googleapis.com/v1beta1/projects/pydantic-ai/locations/global/publishers/google/models/gemini-2.5-flash:generateContent
+  response:
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '555'
+      content-type:
+      - application/json; charset=UTF-8
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    parsed_body:
+      candidates:
+      - content:
+          parts:
+          - text: The capital of France is Paris.
+          role: model
+        finishReason: STOP
+        groundingMetadata: {}
+      createTime: '2026-06-15T18:18:30.977177Z'
+      modelVersion: gemini-2.5-flash
+      responseId: 9kEwapnSO7Ppj8MP-O2CoAw
+      usageMetadata:
+        candidatesTokenCount: 7
+        candidatesTokensDetails:
+        - modality: TEXT
+          tokenCount: 7
+        promptTokenCount: 13
+        promptTokensDetails:
+        - modality: TEXT
+          tokenCount: 13
+        thoughtsTokenCount: 32
+        totalTokenCount: 52
+        trafficType: ON_DEMAND
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -3110,6 +3110,28 @@ async def test_google_vertexai_model_usage_limit_exceeded(
         )
 
 
+async def test_google_vertexai_count_tokens_forwards_native_tools(
+    allow_model_requests: None, vertex_provider: GoogleProvider, vcr: Any
+):  # pragma: lax no cover
+    """Vertex `count_tokens` forwards native tools, mirroring the real request for an accurate count.
+
+    Unlike `AnthropicModel.count_tokens`, which strips native tools because Anthropic's endpoint rejects
+    them (#5704), the Vertex `countTokens` endpoint accepts them (#5781).
+    """
+    model = GoogleModel('gemini-2.5-flash', provider=vertex_provider)
+    agent = Agent(model, instructions='You are a helpful chatbot.', capabilities=[NativeTool(WebSearchTool())])
+
+    result = await agent.run(
+        'What is the capital of France?',
+        usage_limits=UsageLimits(input_tokens_limit=999_999, count_tokens_before_request=True),
+    )
+
+    count_requests = [request for request in vcr.requests if 'countTokens' in request.uri]
+    assert len(count_requests) == 1
+    assert json.loads(count_requests[0].body)['tools'] == snapshot([{'googleSearch': {}}])
+    assert result.output == snapshot('The capital of France is Paris.')
+
+
 def test_map_usage():
     assert (
         _metadata_as_usage(

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -17,6 +17,7 @@ from httpx import AsyncClient as HttpxAsyncClient, Timeout
 from pydantic import BaseModel, Field
 from pytest_mock import MockerFixture
 from typing_extensions import TypedDict
+from vcr.cassette import Cassette
 
 from pydantic_ai import (
     AgentRunResult,
@@ -3111,7 +3112,7 @@ async def test_google_vertexai_model_usage_limit_exceeded(
 
 
 async def test_google_vertexai_count_tokens_forwards_native_tools(
-    allow_model_requests: None, vertex_provider: GoogleProvider, vcr: Any
+    allow_model_requests: None, vertex_provider: GoogleProvider, vcr: Cassette
 ):  # pragma: lax no cover
     """Vertex `count_tokens` forwards native tools, mirroring the real request for an accurate count.
 
@@ -3126,9 +3127,9 @@ async def test_google_vertexai_count_tokens_forwards_native_tools(
         usage_limits=UsageLimits(input_tokens_limit=999_999, count_tokens_before_request=True),
     )
 
-    count_requests = [request for request in vcr.requests if 'countTokens' in request.uri]
-    assert len(count_requests) == 1
-    assert json.loads(count_requests[0].body)['tools'] == snapshot([{'googleSearch': {}}])
+    count_requests = [request for request in vcr.requests if 'countTokens' in request.uri]  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    assert len(count_requests) == 1  # pyright: ignore[reportUnknownArgumentType]
+    assert json.loads(count_requests[0].body)['tools'] == snapshot([{'googleSearch': {}}])  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
     assert result.output == snapshot('The capital of France is Paris.')
 
 


### PR DESCRIPTION
- Closes #5781

Issue #5781 asked whether `GoogleModel.count_tokens` should strip native/server-side tools the way `AnthropicModel.count_tokens` does (#5704). It shouldn't: I verified live that Vertex's `countTokens` endpoint **accepts** native tools (e.g. Google Search grounding) and returns `200`, unlike Anthropic's endpoint which `400`s on them. So the existing Vertex behavior — forwarding `tools` as-is to mirror the real request for an accurate count — is correct.

This PR:

- Adds a comment at the `GoogleModel.count_tokens` Vertex branch documenting that forwarding native tools is intentional and must **not** be "fixed" by copying the Anthropic strip.
- Replaces the `# pragma: lax no cover` on that branch with a real VCR test (`GoogleCloudProvider` + `WebSearchTool` + `count_tokens_before_request=True`) asserting the count request succeeds and the native tool is forwarded.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

