### PR TITLE
fix(groq): support image detail via vendor_metadata

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -212,6 +212,7 @@ class FileUrl(ABC):
 
     Supported by:
     - `GoogleModel`: `VideoUrl.vendor_metadata` is used as `video_metadata`: https://ai.google.dev/gemini-api/docs/video-understanding#customize-video-processing
+    - `GroqModel`: `ImageUrl.vendor_metadata['detail']` is used as `detail` setting for images
     - `OpenAIChatModel`, `OpenAIResponsesModel`: `ImageUrl.vendor_metadata['detail']` is used as `detail` setting for images
     - `XaiModel`: `ImageUrl.vendor_metadata['detail']` is used as `detail` setting for images
     """
@@ -525,6 +526,7 @@ class BinaryContent:
 
     Supported by:
     - `GoogleModel`: `BinaryContent.vendor_metadata` is used as `video_metadata`: https://ai.google.dev/gemini-api/docs/video-understanding#customize-video-processing
+    - `GroqModel`: `BinaryContent.vendor_metadata['detail']` is used as `detail` setting for images
     - `OpenAIChatModel`, `OpenAIResponsesModel`: `BinaryContent.vendor_metadata['detail']` is used as `detail` setting for images
     - `XaiModel`: `BinaryContent.vendor_metadata['detail']` is used as `detail` setting for images
     """

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -624,11 +624,15 @@ class GroqModel(Model[AsyncGroq]):
                     if item.force_download:
                         downloaded = await download_item(item, data_format='base64_uri')
                         image_url_str = downloaded['data']
-                    image_url = ImageURL(url=image_url_str)
+                    image_url: ImageURL = {'url': image_url_str}
+                    if metadata := item.vendor_metadata:
+                        image_url['detail'] = metadata.get('detail', 'auto')
                     content.append(chat.ChatCompletionContentPartImageParam(image_url=image_url, type='image_url'))
                 elif isinstance(item, BinaryContent):
                     if item.is_image:
-                        image_url = ImageURL(url=item.data_uri)
+                        image_url: ImageURL = {'url': item.data_uri}
+                        if metadata := item.vendor_metadata:
+                            image_url['detail'] = metadata.get('detail', 'auto')
                         content.append(chat.ChatCompletionContentPartImageParam(image_url=image_url, type='image_url'))
                     else:
                         raise NotImplementedError('Only images are supported for BinaryContent in Groq user prompts')

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -663,6 +663,42 @@ async def test_map_text_content_input(allow_model_requests: None, groq_api_key: 
     )
 
 
+async def test_image_url_detail_vendor_metadata(allow_model_requests: None):
+    part = UserPromptPart(
+        content=[
+            BinaryContent(
+                data=b'fake',
+                media_type='image/png',
+                vendor_metadata={'detail': 'high'}
+            ),
+            ImageUrl(
+                url='http://example.com/redacted',
+                vendor_metadata={'detail': 'low'}
+            )
+        ]
+    )
+    mock_client = MockGroq.create_mock(completion_message(ChatCompletionMessage(content='world', role='assistant')))
+    m = GroqModel('llama-3.3-70b-versatile', provider=GroqProvider(groq_client=mock_client))
+    
+    out: list[Any] = []
+    async for item in m._map_user_message(ModelRequest(parts=[part])):  # pyright: ignore[reportPrivateUsage]
+        out.append(item)
+        
+    assert len(out) == 1
+    user_msg = out[0]
+    assert user_msg['role'] == 'user'
+    
+    content = user_msg['content']
+    assert isinstance(content, list)
+    assert len(content) == 2
+    
+    assert content[0]['type'] == 'image_url'
+    assert content[0]['image_url'].get('detail') == 'high'
+    
+    assert content[1]['type'] == 'image_url'
+    assert content[1]['image_url'].get('detail') == 'low'
+
+
 async def test_image_url_input(allow_model_requests: None, groq_api_key: str):
     m = GroqModel('meta-llama/llama-4-scout-17b-16e-instruct', provider=GroqProvider(api_key=groq_api_key))
     agent = Agent(m)


### PR DESCRIPTION
Fixes #6011.

This PR addresses an issue where the Groq vision model adapter silently dropped the `detail` setting in `vendor_metadata` when providing images. 

### Changes:
- **`models/groq.py`**: Added mapping logic to pass `detail` from `vendor_metadata` into `ImageURL` for both `ImageUrl` and `BinaryContent` parts in `_map_user_prompt`. This matches the parity already established by the OpenAI and xAI adapters.
- **`messages.py`**: Updated the docstrings for `FileUrl.vendor_metadata` and `BinaryContent.vendor_metadata` to include `GroqModel` in the list of models supporting the `detail` parameter.
- **`tests/models/test_groq.py`**: Added `test_image_url_detail_vendor_metadata` to verify that `detail: high` and `detail: low` are correctly wired to the model.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

