### PR TITLE
fix(cohere): map cached_tokens to cache_read_tokens in _map_usage

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -399,8 +399,10 @@ def _map_usage(response: V2ChatResponse) -> usage.RequestUsage:
 
         request_tokens = int(u.tokens.input_tokens) if u.tokens and u.tokens.input_tokens else 0
         response_tokens = int(u.tokens.output_tokens) if u.tokens and u.tokens.output_tokens else 0
+        cache_read_tokens = int(u.cached_tokens) if getattr(u, 'cached_tokens', None) else 0
         return usage.RequestUsage(
             input_tokens=request_tokens,
             output_tokens=response_tokens,
+            cache_read_tokens=cache_read_tokens,
             details=details,
         )


### PR DESCRIPTION
## Summary

Fixes #5945 — the Cohere v2 API returns prompt cache hit count as `usage.cached_tokens`, but `_map_usage` never reads it. `cache_read_tokens` is always 0 for CohereModel runs, breaking observability, OTel metrics, and genai-prices cost calculations.

## Change

Two lines added to `_map_usage` in `cohere.py`:

1. Extract `cached_tokens` from the Cohere usage object (with `getattr` fallback for older SDK versions)
2. Pass it as `cache_read_tokens` to `RequestUsage`

This matches the pattern from Anthropic, Bedrock, and Gemini providers which already populate `cache_read_tokens` correctly.

## Test Plan

No test changes needed — the Cohere SDK `Usage` type already includes `cached_tokens` in versions ≥ 5.x. The fix is a pure field mapping oversight.

Closes #5945

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

