### PR TITLE
Fix `RetryPromptPart` partial error round-trip

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1400,7 +1400,10 @@ class NativeToolReturnPart(BaseToolReturnPart):
         return narrower(part) if narrower else part
 
 
-error_details_ta = pydantic.TypeAdapter(list[pydantic_core.ErrorDetails], config=pydantic.ConfigDict(defer_build=True))
+_RetryPromptErrorDetails: TypeAlias = Sequence[dict[str, Any] | pydantic_core.ErrorDetails]
+
+
+error_details_ta = pydantic.TypeAdapter(_RetryPromptErrorDetails, config=pydantic.ConfigDict(defer_build=True))
 
 
 @dataclass(repr=False)
@@ -1419,7 +1422,7 @@ class RetryPromptPart:
     * an output validator raised a [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] exception
     """
 
-    content: list[pydantic_core.ErrorDetails] | str
+    content: _RetryPromptErrorDetails | str
     """Details of why and how the model should retry.
 
     If the retry was triggered by a [`ValidationError`][pydantic_core.ValidationError], this will be a list of

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1610,3 +1610,24 @@ def test_retry_prompt_tool_call_keeps_input_for_nested_errors():
     response = part.model_response()
     assert '"input": 42' in response
     assert '"name"' in response
+
+
+def test_retry_prompt_partial_error_details_round_trip():
+    content: list[dict[str, Any]] = [
+        {'type': 'missing', 'loc': ('without_input',), 'msg': 'Field required'},
+        {'type': 'value_error', 'loc': ('without_ctx_url',), 'msg': 'Value error', 'input': 'bad'},
+        {'type': 'int_parsing', 'loc': ['json', 'list', 0], 'msg': 'Input should be a valid integer', 'input': 'x'},
+    ]
+    message = ModelRequest(parts=[RetryPromptPart(content=content, tool_name='tool', tool_call_id='call_1')])
+
+    serialized = ModelMessagesTypeAdapter.dump_json([message])
+    [deserialized] = ModelMessagesTypeAdapter.validate_json(serialized)
+
+    assert isinstance(deserialized, ModelRequest)
+    [part] = deserialized.parts
+    assert isinstance(part, RetryPromptPart)
+    assert part.content == [
+        {'type': 'missing', 'loc': ['without_input'], 'msg': 'Field required'},
+        {'type': 'value_error', 'loc': ['without_ctx_url'], 'msg': 'Value error', 'input': 'bad'},
+        {'type': 'int_parsing', 'loc': ['json', 'list', 0], 'msg': 'Input should be a valid integer', 'input': 'x'},
+    ]


### PR DESCRIPTION
- Closes #5987

### Summary

`RetryPromptPart.content` was typed as `list[pydantic_core.ErrorDetails] | str`, so message histories containing partial error-detail dicts could be serialized but not loaded again. This made `ModelMessagesTypeAdapter.dump_json(...) -> validate_json(...)` fail when an error entry was missing keys such as `input`, even though these partial shapes can come from persisted history or `ValidationError.errors(...)` variants.

This changes the retry-prompt error-details boundary to accept both canonical `ErrorDetails` entries and plain error-detail dictionaries, while keeping the existing `model_response()` formatting behavior.

### Validation

- `uv run python - <<'PY' ...` repro: before the fix, `validate_json` raised `ValidationError` for missing `input`; after the fix, it reloads the serialized history.
- `uv run pytest tests/test_messages.py::test_retry_prompt_partial_error_details_round_trip tests/test_messages.py::test_retry_prompt_strips_input_from_top_level_errors tests/test_messages.py::test_retry_prompt_keeps_input_for_nested_errors tests/test_messages.py::test_retry_prompt_mixed_top_level_and_nested_errors tests/test_messages.py::test_retry_prompt_strips_input_from_top_level_type_errors tests/test_messages.py::test_retry_prompt_tool_call_keeps_input_at_top_level tests/test_messages.py::test_retry_prompt_tool_call_keeps_input_for_nested_errors -q`
- `uv run pytest tests/test_messages.py -q`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/messages.py pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/tool_manager.py pydantic_ai_slim/pydantic_ai/_output.py tests/test_messages.py tests/test_agent.py tests/test_exceptions.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

