### PR TITLE
fix(`GoogleModel`): include `CodeExecutionTool` in `include_server_side_tool_invocations` check

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -711,12 +711,12 @@ class GoogleModel(Model[Client]):
                 function_calling_config['allowed_function_names'] = allowed_function_names
             tool_config['function_calling_config'] = function_calling_config
 
-        # `include_server_side_tool_invocations` makes Gemini emit explicit `tool_call`/`tool_response`
-        # parts for WebSearchTool, WebFetchTool, FileSearchTool. Pre-Gemini-3 models reject the field
-        # ('Tool call context circulation is not enabled'); CodeExecutionTool uses its own
-        # `executable_code`/`code_execution_result` parts; ImageGenerationTool runs through `image_config`.
+        # `include_server_side_tool_invocations` is required on Gemini 3+ when any built-in (server-side)
+        # tool is combined with function calling; pre-Gemini-3 models reject the field ('Tool call context
+        # circulation is not enabled'). ImageGenerationTool runs through `image_config` and is excluded.
         emits_tool_call_invocations = any(
-            isinstance(t, (WebSearchTool, WebFetchTool, FileSearchTool)) for t in model_request_parameters.native_tools
+            isinstance(t, (WebSearchTool, WebFetchTool, FileSearchTool, CodeExecutionTool))
+            for t in model_request_parameters.native_tools
         )
         if emits_tool_call_invocations and self.profile.get('google_supports_server_side_tool_invocations', False):
             tool_config['include_server_side_tool_invocations'] = True

--- a/tests/models/test_tool_choice_unit.py
+++ b/tests/models/test_tool_choice_unit.py
@@ -16,7 +16,7 @@ from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import ModelRequest
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models._tool_choice import resolve_tool_choice
-from pydantic_ai.native_tools import WebSearchTool
+from pydantic_ai.native_tools import CodeExecutionTool, WebSearchTool
 from pydantic_ai.settings import ModelSettings, ToolChoice, ToolOrOutput
 from pydantic_ai.tools import ToolDefinition
 
@@ -616,6 +616,17 @@ NATIVE_TOOL_CONFIG_CASES = [
         model='gemini-2.5-pro',
         request_parameters=ModelRequestParameters(function_tools=[make_tool('get_weather')]),
         expected_tool_config={'function_calling_config': {'mode': 'AUTO'}},
+    ),
+    dict(
+        id='code-execution-gemini-3-sets-server-side-flag',
+        model='gemini-3-flash-preview',
+        request_parameters=ModelRequestParameters(
+            native_tools=[CodeExecutionTool()], function_tools=[make_tool('get_weather')]
+        ),
+        expected_tool_config={
+            'include_server_side_tool_invocations': True,
+            'function_calling_config': {'mode': 'AUTO'},
+        },
     ),
 ]
 


### PR DESCRIPTION
- Closes #6051

## Summary

Combining `CodeExecutionTool` with function tools on Gemini 3 raised an HTTP 400:

```
google.genai.errors.ClientError: 400 INVALID_ARGUMENT
Please enable tool_config.include_server_side_tool_invocations
to use Built-in tools with Function calling.
```

`_get_tool_config` already set `include_server_side_tool_invocations` for `WebSearchTool`, `WebFetchTool`, and `FileSearchTool`, but `CodeExecutionTool` was missing from the `isinstance` guard. One-line fix: add it to the tuple.

## Changes

- `pydantic_ai_slim/pydantic_ai/models/google.py` — add `CodeExecutionTool` to the `emits_tool_call_invocations` check; update comment to reflect that the flag applies to all built-in tools (not just the three previously listed)
- `tests/models/test_tool_choice_unit.py` — new parametrized unit-test case `code-execution-gemini-3-sets-server-side-flag` asserting the request shape directly (VCR can't catch a malformed request since it replays a recorded response without re-validating against the API)

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

