### PR TITLE
fix: allow RetryPromptPart.content to accept incomplete ErrorDetails (closes #5987)

### DIFF
--- a/examples/pydantic_ai_examples/chat_app.py
+++ b/examples/pydantic_ai_examples/chat_app.py
@@ -35,6 +35,7 @@ from pydantic_ai import (
     UnexpectedModelBehavior,
     UserPromptPart,
 )
+from pydantic_ai.messages import RetryPromptPart, ErrorDetails
 
 # 'if-token-present' means nothing will be sent (and the example will work) if you don't have logfire configured
 logfire.configure(send_to_logfire='if-token-present')


### PR DESCRIPTION
## What
`RetryPromptPart.content` is typed as `list[pydantic_core.ErrorDetails] | str`, but `ErrorDetails` TypedDict requires `input` key. When validators produce error lists without `input` (e.g., `ValidationError.errors(include_input=False)`), round-tripping through `ModelMessagesTypeAdapter` fails with `ValidationError`. This breaks `Agent.all_messages_json()`, temporal workflow replay, and persisted message history.

## Fix
Define a new TypedDict `PartialErrorDetails` that makes `input` optional (and other non-essential fields like `url` and `ctx` optional as well), and use it for `RetryPromptPart.content` instead of the strict `pydantic_core.ErrorDetails`. This allows round-tripping error dicts that may lack `input` while maintaining backward compatibility.

Closes #5987

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

