### PR TITLE
fix(messages): register builtin-tool-return tags on ModelRequestPart

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1996,6 +1996,8 @@ ModelRequestPart = Annotated[
     | Annotated[ToolSearchReturnPart, pydantic.Tag('tool-search-return')]
     | Annotated[LoadCapabilityReturnPart, pydantic.Tag('capability-load-return')]
     | Annotated[ToolReturnPart, pydantic.Tag('tool-return')]
+    | Annotated[NativeToolSearchReturnPart, pydantic.Tag('builtin-tool-search-return')]
+    | Annotated[NativeToolReturnPart, pydantic.Tag('builtin-tool-return')]
     | Annotated[RetryPromptPart, pydantic.Tag('retry-prompt')],
     pydantic.Discriminator(_model_request_part_discriminator),
 ]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -796,6 +796,46 @@ And then, call the 'hello_world' tool\
     )
 
 
+def test_model_request_with_native_tool_return_part_round_trips():
+    """Regression: a ModelRequest carrying a NativeToolReturnPart must round-trip.
+
+    The ModelRequestPart union omitted the builtin-tool-return tags that its
+    discriminator can emit, so re-loading any history with a provider-executed
+    (builtin) tool result raised union_tag_invalid, even though ModelResponsePart
+    already handled the symmetric case.
+    """
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Search the web for Python')]),
+        ModelResponse(
+            parts=[
+                TextPart(content='Searching the web...'),
+                NativeToolCallPart(
+                    tool_name='web_search',
+                    args={'query': 'Python'},
+                    tool_call_id='c1',
+                    provider_name='openai',
+                ),
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                NativeToolReturnPart(
+                    tool_name='web_search',
+                    tool_call_id='c1',
+                    content={'results': [{'title': 'Python', 'url': 'python.org'}]},
+                    provider_name='openai',
+                ),
+            ]
+        ),
+    ]
+
+    serialized_json = ModelMessagesTypeAdapter.dump_json(messages)
+    assert ModelMessagesTypeAdapter.validate_json(serialized_json) == messages
+
+    serialized_python = ModelMessagesTypeAdapter.dump_python(messages)
+    assert ModelMessagesTypeAdapter.validate_python(serialized_python) == messages
+
+
 def test_image_url_validation_with_optional_identifier():
     image_url_ta = TypeAdapter(ImageUrl)
     image = image_url_ta.validate_python({'url': 'https://example.com/image.jpg'})

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -35,7 +35,12 @@ from pydantic_ai import (
     UserPromptPart,
     VideoUrl,
 )
-from pydantic_ai.messages import INVALID_JSON_KEY, MULTI_MODAL_CONTENT_TYPES, is_multi_modal_content
+from pydantic_ai.messages import (
+    INVALID_JSON_KEY,
+    MULTI_MODAL_CONTENT_TYPES,
+    NativeToolSearchReturnPart,
+    is_multi_modal_content,
+)
 from pydantic_ai.models.test import TestModel
 
 from ._inline_snapshot import snapshot
@@ -834,6 +839,25 @@ def test_model_request_with_native_tool_return_part_round_trips():
 
     serialized_python = ModelMessagesTypeAdapter.dump_python(messages)
     assert ModelMessagesTypeAdapter.validate_python(serialized_python) == messages
+
+    # The search variant (NativeToolSearchReturnPart, tag 'builtin-tool-search-return')
+    # shares the same request-side path and must round-trip too.
+    search_messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[
+                NativeToolSearchReturnPart(
+                    tool_call_id='c2',
+                    content={'discovered_tools': []},
+                    provider_name='anthropic',
+                ),
+            ]
+        ),
+    ]
+    search_json = ModelMessagesTypeAdapter.dump_json(search_messages)
+    assert ModelMessagesTypeAdapter.validate_json(search_json) == search_messages
+
+    search_python = ModelMessagesTypeAdapter.dump_python(search_messages)
+    assert ModelMessagesTypeAdapter.validate_python(search_python) == search_messages
 
 
 def test_image_url_validation_with_optional_identifier():


### PR DESCRIPTION
## Summary

Closes #6035.

The `ModelRequestPart` discriminated union (`messages.py`) listed only 6 members and did **not** include `NativeToolReturnPart` / `NativeToolSearchReturnPart`, even though `_model_request_part_discriminator` returns `'builtin-tool-return'` / `'builtin-tool-search-return'` for those instances. The symmetric `ModelResponsePart` union already registers both tags, so only the request side was affected.

As a result, any `ModelRequest` carrying a provider-executed (builtin) tool result failed to round-trip through `ModelMessagesTypeAdapter` (`union_tag_invalid`), and the dump step emitted `PydanticSerializationUnexpectedValue` warnings for every such part — fatal under this repo's `filterwarnings = ["error"]`.

This affects real call sites that construct that shape: the AG-UI and Vercel AI adapters build a `ModelRequest(parts=[NativeToolReturnPart])` from a tool result, the `chat_app` persistence pattern reloads history via `validate_json`, and durable-exec (Temporal/Prefect/DBOS) resumes from persisted `message_history`.

## Fix

Add the two missing tagged members to `ModelRequestPart`, restoring request/response symmetry:

```python
| Annotated[NativeToolSearchReturnPart, pydantic.Tag('builtin-tool-search-return')]
| Annotated[NativeToolReturnPart, pydantic.Tag('builtin-tool-return')]
```

## Test

Added `test_model_request_with_native_tool_return_part_round_trips`, which round-trips a `ModelRequest` containing a `NativeToolReturnPart` through both `dump_json`/`validate_json` and `dump_python`/`validate_python`.

Before/after on `main`:
- **without the fix:** the test fails — the dump raises a serializer `UserWarning` (escalated to error by `filterwarnings`), and reload raises `union_tag_invalid`.
- **with the fix:** passes. The rest of the message-union tests in `tests/test_messages.py` pass; `ruff check` and `ruff format --check` are clean. (Two unrelated `test_document*`/`test_binary*` failures reproduce on a clean `main` and are not touched by this change.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

