### PR TITLE
fix(openai): add tool_search when a deferred tool is sent on Responses

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2259,6 +2259,15 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         tools: list[responses.ToolParam] = (
             self._get_native_tools(model_request_parameters) + list(extra_native_tools) + function_tools
         )
+        # OpenAI rejects a request that carries a `defer_loading` tool without an
+        # accompanying `tool_search` tool ("Deferred tools require tools.tool_search").
+        # A revealed deferred capability sets `defer_loading` on its function tool (see
+        # `_map_tool_definition`), but the `ToolSearchTool` that originally contributed the
+        # native `tool_search` entry may no longer be present, so add one back when needed.
+        if any(t.get('defer_loading') for t in function_tools) and not any(
+            t.get('type') == 'tool_search' for t in tools
+        ):
+            tools.append(ToolSearchToolParam(type='tool_search'))
         if not tools:
             tool_choice = None
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4273,6 +4273,35 @@ async def test_tool_choice_fallback_response_api(allow_model_requests: None) -> 
     assert get_mock_responses_kwargs(mock_client)[0]['tool_choice'] == 'auto'
 
 
+async def test_responses_deferred_tool_adds_tool_search(allow_model_requests: None) -> None:
+    """A revealed deferred capability must be accompanied by a `tool_search` tool.
+
+    OpenAI rejects a request that carries a `defer_loading` tool without a
+    `tool_search` tool ("Deferred tools require tools.tool_search"). When the
+    originating `ToolSearchTool` is no longer in `native_tools`, the adapter must
+    add the `tool_search` entry back. See #5938.
+    """
+    mock_client = MockOpenAIResponses.create_mock(response_message([]))
+    model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(openai_client=mock_client))
+
+    # A deferred capability tool surfaces as a function tool with `with_native`
+    # set to the tool-search kind, but with no `ToolSearchTool` in native_tools.
+    params = ModelRequestParameters(
+        function_tools=[ToolDefinition(name='bar', with_native='tool_search', defer_loading=True)],
+    )
+
+    await model._responses_create(  # pyright: ignore[reportPrivateUsage]
+        messages=[ModelRequest(parts=[UserPromptPart(content='hello')])],
+        stream=False,
+        model_settings={},
+        model_request_parameters=params,
+    )
+
+    tools = get_mock_responses_kwargs(mock_client)[0]['tools']
+    assert any(t.get('type') == 'function' and t.get('defer_loading') for t in tools)
+    assert any(t.get('type') == 'tool_search' for t in tools)
+
+
 async def test_openai_model_settings_temperature_ignored_on_gpt_5(allow_model_requests: None, openai_api_key: str):
     m = OpenAIChatModel('gpt-5', provider=OpenAIProvider(api_key=openai_api_key))
     agent = Agent(m)


### PR DESCRIPTION
When a deferred capability is revealed, its function tool is sent with `defer_loading=True`, but the `ToolSearchTool` that originally contributed the native `tool_search` entry may no longer be in `native_tools`. OpenAI then rejects the request with `Invalid Value: tools.defer_loading. Deferred tools require tools.tool_search`. This appends a `tool_search` tool whenever any function tool carries `defer_loading` and none is already present. Adds a unit test on the Responses request path covering the deferred-tool case. Fixes #5938.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

