### PR TITLE
docs: add top_k to ModelSettings and deprecation notice for gateway/gemini:

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -685,7 +685,7 @@ except UsageLimitExceeded as e:
 #### Model (Run) Settings
 
 Pydantic AI offers a [`settings.ModelSettings`][pydantic_ai.settings.ModelSettings] structure to help you fine tune your requests.
-This structure allows you to configure common parameters that influence the model's behavior, such as `temperature`, `max_tokens`,
+This structure allows you to configure common parameters that influence the model's behavior, such as `temperature`, `max_tokens`, `top_k`,
 `timeout`, and more.
 
 There are three ways to apply these settings, with a clear precedence order:

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -73,6 +73,10 @@ Examples of providers and models that can be used are:
 | Groq | `groq`          | `gateway/groq:openai/gpt-oss-120b`       |
 | AWS Bedrock | `bedrock`       | `gateway/bedrock:amazon.nova-micro-v1:0` |
 
+!!! warning "Deprecation"
+    The `gateway/gemini:` prefix is deprecated. Use `gateway/google-cloud:` instead.
+    Support for `gateway/gemini:` will be removed in v2.0.
+
 ### Pydantic AI
 
 Before you start, make sure you are on version 1.16 or later of `pydantic-ai`. To update to the latest version run:


### PR DESCRIPTION
Fixes #5648.

Two documentation updates:

1. **`docs/agent.md`**: Add `top_k` to the ModelSettings parameter list alongside `temperature`, `max_tokens`, and `timeout`.  
   `top_k` was added in PR #5558 and is supported by Gemini, Anthropic, Cohere, and Bedrock (Anthropic and Amazon Nova models only).

2. **`docs/gateway.md`**: Add a deprecation warning for the `gateway/gemini:` prefix.  
   The deprecation was introduced in PR #5543; users should use `gateway/google-cloud:` instead. The `gateway/gemini:` prefix will be removed in v2.0.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

