### PR TITLE
Handle CRLF markdown JSON fences in `strip_markdown_fences`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -764,7 +764,7 @@ def merge_json_schema_defs(schemas: list[dict[str, Any]]) -> tuple[list[dict[str
     return rewritten_schemas, all_defs
 
 
-_MARKDOWN_FENCES_PATTERN = re.compile(r'```(?:\w+)?\n(\{.*?\})\s*(?:\n?```|\Z)', flags=re.DOTALL)
+_MARKDOWN_FENCES_PATTERN = re.compile(r'```(?:\w+)?\r?\n(\{.*?\})\s*(?:\r?\n?```|\Z)', flags=re.DOTALL)
 
 
 def strip_markdown_fences(text: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -790,6 +790,7 @@ def test_merge_json_schema_defs_structurally_equal_with_different_ref_targets():
 def test_strip_markdown_fences():
     assert strip_markdown_fences('{"foo": "bar"}') == '{"foo": "bar"}'
     assert strip_markdown_fences('```json\n{"foo": "bar"}\n```') == '{"foo": "bar"}'
+    assert strip_markdown_fences('```json\r\n{"foo": "bar"}\r\n```') == '{"foo": "bar"}'
     assert strip_markdown_fences('```json\n{\n  "foo": "bar"\n}') == '{\n  "foo": "bar"\n}'
     assert (
         strip_markdown_fences('{"foo": "```json\\n{"foo": "bar"}\\n```"}')


### PR DESCRIPTION
- Closes N/A - small regression fix for CRLF markdown fences.

### What changed

`strip_markdown_fences()` now accepts CRLF line endings around fenced JSON blocks, e.g. ````json`r`n...`r`n````, matching the existing LF behavior.

### Why

The helper already strips fenced JSON returned by models before validation. CRLF-formatted markdown blocks could be left unstripped and then fail downstream as non-JSON text even though the fenced JSON payload is valid.

### Validation

- `PYTHONUTF8=1 uv run pytest tests/test_utils.py::test_strip_markdown_fences -q`
- `PYTHONUTF8=1 uv run ruff check pydantic_ai_slim/pydantic_ai/_utils.py tests/test_utils.py`
- `git diff --check -- pydantic_ai_slim/pydantic_ai/_utils.py tests/test_utils.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

