### PR TITLE
Fix map `downstream_join_id` double-firing the join on a non-empty iterable

### DIFF
--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -706,20 +706,9 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                             elif isinstance(maybe_overridden_result, JoinItem):
                                 result = maybe_overridden_result
                                 parent_fork_id = self.graph.get_parent_fork(result.join_id).fork_id
-                                for i, x in enumerate(result.fork_stack[::-1]):
-                                    if x.fork_id == parent_fork_id:
-                                        # For non-final joins (those that are intermediate nodes of other joins),
-                                        # preserve the fork stack so downstream joins can still associate with the same fork run
-                                        if self.graph.is_final_join(result.join_id):
-                                            # Final join: remove the parent fork from the stack
-                                            downstream_fork_stack = result.fork_stack[: len(result.fork_stack) - i]
-                                        else:
-                                            # Non-final join: preserve the fork stack
-                                            downstream_fork_stack = result.fork_stack
-                                        fork_run_id = x.node_run_id
-                                        break
-                                else:  # pragma: no cover
-                                    raise RuntimeError('Parent fork run not found')
+                                fork_run_id, downstream_fork_stack = self._resolve_join_fork_run(
+                                    result.join_id, result.fork_stack
+                                )
 
                                 join_node = self.graph.nodes[result.join_id]
                                 assert isinstance(join_node, Join), f'Expected a `Join` but got {join_node}'
@@ -964,6 +953,22 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
         else:
             assert_never(next_node)
 
+    def _resolve_join_fork_run(self, join_id: JoinID, fork_stack: ForkStack) -> tuple[NodeRunID, ForkStack]:
+        """Determine which parent fork run a join item belongs to, and the fork stack its output should run under."""
+        parent_fork_id = self.graph.get_parent_fork(join_id).fork_id
+        for i, x in enumerate(fork_stack[::-1]):
+            if x.fork_id == parent_fork_id:
+                if self.graph.is_final_join(join_id):
+                    # Final join: keep the stack up to and including the parent fork, dropping everything
+                    # below it (the fork that directly produced this item, and any deeper forks).
+                    downstream_fork_stack = fork_stack[: len(fork_stack) - i]
+                else:
+                    # Non-final join (an intermediate node of another join): preserve the fork stack so
+                    # downstream joins can still associate with the same fork run.
+                    downstream_fork_stack = fork_stack
+                return x.node_run_id, downstream_fork_stack
+        raise RuntimeError('Parent fork run not found')  # pragma: no cover
+
     def _get_completed_fork_runs(
         self,
         t: GraphTask,
@@ -1026,11 +1031,17 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
         new_tasks: list[GraphTask] = []
         node_run_id = self.get_next_node_run_id()
         if node.is_map:
-            # If the map specifies a downstream join id, eagerly create a join state for it
+            # If the map specifies a downstream join id, eagerly create a join state for it so that the join
+            # still fires (with its initial value) even when the mapped iterable is empty and no items ever
+            # reach it.
             if (join_id := node.downstream_join_id) is not None:
                 join_node = self.graph.nodes[join_id]
                 assert isinstance(join_node, Join)
-                self.active_reducers[(join_id, node_run_id)] = JoinState(join_node.initial_factory(), fork_stack)
+                child_fork_stack = fork_stack + (ForkStackItem(node.id, node_run_id, 0),)
+                fork_run_id, downstream_fork_stack = self._resolve_join_fork_run(join_id, child_fork_stack)
+                self.active_reducers.setdefault(
+                    (join_id, fork_run_id), JoinState(join_node.initial_factory(), downstream_fork_stack)
+                )
 
             # Eagerly raise a clear error if the input value is not iterable as expected
             if _is_any_iterable(inputs):

--- a/tests/graph/builder/test_broadcast_and_spread.py
+++ b/tests/graph/builder/test_broadcast_and_spread.py
@@ -135,6 +135,41 @@ async def test_map_empty_list():
     assert result == []
 
 
+async def test_map_non_empty_list_with_downstream_join_id():
+    """A non-empty map with `downstream_join_id` must fire the join once with the fully reduced value."""
+    g = GraphBuilder(state_type=CounterState, output_type=list[int])
+
+    @g.step
+    async def produce(ctx: StepContext[CounterState, None, None]) -> list[int]:
+        return [1, 2, 3]
+
+    @g.step
+    async def identity(ctx: StepContext[CounterState, None, int]) -> int:
+        return ctx.inputs
+
+    collect = g.join(reduce_list_append, initial_factory=list[int])
+
+    @g.step
+    async def after_join(ctx: StepContext[CounterState, None, list[int]]) -> list[int]:
+        ctx.state.values.append(len(ctx.inputs))
+        return ctx.inputs
+
+    g.add(g.edge_from(g.start_node).to(produce))
+    g.add_mapping_edge(produce, identity, downstream_join_id=collect.id)
+    g.add(
+        g.edge_from(identity).to(collect),
+        g.edge_from(collect).to(after_join),
+        g.edge_from(after_join).to(g.end_node),
+    )
+
+    graph = g.build()
+    state = CounterState()
+    result = await graph.run(state=state)
+    assert sorted(result) == [1, 2, 3]
+    # `after_join` fired exactly once, with the fully reduced list
+    assert state.values == [3]
+
+
 async def test_nested_broadcasts():
     """Test nested broadcast operations."""
     g = GraphBuilder(state_type=CounterState, output_type=list[int])

--- a/tests/graph/builder/test_broadcast_and_spread.py
+++ b/tests/graph/builder/test_broadcast_and_spread.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import anyio
 import pytest
 
 from pydantic_graph import GraphBuilder, StepContext
@@ -168,6 +169,84 @@ async def test_map_non_empty_list_with_downstream_join_id():
     assert sorted(result) == [1, 2, 3]
     # `after_join` fired exactly once, with the fully reduced list
     assert state.values == [3]
+
+
+async def test_parallel_maps_with_downstream_join_id():
+    """Two independent map-and-join pipelines running in parallel, each with its own `downstream_join_id`.
+
+    Each join uses `preferred_parent_fork='closest'` so its reducer is keyed to its own map's fork run
+    rather than to the shared upstream broadcast; the two reducers therefore have distinct fork run ids and
+    can be active at the same time. When that happens, completing a task in one pipeline triggers a
+    completion check that encounters the *other* pipeline's reducer, whose parent fork run is absent from
+    the completing task's fork stack. That reducer must simply be skipped, and both pipelines must still
+    reduce correctly.
+
+    The two events force the completion order `a[0]` then `b` then `a[1]`, so pipeline A's reducer
+    is still active (awaiting its second item) when pipeline B's item completes — the only situation in
+    which the completion check sees a reducer keyed to a fork run outside the completing task's stack.
+    """
+    g = GraphBuilder(state_type=CounterState, output_type=list[list[int]])
+
+    a_started = anyio.Event()
+    b_done = anyio.Event()
+
+    @g.step
+    async def seed(ctx: StepContext[CounterState, None, None]) -> int:
+        return 0
+
+    @g.step
+    async def produce_a(ctx: StepContext[CounterState, None, int]) -> list[int]:
+        return [1, 2]
+
+    @g.step
+    async def produce_b(ctx: StepContext[CounterState, None, int]) -> list[int]:
+        return [3]
+
+    @g.step
+    async def identity_a(ctx: StepContext[CounterState, None, int]) -> int:
+        if ctx.inputs == 1:
+            a_started.set()  # pipeline A's reducer is about to be created
+        else:
+            await b_done.wait()  # hold A's second item until pipeline B has completed
+        return ctx.inputs
+
+    @g.step
+    async def identity_b(ctx: StepContext[CounterState, None, int]) -> int:
+        await a_started.wait()  # let pipeline A's reducer come into existence first
+        b_done.set()
+        return ctx.inputs
+
+    join_a = g.join(reduce_list_append, initial_factory=list[int], preferred_parent_fork='closest')
+    join_b = g.join(reduce_list_append, initial_factory=list[int], preferred_parent_fork='closest')
+    combine = g.join(reduce_list_append, initial_factory=list[list[int]])
+
+    @g.step
+    async def emit_a(ctx: StepContext[CounterState, None, list[int]]) -> list[int]:
+        return sorted(ctx.inputs)
+
+    @g.step
+    async def emit_b(ctx: StepContext[CounterState, None, list[int]]) -> list[int]:
+        return sorted(ctx.inputs)
+
+    g.add(
+        g.edge_from(g.start_node).to(seed),
+        g.edge_from(seed).to(produce_a, produce_b),
+    )
+    g.add_mapping_edge(produce_a, identity_a, downstream_join_id=join_a.id)
+    g.add_mapping_edge(produce_b, identity_b, downstream_join_id=join_b.id)
+    g.add(
+        g.edge_from(identity_a).to(join_a),
+        g.edge_from(identity_b).to(join_b),
+        g.edge_from(join_a).to(emit_a),
+        g.edge_from(join_b).to(emit_b),
+        g.edge_from(emit_a).to(combine),
+        g.edge_from(emit_b).to(combine),
+        g.edge_from(combine).to(g.end_node),
+    )
+
+    graph = g.build()
+    result = await graph.run(state=CounterState())
+    assert sorted(result) == [[1, 2], [3]]
 
 
 async def test_nested_broadcasts():


### PR DESCRIPTION
- Closes #6008

## Summary

With the builder graph API, `add_mapping_edge(..., downstream_join_id=...)` made the node downstream of the join fire **twice** on a non-empty iterable — once with the reducer's initial value and once with the actual reduced result — and the empty initial-value emission could win, silently returning the wrong result. `downstream_join_id` is documented purely as a safeguard for mapping an *empty* iterable, so on a non-empty iterable it should be a no-op.

### Root cause

A join's reducer is keyed by the run id of the join's **parent (dominating) fork**, and live `JoinItem` reductions look that up via `get_parent_fork(join_id)`. But the eager reducer created for a map's `downstream_join_id` (the empty-iterable safeguard) was keyed by the **map fork's own run id** instead. These only coincide when the map fork *is* the join's dominating fork; otherwise you get two reducers for the same join run:

- the eager one, stuck at the initial value, and
- the real one, accumulating the mapped items,

both of which get finalized → the downstream node fires twice.

### Fix

Extract the parent-fork-resolution logic into a shared `_resolve_join_fork_run` helper and use it from both the `JoinItem` path and the eager-create path, so the eager reducer lands on the same key and a non-empty iterable accumulates into a single reducer. The empty-iterable safeguard behavior is unchanged.


### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

