### PR TITLE
fix: preserve ToolMessage ordering before UserMessage in `AGUIAdapter.dump_messages`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -603,16 +603,30 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
             else:
                 assert_never(part)
 
+        # Preserve ordering: tool results must precede the user prompt when they appear first
+        # in the original parts list (e.g. tool-return + follow-up user message in one request).
+        first_tool_idx = next((i for i, p in enumerate(msg.parts) if isinstance(p, ToolReturnPart)), None)
+        first_user_idx = next((i for i, p in enumerate(msg.parts) if isinstance(p, UserPromptPart)), None)
+        tool_before_user = first_tool_idx is not None and (
+            first_user_idx is None or first_tool_idx < first_user_idx
+        )
+
+        def _build_user_message() -> Message | None:
+            if not user_content:
+                return None
+            if len(user_content) == 1 and isinstance(user_content[0], TextInputContent):
+                return UserMessage(id=_new_message_id(), content=user_content[0].text)
+            return UserMessage(id=_new_message_id(), content=user_content)
+
         messages: list[Message] = []
         if system_content:
             messages.append(SystemMessage(id=_new_message_id(), content='\n'.join(system_content)))
-        if user_content:
-            # Simplify to plain string if only single text item
-            if len(user_content) == 1 and isinstance(user_content[0], TextInputContent):
-                messages.append(UserMessage(id=_new_message_id(), content=user_content[0].text))
-            else:
-                messages.append(UserMessage(id=_new_message_id(), content=user_content))
-        messages.extend(result)
+        if tool_before_user:
+            messages.extend(result)
+        if user_msg := _build_user_message():
+            messages.append(user_msg)
+        if not tool_before_user:
+            messages.extend(result)
         return messages
 
     @staticmethod

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1624,6 +1624,45 @@ def test_dump_load_roundtrip_tools() -> None:
     assert reloaded == original
 
 
+def test_dump_messages_tool_return_before_user_prompt_ordering() -> None:
+    """dump_messages must emit ToolMessage before UserMessage when ToolReturnPart precedes UserPromptPart.
+
+    Providers such as Anthropic/Bedrock reject requests where a tool_use block is not immediately
+    followed by a tool_result block, so the serialised ordering must match the original part order.
+    """
+    from ag_ui.core import ToolMessage, UserMessage
+
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Call a tool')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='greet', tool_call_id='call_1', args='{}')]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name='greet', tool_call_id='call_1', content='hello'),
+                UserPromptPart(content='Thanks'),
+            ]
+        ),
+        ModelResponse(parts=[TextPart(content='Done')]),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(messages)
+
+    # Locate the ToolMessage and UserMessage in the output
+    tool_positions = [i for i, m in enumerate(ag_ui_msgs) if isinstance(m, ToolMessage)]
+    user_positions = [i for i, m in enumerate(ag_ui_msgs) if isinstance(m, UserMessage)]
+
+    assert tool_positions, 'expected at least one ToolMessage'
+    assert user_positions, 'expected at least one UserMessage'
+    # The ToolMessage for call_1 must appear before the follow-up UserMessage
+    assert tool_positions[-1] < user_positions[-1], (
+        f'ToolMessage at index {tool_positions[-1]} should precede UserMessage at {user_positions[-1]}'
+    )
+
+    # Full round-trip must also be stable
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    _sync_timestamps(messages, reloaded)
+    assert reloaded == messages
+
+
 def test_dump_load_roundtrip_multiple_thinking_parts() -> None:
     """Test round-trip preserves multiple ThinkingParts with their metadata."""
     original: list[ModelMessage] = [


### PR DESCRIPTION
- Closes #5964

### What's wrong

`AGUIAdapter.dump_messages` always emits a `UserMessage` before any `ToolMessage`s in its output, regardless of the original part ordering in `ModelRequest.parts`. When a `ModelRequest` contains a `ToolReturnPart` followed by a `UserPromptPart` (the normal pattern: tool result then follow-up user turn), the serialised AG-UI sequence becomes `UserMessage → ToolMessage` instead of `ToolMessage → UserMessage`.

Anthropic/Bedrock (and other providers) reject the next request with a 400 because `tool_use` blocks must be immediately followed by `tool_result` blocks.

### Fix

In `_dump_request_parts`, before building the final message list, detect whether the first `ToolReturnPart` precedes the first `UserPromptPart` in `msg.parts`. When it does, extend `result` (ToolMessages) into the output list before appending the `UserMessage`. Existing behaviour (UserMessage first) is unchanged for the common case where user content arrives before any tool return.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

