### PR TITLE
ci: try ubicloud-standard-8-arm in place of ubicloud-premium-4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       # under-subscribes Ubicloud's hyperthreaded vCPUs (premium-4 -> 2 workers
       # instead of 4). `logical` uses all vCPUs; ~39% faster on premium-4, no-op
       # on ubuntu-latest (already 4). See PR benchmark.
-      - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n $(($(nproc) * 2)) --dist=loadgroup
+      - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-${{ matrix.install.name }}
 
@@ -220,7 +220,7 @@ jobs:
           UV_FROZEN: "0"
 
       # `-n logical` (see note on the `test` job): use all vCPUs on Ubicloud.
-      - run: uv run --no-sync coverage run -m pytest --durations=100 -n $(($(nproc) * 2)) --dist=loadgroup
+      - run: uv run --no-sync coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{matrix.python-version}}-lowest-versions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       # under-subscribes Ubicloud's hyperthreaded vCPUs (premium-4 -> 2 workers
       # instead of 4). `logical` uses all vCPUs; ~39% faster on premium-4, no-op
       # on ubuntu-latest (already 4). See PR benchmark.
-      - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n logical --dist=loadgroup
+      - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n $(($(nproc) * 2)) --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-${{ matrix.install.name }}
 
@@ -220,7 +220,7 @@ jobs:
           UV_FROZEN: "0"
 
       # `-n logical` (see note on the `test` job): use all vCPUs on Ubicloud.
-      - run: uv run --no-sync coverage run -m pytest --durations=100 -n logical --dist=loadgroup
+      - run: uv run --no-sync coverage run -m pytest --durations=100 -n $(($(nproc) * 2)) --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{matrix.python-version}}-lowest-versions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
-        && 'ubicloud-premium-4'
+        && 'ubicloud-standard-8-arm'
         || 'ubuntu-latest'
       }}
     timeout-minutes: 20
@@ -174,7 +174,7 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
-        && 'ubicloud-premium-4'
+        && 'ubicloud-standard-8-arm'
         || 'ubuntu-latest'
       }}
     timeout-minutes: 20


### PR DESCRIPTION
## Why try this

89% of CI minutes on this repo (n=30 recent main runs) are on the `test` + `test-lowest-versions` matrix, which currently uses the `ubicloud-premium-4` conditional. Swapping to `ubicloud-standard-8-arm` is interesting on three axes:

1. **~same price/min** — 8-core arm is roughly the same cost as 4-core x86 premium on ubicloud.
2. **2× cores** — should offset slower per-core arm performance for parallelizable variants (`pytest -n auto`).
3. **First arm test coverage** — a meaningful chunk of pydantic-ai users run on Mac M-series (developer) and AWS Graviton (production). Today the test matrix has zero arm signal; an arm-specific regression in the dep tree (`pydantic-core` SIMD path, etc.) wouldn't surface until users hit it.

The `|| 'ubuntu-latest'` fork-PR fallback stays as the still-x86 leg, so fork contributors still get free runners and the matrix retains x86 coverage on every untrusted PR.

## What to look at

This PR's own CI is the measurement. Compare wall-clock on:

| variant | premium-4 today (avg) | -8-arm here (TBD) |
|---|---|---|
| `test on 3.12 (lowest-versions)` | ~9:00 | ? |
| `test on 3.12 (all-extras)` | ~8:30 | ? |
| `test on 3.12 (standard)` | ~5:00 | ? |
| `test on 3.12 (pydantic-evals)` | ~2:10 | ? |
| `test on 3.12 (pydantic-ai-slim)` | ~2:10 | ? |

If the long variants land within ~30% of x86 wall-clock, this is a clean win (~30-40% cost reduction on the bulk of CI plus arm coverage). If `lowest-versions` doubles, we revert — or split the matrix to keep `lowest-versions` on premium and the others on arm.

## Revert

One file (`ci.yml`), 2 lines, easy.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

