### PR TITLE
Fix `ThinkingPart.id` AG-UI round trip

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -472,7 +472,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     builder.add(
                         ThinkingPart(
                             content=reasoning_msg.content,
-                            id=metadata.get('id'),
+                            id=metadata.get('id') or reasoning_msg.id,
                             signature=metadata.get('signature'),
                             provider_name=metadata.get('provider_name'),
                             provider_details=metadata.get('provider_details'),
@@ -661,7 +661,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     encrypted = thinking_encrypted_metadata(part)
                     result.append(
                         ReasoningMessage(
-                            id=_new_message_id(),
+                            id=part.id or _new_message_id(),
                             content=part.content,
                             encrypted_value=json.dumps(encrypted) if encrypted else None,
                         )

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1608,6 +1608,32 @@ def test_dump_load_roundtrip_thinking() -> None:
     assert reloaded == original
 
 
+def test_dump_load_roundtrip_thinking_without_id_preserves_generated_id() -> None:
+    original: list[ModelMessage] = [ModelResponse(parts=[ThinkingPart(content='Working through it...')])]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original, ag_ui_version='0.1.13')
+    reasoning_msg = next(msg for msg in ag_ui_msgs if isinstance(msg, ReasoningMessage))
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    reloaded_response = reloaded[0]
+
+    assert isinstance(reloaded_response, ModelResponse)
+    assert len(reloaded_response.parts) == 1
+    reloaded_part = reloaded_response.parts[0]
+    assert isinstance(reloaded_part, ThinkingPart)
+    assert reloaded_part.id == reasoning_msg.id
+
+
+def test_dump_messages_thinking_uses_existing_part_id() -> None:
+    ag_ui_msgs = AGUIAdapter.dump_messages(
+        [ModelResponse(parts=[ThinkingPart(content='Working through it...', id='thinking-1')])],
+        ag_ui_version='0.1.13',
+    )
+
+    reasoning_msg = next(msg for msg in ag_ui_msgs if isinstance(msg, ReasoningMessage))
+
+    assert reasoning_msg.id == 'thinking-1'
+
+
 def test_dump_load_roundtrip_tools() -> None:
     """Test full round-trip for tool calls and returns."""
     original: list[ModelMessage] = [


### PR DESCRIPTION
- Closes #5599

This keeps `ThinkingPart.id` stable when messages pass through the AG-UI adapter.

What changed:
- `dump_messages` now uses an existing `ThinkingPart.id` as the `ReasoningMessage.id` instead of always generating a new one.
- `load_messages` now falls back to `ReasoningMessage.id` when the encrypted metadata does not contain an `id`, so generated reasoning IDs survive the round trip.

Tests:
- `uv run pytest tests\test_ag_ui.py::test_dump_load_roundtrip_thinking_without_id_preserves_generated_id tests\test_ag_ui.py::test_dump_messages_thinking_uses_existing_part_id -q`
- `uv run pytest tests\test_ag_ui.py::test_dump_load_roundtrip_thinking_without_id_preserves_generated_id tests\test_ag_ui.py::test_dump_messages_thinking_uses_existing_part_id tests\test_ag_ui.py::test_reasoning_message_thinking_roundtrip tests\test_ag_ui.py::test_dump_load_roundtrip_thinking tests\test_ag_ui.py::test_dump_load_roundtrip_multiple_thinking_parts tests\test_ag_ui.py::test_dump_messages_thinking_version_gated -q`
- `uv run ruff format --check pydantic_ai_slim\pydantic_ai\ui\ag_ui\_adapter.py tests\test_ag_ui.py`
- `uv run ruff check pydantic_ai_slim\pydantic_ai\ui\ag_ui\_adapter.py tests\test_ag_ui.py`
- `uv run pyright pydantic_ai_slim\pydantic_ai\ui\ag_ui\_adapter.py tests\test_ag_ui.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

