### PR TITLE
fix(google): set include_server_side_tool_invocations when CodeExecutionTool is combined with function tools

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -715,10 +715,18 @@ class GoogleModel(Model[Client]):
         # parts for WebSearchTool, WebFetchTool, FileSearchTool. Pre-Gemini-3 models reject the field
         # ('Tool call context circulation is not enabled'); CodeExecutionTool uses its own
         # `executable_code`/`code_execution_result` parts; ImageGenerationTool runs through `image_config`.
+        # Gemini 3 also requires the flag when CodeExecutionTool and function tools are combined — without
+        # it the API returns "Please enable tool_config.include_server_side_tool_invocations to use
+        # Built-in tools with Function calling" (HTTP 400).
         emits_tool_call_invocations = any(
             isinstance(t, (WebSearchTool, WebFetchTool, FileSearchTool)) for t in model_request_parameters.native_tools
         )
-        if emits_tool_call_invocations and self.profile.get('google_supports_server_side_tool_invocations', False):
+        code_exec_with_functions = bool(tool_defs) and any(
+            isinstance(t, CodeExecutionTool) for t in model_request_parameters.native_tools
+        )
+        if (emits_tool_call_invocations or code_exec_with_functions) and self.profile.get(
+            'google_supports_server_side_tool_invocations', False
+        ):
             tool_config['include_server_side_tool_invocations'] = True
 
         tools: list[ToolDict] = [

--- a/tests/models/google/test_native_tools.py
+++ b/tests/models/google/test_native_tools.py
@@ -20,11 +20,13 @@ from pydantic_ai.messages import (
     NativeToolReturnPart,
     TextPart,
 )
+from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.native_tools import (
     CodeExecutionTool,
     FileSearchTool,
     WebSearchTool,
 )
+from pydantic_ai.tools import ToolDefinition
 
 from ...conftest import try_import
 
@@ -32,8 +34,12 @@ with try_import() as imports_successful:
     from google.genai.types import ToolType
 
     from pydantic_ai.models.google import (
+        GoogleModel,
+        GoogleModelSettings,
         _content_model_response,  # pyright: ignore[reportPrivateUsage]
     )
+    from pydantic_ai.profiles.google import GoogleModelProfile
+    from pydantic_ai.providers.google import GoogleProvider
 
 pytestmark = pytest.mark.skipif(not imports_successful(), reason='google-genai not installed')
 
@@ -190,3 +196,38 @@ def test_content_model_response_pre_gemini_3_preserves_code_execution(supports_t
             ],
         }
     )
+
+
+def test_get_tool_config_code_execution_alone_omits_server_side_flag():
+    """CodeExecutionTool without function tools does NOT set include_server_side_tool_invocations."""
+    profile = GoogleModelProfile(google_supports_server_side_tool_invocations=True)
+    m = GoogleModel('gemini-3-flash-preview', provider=GoogleProvider(api_key='test'), profile=profile)
+
+    params = ModelRequestParameters(
+        function_tools=[],
+        native_tools=[CodeExecutionTool()],
+    )
+    _, tool_config, _ = m._get_tool_config(params, GoogleModelSettings())  # pyright: ignore[reportPrivateUsage]
+
+    assert tool_config is None or not tool_config.get('include_server_side_tool_invocations', False)
+
+
+def test_get_tool_config_code_execution_with_functions_sets_server_side_flag():
+    """CodeExecutionTool + function tools requires include_server_side_tool_invocations=True on Gemini 3.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/6051.
+    Without the fix, combining CodeExecutionTool with function tools on Gemini 3 raises HTTP 400:
+    "Please enable tool_config.include_server_side_tool_invocations to use Built-in tools with Function calling."
+    """
+    profile = GoogleModelProfile(google_supports_server_side_tool_invocations=True)
+    m = GoogleModel('gemini-3-flash-preview', provider=GoogleProvider(api_key='test'), profile=profile)
+
+    dummy_tool = ToolDefinition(name='my_tool', description='A function tool', parameters_json_schema={})
+    params = ModelRequestParameters(
+        function_tools=[dummy_tool],
+        native_tools=[CodeExecutionTool()],
+    )
+    _, tool_config, _ = m._get_tool_config(params, GoogleModelSettings())  # pyright: ignore[reportPrivateUsage]
+
+    assert tool_config is not None
+    assert tool_config.get('include_server_side_tool_invocations') is True


### PR DESCRIPTION
Closes #6051.

## Problem

On Gemini 3, combining `CodeExecutionTool` with any user-defined function tool fails with HTTP 400:

```
google.genai.errors.ClientError: 400 INVALID_ARGUMENT.
{'error': {'code': 400, 'message': 'Please enable tool_config.include_server_side_tool_invocations
to use Built-in tools with Function calling.', 'status': 'INVALID_ARGUMENT'}}
```

`GoogleModel._get_tool_config` only set `include_server_side_tool_invocations=True` for `WebSearchTool`, `WebFetchTool`, and `FileSearchTool` — but Gemini 3 also requires the flag when `CodeExecutionTool` is paired with function tools.

## Fix

Extend the existing condition in `_get_tool_config` to also trigger when `CodeExecutionTool` is present alongside at least one function tool and the model profile supports server-side tool invocations (`google_supports_server_side_tool_invocations=True`, set automatically for Gemini 3+ profiles).

```python
# Before
emits_tool_call_invocations = any(isinstance(t, (WebSearchTool, WebFetchTool, FileSearchTool)) ...)
if emits_tool_call_invocations and ...:
    tool_config['include_server_side_tool_invocations'] = True

# After
code_exec_with_functions = bool(tool_defs) and any(isinstance(t, CodeExecutionTool) ...)
if (emits_tool_call_invocations or code_exec_with_functions) and ...:
    tool_config['include_server_side_tool_invocations'] = True
```

`CodeExecutionTool` alone (without function tools) is **not** affected — it already works without the flag via `executable_code`/`code_execution_result` parts.

## Changes

| File | Change |
|------|--------|
| `models/google.py` | Add `code_exec_with_functions` guard in `_get_tool_config` |
| `tests/models/google/test_native_tools.py` | Two unit tests directly exercising `_get_tool_config` |

## Tests

- `test_get_tool_config_code_execution_alone_omits_server_side_flag` — verifies `CodeExecutionTool` alone does not set the flag (no regression)
- `test_get_tool_config_code_execution_with_functions_sets_server_side_flag` — verifies `CodeExecutionTool + function tool` now sets `include_server_side_tool_invocations=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

