### PR TITLE
fix(openai-responses): inject tool_search when a deferred function tool is present

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2181,6 +2181,15 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         tools: list[responses.ToolParam] = (
             self._get_native_tools(model_request_parameters) + list(extra_native_tools) + function_tools
         )
+        # OpenAI rejects requests where any function tool carries `defer_loading=True`
+        # but no `tool_search` builtin is present ("Deferred tools require tools.tool_search").
+        # This can happen on the follow-up request after a capability is loaded: the revealed
+        # function tool has `defer_loading=True` but there is no explicit ToolSearchTool in
+        # native_tools for that turn.
+        if any(t.get('defer_loading') for t in function_tools) and not any(
+            t.get('type') == 'tool_search' for t in tools
+        ):
+            tools.insert(0, ToolSearchToolParam(type='tool_search'))
         if not tools:
             tool_choice = None
 

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -12321,3 +12321,49 @@ def test_openai_responses_phase_profile_flag():
     assert openai_model_profile('gpt-5.2').get('openai_supports_phase', False) is False
     assert openai_model_profile('gpt-5').get('openai_supports_phase', False) is False
     assert openai_model_profile('gpt-4o').get('openai_supports_phase', False) is False
+
+
+async def test_openai_responses_defer_loading_injects_tool_search(allow_model_requests: None):
+    """Regression: when a deferred-capability function tool (defer_loading=True) is in the
+    request but no ToolSearchTool is in native_tools, OpenAI rejects with
+    'Deferred tools require tools.tool_search'. The adapter must inject tool_search automatically.
+
+    Covers the follow-up request after load_capability: the revealed tool carries
+    with_native='tool_search' (so defer_loading=True on the wire) but ToolSearchTool is no
+    longer explicitly listed in native_tools for that turn.
+    """
+    from pydantic_ai.native_tools._tool_search import ToolSearchTool
+
+    c = response_message(
+        [
+            ResponseOutputMessage(
+                id='msg_001',
+                content=cast(list[Content], [ResponseOutputText(text='done', type='output_text', annotations=[])]),
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(c)
+    model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(openai_client=mock_client))
+
+    # A deferred capability tool: with_native='tool_search' causes _map_tool_definition to
+    # set defer_loading=True on the wire. No ToolSearchTool in native_tools this turn.
+    deferred_tool = ToolDefinition(
+        name='my_capability',
+        parameters_json_schema={'type': 'object', 'properties': {}},
+        with_native=ToolSearchTool.kind,
+    )
+    mrp = ModelRequestParameters(function_tools=[deferred_tool], allow_text_output=True)
+
+    await model.request([ModelRequest.user_text_prompt('use my_capability')], None, mrp)
+
+    sent_tools = get_mock_responses_kwargs(mock_client)[0]['tools']
+    tool_types = [t.get('type') for t in sent_tools]
+    # tool_search must be present even though it wasn't in native_tools
+    assert 'tool_search' in tool_types
+    # the deferred function tool must also be present with defer_loading=True
+    fn_tools = [t for t in sent_tools if t.get('type') == 'function']
+    assert len(fn_tools) == 1
+    assert fn_tools[0].get('defer_loading') is True


### PR DESCRIPTION
## Problem

OpenAI rejects Responses API requests where any function tool has `defer_loading: true` but no `tool_search` builtin is included:

```
Invalid Value: tools.defer_loading. Deferred tools require tools.tool_search.
```

This happens on the **follow-up request after `load_capability`**: the revealed function tool carries `with_native='tool_search'` (so `_map_tool_definition` sets `defer_loading=True` on the wire), but there is no explicit `ToolSearchTool` in `native_tools` for that turn — `_get_native_tools` therefore doesn't add `tool_search`, and the request is rejected.

## Fix

In `_build_responses_request_params`, after assembling the tools list, check whether any function tool has `defer_loading=True` without a `tool_search` entry already present. If so, prepend `ToolSearchToolParam(type='tool_search')`.

This mirrors what OpenAI documents: `tool_search` must accompany any `defer_loading=True` tool.

## Changes

| File | Change |
|---|---|
| `models/openai.py` | Auto-inject `tool_search` when `defer_loading=True` present without it |
| `tests/models/test_openai_responses.py` | Regression: `ToolDefinition(with_native='tool_search')` → verifies `tool_search` and `defer_loading=True` both appear in outgoing tools |

Closes #5938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

