### PR TITLE
Fix minor type annotation and docstring issues

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_cli/web.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/web.py
@@ -33,6 +33,9 @@ def run_web_command(
         instructions: System instructions passed as extra instructions to each agent run.
         default_model: Default model to use when no agent or models are specified.
         html_source: URL or file path for the chat UI HTML.
+
+    Returns:
+        Exit code: 0 for success, 1 for failure.
     """
     console = Console()
 

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -799,7 +799,7 @@ def get_union_args(tp: Any) -> tuple[Any, ...]:
         return ()
 
 
-def get_event_loop():
+def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         event_loop = asyncio.get_event_loop()
     except RuntimeError:  # pragma: lax no cover

--- a/pydantic_evals/pydantic_evals/_utils.py
+++ b/pydantic_evals/pydantic_evals/_utils.py
@@ -79,7 +79,7 @@ _P = ParamSpec('_P')
 _R = TypeVar('_R')
 
 
-def get_event_loop():
+def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         event_loop = asyncio.get_event_loop()
     except RuntimeError:  # pragma: lax no cover

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
         return None
 
 
-def get_event_loop():
+def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         event_loop = asyncio.get_event_loop()
     except RuntimeError:
@@ -89,6 +89,12 @@ def get_parent_namespace(frame: types.FrameType | None) -> dict[str, Any] | None
 
     If the graph is defined with generics `Graph[a, b]` then another frame is inserted, and we have to skip that
     to get the correct namespace.
+
+    Args:
+        frame: The frame to start searching from, or `None`.
+
+    Returns:
+        The local namespace dict of the defining frame, or `None` if the frame was `None`.
     """
     if frame is not None:  # pragma: no branch
         if back := frame.f_back:  # pragma: no branch

--- a/pydantic_graph/pydantic_graph/paths.py
+++ b/pydantic_graph/pydantic_graph/paths.py
@@ -52,7 +52,7 @@ class TransformFunction(Protocol[StateT, DepsT, InputT, OutputT]):
             ctx: The step context containing state, dependencies, and inputs
 
         Returns:
-            An awaitable that resolves to the step's output
+            The step's output
         """
         raise NotImplementedError
 


### PR DESCRIPTION
- Add missing return type `-> asyncio.AbstractEventLoop` to three `get_event_loop()` definitions across packages
- Fix `TransformFunction.__call__` docstring: the method returns a sync value, not an awaitable (matching the protocol description above that says "must be sync instead of async")
- Add missing `Args` and `Returns` sections to `get_parent_namespace` docstring
- Add missing `Returns` section to `run_web_command` docstring

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

