### PR TITLE
Buffer partial thinking tags across stream chunks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -322,9 +322,7 @@ class ModelResponsePartsManager:
         buffered = self._thinking_tag_buffer
         self._thinking_tag_buffer = ''
         if self._is_in_embedded_thinking(vendor_part_id):
-            yield from self._append_embedded_thinking_content(
-                vendor_part_id, buffered, provider_name, provider_details
-            )
+            yield from self._append_embedded_thinking_content(vendor_part_id, buffered, provider_name, provider_details)
         else:
             yield from self._handle_plain_text_delta(
                 vendor_part_id=vendor_part_id,
@@ -355,9 +353,12 @@ class ModelResponsePartsManager:
             existing_thinking_part_and_index = self._latest_part_if_of_type(ThinkingPart)
         else:
             part_index = self._vendor_id_to_part_index.get(vendor_part_id)
-            if part_index is None or not isinstance(self._parts[part_index], ThinkingPart):
+            if part_index is None:
                 raise UnexpectedModelBehavior('Cannot append embedded thinking content without a ThinkingPart')
-            existing_thinking_part_and_index = self._parts[part_index], part_index
+            part = self._parts[part_index]
+            if not isinstance(part, ThinkingPart):
+                raise UnexpectedModelBehavior('Cannot append embedded thinking content without a ThinkingPart')
+            existing_thinking_part_and_index = part, part_index
 
         if existing_thinking_part_and_index is None:
             raise UnexpectedModelBehavior('Cannot append embedded thinking content without a ThinkingPart')

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -326,10 +326,9 @@ class ModelResponsePartsManager:
                 vendor_part_id, buffered, provider_name, provider_details
             )
         else:
-            yield from self._handle_text_delta_with_thinking_tags(
+            yield from self._handle_plain_text_delta(
                 vendor_part_id=vendor_part_id,
                 content=buffered,
-                thinking_tags=thinking_tags,
                 id=id,
                 provider_name=provider_name,
                 provider_details=provider_details,

--- a/pydantic_ai_slim/pydantic_ai/_parts_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/_parts_manager.py
@@ -44,6 +44,16 @@ VendorId = Hashable
 Type alias for a vendor identifier, which can be any hashable type (e.g., a string, UUID, etc.)
 """
 
+
+def _suffix_prefix_overlap(text: str, tag: str) -> int:
+    """Return the length of the longest suffix of `text` that is a prefix of `tag`."""
+    max_overlap = min(len(text), len(tag) - 1)
+    for overlap in range(max_overlap, 0, -1):
+        if tag.startswith(text[-overlap:]):
+            return overlap
+    return 0
+
+
 ManagedPart = ModelResponsePart | ToolCallPartDelta
 """
 A union of types that are managed by the ModelResponsePartsManager.
@@ -74,6 +84,8 @@ class ModelResponsePartsManager:
     """Maps a vendor's "part" ID (if provided) to the index in `_parts` where that part resides."""
     _tool_kind_by_name: dict[str, ToolPartKind] = field(default_factory=dict[str, ToolPartKind], init=False, repr=False)
     """Cached `{tool_name: tool_kind}` built from `function_tools` at construction time."""
+    _thinking_tag_buffer: str = field(default='', init=False, repr=False)
+    """Buffered suffix that may be the start of a thinking tag split across stream chunks."""
 
     def __post_init__(self) -> None:
         self._tool_kind_by_name = {
@@ -153,36 +165,49 @@ class ModelResponsePartsManager:
         Raises:
             UnexpectedModelBehavior: If attempting to apply text content to a part that is not a TextPart.
         """
+        if thinking_tags is not None:
+            yield from self._handle_text_delta_with_thinking_tags(
+                vendor_part_id=vendor_part_id,
+                content=content,
+                thinking_tags=thinking_tags,
+                id=id,
+                provider_name=provider_name,
+                provider_details=provider_details,
+                ignore_leading_whitespace=ignore_leading_whitespace,
+            )
+            return
+
+        yield from self._handle_plain_text_delta(
+            vendor_part_id=vendor_part_id,
+            content=content,
+            id=id,
+            provider_name=provider_name,
+            provider_details=provider_details,
+            ignore_leading_whitespace=ignore_leading_whitespace,
+        )
+
+    def _handle_plain_text_delta(
+        self,
+        *,
+        vendor_part_id: VendorId | None,
+        content: str,
+        id: str | None = None,
+        provider_name: str | None = None,
+        provider_details: dict[str, Any] | None = None,
+        ignore_leading_whitespace: bool = False,
+    ) -> Iterator[ModelResponseStreamEvent]:
         existing_text_part_and_index: tuple[TextPart, int] | None = None
 
         if vendor_part_id is None:
-            # If the vendor_part_id is None, check if the latest part is a TextPart to update
             existing_text_part_and_index = self._latest_part_if_of_type(TextPart)
         else:
-            # Otherwise, attempt to look up an existing TextPart by vendor_part_id
             part_index = self._vendor_id_to_part_index.get(vendor_part_id)
             if part_index is not None:
                 existing_part = self._parts[part_index]
-
-                if thinking_tags and isinstance(existing_part, ThinkingPart):
-                    # We may be building a thinking part instead of a text part if we had previously seen a thinking tag
-                    if content == thinking_tags[1]:
-                        # When we see the thinking end tag, we're done with the thinking part and the next text delta will need a new part
-                        self._handle_embedded_thinking_end(vendor_part_id)
-                        return
-                    yield from self._handle_embedded_thinking_content(
-                        existing_part, part_index, content, provider_name, provider_details
-                    )
-                    return
-                elif isinstance(existing_part, TextPart):
+                if isinstance(existing_part, TextPart):
                     existing_text_part_and_index = existing_part, part_index
                 else:
                     raise UnexpectedModelBehavior(f'Cannot apply a text delta to {existing_part=}')
-
-        if thinking_tags and content == thinking_tags[0]:
-            # When we see a thinking start tag (which is a single token), we'll build a new thinking part instead
-            yield from self._handle_embedded_thinking_start(vendor_part_id, provider_name, provider_details)
-            return
 
         if existing_text_part_and_index is None:
             # This is a workaround for models that emit `<think>\n</think>\n\n` or an empty text part ahead of tool calls (e.g. Ollama + Qwen3),
@@ -190,12 +215,10 @@ class ModelResponsePartsManager:
             if ignore_leading_whitespace and (len(content) == 0 or content.isspace()):
                 return
 
-            # There is no existing text part that should be updated, so create a new one
             part = TextPart(content=content, id=id, provider_name=provider_name, provider_details=provider_details)
             new_part_index = self._append_part(part, vendor_part_id)
             yield PartStartEvent(index=new_part_index, part=part)
         else:
-            # Update the existing TextPart with the new content delta
             existing_text_part, part_index = existing_text_part_and_index
 
             part_delta = TextPartDelta(
@@ -205,6 +228,145 @@ class ModelResponsePartsManager:
             )
             self._parts[part_index] = part_delta.apply(existing_text_part)
             yield PartDeltaEvent(index=part_index, delta=part_delta)
+
+    def _handle_text_delta_with_thinking_tags(
+        self,
+        *,
+        vendor_part_id: VendorId | None,
+        content: str,
+        thinking_tags: tuple[str, str],
+        id: str | None = None,
+        provider_name: str | None = None,
+        provider_details: dict[str, Any] | None = None,
+        ignore_leading_whitespace: bool = False,
+    ) -> Iterator[ModelResponseStreamEvent]:
+        start_tag, end_tag = thinking_tags
+        data = self._thinking_tag_buffer + content
+        self._thinking_tag_buffer = ''
+
+        in_thinking = self._is_in_embedded_thinking(vendor_part_id)
+        index = 0
+        while index < len(data):
+            if not in_thinking:
+                start_index = data.find(start_tag, index)
+                if start_index == -1:
+                    remaining = data[index:]
+                    overlap = _suffix_prefix_overlap(remaining, start_tag)
+                    if overlap:
+                        text_content = remaining[:-overlap]
+                        self._thinking_tag_buffer = remaining[-overlap:]
+                    else:
+                        text_content = remaining
+                    if text_content:
+                        yield from self._handle_plain_text_delta(
+                            vendor_part_id=vendor_part_id,
+                            content=text_content,
+                            id=id,
+                            provider_name=provider_name,
+                            provider_details=provider_details,
+                            ignore_leading_whitespace=ignore_leading_whitespace,
+                        )
+                    break
+
+                if start_index > index:
+                    yield from self._handle_plain_text_delta(
+                        vendor_part_id=vendor_part_id,
+                        content=data[index:start_index],
+                        id=id,
+                        provider_name=provider_name,
+                        provider_details=provider_details,
+                        ignore_leading_whitespace=ignore_leading_whitespace,
+                    )
+
+                yield from self._handle_embedded_thinking_start(vendor_part_id, provider_name, provider_details)
+                in_thinking = True
+                index = start_index + len(start_tag)
+            else:
+                end_index = data.find(end_tag, index)
+                if end_index == -1:
+                    remaining = data[index:]
+                    overlap = _suffix_prefix_overlap(remaining, end_tag)
+                    if overlap:
+                        thinking_content = remaining[:-overlap]
+                        self._thinking_tag_buffer = remaining[-overlap:]
+                    else:
+                        thinking_content = remaining
+                    if thinking_content:
+                        yield from self._append_embedded_thinking_content(
+                            vendor_part_id, thinking_content, provider_name, provider_details
+                        )
+                    break
+
+                if end_index > index:
+                    yield from self._append_embedded_thinking_content(
+                        vendor_part_id, data[index:end_index], provider_name, provider_details
+                    )
+
+                self._handle_embedded_thinking_end(vendor_part_id)
+                in_thinking = False
+                index = end_index + len(end_tag)
+
+    def flush_thinking_tag_buffer(
+        self,
+        *,
+        vendor_part_id: VendorId | None,
+        thinking_tags: tuple[str, str],
+        id: str | None = None,
+        provider_name: str | None = None,
+        provider_details: dict[str, Any] | None = None,
+        ignore_leading_whitespace: bool = False,
+    ) -> Iterator[ModelResponseStreamEvent]:
+        """Flush any buffered partial thinking tag content at the end of a stream."""
+        if not self._thinking_tag_buffer:
+            return
+        buffered = self._thinking_tag_buffer
+        self._thinking_tag_buffer = ''
+        if self._is_in_embedded_thinking(vendor_part_id):
+            yield from self._append_embedded_thinking_content(
+                vendor_part_id, buffered, provider_name, provider_details
+            )
+        else:
+            yield from self._handle_text_delta_with_thinking_tags(
+                vendor_part_id=vendor_part_id,
+                content=buffered,
+                thinking_tags=thinking_tags,
+                id=id,
+                provider_name=provider_name,
+                provider_details=provider_details,
+                ignore_leading_whitespace=ignore_leading_whitespace,
+            )
+
+    def _is_in_embedded_thinking(self, vendor_part_id: VendorId | None) -> bool:
+        if vendor_part_id is None:
+            latest = self._latest_part_if_of_type(ThinkingPart)
+            return latest is not None
+        part_index = self._vendor_id_to_part_index.get(vendor_part_id)
+        if part_index is None:
+            return False
+        return isinstance(self._parts[part_index], ThinkingPart)
+
+    def _append_embedded_thinking_content(
+        self,
+        vendor_part_id: VendorId | None,
+        content: str,
+        provider_name: str | None,
+        provider_details: dict[str, Any] | None,
+    ) -> Iterator[ModelResponseStreamEvent]:
+        if vendor_part_id is None:
+            existing_thinking_part_and_index = self._latest_part_if_of_type(ThinkingPart)
+        else:
+            part_index = self._vendor_id_to_part_index.get(vendor_part_id)
+            if part_index is None or not isinstance(self._parts[part_index], ThinkingPart):
+                raise UnexpectedModelBehavior('Cannot append embedded thinking content without a ThinkingPart')
+            existing_thinking_part_and_index = self._parts[part_index], part_index
+
+        if existing_thinking_part_and_index is None:
+            raise UnexpectedModelBehavior('Cannot append embedded thinking content without a ThinkingPart')
+
+        existing_part, part_index = existing_thinking_part_and_index
+        yield from self._handle_embedded_thinking_content(
+            existing_part, part_index, content, provider_name, provider_details
+        )
 
     def handle_thinking_delta(
         self,

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -169,7 +169,9 @@ def test_handle_text_deltas_with_think_tags_split_across_chunks():
     thinking_tags = ModelProfile().thinking_tags
     start_tag, end_tag = thinking_tags
 
-    events = list(manager.handle_text_delta(vendor_part_id='content', content=start_tag[:1], thinking_tags=thinking_tags))
+    events = list(
+        manager.handle_text_delta(vendor_part_id='content', content=start_tag[:1], thinking_tags=thinking_tags)
+    )
     assert events == []
 
     events = list(
@@ -199,7 +201,9 @@ def test_handle_text_deltas_with_think_tags_split_across_chunks():
     )
     assert events == snapshot(
         [
-            PartStartEvent(index=1, part=TextPart(content='\nNormal content.', part_kind='text'), event_kind='part_start'),
+            PartStartEvent(
+                index=1, part=TextPart(content='\nNormal content.', part_kind='text'), event_kind='part_start'
+            ),
         ]
     )
 
@@ -231,7 +235,9 @@ def test_handle_text_deltas_with_think_tags_single_chunk_with_trailing_text():
                 delta=ThinkingPartDelta(content_delta='\nthinking content', part_delta_kind='thinking'),
                 event_kind='part_delta',
             ),
-            PartStartEvent(index=1, part=TextPart(content='\nNormal content.', part_kind='text'), event_kind='part_start'),
+            PartStartEvent(
+                index=1, part=TextPart(content='\nNormal content.', part_kind='text'), event_kind='part_start'
+            ),
         ]
     )
 
@@ -243,7 +249,138 @@ def test_handle_text_deltas_with_think_tags_single_chunk_with_trailing_text():
     assert parts[1].content == '\nNormal content.'
 
 
-def test_handle_tool_call_deltas():
+def test_flush_thinking_tag_buffer_emits_partial_start_tag_as_text():
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    thinking_tags = ModelProfile().thinking_tags
+    start_tag, _ = thinking_tags
+
+    list(
+        manager.handle_text_delta(
+            vendor_part_id='content',
+            content='Hello ' + start_tag[:5],
+            thinking_tags=thinking_tags,
+        )
+    )
+    events = list(manager.flush_thinking_tag_buffer(vendor_part_id='content', thinking_tags=thinking_tags))
+    assert events == snapshot(
+        [
+            PartDeltaEvent(
+                index=0,
+                delta=TextPartDelta(content_delta='<thin', part_delta_kind='text'),
+                event_kind='part_delta',
+            ),
+        ]
+    )
+    assert manager.get_parts() == snapshot([TextPart(content='Hello <thin', part_kind='text')])
+
+
+def test_flush_thinking_tag_buffer_emits_partial_end_tag_as_thinking():
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    thinking_tags = ModelProfile().thinking_tags
+    start_tag, end_tag = thinking_tags
+
+    list(
+        manager.handle_text_delta(
+            vendor_part_id='content',
+            content=f'{start_tag}\nthinking',
+            thinking_tags=thinking_tags,
+        )
+    )
+    list(
+        manager.handle_text_delta(
+            vendor_part_id='content',
+            content=end_tag[:5],
+            thinking_tags=thinking_tags,
+        )
+    )
+    events = list(manager.flush_thinking_tag_buffer(vendor_part_id='content', thinking_tags=thinking_tags))
+    assert events == snapshot(
+        [
+            PartDeltaEvent(
+                index=0,
+                delta=ThinkingPartDelta(content_delta='</thi', part_delta_kind='thinking'),
+                event_kind='part_delta',
+            ),
+        ]
+    )
+    assert manager.get_parts() == snapshot([ThinkingPart(content='\nthinking</thi', part_kind='thinking')])
+
+
+def test_handle_text_deltas_with_think_tags_text_before_start():
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    thinking_tags = ModelProfile().thinking_tags
+    start_tag, end_tag = thinking_tags
+
+    events = list(
+        manager.handle_text_delta(
+            vendor_part_id='content',
+            content=f'pre-{start_tag}\nthinking{end_tag}',
+            thinking_tags=thinking_tags,
+        )
+    )
+    assert events == snapshot(
+        [
+            PartStartEvent(index=0, part=TextPart(content='pre-', part_kind='text'), event_kind='part_start'),
+            PartStartEvent(index=1, part=ThinkingPart(content='', part_kind='thinking'), event_kind='part_start'),
+            PartDeltaEvent(
+                index=1,
+                delta=ThinkingPartDelta(content_delta='\nthinking', part_delta_kind='thinking'),
+                event_kind='part_delta',
+            ),
+        ]
+    )
+
+
+def test_handle_text_deltas_with_think_tags_partial_end_tag_overlap_only():
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    thinking_tags = ModelProfile().thinking_tags
+    start_tag, end_tag = thinking_tags
+
+    list(
+        manager.handle_text_delta(
+            vendor_part_id='content',
+            content=f'{start_tag}\nthinking',
+            thinking_tags=thinking_tags,
+        )
+    )
+    events = list(
+        manager.handle_text_delta(
+            vendor_part_id='content',
+            content=end_tag[:1],
+            thinking_tags=thinking_tags,
+        )
+    )
+    assert events == []
+
+
+def test_handle_text_deltas_with_think_tags_vendor_part_id_none():
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    thinking_tags = ModelProfile().thinking_tags
+    start_tag, end_tag = thinking_tags
+
+    list(
+        manager.handle_text_delta(
+            vendor_part_id=None,
+            content=f'{start_tag}\nthinking{end_tag}\npost',
+            thinking_tags=thinking_tags,
+        )
+    )
+    events = list(manager.flush_thinking_tag_buffer(vendor_part_id=None, thinking_tags=thinking_tags))
+    assert events == []
+    assert manager.get_parts() == snapshot(
+        [
+            ThinkingPart(content='\nthinking', part_kind='thinking'),
+            TextPart(content='\npost', part_kind='text'),
+        ]
+    )
+
+
+def test_append_embedded_thinking_content_errors_without_thinking_part():
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+
+    with pytest.raises(UnexpectedModelBehavior, match='Cannot append embedded thinking content'):
+        list(manager._append_embedded_thinking_content('content', 'thinking', None, None))
+
     manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
 
     event = manager.handle_tool_call_delta(vendor_part_id='first', tool_name=None, args='{"arg1":', tool_call_id=None)

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -169,28 +169,46 @@ def test_handle_text_deltas_with_think_tags_split_across_chunks():
     thinking_tags = ModelProfile().thinking_tags
     start_tag, end_tag = thinking_tags
 
-    list(manager.handle_text_delta(vendor_part_id='content', content=start_tag[:1], thinking_tags=thinking_tags))
-    list(
+    events = list(manager.handle_text_delta(vendor_part_id='content', content=start_tag[:1], thinking_tags=thinking_tags))
+    assert events == []
+
+    events = list(
         manager.handle_text_delta(
             vendor_part_id='content',
             content=start_tag[1:] + '\nthinking content',
             thinking_tags=thinking_tags,
         )
     )
-    list(
+    assert events == snapshot(
+        [
+            PartStartEvent(index=0, part=ThinkingPart(content='', part_kind='thinking'), event_kind='part_start'),
+            PartDeltaEvent(
+                index=0,
+                delta=ThinkingPartDelta(content_delta='\nthinking content', part_delta_kind='thinking'),
+                event_kind='part_delta',
+            ),
+        ]
+    )
+
+    events = list(
         manager.handle_text_delta(
             vendor_part_id='content',
             content=end_tag + '\nNormal content.',
             thinking_tags=thinking_tags,
         )
     )
+    assert events == snapshot(
+        [
+            PartStartEvent(index=1, part=TextPart(content='\nNormal content.', part_kind='text'), event_kind='part_start'),
+        ]
+    )
 
     parts = manager.get_parts()
     assert len(parts) == 2
     assert isinstance(parts[0], ThinkingPart)
-    assert parts[0].content.strip() == 'thinking content'
+    assert parts[0].content == '\nthinking content'
     assert isinstance(parts[1], TextPart)
-    assert parts[1].content.strip() == 'Normal content.'
+    assert parts[1].content == '\nNormal content.'
 
 
 def test_handle_text_deltas_with_think_tags_single_chunk_with_trailing_text():
@@ -198,20 +216,31 @@ def test_handle_text_deltas_with_think_tags_single_chunk_with_trailing_text():
     thinking_tags = ModelProfile().thinking_tags
     start_tag, end_tag = thinking_tags
 
-    list(
+    events = list(
         manager.handle_text_delta(
             vendor_part_id='content',
             content=f'{start_tag}\nthinking content{end_tag}\nNormal content.',
             thinking_tags=thinking_tags,
         )
     )
+    assert events == snapshot(
+        [
+            PartStartEvent(index=0, part=ThinkingPart(content='', part_kind='thinking'), event_kind='part_start'),
+            PartDeltaEvent(
+                index=0,
+                delta=ThinkingPartDelta(content_delta='\nthinking content', part_delta_kind='thinking'),
+                event_kind='part_delta',
+            ),
+            PartStartEvent(index=1, part=TextPart(content='\nNormal content.', part_kind='text'), event_kind='part_start'),
+        ]
+    )
 
     parts = manager.get_parts()
     assert len(parts) == 2
     assert isinstance(parts[0], ThinkingPart)
-    assert parts[0].content.strip() == 'thinking content'
+    assert parts[0].content == '\nthinking content'
     assert isinstance(parts[1], TextPart)
-    assert parts[1].content.strip() == 'Normal content.'
+    assert parts[1].content == '\nNormal content.'
 
 
 def test_handle_tool_call_deltas():

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -19,6 +19,7 @@ from pydantic_ai import (
 )
 from pydantic_ai._parts_manager import ModelResponsePartsManager
 from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.profiles import ModelProfile
 
 from ._inline_snapshot import snapshot
 from .conftest import IsStr
@@ -161,6 +162,56 @@ def test_handle_text_deltas_with_think_tags():
             TextPart(content='post-thinking', part_kind='text'),
         ]
     )
+
+
+def test_handle_text_deltas_with_think_tags_split_across_chunks():
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    thinking_tags = ModelProfile().thinking_tags
+    start_tag, end_tag = thinking_tags
+
+    list(manager.handle_text_delta(vendor_part_id='content', content=start_tag[:1], thinking_tags=thinking_tags))
+    list(
+        manager.handle_text_delta(
+            vendor_part_id='content',
+            content=start_tag[1:] + '\nthinking content',
+            thinking_tags=thinking_tags,
+        )
+    )
+    list(
+        manager.handle_text_delta(
+            vendor_part_id='content',
+            content=end_tag + '\nNormal content.',
+            thinking_tags=thinking_tags,
+        )
+    )
+
+    parts = manager.get_parts()
+    assert len(parts) == 2
+    assert isinstance(parts[0], ThinkingPart)
+    assert parts[0].content.strip() == 'thinking content'
+    assert isinstance(parts[1], TextPart)
+    assert parts[1].content.strip() == 'Normal content.'
+
+
+def test_handle_text_deltas_with_think_tags_single_chunk_with_trailing_text():
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    thinking_tags = ModelProfile().thinking_tags
+    start_tag, end_tag = thinking_tags
+
+    list(
+        manager.handle_text_delta(
+            vendor_part_id='content',
+            content=f'{start_tag}\nthinking content{end_tag}\nNormal content.',
+            thinking_tags=thinking_tags,
+        )
+    )
+
+    parts = manager.get_parts()
+    assert len(parts) == 2
+    assert isinstance(parts[0], ThinkingPart)
+    assert parts[0].content.strip() == 'thinking content'
+    assert isinstance(parts[1], TextPart)
+    assert parts[1].content.strip() == 'Normal content.'
 
 
 def test_handle_tool_call_deltas():

--- a/tests/test_parts_manager.py
+++ b/tests/test_parts_manager.py
@@ -376,10 +376,27 @@ def test_handle_text_deltas_with_think_tags_vendor_part_id_none():
 
 
 def test_append_embedded_thinking_content_errors_without_thinking_part():
-    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    """Guards in `_append_embedded_thinking_content` for a missing `ThinkingPart`.
 
+    Unit-tested rather than driven through the public API because every caller is gated on
+    `_is_in_embedded_thinking()`, which already excludes all three of these cases, so no model
+    output can reach them. They are pinned so the guards survive that gate being changed.
+    """
+    # Unknown vendor part id.
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
     with pytest.raises(UnexpectedModelBehavior, match='Cannot append embedded thinking content'):
-        list(manager._append_embedded_thinking_content('content', 'thinking', None, None))
+        list(manager._append_embedded_thinking_content('content', 'thinking', None, None))  # pyright: ignore[reportPrivateUsage]
+
+    # Known vendor part id, but the part is not a `ThinkingPart`.
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    list(manager.handle_text_delta(vendor_part_id='text', content='hello'))
+    with pytest.raises(UnexpectedModelBehavior, match='Cannot append embedded thinking content'):
+        list(manager._append_embedded_thinking_content('text', 'thinking', None, None))  # pyright: ignore[reportPrivateUsage]
+
+    # No vendor part id, and no latest `ThinkingPart` to append to.
+    manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
+    with pytest.raises(UnexpectedModelBehavior, match='Cannot append embedded thinking content'):
+        list(manager._append_embedded_thinking_content(None, 'thinking', None, None))  # pyright: ignore[reportPrivateUsage]
 
     manager = ModelResponsePartsManager(model_request_parameters=ModelRequestParameters())
 


### PR DESCRIPTION
- Closes #3007

### Summary

Streaming models (e.g. Gemini via LiteLLM) can split thinking tags like `<think>` across multiple text deltas. `ModelResponsePartsManager.handle_text_delta` previously only recognized tags when an entire delta exactly matched the start or end tag.

This change buffers partial tag suffixes between deltas and parses thinking regions incrementally, so a stream can yield separate `ThinkingPart` and trailing `TextPart` values — including when both appear in a single delta after the closing tag.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

