### PR TITLE
fix(utils): run sync callbacks inline on Pyodide/emscripten by default

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
 _P = ParamSpec('_P')
 _R = TypeVar('_R')
 
-_disable_threads: ContextVar[bool] = ContextVar('_disable_threads', default=False)
+_disable_threads: ContextVar[bool] = ContextVar('_disable_threads', default=sys.platform == 'emscripten')
 _thread_executor: ContextVar[Executor | None] = ContextVar('_thread_executor', default=None)
 
 
@@ -79,7 +79,9 @@ def disable_threads() -> Generator[None]:
     being sent to a thread pool via [`anyio.to_thread.run_sync`][anyio.to_thread.run_sync].
 
     This is useful in environments where threading is restricted, such as
-    Temporal workflows which use a sandboxed event loop.
+    Temporal workflows which use a sandboxed event loop. On emscripten,
+    sync callbacks already run inline by default because Python threads are
+    unavailable there.
 
     Yields:
         None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ from importlib.metadata import distributions
 
 import pytest
 
+import pydantic_ai._utils as utils_module
 from pydantic_ai import UserError
 from pydantic_ai._utils import (
     UNSET,
@@ -25,7 +26,6 @@ from pydantic_ai._utils import (
     strip_markdown_fences,
     using_thread_executor,
 )
-import pydantic_ai._utils as utils_module
 
 from ._inline_snapshot import snapshot
 from .models.mock_async_stream import MockAsyncStream

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -251,14 +251,23 @@ async def test_disable_threads_takes_priority_over_custom_executor() -> None:
         executor.shutdown(wait=True)
 
 
-def test_disable_threads_defaults_false_on_non_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_disable_threads_defaults_false_on_non_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:
     import importlib
 
     import pydantic_ai._utils as utils_module
 
     monkeypatch.setattr('sys.platform', 'linux')
     importlib.reload(utils_module)
-    assert utils_module._disable_threads.get() is False
+    try:
+        main_thread = threading.current_thread()
+
+        def check_thread() -> threading.Thread:
+            return threading.current_thread()
+
+        result = await utils_module.run_in_executor(check_thread)
+        assert result is not main_thread
+    finally:
+        importlib.reload(utils_module)
 
 
 async def test_run_in_executor_runs_inline_by_default_on_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,9 @@ from __future__ import annotations as _annotations
 import asyncio
 import contextvars
 import functools
+import importlib
 import os
+import sys
 import threading
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
@@ -23,6 +25,7 @@ from pydantic_ai._utils import (
     strip_markdown_fences,
     using_thread_executor,
 )
+import pydantic_ai._utils as utils_module
 
 from ._inline_snapshot import snapshot
 from .models.mock_async_stream import MockAsyncStream
@@ -252,11 +255,7 @@ async def test_disable_threads_takes_priority_over_custom_executor() -> None:
 
 
 async def test_disable_threads_defaults_false_on_non_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:
-    import importlib
-
-    import pydantic_ai._utils as utils_module
-
-    monkeypatch.setattr('sys.platform', 'linux')
+    monkeypatch.setattr(sys, 'platform', 'linux')
     importlib.reload(utils_module)
     try:
         main_thread = threading.current_thread()
@@ -271,11 +270,7 @@ async def test_disable_threads_defaults_false_on_non_emscripten(monkeypatch: pyt
 
 
 async def test_run_in_executor_runs_inline_by_default_on_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:
-    import importlib
-
-    import pydantic_ai._utils as utils_module
-
-    monkeypatch.setattr('sys.platform', 'emscripten')
+    monkeypatch.setattr(sys, 'platform', 'emscripten')
     importlib.reload(utils_module)
     try:
         main_thread = threading.current_thread()
@@ -286,7 +281,7 @@ async def test_run_in_executor_runs_inline_by_default_on_emscripten(monkeypatch:
         result = await utils_module.run_in_executor(check_thread)
         assert result is main_thread
     finally:
-        monkeypatch.setattr('sys.platform', 'linux')
+        monkeypatch.setattr(sys, 'platform', 'linux')
         importlib.reload(utils_module)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -251,6 +251,36 @@ async def test_disable_threads_takes_priority_over_custom_executor() -> None:
         executor.shutdown(wait=True)
 
 
+def test_disable_threads_defaults_false_on_non_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+
+    import pydantic_ai._utils as utils_module
+
+    monkeypatch.setattr('sys.platform', 'linux')
+    importlib.reload(utils_module)
+    assert utils_module._disable_threads.get() is False
+
+
+async def test_run_in_executor_runs_inline_by_default_on_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+
+    import pydantic_ai._utils as utils_module
+
+    monkeypatch.setattr('sys.platform', 'emscripten')
+    importlib.reload(utils_module)
+    try:
+        main_thread = threading.current_thread()
+
+        def check_thread() -> threading.Thread:
+            return threading.current_thread()
+
+        result = await utils_module.run_in_executor(check_thread)
+        assert result is main_thread
+    finally:
+        monkeypatch.setattr('sys.platform', 'linux')
+        importlib.reload(utils_module)
+
+
 def test_is_async_callable():
     def sync_func(): ...  # pragma: no branch
 


### PR DESCRIPTION
## Summary

Default `_disable_threads` to `True` when `sys.platform == 'emscripten'`, so sync tools and callbacks use the existing inline execution path instead of `anyio.to_thread.run_sync`, which crashes on Pyodide with `RuntimeError: can't start new thread`.

## Motivation

Running agents in the browser via Pyodide fails whenever a synchronous tool (or other sync callback routed through `run_in_executor`) is invoked. Async tools work around the issue, but sync tools are a common authoring style and should not hard-crash on emscripten.

Fixes #6086

## Changes

| File | Change |
|------|--------|
| `pydantic_ai_slim/pydantic_ai/_utils.py` | Default `_disable_threads` to `sys.platform == 'emscripten'`; clarify `disable_threads()` docstring |
| `tests/test_utils.py` | Add regression tests for emscripten default inline execution and non-emscripten default |

## Tests

- `uv run pytest tests/test_utils.py::test_disable_threads_defaults_false_on_non_emscripten tests/test_utils.py::test_run_in_executor_runs_inline_by_default_on_emscripten tests/test_utils.py::test_run_in_executor_with_disable_threads tests/test_utils.py::test_disable_threads_takes_priority_over_custom_executor` — all passed
- `uv run ruff check` on changed files — passed
- `uv run pyright pydantic_ai_slim/pydantic_ai/_utils.py` — passed

## Notes

- CPython behavior is unchanged (`default=False` on non-emscripten platforms).
- Reuses the existing `_disable_threads` / `disable_threads()` path already used by Temporal workflows.
- Provider-internal call sites that call `anyio.to_thread.run_sync` directly (e.g. Bedrock) are out of scope for this fix, as noted in the issue.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

