### PR TITLE
fix(bedrock): split tool results from attachment user messages

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -939,6 +939,14 @@ class BedrockConverseModel(Model[BaseClient]):
 
         return tool_config
 
+    @staticmethod
+    def _bedrock_user_content_has_tool_result(content: list[ContentBlockUnionTypeDef]) -> bool:
+        return any('toolResult' in block for block in content)
+
+    @staticmethod
+    def _bedrock_user_content_has_attachment(content: list[ContentBlockUnionTypeDef]) -> bool:
+        return any(any(key in block for key in ('document', 'image', 'video')) for block in content)
+
     async def _map_messages(  # noqa: C901
         self,
         messages: Sequence[ModelMessage],
@@ -1121,9 +1129,23 @@ class BedrockConverseModel(Model[BaseClient]):
                 and current_message['role'] == last_message['role']
                 and current_message['role'] == 'user'
             ):
-                # Add the new user content onto the existing user message.
                 last_content = list(last_message['content'])
-                last_content.extend(current_message['content'])
+                current_content = list(current_message['content'])
+                # Anthropic models on Bedrock reject user messages that combine tool
+                # results with attachment blocks (document/image/video).
+                if (
+                    self._bedrock_user_content_has_tool_result(last_content)
+                    and self._bedrock_user_content_has_attachment(current_content)
+                ) or (
+                    self._bedrock_user_content_has_attachment(last_content)
+                    and self._bedrock_user_content_has_tool_result(current_content)
+                ):
+                    processed_messages.append(current_message)
+                    last_message = cast(dict[str, Any], current_message)
+                    continue
+
+                # Add the new user content onto the existing user message.
+                last_content.extend(current_content)
                 last_message['content'] = last_content
                 continue
 

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -2512,6 +2512,53 @@ async def test_bedrock_group_consecutive_tool_return_parts(bedrock_provider: Bed
     )
 
 
+async def test_bedrock_split_tool_result_from_attachment_user_message(bedrock_provider: BedrockProvider):
+    """Tool results and attachment blocks must not share a Bedrock user message."""
+    from pydantic_ai._agent_graph import _clean_message_history  # pyright: ignore[reportPrivateUsage]
+
+    model = BedrockConverseModel('us.anthropic.claude-opus-4-6-v1', provider=bedrock_provider)
+    history = [
+        ModelRequest(parts=[UserPromptPart(content='show me my expenses')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='get', args={}, tool_call_id='t1')]),
+        ModelRequest(parts=[ToolReturnPart(tool_name='get', content='ok', tool_call_id='t1')]),
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        'what accounts are in this?',
+                        DocumentUrl(url='s3://bucket/file.csv', media_type='text/csv'),
+                    ]
+                )
+            ]
+        ),
+    ]
+
+    _, bedrock_messages = await model._map_messages(  # type: ignore[reportPrivateUsage]
+        _clean_message_history(history), ModelRequestParameters(), BedrockModelSettings()
+    )
+
+    assert bedrock_messages == snapshot(
+        [
+            {'role': 'user', 'content': [{'text': 'show me my expenses'}]},
+            {'role': 'assistant', 'content': [{'toolUse': {'toolUseId': 't1', 'name': 'get', 'input': {}}}]},
+            {'role': 'user', 'content': [{'toolResult': {'toolUseId': 't1', 'content': [{'text': 'ok'}], 'status': 'success'}}]},
+            {
+                'role': 'user',
+                'content': [
+                    {'text': 'what accounts are in this?'},
+                    {
+                        'document': {
+                            'format': 'csv',
+                            'name': 'Document 1',
+                            'source': {'s3Location': {'uri': 's3://bucket/file.csv'}},
+                        }
+                    },
+                ],
+            },
+        ]
+    )
+
+
 async def test_bedrock_model_thinking_part_stream(allow_model_requests: None, bedrock_provider: BedrockProvider):
     m = BedrockConverseModel(
         'us.anthropic.claude-sonnet-4-20250514-v1:0',

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -2541,7 +2541,10 @@ async def test_bedrock_split_tool_result_from_attachment_user_message(bedrock_pr
         [
             {'role': 'user', 'content': [{'text': 'show me my expenses'}]},
             {'role': 'assistant', 'content': [{'toolUse': {'toolUseId': 't1', 'name': 'get', 'input': {}}}]},
-            {'role': 'user', 'content': [{'toolResult': {'toolUseId': 't1', 'content': [{'text': 'ok'}], 'status': 'success'}}]},
+            {
+                'role': 'user',
+                'content': [{'toolResult': {'toolUseId': 't1', 'content': [{'text': 'ok'}], 'status': 'success'}}],
+            },
             {
                 'role': 'user',
                 'content': [


### PR DESCRIPTION
## Summary
Prevent the Bedrock adapter from merging consecutive user messages when one contains `toolResult` blocks and the next contains attachment blocks (`document` / `image` / `video`).

## Motivation
Anthropic Claude models on Amazon Bedrock reject user messages that combine `toolResult` with attachment blocks, returning a misleading `ValidationException` about missing `tool_result` blocks. This shape appears naturally when a tool call ends a turn and the user's next turn includes a file attachment.

Fixes #6081

## Changes
- Add helpers to detect tool-result and attachment content blocks in Bedrock user messages.
- Skip sequential user-message merging when those block types would be combined.
- Add a regression test using `_clean_message_history` + `_map_messages`.

## Tests
- `uv run pytest tests/models/test_bedrock.py::test_bedrock_split_tool_result_from_attachment_user_message -v` — PASSED
- `uv run pytest tests/models/test_bedrock.py -k "group_consecutive_tool or map_messages_builtin" -v` — PASSED (2 tests)

## Notes
- Text-only user content can still be merged with a preceding `toolResult` message, matching Bedrock's accepted `[toolResult, text]` shape.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

