### PR TITLE
fix(_utils): initialise group_start_time to None so first-group debounce window starts on first item

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -323,7 +323,7 @@ async def group_by_temporal(
                 'soft_max_interval must be a positive number'
             )
             buffer: list[T] = []
-            group_start_time = time.monotonic()
+            group_start_time: float | None = None
 
             while True:
                 if group_start_time is None:


### PR DESCRIPTION
Fixes #5946.

## Problem

`group_by_temporal` starts each group's debounce window when the first item of that group arrives — except for the **first** group. `group_start_time` was initialised to `time.monotonic()` at function entry, so the `if group_start_time is None:` branch (which is meant to start the window on first item arrival) never ran for the first group. If the first item was delayed past `soft_max_interval`, the window had already elapsed by the time it arrived and it was emitted alone instead of being batched with items that followed within the interval.

## Fix

Change the initialisation from `time.monotonic()` to `None`. The `if group_start_time is None:` branch already handles this correctly for every subsequent group (it is reset to `None` after each emitted group), so this one-character change makes the first group consistent with the rest.

```python
# before
group_start_time = time.monotonic()

# after
group_start_time: float | None = None
```

## Reproduction (from issue)

```python
import asyncio
from pydantic_ai._utils import group_by_temporal

async def stream():
    await asyncio.sleep(0.08)  # first item delayed past the window
    yield 1
    await asyncio.sleep(0.01)  # second item arrives within the window of the first
    yield 2
    await asyncio.sleep(0.2)
    yield 3

async def main():
    async with group_by_temporal(stream(), soft_max_interval=0.04) as groups:
        print([g async for g in groups])

asyncio.run(main())
# Before fix: [[1], [2], [3]]
# After fix:  [[1, 2], [3]]
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

