### PR TITLE
CI: pilot migrating paid test runners from Depot to Ubicloud

### DIFF
--- a/.github/scripts/ci_duration.py
+++ b/.github/scripts/ci_duration.py
@@ -462,6 +462,8 @@ def parse_runner_class(runner_group_name: str | None, runner_name: str | None, l
     lower_values = ' '.join([runner_group_name or '', runner_name or '', *label_values]).lower()
     if 'depot' in lower_values:
         return 'depot'
+    if 'ubicloud' in lower_values:
+        return 'ubicloud'
     if 'github actions' in lower_values or 'ubuntu' in lower_values:
         return 'github-hosted'
     if 'self-hosted' in lower_values:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
 
   test:
     name: test on ${{ matrix.python-version }} (${{ matrix.install.name }})
-    # Use Depot 4-core runners for all-extras (the slowest variant) when run by maintainers or opted in via 'ci:fast' label
-    # Use 'ci:slow' label to force standard GitHub runners (e.g. during Depot outages)
+    # Use Ubicloud 4-core runners for all-extras (the slowest variant) when run by maintainers or opted in via 'ci:fast' label
+    # Use 'ci:slow' label to force standard GitHub runners (e.g. during Ubicloud outages)
     runs-on: >-
       ${{
         !contains(github.event.pull_request.labels.*.name, 'ci:slow')
@@ -105,7 +105,7 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
-        && 'depot-ubuntu-24.04-4'
+        && 'ubicloud-premium-4'
         || 'ubuntu-latest'
       }}
     timeout-minutes: 20
@@ -161,8 +161,8 @@ jobs:
 
   test-lowest-versions:
     name: test on ${{ matrix.python-version }} (lowest-versions)
-    # Use Depot 4-core runners for maintainers or opted in via 'ci:fast' label
-    # Use 'ci:slow' label to force standard GitHub runners (e.g. during Depot outages)
+    # Use Ubicloud 4-core runners for maintainers or opted in via 'ci:fast' label
+    # Use 'ci:slow' label to force standard GitHub runners (e.g. during Ubicloud outages)
     runs-on: >-
       ${{
         !contains(github.event.pull_request.labels.*.name, 'ci:slow')
@@ -170,7 +170,7 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
-        && 'depot-ubuntu-24.04-4'
+        && 'ubicloud-premium-4'
         || 'ubuntu-latest'
       }}
     timeout-minutes: 20


### PR DESCRIPTION
## What

Pilot: migrate the **paid** CI runners in `ci.yml` from Depot to Ubicloud. Swaps the conditional `depot-ubuntu-24.04-4` label to `ubicloud-premium-4` in the only two jobs that use paid compute:

- `test` — the `all-extras` matrix variant (5 Python versions)
- `test-lowest-versions` (5 Python versions)

Everything else already runs on free GitHub-hosted `ubuntu-latest` (this is a public repo) and is **unchanged**.

Also teaches `.github/scripts/ci_duration.py` to bucket the new runner as `ubicloud` (instead of `unknown`) so the CI duration report keeps tracking it.

## Why

We want to feel out the cost/benefit of Ubicloud before touching the `platform` monorepo (where the real CI spend is). pydantic-ai is the low-stakes place to pilot — the only paid compute here is these two jobs, gated to maintainer PRs.

- New Ubicloud customers must use the `premium` tier — `standard` was deprecated for new signups in June 2026.

## Pilot results ✅ (cheaper AND faster)

Durations summed across the 5-Python matrix (Depot = median of last 3 maintainer PRs; Ubicloud = this PR):

| Job group (5 Pythons) | Depot | Ubicloud | Wall-clock | Depot cost | Ubicloud cost | Saved |
|---|---|---|---|---|---|---|
| `all-extras` | 39.8 min | 31.6 min | 21% faster | $0.318 | $0.101 | 68% |
| `test-lowest-versions` | 49.5 min | 34.3 min | 31% faster | $0.396 | $0.110 | 72% |
| **Per run (10 jobs)** | **89.3 min** | **65.9 min** | **26% faster** | **$0.714** | **$0.211** | **~70%** |

~70% cost cut = 60% from the rate ($0.0032 vs $0.008/min) + ~26% fewer minutes (faster Ryzen 9 premium hardware). All 10 jobs green — correctness parity.

## Unchanged / safety

- Same gating: only same-repo PRs (or `ci:fast`-labelled) hit the paid runner; fork PRs and `ci:slow` fall back to `ubuntu-latest`. Untrusted fork code never runs on the paid fleet.
- The `ci:slow` label remains the outage escape hatch (now for Ubicloud outages).

## Setup (done)

- [x] Ubicloud account + card
- [x] **Ubicloud Managed Runners** GitHub App installed on the `pydantic` org (all repos)

No repo secret needed — Ubicloud auths via the GitHub App.

## Follow-ups (not in this PR)

- Update the `ci:fast` / `ci:slow` label descriptions (still say "Depot").
- If this holds up over a week of real PRs, do the same swap in the `platform` monorepo (bigger savings; keep Depot **Build** for multi-arch images there).
