### PR TITLE
Add `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,16 +3,20 @@ title: Pydantic AI
 message: 'If you use this software, please cite it as below.'
 type: software
 authors:
-  - family-names: Colvin
-    given-names: Samuel
-  - family-names: Trylesinski
-    given-names: Marcelo
-  - family-names: Montague
-    given-names: David
-  - family-names: Hall
-    given-names: Alex
   - family-names: Maan
     given-names: Douwe
+  - family-names: Sanchez
+    given-names: David
+  - family-names: Vardhan
+    given-names: Aditya
+  - family-names: Montague
+    given-names: David
+  - family-names: Trylesinski
+    given-names: Marcelo
+  - family-names: Hall
+    given-names: Alex
+  - family-names: Colvin
+    given-names: Samuel
 repository-code: 'https://github.com/pydantic/pydantic-ai'
 url: 'https://ai.pydantic.dev'
 abstract: >-
@@ -29,5 +33,3 @@ keywords:
   - genai
   - pydantic
 license: MIT
-version: v2.0.0
-date-released: 2026-06-23

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+cff-version: 1.2.0
+title: Pydantic AI
+message: 'If you use this software, please cite it as below.'
+type: software
+authors:
+  - family-names: Colvin
+    given-names: Samuel
+  - family-names: Trylesinski
+    given-names: Marcelo
+  - family-names: Montague
+    given-names: David
+  - family-names: Hall
+    given-names: Alex
+  - family-names: Maan
+    given-names: Douwe
+repository-code: 'https://github.com/pydantic/pydantic-ai'
+url: 'https://ai.pydantic.dev'
+abstract: >-
+  Pydantic AI is a Python agent framework designed to make it less
+  painful to build production grade applications and workflows with
+  Generative AI. Provider-agnostic, type-safe, and built by the team
+  behind Pydantic.
+keywords:
+  - python
+  - ai
+  - agents
+  - llm
+  - agent-framework
+  - genai
+  - pydantic
+license: MIT
+version: v2.0.0
+date-released: 2026-06-23

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -13,13 +13,15 @@ bump = true
 [project]
 name = "pydantic-ai-slim"
 dynamic = ["version", "dependencies", "optional-dependencies"]
-description = "Agent Framework / shim to use Pydantic with LLMs, slim package"
+description = "AI Agent Framework, the Pydantic way, slim package"
 authors = [
-    { name = "Samuel Colvin", email = "samuel@pydantic.dev" },
-    { name = "Marcelo Trylesinski", email = "marcelotryle@gmail.com" },
-    { name = "David Montague", email = "david@pydantic.dev" },
-    { name = "Alex Hall", email = "alex@pydantic.dev" },
     { name = "Douwe Maan", email = "douwe@pydantic.dev" },
+    { name = "David Sanchez", email = "david.sanchez@pydantic.dev" },
+    { name = "Aditya Vardhan", email = "aditya@pydantic.dev" },
+    { name = "David Montague", email = "david@pydantic.dev" },
+    { name = "Marcelo Trylesinski", email = "marcelotryle@gmail.com" },
+    { name = "Alex Hall", email = "alex@pydantic.dev" },
+    { name = "Samuel Colvin", email = "samuel@pydantic.dev" },
 ]
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ bump = true
 [project]
 name = "pydantic-ai"
 dynamic = ["version", "dependencies", "optional-dependencies"]
-description = "Agent Framework / shim to use Pydantic with LLMs"
+description = "AI Agent Framework, the Pydantic way"
 authors = [
     { name = "Douwe Maan", email = "douwe@pydantic.dev" },
     { name = "David Sanchez", email = "david.sanchez@pydantic.dev" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,13 @@ name = "pydantic-ai"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 description = "Agent Framework / shim to use Pydantic with LLMs"
 authors = [
-    { name = "Samuel Colvin", email = "samuel@pydantic.dev" },
-    { name = "Marcelo Trylesinski", email = "marcelotryle@gmail.com" },
-    { name = "David Montague", email = "david@pydantic.dev" },
-    { name = "Alex Hall", email = "alex@pydantic.dev" },
     { name = "Douwe Maan", email = "douwe@pydantic.dev" },
+    { name = "David Sanchez", email = "david.sanchez@pydantic.dev" },
+    { name = "Aditya Vardhan", email = "aditya@pydantic.dev" },
+    { name = "David Montague", email = "david@pydantic.dev" },
+    { name = "Marcelo Trylesinski", email = "marcelotryle@gmail.com" },
+    { name = "Alex Hall", email = "alex@pydantic.dev" },
+    { name = "Samuel Colvin", email = "samuel@pydantic.dev" },
 ]
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
- Closes #3493

Adds a `CITATION.cff` at the repo root so Pydantic AI can be cited in papers, modeled on [pydantic's `CITATION.cff`](https://github.com/pydantic/pydantic/blob/main/CITATION.cff). Validated against CFF schema 1.2.0 with `cffconvert --validate`.

This addresses the two open questions from @DouweM's comment on the issue:

**(a) Author-list criteria — synced with `pyproject.toml`.** Per your suggestion, the `authors` list mirrors the root `pyproject.toml` `authors`, in the same order: Samuel Colvin, Marcelo Trylesinski, David Montague, Alex Hall, Douwe Maan. `license` is likewise synced to the repo's `MIT`.

**(b) Auto-updating `version` / `date-released` on release — flagged for your decision.** Pydantic ports this via [`release/prepare.py`](https://github.com/pydantic/pydantic/blob/main/release/prepare.py), whose `update_citation` step rewrites the `version:` and `date-released:` lines by regex during the manual version bump:

```python
citation_text = re.sub(r'(?<=\nversion: ).*', f'v{new_version}', citation_text)
citation_text = re.sub(r'(?<=date-released: ).*', date_today_str, citation_text)
```

Pydantic AI has **no equivalent release-prep script** to port that into: versioning is fully git-tag driven via `uv-dynamic-versioning` (`[tool.hatch.version] source = "uv-dynamic-versioning"`, `vcs = "git"`), and the release job in `ci.yml` infers the version from the pushed tag — there's no hardcoded version file or `prepare.py` to bump. So rather than invent a release-prep step, I've seeded `version`/`date-released` to the current release (`v2.0.0`, 2026-06-23) and left the auto-update wiring for you to decide. Options:

1. Keep the file static and refresh it manually at each release (cheapest; the fields are citation-nice-to-haves, not correctness-critical).
2. Add a step to the tag-triggered release flow that rewrites the two lines (mirroring pydantic's regex) — note this would mean committing back to `main` from CI, which the current tag-driven flow doesn't do today.
3. Drop `version`/`date-released` entirely and cite by repository + DOI only.

Happy to follow up with whichever you prefer.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

