### PR TITLE
Add scheduled lychee workflow to check docs links

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -11,6 +11,7 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,33 @@
+name: Link check
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # weekly on Monday
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --no-progress --config .github/workflows/lychee.toml './docs/**/*.md' './*.md'
+          fail: false
+
+      - name: Open issue on broken links
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
+        with:
+          title: Broken links found in docs
+          content-filepath: ./lychee/out.md
+          labels: docs

--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -17,11 +17,17 @@ timeout = 30
 exclude_all_private = true
 exclude_loopback = true
 
-# Hosts that flake or hard-block automated checks; not worth failing the run over.
+# Relative doc links are resolved by mkdocs, not as filesystem paths; skip the
+# `file://` links lychee derives from them.
+scheme = ["https", "http"]
+
+# Login-gated or bot-blocking hosts that return non-2xx to automated checks even
+# though the links are valid in a browser; not worth failing the run over.
 exclude = [
   "platform\\.openai\\.com",
   "openai\\.com",
   "console\\.mistral\\.ai",
+  "dash\\.voyageai\\.com",
   "spec\\.modelcontextprotocol\\.io",
   "customerioforms\\.com",
 ]

--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -1,0 +1,27 @@
+# Configuration for the scheduled docs link check (see link-check.yml).
+# Tuned to avoid false positives from sites that block bots or rate-limit, so the
+# issue it opens only lists genuinely broken links.
+
+# Some sites return 403/429 to non-browser clients even though the link is fine.
+accept = ["200..=299", "403", "429"]
+
+# Browser-like UA reduces bot-blocking 403s.
+user_agent = "Mozilla/5.0 (compatible; lychee link checker)"
+
+max_redirects = 10
+max_retries = 3
+retry_wait_time = 2
+timeout = 30
+
+# Don't check localhost example URLs or form-submission endpoints.
+exclude_all_private = true
+exclude_loopback = true
+
+# Hosts that flake or hard-block automated checks; not worth failing the run over.
+exclude = [
+  "platform\\.openai\\.com",
+  "openai\\.com",
+  "console\\.mistral\\.ai",
+  "spec\\.modelcontextprotocol\\.io",
+  "customerioforms\\.com",
+]


### PR DESCRIPTION
Adds a weekly GitHub Action (lychee) that checks all docs links return 2xx and opens an issue listing any that are broken.

There was no automated link checking before, so broken external links (e.g. the temporalio API references fixed in #5740) went unnoticed. mkdocs only validates internal links, and CI builds with `--no-strict`.

- Runs weekly + `workflow_dispatch` (not per-PR, since external links flake and would fail unrelated PRs)
- Checks `docs/**/*.md` and root `*.md`
- Opens a `docs`-labelled issue on failure
- `lychee.toml` tunes out bot-blocking 403s, login redirects, localhost examples, and TLS flakes so the issue stays high-signal

Verified locally: catches the exact 404s #5740 fixes, and surfaces two genuine broken links already in the docs (`docs.x.ai/developers/tools/collection-search`, `www.aci.dev/tools`) which can be fixed separately.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

