### PR TITLE
CI: use all vCPUs on Ubicloud test runners (-n logical), ~39% faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,11 @@ jobs:
           restore-keys: |
             hf-${{ runner.os }}-
 
-      - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n auto --dist=loadgroup
+      # `-n logical`, not `-n auto`: xdist `auto` counts *physical* cores, which
+      # under-subscribes Ubicloud's hyperthreaded vCPUs (premium-4 -> 2 workers
+      # instead of 4). `logical` uses all vCPUs; ~39% faster on premium-4, no-op
+      # on ubuntu-latest (already 4). See PR benchmark.
+      - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-${{ matrix.install.name }}
 
@@ -206,7 +210,8 @@ jobs:
         env:
           UV_FROZEN: "0"
 
-      - run: uv run --no-sync coverage run -m pytest --durations=100 -n auto --dist=loadgroup
+      # `-n logical` (see note on the `test` job): use all vCPUs on Ubicloud.
+      - run: uv run --no-sync coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{matrix.python-version}}-lowest-versions
 


### PR DESCRIPTION
## What
Switch the two Ubicloud-capable pytest invocations (`test` all-extras and `test-lowest-versions`) from `-n auto` to **`-n logical`** so they use all vCPUs.

## Why
`pytest-xdist -n auto` counts **physical** cores. Ubicloud `premium-4` presents as **2 physical / 4 logical** cores, so `auto` spawned only **2 xdist workers** — while free `ubuntu-latest` gets **4**. We were paying for premium runners and getting half the test parallelism.

## Benchmark (all-extras suite, py3.12, real Ubicloud runs)
| Config | Wall-clock | vs current | $/min | Cost/job |
|---|---|---|---|---|
| premium-4 `-n auto` (current) | 489s | — | 0.0032 | $0.0261 |
| **premium-4 `-n logical` (this PR)** | **298s** | **−39%** | 0.0032 | **$0.0159** |
| premium-8 `-n 8` | 257s | −47% | 0.0064 | $0.0274 |

**39% faster and 39% cheaper** on the same runner. (Premium-8 was only 14% faster than this for 72% more cost — the workload caps out ~4 workers — so we stay on premium-4.)

`-n logical` is a no-op on `ubuntu-latest` (already 4 workers), so the non-all-extras `test` variants and the `ci:slow`/fork fallback are unaffected.

## Not in this PR — separate llama-cpp follow-up
The slowest leg, `test on 3.12 (lowest-versions)`, also spends **~191s building `llama-cpp-python==0.3.31` from source every run** (`12:47:38 → 12:50:49`). Root cause: it's a *transitive* dep (via `outlines[llamacpp]`), so `--resolution lowest-direct` doesn't lower it — it resolves to the latest release, which has no PyPI wheel and churns constantly, defeating the uv cache. Fixing that (e.g. installing from the prebuilt CPU wheel index, or constraining the version) is a dependency-policy change, so it's split out.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

