### PR TITLE
Preserve exception tracebacks in the gh-aw shim's error handlers

### DIFF
--- a/.github/scripts/pydantic-ai-runner
+++ b/.github/scripts/pydantic-ai-runner
@@ -3,11 +3,10 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #   "pydantic-ai-slim[anthropic,mcp]>=1.105.0",
-#   # The Bash/Read/Write/Edit tools are backed by harness FileSystem/Shell.
-#   # Those capabilities are on harness `main` but not yet on PyPI (the latest
-#   # release ships only `code_mode`), so pin the commit until a release carries
-#   # them, then switch this to a normal version constraint.
-#   "pydantic-ai-harness @ git+https://github.com/pydantic/pydantic-ai-harness@24fd30e70c0e12c4d4b4507b1643141830ba6cbf",
+#   # The Bash/Read/Write/Edit tools are backed by harness FileSystem/Shell,
+#   # which ship as stable top-level modules from 0.4.0 onwards. Keep this in
+#   # sync with the lint-group pin in the root pyproject.toml.
+#   "pydantic-ai-harness>=0.4.0",
 #   "logfire",
 #   "opentelemetry-instrumentation-httpx",
 # ]

--- a/.github/scripts/pydantic-ai-runner
+++ b/.github/scripts/pydantic-ai-runner
@@ -2,7 +2,12 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#   "pydantic-ai-slim[anthropic,mcp]>=1.95.1",
+#   "pydantic-ai-slim[anthropic,mcp]>=1.105.0",
+#   # The Bash/Read/Write/Edit tools are backed by harness FileSystem/Shell.
+#   # Those capabilities are on harness `main` but not yet on PyPI (the latest
+#   # release ships only `code_mode`), so pin the commit until a release carries
+#   # them, then switch this to a normal version constraint.
+#   "pydantic-ai-harness @ git+https://github.com/pydantic/pydantic-ai-harness@24fd30e70c0e12c4d4b4507b1643141830ba6cbf",
 #   "logfire",
 #   "opentelemetry-instrumentation-httpx",
 # ]

--- a/.github/scripts/pydantic_ai_gh_aw_shim/__init__.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/__init__.py
@@ -41,13 +41,15 @@ from .read import read_file
 from .todo_write import todo_write
 from .write import write_file
 
-# All Claude Code tools are sync callables returning `str`. Their argument
-# signatures vary by tool (Claude's `Bash` takes `(command, timeout?)`,
-# `MultiEdit` takes `(file_path, edits)`, etc.), so the precise per-tool
-# shape is enforced at the tool's own definition site — at the registry
-# layer the meaningful contract is "callable that returns a string the
-# model can read".
-ClaudeCodeToolFn: TypeAlias = Callable[..., str]
+# Claude Code tools are callables returning `str`, sync or async: the
+# harness-backed file/shell tools (`Bash`, `Read`, `Write`, `Edit`) are async
+# because they await `ShellToolset` / `FileSystemToolset`, while the remaining
+# ones stay sync. Their argument signatures vary by tool (Claude's `Bash` takes
+# `(command, timeout?)`, `MultiEdit` takes `(file_path, edits)`, etc.), so the
+# precise per-tool shape is enforced at the tool's own definition site — at the
+# registry layer the meaningful contract is "callable that returns (or awaits)
+# a string the model can read".
+ClaudeCodeToolFn: TypeAlias = Callable[..., str | Awaitable[str]]
 
 # `Task` is the only async tool exposed by the shim. Its signature is
 # fully pinned here so that consumers of `build_claude_code_toolset(task=...)`

--- a/.github/scripts/pydantic_ai_gh_aw_shim/_backends.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/_backends.py
@@ -1,0 +1,91 @@
+"""Harness-backed toolsets that execute the Claude file/shell tools.
+
+The Claude-named tool callables in this package (`Bash`, `Read`, `Write`,
+`Edit`) keep their Claude Code signatures but delegate the actual work to
+pydantic-ai-harness's `ShellToolset` and `FileSystemToolset`. The harness owns
+the parts that were previously hand-rolled here: subprocess execution and
+output truncation, path containment, symlink resolution before access, and
+binary-file detection. The shim keeps only the thin signature adapters.
+
+The toolsets are built per call so `workspace()` (and a test's
+`GITHUB_WORKSPACE`) is read live; construction is cheap. They are used by
+calling their methods directly, not by registering them on an agent, so the
+agent still sees exactly the Claude tool surface gh-aw expects.
+"""
+
+import os
+from pathlib import Path
+
+from pydantic_ai_harness.filesystem import FileSystemToolset
+from pydantic_ai_harness.shell import ShellToolset
+
+from .shared import MAX_TOOL_OUTPUT, workspace
+
+# Standard Unix binary locations prepended to PATH so `rg`, `make`, `git`, and
+# `uv` are reachable even when the AWF sandbox starts with a minimal inherited
+# PATH. Moved here from the old hand-rolled `bash` tool.
+_STANDARD_PATHS = [
+    '/opt/hostedtoolcache/gh-aw-tools/current/x64/bin',  # rg + uv (install-sandbox-tools.sh)
+    '/tmp/gh-aw/bin',  # fallback; launcher lives here too
+    '/usr/local/bin',
+    '/usr/bin',
+    '/bin',
+    '/usr/local/sbin',
+    '/usr/sbin',
+    '/sbin',
+]
+
+# Claude's `Bash` timeout contract: default 120s, hard-capped at 600s.
+BASH_DEFAULT_TIMEOUT = 120
+BASH_MAX_TIMEOUT = 600
+
+
+def augmented_env() -> dict[str, str]:
+    """The process environment with the standard tool paths prepended to PATH."""
+    env = dict(os.environ)
+    current = env.get('PATH', '')
+    existing = set(current.split(':'))
+    extra = ':'.join(p for p in _STANDARD_PATHS if p not in existing)
+    env['PATH'] = f'{extra}:{current}' if extra else current
+    return env
+
+
+def filesystem() -> FileSystemToolset[None]:
+    """`FileSystemToolset` rooted at the live workspace.
+
+    `protected_patterns=[]` keeps the prior behavior of allowing writes anywhere
+    under the workspace. The harness still enforces containment (no path escapes
+    the workspace root) and resolves symlinks before access -- a change from the
+    old tools, which resolved any absolute path. For gh-aw the agent operates
+    within `$GITHUB_WORKSPACE`, so containment to that root is the intended scope.
+    """
+    return FileSystemToolset[None](
+        root_dir=Path(workspace()),
+        allowed_patterns=[],
+        denied_patterns=[],
+        protected_patterns=[],
+        max_read_lines=2000,
+        max_search_results=1000,
+        max_find_results=1000,
+    )
+
+
+def shell() -> ShellToolset[None]:
+    """`ShellToolset` rooted at the live workspace, PATH augmented for the sandbox.
+
+    Command/operator denylists are left empty to preserve the old `Bash` tool's
+    "run anything" contract; the AWF sandbox is the security boundary. Output is
+    capped at `MAX_TOOL_OUTPUT`, keeping the tail (where errors and exit info land).
+    """
+    return ShellToolset[None](
+        cwd=Path(workspace()),
+        allowed_commands=[],
+        denied_commands=[],
+        denied_operators=[],
+        default_timeout=float(BASH_DEFAULT_TIMEOUT),
+        max_output_chars=MAX_TOOL_OUTPUT,
+        persist_cwd=False,
+        allow_interactive=True,
+        env=augmented_env(),
+        denied_env_patterns=[],
+    )

--- a/.github/scripts/pydantic_ai_gh_aw_shim/bash.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/bash.py
@@ -1,51 +1,27 @@
-"""Claude's `Bash` tool — run a shell command in the workspace."""
+"""Claude's `Bash` tool -- run a shell command in the workspace.
 
-import os
-import subprocess
+Backed by pydantic-ai-harness's `ShellToolset`, which handles subprocess
+execution, the per-command timeout, and tail-keeping output truncation. The
+Claude `Bash` signature (`command`, optional `timeout` in seconds) and the
+sandbox PATH augmentation are preserved by the adapter.
+"""
 
-from .shared import clip, workspace
+from pydantic_ai.exceptions import ModelRetry
 
-# Standard Unix binary locations prepended to whatever PATH the process
-# inherits so tools like `rg`, `make`, `git`, and `uv` are reliably reachable
-# even if the AWF sandbox launches with a minimal inherited PATH.
-_STANDARD_PATHS = [
-    '/opt/hostedtoolcache/gh-aw-tools/current/x64/bin',  # rg + uv installed by install-sandbox-tools.sh
-    '/tmp/gh-aw/bin',  # fallback; launcher lives here too
-    '/usr/local/bin',
-    '/usr/bin',
-    '/bin',
-    '/usr/local/sbin',
-    '/usr/sbin',
-    '/sbin',
-]
+from ._backends import BASH_DEFAULT_TIMEOUT, BASH_MAX_TIMEOUT, shell
 
 
-def _augmented_env() -> dict[str, str]:
-    env = dict(os.environ)
-    current = env.get('PATH', '')
-    existing = set(current.split(':'))
-    extra = ':'.join(p for p in _STANDARD_PATHS if p not in existing)
-    env['PATH'] = f'{extra}:{current}' if extra else current
-    return env
-
-
-def bash(command: str, timeout: int | None = None) -> str:
+async def bash(command: str, timeout: int | None = None) -> str:
     """Run a shell command in the repository workspace.
 
-    Returns combined stdout+stderr (truncated). `timeout` is in seconds
-    (default 120, capped at 600).
+    Returns the command's labeled stdout/stderr (truncated). `timeout` is in
+    seconds (default 120, capped at 600).
     """
-    secs = 120 if not timeout or timeout <= 0 else min(int(timeout), 600)
+    secs = BASH_DEFAULT_TIMEOUT if not timeout or timeout <= 0 else min(int(timeout), BASH_MAX_TIMEOUT)
     try:
-        r = subprocess.run(
-            command,
-            shell=True,
-            cwd=workspace(),
-            capture_output=True,
-            text=True,
-            timeout=secs,
-            env=_augmented_env(),
-        )
-        return clip(f'exit={r.returncode}\n{r.stdout}{r.stderr}')
-    except subprocess.TimeoutExpired:
-        return f'error: command timed out after {secs}s'
+        return await shell().run_command(command, timeout_seconds=float(secs))
+    except ModelRetry as exc:
+        # The harness raises `ModelRetry` for a blocked command; the shim's tools
+        # have always surfaced such conditions as a returned error string rather
+        # than a model-facing retry, so preserve that.
+        return f'error: {exc}'

--- a/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
@@ -35,6 +35,7 @@ annotations breaks pydantic-ai's `takes_run_context` detection.
 import argparse
 import asyncio
 import dataclasses
+import faulthandler
 import json
 import logging
 import os
@@ -132,6 +133,11 @@ _LLM_MAX_RETRIES = 4
 RUN_TIMEOUT_SECS = 28 * 60  # 28 min — just under the 30 min gh-aw job cap
 SUBAGENT_TIMEOUT_SECS = 15 * 60  # 15 min per Task sub-agent
 COMPACTION_TIMEOUT_SECS = 120  # 2 min for the compaction summariser call
+
+# `faulthandler` dumps the live thread stacks at `RUN_TIMEOUT_SECS`; `wait_for`
+# is given this much extra grace so the dump captures the *stuck* stack before
+# cancellation unwinds it out of view. See `_run_with_timeout`.
+FAULT_DUMP_GRACE_SECS = 10
 
 # Static prefix for `Agent(instructions=[INSTRUCTIONS, prompt])`. Sequence
 # form lets Anthropic's prompt-prefix cache hit `INSTRUCTIONS` across runs.
@@ -377,9 +383,14 @@ async def _compact_history(ctx: RunContext[None], messages: list[ModelMessage]) 
         )
         summary = str(r.output or '').strip() or '(empty summary)'
     except Exception as exc:
+        # Well-handled fallback: the run continues on the trimmed history, so the
+        # stack is kept available (`exc_info`) without escalating the log level.
+        # A bare `TimeoutError` stringifies to '' — fall back to the type name so
+        # the emitted `error` is never empty.
         ctx.usage.incr(sub_usage)
-        logger.warning('compaction summarisation failed (%r); falling back', exc)
-        emit({'type': 'system', 'subtype': 'compaction_summary_failed', 'error': str(exc)})
+        detail = f'{type(exc).__name__}: {exc}' if str(exc) else type(exc).__name__
+        logger.warning('compaction summarisation failed (%s); falling back', detail, exc_info=True)
+        emit({'type': 'system', 'subtype': 'compaction_summary_failed', 'error': detail})
         return [prior_synthetic, *tail] if prior_synthetic else tail
     ctx.usage.incr(sub_usage)
     # If the summariser produces output larger than the middle it's replacing,
@@ -587,11 +598,16 @@ def build_mcp_servers(args: Args) -> list[AbstractToolset[None]]:
         return []
     try:
         loaded = load_mcp_toolsets(path)
+    # `repr` is sufficient diagnostically here (a `ValidationError` already
+    # enumerates the bad fields, `FileNotFoundError` names the path), so no
+    # traceback — but returning `[]` drops the *entire* GitHub/safeoutputs tool
+    # surface, a drastic behaviour change, so log it at `error` to make a run
+    # that silently lost its tools obvious in the artifact.
     except FileNotFoundError as exc:
-        logger.warning('MCP config %r missing: %r — running without external tools', path, exc)
+        logger.error('MCP config %r missing (%r) — agent will run with NO external tools', path, exc)
         return []
     except (ValidationError, ValueError) as exc:
-        logger.warning('MCP config %r is malformed: %r — running without external tools', path, exc)
+        logger.error('MCP config %r is malformed (%r) — agent will run with NO external tools', path, exc)
         return []
 
     servers: list[AbstractToolset[None]] = []
@@ -781,8 +797,18 @@ async def task(ctx: RunContext[None], description: str, prompt: str) -> str:
             sub.run(RUN_TRIGGER, usage_limits=UsageLimits(request_limit=SUBAGENT_REQUEST_LIMIT), usage=sub_usage),
             timeout=SUBAGENT_TIMEOUT_SECS,
         )
-    except Exception as exc:
+    except asyncio.TimeoutError:
+        # A bare `TimeoutError` stringifies to '' — without an explicit message
+        # the model (and the log) would see `sub-agent failed:` with no payload.
         ctx.usage.incr(sub_usage)
+        logger.error('sub-agent timed out after %.0f min: %s', SUBAGENT_TIMEOUT_SECS / 60, description[:120])
+        return f'error: sub-agent timed out after {SUBAGENT_TIMEOUT_SECS // 60}min'
+    except Exception as exc:
+        # The parent agent reacts to the returned string, but a sub-agent can hit
+        # the same nested `ExceptionGroup`/`McpError` as the main run — log the
+        # full stack so the failure isn't reduced to a one-line repr in the logs.
+        ctx.usage.incr(sub_usage)
+        logger.exception('sub-agent failed: %s', description[:120])
         return f'error: sub-agent failed: {exc}'
     ctx.usage.incr(sub_usage)
     logger.info('Task done: +%d sub-requests (run total now %d)', sub_usage.requests, ctx.usage.requests)
@@ -798,13 +824,22 @@ async def _run_with_timeout(
     session_id: str,
 ) -> int:
     """Wrap `run()` with the global wall-clock cap and emit a clean result on timeout."""
+    # Arm a faulthandler dump a few seconds *before* `wait_for` cancels the run.
+    # A `TimeoutError` carries no useful traceback — `wait_for` raises it only
+    # after cancelling and unwinding the inner coroutine, so the actually-stuck
+    # frame (a wedged streaming read, an MCP `call_tool` that never returns) is
+    # already gone by the time we reach the `except`. Dumping the live thread
+    # stacks at `RUN_TIMEOUT_SECS`, while the coroutine is still blocked, lands
+    # the hang location in `agent-stdio.log`. `exit=False` keeps the process
+    # alive so we still emit a clean result line.
+    faulthandler.dump_traceback_later(RUN_TIMEOUT_SECS, exit=False)
     try:
         return await asyncio.wait_for(
             run(prompt, model, label, claude_code_toolset, mcp_servers, session_id),
-            timeout=RUN_TIMEOUT_SECS,
+            timeout=RUN_TIMEOUT_SECS + FAULT_DUMP_GRACE_SECS,
         )
     except asyncio.TimeoutError:
-        logger.error('run timed out after %.0f min', RUN_TIMEOUT_SECS / 60)
+        logger.error('run timed out after %.0f min (see faulthandler stack dump above)', RUN_TIMEOUT_SECS / 60)
         emit_result(
             f'run timed out after {RUN_TIMEOUT_SECS // 60}min',
             usage=None,
@@ -812,6 +847,8 @@ async def _run_with_timeout(
             is_error=True,
         )
         return 1
+    finally:
+        faulthandler.cancel_dump_traceback_later()
 
 
 async def run(
@@ -842,7 +879,14 @@ async def run(
         async with agent:
             result = await agent.run(RUN_TRIGGER, usage_limits=limits)
     except Exception as exc:
-        logger.warning('agent run failed: %r', exc)
+        # `%r` on an `ExceptionGroup` (e.g. the MCP `TaskGroup` failures seen in
+        # CI) discards every frame and every nested sub-exception's stack, which
+        # is what made the original incident so hard to root-cause. `exception()`
+        # renders the full traceback — and, on 3.11+, each group leaf's stack —
+        # to stderr, which gh-aw captures into the uploaded `agent-stdio.log`,
+        # so the run is self-explaining without a re-run. The `result` text
+        # stays a one-liner because gh-aw parses it.
+        logger.exception('agent run failed')
         emit_result(
             f'agent run failed: {exc}',
             usage=None,
@@ -894,9 +938,16 @@ def main() -> int:
         rc = asyncio.run(_run_with_timeout(prompt, model, label, claude_code_toolset, mcp_servers, session_id))
         logger.info('done in %.1fs rc=%d', time.time() - started, rc)
         return rc
-    except (Exception, SystemExit) as exc:
+    except SystemExit as exc:
         # `argparse` raises `SystemExit` (not `Exception`) on unknown-flag
-        # rejection; gh-aw still needs a structured result line.
+        # rejection — an expected, clean exit, so a traceback would be noise.
+        # gh-aw still needs a structured result line.
         logger.error('FATAL startup error: %r', exc)
+        emit_result(f'shim startup failed: {exc}', usage=None, session_id=session_id, is_error=True)
+        return 1
+    except Exception as exc:
+        # A real crash before the agent run (model build, MCP load, …) — dump the
+        # full stack so a blind FATAL doesn't cost another long investigation.
+        logger.exception('FATAL startup error')
         emit_result(f'shim startup failed: {exc}', usage=None, session_id=session_id, is_error=True)
         return 1

--- a/.github/scripts/pydantic_ai_gh_aw_shim/edit.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/edit.py
@@ -1,20 +1,43 @@
-"""Claude's `Edit` tool — replace a string in a workspace file."""
+"""Claude's `Edit` tool -- replace a string in a workspace file.
 
+The single-occurrence case is backed by pydantic-ai-harness's
+`FileSystemToolset.edit_file`, which requires `old_string` to match exactly once
+-- the same uniqueness rule Claude Code's own `Edit` enforces. `replace_all=True`
+has no harness equivalent, so it keeps the prior in-place read/replace/write.
+"""
+
+from pydantic_ai.exceptions import ModelRetry
+
+from ._backends import filesystem
 from .shared import attach_context, resolve
 
 
-def edit_file(file_path: str, old_string: str, new_string: str, replace_all: bool = False) -> str:
+async def edit_file(file_path: str, old_string: str, new_string: str, replace_all: bool = False) -> str:
     """Replace `old_string` with `new_string` in a workspace file.
 
-    Replaces the first occurrence, or every occurrence when `replace_all`.
+    Replaces the single (unique) occurrence, or every occurrence when `replace_all`.
+    """
+    if replace_all:
+        return _replace_all(file_path, old_string, new_string)
+    try:
+        result = await filesystem().edit_file(file_path, old_string, new_string)
+    except ModelRetry as exc:
+        return f'error: {exc}'
+    return attach_context(file_path) + result
+
+
+def _replace_all(file_path: str, old_string: str, new_string: str) -> str:
+    """Replace every occurrence of `old_string`.
+
+    The harness `edit_file` rejects non-unique matches, so replace-all stays an
+    in-place rewrite (as the tool did before it was harness-backed).
     """
     try:
         p = resolve(file_path)
         text = p.read_text(encoding='utf-8')
         if old_string not in text:
             return 'error: `old_string` not found'
-        edited = text.replace(old_string, new_string, -1 if replace_all else 1)
-        p.write_text(edited, encoding='utf-8')
+        p.write_text(text.replace(old_string, new_string, -1), encoding='utf-8')
         return attach_context(file_path) + f'edited {p}'
     except OSError as exc:
         return f'error: {exc}'

--- a/.github/scripts/pydantic_ai_gh_aw_shim/read.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/read.py
@@ -1,21 +1,26 @@
-"""Claude's `Read` tool — read a UTF-8 text file."""
+"""Claude's `Read` tool -- read a UTF-8 text file.
 
-from .shared import attach_context, clip, resolve
+Backed by pydantic-ai-harness's `FileSystemToolset.read_file`: path containment,
+symlink resolution, and binary-file detection come from the harness. The Claude
+`Read` signature (1-based `offset`, `limit`) is preserved, and the
+directory-scoped AGENTS.md / CLAUDE.md context blocks are still prepended.
+"""
+
+from pydantic_ai.exceptions import ModelRetry
+
+from ._backends import filesystem
+from .shared import attach_context, clip
 
 
-def read_file(file_path: str, offset: int | None = None, limit: int | None = None) -> str:
+async def read_file(file_path: str, offset: int | None = None, limit: int | None = None) -> str:
     """Read a UTF-8 text file. Relative paths resolve under the workspace.
 
     Optional 1-based line `offset` and line `limit` mirror Claude's Read tool.
     """
+    # Claude's `offset` is a 1-based line number; the harness uses a 0-based offset.
+    zero_based = max((offset or 1) - 1, 0)
     try:
-        text = resolve(file_path).read_text(encoding='utf-8', errors='replace')
-    except OSError as exc:
+        body = await filesystem().read_file(file_path, offset=zero_based, limit=limit)
+    except ModelRetry as exc:
         return f'error: {exc}'
-    ctx_prefix = attach_context(file_path)
-    if offset is None and limit is None:
-        return clip(ctx_prefix + text)
-    lines = text.splitlines()
-    start = max((offset or 1) - 1, 0)
-    end = start + limit if limit else len(lines)
-    return clip(ctx_prefix + '\n'.join(lines[start:end]))
+    return clip(attach_context(file_path) + body)

--- a/.github/scripts/pydantic_ai_gh_aw_shim/write.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/write.py
@@ -1,14 +1,27 @@
-"""Claude's `Write` tool — create or overwrite a workspace text file."""
+"""Claude's `Write` tool -- create or overwrite a workspace text file.
 
-from .shared import attach_context, resolve
+Backed by pydantic-ai-harness's `FileSystemToolset.write_file` (path
+containment, symlink resolution). Claude's `Write` creates missing parent
+directories, and the harness `write_file` requires the parent to exist, so the
+adapter calls `create_directory` first to keep that behavior.
+"""
+
+import os
+
+from pydantic_ai.exceptions import ModelRetry
+
+from ._backends import filesystem
+from .shared import attach_context
 
 
-def write_file(file_path: str, content: str) -> str:
+async def write_file(file_path: str, content: str) -> str:
     """Create or overwrite a UTF-8 text file under the workspace."""
+    fs = filesystem()
+    parent = os.path.dirname(file_path)
     try:
-        p = resolve(file_path)
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(content, encoding='utf-8')
-        return attach_context(file_path) + f'wrote {len(content)} chars to {p}'
-    except OSError as exc:
+        if parent:
+            await fs.create_directory(parent)
+        result = await fs.write_file(file_path, content)
+    except ModelRetry as exc:
         return f'error: {exc}'
+    return attach_context(file_path) + result

--- a/.github/scripts/test_pydantic_ai_runner.py
+++ b/.github/scripts/test_pydantic_ai_runner.py
@@ -189,32 +189,43 @@ def test_claude_code_tool_names():
 # --------------------------------------------------------------------------- #
 # Claude Code tool behavior
 # --------------------------------------------------------------------------- #
-def test_file_tools_roundtrip(tmp_path: Path):
+def test_file_tools_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # The harness-backed Read/Write/Edit are contained to the workspace root.
+    monkeypatch.setenv('GITHUB_WORKSPACE', str(tmp_path))
     f = tmp_path / 'sub' / 'note.txt'
-    assert 'wrote' in pkg.write_file(str(f), 'hello\nworld\n')
-    assert pkg.read_file(str(f)) == 'hello\nworld\n'
-    assert 'edited' in pkg.edit_file(str(f), 'world', 'there')
-    assert 'there' in pkg.read_file(str(f))
+    # Write creates the missing parent directory, mirroring Claude's `Write`.
+    assert 'Wrote' in asyncio.run(pkg.write_file(str(f), 'hello\nworld\n'))
+    body = asyncio.run(pkg.read_file(str(f)))
+    assert 'hello' in body and 'world' in body
+    assert 'Edited' in asyncio.run(pkg.edit_file(str(f), 'world', 'there'))
+    assert 'there' in asyncio.run(pkg.read_file(str(f)))
     assert 'note.txt' in pkg.list_dir(str(tmp_path / 'sub'))
-    assert pkg.edit_file(str(f), 'absent', 'x') == 'error: `old_string` not found'
+    # The harness requires a unique match; a missing string comes back as an error.
+    miss = asyncio.run(pkg.edit_file(str(f), 'absent', 'x'))
+    assert miss.startswith('error:') and 'not found' in miss
 
 
-def test_read_file_offset_and_limit(tmp_path: Path):
+def test_read_file_offset_and_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('GITHUB_WORKSPACE', str(tmp_path))
     f = tmp_path / 'n.txt'
     f.write_text('l1\nl2\nl3\nl4\n', encoding='utf-8')
-    assert pkg.read_file(str(f), offset=2, limit=2) == 'l2\nl3'
+    # Claude's 1-based offset=2 maps to the harness 0-based offset; limit=2.
+    out = asyncio.run(pkg.read_file(str(f), offset=2, limit=2))
+    assert 'l2' in out and 'l3' in out
+    assert 'l1' not in out and 'l4' not in out
 
 
 def test_edit_file_replace_all(tmp_path: Path):
+    # `replace_all` has no harness equivalent, so it stays an in-place rewrite.
     f = tmp_path / 'r.txt'
     f.write_text('a a a', encoding='utf-8')
-    pkg.edit_file(str(f), 'a', 'b', replace_all=True)
+    asyncio.run(pkg.edit_file(str(f), 'a', 'b', replace_all=True))
     assert f.read_text(encoding='utf-8') == 'b b b'
 
 
 def test_bash_tool():
-    out = pkg.bash('echo hello-from-bash')
-    assert 'exit=0' in out and 'hello-from-bash' in out
+    out = asyncio.run(pkg.bash('echo hello-from-bash'))
+    assert 'hello-from-bash' in out
 
 
 def test_grep_tool(tmp_path: Path):
@@ -479,7 +490,7 @@ def test_read_file_prepends_context(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     (tmp_path / 'AGENTS.md').write_text('repo rules', encoding='utf-8')
     (tmp_path / 'f.txt').write_text('file body', encoding='utf-8')
     shared.reset_context_state()
-    out = pkg.read_file('f.txt')
+    out = asyncio.run(pkg.read_file('f.txt'))
     assert 'context: AGENTS.md' in out and 'repo rules' in out and 'file body' in out
 
 
@@ -976,13 +987,15 @@ def test_stream_events_tags_retry_prompt_as_error():
 # --------------------------------------------------------------------------- #
 # disk / IO failure paths for the file tools
 # --------------------------------------------------------------------------- #
-def test_read_missing_file_returns_error(tmp_path: Path):
-    out = pkg.read_file(str(tmp_path / 'nope.txt'))
+def test_read_missing_file_returns_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('GITHUB_WORKSPACE', str(tmp_path))
+    out = asyncio.run(pkg.read_file(str(tmp_path / 'nope.txt')))
     assert out.startswith('error:')
 
 
-def test_edit_missing_file_returns_error(tmp_path: Path):
-    out = pkg.edit_file(str(tmp_path / 'missing.txt'), 'old', 'new')
+def test_edit_missing_file_returns_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('GITHUB_WORKSPACE', str(tmp_path))
+    out = asyncio.run(pkg.edit_file(str(tmp_path / 'missing.txt'), 'old', 'new'))
     assert out.startswith('error:')
 
 
@@ -996,12 +1009,12 @@ def test_list_dir_missing_path_returns_error(tmp_path: Path):
     assert out.startswith('error:')
 
 
-def test_write_to_existing_parent_succeeds_otherwise_creates(tmp_path: Path):
-    # write_file's own `parent.mkdir(parents=True, exist_ok=True)` handles
-    # missing parents; the OSError path triggers only on a real permission
-    # error or invalid path. Verify the happy + nested-parent paths here.
+def test_write_to_existing_parent_succeeds_otherwise_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # The harness `write_file` requires an existing parent; the Write adapter
+    # calls `create_directory` first, so nested writes still succeed.
+    monkeypatch.setenv('GITHUB_WORKSPACE', str(tmp_path))
     nested = tmp_path / 'a' / 'b' / 'c.txt'
-    assert 'wrote' in pkg.write_file(str(nested), 'ok')
+    assert 'Wrote' in asyncio.run(pkg.write_file(str(nested), 'ok'))
     assert nested.read_text(encoding='utf-8') == 'ok'
 
 

--- a/.github/scripts/test_pydantic_ai_runner.py
+++ b/.github/scripts/test_pydantic_ai_runner.py
@@ -1098,6 +1098,8 @@ def test_run_with_timeout_emits_error_on_global_timeout(monkeypatch: pytest.Monk
 
     monkeypatch.setattr(shim, 'run', _hang)
     monkeypatch.setattr(shim, 'RUN_TIMEOUT_SECS', 0.01)
+    # Keep the faulthandler grace tiny so the test doesn't wait the real 10s.
+    monkeypatch.setattr(shim, 'FAULT_DUMP_GRACE_SECS', 0.05)
     buf = io.StringIO()
     with redirect_stdout(buf):
         rc = asyncio.run(

--- a/.github/scripts/test_pydantic_ai_runner.py
+++ b/.github/scripts/test_pydantic_ai_runner.py
@@ -701,7 +701,7 @@ def test_trim_logs_substitution_counts_only_when_changes_fired(caplog: LogCaptur
     ]
     with caplog.at_level('INFO', logger='pydantic_ai_gh_aw_shim'):
         shim._trim_tool_results(tiny_msgs)  # pyright: ignore[reportPrivateUsage]
-    assert not any('compaction trim' in m for m in caplog.messages)
+    assert not any('trim: deduped' in m for m in caplog.messages)
     caplog.clear()
 
     big = 'Z' * 20_000
@@ -717,7 +717,7 @@ def test_trim_logs_substitution_counts_only_when_changes_fired(caplog: LogCaptur
         msgs.append(ModelRequest(parts=[UserPromptPart(content=f't{i}')]))
     with caplog.at_level('INFO', logger='pydantic_ai_gh_aw_shim'):
         shim._trim_tool_results(msgs)  # pyright: ignore[reportPrivateUsage]
-    log_line = next((m for m in caplog.messages if 'compaction trim' in m), None)
+    log_line = next((m for m in caplog.messages if 'trim: deduped' in m), None)
     assert log_line is not None
     assert 'deduped 1' in log_line and 'truncated 2' in log_line and 'saved' in log_line
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,16 @@ dev = [
     "genai-prices>=0.0.62",
     "brotli>=1.2.0",
 ]
-lint = ["mypy>=1.11.2", "pyright>=1.1.408", "ruff>=0.14.14"]
+lint = [
+    "mypy>=1.11.2",
+    "pyright>=1.1.408",
+    "ruff>=0.14.14",
+    # The gh-aw shim (.github/scripts/pydantic_ai_gh_aw_shim) backs its
+    # Bash/Read/Write/Edit tools with harness FileSystem/Shell, so pyright needs
+    # the harness installed to resolve those types. Keep this in sync with the
+    # runner's pin (.github/scripts/pydantic-ai-runner).
+    "pydantic-ai-harness>=0.4.0",
+]
 docs = [
     "pydantic-ai[a2a]",
     "black>=24.10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -7230,6 +7230,7 @@ docs-upload = [
 ]
 lint = [
     { name = "mypy" },
+    { name = "pydantic-ai-harness" },
     { name = "pyright" },
     { name = "ruff" },
 ]
@@ -7295,6 +7296,7 @@ docs-upload = [
 ]
 lint = [
     { name = "mypy", specifier = ">=1.11.2" },
+    { name = "pydantic-ai-harness", specifier = ">=0.4.0" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "ruff", specifier = ">=0.14.14" },
 ]
@@ -7337,6 +7339,19 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.17" },
     { name = "rich", specifier = ">=13.9.2" },
     { name = "uvicorn", specifier = ">=0.32.0" },
+]
+
+[[package]]
+name = "pydantic-ai-harness"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic-ai-slim" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/7b/b0ec85f6a7d62e19524753715ff77046a9fce3a3e1a98df858bf5cde8151/pydantic_ai_harness-0.4.0.tar.gz", hash = "sha256:78daa5a9d3289e2c90deae140c2ed59617cc91a945726b8aad70a8fa15348387", size = 733974, upload-time = "2026-06-17T11:07:42.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/8b/fe2e9b3053f1a5f9278eadc80da9898154b2542bbbac4ee74f544001484a/pydantic_ai_harness-0.4.0-py3-none-any.whl", hash = "sha256:cf231f8c5b4dcf5096f9f318459ee97f1c8dc8dc50b8b26a7abc71dfcf7c74be", size = 164741, upload-time = "2026-06-17T11:07:41.258Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Closes #<issue>

## What & why

The `pydantic_ai_gh_aw_shim` runs **headless** in a firewalled CI container as the engine for this repo's gh-aw workflows. The only diagnostics that survive a run are stderr (uploaded as `agent-stdio.log`) and the stream-json `result` line gh-aw parses.

A recurring CI failure — `ExceptionGroup('unhandled errors in a TaskGroup', [McpError(...)])` escaping `agent.run()` — took an extremely long investigation to root-cause, almost entirely because the shim logged exceptions by their **repr** (`logger.warning('%r', exc)`). `%r` on an `ExceptionGroup` prints `ExceptionGroup(..., [McpError(...)])` but discards every frame and every nested sub-exception's stack, so we could never see where the error actually escaped.

This change makes the genuinely-blind handlers self-explaining from the uploaded log, while leaving intentional, well-handled fallbacks quiet (a traceback there would just be noise).

## Changes (`.github/scripts/pydantic_ai_gh_aw_shim/cli.py`)

- **`run`** — `logger.exception` instead of `logger.warning('%r')`, so the full traceback (and each `ExceptionGroup` leaf's stack on 3.11+) lands in `agent-stdio.log`. The `result` line stays a one-liner because gh-aw parses it.
- **`_run_with_timeout`** — arm `faulthandler.dump_traceback_later` so a wall-clock timeout dumps the **live stuck stack** before `wait_for` cancels and unwinds it (a `TimeoutError` itself carries no useful traceback). One-shot timer, cancelled in a `finally`.
- **`task`** — `logger.exception` for sub-agent failures, plus a distinct `asyncio.TimeoutError` branch so a bare timeout isn't surfaced as an empty `sub-agent failed:` message.
- **`main`** — split `except SystemExit` (argparse rejection — repr is enough) from `except Exception` (real startup crash → `logger.exception`).
- **`_compact_history`** — keep the warning-level fallback but add `exc_info` and a non-empty detail for bare `TimeoutError`.
- **`build_mcp_servers`** — log at `error` when a bad config drops the entire external-tool surface, so a silently tool-less run is obvious.

Intentional fallbacks (native file/shell tools, observability wiring, context auto-load, grep timeout) are deliberately left quiet.

The traceback is sent only to stderr (already the uploaded `agent-stdio.log`) — **not** embedded into the gh-aw-parsed `result` line — so the human-facing message and gh-aw's parsing are unchanged.

## Notes

- This branch **stacks on two earlier, still-unmerged gh-aw shim commits** (`a186b7e9e` harness-backed file/shell tools, `87607a7b6` released `pydantic-ai-harness>=0.4.0`); they show up in the diff. Happy to rebase onto a standalone branch if you'd prefer the traceback change reviewed in isolation.
- Verified the change cannot trip CI/alert detection: the shim's log format omits the level name, and run success/failure is driven by the stream-json `result` `is_error` field (unchanged here), not by grepping the log.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

