### PR TITLE
fix(cohere): map cached tokens to usage

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -361,8 +361,11 @@ def _map_usage(response: V2ChatResponse) -> usage.RequestUsage:
 
         request_tokens = int(u.tokens.input_tokens) if u.tokens and u.tokens.input_tokens else 0
         response_tokens = int(u.tokens.output_tokens) if u.tokens and u.tokens.output_tokens else 0
+        cached_tokens = getattr(u, 'cached_tokens', None)
+        cache_read_tokens = int(cached_tokens) if cached_tokens else 0
         return usage.RequestUsage(
             input_tokens=request_tokens,
             output_tokens=response_tokens,
+            cache_read_tokens=cache_read_tokens,
             details=details,
         )

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -203,6 +203,38 @@ async def test_request_simple_usage(allow_model_requests: None):
     )
 
 
+async def test_request_simple_usage_with_cached_tokens(allow_model_requests: None):
+    c = completion_message(
+        AssistantMessageResponse(
+            content=[TextAssistantMessageResponseContentItem(text='world')],
+            role='assistant',
+        ),
+        usage=cohere.Usage(
+            tokens=cohere.UsageTokens(input_tokens=10, output_tokens=5),
+            billed_units=cohere.UsageBilledUnits(input_tokens=10, output_tokens=5),
+            cached_tokens=42,
+        ),
+    )
+    mock_client = MockAsyncClientV2.create_mock(c)
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    result = await agent.run('Hello')
+    assert result.output == 'world'
+    assert result.usage == snapshot(
+        RunUsage(
+            requests=1,
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_tokens=42,
+            details={
+                'input_tokens': 10,
+                'output_tokens': 5,
+            },
+        )
+    )
+
+
 async def test_request_structured_response(allow_model_requests: None):
     c = completion_message(
         AssistantMessageResponse(


### PR DESCRIPTION
## What
- Map Cohere `usage.cached_tokens` to `RequestUsage.cache_read_tokens`
- Add a focused regression test for Cohere cached-token usage accounting

## Why
Cohere v2 responses can include prompt cache hits in `usage.cached_tokens`, but the adapter dropped that value, so run usage underreported cache reads.

Fixes #5945

## Test
- `uv run pytest tests/models/test_cohere.py -k simple_usage`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

