### PR TITLE
Preserve `FilePart.content.vendor_metadata` in AG-UI and Vercel AI adapter round-trips

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -489,7 +489,10 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             )
                         binary_content = BinaryContent.from_data_uri(url)
                         vendor_metadata = activity_content.get('vendor_metadata')
-                        if vendor_metadata is not None:
+                        # `vendor_metadata` is client-supplied and typed `Any`; assignment on the
+                        # (non-`validate_assignment`) `BinaryContent` dataclass bypasses validation,
+                        # so ignore anything that isn't a dict rather than let it reach the provider.
+                        if is_str_dict(vendor_metadata):
                             binary_content.vendor_metadata = vendor_metadata
                         builder.add(
                             FilePart(

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -487,9 +487,13 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             raise ValueError(
                                 f'ActivityMessage with activity_type={FILE_ACTIVITY_TYPE!r} must have a non-empty url.'
                             )
+                        binary_content = BinaryContent.from_data_uri(url)
+                        vendor_metadata = activity_content.get('vendor_metadata')
+                        if vendor_metadata is not None:
+                            binary_content.vendor_metadata = vendor_metadata
                         builder.add(
                             FilePart(
-                                content=BinaryContent.from_data_uri(url),
+                                content=binary_content,
                                 id=activity_content.get('id'),
                                 provider_name=activity_content.get('provider_name'),
                                 provider_details=activity_content.get('provider_details'),
@@ -708,6 +712,8 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                         file_content['provider_name'] = part.provider_name
                     if part.provider_details is not None:
                         file_content['provider_details'] = part.provider_details
+                    if part.content.vendor_metadata is not None:
+                        file_content['vendor_metadata'] = part.content.vendor_metadata
                     result.append(
                         ActivityMessage(
                             id=_new_message_id(),

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
@@ -51,7 +51,7 @@ class FileActivityContent(TypedDict, total=False):
     id: str
     provider_name: str
     provider_details: dict[str, Any]
-    vendor_metadata: Any
+    vendor_metadata: dict[str, Any]
 
 
 class UploadedFileActivityContent(TypedDict, total=False):
@@ -61,7 +61,7 @@ class UploadedFileActivityContent(TypedDict, total=False):
     provider_name: Required[str]
     media_type: str
     identifier: str
-    vendor_metadata: Any
+    vendor_metadata: dict[str, Any]
 
 
 _AG_UI_VERSION_RE = re.compile(r'(\d+(?:\.\d+)*)')

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
@@ -51,6 +51,7 @@ class FileActivityContent(TypedDict, total=False):
     id: str
     provider_name: str
     provider_details: dict[str, Any]
+    vendor_metadata: Any
 
 
 class UploadedFileActivityContent(TypedDict, total=False):

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -348,6 +348,9 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                                 'Vercel AI integration can currently only handle assistant file parts with data URIs.'
                             ) from e
                         provider_meta = load_provider_metadata(part.provider_metadata)
+                        vendor_metadata = provider_meta.get('vendor_metadata')
+                        if vendor_metadata is not None:
+                            file.vendor_metadata = vendor_metadata
                         builder.add(
                             FilePart(
                                 content=file,
@@ -581,7 +584,10 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                         url=part.content.data_uri,
                         media_type=part.content.media_type,
                         provider_metadata=dump_provider_metadata(
-                            id=part.id, provider_name=part.provider_name, provider_details=part.provider_details
+                            id=part.id,
+                            provider_name=part.provider_name,
+                            provider_details=part.provider_details,
+                            vendor_metadata=part.content.vendor_metadata,
                         ),
                     )
                 )

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -349,7 +349,10 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                             ) from e
                         provider_meta = load_provider_metadata(part.provider_metadata)
                         vendor_metadata = provider_meta.get('vendor_metadata')
-                        if vendor_metadata is not None:
+                        # `vendor_metadata` is client-supplied and unconstrained; assignment on the
+                        # (non-`validate_assignment`) `BinaryContent` dataclass bypasses validation,
+                        # so ignore anything that isn't a dict rather than let it reach the provider.
+                        if _is_str_dict(vendor_metadata):
                             file.vendor_metadata = vendor_metadata
                         builder.add(
                             FilePart(

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1679,6 +1679,23 @@ def test_dump_load_roundtrip_binary_content() -> None:
             ],
             id='file-only',
         ),
+        pytest.param(
+            [
+                ModelRequest(parts=[UserPromptPart(content='Generate an image')]),
+                ModelResponse(
+                    parts=[
+                        FilePart(
+                            content=BinaryImage(
+                                data=b'generated file content',
+                                media_type='image/png',
+                                vendor_metadata={'detail': 'high'},
+                            ),
+                        ),
+                    ]
+                ),
+            ],
+            id='vendor-metadata',
+        ),
     ],
 )
 def test_dump_load_roundtrip_file_part(original: list[ModelMessage]) -> None:
@@ -3910,6 +3927,45 @@ def test_dump_messages_uploaded_file_without_vendor_metadata() -> None:
             }
         ]
     )
+
+
+def test_dump_messages_file_part_with_vendor_metadata() -> None:
+    """Test dump_messages includes vendor_metadata in the file ActivityMessage when present on a FilePart."""
+    messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                FilePart(
+                    content=BinaryImage(
+                        data=b'generated file content',
+                        media_type='image/png',
+                        vendor_metadata={'detail': 'high'},
+                    ),
+                ),
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(messages, preserve_file_data=True)
+    activity_msgs = [m for m in ag_ui_msgs if isinstance(m, ActivityMessage)]
+    assert len(activity_msgs) == 1
+    assert activity_msgs[0].activity_type == 'pydantic_ai_file'
+    assert activity_msgs[0].content.get('vendor_metadata') == {'detail': 'high'}
+
+
+def test_dump_messages_file_part_without_vendor_metadata() -> None:
+    """Test dump_messages omits vendor_metadata from the file ActivityMessage when None on a FilePart."""
+    messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                FilePart(content=BinaryImage(data=b'generated file content', media_type='image/png')),
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(messages, preserve_file_data=True)
+    activity_msgs = [m for m in ag_ui_msgs if isinstance(m, ActivityMessage)]
+    assert len(activity_msgs) == 1
+    assert 'vendor_metadata' not in activity_msgs[0].content
 
 
 # endregion

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -3968,6 +3968,24 @@ def test_dump_messages_file_part_without_vendor_metadata() -> None:
     assert 'vendor_metadata' not in activity_msgs[0].content
 
 
+def test_load_messages_file_part_ignores_non_dict_vendor_metadata() -> None:
+    """Test load_messages ignores client-supplied vendor_metadata that isn't a dict.
+
+    `vendor_metadata` is typed `Any` in the wire schema and set on a `BinaryContent` that
+    doesn't validate on assignment, so a malformed value must not reach the model.
+    """
+    data_uri = BinaryImage(data=b'generated file content', media_type='image/png').data_uri
+    content: dict[str, Any] = {'url': data_uri, 'media_type': 'image/png', 'vendor_metadata': 'not-a-dict'}
+
+    reloaded = AGUIAdapter.load_messages(
+        [ActivityMessage(id='activity-1', activity_type='pydantic_ai_file', content=content)],
+        preserve_file_data=True,
+    )
+    file_parts = [part for message in reloaded for part in message.parts if isinstance(part, FilePart)]
+    assert len(file_parts) == 1
+    assert file_parts[0].content.vendor_metadata is None
+
+
 # endregion
 
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -6526,6 +6526,38 @@ async def test_adapter_dump_filepart_carries_vendor_metadata_in_provider_metadat
     assert provider_meta.get('vendor_metadata') == {'detail': 'high'}
 
 
+async def test_adapter_load_filepart_ignores_non_dict_vendor_metadata():
+    """A malformed (non-dict) client-supplied vendor_metadata is ignored on load, not forwarded.
+
+    Assignment onto the non-`validate_assignment` `BinaryContent` bypasses validation, so the load
+    path guards with `is_str_dict`; this pins that guard.
+    """
+    messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                FilePart(
+                    content=BinaryContent(
+                        data=b'fake video bytes',
+                        media_type='video/mp4',
+                        vendor_metadata={'detail': 'high'},
+                    ),
+                ),
+            ]
+        ),
+    ]
+
+    ui_messages = VercelAIAdapter.dump_messages(messages)
+    file_ui_part = ui_messages[0].parts[0]
+    assert isinstance(file_ui_part, FileUIPart)
+    assert file_ui_part.provider_metadata is not None
+    file_ui_part.provider_metadata['pydantic_ai']['vendor_metadata'] = 'not-a-dict'
+
+    reloaded = VercelAIAdapter.load_messages(ui_messages)
+    reloaded_part = reloaded[0].parts[0]
+    assert isinstance(reloaded_part, FilePart)
+    assert reloaded_part.content.vendor_metadata is None
+
+
 async def test_adapter_builtin_tool_part_with_provider_metadata():
     """Test NativeToolCallPart with id, provider_name, provider_details and roundtrips."""
     # Use JSON string for content since that's what load_messages produces

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -6469,6 +6469,63 @@ async def test_adapter_load_messages_file_with_provider_metadata():
     )
 
 
+async def test_adapter_dump_load_roundtrip_filepart_vendor_metadata():
+    """FilePart vendor_metadata survives Vercel AI adapter dump/load round-trip."""
+    messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                FilePart(
+                    content=BinaryContent(
+                        data=b'fake video bytes',
+                        media_type='video/mp4',
+                        vendor_metadata={
+                            'fps': 24,
+                            'start_offset': '12.5s',
+                            'end_offset': '67.0s',
+                        },
+                    ),
+                    provider_name='google',
+                    provider_details={'model': 'gemini-2.5-flash'},
+                ),
+            ]
+        ),
+    ]
+
+    ui_messages = VercelAIAdapter.dump_messages(messages)
+    reloaded = VercelAIAdapter.load_messages(ui_messages)
+
+    reloaded_part = reloaded[0].parts[0]
+    assert isinstance(reloaded_part, FilePart)
+    assert reloaded_part.content.vendor_metadata == {
+        'fps': 24,
+        'start_offset': '12.5s',
+        'end_offset': '67.0s',
+    }
+
+
+async def test_adapter_dump_filepart_carries_vendor_metadata_in_provider_metadata():
+    """Dumped FileUIPart carries vendor_metadata in provider_metadata for wire-format round-trip."""
+    messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                FilePart(
+                    content=BinaryContent(
+                        data=b'fake video bytes',
+                        media_type='video/mp4',
+                        vendor_metadata={'detail': 'high'},
+                    ),
+                ),
+            ]
+        ),
+    ]
+
+    ui_messages = VercelAIAdapter.dump_messages(messages)
+    file_ui_part = ui_messages[0].parts[0]
+    assert isinstance(file_ui_part, FileUIPart)
+    provider_meta = load_provider_metadata(file_ui_part.provider_metadata)
+    assert provider_meta.get('vendor_metadata') == {'detail': 'high'}
+
+
 async def test_adapter_builtin_tool_part_with_provider_metadata():
     """Test NativeToolCallPart with id, provider_name, provider_details and roundtrips."""
     # Use JSON string for content since that's what load_messages produces


### PR DESCRIPTION
- Closes #6087

## Problem

`AGUIAdapter` handled `vendor_metadata` for the `UploadedFile` path (both dump and load), but **not** for the `FilePart` (model-response) path. So when an AG-UI client round-trips a conversation back as `message_history`, `FilePart.content.vendor_metadata` was silently dropped on `dump_messages` → `load_messages`.

This matters because `vendor_metadata` is load-bearing for several providers (documented on `BinaryContent`): Gemini uses it as `video_metadata`, and OpenAI/Xai/Groq use `vendor_metadata['detail']` for image detail. Losing it on resume silently degrades the next request to the model.

## Fix

- **Dump** (`_dump_response_parts`): include `vendor_metadata` in the file `ActivityMessage` content when present.
- **Load** (`load_messages`): restore `vendor_metadata` onto the rehydrated `BinaryContent`.
- **Schema** (`FileActivityContent`): declare `vendor_metadata`, matching the sibling `UploadedFileActivityContent` so the canonical TypedDict reflects the field.

Mirrors the existing `UploadedFile` handling.

## Tests

- Added a `vendor-metadata` case to `test_dump_loa before the fix, passes after).
- Added `test_dump_messages_file_part_with/without_vendor_metadata`, mirroring the existing `UploadedFile` dump-shape tests.

All AG-UI and UI adapter tests pass; ruff format/lint and pyright are clean locally.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with tpolicy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

---

## Update: Vercel AI adapter folded in (supersedes #6103)

The same `FilePart.content.vendor_metadata` round-trip bug was reported for the Vercel AI adapter (#6102) and fixed by @syf2211 in #6103. Since it's the identical minimal fix on a sibling adapter — and matches the both-adapters-in-one-PR precedent of #5790 — it's folded into this PR:

- **@syf2211's commit is cherry-picked** here (authorship preserved), covering the Vercel dump/load of `vendor_metadata` via `provider_metadata`.
- **Load-side validation made consistent across both adapters:** the Vercel load path guard was changed from a bare `is not None` check to `is_str_dict(...)`, matching the AG-UI fix — a client-supplied `vendor_metadata` is only trusted if it's actually a dict, since assignment onto the non-`validate_assignment` `BinaryContent` bypasses validation before the value reaches the provider (Gemini `video_metadata`, OpenAI/xAI/Groq image `detail`). A regression test was added.

This PR now resolves both #6087 (AG-UI) and #6102 (Vercel). #6103 can stay closed.