### PR TITLE
fix(ag-ui): preserve ModelRequest part order in _dump_request_parts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -581,6 +581,14 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             if converted is not None:
                                 user_content.append(converted)
             elif isinstance(part, ToolReturnPart):
+                # Flush buffered user content before tool returns so
+                # messages preserve the original ModelRequest.parts order.
+                if user_content:
+                    if len(user_content) == 1 and isinstance(user_content[0], TextInputContent):
+                        result.append(UserMessage(id=_new_message_id(), content=user_content[0].text))
+                    else:
+                        result.append(UserMessage(id=_new_message_id(), content=user_content))
+                    user_content = []
                 result.append(
                     ToolMessage(
                         id=_new_message_id(),


### PR DESCRIPTION
## Summary

Fixes #5964 — `AGUIAdapter.dump_messages()` reorders messages when a `ModelRequest` contains both a `ToolReturnPart` and a `UserPromptPart`.

## Problem

`_dump_request_parts` buffered all `UserPromptPart` content in a separate list and flushed it at the end, before the already-accumulated tool returns. This always placed user messages before tool messages, regardless of the original part order.

For providers like Anthropic/Bedrock, this causes a 400 error because the `tool_use` block appears without an immediately following `tool_result`.

## Fix

Flush buffered user content when encountering a `ToolReturnPart` during iteration, preserving the original `ModelRequest.parts` order. The existing user-content combining logic (consecutive `UserPromptPart`s → single `UserMessage`) is unchanged.

## Test Plan

The MRE from #5964 now passes — `[ToolReturnPart, UserPromptPart]` dumps as `[ToolMessage, UserMessage]` in the correct order.

Closes #5964

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

