### PR TITLE
Fix new_messages boundary for rebuilt resumed requests

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -204,6 +204,7 @@ class GraphAgentDeps(Generic[DepsT, OutputDataT]):
     prompt: str | Sequence[_messages.UserContent] | None
     new_message_index: int
     resumed_request: _messages.ModelRequest | None
+    resumed_request_index: int | None
 
     model: models.Model
     get_model_settings: Callable[[RunContext[DepsT]], ModelSettings | None]
@@ -634,7 +635,10 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             # SkipModelRequest in stream path: yield an empty stream and finish handling
             # new_message_index wasn't updated in _prepare_request, fix it here
             ctx.deps.new_message_index = _first_new_message_index(
-                ctx.state.message_history, ctx.state.run_id, resumed_request=ctx.deps.resumed_request
+                ctx.state.message_history,
+                ctx.state.run_id,
+                resumed_request=ctx.deps.resumed_request,
+                resumed_request_index=ctx.deps.resumed_request_index,
             )
             self._did_stream = True
             ctx.state.usage.requests += 1
@@ -819,7 +823,10 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         except exceptions.SkipModelRequest as e:
             # new_message_index wasn't updated in _prepare_request, fix it here
             ctx.deps.new_message_index = _first_new_message_index(
-                ctx.state.message_history, ctx.state.run_id, resumed_request=ctx.deps.resumed_request
+                ctx.state.message_history,
+                ctx.state.run_id,
+                resumed_request=ctx.deps.resumed_request,
+                resumed_request_index=ctx.deps.resumed_request_index,
             )
             ctx.state.usage.requests += 1
             return await self._finish_handling(ctx, e.response)
@@ -916,6 +923,10 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         model_settings = ctx.deps.get_model_settings(run_context) or ModelSettings()
         run_context.model_settings = model_settings
 
+        if self.is_resuming_without_prompt:
+            ctx.deps.resumed_request = self.request
+            ctx.deps.resumed_request_index = len(ctx.state.message_history) - 1
+
         request_context = ModelRequestContext(
             model=ctx.deps.model,
             messages=ctx.state.message_history[:],
@@ -942,13 +953,14 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         # Fill in framework metadata the history processors may have left unset on a new `ModelRequest`.
         fill_run_metadata(messages[-1], run_id=ctx.state.run_id, conversation_id=ctx.state.conversation_id)
 
-        if self.is_resuming_without_prompt:
-            ctx.deps.resumed_request = self.request
         # `ctx.state.message_history` is the same list used by `capture_run_messages`, so we should replace its contents, not the reference
         ctx.state.message_history[:] = messages
         # Update the new message index to ensure `result.new_messages()` returns the correct messages
         ctx.deps.new_message_index = _first_new_message_index(
-            messages, ctx.state.run_id, resumed_request=ctx.deps.resumed_request
+            messages,
+            ctx.state.run_id,
+            resumed_request=ctx.deps.resumed_request,
+            resumed_request_index=ctx.deps.resumed_request_index,
         )
 
         # Merge possible consecutive trailing `ModelRequest`s into one, with tool call parts before user parts,
@@ -1674,6 +1686,7 @@ def _first_new_message_index(
     run_id: str,
     *,
     resumed_request: _messages.ModelRequest | None,
+    resumed_request_index: int | None = None,
 ) -> int:
     """Return the first index that should be included in `new_messages()`."""
     if resumed_request is not None:
@@ -1687,6 +1700,9 @@ def _first_new_message_index(
         for index in range(len(messages) - 1, -1, -1):
             if _is_same_request(messages[index], resumed_request):
                 return index + 1
+        if resumed_request_index is not None and 0 <= resumed_request_index < len(messages):
+            if isinstance(messages[resumed_request_index], _messages.ModelRequest):
+                return resumed_request_index + 1
     return _first_run_id_index(messages, run_id)
 
 

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1371,6 +1371,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             prompt=user_prompt,
             new_message_index=len(message_history) if message_history else 0,
             resumed_request=None,
+            resumed_request_index=None,
             model=model_used,
             get_model_settings=get_model_settings,
             usage_limits=usage_limits,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -60,7 +60,14 @@ from pydantic_ai._output import (
     TextOutput,
 )
 from pydantic_ai.agent import AgentRunResult, WrapperAgent
-from pydantic_ai.capabilities import AbstractCapability, NativeTool, PrepareOutputTools, PrepareTools, WrapRunHandler
+from pydantic_ai.capabilities import (
+    AbstractCapability,
+    NativeTool,
+    PrepareOutputTools,
+    PrepareTools,
+    ProcessHistory,
+    WrapRunHandler,
+)
 from pydantic_ai.exceptions import ContentFilterError
 from pydantic_ai.messages import FunctionToolResultEvent, ModelResponseStreamEvent
 from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
@@ -3400,6 +3407,21 @@ def test_run_with_history_ending_on_model_request_and_no_user_prompt():
             ),
         ]
     )
+
+    assert result.new_messages() == result.all_messages()[-1:]
+
+
+def test_run_with_history_ending_on_rebuilt_model_request_excludes_request():
+    def rebuild_trailing_request(messages: list[ModelMessage]) -> list[ModelMessage]:
+        updated = list(messages)
+        assert isinstance(updated[-1], ModelRequest)
+        updated[-1] = replace(updated[-1], metadata={'touched': True})
+        return updated
+
+    agent = Agent(TestModel())
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(content='Hello')])]
+
+    result = agent.run_sync(message_history=messages, capabilities=[ProcessHistory(rebuild_trailing_request)])
 
     assert result.new_messages() == result.all_messages()[-1:]
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -1482,6 +1482,32 @@ async def test_run_stream_text_and_thinking():
     )
 
 
+async def test_run_stream_native_excludes_first_turn_frontend_request_from_new_messages():
+    agent = Agent(model=TestModel(custom_output_text='hi'), system_prompt='You are helpful.')
+    request = SubmitMessage(
+        id='foo',
+        messages=[
+            UIMessage(
+                id='bar',
+                role='user',
+                parts=[TextUIPart(text='Hello')],
+            ),
+        ],
+    )
+
+    adapter = VercelAIAdapter(agent, request)
+    result: AgentRunResult[Any] | None = None
+    async for event in adapter.run_stream_native():
+        if isinstance(event, AgentRunResultEvent):
+            result = event.result
+
+    assert result is not None
+    assert not any(
+        isinstance(message, ModelRequest) and any(isinstance(part, UserPromptPart) for part in message.parts)
+        for message in result.new_messages()
+    )
+
+
 async def test_run_stream_thinking_with_signature():
     """Test that thinking parts with signatures include providerMetadata in reasoning-end events."""
 


### PR DESCRIPTION
Fixes #6025.

## Summary

`new_messages()` could include the inbound user `ModelRequest` when a run resumed from a trailing request and a capability or history processor rebuilt that request before the new-message boundary was computed. The default Vercel/AG-UI `manage_system_prompt='server'` path triggers this on the first turn because `ReinjectSystemPrompt` prepends a system prompt by replacing the first `ModelRequest`.

This keeps tracking the resumed request object for the existing fast paths, and also records the resumed request's pre-processor index. If identity and value matching fail because the request was rebuilt, the boundary can still exclude that inbound request by position instead of falling back to the current `run_id`.

## Validation

- `uv run pytest tests/test_vercel_ai.py::test_run_stream_native_excludes_first_turn_frontend_request_from_new_messages -q` failed before the fix with `assert not True`, then passed after the fix.
- `uv run pytest tests/test_vercel_ai.py::test_run_stream_native_excludes_first_turn_frontend_request_from_new_messages tests/test_agent.py::test_run_with_history_ending_on_rebuilt_model_request_excludes_request tests/test_agent.py::test_run_with_history_ending_on_model_request_and_no_user_prompt tests/test_agent.py::test_run_with_history_ending_on_model_response_with_tool_calls_and_no_user_prompt tests/test_agent.py::test_run_with_history_ending_on_model_response_without_tool_calls_or_user_prompt -q` -> 5 passed.
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/agent/__init__.py tests/test_agent.py tests/test_vercel_ai.py` -> passed.
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/agent/__init__.py tests/test_agent.py tests/test_vercel_ai.py` -> 4 files already formatted.
- `git diff --check` -> passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

