### PR TITLE
Forward `detail` metadata for Groq image inputs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -518,6 +518,7 @@ class BinaryContent:
 
     Supported by:
     - `GoogleModel`: `BinaryContent.vendor_metadata` is used as `video_metadata`: https://ai.google.dev/gemini-api/docs/video-understanding#customize-video-processing
+    - `GroqModel`: `BinaryContent.vendor_metadata['detail']` is used as `detail` setting for images
     - `OpenAIChatModel`, `OpenAIResponsesModel`: `BinaryContent.vendor_metadata['detail']` is used as `detail` setting for images
     - `XaiModel`: `BinaryContent.vendor_metadata['detail']` is used as `detail` setting for images
     """

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -629,10 +629,14 @@ class GroqModel(Model[AsyncGroq]):
                         downloaded = await download_item(item, data_format='base64_uri')
                         image_url_str = downloaded['data']
                     image_url = ImageURL(url=image_url_str)
+                    if metadata := item.vendor_metadata:
+                        image_url['detail'] = metadata.get('detail', 'auto')
                     content.append(chat.ChatCompletionContentPartImageParam(image_url=image_url, type='image_url'))
                 elif isinstance(item, BinaryContent):
                     if item.is_image:
                         image_url = ImageURL(url=item.data_uri)
+                        if metadata := item.vendor_metadata:
+                            image_url['detail'] = metadata.get('detail', 'auto')
                         content.append(chat.ChatCompletionContentPartImageParam(image_url=image_url, type='image_url'))
                     else:
                         raise NotImplementedError('Only images are supported for BinaryContent in Groq user prompts')

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -94,6 +94,7 @@ class MockGroq:
     stream: Sequence[MockChatCompletionChunk] | Sequence[Sequence[MockChatCompletionChunk]] | None = None
     index: int = 0
     base_url: str = 'https://api.groq.com'
+    calls: list[dict[str, Any]] | None = None
 
     @cached_property
     def chat(self) -> Any:
@@ -112,8 +113,11 @@ class MockGroq:
         return cast(AsyncGroq, cls(stream=stream))
 
     async def chat_completions_create(
-        self, *_args: Any, stream: bool = False, **_kwargs: Any
+        self, *_args: Any, stream: bool = False, **kwargs: Any
     ) -> chat.ChatCompletion | MockAsyncStream[MockChatCompletionChunk]:
+        if self.calls is None:
+            self.calls = []
+        self.calls.append(kwargs)
         if stream:
             assert self.stream is not None, 'you can only used `stream=True` if `stream` is provided'
             if isinstance(self.stream[0], Sequence):
@@ -665,6 +669,30 @@ async def test_image_url_input(allow_model_requests: None, groq_api_key: str):
     )
     assert result.output == snapshot(
         'The fruit depicted in the image is a potato. Although commonly mistaken as a vegetable, potatoes are technically fruits because they are the edible, ripened ovary of a flower, containing seeds. However, in culinary and everyday contexts, potatoes are often referred to as a vegetable due to their savory flavor and uses in dishes. The botanical classification of a potato as a fruit comes from its origin as the tuberous part of the Solanum tuberosum plant, which produces flowers and subsequently the potato as a fruit that grows underground.'
+    )
+
+
+async def test_image_detail_vendor_metadata(allow_model_requests: None):
+    c = completion_message(ChatCompletionMessage(content='done', role='assistant'))
+    mock_client = MockGroq(completions=c)
+    model = GroqModel(
+        'meta-llama/llama-4-scout-17b-16e-instruct', provider=GroqProvider(groq_client=cast(AsyncGroq, mock_client))
+    )
+    agent = Agent(model)
+
+    image_url = ImageUrl('https://example.com/image.png', vendor_metadata={'detail': 'low'})
+    binary_image = BinaryContent(b'\x89PNG', media_type='image/png', vendor_metadata={'detail': 'high'})
+
+    await agent.run(['Describe these inputs.', image_url, binary_image])
+
+    assert mock_client.calls is not None
+    message_content = cast(list[dict[str, Any]], mock_client.calls[0]['messages'][0]['content'])
+    image_parts = [item['image_url'] for item in message_content if item['type'] == 'image_url']
+    assert image_parts == snapshot(
+        [
+            {'url': 'https://example.com/image.png', 'detail': 'low'},
+            {'url': 'data:image/png;base64,iVBORw==', 'detail': 'high'},
+        ]
     )
 
 


### PR DESCRIPTION
- Closes #6011

### Summary

- forward `vendor_metadata['detail']` from Groq `ImageUrl` and image `BinaryContent` inputs into the provider `image_url` payload
- document Groq support in `BinaryContent.vendor_metadata`
- add regression coverage for both URL and binary image inputs

### Validation

- `uv run pytest tests/models/test_groq.py::test_image_detail_vendor_metadata -q`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/models/groq.py pydantic_ai_slim/pydantic_ai/messages.py tests/models/test_groq.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/groq.py pydantic_ai_slim/pydantic_ai/messages.py tests/models/test_groq.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/models/groq.py pydantic_ai_slim/pydantic_ai/messages.py tests/models/test_groq.py`
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy uv run pytest tests/models/test_groq.py::test_map_text_content_input tests/models/test_groq.py::test_image_detail_vendor_metadata tests/models/test_groq.py::test_audio_as_binary_content_input -q`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

