### PR TITLE
Convert `ExceptionGroup`-wrapped tool errors to `ModelRetry` in `MCPToolset`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -1202,6 +1202,24 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 if self.tool_error_behavior == 'retry':
                     raise exceptions.ModelRetry(message=str(e)) from e
                 raise
+            except _utils.BaseExceptionGroup as eg:
+                # The FastMCP client runs the MCP session in an anyio task group, so a tool/protocol
+                # error can surface wrapped in an `ExceptionGroup` rather than as a bare
+                # `ToolError`/`McpError`. This has been observed in production (an empty-bodied tool
+                # error racing with the session's GET-stream teardown), though the exact frame it
+                # unwinds from is not pinned down — so this is a best-effort guard: when the group
+                # contains only tool/protocol errors, treat it like the bare case above; otherwise
+                # re-raise unchanged so a concurrent cancellation grouped alongside is never swallowed.
+                if self.tool_error_behavior != 'retry':
+                    raise
+                matched, rest = eg.split((ToolError, mcp_exceptions.McpError))
+                if matched is None or rest is not None:
+                    raise
+                # `matched` holds only tool/protocol errors; descend through any nesting to a leaf.
+                error: BaseException = matched
+                while isinstance(error, _utils.BaseExceptionGroup):
+                    error = error.exceptions[0]
+                raise exceptions.ModelRetry(message=str(error)) from eg
 
         # Prefer structured content if all parts are text (per the docs they contain the JSON-encoded
         # structured content for backward compatibility).

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -17,12 +17,14 @@ from tempfile import TemporaryDirectory
 from typing import Any
 from unittest.mock import AsyncMock
 
+import anyio
 import httpx
 import pytest
 from inline_snapshot import snapshot
 
 from pydantic_ai import models
 from pydantic_ai._run_context import RunContext
+from pydantic_ai._utils import BaseExceptionGroup
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
@@ -478,6 +480,75 @@ class TestMCPToolsetIntegration:
             tools = await toolset.get_tools(run_context)
             with pytest.raises(ToolError):
                 await toolset.call_tool('boom', {}, run_context, tools['boom'])
+
+    @pytest.mark.parametrize(
+        'leaf_factory',
+        [
+            pytest.param(lambda: ToolError('grouped tool error'), id='tool-error'),
+            pytest.param(lambda: McpError(mcp_types.ErrorData(code=400, message='grouped tool error')), id='mcp-error'),
+        ],
+    )
+    async def test_call_tool_unwraps_real_exception_group_to_model_retry(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext, leaf_factory: Any
+    ):
+        """A tool/protocol error that surfaces wrapped in an `ExceptionGroup` is converted to a
+        recoverable `ModelRetry`, not a fatal crash.
+
+        This is a unit test because the wrapping is a timing-dependent race in the MCP client's
+        anyio task group (an empty-bodied tool error colliding with the session's GET-stream
+        teardown) that can't be triggered deterministically. Rather than hand-build the group, we
+        inject a failure at the real escape seam — `self.client.call_tool` — and let a genuine
+        `anyio` task group produce the `ExceptionGroup`, so its structure matches production.
+        """
+        toolset = MCPToolset(fastmcp_server)
+
+        async def call_tool_in_failing_task_group(*args: Any, **kwargs: Any) -> Any:
+            async def fail() -> None:
+                raise leaf_factory()
+
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(fail)
+
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            toolset.client.call_tool = call_tool_in_failing_task_group
+            with pytest.raises(ModelRetry, match='grouped tool error'):
+                await toolset.call_tool('echo', {'message': 'hi'}, run_context, tools['echo'])
+
+    async def test_call_tool_reraises_grouped_errors_it_must_not_convert(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext
+    ):
+        """Groups we must not silently turn into a retry are re-raised unchanged: a group that also
+        contains a non-tool error, and (with `tool_error_behavior='error'`) any grouped tool error."""
+
+        def failing_call_tool(*excs: BaseException) -> Any:
+            async def call_tool(*args: Any, **kwargs: Any) -> Any:
+                async def fail(exc: BaseException) -> None:
+                    raise exc
+
+                async with anyio.create_task_group() as tg:
+                    for exc in excs:
+                        tg.start_soon(fail, exc)
+
+            return call_tool
+
+        # A mixed group (tool error + an unrelated error) must propagate, not be swallowed.
+        retry_toolset = MCPToolset(fastmcp_server)
+        async with retry_toolset:
+            tools = await retry_toolset.get_tools(run_context)
+            retry_toolset.client.call_tool = failing_call_tool(
+                ToolError('grouped tool error'), ValueError('unrelated failure')
+            )
+            with pytest.raises(BaseExceptionGroup):
+                await retry_toolset.call_tool('echo', {'message': 'hi'}, run_context, tools['echo'])
+
+        # With `tool_error_behavior='error'`, even a pure tool-error group propagates unchanged.
+        error_toolset = MCPToolset(fastmcp_server, tool_error_behavior='error')
+        async with error_toolset:
+            tools = await error_toolset.get_tools(run_context)
+            error_toolset.client.call_tool = failing_call_tool(ToolError('grouped tool error'))
+            with pytest.raises(BaseExceptionGroup):
+                await error_toolset.call_tool('echo', {'message': 'hi'}, run_context, tools['echo'])
 
     async def test_process_tool_call_hook_runs(self, fastmcp_server: FastMCP[None], run_context: RunContext):
         seen: list[tuple[str, dict[str, Any]]] = []


### PR DESCRIPTION
## What

A tool call through `MCPToolset` (the FastMCP-based client, and the only MCP client `load_mcp_toolsets` builds) can fail with the underlying error **wrapped in an `ExceptionGroup`** (`"unhandled errors in a TaskGroup"`) rather than as a bare `ToolError`/`McpError`, because the MCP client session runs inside an anyio task group. The existing `except ToolError` in `MCPToolset._call_tool` doesn't match an `ExceptionGroup`, so the error escaped as a fatal exception out of `agent.run()` instead of being converted to a recoverable `ModelRetry`.

This was discovered by this repo's own **Pydantic AI PR Review** workflow (gh-aw), whose runner *is* a Pydantic AI agent: when the reviewer had nothing to flag it submitted an empty-bodied review, the gh-aw safe-outputs server rejected it with `ERR_VALIDATION`, and the resulting error came back wrapped in an `ExceptionGroup` — crashing the agent on every retry (`is_error`, 0 tokens) instead of being a recoverable retry the model could resolve.

## Fix

Add an `except BaseExceptionGroup` alongside the existing `except ToolError` in `MCPToolset._call_tool`, around `await self.client.call_tool(...)`:

- `eg.split((ToolError, McpError))` separates tool/protocol errors from anything else.
- Group of **only** `ToolError`/`McpError` → descend to the leaf and convert to `ModelRetry` (matching the bare case; honors `tool_error_behavior='error'`, which still propagates).
- Otherwise re-raise unchanged, so a concurrent `CancelledError` (or anything else) grouped alongside is never swallowed.

3.10-compatible via the repo's existing `_utils.BaseExceptionGroup`.

> **Note — earlier revision.** A previous version of this PR placed the guard on `MCPServer.direct_call_tool`. That class is **deprecated** and `load_mcp_toolsets` never instantiates it, so the guard never ran on the path the workflow actually hits. It has been moved to `MCPToolset`, the live FastMCP path.

## What's proven vs. defended

The production run artifact proves the failure shape — `ExceptionGroup([McpError])` escaping `agent.run()` on the `MCPToolset` path. The **exact frame it unwinds from** (the guarded `await self.client.call_tool` vs. the session-context exit) and the **task-group race that births it** (an empty-bodied tool error colliding with the session's GET-stream teardown) are **inferred, not reproduced** — every faithful local reproduction, at the exact failing versions, converted cleanly. So this is a deliberately **defensive** guard, strictly safer than the status quo. Capturing the real traceback in the gh-aw shim (a separate change) would let us confirm the placement.

## Tests

`tests/test_mcp_toolset.py::TestMCPToolsetIntegration::test_call_tool_unwraps_real_exception_group_to_model_retry` — drives the in-process FastMCP toolset, injecting a failure at the real seam (`self.client.call_tool`) and letting a **genuine `anyio` task group** produce the `ExceptionGroup` (parametrized over `ToolError` and the production-realistic `McpError`), then asserts `ModelRetry`. Unit test because the wrapping race can't be triggered deterministically; verified it fails without the guard.

No public API or behavior change a user configures, so no docs update.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).