### PR TITLE
fix(cohere): forward cached_tokens to RequestUsage.cache_read_tokens in _map_usage

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -399,8 +399,12 @@ def _map_usage(response: V2ChatResponse) -> usage.RequestUsage:
 
         request_tokens = int(u.tokens.input_tokens) if u.tokens and u.tokens.input_tokens else 0
         response_tokens = int(u.tokens.output_tokens) if u.tokens and u.tokens.output_tokens else 0
+        cached_tokens = int(u.cached_tokens) if u.cached_tokens else 0
+        if cached_tokens:
+            details['cache_read_tokens'] = cached_tokens
         return usage.RequestUsage(
             input_tokens=request_tokens,
             output_tokens=response_tokens,
+            cache_read_tokens=cached_tokens,
             details=details,
         )


### PR DESCRIPTION
Fixes #5945.

## Problem

`CohereModel._map_usage` reads `u.billed_units` and `u.tokens` but never reads `u.cached_tokens`, so prompt-cache hits are silently dropped. `result.usage().cache_read_tokens` is always `0` for Cohere runs that hit the inference cache, and `details` does not include `cached_tokens` either.

This is inconsistent with `AnthropicModel`, `BedrockModel`, and `GoogleModel`, which all forward their equivalent cache-hit counts to `RequestUsage.cache_read_tokens`.

## Fix

Read `u.cached_tokens` and forward it to `cache_read_tokens`, mirroring it into `details` for parity with how other providers report cache usage:

```python
cached_tokens = int(u.cached_tokens) if u.cached_tokens else 0
if cached_tokens:
    details['cache_read_tokens'] = cached_tokens
return usage.RequestUsage(
    input_tokens=request_tokens,
    output_tokens=response_tokens,
    cache_read_tokens=cached_tokens,
    details=details,
)
```

The `cached_tokens` field is documented on the Cohere v2 API and typed as `Optional[float]` in `cohere-python >= 5.x` (`src/cohere/types/usage.py`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

