### PR TITLE
fix(google): enable `include_server_side_tool_invocations` for `CodeExecutionTool`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -712,11 +712,11 @@ class GoogleModel(Model[Client]):
             tool_config['function_calling_config'] = function_calling_config
 
         # `include_server_side_tool_invocations` makes Gemini emit explicit `tool_call`/`tool_response`
-        # parts for WebSearchTool, WebFetchTool, FileSearchTool. Pre-Gemini-3 models reject the field
-        # ('Tool call context circulation is not enabled'); CodeExecutionTool uses its own
-        # `executable_code`/`code_execution_result` parts; ImageGenerationTool runs through `image_config`.
+        # parts for WebSearchTool, WebFetchTool, FileSearchTool, CodeExecutionTool. Pre-Gemini-3 models
+        # reject the field ('Tool call context circulation is not enabled').
         emits_tool_call_invocations = any(
-            isinstance(t, (WebSearchTool, WebFetchTool, FileSearchTool)) for t in model_request_parameters.native_tools
+            isinstance(t, (WebSearchTool, WebFetchTool, FileSearchTool, CodeExecutionTool))
+            for t in model_request_parameters.native_tools
         )
         if emits_tool_call_invocations and self.profile.get('google_supports_server_side_tool_invocations', False):
             tool_config['include_server_side_tool_invocations'] = True

--- a/tests/models/test_tool_choice_unit.py
+++ b/tests/models/test_tool_choice_unit.py
@@ -16,7 +16,7 @@ from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import ModelRequest
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.models._tool_choice import resolve_tool_choice
-from pydantic_ai.native_tools import WebSearchTool
+from pydantic_ai.native_tools import CodeExecutionTool, WebSearchTool
 from pydantic_ai.settings import ModelSettings, ToolChoice, ToolOrOutput
 from pydantic_ai.tools import ToolDefinition
 
@@ -609,6 +609,12 @@ NATIVE_TOOL_CONFIG_CASES = [
         id='native-only-gemini-3-keeps-only-server-side-flag',
         model='gemini-3-flash-preview',
         request_parameters=ModelRequestParameters(native_tools=[WebSearchTool()]),
+        expected_tool_config={'include_server_side_tool_invocations': True},
+    ),
+    dict(
+        id='code-exec-only-gemini-3-keeps-server-side-flag',
+        model='gemini-3-flash-preview',
+        request_parameters=ModelRequestParameters(native_tools=[CodeExecutionTool()]),
         expected_tool_config={'include_server_side_tool_invocations': True},
     ),
     dict(


### PR DESCRIPTION
On Gemini 3 models, combining the built-in `CodeExecutionTool` with any user-defined function tool in the same request causes the Gemini API to reject the request with HTTP 400:
`Please enable tool_config.include_server_side_tool_invocations to use Built-in tools with Function calling.`

This happens because `GoogleModel._get_tool_config` only sets `include_server_side_tool_invocations` when one of `(WebSearchTool, WebFetchTool, FileSearchTool)` is present, missing `CodeExecutionTool`.

This PR fixes the bug by:
1. Adding `CodeExecutionTool` to the tuple of native tools checked for `include_server_side_tool_invocations`.
2. Updating the unit tests in `tests/models/test_tool_choice_unit.py` to assert that `CodeExecutionTool` correctly triggers this configuration.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

