### PR TITLE
Fix `group_by_temporal` first group timing

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -323,7 +323,7 @@ async def group_by_temporal(
                 'soft_max_interval must be a positive number'
             )
             buffer: list[T] = []
-            group_start_time = time.monotonic()
+            group_start_time = None
 
             while True:
                 if group_start_time is None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,6 +55,20 @@ async def test_group_by_temporal(interval: float | None, expected: list[list[int
         assert groups == expected
 
 
+async def test_group_by_temporal_starts_first_window_on_first_item():
+    async def yield_groups() -> AsyncIterator[int]:
+        await asyncio.sleep(0.08)
+        yield 1
+        await asyncio.sleep(0.01)
+        yield 2
+        await asyncio.sleep(0.2)
+        yield 3
+
+    async with group_by_temporal(yield_groups(), soft_max_interval=0.04) as groups_iter:
+        groups: list[list[int]] = [g async for g in groups_iter]
+        assert groups == snapshot([[1, 2], [3]])
+
+
 def test_check_object_json_schema():
     object_schema = {'type': 'object', 'properties': {'a': {'type': 'string'}}}
     assert check_object_json_schema(object_schema) == object_schema


### PR DESCRIPTION
- Closes #5946

This fixes `group_by_temporal` so the first group's debounce window starts when the first item arrives, matching the behavior already used after later group resets.

The previous initialization measured the first window from iterator setup time, so a delayed first streamed item could be emitted alone even when the next item arrived within `soft_max_interval`.

Validation:

- `uv run pytest tests/test_utils.py::test_group_by_temporal tests/test_utils.py::test_group_by_temporal_starts_first_window_on_first_item -q`
- manual reproduction script from #5946 now prints `[[1, 2], [3]]`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/_utils.py tests/test_utils.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_utils.py tests/test_utils.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/_utils.py tests/test_utils.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

