### PR TITLE
fix(temporal): add return type annotation to `PydanticAIPlugin.__init__`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -116,7 +116,7 @@ def _workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner:
 class PydanticAIPlugin(SimplePlugin):
     """Temporal client and worker plugin for Pydantic AI."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(  # type: ignore[reportUnknownMemberType]
             name='PydanticAIPlugin',
             data_converter=_data_converter,


### PR DESCRIPTION
## Summary

Add an explicit `-> None` return annotation to `PydanticAIPlugin.__init__` so the constructor is fully typed under mypy strict mode.

## Motivation

Fixes #6063

Calling `PydanticAIPlugin()` in typed code fails mypy strict with `no-untyped-call` because the zero-parameter `__init__` had no type annotations. `LogfirePlugin` is unaffected because its `__init__` already has annotated parameters.

## Changes

- `pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py`: add `-> None` to `PydanticAIPlugin.__init__`

## Tests

- `uv run mypy --strict` on the issue MRE (`PydanticAIPlugin()`) — passes
- `uv run ruff check` on the changed file — passes

## Notes

`AgentPlugin.__init__` already passes strict mypy because its `agent` parameter is annotated; no change needed there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

