### PR TITLE
fix(xai): drop unsigned/foreign thinking parts by default to prevent reasoning leak

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -461,7 +461,8 @@ class XaiModel(Model[AsyncClient]):
         """Map a `ThinkingPart` into a single xAI assistant message.
 
         - Native xAI thinking (with optional signature) is sent via `reasoning_content`/`encrypted_content`
-        - Non-xAI (or non-native) thinking is preserved by wrapping in the model profile's thinking tags
+        - Non-xAI (or non-native) thinking is dropped by default, or re-rendered in the model profile's
+          thinking tags when `grok_send_back_thinking_parts='tags'`
         """
         if item.provider_name == self.system and (item.content or item.signature):
             msg = assistant('')
@@ -470,7 +471,10 @@ class XaiModel(Model[AsyncClient]):
             if item.signature:
                 msg.encrypted_content = item.signature
             return msg
-        elif item.content:
+        elif item.content and GrokModelProfile.from_profile(self.profile).grok_send_back_thinking_parts == 'tags':
+            # xAI does not re-absorb `<think>` tags from history, so re-rendering an unsigned/foreign part
+            # as text teaches the model to mimic the format in its user-visible output. `'auto'` drops
+            # these; `'tags'` opts back in.
             start_tag, end_tag = self.profile.thinking_tags
             return assistant('\n'.join([start_tag, item.content, end_tag]))
         else:

--- a/pydantic_ai_slim/pydantic_ai/profiles/grok.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/grok.py
@@ -48,6 +48,21 @@ class GrokModelProfile(ModelProfile):
     grok_reasoning_efforts: frozenset[GrokReasoningEffort] = frozenset()
     """Native `reasoning_effort` values supported by the Grok model."""
 
+    grok_send_back_thinking_parts: Literal['auto', 'tags'] = 'auto'
+    """How unsigned or foreign-provider thinking parts in history are sent back to xAI.
+
+    Signed, same-provider thinking parts are always sent back natively via `reasoning_content`/
+    `encrypted_content`. This setting only governs parts that *can't* be sent natively — those without a
+    signature, or produced by a different provider (e.g. another model in a `FallbackModel` chain, or
+    rebuilt by a history processor):
+
+    * `'auto'` (default): such parts are dropped. xAI does not re-absorb `<think>` tags from history, so
+    re-rendering them as text teaches the model to mimic the format in its user-visible answers, leaking
+    reasoning to end users.
+    * `'tags'`: such parts are re-rendered as text wrapped in the `thinking_tags`, the behavior from
+    before this setting existed.
+    """
+
 
 def grok_model_profile(model_name: str) -> ModelProfile | None:
     """Get the model profile for a Grok model."""

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -3825,7 +3825,8 @@ async def test_xai_thinking_part_in_message_history(allow_model_requests: None):
     # Include user-supplied `<think>` tags to confirm they are treated as plain user text.
     result2 = await agent.run('Second question <think>user think</think>', message_history=message_history)
 
-    # Verify kwargs - second call should have ThinkingPart mapped with reasoning_content
+    # Verify kwargs - the unsigned, foreign-provider thinking part is dropped by default
+    # (`grok_send_back_thinking_parts='auto'`) rather than re-rendered as `<think>` text.
     assert get_mock_chat_create_kwargs(mock_client) == snapshot(
         [
             {
@@ -3841,18 +3842,6 @@ async def test_xai_thinking_part_in_message_history(allow_model_requests: None):
                 'model': XAI_REASONING_MODEL,
                 'messages': [
                     {'content': [{'text': 'First question'}], 'role': 'ROLE_USER'},
-                    {
-                        'content': [
-                            {
-                                'text': """\
-<think>
-First reasoning
-</think>\
-"""
-                            }
-                        ],
-                        'role': 'ROLE_ASSISTANT',
-                    },
                     {'content': [{'text': 'first response'}], 'role': 'ROLE_ASSISTANT'},
                     {'content': [{'text': 'Second question <think>user think</think>'}], 'role': 'ROLE_USER'},
                 ],
@@ -3919,6 +3908,48 @@ First reasoning
             ),
         ]
     )
+
+
+async def test_xai_send_back_thinking_parts_tags(allow_model_requests: None):
+    """`grok_send_back_thinking_parts='tags'` re-renders unsigned/foreign thinking parts as `<think>` text."""
+    response1 = create_response(
+        content='first response',
+        reasoning_content='First reasoning',
+        usage=create_usage(prompt_tokens=10, completion_tokens=5),
+    )
+    response2 = create_response(
+        content='second response',
+        usage=create_usage(prompt_tokens=20, completion_tokens=5),
+    )
+
+    mock_client = MockXai.create_mock([response1, response2])
+    profile = GrokModelProfile(grok_send_back_thinking_parts='tags')
+    m = XaiModel(XAI_REASONING_MODEL, provider=XaiProvider(xai_client=mock_client), profile=profile)
+    agent = Agent(m)
+
+    result1 = await agent.run('First question')
+    result2 = await agent.run('Second question', message_history=result1.new_messages())
+
+    assert get_mock_chat_create_kwargs(mock_client)[1]['messages'] == snapshot(
+        [
+            {'content': [{'text': 'First question'}], 'role': 'ROLE_USER'},
+            {
+                'content': [
+                    {
+                        'text': """\
+<think>
+First reasoning
+</think>\
+"""
+                    }
+                ],
+                'role': 'ROLE_ASSISTANT',
+            },
+            {'content': [{'text': 'first response'}], 'role': 'ROLE_ASSISTANT'},
+            {'content': [{'text': 'Second question'}], 'role': 'ROLE_USER'},
+        ]
+    )
+    assert result2.output == 'second response'
 
 
 async def test_xai_thinking_part_with_content_and_signature_in_history(allow_model_requests: None):


### PR DESCRIPTION
Fixes #5927 (scoped to xai).

Unsigned or foreign-provider `ThinkingPart`s in history were re-rendered as literal `<think>...</think>` text in the xAI assistant turn. Since xAI reads reasoning from native fields and does not re-absorb `<think>` tags, the model mimics the format into its user-visible answer, leaking reasoning to end users; the same class of bug fixed for Anthropic/Bedrock in #5920.

This mirrors #5920's approach: a `grok_send_back_thinking_parts: Literal['auto', 'tags'] = 'auto'` profile setting (using `GrokModelProfile`'s `grok_` prefix convention). `'auto'` (the default) drops such parts; `'tags'` restores the previous re-render. Signed, same-provider parts still round-trip natively via `reasoning_content`/`encrypted_content`.

Scoped to xai, the one provider the issue's verification table confirms leaks. groq is conditional on `groq_reasoning_format` and huggingface is unverified on the re-absorption half, so they are left out following #5920's narrowest-fix-first discipline.

Tests: updated the existing message-history snapshot to reflect the drop, added `test_xai_send_back_thinking_parts_tags` for the opt-in. `test_xai.py` passes (110) and ruff is clean.

Note: #5920 (the Anthropic blueprint this follows) is still open; happy to align on naming/scope or rebase once it lands.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

