### PR TITLE
docs: fix multi-agent graph link

### DIFF
--- a/docs/multi-agent-applications.md
+++ b/docs/multi-agent-applications.md
@@ -5,7 +5,7 @@ There are roughly five levels of complexity when building applications with Pyda
 1. Single agent workflows — what most of the `pydantic_ai` documentation covers
 2. [Agent delegation](#agent-delegation) — agents using another agent via tools
 3. [Programmatic agent hand-off](#programmatic-agent-hand-off) — one agent runs, then application code calls another agent
-4. [Graph based control flow](graph.md) — for the most complex cases, a graph-based state machine can be used to control the execution of multiple agents
+4. [Graph based control flow](https://ai.pydantic.dev/graph) — for the most complex cases, a graph-based state machine can be used to control the execution of multiple agents
 5. [Deep Agents](#deep-agents) — autonomous agents with planning, file operations, task delegation, and sandboxed code execution
 
 Of course, you can combine multiple strategies in a single application.
@@ -321,7 +321,7 @@ graph TB
 
 ## Pydantic Graphs
 
-See the [graph](graph.md) documentation on when and how to use graphs.
+See the [graph](https://ai.pydantic.dev/graph) documentation on when and how to use graphs.
 
 ## Deep Agents
 


### PR DESCRIPTION
﻿- Closes #6005

Fixes the graph links on the multi-agent applications guide to use the canonical Pydantic AI graph docs entry point. The previous relative `graph.md` link resolves to a 404 on the published `pydantic.dev/docs/ai` site.

Verification:
- `git diff --check`
- `curl.exe -I -L https://ai.pydantic.dev/graph` returns a 301 to `https://pydantic.dev/docs/ai/graph/graph/`, then 200
- `PYTHONUTF8=1 python -m uv run mkdocs build --strict` was attempted locally, but did not complete cleanly because this Windows environment hit an external mkdocstrings inventory fetch error for `https://modelcontextprotocol.github.io/python-sdk/objects.inv` and existing CairoSVG/libcairo warnings unrelated to this link change.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

