### PR TITLE
fix(graph): avoid duplicate `downstream_join_id` map join emission

### DIFF
--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -983,6 +983,24 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
 
         return completed_fork_runs
 
+    def _get_join_parent_fork_run_id(
+        self,
+        join_id: JoinID,
+        fork_stack: ForkStack,
+        current_fork: Fork[Any, Any] | None = None,
+        current_fork_run_id: NodeRunID | None = None,
+    ) -> NodeRunID:
+        parent_fork_id = self.graph.get_parent_fork(join_id).fork_id
+        if current_fork is not None and parent_fork_id == current_fork.id:
+            assert current_fork_run_id is not None
+            return current_fork_run_id
+
+        for item in fork_stack[::-1]:
+            if item.fork_id == parent_fork_id:
+                return item.node_run_id
+
+        raise RuntimeError('Parent fork run not found')
+
     def _handle_path(self, path: Path, inputs: Any, fork_stack: ForkStack) -> Sequence[GraphTask]:
         if not path.items:
             return []  # pragma: no cover
@@ -1030,7 +1048,8 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
             if (join_id := node.downstream_join_id) is not None:
                 join_node = self.graph.nodes[join_id]
                 assert isinstance(join_node, Join)
-                self.active_reducers[(join_id, node_run_id)] = JoinState(join_node.initial_factory(), fork_stack)
+                fork_run_id = self._get_join_parent_fork_run_id(join_id, fork_stack, node, node_run_id)
+                self.active_reducers[(join_id, fork_run_id)] = JoinState(join_node.initial_factory(), fork_stack)
 
             # Eagerly raise a clear error if the input value is not iterable as expected
             if _is_any_iterable(inputs):

--- a/tests/graph/builder/test_broadcast_and_spread.py
+++ b/tests/graph/builder/test_broadcast_and_spread.py
@@ -135,6 +135,40 @@ async def test_map_empty_list():
     assert result == []
 
 
+async def test_map_with_downstream_join_id_non_empty_list():
+    """Test downstream_join_id does not emit the join initial value for non-empty maps."""
+    g = GraphBuilder(state_type=CounterState, output_type=list[int])
+    emitted: list[list[int]] = []
+
+    @g.step
+    async def generate_list(ctx: StepContext[CounterState, None, None]) -> list[int]:
+        return [1, 2, 3]
+
+    @g.step
+    async def identity(ctx: StepContext[CounterState, None, int]) -> int:
+        return ctx.inputs
+
+    collect = g.join(reduce_list_append, initial_factory=list[int])
+
+    @g.step
+    async def after_join(ctx: StepContext[CounterState, None, list[int]]) -> list[int]:
+        emitted.append(sorted(ctx.inputs))
+        return ctx.inputs
+
+    g.add_mapping_edge(generate_list, identity, downstream_join_id=collect.id)
+    g.add(
+        g.edge_from(g.start_node).to(generate_list),
+        g.edge_from(identity).to(collect),
+        g.edge_from(collect).to(after_join),
+        g.edge_from(after_join).to(g.end_node),
+    )
+
+    graph = g.build()
+    result = await graph.run(state=CounterState())
+    assert sorted(result) == [1, 2, 3]
+    assert emitted == [[1, 2, 3]]
+
+
 async def test_nested_broadcasts():
     """Test nested broadcast operations."""
     g = GraphBuilder(state_type=CounterState, output_type=list[int])


### PR DESCRIPTION
- Closes #6008

This fixes a `GraphBuilder.add_mapping_edge(..., downstream_join_id=...)` case where a non-empty mapped iterable could emit the downstream join twice. The eager reducer created for `downstream_join_id` was keyed by the map fork run id, while the actual mapped values reduce under the downstream join parent fork run id. That left two reducer states alive, so the join could first emit its initial value and then the actual reduced value.

The fix keys the eager downstream join state by the downstream join parent fork run id, reusing the current fork run id when the mapping fork is the parent and otherwise looking it up from the active fork stack. I added a regression test covering the non-empty `downstream_join_id` path and asserting that the post-join node fires once with the reduced values.

Reproduced on current `origin/main` before the fix:

```text
run output: []
join emitted: [[], [1, 2, 3]]
```

Validation:

```text
uv run pytest tests/graph/builder/test_broadcast_and_spread.py::test_map_with_downstream_join_id_non_empty_list -q
uv run pytest tests/graph/builder/test_broadcast_and_spread.py -q
uv run ruff check pydantic_graph/pydantic_graph/graph_builder.py tests/graph/builder/test_broadcast_and_spread.py
uv run ruff format --check pydantic_graph/pydantic_graph/graph_builder.py tests/graph/builder/test_broadcast_and_spread.py
PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_graph/pydantic_graph/graph_builder.py
git diff --check
```

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

AI assistance was used to prepare this patch. I reviewed the diff and validation evidence before opening the PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

