### PR TITLE
Relax readiness `wait_for` timeouts in agent cancellation tests to fix CI flake

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -169,6 +169,11 @@ requires_groq = pytest.mark.skipif(GroqProvider is None, reason='groq not instal
 requires_litellm = pytest.mark.skipif(LiteLLMProvider is None, reason='litellm not installed')  # pyright: ignore[reportUnnecessaryComparison]
 requires_mistral = pytest.mark.skipif(MistralProvider is None, reason='mistral not installed')  # pyright: ignore[reportUnnecessaryComparison]
 
+# Wall-clock guard for the readiness `Event.wait()`s in the cancellation tests below. The events are set
+# near-instantly; the timeout only exists to fail fast on a genuine hang, since no global pytest timeout is
+# configured. `timeout=1` was too tight under heavy xdist load and flaked (#5399), so allow generous headroom.
+READINESS_WAIT_TIMEOUT = 10
+
 
 def test_result_tuple():
     def return_tuple(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -6621,8 +6626,8 @@ class TestMultipleToolCalls:
             return 'done'  # pragma: no cover
 
         task = asyncio.create_task(agent.run('test'))
-        await asyncio.wait_for(first_done.wait(), timeout=1)
-        await asyncio.wait_for(pending_started.wait(), timeout=1)
+        await asyncio.wait_for(first_done.wait(), timeout=READINESS_WAIT_TIMEOUT)
+        await asyncio.wait_for(pending_started.wait(), timeout=READINESS_WAIT_TIMEOUT)
 
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -6946,7 +6951,7 @@ async def test_tool_execution_cancellation_captures_partial_request() -> None:
                 captured = list(messages)
 
     task = asyncio.create_task(consume())
-    await asyncio.wait_for(first_done.wait(), timeout=1)
+    await asyncio.wait_for(first_done.wait(), timeout=READINESS_WAIT_TIMEOUT)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
@@ -9048,8 +9053,8 @@ async def test_parallel_tool_outer_cancellation_only_cancels_pending_tool_tasks(
         return 'done'  # pragma: no cover
 
     task = asyncio.create_task(agent.run('call tools'))
-    await asyncio.wait_for(completed_tool_finished.wait(), timeout=1)
-    await asyncio.wait_for(pending_tool_started.wait(), timeout=1)
+    await asyncio.wait_for(completed_tool_finished.wait(), timeout=READINESS_WAIT_TIMEOUT)
+    await asyncio.wait_for(pending_tool_started.wait(), timeout=READINESS_WAIT_TIMEOUT)
 
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -9082,7 +9087,7 @@ async def test_wrap_run_readiness_wait_cancels_wrapper_task_on_outer_cancellatio
     agent = Agent(TestModel(), capabilities=[WrapRunCapability()])
 
     task = asyncio.create_task(agent.run('test'))
-    await asyncio.wait_for(started.wait(), timeout=1)
+    await asyncio.wait_for(started.wait(), timeout=READINESS_WAIT_TIMEOUT)
 
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -9131,11 +9136,11 @@ async def test_parallel_tool_outer_cancellation_waits_for_tool_cleanup():
         return 'done'  # pragma: no cover
 
     task = asyncio.create_task(agent.run('call tools'))
-    await asyncio.wait_for(started.wait(), timeout=1)
+    await asyncio.wait_for(started.wait(), timeout=READINESS_WAIT_TIMEOUT)
 
     task.cancel()
 
-    await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+    await asyncio.wait_for(cleanup_started.wait(), timeout=READINESS_WAIT_TIMEOUT)
     assert not task.done()
     cleanup_can_finish.set()
 


### PR DESCRIPTION
Addresses **item D** (async-cancellation timing flakes) of #5399. That issue tracks several distinct, unrelated flakes, so this PR intentionally does **not** close it.

### Problem

The cancellation tests in `tests/test_agent.py` spawn `agent.run(...)` as a task and then `await asyncio.wait_for(<event>.wait(), timeout=1)` to synchronize on a readiness `Event` that the spawned task sets near-instantly (e.g. the first line of a wrapper/tool body running on `TestModel()`). The `timeout=1` exists only as a hang-guard — no global pytest timeout is configured — but 1s of wall clock is too tight under heavy `xdist` load: a starved worker can fail to schedule the task within 1s, surfacing as a spurious `asyncio.TimeoutError` *before* the test even reaches the `task.cancel()` it means to exercise.

Most recently seen on the `test on 3.10 (lowest-versions)` shard of an unrelated PR ([run 28252945839](https://github.com/pydantic/pydantic-ai/actions/runs/28252945839/job/83708778948)), where `test_wrap_run_readiness_wait_cancels_wrapper_task_on_outer_cancellation` timed out while a 32s doc-example test ran concurrently on the same worker. Both that test and `test_parallel_tool_outer_cancellation_only_cancels_pending_tool_tasks` are already logged under #5399 item D.

### Change

Centralize the budget in a documented `READINESS_WAIT_TIMEOUT = 10` constant and use it for all 8 readiness `wait_for`s in the cancellation tests. This is a pure relaxation: the events fire in milliseconds normally, so passing tests are unaffected; the only behavior change is that a genuine hang now fails after 10s instead of 1s. All 8 call sites share the identical footgun, so all are updated together to keep the same flake from recurring on the untouched siblings.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

