### PR TITLE
fix(messages): round-trip `RetryPromptPart.content` with partial `ErrorDetails`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -18,7 +18,7 @@ import pydantic
 import pydantic_core
 from genai_prices import calc_price, types as genai_types
 from pydantic.dataclasses import dataclass as pydantic_dataclass
-from typing_extensions import TypeAliasType, TypeVar, assert_never
+from typing_extensions import TypeAliasType, TypedDict, TypeVar, assert_never
 
 from . import _otel_messages, _utils
 from ._instrumentation import serialize_any
@@ -1486,7 +1486,32 @@ class NativeToolReturnPart(BaseToolReturnPart):
         return _narrow_return(part, _NATIVE_RETURN_NARROWERS, tool_kind)
 
 
-error_details_ta = pydantic.TypeAdapter(list[pydantic_core.ErrorDetails], config=pydantic.ConfigDict(defer_build=True))
+if TYPE_CHECKING:
+    _RetryErrorDetails: TypeAlias = pydantic_core.ErrorDetails
+else:
+
+    class _RetryErrorDetails(TypedDict, total=False):
+        """Runtime-loose form of [`pydantic_core.ErrorDetails`][pydantic_core.ErrorDetails].
+
+        `pydantic_core.ErrorDetails` is a `TypedDict` that marks every key except `ctx`/`url` as
+        required, so it is not enforced when a `RetryPromptPart` is constructed but *is* enforced by
+        `ModelMessagesTypeAdapter` on (de)serialization. `RetryPromptPart.content` is populated from
+        several sources that legitimately omit some of those keys, e.g.
+        `ValidationError.errors(include_input=False)`, custom validators that build their own dicts,
+        or older persisted history. Validating/serializing against this `total=False` shape keeps
+        message history round-tripping (and stops the `PydanticSerializationUnexpectedValue`
+        warning) while the public, static type stays `ErrorDetails` for tooling.
+        """
+
+        type: str
+        loc: tuple[int | str, ...]
+        msg: str
+        input: Any
+        ctx: dict[str, Any]
+        url: str
+
+
+error_details_ta = pydantic.TypeAdapter(list[_RetryErrorDetails], config=pydantic.ConfigDict(defer_build=True))
 
 
 @dataclass(repr=False)
@@ -1505,7 +1530,7 @@ class RetryPromptPart:
     * an output validator raised a [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] exception
     """
 
-    content: list[pydantic_core.ErrorDetails] | str
+    content: list[_RetryErrorDetails] | str
     """Details of why and how the model should retry.
 
     If the retry was triggered by a [`ValidationError`][pydantic_core.ValidationError], this will be a list of

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -735,6 +735,50 @@ def test_model_messages_type_adapter_back_compat_missing_conversation_id():
     assert all(m.conversation_id is None for m in deserialized)
 
 
+def test_retry_prompt_round_trip_with_minimal_error_details():
+    """`RetryPromptPart.content` should round-trip even when entries omit `ErrorDetails` keys.
+
+    `pydantic_core.ErrorDetails` marks `type`/`loc`/`msg`/`input` as required, but the dicts that
+    populate `content` (e.g. `ValidationError.errors(include_input=False)`, custom validators, or
+    older persisted history) routinely omit some of them. Previously `dump_json` emitted a
+    `PydanticSerializationUnexpectedValue` warning and `validate_json` raised, making such a history
+    a one-way door. See https://github.com/pydantic/pydantic-ai/issues/5987.
+    """
+    content: list[dict[str, Any]] = [
+        {'type': 'missing', 'loc': ('x',), 'msg': 'Field required'},
+    ]
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[RetryPromptPart(content=cast(Any, content), tool_name='foo', tool_call_id='call_1')])
+    ]
+
+    with warnings.catch_warnings():
+        # A serialization warning here means the loose schema regressed.
+        warnings.simplefilter('error')
+        serialized = ModelMessagesTypeAdapter.dump_json(messages)
+
+    deserialized = ModelMessagesTypeAdapter.validate_json(serialized)
+    retry_part = deserialized[0].parts[0]
+    assert isinstance(retry_part, RetryPromptPart)
+    assert retry_part.content == content
+
+
+def test_retry_prompt_round_trip_preserves_full_error_details():
+    """The canonical 4-key `ErrorDetails` shape must still round-trip unchanged."""
+    content: list[dict[str, Any]] = [
+        {'type': 'greater_than', 'loc': ('a', 'b'), 'msg': 'Input should be greater than 0', 'input': -1},
+    ]
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[RetryPromptPart(content=cast(Any, content), tool_name='foo', tool_call_id='call_1')])
+    ]
+
+    serialized = ModelMessagesTypeAdapter.dump_json(messages)
+    deserialized = ModelMessagesTypeAdapter.validate_json(serialized)
+    retry_part = deserialized[0].parts[0]
+    assert isinstance(retry_part, RetryPromptPart)
+    # `loc` is coerced back to a tuple, matching the original.
+    assert retry_part.content == content
+
+
 def test_model_messages_type_adapter_preserves_user_text_prompt_metadata():
     messages: list[ModelMessage] = [
         ModelRequest(


### PR DESCRIPTION
## Summary

- `RetryPromptPart.content` now round-trips through `ModelMessagesTypeAdapter` even when its error-detail dicts omit some `pydantic_core.ErrorDetails` keys (most commonly `input`).
- Stops the `PydanticSerializationUnexpectedValue` warning on `dump_json` for such histories and removes the silent data-loss / `validate_json` hard failure.

## Motivation

Closes #5987.

`RetryPromptPart.content` is typed `list[pydantic_core.ErrorDetails] | str`. `ErrorDetails` is a `TypedDict` whose `type`/`loc`/`msg`/`input` keys are **required**. That requirement is not enforced at construction time, but it *is* enforced by `ModelMessagesTypeAdapter` — the boundary used by `Agent.all_messages_json`, `result.new_messages_json`, durable-exec/Temporal replay, and any persisted-then-reloaded history.

`content` is populated from sources that legitimately omit some of those keys:
- `ValidationError.errors(include_input=False)` (a documented public option),
- the framework's own `error.errors(include_url=False, include_context=False)` (already omits `url`/`ctx`),
- custom validators / third-party code that build their own `{type, loc, msg}` dicts,
- older persisted history.

The moment any such entry is serialized, `dump_json` emits a `PydanticSerializationUnexpectedValue` `UserWarning` and the resulting JSON can no longer be reloaded — `validate_json` raises `ValidationError: ... content.list[ErrorDetails].0.input Field required`. It's a one-way door that silently loses the message.

## Root cause

The runtime (de)serialization schema (`error_details_ta` and the `RetryPromptPart.content` annotation) is built from `pydantic_core.ErrorDetails`, whose required keys make any partial entry invalid on the round-trip.

## Fix

Validate/serialize `content` against a `total=False` runtime `TypedDict` (`_RetryErrorDetails`) carrying the same documented field names. Every subset (`{type,loc,msg}`, `include_input=False`, `include_url/context=False`, full 4-key) now round-trips and the serialization warning stops firing.

The **public, static type is unchanged**: under `TYPE_CHECKING` the alias resolves to `pydantic_core.ErrorDetails`, so users and tooling still see `content: list[ErrorDetails] | str`. Only the runtime validation/serialization shape is loosened — matching the fact that `ErrorDetails`'s keys were never enforced at construction in the first place.

```diff
-error_details_ta = pydantic.TypeAdapter(list[pydantic_core.ErrorDetails], ...)
+if TYPE_CHECKING:
+    _RetryErrorDetails: TypeAlias = pydantic_core.ErrorDetails
+else:
+    class _RetryErrorDetails(TypedDict, total=False):
+        type: str; loc: tuple[int | str, ...]; msg: str; input: Any; ctx: dict[str, Any]; url: str
+error_details_ta = pydantic.TypeAdapter(list[_RetryErrorDetails], ...)
```

## Tests

- **`test_retry_prompt_round_trip_with_minimal_error_details`** — the exact issue repro (`{type, loc, msg}`, no `input`). FAILS on `main` (UserWarning → ValidationError), passes with the fix. Uses `warnings.simplefilter('error')` so a re-introduced serialization warning also fails the test.
- **`test_retry_prompt_round_trip_preserves_full_error_details`** — guards the canonical 4-key shape; passes both with and without the fix (so it protects against over-loosening), and asserts `loc` is still coerced back to a tuple.

## Verification

```
$ uv run pytest tests/test_messages.py -q
141 passed

$ uv run pytest tests/test_exceptions.py tests/test_tools.py -q
165 passed

# regression test genuinely guards the fix:
$ git stash -- pydantic_ai_slim/pydantic_ai/messages.py
$ uv run pytest tests/test_messages.py::test_retry_prompt_round_trip_with_minimal_error_details -q
1 failed   # UserWarning -> ValidationError

$ uv run ruff format --check ... && uv run ruff check ...   # clean
$ uv run pyright pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py   # 0 errors
$ uv run mypy   # Success: no issues found in 2 source files
```

## Real behavior proof

Captured on Python 3.12, pydantic 2.13.4 / pydantic-core 2.46.4, on this branch:

**Before fix** (`main`):
```
SER WARNINGS: ['Pydantic serializer warnings:\n  PydanticSerializationUnexpectedValue ...']
ROUNDTRIP FAILED: ValidationError 2 validation errors for list[tagged-union[ModelRequest,ModelResponse]]
0.request.parts.0.retry-prompt.content.list[ErrorDetails].0.input
  Field required [type=missing, input_value={'type': 'missing', ...}]
```

**After fix** (this branch):
```
SER WARNINGS: []
JSON: [{"parts":[{"content":[{"type":"missing","loc":["x"],"msg":"Field required"}],"tool_name":"foo","tool_call_id":"call_1",...,"part_kind":"retry-prompt"}],...
ROUNDTRIP OK
```

## What was NOT changed

- `RetryPromptPart.model_response()` and `exceptions.py::_format_error_details` still read `type`/`loc`/`msg`/`input` — they already guard via `.get(...)` / handle the tool-name branches, and the existing `exclude=` logic is untouched.
- No change to the static/public type surface (`ErrorDetails` remains the documented type).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

