### PR TITLE
Gate `pydantic-ai-ui-security-review` behind a maintainer click-to-start approval

### DIFF
--- a/.github/workflows/pydantic-ai-ui-security-review.lock.yml
+++ b/.github/workflows/pydantic-ai-ui-security-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"034be594b4c88140b199a72b954cbc9bd1efc20b880eed8e61d8a2ad581527f0","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5d947e77ed3bb0c51535bc5852d044b2a42bd7f5b6a63286859081e9babe678d","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_READ_EXTERNAL_VARIABLES","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -65,21 +65,15 @@
 #   - ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388
 #   - ghcr.io/github/github-mcp-server:v1.0.4
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
+#
+# Manual approval required: environment 'ui-security-review'
 
 name: "Pydantic AI UI Security Review"
 on:
+  # manual-approval: ui-security-review # Manual approval processed as environment field in activation job
+  needs:
+  - detect
   pull_request:
-    paths:
-    - pydantic_ai_slim/pydantic_ai/ui/**
-    - pydantic_ai_slim/pydantic_ai/_ssrf.py
-    - pydantic_ai_slim/pydantic_ai/messages.py
-    - pydantic_ai_slim/pydantic_ai/common_tools/web_fetch.py
-    - docs/ui/**
-    - docs/input.md
-    - tests/test_vercel_ai.py
-    - tests/test_ag_ui.py
-    - tests/test_ui.py
-    - tests/test_ui_web.py
     types:
     - opened
     - synchronize
@@ -113,11 +107,14 @@ env:
 jobs:
   activation:
     needs:
+      - detect
       - fetch_dynamic_prompt
       - pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)
+      needs.pre_activation.outputs.activated == 'true' && ((needs.detect.outputs.touched == 'true') && (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
+    environment: ui-security-review
     permissions:
       actions: read
       contents: read
@@ -248,20 +245,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b8ee0d1e229ac054_EOF'
+          cat << 'GH_AW_PROMPT_6239cb917cb8f45b_EOF'
           <system>
-          GH_AW_PROMPT_b8ee0d1e229ac054_EOF
+          GH_AW_PROMPT_6239cb917cb8f45b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b8ee0d1e229ac054_EOF'
+          cat << 'GH_AW_PROMPT_6239cb917cb8f45b_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:30), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_b8ee0d1e229ac054_EOF
+          GH_AW_PROMPT_6239cb917cb8f45b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_b8ee0d1e229ac054_EOF'
+          cat << 'GH_AW_PROMPT_6239cb917cb8f45b_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -293,9 +290,9 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_b8ee0d1e229ac054_EOF
+          GH_AW_PROMPT_6239cb917cb8f45b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b8ee0d1e229ac054_EOF'
+          cat << 'GH_AW_PROMPT_6239cb917cb8f45b_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/network-vendor-domains.md}}
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
@@ -308,7 +305,7 @@ jobs:
           {{#runtime-import .github/workflows/shared/pre-steps.md}}
           {{#runtime-import .github/workflows/shared/pre-agent-steps.md}}
           {{#runtime-import .github/workflows/pydantic-ai-ui-security-review.md}}
-          GH_AW_PROMPT_b8ee0d1e229ac054_EOF
+          GH_AW_PROMPT_6239cb917cb8f45b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -391,7 +388,10 @@ jobs:
   agent:
     needs:
       - activation
+      - detect
       - fetch_dynamic_prompt
+    if: >
+      (needs.detect.outputs.touched == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -535,9 +535,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_87b1453bac1b1702_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b4c2906f9a460717_EOF'
           {"create_pull_request_review_comment":{"max":30,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"footer":"none","max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_87b1453bac1b1702_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_b4c2906f9a460717_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -761,7 +761,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_f5223c6088d4bdff_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_41ba5d36ff0887a8_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -791,7 +791,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_f5223c6088d4bdff_EOF
+          GH_AW_MCP_CONFIG_41ba5d36ff0887a8_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1103,6 +1103,7 @@ jobs:
     needs:
       - activation
       - agent
+      - detect
       - detection
       - fetch_dynamic_prompt
       - safe_outputs
@@ -1243,6 +1244,41 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_agent_failure.cjs');
             await main();
+
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    timeout-minutes: 5
+    outputs:
+      touched: ${{ steps.filter.outputs.touched }}
+    steps:
+      - name: Configure GH_HOST for enterprise compatibility
+        id: ghes-host-config
+        shell: bash
+        run: |
+          # Derive GH_HOST from GITHUB_SERVER_URL so the gh CLI targets the correct
+          # GitHub instance (GHES/GHEC). On github.com this is a harmless no-op.
+          GH_HOST="${GITHUB_SERVER_URL#https://}"
+          GH_HOST="${GH_HOST#http://}"
+          echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
+      - name: Detect UI security paths in the PR
+        id: filter
+        if: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          files="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+          if printf '%s\n' "$files" | grep -qE '^(pydantic_ai_slim/pydantic_ai/ui/|pydantic_ai_slim/pydantic_ai/_ssrf\.py$|pydantic_ai_slim/pydantic_ai/messages\.py$|pydantic_ai_slim/pydantic_ai/common_tools/web_fetch\.py$|docs/ui/|docs/input\.md$|tests/test_vercel_ai\.py$|tests/test_ag_ui\.py$|tests/test_ui\.py$|tests/test_ui_web\.py$)'; then
+            echo 'touched=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'touched=false' >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
 
   detection:
     needs:
@@ -1491,7 +1527,7 @@ jobs:
           logfire-variable-key: gh_aw_pydantic_ai_ui_security_review_prompt
 
   pre_activation:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
+    needs: detect
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}

--- a/.github/workflows/pydantic-ai-ui-security-review.md
+++ b/.github/workflows/pydantic-ai-ui-security-review.md
@@ -3,26 +3,39 @@ emoji: "🛡️"
 name: "Pydantic AI UI Security Review"
 description: "Security review of UI-adapter PRs (Vercel AI + AG-UI): audits the client/server trust boundary for outbound leakage and inbound abuse. Inline comments + a non-voting COMMENT-type review summary (pydantic-ai-pr-review owns the merge-gate verdict until gh-aw check-runs land). Prompt iterable from a Logfire managed variable; read-only via gh-aw safe-outputs."
 on:
+  # Runs on EVERY PR (no `paths:` filter) so the review's check is always
+  # reported on the head commit. The UI-path selection moved into the `detect`
+  # job below: non-UI PRs skip the agent via `if:` (a job skipped by `if:`
+  # reports as success, so it never blocks merge), while UI PRs gate the agent
+  # behind the `ui-security-review` Environment (required reviewers) — a
+  # maintainer clicks "Approve" to start the AI run, and the pending approval
+  # blocks merge until the review has run. `synchronize` is kept so a new
+  # commit re-reports the check on the new head and re-pends the approval.
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    # Additive security lens for the UI adapters (SSRF boundary). PRs not
-    # touching these paths get only the general pydantic-ai-pr-review.
-    paths:
-      - 'pydantic_ai_slim/pydantic_ai/ui/**'
-      - 'pydantic_ai_slim/pydantic_ai/_ssrf.py'
-      - 'pydantic_ai_slim/pydantic_ai/messages.py'
-      - 'pydantic_ai_slim/pydantic_ai/common_tools/web_fetch.py'
-      - 'docs/ui/**'
-      - 'docs/input.md'
-      - 'tests/test_vercel_ai.py'
-      - 'tests/test_ag_ui.py'
-      - 'tests/test_ui.py'
-      - 'tests/test_ui_web.py'
   workflow_dispatch:
   # Fork-PR safety: only trigger when the actor has admin/maintainer/write
   # access. Without this, any established external contributor's PR would
   # consume the configured Anthropic key and a model run.
   roles: [admin, maintainer, write]
+  # Make the activation chain wait on the cheap `detect` job below so the
+  # top-level `if:` (which gh-aw copies onto the activation + agent jobs) can
+  # reference `needs.detect.outputs.touched` validly. Listing it here makes
+  # `detect` a pre-activation dependency; without it gh-aw would make `detect`
+  # depend on `activation`, and the `if:` reference would point at a
+  # non-dependency.
+  needs: [detect]
+  # Pause for a maintainer's approval of the `ui-security-review` Environment
+  # before the agent runs. This gates the `activation` job, but because
+  # `activation` is itself gated by the `if:` below, the approval is only
+  # requested on UI-touching PRs (a skipped job never requests Environment
+  # approval). The pending approval keeps the agent's required check pending,
+  # blocking merge until a maintainer clicks Approve to start the review.
+  manual-approval: ui-security-review
+# Only run the review (and request approval) when the PR touches the UI
+# security surface. Non-UI PRs skip the activation chain, so the agent reports
+# "skipped" (= success for required checks) and never blocks merge.
+if: ${{ needs.detect.outputs.touched == 'true' }}
 permissions:
   contents: read
   # safe-outputs perform the actual writes in a separate conclusion job; the
@@ -91,6 +104,34 @@ pre-agent-steps:
       fi
 
 jobs:
+  detect:
+    # Cheap, no-AI path filter: does this PR touch the UI security surface?
+    # The agent job's top-level `if:` keys on this output. Replaces the old
+    # trigger-level `paths:` filter so the workflow still runs (and reports a
+    # check) on every PR — non-UI PRs skip the agent and merge freely.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      touched: ${{ steps.filter.outputs.touched }}
+    steps:
+      - name: Detect UI security paths in the PR
+        id: filter
+        if: ${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          files="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+          if printf '%s\n' "$files" | grep -qE '^(pydantic_ai_slim/pydantic_ai/ui/|pydantic_ai_slim/pydantic_ai/_ssrf\.py$|pydantic_ai_slim/pydantic_ai/messages\.py$|pydantic_ai_slim/pydantic_ai/common_tools/web_fetch\.py$|docs/ui/|docs/input\.md$|tests/test_vercel_ai\.py$|tests/test_ag_ui\.py$|tests/test_ui\.py$|tests/test_ui_web\.py$)'; then
+            echo 'touched=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'touched=false' >> "$GITHUB_OUTPUT"
+          fi
   fetch_dynamic_prompt:
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
> **Proposal for @strawgate's review** — this reshapes one of the gh-aw workflows you own
> (`pydantic-ai-ui-security-review`). Nothing here is final; the job-graph wiring in particular is
> yours to sign off on. It compiles on the **current pinned gh-aw `v0.74.8`** — no version bump.

### What this changes and why

Today `pydantic-ai-ui-security-review` auto-runs on every push to any PR that touches the UI paths —
an expensive AI run firing on every commit. This makes it **manual and approval-gated** using a
GitHub **Environment with required reviewers**, and (once the repo-admin steps below are in place)
lets a UI-touching PR be **blocked from merging until the review has been started and run**.

The shape:

- **Runs on every PR** (the trigger's `paths:` filter is removed). A new cheap, no-AI **`detect`**
  job applies the same UI-path list and outputs whether the UI security surface was touched.
- **Non-UI PR** → the agent is skipped via `if:` → its check reports **`skipped` = success**, so it
  never blocks merge. No AI, no approval prompt.
- **UI PR** → the `activation` job references the **`ui-security-review`** Environment, so the run
  **pauses** showing a **"Review deployments → Approve"** button. A maintainer clicks Approve to
  **start** the AI review. While pending, the agent's check stays pending → **merge is blocked**
  until the review has run. `synchronize` is kept so a new commit re-reports the check and re-pends
  the approval.

`tests`, `coverage`, `lint` and every other check are **completely untouched** — this is a separate
workflow with its own check context; making it manual/gated can't block or obscure them.

### How the gating is wired (the part for @strawgate)

The intuitive approaches don't compile cleanly on `v0.74.8`, so I used the gh-aw-native combination
that does (details + the dead-ends in `local-notes/design-report.md`, happy to walk through):

- **`on.needs: [detect]`** makes `detect` a *pre-activation* dependency, so the top-level
  **`if: needs.detect.outputs.touched == 'true'`** (which gh-aw copies onto the `activation` + `agent`
  jobs) references a real dependency rather than a non-dependency.
- **`on.manual-approval: ui-security-review`** puts the Environment gate on `activation`. Because
  `activation` is itself gated by the `if:` above, **approval is requested only on UI PRs** (a
  skipped job never requests Environment approval) — so `manual-approval` here is *not* the
  "gates every run" footgun it would be on its own.

Why not the alternatives:
- **Top-level `environment:`** stamps the gate onto `pre_activation` too, which has no `if:` and runs
  on every PR → it would prompt for approval on *non-UI* PRs.
- **A custom downstream `approval_gate` job** referenced via the top-level `if:` produces an invalid
  `needs.` reference on `activation` (or a dependency cycle), because custom jobs sit downstream of
  `activation` while gh-aw applies the `if:` *to* `activation`.

I verified the compiled graph is **cycle-free** and every `if:` reference resolves to a real
dependency. The lockfile diff is only this change — no `ERR_CONFIG`/domain/import drift.

**One side effect to flag:** none from this approach (top-level `environment:` would have suppressed
gh-aw's secret-validation step; `on.manual-approval` does not). The `detect` job lists the UI paths
in one regex — if that list drifts from the security surface, update it there.

### Not in this PR (David's repo-admin steps, separate)

- Create the **`ui-security-review`** Environment with **required reviewers** (maintainers / a team).
- Mark the security-review **agent job's check** as a **required status check** in branch protection
  for the merge-gate to take effect.

The workflow's `description:` still says *"pydantic-ai-pr-review owns the merge-gate verdict until
gh-aw check-runs land"* — left as-is for you to update if you adopt this gate.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

