### PR TITLE
roundtrip-sweep: dedupe against existing open PRs/issues before filing

### DIFF
--- a/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
@@ -46,19 +46,32 @@ existing suite. The bug must be one you triggered and observed.
 
 - Speculation without a failing reproduction.
 - By-design lossy fields explicitly documented as such.
-- Behavior already tracked by an open issue — **search issues first**.
+- Behavior already tracked by an open issue or fixed by an open PR — **search both first**.
 
 ## Deduplication — mandatory BEFORE filing an issue
 
-Search for existing issues using the MCP
-GitHub tools (not `gh` CLI — it's blocked by the firewall proxy):
+The gap may already be tracked by an open **issue** or already fixed by an
+open **PR** — check both. Use the MCP GitHub tools (not `gh` CLI — it's
+blocked by the firewall proxy).
+
+**(a) Existing issues** — by sweep signature and by the specific
+boundary/function you investigated:
 
 ```
 mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open "[roundtrip-sweep]" OR "round-trip" OR "serialize"
 ```
 
-Also search for the specific boundary/function you plan to investigate. If a
-matching issue already exists, call `mcp__safeoutputs__noop` immediately.
+**(b) Existing PRs** — a fix may already be open (and even approved). Search
+open PRs touching the failing symbol or file:
+
+```
+mcp__github__search_pull_requests repo:pydantic/pydantic-ai is:pr is:open <failing symbol / file path>
+```
+
+If a matching open issue or PR exists, call `mcp__safeoutputs__noop`
+immediately instead of filing. If a PR looks related but you cannot confirm it
+covers this exact gap, still file but add a **`Possibly addressed by #<N>`**
+line near the top of the issue body linking that PR.
 
 ## Sandbox notes
 

--- a/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
@@ -70,8 +70,9 @@ mcp__github__search_pull_requests repo:pydantic/pydantic-ai is:pr is:open <faili
 
 If a matching open issue or PR exists, call `mcp__safeoutputs__noop`
 immediately instead of filing. If a PR looks related but you cannot confirm it
-covers this exact gap, still file but add a **`Possibly addressed by #<N>`**
-line near the top of the issue body linking that PR.
+covers this exact gap, still file but fill in the optional **`Possibly
+addressed by #<N>`** row at the top of the body template (see Issue Format),
+linking that PR.
 
 ## Sandbox notes
 
@@ -87,8 +88,10 @@ concrete, minimal, failing round-trip reproduction with observed output.
 
 **Title:** `<boundary>: <what is lost> on round-trip`
 
-**Body:**
+**Body:** (include the first row only for an uncertain PR match; omit it otherwise)
 
+> **Possibly addressed by #<N>** — [link the related open PR]
+>
 > ## Impact
 > [Who is affected; e.g. resumed runs, Temporal workflows, AG-UI clients]
 >


### PR DESCRIPTION
David's AICA here:

## Motivating case

The round-trip sweep workflow auto-filed [roundtrip-sweep] **#5811** ("BinaryContent tool return doesn't round-trip") while PR **#5255** — which fixes exactly that — was already **open and approved**. The sweep's dedup step searched only existing *issues*, never open *PRs*, so it couldn't see that a fix was already in flight.

## Change

`.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md` (the sweep's agentic prompt / Logfire-managed default). The "Deduplication — mandatory BEFORE filing an issue" step now checks **both** surfaces:

- **(a) existing open issues** — unchanged sweep-signature search.
- **(b) existing open PRs** — new `mcp__github__search_pull_requests` query on the failing symbol/path. A relevant open PR → `mcp__safeoutputs__noop` (skip filing); an uncertain match → still file, but annotate the body with a `Possibly addressed by #<N>` link.

Also updated the "What to Skip" bullet to mention open PRs for consistency.

No lockfile change: the prompt is fetched dynamically at runtime (not inlined into `.lock.yml`), so `gh aw compile` is a no-op here — confirmed.

cc @strawgate (gh-aw owner) — kept this a minimal first pass; the exact skip-vs-annotate behavior is your call to refine.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

