### PR TITLE
fix(openai-responses): drop stray post-done function-call arguments delta

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3379,6 +3379,9 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
             # `TextPart.provider_details` on `output_text.done`.
             _phase_by_item: dict[str, Literal['commentary', 'final_answer']] = {}
             mcp_list_tools_return_ids: set[str] = set()
+            # Track function-call item_ids that have received their done event so we can
+            # drop any stray post-done arguments deltas from non-conforming endpoints.
+            _done_fn_item_ids: set[str] = set()
 
             if self._provider_timestamp is not None:  # pragma: no branch
                 self.provider_details = {'timestamp': self._provider_timestamp}
@@ -3427,15 +3430,16 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                     self._usage += self._map_usage(chunk.response)
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDeltaEvent):
-                    maybe_event = self._parts_manager.handle_tool_call_delta(
-                        vendor_part_id=chunk.item_id,
-                        args=chunk.delta,
-                    )
-                    if maybe_event is not None:  # pragma: no branch
-                        yield maybe_event
+                    if chunk.item_id not in _done_fn_item_ids:
+                        maybe_event = self._parts_manager.handle_tool_call_delta(
+                            vendor_part_id=chunk.item_id,
+                            args=chunk.delta,
+                        )
+                        if maybe_event is not None:  # pragma: no branch
+                            yield maybe_event
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDoneEvent):
-                    pass  # there's nothing we need to do here
+                    _done_fn_item_ids.add(chunk.item_id)
 
                 elif isinstance(chunk, responses.ResponseIncompleteEvent):  # pragma: no cover
                     self._usage += self._map_usage(chunk.response)

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -12321,3 +12321,103 @@ def test_openai_responses_phase_profile_flag():
     assert openai_model_profile('gpt-5.2').get('openai_supports_phase', False) is False
     assert openai_model_profile('gpt-5').get('openai_supports_phase', False) is False
     assert openai_model_profile('gpt-4o').get('openai_supports_phase', False) is False
+
+
+async def test_openai_responses_stray_post_done_args_delta_dropped(allow_model_requests: None):
+    """Regression: a stray ResponseFunctionCallArgumentsDeltaEvent arriving after
+    ResponseFunctionCallArgumentsDoneEvent must not corrupt the final ToolCallPart.args.
+
+    Non-conforming endpoints (e.g. certain proxies) emit an extra arguments delta
+    after the done event. Without the guard the delta is applied to the already-closed
+    part slot, producing invalid JSON in the final ModelResponse.
+    """
+    from openai.types import responses as resp
+    from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
+
+    base_response = resp.Response(
+        id='resp_001',
+        model='gpt-4o',
+        object='response',
+        created_at=1704067200,
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice='auto',
+        tools=[],
+    )
+    fn_item = ResponseFunctionToolCall(
+        id='call_001',
+        call_id='call_001',
+        name='get_weather',
+        arguments='',
+        type='function_call',
+        status='in_progress',
+    )
+
+    stream: list[resp.ResponseStreamEvent] = [
+        resp.ResponseCreatedEvent(response=base_response, type='response.created', sequence_number=0),
+        resp.ResponseInProgressEvent(response=base_response, type='response.in_progress', sequence_number=1),
+        resp.ResponseOutputItemAddedEvent(
+            item=fn_item,
+            output_index=0,
+            type='response.output_item.added',
+            sequence_number=2,
+        ),
+        resp.ResponseFunctionCallArgumentsDeltaEvent(
+            item_id='call_001',
+            output_index=0,
+            delta='{"x":',
+            type='response.function_call_arguments.delta',
+            sequence_number=3,
+        ),
+        resp.ResponseFunctionCallArgumentsDeltaEvent(
+            item_id='call_001',
+            output_index=0,
+            delta='1}',
+            type='response.function_call_arguments.delta',
+            sequence_number=4,
+        ),
+        resp.ResponseFunctionCallArgumentsDoneEvent(
+            item_id='call_001',
+            output_index=0,
+            arguments='{"x":1}',
+            name='get_weather',
+            type='response.function_call_arguments.done',
+            sequence_number=5,
+        ),
+        # Stray delta emitted AFTER the done event by a non-conforming endpoint.
+        resp.ResponseFunctionCallArgumentsDeltaEvent(
+            item_id='call_001',
+            output_index=0,
+            delta='}',
+            type='response.function_call_arguments.delta',
+            sequence_number=6,
+        ),
+        resp.ResponseOutputItemDoneEvent(
+            item=fn_item.model_copy(update={'arguments': '{"x":1}', 'status': 'completed'}),
+            output_index=0,
+            type='response.output_item.done',
+            sequence_number=7,
+        ),
+        resp.ResponseCompletedEvent(
+            response=base_response.model_copy(update={'status': 'completed'}),
+            type='response.completed',
+            sequence_number=8,
+        ),
+    ]
+
+    mock_client = MockOpenAIResponses.create_mock_stream(stream)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+    mrp = ModelRequestParameters(
+        function_tools=[ToolDefinition(name='get_weather', parameters_json_schema={'type': 'object', 'properties': {}})],
+        allow_text_output=True,
+    )
+
+    async with model.request_stream([ModelRequest.user_text_prompt('weather?')], None, mrp) as streamed:
+        async for _ in streamed:
+            pass
+        result = streamed.get()
+
+    tool_parts = [p for p in result.parts if isinstance(p, ToolCallPart)]
+    assert len(tool_parts) == 1
+    # The stray post-done '}' must not have been appended — args must be valid JSON.
+    assert tool_parts[0].args == snapshot('{"x":1}')


### PR DESCRIPTION
## Problem

Non-conforming Responses-API endpoints (certain proxies and gateway providers) emit a `ResponseFunctionCallArgumentsDeltaEvent` *after* the matching `ResponseFunctionCallArgumentsDoneEvent` for the same `item_id`. The existing code applied the delta unconditionally, appending to the already-closed part slot and producing invalid JSON in the final `ModelResponse`.

In the reported scenario the stray delta was `'}'`, so final tool-call `args` became e.g. `'{"x":1}}'` — invalid JSON that breaks downstream tool-arg parsing.

## Fix

Track done function-call item_ids in `_done_fn_item_ids: set[str]` at the top of `_get_event_iterator`. When `ResponseFunctionCallArgumentsDoneEvent` is received, record the `item_id`. When a subsequent `ResponseFunctionCallArgumentsDeltaEvent` arrives for an already-done `item_id`, skip it.

`ResponseFunctionCallArgumentsDoneEvent` was previously a no-op `pass` — it now has a real purpose.

## Changes

| File | Change |
|---|---|
| `models/openai.py` | Add `_done_fn_item_ids: set[str]`, guard delta handler, record done signal |
| `tests/models/test_openai_responses.py` | Regression test: synthetic stream with stray post-done delta verifies args are not corrupted |

## Test

`test_openai_responses_stray_post_done_args_delta_dropped` — feeds a synthetic stream where `ResponseFunctionCallArgumentsDoneEvent` is followed by a stray `ResponseFunctionCallArgumentsDeltaEvent` with `delta='}'`. Asserts the final `ToolCallPart.args` is `'{"x":1}'` (not `'{"x":1}}'`).

Closes #5757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

