### PR TITLE
Fix #5774 - Add null guard for Bedrock streaming crash in _map_usage

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2098,6 +2098,11 @@ def _map_usage(
     if isinstance(message, BetaMessage):
         response_usage = message.usage
     elif isinstance(message, BetaRawMessageStartEvent):
+        if message.message is None:
+            # Bedrock's SDK decoder can drop event types, resulting in
+            # message.message being None. Fall back to existing usage or
+            # an empty default to avoid crashing.
+            return existing_usage or usage.RequestUsage()
         response_usage = message.message.usage
     elif isinstance(message, BetaRawMessageDeltaEvent):
         response_usage = message.usage
@@ -2144,10 +2149,11 @@ class AnthropicStreamedResponse(StreamedResponse):
             async for event in self._response:
                 if isinstance(event, BetaRawMessageStartEvent):
                     self._usage = _map_usage(event, self._provider_name, self._provider_url, self._model_name)
-                    self.provider_response_id = event.message.id
-                    if event.message.container:
-                        self.provider_details = self.provider_details or {}
-                        self.provider_details['container_id'] = event.message.container.id
+                    if event.message is not None:
+                        self.provider_response_id = event.message.id
+                        if event.message.container:
+                            self.provider_details = self.provider_details or {}
+                            self.provider_details['container_id'] = event.message.container.id
 
                 elif isinstance(event, BetaRawContentBlockStartEvent):
                     current_block = event.content_block


### PR DESCRIPTION
# PR Description: Fix #5774 - Add null guard for Bedrock streaming crash in _map_usage

## Issue Title
_map_usage crashes on Bedrock streams: RawMessageStartEvent(message=None) from type-less chunks

## Issue Description
When using pydantic-ai with Amazon Bedrock (via `AsyncAnthropicBedrock`/`AnthropicProvider`), streaming calls crash with `AttributeError: 'NoneType' object has no attribute 'usage'`. The Bedrock SDK's stream decoder drops SSE event types, causing Bedrock-only chunks like `amazon-bedrock-invocationMetrics` to be constructed as `BetaRawMessageStartEvent(message=None)`. Non-streaming calls with high `max_tokens` trigger internal streaming fallback, which also hits this crash on Bedrock.

**Reported by:** Community user

## Root Cause Analysis
The `_map_usage` function in `pydantic_ai/models/anthropic.py` unconditionally accessed `message.message.usage` for `BetaRawMessageStartEvent` without guarding for `message=None`. On Bedrock, the Anthropic SDK's stream decoder drops event types, producing non-validating `construct_type` events with `message=None`.

## Changes Made

**File 1: `pydantic_ai_slim/pydantic_ai/models/anthropic.py`**
- Added `if message.message is None:` early return guard in `_map_usage()`, falling back to `existing_usage` or an empty `RequestUsage()`
- Added null guards in the event iterator to skip `message.id` and container accesses when the message is None

**File 2: `pydantic_ai_slim/pyproject.toml`**
- Updated dependency version constraints

## Risk Assessment
**Low** - The change adds defensive null guards for edge case events produced by the Bedrock SDK. All normal call paths with valid `message.message` objects continue to work identically. The fix only affects the error handling path for malformed streaming events.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

