### PR TITLE
Route remaining instrumentation serialization through `safe_to_json`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -90,7 +90,7 @@ def serialize_any(value: Any) -> str:
             return f'Unable to serialize: {e}'
 
 
-def safe_to_json(value: Any) -> bytes:
+def safe_to_json(value: object) -> bytes:
     """Serialize `value` to compact JSON bytes, tolerating lone surrogates.
 
     `to_json` raises on unpaired surrogates (e.g. text decoded with `errors='surrogateescape'`),
@@ -126,7 +126,7 @@ def model_attributes(model: Model) -> dict[str, AttributeValue]:
 def model_request_parameters_attributes(
     model_request_parameters: ModelRequestParameters,
 ) -> dict[str, AttributeValue]:
-    return {'model_request_parameters': to_json(serialize_any(model_request_parameters)).decode()}
+    return {'model_request_parameters': safe_to_json(serialize_any(model_request_parameters)).decode()}
 
 
 def annotate_tool_call_otel_metadata(response: ModelResponse, parameters: ModelRequestParameters) -> None:
@@ -218,7 +218,7 @@ def open_model_request_span(
 
     tool_definitions = build_tool_definitions(prepared_parameters)
     if tool_definitions:
-        attributes['gen_ai.tool.definitions'] = to_json(tool_definitions).decode()
+        attributes['gen_ai.tool.definitions'] = safe_to_json(tool_definitions).decode()
 
     if prepared_settings:
         for key in MODEL_SETTING_ATTRIBUTES:

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -2071,6 +2071,40 @@ async def test_instrumented_model_with_tools_and_finish_reason(capfire: CaptureL
     assert attrs['gen_ai.response.id'] == 'resp-123'
 
 
+async def test_instrumented_model_tolerates_lone_surrogates_in_request_parameters(capfire: CaptureLogfire):
+    """Lone surrogates in tool definitions / request parameters must not crash instrumentation.
+
+    `gen_ai.tool.definitions` and `model_request_parameters` are serialized on the model-request
+    span regardless of `include_content`; routing them through `safe_to_json` keeps a surrogate
+    (e.g. text decoded with `errors='surrogateescape'`) in a tool description from raising
+    `PydanticSerializationError` and crashing an otherwise-successful run.
+    """
+    from pydantic_ai.tools import ToolDefinition
+
+    tool_def = ToolDefinition(name='weather', description='get the weather before\udce4after')
+
+    model = InstrumentedModel(MyModel())
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('Hello')], timestamp=IsDatetime())]
+    await model.request(
+        messages,
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(function_tools=[tool_def]),
+    )
+
+    attrs = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)[0]['attributes']
+    assert attrs['gen_ai.tool.definitions'] == snapshot(
+        [
+            {
+                'type': 'function',
+                'name': 'weather',
+                'description': 'get the weather before\udce4after',
+                'parameters': {'type': 'object', 'properties': {}},
+            }
+        ]
+    )
+    assert 'weather' in attrs['model_request_parameters']['function_tools'][0]['name']
+
+
 async def test_instrumented_model_request_error(capfire: CaptureLogfire):
     """Test _instrument() when the wrapped model raises before finish() is called."""
 

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -40,6 +40,7 @@ from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
 from pydantic_ai.models.instrumented import InstrumentationSettings, InstrumentedModel
 from pydantic_ai.settings import ModelSettings
+from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage
 
 from .._inline_snapshot import snapshot, warns
@@ -2079,8 +2080,6 @@ async def test_instrumented_model_tolerates_lone_surrogates_in_request_parameter
     (e.g. text decoded with `errors='surrogateescape'`) in a tool description from raising
     `PydanticSerializationError` and crashing an otherwise-successful run.
     """
-    from pydantic_ai.tools import ToolDefinition
-
     tool_def = ToolDefinition(name='weather', description='get the weather before\udce4after')
 
     model = InstrumentedModel(MyModel())


### PR DESCRIPTION
Follow-up to #6045, which added `safe_to_json` (tolerant of lone surrogates) and routed the OTel **message** attributes through it. Two sibling serialization sites on the model-request span were left on raw `to_json`, so they still carry the crash this helper was introduced to prevent:

- `_instrumentation.py` · `model_request_parameters_attributes` → `model_request_parameters` (serialized on **every** model-request span, independent of `include_content`)
- `_instrumentation.py` · `open_model_request_span` → `gen_ai.tool.definitions` (serializes user-authored tool names / descriptions / JSON schemas)

A lone surrogate (e.g. text decoded with `errors='surrogateescape'`) in either path raises `PydanticSerializationError` and crashes an otherwise-successful run from inside instrumentation — exactly the failure mode `safe_to_json` exists to absorb. This routes both through `safe_to_json`. Output is **byte-identical to `to_json` for all non-surrogate inputs** (`safe_to_json` only diverges on the fallback path), so there is no snapshot churn on existing tests.

Also widens `safe_to_json`'s parameter from `Any` to `object` (it accepts any value; `to_json` does too).

### Test
Adds `test_instrumented_model_tolerates_lone_surrogates_in_request_parameters`, which drives the public `model.request` path with a lone-surrogate tool description and asserts the span emits (rather than crashes on) `gen_ai.tool.definitions` and `model_request_parameters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

