### PR TITLE
[EXPERIMENT — do not merge] standard-4 vs premium-4 end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,11 @@ jobs:
           restore-keys: |
             hf-${{ runner.os }}-
 
-      - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n auto --dist=loadgroup
+      # `-n logical`, not `-n auto`: xdist `auto` counts *physical* cores, which
+      # under-subscribes Ubicloud's hyperthreaded vCPUs (premium-4 -> 2 workers
+      # instead of 4). `logical` uses all vCPUs; ~39% faster on premium-4, no-op
+      # on ubuntu-latest (already 4). See PR benchmark.
+      - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-${{ matrix.install.name }}
 
@@ -206,7 +210,8 @@ jobs:
         env:
           UV_FROZEN: "0"
 
-      - run: uv run --no-sync coverage run -m pytest --durations=100 -n auto --dist=loadgroup
+      # `-n logical` (see note on the `test` job): use all vCPUs on Ubicloud.
+      - run: uv run --no-sync coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{matrix.python-version}}-lowest-versions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
-        && 'ubicloud-premium-4'
+        && 'ubicloud-standard-4'
         || 'ubuntu-latest'
       }}
     timeout-minutes: 20
@@ -174,7 +174,7 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
-        && 'ubicloud-premium-4'
+        && 'ubicloud-standard-4'
         || 'ubuntu-latest'
       }}
     timeout-minutes: 20


### PR DESCRIPTION
Throwaway: identical to #6001 (`-n logical`) but on `ubicloud-standard-4` instead of premium-4, to measure real end-to-end time-to-green vs cost. Will close + delete branch after.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

