### PR TITLE
CI: install llama-cpp-python from prebuilt wheel in lowest-versions (kill ~190s/run source build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,16 @@ jobs:
           restore-keys: |
             hf-${{ runner.os }}-
 
-      - run: uv sync --all-extras --no-extra outlines-vllm-offline --resolution lowest-direct
+      # llama-cpp-python ships sdist-only on PyPI, so `--resolution lowest-direct`
+      # floats its (transitive) version to the latest release and recompiles it
+      # (~3 min) on every run — the build never caches because the version churns.
+      # Install the prebuilt CPU wheel from the maintainer's official index and
+      # forbid source builds, so uv picks the newest version that ships a wheel.
+      # CI-only: not applied to local dev or the published package metadata.
+      - run: >-
+          uv sync --all-extras --no-extra outlines-vllm-offline --resolution lowest-direct
+          --index https://abetlen.github.io/llama-cpp-python/whl/cpu
+          --no-build-package llama-cpp-python
         env:
           UV_FROZEN: "0"
 


### PR DESCRIPTION
## What
The `test-lowest-versions` CI job spends **~190s compiling `llama-cpp-python` from source on every run** — it's the biggest chunk of the slowest job on the critical path.

## Why it happens
`llama-cpp-python` is a *transitive* dep (via `outlines[llamacpp]`) that ships **sdist-only on PyPI** (zero wheels). Under `--resolution lowest-direct` it isn't lowered (only direct deps are), so it floats to the **latest** release and recompiles every run — the build never caches because the resolved version churns.

## Fix
Add the maintainer's official prebuilt **CPU wheel index** plus `--no-build-package llama-cpp-python` to the lowest-versions `uv sync`. uv then installs the **newest version that ships a wheel** (currently 0.3.30) instead of building the latest sdist. Validated locally: `llama-cpp-python 0.3.16 → 0.3.30`, no source build.

- **No version pin** — it still floats to whatever the wheel index's latest is.
- **CI-only** — the flags are on the workflow command, *not* in `pyproject.toml`/`uv.lock`, so **local dev and the published package are unaffected** (users still resolve `llama-cpp-python` from PyPI as before). Deliberately kept out of dev: the build is a one-time local cost there, and not pulling from an external index on dev machines is the safer supply-chain scoping.

## Supply chain
The index (`abetlen.github.io/llama-cpp-python/whl/cpu`) is the **package author's own** official wheel channel — the same code you already build + run from his PyPI sdist, just precompiled. HTTPS/GitHub-hosted, and `uv.lock` hash-pins the frozen jobs.

## Expected impact
Slowest critical-path leg (`test on 3.12 (lowest-versions)`) drops by ~190s; end-to-end to green improves accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

