### PR TITLE
fix(utils): start group_by_temporal debounce on first item arrival

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -334,7 +334,7 @@ async def group_by_temporal(
                 'soft_max_interval must be a positive number'
             )
             buffer: list[T] = []
-            group_start_time = time.monotonic()
+            group_start_time: float | None = None
 
             while True:
                 if group_start_time is None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,6 +54,20 @@ async def test_group_by_temporal(interval: float | None, expected: list[list[int
         assert groups == expected
 
 
+async def test_group_by_temporal_delayed_first_item():
+    async def stream() -> AsyncIterator[int]:
+        await asyncio.sleep(0.08)
+        yield 1
+        await asyncio.sleep(0.01)
+        yield 2
+        await asyncio.sleep(0.2)
+        yield 3
+
+    async with group_by_temporal(stream(), soft_max_interval=0.04) as groups_iter:
+        groups: list[list[int]] = [g async for g in groups_iter]
+        assert groups == [[1, 2], [3]]
+
+
 def test_check_object_json_schema():
     object_schema = {'type': 'object', 'properties': {'a': {'type': 'string'}}}
     assert check_object_json_schema(object_schema) == object_schema


### PR DESCRIPTION
## Summary

Fix `group_by_temporal` so the debounce window for the first group starts when its first item arrives, not when iteration begins.

## Motivation

When the first streamed item is delayed (for example, model first-token latency), the debounce clock previously started at iteration time. If that delay exceeded `soft_max_interval`, the first item was emitted in its own group even when the next item arrived within the interval.

Fixes #5946

## Changes

- Initialize `group_start_time` to `None` in `group_by_temporal` instead of `time.monotonic()`
- Add regression test `test_group_by_temporal_delayed_first_item` covering a delayed first item followed by a nearby second item

## Tests

```bash
uv run pytest tests/test_utils.py::test_group_by_temporal tests/test_utils.py::test_group_by_temporal_delayed_first_item -q
```

Result: `6 passed`

## Notes

This is a one-line behavioral fix that reuses the existing first-item branch already used after each emitted group. composer-2.5 review: APPROVE.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

