### PR TITLE
docs: remove `beta` from Upgrade Guide and Version Policy for the stable v2.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,18 @@
 # Upgrade Guide
 
-In September 2025, Pydantic AI reached V1 and committed to API stability: no changes that break your code until V2. V2 is now available as a beta pre-release, collecting the breaking and behavior changes that stability guarantee didn't allow. This guide is the canonical place to learn what's in V2, how to install it, and how to upgrade; for the guarantees behind these version numbers, see the [Version Policy](version-policy.md).
+In September 2025, Pydantic AI reached V1 and committed to API stability: no changes that break your code until V2. V2 is now available, collecting the breaking and behavior changes that stability guarantee didn't allow. This guide is the canonical place to learn what's in V2, how to install it, and how to upgrade; for the guarantees behind these version numbers, see the [Version Policy](version-policy.md).
 
 ## Breaking Changes
 
 Here's a filtered list of the breaking changes for each version to help you upgrade Pydantic AI.
+
+### v2.0.0 (2026-06-23)
+
+The stable V2.0 release. There are no new breaking or behavior changes since the betas; the full breaking-change list and recommended upgrade path are in the [v2.0.0b1](#v200b1-2026-05-20) entry below. Install it with:
+
+```bash
+uv add pydantic-ai
+```
 
 ### v2.0.0b7 (2026-06-10)
 
@@ -84,17 +92,7 @@ For the full breaking-change list and the recommended upgrade path, see the [v2.
 
 ### v2.0.0b1 (2026-05-20)
 
-<!-- TODO(v2-launch): at stable V2.0 release, add a `v2.0.0 (<date>)` heading for any changes since the last beta, drop the "beta" framing and the pre-release install pinning below, and update the dates in the Version Policy intro. -->
-
 The first V2 beta, forked from **v1.100.0**, which deprecates most of what V2 removes. V2 leans into a harness-first design with [capabilities](capabilities.md) as a core primitive: a single, composable unit that bundles an agent's tools, [hooks](hooks.md), instructions, and model settings, reaching every layer of the agent through one concept. Many of V2's changes move configuration that used to be spread across `Agent` arguments onto that primitive, alongside the behavior changes that V1's stability guarantee didn't allow. Pydantic AI stays a small core: some capabilities ship with it, more come from the first-party [Pydantic AI Harness](harness/overview.md), and others are third-party or your own.
-
-To install the beta, pin the exact pre-release version. Find the current beta on [PyPI](https://pypi.org/project/pydantic-ai/#history) or the [GitHub releases page](https://github.com/pydantic/pydantic-ai/releases), then (replacing `bN` with that version):
-
-```bash
-pip/uv-add "pydantic-ai==2.0.0bN"
-```
-
-The V2 API and behaviors aren't yet covered by our [stability guarantee](version-policy.md) — we don't expect major changes but may still adjust in response to feedback before the stable V2.0 release. Please [try it and report issues](https://github.com/pydantic/pydantic-ai/issues), or reach out in the `#pydantic-ai` channel on [Slack](help.md#slack).
 
 The breaking changes below are split into two groups:
 

--- a/docs/version-policy.md
+++ b/docs/version-policy.md
@@ -1,10 +1,8 @@
 # Version Policy
 
-<!-- TODO(v2-launch): at stable V2.0 release, update the beta/GA dates below to reflect the actual V2.0 release. -->
+Pydantic AI V1 was released in September 2025, and the stable V2.0 was released on June 23, 2026; see the [Upgrade Guide](changelog.md) for what's in V2, how to install it, and how to upgrade.
 
-Pydantic AI V1 was released in September 2025. The first V2 beta (`v2.0.0b1`) was released on May 20, 2026, with a stable V2.0 expected within roughly two weeks; see the [Upgrade Guide](changelog.md) for what's in V2, how to install the beta, and how to upgrade.
-
-We will not intentionally make breaking changes in minor releases. Functionality marked as deprecated in a release is not removed until the next major version, which we won't release sooner than 3 months after V2.0 ships stable. During the V2 beta, the V2 API and behaviors aren't yet covered by this guarantee — we don't expect major changes but may still adjust in response to feedback before the stable V2.0 release.
+We will not intentionally make breaking changes in minor releases. Functionality marked as deprecated in a release is not removed until the next major version, which we won't release sooner than 3 months after V2.0.
 
 We'll continue to provide security fixes for V1 for at least 6 months after V2's stable release, so you have time to upgrade your applications. When you're ready to make the jump, the [Upgrade Guide](changelog.md) lists the breaking changes for each version, along with our recommended path to V2.
 


### PR DESCRIPTION
Resolves the `TODO(v2-launch)` markers in `docs/changelog.md` and `docs/version-policy.md` for the stable v2.0 release:

- Add a `v2.0.0 (2026-06-23)` entry at the top of the Upgrade Guide with the plain `uv add pydantic-ai` install.
- Drop the beta framing + pre-release install pinning from the intro and the `v2.0.0b1` entry (kept the dated b1–b7 entries as historical record).
- Update the Version Policy intro: V2.0 released date + remove the 'not yet covered by this guarantee' beta caveat.

Docs-only; no logic changes. Lands ahead of cutting the `v2.0.0` tag.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

