### PR TITLE
fix: use running loop in chat app example

### DIFF
--- a/examples/pydantic_ai_examples/chat_app.py
+++ b/examples/pydantic_ai_examples/chat_app.py
@@ -161,7 +161,7 @@ class Database:
         cls, file: Path = THIS_DIR / '.chat_app_messages.sqlite'
     ) -> AsyncGenerator[Database]:
         with logfire.span('connect to DB'):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             executor = ThreadPoolExecutor(max_workers=1)
             con = await loop.run_in_executor(executor, cls._connect, file)
             slf = cls(con, loop, executor)


### PR DESCRIPTION
## Summary

Updates the chat app example to use `asyncio.get_running_loop()` inside the async `Database.connect()` context manager.

## Problem

`Database.connect()` is already running inside an active event loop. `asyncio.get_event_loop()` is the older, looser API and can depend on event-loop policy behavior, while `get_running_loop()` directly expresses that this code requires the currently running loop.

## Before / after

Before: the example retrieved the loop with `asyncio.get_event_loop()`.

After: the example retrieves the active loop with `asyncio.get_running_loop()` before using `run_in_executor()`.

## Verification

- `python -m compileall examples/pydantic_ai_examples/chat_app.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

