### PR TITLE
fix: allow `RetryPromptPart` partial error round-trips

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1366,7 +1366,9 @@ class NativeToolReturnPart(BaseToolReturnPart):
         return narrower(part) if narrower else part
 
 
-error_details_ta = pydantic.TypeAdapter(list[pydantic_core.ErrorDetails], config=pydantic.ConfigDict(defer_build=True))
+RetryPromptErrorDetails: TypeAlias = dict[str, Any]
+
+error_details_ta = pydantic.TypeAdapter(list[RetryPromptErrorDetails], config=pydantic.ConfigDict(defer_build=True))
 
 
 @dataclass(repr=False)
@@ -1385,7 +1387,7 @@ class RetryPromptPart:
     * an output validator raised a [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] exception
     """
 
-    content: list[pydantic_core.ErrorDetails] | str
+    content: list[RetryPromptErrorDetails] | str
     """Details of why and how the model should retry.
 
     If the retry was triggered by a [`ValidationError`][pydantic_core.ValidationError], this will be a list of

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1649,3 +1649,35 @@ def test_retry_prompt_tool_call_keeps_input_for_nested_errors():
     response = part.model_response()
     assert '"input": 42' in response
     assert '"name"' in response
+
+
+@pytest.mark.parametrize(
+    'content',
+    [
+        pytest.param(
+            [{'type': 'missing', 'loc': ('x',), 'msg': 'Field required'}],
+            id='minimal',
+        ),
+        pytest.param(
+            [{'type': 'missing', 'loc': ('x',), 'msg': 'Field required', 'input': dict[str, object]()}],
+            id='framework-generated',
+        ),
+        pytest.param(
+            [{'type': 'missing', 'loc': ['x'], 'msg': 'Field required'}],
+            id='json-normalized-loc',
+        ),
+    ],
+)
+def test_retry_prompt_partial_error_details_round_trip(content: list[dict[str, object]]):
+    part = RetryPromptPart(content=content, tool_name='foo', tool_call_id='call_1')
+    messages: list[ModelMessage] = [ModelRequest(parts=[part])]
+
+    serialized = ModelMessagesTypeAdapter.dump_json(messages)
+    deserialized = ModelMessagesTypeAdapter.validate_json(serialized)
+    reserialized = ModelMessagesTypeAdapter.dump_json(deserialized)
+    reloaded = ModelMessagesTypeAdapter.validate_json(reserialized)
+
+    assert reloaded == deserialized
+    deserialized_part = deserialized[0].parts[0]
+    assert isinstance(deserialized_part, RetryPromptPart)
+    assert deserialized_part.content == [{**content[0], 'loc': ['x']}]


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #5987

This fixes the `RetryPromptPart.content` serialization boundary so persisted message history can round-trip retry prompt error details that omit optional/historical `ErrorDetails` keys such as `input`, `ctx`, or `url`.

Root cause: `RetryPromptPart.content` was typed as `list[pydantic_core.ErrorDetails] | str`, so `ModelMessagesTypeAdapter.dump_json()` and `validate_json()` enforced the full `ErrorDetails` `TypedDict` shape even though runtime and historical payloads may contain partial error-detail dictionaries. The change keeps the field as a list of error-detail dictionaries, but no longer requires the full typed-dict key set at the persisted-history boundary.

Validation:

- `uv run pytest tests/test_messages.py::test_retry_prompt_strips_input_from_top_level_errors tests/test_messages.py::test_retry_prompt_keeps_input_for_nested_errors tests/test_messages.py::test_retry_prompt_mixed_top_level_and_nested_errors tests/test_messages.py::test_retry_prompt_tool_call_keeps_input_at_top_level tests/test_messages.py::test_retry_prompt_tool_call_keeps_input_for_nested_errors tests/test_messages.py::test_retry_prompt_partial_error_details_round_trip -q` -> `8 passed`
- `uv run pytest tests/test_messages.py -q` -> `143 passed`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py` -> `0 errors, 0 warnings, 0 informations`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py` -> passed
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/messages.py tests/test_messages.py` -> `2 files already formatted`
- `git diff --check` -> clean

Duplicate check before opening:

- `gh search prs --repo pydantic/pydantic-ai '5987 OR RetryPromptPart content input ModelMessagesTypeAdapter roundtrip' --state open --json number,title,url,author,updatedAt,state --limit 20` -> no results
- Same closed-PR search -> no results

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

