### PR TITLE
Fix `downstream_join_id` map reducer reuse

### DIFF
--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -1005,7 +1005,18 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
             if (join_id := node.downstream_join_id) is not None:
                 join_node = self.graph.nodes[join_id]
                 assert isinstance(join_node, Join)
-                self.active_reducers[(join_id, node_run_id)] = JoinState(join_node.initial_factory(), fork_stack)
+                parent_fork_id = self.graph.get_parent_fork(join_id).fork_id
+                for fsi in reversed(fork_stack):
+                    if fsi.fork_id == parent_fork_id:
+                        fork_run_id = fsi.node_run_id
+                        break
+                else:
+                    if node.id == parent_fork_id:
+                        fork_run_id = node_run_id
+                    else:  # pragma: no cover
+                        raise RuntimeError('Parent fork run not found')
+                if (join_id, fork_run_id) not in self.active_reducers:
+                    self.active_reducers[(join_id, fork_run_id)] = JoinState(join_node.initial_factory(), fork_stack)
 
             # Eagerly raise a clear error if the input value is not iterable as expected
             if _is_any_iterable(inputs):

--- a/tests/graph/beta/test_joins_and_reducers.py
+++ b/tests/graph/beta/test_joins_and_reducers.py
@@ -81,6 +81,39 @@ async def test_reduce_list_append():
     assert sorted(result) == ['item-1', 'item-2', 'item-3', 'item-4']
 
 
+async def test_downstream_join_id_non_empty_map_reuses_parent_reducer():
+    """Test that downstream_join_id doesn't fire an empty join before map results."""
+    g = GraphBuilder(output_type=list[int])
+    join_inputs_seen: list[list[int]] = []
+
+    @g.step
+    async def generate_numbers(ctx: StepContext[None, None, None]) -> list[int]:
+        return [1, 2, 3]
+
+    @g.step
+    async def passthrough(ctx: StepContext[None, None, int]) -> int:
+        return ctx.inputs
+
+    collect = g.join(reduce_list_append, initial_factory=list[int])
+
+    @g.step
+    async def after_join(ctx: StepContext[None, None, list[int]]) -> list[int]:
+        join_inputs_seen.append(sorted(ctx.inputs))
+        return ctx.inputs
+
+    g.add(
+        g.edge_from(g.start_node).to(generate_numbers),
+        g.edge_from(generate_numbers).map(downstream_join_id=collect.id).to(passthrough),
+        g.edge_from(passthrough).to(collect),
+        g.edge_from(collect).to(after_join),
+        g.edge_from(after_join).to(g.end_node),
+    )
+
+    result = await g.build().run()
+    assert sorted(result) == [1, 2, 3]
+    assert join_inputs_seen == [[1, 2, 3]]
+
+
 async def test_reduce_dict_update():
     """Test reduce_dict_update that merges dictionaries."""
     g = GraphBuilder(state_type=SimpleState, output_type=dict[str, int])


### PR DESCRIPTION
- Closes #6008

### Summary

This fixes `add_mapping_edge(..., downstream_join_id=...)` for non-empty maps.

The eager reducer state for `downstream_join_id` was keyed by the map fork's run id. Join items later look up reducer state by the join's actual parent fork run id, so a non-empty map could create two reducers: an empty eager reducer and a populated reducer from the mapped items. That made the downstream join run twice and could return the empty initial value.

This changes eager reducer initialization to use the downstream join's parent fork run id and reuses any existing reducer for that `(join_id, fork_run_id)` pair.

### Validation

```bash
uv run pytest tests/graph/beta/test_joins_and_reducers.py::test_downstream_join_id_non_empty_map_reuses_parent_reducer tests/graph/beta/test_broadcast_and_spread.py::test_map_empty_list tests/graph/beta/test_edge_cases.py::test_null_reducer_with_no_inputs -q
uv run pytest tests/graph/beta/test_joins_and_reducers.py tests/graph/beta/test_broadcast_and_spread.py::test_map_empty_list tests/graph/beta/test_edge_cases.py::test_null_reducer_with_no_inputs -q
uv run ruff format --check pydantic_graph/pydantic_graph/graph_builder.py tests/graph/beta/test_joins_and_reducers.py
uv run ruff check pydantic_graph/pydantic_graph/graph_builder.py tests/graph/beta/test_joins_and_reducers.py
PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_graph/pydantic_graph/graph_builder.py tests/graph/beta/test_joins_and_reducers.py
```

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

