### PR TITLE
Preserve exception tracebacks in the gh-aw shim's error handlers

### DIFF
--- a/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
@@ -377,9 +377,14 @@ async def _compact_history(ctx: RunContext[object], messages: list[ModelMessage]
         )
         summary = str(r.output or '').strip() or '(empty summary)'
     except Exception as exc:
+        # Well-handled fallback: the run continues on the trimmed history, so the
+        # stack is kept available (`exc_info`) without escalating the log level.
+        # A bare `TimeoutError` stringifies to '' — fall back to the type name so
+        # the emitted `error` is never empty.
         ctx.usage.incr(sub_usage)
-        logger.warning('compaction summarisation failed (%r); falling back', exc)
-        emit({'type': 'system', 'subtype': 'compaction_summary_failed', 'error': str(exc)})
+        detail = f'{type(exc).__name__}: {exc}' if str(exc) else type(exc).__name__
+        logger.warning('compaction summarisation failed (%s); falling back', detail, exc_info=True)
+        emit({'type': 'system', 'subtype': 'compaction_summary_failed', 'error': detail})
         return [prior_synthetic, *tail] if prior_synthetic else tail
     ctx.usage.incr(sub_usage)
     # If the summariser produces output larger than the middle it's replacing,
@@ -587,11 +592,16 @@ def build_mcp_servers(args: Args) -> list[AbstractToolset[object]]:
         return []
     try:
         loaded = load_mcp_toolsets(path)
+    # `repr` is sufficient diagnostically here (a `ValidationError` already
+    # enumerates the bad fields, `FileNotFoundError` names the path), so no
+    # traceback — but returning `[]` drops the *entire* GitHub/safeoutputs tool
+    # surface, a drastic behaviour change, so log it at `error` to make a run
+    # that silently lost its tools obvious in the artifact.
     except FileNotFoundError as exc:
-        logger.warning('MCP config %r missing: %r — running without external tools', path, exc)
+        logger.error('MCP config %r missing (%r) — agent will run with NO external tools', path, exc)
         return []
     except (ValidationError, ValueError) as exc:
-        logger.warning('MCP config %r is malformed: %r — running without external tools', path, exc)
+        logger.error('MCP config %r is malformed (%r) — agent will run with NO external tools', path, exc)
         return []
 
     servers: list[AbstractToolset[object]] = []
@@ -781,8 +791,18 @@ async def task(ctx: RunContext[object], description: str, prompt: str) -> str:
             sub.run(RUN_TRIGGER, usage_limits=UsageLimits(request_limit=SUBAGENT_REQUEST_LIMIT), usage=sub_usage),
             timeout=SUBAGENT_TIMEOUT_SECS,
         )
-    except Exception as exc:
+    except asyncio.TimeoutError:
+        # A bare `TimeoutError` stringifies to '' — without an explicit message
+        # the model (and the log) would see `sub-agent failed:` with no payload.
         ctx.usage.incr(sub_usage)
+        logger.error('sub-agent timed out after %.0f min: %s', SUBAGENT_TIMEOUT_SECS / 60, description[:120])
+        return f'error: sub-agent timed out after {SUBAGENT_TIMEOUT_SECS // 60}min'
+    except Exception as exc:
+        # The parent agent reacts to the returned string, but a sub-agent can hit
+        # the same nested `ExceptionGroup`/`McpError` as the main run — log the
+        # full stack so the failure isn't reduced to a one-line repr in the logs.
+        ctx.usage.incr(sub_usage)
+        logger.exception('sub-agent failed: %s', description[:120])
         return f'error: sub-agent failed: {exc}'
     ctx.usage.incr(sub_usage)
     logger.info('Task done: +%d sub-requests (run total now %d)', sub_usage.requests, ctx.usage.requests)
@@ -842,7 +862,14 @@ async def run(
         async with agent:
             result = await agent.run(RUN_TRIGGER, usage_limits=limits)
     except Exception as exc:
-        logger.warning('agent run failed: %r', exc)
+        # `%r` on an `ExceptionGroup` (e.g. the MCP `TaskGroup` failures seen in
+        # CI) discards every frame and every nested sub-exception's stack, which
+        # is what made the original incident so hard to root-cause. `exception()`
+        # renders the full traceback — and, on 3.11+, each group leaf's stack —
+        # to stderr, which gh-aw captures into the uploaded `agent-stdio.log`,
+        # so the run is self-explaining without a re-run. The `result` text
+        # stays a one-liner because gh-aw parses it.
+        logger.exception('agent run failed')
         emit_result(
             f'agent run failed: {exc}',
             usage=None,
@@ -894,9 +921,16 @@ def main() -> int:
         rc = asyncio.run(_run_with_timeout(prompt, model, label, claude_code_toolset, mcp_servers, session_id))
         logger.info('done in %.1fs rc=%d', time.time() - started, rc)
         return rc
-    except (Exception, SystemExit) as exc:
+    except SystemExit as exc:
         # `argparse` raises `SystemExit` (not `Exception`) on unknown-flag
-        # rejection; gh-aw still needs a structured result line.
+        # rejection — an expected, clean exit, so a traceback would be noise.
+        # gh-aw still needs a structured result line.
         logger.error('FATAL startup error: %r', exc)
+        emit_result(f'shim startup failed: {exc}', usage=None, session_id=session_id, is_error=True)
+        return 1
+    except Exception as exc:
+        # A real crash before the agent run (model build, MCP load, …) — dump the
+        # full stack so a blind FATAL doesn't cost another long investigation.
+        logger.exception('FATAL startup error')
         emit_result(f'shim startup failed: {exc}', usage=None, session_id=session_id, is_error=True)
         return 1


### PR DESCRIPTION
- Closes #<issue>

## What & why

The `pydantic_ai_gh_aw_shim` runs **headless** in a firewalled CI container as the engine for this repo's gh-aw workflows. The only diagnostics that survive a run are stderr (uploaded as `agent-stdio.log`) and the stream-json `result` line gh-aw parses.

A recurring CI failure — `ExceptionGroup('unhandled errors in a TaskGroup', [McpError(...)])` escaping `agent.run()` — took an extremely long investigation to root-cause, almost entirely because the shim logged exceptions by their **repr** (`logger.warning('%r', exc)`). `%r` on an `ExceptionGroup` prints `ExceptionGroup(..., [McpError(...)])` but discards every frame and every nested sub-exception's stack, so we could never see where the error actually escaped.

This makes the genuinely-blind handlers self-explaining from the uploaded log, while leaving intentional, well-handled fallbacks quiet (a traceback there would just be noise).

## Changes (`.github/scripts/pydantic_ai_gh_aw_shim/cli.py`)

- **`run`** — `logger.exception` instead of `logger.warning('%r')`, so the full traceback (and each `ExceptionGroup` leaf's stack on 3.11+) lands in `agent-stdio.log`. The `result` line stays a one-liner because gh-aw parses it.
- **`task`** — `logger.exception` for sub-agent failures, plus a distinct `asyncio.TimeoutError` branch so a bare timeout isn't surfaced as an empty `sub-agent failed:` message.
- **`main`** — split `except SystemExit` (argparse rejection — repr is enough) from `except Exception` (real startup crash → `logger.exception`).
- **`_compact_history`** — keep the warning-level fallback but add `exc_info` and a non-empty detail for bare `TimeoutError`.
- **`build_mcp_servers`** — log at `error` when a bad config drops the entire external-tool surface, so a silently tool-less run is obvious.

Intentional fallbacks (native file/shell tools, observability wiring, context auto-load, grep timeout) are deliberately left quiet.

Tracebacks go only to stderr (already the uploaded `agent-stdio.log`) — **not** embedded into the gh-aw-parsed `result` line — so the human-facing message and gh-aw's parsing are unchanged. Verified the change can't trip CI/alert detection: the shim's log format omits the level name, and run success/failure is driven by the stream-json `result` `is_error` field (unchanged here), not by grepping the log.

The `_run_with_timeout` wall-clock path is deliberately left as-is: a `TimeoutError` from `wait_for` carries no useful traceback (the stuck frame is already unwound by cancellation), and that's a speculative failure mode rather than the reproduced defect — not worth the maintenance burden of a stack-dump mechanism here.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)