### PR TITLE
Fix new_messages for reinjected resumed requests

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1706,7 +1706,7 @@ def _is_same_request(message: _messages.ModelMessage, request: _messages.ModelRe
 
 
 def _same_request_parts_ignoring_system_prompts(
-    left: list[_messages.ModelRequestPart], right: list[_messages.ModelRequestPart]
+    left: Sequence[_messages.ModelRequestPart], right: Sequence[_messages.ModelRequestPart]
 ) -> bool:
     """Compare request parts while allowing capabilities to rewrite system prompts."""
     if left == right:

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1698,11 +1698,22 @@ def _is_same_request(message: _messages.ModelMessage, request: _messages.ModelRe
     # Intentionally excludes run_id: the resumed request may not have
     # run_id set yet when this comparison is performed.
     return (
-        message.parts == request.parts
+        _same_request_parts_ignoring_system_prompts(message.parts, request.parts)
         and message.timestamp == request.timestamp
         and message.instructions == request.instructions
         and message.metadata == request.metadata
     )
+
+
+def _same_request_parts_ignoring_system_prompts(
+    left: list[_messages.ModelRequestPart], right: list[_messages.ModelRequestPart]
+) -> bool:
+    """Compare request parts while allowing capabilities to rewrite system prompts."""
+    if left == right:
+        return True
+    left_without_system = [part for part in left if not isinstance(part, _messages.SystemPromptPart)]
+    right_without_system = [part for part in right if not isinstance(part, _messages.SystemPromptPart)]
+    return left_without_system == right_without_system
 
 
 def _clean_message_history(messages: list[_messages.ModelMessage]) -> list[_messages.ModelMessage]:

--- a/tests/test_history_processor.py
+++ b/tests/test_history_processor.py
@@ -18,7 +18,7 @@ from pydantic_ai import (
     UserPromptPart,
     capture_run_messages,
 )
-from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.capabilities import ProcessHistory, ReinjectSystemPrompt
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.tools import RunContext
@@ -1669,6 +1669,51 @@ async def test_history_processor_rebuild_resuming_without_prompt(
         ]
     )
 
+    assert result.new_messages() == result.all_messages()[-1:]
+
+
+async def test_reinject_system_prompt_resuming_without_prompt_excludes_resumed_request(
+    function_model: FunctionModel, received_messages: list[ModelMessage]
+):
+    """
+    When resuming from UI-provided message history without a new user prompt,
+    system prompt reinjection may rebuild the resumed `ModelRequest`. It should
+    still be treated as prior history and excluded from new_messages().
+    """
+
+    agent = Agent(
+        function_model,
+        system_prompt='Server prompt',
+        capabilities=[ReinjectSystemPrompt(replace_existing=True)],
+    )
+
+    message_history = [
+        ModelRequest(parts=[UserPromptPart(content='Original prompt')]),
+    ]
+
+    with capture_run_messages() as captured_messages:
+        result = await agent.run(message_history=message_history)
+
+    assert received_messages == snapshot(
+        [
+            ModelRequest(
+                parts=[
+                    SystemPromptPart(
+                        content='Server prompt',
+                        timestamp=IsDatetime(),
+                    ),
+                    UserPromptPart(
+                        content='Original prompt',
+                        timestamp=IsDatetime(),
+                    ),
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            )
+        ]
+    )
+    assert captured_messages == result.all_messages()
     assert result.new_messages() == result.all_messages()[-1:]
 
 


### PR DESCRIPTION
- Closes #6025

### Summary

- Treat a resumed `ModelRequest` as the same prior-history request when a capability only rewrites its `SystemPromptPart`s.
- Add regression coverage for no-prompt resume with `ReinjectSystemPrompt(replace_existing=True)`, matching the UI adapter server-managed system prompt path.
- Preserve the existing fallback behavior for history processors that replace the resumed request with unrelated content.

### Tests

- `uv run pytest tests/test_history_processor.py::test_reinject_system_prompt_resuming_without_prompt_excludes_resumed_request tests/test_history_processor.py::test_history_processor_resuming_without_prompt tests/test_history_processor.py::test_resuming_without_prompt_with_tool_calls_excludes_resumed_request tests/test_history_processor.py::test_resuming_without_prompt_excludes_request_with_different_run_id tests/test_history_processor.py::test_history_processor_deepcopy_resuming_without_prompt tests/test_history_processor.py::test_history_processor_rebuild_resuming_without_prompt tests/test_history_processor.py::test_history_processor_replace_resumed_request_falls_through -q`
- `uv run pytest tests/test_history_processor.py -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_history_processor.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_history_processor.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

