### PR TITLE
fix(litellm): default openai_chat_supports_multiple_system_messages=False for models without recognized provider prefix

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/litellm.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/litellm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+from dataclasses import replace
 from typing import overload
 
 from httpx import AsyncClient as AsyncHTTPClient
@@ -67,12 +68,14 @@ class LiteLLMProvider(Provider[AsyncOpenAI]):
         }
 
         profile = None
+        has_recognized_prefix = False
 
         # Check if model name contains a provider prefix (e.g., "anthropic/claude-3")
         if '/' in model_name:
             provider_prefix, model_suffix = model_name.split('/', 1)
             if provider_prefix in provider_to_profile:
                 profile = provider_to_profile[provider_prefix](model_suffix)
+                has_recognized_prefix = True
 
         # If no profile found, default to OpenAI profile
         if profile is None:
@@ -80,7 +83,15 @@ class LiteLLMProvider(Provider[AsyncOpenAI]):
 
         # As LiteLLMProvider is used with OpenAIModel, which uses OpenAIJsonSchemaTransformer,
         # we maintain that behavior
-        return OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+        result = OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer).update(profile)
+
+        # Models without a recognized provider prefix are often custom backends (e.g. vLLM deployments)
+        # that require exactly one system message at the start of the conversation. Default to merging
+        # consecutive system messages to avoid "System message must be at the beginning" errors.
+        if not has_recognized_prefix:
+            result = replace(result, openai_chat_supports_multiple_system_messages=False)
+
+        return result
 
     @overload
     def __init__(

--- a/tests/providers/test_litellm.py
+++ b/tests/providers/test_litellm.py
@@ -135,6 +135,27 @@ def test_model_profile_with_different_models(mocker: MockerFixture):
     mock_profiles['openai'].assert_called_once_with('unknown-provider/some-model')
 
 
+def test_model_profile_multiple_system_messages():
+    """Models without a recognized provider prefix default to merging system messages (vLLM compat)."""
+    provider = LiteLLMProvider(api_key='test-key')
+
+    # No prefix → conservative default for strict backends (e.g. vLLM)
+    for model in ['my-custom-model', 'llama2-70b', 'gpt-3.5-turbo']:
+        profile = provider.model_profile(model)
+        assert isinstance(profile, OpenAIModelProfile)
+        assert profile.openai_chat_supports_multiple_system_messages is False, model
+
+    # Unknown prefix → also conservative
+    profile = provider.model_profile('unknown-provider/some-model')
+    assert isinstance(profile, OpenAIModelProfile)
+    assert profile.openai_chat_supports_multiple_system_messages is False
+
+    # Recognized provider prefix → use the provider's own setting (True for openai)
+    profile = provider.model_profile('openai/gpt-4o')
+    assert isinstance(profile, OpenAIModelProfile)
+    assert profile.openai_chat_supports_multiple_system_messages is True
+
+
 async def test_create_http_client_usage(mocker: MockerFixture):
     # Create a real AsyncClient for the mock
     async with httpx.AsyncClient() as mock_client:


### PR DESCRIPTION
## Summary

Fixes #5812.

When `LiteLLMProvider` is used with a model that has no recognized provider prefix (e.g. a bare model name like `my-vllm-model` for a custom vLLM deployment), the backend often rejects multiple consecutive system messages with `400 Bad Request: System message must be at the beginning`. The `OpenAIModelProfile.openai_chat_supports_multiple_system_messages` docstring already notes this: _"Set to `False` for strict OpenAI-compatible backends (e.g. some LiteLLM/vLLM deployments)"_.

## Changes

**`pydantic_ai_slim/pydantic_ai/providers/litellm.py`**
- Track whether the model name had a recognized provider prefix (e.g. `openai/`, `anthropic/`)
- For models **without** a recognized prefix, override `openai_chat_supports_multiple_system_messages=False` after building the profile, causing consecutive leading system messages to be merged before the request is sent
- Models **with** a recognized prefix (e.g. `openai/gpt-4o`, `anthropic/claude-3`) keep their provider-specific setting unchanged

**`tests/providers/test_litellm.py`**
- New test `test_model_profile_multiple_system_messages` verifying the correct value for bare names, unknown prefixes, and recognized prefixes

## Behaviour

| Model name | `openai_chat_supports_multiple_system_messages` | Why |
|---|---|---|
| `my-vllm-model` | `False` (new) | No prefix — conservative default for strict backends |
| `unknown-provider/model` | `False` (new) | Unrecognized prefix — treated as custom |
| `openai/gpt-4o` | `True` (unchanged) | Known prefix, OpenAI profile preserved |
| `anthropic/claude-3` | `True` (unchanged) | Known prefix, Anthropic profile preserved |

The manual workaround from the issue (passing `OpenAIModelProfile(openai_chat_supports_multiple_system_messages=False)`) still works and takes precedence over the provider default.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/5999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

