### PR TITLE
feat(cohere): implement `request_stream` / `CohereStreamedResponse`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -484,10 +484,14 @@ class CohereStreamedResponse(StreamedResponse):
     _timestamp: datetime = field(default_factory=_now_utc)
 
     async def close_stream(self) -> None:
+        aclose = getattr(self._response, 'aclose', None)
+        if aclose is None:
+            return
         try:
-            await self._response.aclose()  # pyright: ignore[reportAttributeAccessIssue]
-        except (RuntimeError, AttributeError):
-            pass
+            await aclose()
+        except RuntimeError as e:
+            if 'async generator is already running' not in str(e):
+                raise
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         thinking_indices: set[int] = set()

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import AsyncGenerator, AsyncIterator, Iterable
-from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator, AsyncIterator, Generator, Iterable
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from types import EllipsisType
@@ -96,6 +96,17 @@ Since Cohere supports a variety of date-stamped models, we explicitly list the l
 allow any name in the type hints.
 See [Cohere's docs](https://docs.cohere.com/v2/docs/models) for a list of all available models.
 """
+
+
+@contextmanager
+def _map_api_errors(model_name: str) -> Generator[None]:
+    try:
+        yield
+    except ApiError as e:
+        if (status_code := e.status_code) and status_code >= 400:
+            raise ModelHTTPError(status_code=status_code, model_name=model_name, body=e.body) from e
+        raise ModelAPIError(model_name=model_name, message=str(e)) from e
+
 
 _FINISH_REASON_MAP: dict[ChatFinishReason, FinishReason] = {
     'COMPLETE': 'stop',
@@ -204,7 +215,7 @@ class CohereModel(Model[AsyncClientV2]):
         cohere_settings = cast(CohereModelSettings, model_settings or {})
         tools, tool_choice = self._get_tool_choice(model_request_parameters, cohere_settings)
         cohere_messages = self._map_messages(messages, model_request_parameters)
-        try:
+        with _map_api_errors(self.model_name):
             response_iter = self.client.chat_stream(
                 model=self._model_name,
                 messages=cohere_messages,
@@ -219,10 +230,6 @@ class CohereModel(Model[AsyncClientV2]):
                 presence_penalty=cohere_settings.get('presence_penalty', OMIT),
                 frequency_penalty=cohere_settings.get('frequency_penalty', OMIT),
             )
-        except ApiError as e:
-            if (status_code := e.status_code) and status_code >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
-            raise ModelAPIError(model_name=self.model_name, message=str(e)) from e
         yield CohereStreamedResponse(
             model_request_parameters=model_request_parameters,
             _model_name=self._model_name,
@@ -240,7 +247,7 @@ class CohereModel(Model[AsyncClientV2]):
         tools, tool_choice = self._get_tool_choice(model_request_parameters, model_settings)
 
         cohere_messages = self._map_messages(messages, model_request_parameters)
-        try:
+        with _map_api_errors(self.model_name):
             return await self.client.chat(
                 model=self._model_name,
                 messages=cohere_messages,
@@ -255,10 +262,6 @@ class CohereModel(Model[AsyncClientV2]):
                 presence_penalty=model_settings.get('presence_penalty', OMIT),
                 frequency_penalty=model_settings.get('frequency_penalty', OMIT),
             )
-        except ApiError as e:
-            if (status_code := e.status_code) and status_code >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
-            raise ModelAPIError(model_name=self.model_name, message=str(e)) from e
 
     def _get_tool_choice(
         self,
@@ -497,64 +500,78 @@ class CohereStreamedResponse(StreamedResponse):
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
         thinking_indices: set[int] = set()
 
-        async for event in self._response:
-            if isinstance(event, ContentStartV2ChatStreamResponse):
-                if event.index is not None:
-                    content_type = (
-                        event.delta
+        with _map_api_errors(self._model_name):
+            async for event in self._response:
+                if isinstance(event, ContentStartV2ChatStreamResponse):
+                    if event.index is not None:
+                        content_type = (
+                            event.delta
+                            and event.delta.message
+                            and event.delta.message.content
+                            and event.delta.message.content.type
+                        )
+                        if content_type == 'thinking':
+                            thinking_indices.add(event.index)
+
+                elif isinstance(event, ContentDeltaV2ChatStreamResponse):
+                    if event.index is not None and event.delta and event.delta.message and event.delta.message.content:
+                        mc = event.delta.message.content
+                        if event.index in thinking_indices:
+                            if thinking := mc.thinking:
+                                for ev in self._parts_manager.handle_thinking_delta(
+                                    vendor_part_id=event.index,
+                                    content=thinking,
+                                ):
+                                    yield ev
+                        else:
+                            if text := mc.text:
+                                for ev in self._parts_manager.handle_text_delta(
+                                    vendor_part_id=event.index,
+                                    content=text,
+                                ):
+                                    yield ev
+
+                elif isinstance(event, ToolCallStartV2ChatStreamResponse):
+                    if (
+                        event.index is not None
+                        and event.delta
                         and event.delta.message
-                        and event.delta.message.content
-                        and event.delta.message.content.type
-                    )
-                    if content_type == 'thinking':
-                        thinking_indices.add(event.index)
+                        and event.delta.message.tool_calls
+                    ):
+                        tc = event.delta.message.tool_calls
+                        maybe_event = self._parts_manager.handle_tool_call_delta(
+                            vendor_part_id=event.index,
+                            tool_name=tc.function.name if tc.function else None,
+                            tool_call_id=tc.id,
+                        )
+                        if maybe_event is not None:
+                            yield maybe_event
 
-            elif isinstance(event, ContentDeltaV2ChatStreamResponse):
-                if event.index is not None and event.delta and event.delta.message and event.delta.message.content:
-                    mc = event.delta.message.content
-                    if event.index in thinking_indices:
-                        if thinking := mc.thinking:
-                            for ev in self._parts_manager.handle_thinking_delta(
-                                vendor_part_id=event.index,
-                                content=thinking,
-                            ):
-                                yield ev
-                    else:
-                        if text := mc.text:
-                            for ev in self._parts_manager.handle_text_delta(
-                                vendor_part_id=event.index,
-                                content=text,
-                            ):
-                                yield ev
+                elif isinstance(event, ToolCallDeltaV2ChatStreamResponse):
+                    if (
+                        event.index is not None
+                        and event.delta
+                        and event.delta.message
+                        and event.delta.message.tool_calls
+                    ):
+                        tc = event.delta.message.tool_calls
+                        maybe_event = self._parts_manager.handle_tool_call_delta(
+                            vendor_part_id=event.index,
+                            args=tc.function.arguments if tc.function else None,
+                        )
+                        if maybe_event is not None:
+                            yield maybe_event
 
-            elif isinstance(event, ToolCallStartV2ChatStreamResponse):
-                if event.index is not None and event.delta and event.delta.message and event.delta.message.tool_calls:
-                    tc = event.delta.message.tool_calls
-                    maybe_event = self._parts_manager.handle_tool_call_delta(
-                        vendor_part_id=event.index,
-                        tool_name=tc.function.name if tc.function else None,
-                        tool_call_id=tc.id,
-                    )
-                    if maybe_event is not None:
-                        yield maybe_event
-
-            elif isinstance(event, ToolCallDeltaV2ChatStreamResponse):
-                if event.index is not None and event.delta and event.delta.message and event.delta.message.tool_calls:
-                    tc = event.delta.message.tool_calls
-                    maybe_event = self._parts_manager.handle_tool_call_delta(
-                        vendor_part_id=event.index,
-                        args=tc.function.arguments if tc.function else None,
-                    )
-                    if maybe_event is not None:
-                        yield maybe_event
-
-            elif isinstance(event, MessageEndV2ChatStreamResponse):
-                if event.delta:
-                    if raw_finish_reason := event.delta.finish_reason:
-                        self.provider_details = {**(self.provider_details or {}), 'finish_reason': raw_finish_reason}
-                        self.finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
-                    if event.delta.usage:
-                        self._usage += _map_cohere_usage(event.delta.usage)
+                elif isinstance(event, MessageEndV2ChatStreamResponse):
+                    if event.delta:
+                        if raw_finish_reason := event.delta.finish_reason:
+                            self.provider_details = {
+                                **(self.provider_details or {}),
+                                'finish_reason': raw_finish_reason,
+                            }
+                            self.finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
+                        if event.delta.usage:
+                            self._usage += _map_cohere_usage(event.delta.usage)
 
     @property
     def model_name(self) -> CohereModelName:

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -1,17 +1,18 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncGenerator, AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from types import EllipsisType
-from typing import Any, AsyncGenerator, Literal, cast
+from typing import Any, Literal, cast
 
 from typing_extensions import assert_never
 
 from pydantic_ai.exceptions import ModelAPIError
 
 from .. import ModelHTTPError, usage
+from .._run_context import RunContext
 from .._utils import (
     generate_tool_call_id as _generate_tool_call_id,
     guard_tool_call_id as _guard_tool_call_id,
@@ -42,7 +43,7 @@ from ..profiles import ModelProfileSpec
 from ..providers import Provider, infer_provider
 from ..settings import ModelSettings
 from ..tools import ToolDefinition
-from . import Model, ModelRequestParameters, RunContext, StreamedResponse, check_allow_model_requests
+from . import Model, ModelRequestParameters, StreamedResponse, check_allow_model_requests
 from ._tool_choice import resolve_tool_choice
 
 try:
@@ -493,7 +494,7 @@ class CohereStreamedResponse(StreamedResponse):
             if 'async generator is already running' not in str(e):
                 raise
 
-    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
         thinking_indices: set[int] = set()
 
         async for event in self._response:

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -1,16 +1,22 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import Iterable
+from collections.abc import AsyncIterator, Iterable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
+from datetime import datetime
 from types import EllipsisType
-from typing import Literal, cast
+from typing import Any, AsyncGenerator, Literal, cast
 
 from typing_extensions import assert_never
 
 from pydantic_ai.exceptions import ModelAPIError
 
 from .. import ModelHTTPError, usage
-from .._utils import generate_tool_call_id as _generate_tool_call_id, guard_tool_call_id as _guard_tool_call_id
+from .._utils import (
+    generate_tool_call_id as _generate_tool_call_id,
+    guard_tool_call_id as _guard_tool_call_id,
+    now_utc as _now_utc,
+)
 from ..messages import (
     CachePoint,
     CompactionPart,
@@ -20,6 +26,7 @@ from ..messages import (
     ModelRequest,
     ModelResponse,
     ModelResponsePart,
+    ModelResponseStreamEvent,
     NativeToolCallPart,
     NativeToolReturnPart,
     RetryPromptPart,
@@ -35,7 +42,7 @@ from ..profiles import ModelProfileSpec
 from ..providers import Provider, infer_provider
 from ..settings import ModelSettings
 from ..tools import ToolDefinition
-from . import Model, ModelRequestParameters, check_allow_model_requests
+from . import Model, ModelRequestParameters, RunContext, StreamedResponse, check_allow_model_requests
 from ._tool_choice import resolve_tool_choice
 
 try:
@@ -45,15 +52,21 @@ try:
         ChatFinishReason,
         ChatMessageV2,
         Content as CohereContent,
+        ContentDeltaV2ChatStreamResponse,
+        ContentStartV2ChatStreamResponse,
+        MessageEndV2ChatStreamResponse,
         SystemChatMessageV2,
         TextAssistantMessageV2ContentOneItem,
         TextContent as CohereTextContent,
         ThinkingAssistantMessageV2ContentOneItem,
+        ToolCallDeltaV2ChatStreamResponse,
+        ToolCallStartV2ChatStreamResponse,
         ToolCallV2,
         ToolCallV2Function,
         ToolChatMessageV2,
         ToolV2,
         ToolV2Function,
+        Usage as CohereUsage,
         UserChatMessageV2,
         V2ChatResponse,
     )
@@ -173,6 +186,49 @@ class CohereModel(Model[AsyncClientV2]):
         response = await self._chat(messages, cast(CohereModelSettings, model_settings or {}), model_request_parameters)
         model_response = self._process_response(response)
         return model_response
+
+    @asynccontextmanager
+    async def request_stream(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+        run_context: RunContext[Any] | None = None,
+    ) -> AsyncGenerator[StreamedResponse]:
+        check_allow_model_requests()
+        model_settings, model_request_parameters = self.prepare_request(
+            model_settings,
+            model_request_parameters,
+        )
+        cohere_settings = cast(CohereModelSettings, model_settings or {})
+        tools, tool_choice = self._get_tool_choice(model_request_parameters, cohere_settings)
+        cohere_messages = self._map_messages(messages, model_request_parameters)
+        try:
+            response_iter = self.client.chat_stream(
+                model=self._model_name,
+                messages=cohere_messages,
+                tools=tools or OMIT,
+                tool_choice=tool_choice,
+                max_tokens=cohere_settings.get('max_tokens', OMIT),
+                stop_sequences=cohere_settings.get('stop_sequences', OMIT),
+                temperature=cohere_settings.get('temperature', OMIT),
+                p=cohere_settings.get('top_p', OMIT),
+                k=cohere_settings.get('top_k', OMIT),
+                seed=cohere_settings.get('seed', OMIT),
+                presence_penalty=cohere_settings.get('presence_penalty', OMIT),
+                frequency_penalty=cohere_settings.get('frequency_penalty', OMIT),
+            )
+        except ApiError as e:
+            if (status_code := e.status_code) and status_code >= 400:
+                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
+            raise ModelAPIError(model_name=self.model_name, message=str(e)) from e
+        yield CohereStreamedResponse(
+            model_request_parameters=model_request_parameters,
+            _model_name=self._model_name,
+            _provider_name=self._provider.name,
+            _provider_url=self.base_url,
+            _response=response_iter,
+        )
 
     async def _chat(
         self,
@@ -390,24 +446,127 @@ def _map_usage(response: V2ChatResponse) -> usage.RequestUsage:
     u = response.usage
     if u is None:
         return usage.RequestUsage()
-    else:
-        details: dict[str, int] = {}
-        if u.billed_units is not None:
-            if u.billed_units.input_tokens:  # pragma: no branch
-                details['input_tokens'] = int(u.billed_units.input_tokens)
-            if u.billed_units.output_tokens:
-                details['output_tokens'] = int(u.billed_units.output_tokens)
-            if u.billed_units.search_units:  # pragma: no cover
-                details['search_units'] = int(u.billed_units.search_units)
-            if u.billed_units.classifications:  # pragma: no cover
-                details['classifications'] = int(u.billed_units.classifications)
+    return _map_cohere_usage(u)
 
-        request_tokens = int(u.tokens.input_tokens) if u.tokens and u.tokens.input_tokens else 0
-        response_tokens = int(u.tokens.output_tokens) if u.tokens and u.tokens.output_tokens else 0
-        cache_read_tokens = int(u.cached_tokens) if u.cached_tokens else 0
-        return usage.RequestUsage(
-            input_tokens=request_tokens,
-            output_tokens=response_tokens,
-            cache_read_tokens=cache_read_tokens,
-            details=details,
-        )
+
+def _map_cohere_usage(u: CohereUsage) -> usage.RequestUsage:
+    details: dict[str, int] = {}
+    if u.billed_units is not None:
+        if u.billed_units.input_tokens:  # pragma: no branch
+            details['input_tokens'] = int(u.billed_units.input_tokens)
+        if u.billed_units.output_tokens:
+            details['output_tokens'] = int(u.billed_units.output_tokens)
+        if u.billed_units.search_units:  # pragma: no cover
+            details['search_units'] = int(u.billed_units.search_units)
+        if u.billed_units.classifications:  # pragma: no cover
+            details['classifications'] = int(u.billed_units.classifications)
+
+    request_tokens = int(u.tokens.input_tokens) if u.tokens and u.tokens.input_tokens else 0
+    response_tokens = int(u.tokens.output_tokens) if u.tokens and u.tokens.output_tokens else 0
+    cache_read_tokens = int(u.cached_tokens) if u.cached_tokens else 0
+    return usage.RequestUsage(
+        input_tokens=request_tokens,
+        output_tokens=response_tokens,
+        cache_read_tokens=cache_read_tokens,
+        details=details,
+    )
+
+
+@dataclass
+class CohereStreamedResponse(StreamedResponse):
+    """Implementation of `StreamedResponse` for Cohere models."""
+
+    model_request_parameters: ModelRequestParameters
+    _model_name: CohereModelName
+    _provider_name: str
+    _provider_url: str
+    _response: AsyncIterator[Any]
+    _timestamp: datetime = field(default_factory=_now_utc)
+
+    async def close_stream(self) -> None:
+        try:
+            await self._response.aclose()  # pyright: ignore[reportAttributeAccessIssue]
+        except (RuntimeError, AttributeError):
+            pass
+
+    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+        thinking_indices: set[int] = set()
+
+        async for event in self._response:
+            if isinstance(event, ContentStartV2ChatStreamResponse):
+                if event.index is not None:
+                    content_type = (
+                        event.delta
+                        and event.delta.message
+                        and event.delta.message.content
+                        and event.delta.message.content.type
+                    )
+                    if content_type == 'thinking':
+                        thinking_indices.add(event.index)
+
+            elif isinstance(event, ContentDeltaV2ChatStreamResponse):
+                if event.index is not None and event.delta and event.delta.message and event.delta.message.content:
+                    mc = event.delta.message.content
+                    if event.index in thinking_indices:
+                        if thinking := mc.thinking:
+                            for ev in self._parts_manager.handle_thinking_delta(
+                                vendor_part_id=event.index,
+                                content=thinking,
+                            ):
+                                yield ev
+                    else:
+                        if text := mc.text:
+                            for ev in self._parts_manager.handle_text_delta(
+                                vendor_part_id=event.index,
+                                content=text,
+                            ):
+                                yield ev
+
+            elif isinstance(event, ToolCallStartV2ChatStreamResponse):
+                if event.index is not None and event.delta and event.delta.message and event.delta.message.tool_calls:
+                    tc = event.delta.message.tool_calls
+                    maybe_event = self._parts_manager.handle_tool_call_delta(
+                        vendor_part_id=event.index,
+                        tool_name=tc.function.name if tc.function else None,
+                        tool_call_id=tc.id,
+                    )
+                    if maybe_event is not None:
+                        yield maybe_event
+
+            elif isinstance(event, ToolCallDeltaV2ChatStreamResponse):
+                if event.index is not None and event.delta and event.delta.message and event.delta.message.tool_calls:
+                    tc = event.delta.message.tool_calls
+                    maybe_event = self._parts_manager.handle_tool_call_delta(
+                        vendor_part_id=event.index,
+                        args=tc.function.arguments if tc.function else None,
+                    )
+                    if maybe_event is not None:
+                        yield maybe_event
+
+            elif isinstance(event, MessageEndV2ChatStreamResponse):
+                if event.delta:
+                    if raw_finish_reason := event.delta.finish_reason:
+                        self.provider_details = {**(self.provider_details or {}), 'finish_reason': raw_finish_reason}
+                        self.finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
+                    if event.delta.usage:
+                        self._usage += _map_cohere_usage(event.delta.usage)
+
+    @property
+    def model_name(self) -> CohereModelName:
+        """Get the model name of the response."""
+        return self._model_name
+
+    @property
+    def provider_name(self) -> str:
+        """Get the provider name."""
+        return self._provider_name
+
+    @property
+    def provider_url(self) -> str:
+        """Get the provider URL."""
+        return self._provider_url
+
+    @property
+    def timestamp(self) -> datetime:
+        """Get the timestamp of the response."""
+        return self._timestamp

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -519,10 +519,14 @@ class CohereStreamedResponse(StreamedResponse):
     _timestamp: datetime = field(default_factory=_now_utc)
 
     async def close_stream(self) -> None:
+        aclose = getattr(self._response, 'aclose', None)
+        if aclose is None:
+            return
         try:
-            await self._response.aclose()  # pyright: ignore[reportAttributeAccessIssue]
-        except (RuntimeError, AttributeError):
-            pass
+            await aclose()
+        except RuntimeError as e:
+            if 'async generator is already running' not in str(e):
+                raise
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
         thinking_indices: set[int] = set()

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -1,17 +1,18 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncGenerator, AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from types import EllipsisType
-from typing import Any, AsyncGenerator, Literal, cast
+from typing import Any, Literal, cast
 
 from typing_extensions import assert_never
 
 from pydantic_ai.exceptions import ModelAPIError
 
 from .. import ModelHTTPError, usage
+from .._run_context import RunContext
 from .._utils import (
     generate_tool_call_id as _generate_tool_call_id,
     guard_tool_call_id as _guard_tool_call_id,
@@ -48,7 +49,6 @@ from ..tools import ToolDefinition
 from . import (
     Model,
     ModelRequestParameters,
-    RunContext,
     StreamedResponse,
     _unconverted_speech_part_error,  # pyright: ignore[reportPrivateUsage]
     _unsynthesized_tool_availability_delta_error,  # pyright: ignore[reportPrivateUsage]
@@ -528,7 +528,7 @@ class CohereStreamedResponse(StreamedResponse):
             if 'async generator is already running' not in str(e):
                 raise
 
-    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
         thinking_indices: set[int] = set()
 
         async for event in self._response:

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -14,6 +14,7 @@ from pydantic_ai.exceptions import ModelAPIError
 from .. import ModelHTTPError, usage
 from .._run_context import RunContext
 from .._utils import (
+    PeekableAsyncStream as _PeekableAsyncStream,
     generate_tool_call_id as _generate_tool_call_id,
     guard_tool_call_id as _guard_tool_call_id,
     is_str_dict as _is_str_dict,
@@ -80,6 +81,7 @@ try:
         Usage as CohereUsage,
         UserChatMessageV2,
         V2ChatResponse,
+        V2ChatStreamResponse,
     )
     from cohere.core.api_error import ApiError
     from cohere.v2.client import OMIT
@@ -240,13 +242,24 @@ class CohereModel(Model[AsyncClientV2]):
                 presence_penalty=cohere_settings.get('presence_penalty', OMIT),
                 frequency_penalty=cohere_settings.get('frequency_penalty', OMIT),
             )
-        yield CohereStreamedResponse(
-            model_request_parameters=model_request_parameters,
-            _model_name=self._model_name,
-            _provider_name=self._provider.name,
-            _provider_url=self.base_url,
-            _response=response_iter,
+        peekable_response: _PeekableAsyncStream[V2ChatStreamResponse, AsyncIterator[V2ChatStreamResponse]] = (
+            _PeekableAsyncStream(response_iter)
         )
+        try:
+            yield CohereStreamedResponse(
+                model_request_parameters=model_request_parameters,
+                _model_name=self._model_name,
+                _provider_name=self._provider.name,
+                _provider_url=self.base_url,
+                _response=peekable_response,
+            )
+        finally:
+            # `chat_stream` is an async generator wrapping the SDK's `async with` on the HTTP
+            # response, so abandoning it early (a `break`, or an exception) leaves the connection
+            # open until GC unless we close it here. Same shape as `GoogleModel.request_stream`.
+            aclose = getattr(response_iter, 'aclose', None)
+            if aclose is not None:  # pragma: no branch
+                await aclose()
 
     async def _chat(
         self,
@@ -516,18 +529,11 @@ class CohereStreamedResponse(StreamedResponse):
     _model_name: CohereModelName
     _provider_name: str
     _provider_url: str
-    _response: AsyncIterator[Any]
+    _response: _PeekableAsyncStream[V2ChatStreamResponse, AsyncIterator[V2ChatStreamResponse]]
     _timestamp: datetime = field(default_factory=_now_utc)
 
     async def close_stream(self) -> None:
-        aclose = getattr(self._response, 'aclose', None)
-        if aclose is None:
-            return
-        try:
-            await aclose()
-        except RuntimeError as e:
-            if 'async generator is already running' not in str(e):
-                raise
+        await self._response.aclose()
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
         thinking_indices: set[int] = set()

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import AsyncGenerator, AsyncIterator, Iterable
-from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator, AsyncIterator, Generator, Iterable
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from types import EllipsisType
@@ -106,6 +106,17 @@ Since Cohere supports a variety of date-stamped models, we explicitly list the l
 allow any name in the type hints.
 See [Cohere's docs](https://docs.cohere.com/v2/docs/models) for a list of all available models.
 """
+
+
+@contextmanager
+def _map_api_errors(model_name: str) -> Generator[None]:
+    try:
+        yield
+    except ApiError as e:
+        if (status_code := e.status_code) and status_code >= 400:
+            raise ModelHTTPError(status_code=status_code, model_name=model_name, body=e.body, headers=e.headers) from e
+        raise ModelAPIError(model_name=model_name, message=str(e)) from e
+
 
 _FINISH_REASON_MAP: dict[ChatFinishReason, FinishReason] = {
     'COMPLETE': 'stop',
@@ -214,7 +225,7 @@ class CohereModel(Model[AsyncClientV2]):
         cohere_settings = cast(CohereModelSettings, model_settings or {})
         tools, tool_choice = self._get_tool_choice(model_request_parameters, cohere_settings)
         cohere_messages = self._map_messages(messages, model_request_parameters)
-        try:
+        with _map_api_errors(self.model_name):
             response_iter = self.client.chat_stream(
                 model=self._model_name,
                 messages=cohere_messages,
@@ -229,10 +240,6 @@ class CohereModel(Model[AsyncClientV2]):
                 presence_penalty=cohere_settings.get('presence_penalty', OMIT),
                 frequency_penalty=cohere_settings.get('frequency_penalty', OMIT),
             )
-        except ApiError as e:
-            if (status_code := e.status_code) and status_code >= 400:
-                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
-            raise ModelAPIError(model_name=self.model_name, message=str(e)) from e
         yield CohereStreamedResponse(
             model_request_parameters=model_request_parameters,
             _model_name=self._model_name,
@@ -250,7 +257,7 @@ class CohereModel(Model[AsyncClientV2]):
         tools, tool_choice = self._get_tool_choice(model_request_parameters, model_settings)
 
         cohere_messages = self._map_messages(messages, model_request_parameters)
-        try:
+        with _map_api_errors(self.model_name):
             return await self.client.chat(
                 model=self._model_name,
                 messages=cohere_messages,
@@ -265,12 +272,6 @@ class CohereModel(Model[AsyncClientV2]):
                 presence_penalty=model_settings.get('presence_penalty', OMIT),
                 frequency_penalty=model_settings.get('frequency_penalty', OMIT),
             )
-        except ApiError as e:
-            if (status_code := e.status_code) and status_code >= 400:
-                raise ModelHTTPError(
-                    status_code=status_code, model_name=self.model_name, body=e.body, headers=e.headers
-                ) from e
-            raise ModelAPIError(model_name=self.model_name, message=str(e)) from e
 
     def _get_tool_choice(
         self,
@@ -531,66 +532,80 @@ class CohereStreamedResponse(StreamedResponse):
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
         thinking_indices: set[int] = set()
 
-        async for event in self._response:
-            if isinstance(event, ContentStartV2ChatStreamResponse):
-                if event.index is not None:
-                    content_type = (
-                        event.delta
-                        and event.delta.message
-                        and event.delta.message.content
-                        and event.delta.message.content.type
-                    )
-                    if content_type == 'thinking':
-                        thinking_indices.add(event.index)
-
-            elif isinstance(event, ContentDeltaV2ChatStreamResponse):
-                if event.index is not None and event.delta and event.delta.message and event.delta.message.content:
-                    mc = event.delta.message.content
-                    if event.index in thinking_indices:
-                        if thinking := mc.thinking:
-                            for ev in self._parts_manager.handle_thinking_delta(
-                                vendor_part_id=event.index,
-                                content=thinking,
-                            ):
-                                yield ev
-                    else:
-                        if text := mc.text:
-                            for ev in self._parts_manager.handle_text_delta(
-                                vendor_part_id=event.index,
-                                content=text,
-                            ):
-                                yield ev
-
-            elif isinstance(event, ToolCallStartV2ChatStreamResponse):
-                if event.index is not None and event.delta and event.delta.message and event.delta.message.tool_calls:
-                    tc = event.delta.message.tool_calls
-                    maybe_event = self._parts_manager.handle_tool_call_delta(
-                        vendor_part_id=event.index,
-                        tool_name=tc.function.name if tc.function else None,
-                        tool_call_id=tc.id,
-                    )
-                    if maybe_event is not None:
-                        yield maybe_event
-
-            elif isinstance(event, ToolCallDeltaV2ChatStreamResponse):
-                if event.index is not None and event.delta and event.delta.message and event.delta.message.tool_calls:
-                    tc = event.delta.message.tool_calls
-                    maybe_event = self._parts_manager.handle_tool_call_delta(
-                        vendor_part_id=event.index,
-                        args=tc.function.arguments if tc.function else None,
-                    )
-                    if maybe_event is not None:
-                        yield maybe_event
-
-            elif isinstance(event, MessageEndV2ChatStreamResponse):
-                if event.delta:
-                    if raw_finish_reason := event.delta.finish_reason:
-                        self.provider_details = {**(self.provider_details or {}), 'finish_reason': raw_finish_reason}
-                        self.finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
-                    if event.delta.usage:
-                        self._usage += _map_cohere_usage(
-                            event.delta.usage, self._provider_name, self._provider_url, self._model_name
+        with _map_api_errors(self._model_name):
+            async for event in self._response:
+                if isinstance(event, ContentStartV2ChatStreamResponse):
+                    if event.index is not None:
+                        content_type = (
+                            event.delta
+                            and event.delta.message
+                            and event.delta.message.content
+                            and event.delta.message.content.type
                         )
+                        if content_type == 'thinking':
+                            thinking_indices.add(event.index)
+
+                elif isinstance(event, ContentDeltaV2ChatStreamResponse):
+                    if event.index is not None and event.delta and event.delta.message and event.delta.message.content:
+                        mc = event.delta.message.content
+                        if event.index in thinking_indices:
+                            if thinking := mc.thinking:
+                                for ev in self._parts_manager.handle_thinking_delta(
+                                    vendor_part_id=event.index,
+                                    content=thinking,
+                                ):
+                                    yield ev
+                        else:
+                            if text := mc.text:
+                                for ev in self._parts_manager.handle_text_delta(
+                                    vendor_part_id=event.index,
+                                    content=text,
+                                ):
+                                    yield ev
+
+                elif isinstance(event, ToolCallStartV2ChatStreamResponse):
+                    if (
+                        event.index is not None
+                        and event.delta
+                        and event.delta.message
+                        and event.delta.message.tool_calls
+                    ):
+                        tc = event.delta.message.tool_calls
+                        maybe_event = self._parts_manager.handle_tool_call_delta(
+                            vendor_part_id=event.index,
+                            tool_name=tc.function.name if tc.function else None,
+                            tool_call_id=tc.id,
+                        )
+                        if maybe_event is not None:
+                            yield maybe_event
+
+                elif isinstance(event, ToolCallDeltaV2ChatStreamResponse):
+                    if (
+                        event.index is not None
+                        and event.delta
+                        and event.delta.message
+                        and event.delta.message.tool_calls
+                    ):
+                        tc = event.delta.message.tool_calls
+                        maybe_event = self._parts_manager.handle_tool_call_delta(
+                            vendor_part_id=event.index,
+                            args=tc.function.arguments if tc.function else None,
+                        )
+                        if maybe_event is not None:
+                            yield maybe_event
+
+                elif isinstance(event, MessageEndV2ChatStreamResponse):
+                    if event.delta:
+                        if raw_finish_reason := event.delta.finish_reason:
+                            self.provider_details = {
+                                **(self.provider_details or {}),
+                                'finish_reason': raw_finish_reason,
+                            }
+                            self.finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
+                        if event.delta.usage:
+                            self._usage += _map_cohere_usage(
+                                event.delta.usage, self._provider_name, self._provider_url, self._model_name
+                            )
 
     @property
     def model_name(self) -> CohereModelName:

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -1,9 +1,11 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import Iterable
+from collections.abc import AsyncIterator, Iterable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
+from datetime import datetime
 from types import EllipsisType
-from typing import Literal, cast
+from typing import Any, AsyncGenerator, Literal, cast
 
 from typing_extensions import assert_never
 
@@ -14,6 +16,7 @@ from .._utils import (
     generate_tool_call_id as _generate_tool_call_id,
     guard_tool_call_id as _guard_tool_call_id,
     is_str_dict as _is_str_dict,
+    now_utc as _now_utc,
 )
 from ..messages import (
     CachePoint,
@@ -24,6 +27,7 @@ from ..messages import (
     ModelRequest,
     ModelResponse,
     ModelResponsePart,
+    ModelResponseStreamEvent,
     NativeToolCallPart,
     NativeToolReturnPart,
     RetryPromptPart,
@@ -44,6 +48,8 @@ from ..tools import ToolDefinition
 from . import (
     Model,
     ModelRequestParameters,
+    RunContext,
+    StreamedResponse,
     _unconverted_speech_part_error,  # pyright: ignore[reportPrivateUsage]
     _unsynthesized_tool_availability_delta_error,  # pyright: ignore[reportPrivateUsage]
     check_allow_model_requests,
@@ -57,15 +63,21 @@ try:
         ChatFinishReason,
         ChatMessageV2,
         Content as CohereContent,
+        ContentDeltaV2ChatStreamResponse,
+        ContentStartV2ChatStreamResponse,
+        MessageEndV2ChatStreamResponse,
         SystemChatMessageV2,
         TextAssistantMessageV2ContentOneItem,
         TextContent as CohereTextContent,
         ThinkingAssistantMessageV2ContentOneItem,
+        ToolCallDeltaV2ChatStreamResponse,
+        ToolCallStartV2ChatStreamResponse,
         ToolCallV2,
         ToolCallV2Function,
         ToolChatMessageV2,
         ToolV2,
         ToolV2Function,
+        Usage as CohereUsage,
         UserChatMessageV2,
         V2ChatResponse,
     )
@@ -185,6 +197,49 @@ class CohereModel(Model[AsyncClientV2]):
         response = await self._chat(messages, cast(CohereModelSettings, model_settings or {}), model_request_parameters)
         model_response = self._process_response(response)
         return model_response
+
+    @asynccontextmanager
+    async def request_stream(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+        run_context: RunContext[Any] | None = None,
+    ) -> AsyncGenerator[StreamedResponse]:
+        check_allow_model_requests()
+        model_settings, model_request_parameters = self.prepare_request(
+            model_settings,
+            model_request_parameters,
+        )
+        cohere_settings = cast(CohereModelSettings, model_settings or {})
+        tools, tool_choice = self._get_tool_choice(model_request_parameters, cohere_settings)
+        cohere_messages = self._map_messages(messages, model_request_parameters)
+        try:
+            response_iter = self.client.chat_stream(
+                model=self._model_name,
+                messages=cohere_messages,
+                tools=tools or OMIT,
+                tool_choice=tool_choice,
+                max_tokens=cohere_settings.get('max_tokens', OMIT),
+                stop_sequences=cohere_settings.get('stop_sequences', OMIT),
+                temperature=cohere_settings.get('temperature', OMIT),
+                p=cohere_settings.get('top_p', OMIT),
+                k=cohere_settings.get('top_k', OMIT),
+                seed=cohere_settings.get('seed', OMIT),
+                presence_penalty=cohere_settings.get('presence_penalty', OMIT),
+                frequency_penalty=cohere_settings.get('frequency_penalty', OMIT),
+            )
+        except ApiError as e:
+            if (status_code := e.status_code) and status_code >= 400:
+                raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.body) from e
+            raise ModelAPIError(model_name=self.model_name, message=str(e)) from e
+        yield CohereStreamedResponse(
+            model_request_parameters=model_request_parameters,
+            _model_name=self._model_name,
+            _provider_name=self._provider.name,
+            _provider_url=self.base_url,
+            _response=response_iter,
+        )
 
     async def _chat(
         self,
@@ -413,32 +468,142 @@ def _map_usage(response: V2ChatResponse, provider: str, provider_url: str, model
     u = response.usage
     if u is None:
         return usage.RequestUsage()
-    else:
-        details: dict[str, int] = {}
-        if u.billed_units is not None:
-            if u.billed_units.input_tokens:  # pragma: no branch
-                details['input_tokens'] = int(u.billed_units.input_tokens)
-            if u.billed_units.output_tokens:
-                details['output_tokens'] = int(u.billed_units.output_tokens)
-            if u.billed_units.search_units:  # pragma: no cover
-                details['search_units'] = int(u.billed_units.search_units)
-            if u.billed_units.classifications:  # pragma: no cover
-                details['classifications'] = int(u.billed_units.classifications)
+    return _map_cohere_usage(u, provider, provider_url, model)
 
-        usage_data: dict[str, object] = u.model_dump(exclude_none=True)
-        # Cohere SDK usage counts are typed as floats, while genai-prices extracts integer token fields.
-        if _is_str_dict(tokens := usage_data.get('tokens')):
-            for key in ('input_tokens', 'output_tokens'):
-                if isinstance(value := tokens.get(key), int | float):
-                    tokens[key] = int(value)
-        if isinstance(cached_tokens := usage_data.get('cached_tokens'), int | float):
-            usage_data['cached_tokens'] = int(cached_tokens)
 
-        return usage.RequestUsage.extract(
-            dict(model=model, usage=usage_data),
-            provider=provider,
-            provider_url=provider_url,
-            provider_fallback='cohere',
-            api_flavor='tokens',
-            details=details or None,
-        )
+def _map_cohere_usage(u: CohereUsage, provider: str, provider_url: str, model: str) -> usage.RequestUsage:
+    """Map a bare Cohere `Usage` object to a `RequestUsage`.
+
+    Split out of `_map_usage` so the streaming path can reuse it: `MessageEndV2ChatStreamResponse`
+    carries a `Usage` directly rather than a full `V2ChatResponse`.
+    """
+    details: dict[str, int] = {}
+    if u.billed_units is not None:
+        if u.billed_units.input_tokens:  # pragma: no branch
+            details['input_tokens'] = int(u.billed_units.input_tokens)
+        if u.billed_units.output_tokens:
+            details['output_tokens'] = int(u.billed_units.output_tokens)
+        if u.billed_units.search_units:  # pragma: no cover
+            details['search_units'] = int(u.billed_units.search_units)
+        if u.billed_units.classifications:  # pragma: no cover
+            details['classifications'] = int(u.billed_units.classifications)
+
+    usage_data: dict[str, object] = u.model_dump(exclude_none=True)
+    # Cohere SDK usage counts are typed as floats, while genai-prices extracts integer token fields.
+    if _is_str_dict(tokens := usage_data.get('tokens')):
+        for key in ('input_tokens', 'output_tokens'):
+            if isinstance(value := tokens.get(key), int | float):
+                tokens[key] = int(value)
+    if isinstance(cached_tokens := usage_data.get('cached_tokens'), int | float):
+        usage_data['cached_tokens'] = int(cached_tokens)
+
+    return usage.RequestUsage.extract(
+        dict(model=model, usage=usage_data),
+        provider=provider,
+        provider_url=provider_url,
+        provider_fallback='cohere',
+        api_flavor='tokens',
+        details=details or None,
+    )
+
+
+@dataclass
+class CohereStreamedResponse(StreamedResponse):
+    """Implementation of `StreamedResponse` for Cohere models."""
+
+    model_request_parameters: ModelRequestParameters
+    _model_name: CohereModelName
+    _provider_name: str
+    _provider_url: str
+    _response: AsyncIterator[Any]
+    _timestamp: datetime = field(default_factory=_now_utc)
+
+    async def close_stream(self) -> None:
+        try:
+            await self._response.aclose()  # pyright: ignore[reportAttributeAccessIssue]
+        except (RuntimeError, AttributeError):
+            pass
+
+    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+        thinking_indices: set[int] = set()
+
+        async for event in self._response:
+            if isinstance(event, ContentStartV2ChatStreamResponse):
+                if event.index is not None:
+                    content_type = (
+                        event.delta
+                        and event.delta.message
+                        and event.delta.message.content
+                        and event.delta.message.content.type
+                    )
+                    if content_type == 'thinking':
+                        thinking_indices.add(event.index)
+
+            elif isinstance(event, ContentDeltaV2ChatStreamResponse):
+                if event.index is not None and event.delta and event.delta.message and event.delta.message.content:
+                    mc = event.delta.message.content
+                    if event.index in thinking_indices:
+                        if thinking := mc.thinking:
+                            for ev in self._parts_manager.handle_thinking_delta(
+                                vendor_part_id=event.index,
+                                content=thinking,
+                            ):
+                                yield ev
+                    else:
+                        if text := mc.text:
+                            for ev in self._parts_manager.handle_text_delta(
+                                vendor_part_id=event.index,
+                                content=text,
+                            ):
+                                yield ev
+
+            elif isinstance(event, ToolCallStartV2ChatStreamResponse):
+                if event.index is not None and event.delta and event.delta.message and event.delta.message.tool_calls:
+                    tc = event.delta.message.tool_calls
+                    maybe_event = self._parts_manager.handle_tool_call_delta(
+                        vendor_part_id=event.index,
+                        tool_name=tc.function.name if tc.function else None,
+                        tool_call_id=tc.id,
+                    )
+                    if maybe_event is not None:
+                        yield maybe_event
+
+            elif isinstance(event, ToolCallDeltaV2ChatStreamResponse):
+                if event.index is not None and event.delta and event.delta.message and event.delta.message.tool_calls:
+                    tc = event.delta.message.tool_calls
+                    maybe_event = self._parts_manager.handle_tool_call_delta(
+                        vendor_part_id=event.index,
+                        args=tc.function.arguments if tc.function else None,
+                    )
+                    if maybe_event is not None:
+                        yield maybe_event
+
+            elif isinstance(event, MessageEndV2ChatStreamResponse):
+                if event.delta:
+                    if raw_finish_reason := event.delta.finish_reason:
+                        self.provider_details = {**(self.provider_details or {}), 'finish_reason': raw_finish_reason}
+                        self.finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
+                    if event.delta.usage:
+                        self._usage += _map_cohere_usage(
+                            event.delta.usage, self._provider_name, self._provider_url, self._model_name
+                        )
+
+    @property
+    def model_name(self) -> CohereModelName:
+        """Get the model name of the response."""
+        return self._model_name
+
+    @property
+    def provider_name(self) -> str:
+        """Get the provider name."""
+        return self._provider_name
+
+    @property
+    def provider_url(self) -> str:
+        """Get the provider URL."""
+        return self._provider_url
+
+    @property
+    def timestamp(self) -> datetime:
+        """Get the timestamp of the response."""
+        return self._timestamp

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -988,6 +988,41 @@ async def test_stream_request_non_http_error(allow_model_requests: None) -> None
     assert exc_info.value.model_name == 'command-r'
 
 
+async def test_stream_request_status_error_mid_stream(allow_model_requests: None) -> None:
+    """Regression: `chat_stream()` returns an async iterator without making any request, so an
+    `ApiError` from the underlying HTTP call only ever surfaces once the stream is iterated, not
+    when it's opened. It must still be mapped to `ModelHTTPError` like the call-opening case above.
+    """
+    events: list[MockStreamEvent] = [
+        *_text_stream_events(['hello '])[:-1],  # content-start + content-delta, no message-end yet
+        ApiError(status_code=500, body={'error': 'test error'}),
+    ]
+    mock_client = MockAsyncClientV2.create_stream_mock(events)
+    m = CohereModel('command-r', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+    with pytest.raises(ModelHTTPError) as exc_info:
+        async with agent.run_stream('hello') as result:
+            async for _ in result.stream_text(debounce_by=None):
+                pass
+    assert str(exc_info.value) == snapshot("status_code: 500, model_name: command-r, body: {'error': 'test error'}")
+
+
+async def test_stream_request_non_http_error_mid_stream(allow_model_requests: None) -> None:
+    """Same as above but for the non-HTTP (`status_code=None`) branch of the error mapping."""
+    events: list[MockStreamEvent] = [
+        *_text_stream_events(['hello '])[:-1],
+        ApiError(status_code=None, body={'error': 'connection error'}),
+    ]
+    mock_client = MockAsyncClientV2.create_stream_mock(events)
+    m = CohereModel('command-r', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+    with pytest.raises(ModelAPIError) as exc_info:
+        async with agent.run_stream('hello') as result:
+            async for _ in result.stream_text(debounce_by=None):
+                pass
+    assert exc_info.value.model_name == 'command-r'
+
+
 async def test_stream_event_edge_cases():
     """Regression: boundary conditions in `_get_event_iterator` that must yield no part event."""
     events: list[Any] = [

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -71,11 +71,18 @@ with try_import() as imports_successful:
     )
     from cohere.core.api_error import ApiError
 
-    from pydantic_ai.models.cohere import CohereModel, CohereStreamedResponse
+    from pydantic_ai.models.cohere import CohereModel
     from pydantic_ai.providers.cohere import CohereProvider
 
     MockChatResponse = ChatResponse | Exception
-    MockStreamEvent = ContentStartV2ChatStreamResponse | ContentDeltaV2ChatStreamResponse | ToolCallStartV2ChatStreamResponse | ToolCallDeltaV2ChatStreamResponse | MessageEndV2ChatStreamResponse | Exception
+    MockStreamEvent = (
+        ContentStartV2ChatStreamResponse
+        | ContentDeltaV2ChatStreamResponse
+        | ToolCallStartV2ChatStreamResponse
+        | ToolCallDeltaV2ChatStreamResponse
+        | MessageEndV2ChatStreamResponse
+        | Exception
+    )
 
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='cohere not installed'),
@@ -887,3 +894,72 @@ async def test_stream_finish_reason(allow_model_requests: None):
     last_response = next(msg for msg in reversed(messages) if isinstance(msg, ModelResponse))
     assert last_response.finish_reason == snapshot('length')
     assert last_response.provider_details == snapshot({'finish_reason': 'MAX_TOKENS'})
+
+
+async def test_stream_thinking(allow_model_requests: None):
+    """Regression: thinking-block streaming (index tracking + handle_thinking_delta)."""
+    thinking_events: list[MockStreamEvent] = [
+        ContentStartV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentStartEventDelta(
+                message=ChatContentStartEventDeltaMessage(
+                    content=ChatContentStartEventDeltaMessageContent(type='thinking')
+                )
+            ),
+        ),
+        ContentDeltaV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(
+                    content=ChatContentDeltaEventDeltaMessageContent(thinking='I am thinking...')
+                )
+            ),
+        ),
+        ContentDeltaV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(
+                    content=ChatContentDeltaEventDeltaMessageContent(thinking=' carefully.')
+                )
+            ),
+        ),
+        ContentStartV2ChatStreamResponse(
+            index=1,
+            delta=ChatContentStartEventDelta(
+                message=ChatContentStartEventDeltaMessage(
+                    content=ChatContentStartEventDeltaMessageContent(type='text')
+                )
+            ),
+        ),
+        ContentDeltaV2ChatStreamResponse(
+            index=1,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(
+                    content=ChatContentDeltaEventDeltaMessageContent(text='The answer is 42.')
+                )
+            ),
+        ),
+        MessageEndV2ChatStreamResponse(
+            delta=ChatMessageEndEventDelta(
+                finish_reason='COMPLETE',
+                usage=Usage(tokens=UsageTokens(input_tokens=5, output_tokens=4)),
+            )
+        ),
+    ]
+    mock_client = MockAsyncClientV2.create_stream_mock(thinking_events)
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('think about it') as result:
+        chunks = [c async for c in result.stream_text(debounce_by=None)]
+
+    assert chunks == snapshot(['The answer is 42.'])
+    messages = result.all_messages()
+    last_response = next(msg for msg in reversed(messages) if isinstance(msg, ModelResponse))
+    thinking_parts = [p for p in last_response.parts if isinstance(p, ThinkingPart)]
+    text_parts = [p for p in last_response.parts if isinstance(p, TextPart)]
+    assert len(thinking_parts) == 1
+    assert thinking_parts[0].content == snapshot('I am thinking... carefully.')
+    assert len(text_parts) == 1
+    assert text_parts[0].content == snapshot('The answer is 42.')
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=5, output_tokens=4))

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -35,25 +35,47 @@ from pydantic_ai.usage import RequestUsage, RunUsage
 
 from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, raise_if_exception, try_import
+from .mock_async_stream import MockAsyncStream
 
 with try_import() as imports_successful:
     import cohere
     from cohere import (
         AssistantMessageResponse,
         AsyncClientV2,
+        ChatMessageEndEventDelta,
         ChatResponse,
+        ChatContentDeltaEventDelta,
+        ChatContentDeltaEventDeltaMessage,
+        ChatContentDeltaEventDeltaMessageContent,
+        ChatContentStartEventDelta,
+        ChatContentStartEventDeltaMessage,
+        ChatContentStartEventDeltaMessageContent,
+        ChatToolCallDeltaEventDelta,
+        ChatToolCallDeltaEventDeltaMessage,
+        ChatToolCallDeltaEventDeltaMessageToolCalls,
+        ChatToolCallDeltaEventDeltaMessageToolCallsFunction,
+        ChatToolCallStartEventDelta,
+        ChatToolCallStartEventDeltaMessage,
+        ContentDeltaV2ChatStreamResponse,
+        ContentStartV2ChatStreamResponse,
+        MessageEndV2ChatStreamResponse,
         TextAssistantMessageResponseContentItem,
         TextContent as CohereTextContent,
+        ToolCallDeltaV2ChatStreamResponse,
+        ToolCallStartV2ChatStreamResponse,
         ToolCallV2,
         ToolCallV2Function,
+        Usage,
+        UsageTokens,
         UserChatMessageV2,
     )
     from cohere.core.api_error import ApiError
 
-    from pydantic_ai.models.cohere import CohereModel
+    from pydantic_ai.models.cohere import CohereModel, CohereStreamedResponse
     from pydantic_ai.providers.cohere import CohereProvider
 
     MockChatResponse = ChatResponse | Exception
+    MockStreamEvent = ContentStartV2ChatStreamResponse | ContentDeltaV2ChatStreamResponse | ToolCallStartV2ChatStreamResponse | ToolCallDeltaV2ChatStreamResponse | MessageEndV2ChatStreamResponse | Exception
 
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='cohere not installed'),
@@ -79,7 +101,8 @@ class MockClientWrapper:
 @dataclass
 class MockAsyncClientV2:
     completions: MockChatResponse | Sequence[MockChatResponse] | None = None
-    index = 0
+    stream: Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]] | None = None
+    index: int = 0
     chat_kwargs: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
     _client_wrapper: MockClientWrapper = None  # type: ignore
 
@@ -90,6 +113,10 @@ class MockAsyncClientV2:
     def create_mock(cls, completions: MockChatResponse | Sequence[MockChatResponse]) -> AsyncClientV2:
         return cast(AsyncClientV2, cls(completions=completions))
 
+    @classmethod
+    def create_stream_mock(cls, stream: Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]]) -> AsyncClientV2:
+        return cast(AsyncClientV2, cls(stream=stream))
+
     async def chat(self, *_args: Any, **kwargs: Any) -> ChatResponse:
         self.chat_kwargs.append(kwargs)
         assert self.completions is not None
@@ -99,6 +126,16 @@ class MockAsyncClientV2:
         else:
             raise_if_exception(self.completions)
             response = cast(ChatResponse, self.completions)
+        self.index += 1
+        return response
+
+    def chat_stream(self, *_args: Any, **kwargs: Any) -> MockAsyncStream[MockStreamEvent]:
+        self.chat_kwargs.append(kwargs)
+        assert self.stream is not None
+        if isinstance(self.stream[0], Sequence):
+            response = MockAsyncStream(iter(cast(list[MockStreamEvent], self.stream[self.index])))
+        else:
+            response = MockAsyncStream(iter(cast(list[MockStreamEvent], self.stream)))
         self.index += 1
         return response
 
@@ -715,3 +752,138 @@ async def test_cohere_empty_response_skipped_in_history(allow_model_requests: No
     second_call_messages = cast(MockAsyncClientV2, mock_client).chat_kwargs[1]['messages']
     assert not any(message.role == 'assistant' for message in second_call_messages)
     assert [message.role for message in second_call_messages] == snapshot(['user', 'user'])
+
+
+def _text_stream_events(chunks: list[str], *, finish_reason: str = 'COMPLETE') -> list[MockStreamEvent]:
+    events: list[MockStreamEvent] = [
+        ContentStartV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentStartEventDelta(
+                message=ChatContentStartEventDeltaMessage(
+                    content=ChatContentStartEventDeltaMessageContent(type='text')
+                )
+            ),
+        )
+    ]
+    for chunk in chunks:
+        events.append(
+            ContentDeltaV2ChatStreamResponse(
+                index=0,
+                delta=ChatContentDeltaEventDelta(
+                    message=ChatContentDeltaEventDeltaMessage(
+                        content=ChatContentDeltaEventDeltaMessageContent(text=chunk)
+                    )
+                ),
+            )
+        )
+    events.append(
+        MessageEndV2ChatStreamResponse(
+            delta=ChatMessageEndEventDelta(
+                finish_reason=finish_reason,
+                usage=Usage(tokens=UsageTokens(input_tokens=10, output_tokens=len(chunks))),
+            )
+        )
+    )
+    return events
+
+
+async def test_stream_text(allow_model_requests: None):
+    mock_client = MockAsyncClientV2.create_stream_mock(_text_stream_events(['hello ', 'world']))
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('hi') as result:
+        chunks = [c async for c in result.stream_text(debounce_by=None)]
+
+    assert chunks == snapshot(['hello ', 'hello world'])
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=10, output_tokens=2))
+
+
+async def test_stream_text_multiple_calls(allow_model_requests: None):
+    mock_client = MockAsyncClientV2.create_stream_mock(
+        [
+            _text_stream_events(['first ', 'call']),
+            _text_stream_events(['second ', 'call']),
+        ]
+    )
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('first') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(['first ', 'first call'])
+
+    async with agent.run_stream('second') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(['second ', 'second call'])
+
+
+async def test_stream_tool_call(allow_model_requests: None):
+    tool_call_events: list[MockStreamEvent] = [
+        ToolCallStartV2ChatStreamResponse(
+            index=0,
+            delta=ChatToolCallStartEventDelta(
+                message=ChatToolCallStartEventDeltaMessage(
+                    tool_calls=ToolCallV2(
+                        id='tc-1',
+                        type='function',
+                        function=ToolCallV2Function(name='get_weather', arguments=None),
+                    )
+                )
+            ),
+        ),
+        ToolCallDeltaV2ChatStreamResponse(
+            index=0,
+            delta=ChatToolCallDeltaEventDelta(
+                message=ChatToolCallDeltaEventDeltaMessage(
+                    tool_calls=ChatToolCallDeltaEventDeltaMessageToolCalls(
+                        function=ChatToolCallDeltaEventDeltaMessageToolCallsFunction(arguments='{"city"')
+                    )
+                )
+            ),
+        ),
+        ToolCallDeltaV2ChatStreamResponse(
+            index=0,
+            delta=ChatToolCallDeltaEventDelta(
+                message=ChatToolCallDeltaEventDeltaMessage(
+                    tool_calls=ChatToolCallDeltaEventDeltaMessageToolCalls(
+                        function=ChatToolCallDeltaEventDeltaMessageToolCallsFunction(arguments=': "London"}')
+                    )
+                )
+            ),
+        ),
+        MessageEndV2ChatStreamResponse(
+            delta=ChatMessageEndEventDelta(
+                finish_reason='TOOL_CALL',
+                usage=Usage(tokens=UsageTokens(input_tokens=5, output_tokens=8)),
+            )
+        ),
+    ]
+    mock_client = MockAsyncClientV2.create_stream_mock(
+        [tool_call_events, _text_stream_events(['Sunny in London'])]
+    )
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+
+    agent = Agent(m, output_type=str)
+
+    @agent.tool_plain
+    async def get_weather(city: str) -> str:
+        return f'Sunny in {city}'
+
+    async with agent.run_stream('Weather in London?') as result:
+        output = await result.get_output()
+
+    assert output == snapshot('Sunny in London')
+    assert result.usage == snapshot(RunUsage(requests=2, input_tokens=15, output_tokens=9, tool_calls=1))
+
+
+async def test_stream_finish_reason(allow_model_requests: None):
+    mock_client = MockAsyncClientV2.create_stream_mock(_text_stream_events(['done'], finish_reason='MAX_TOKENS'))
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('hi') as result:
+        _ = [c async for c in result.stream_text(debounce_by=None)]
+
+    messages = result.all_messages()
+    last_response = next(msg for msg in reversed(messages) if isinstance(msg, ModelResponse))
+    assert last_response.finish_reason == snapshot('length')
+    assert last_response.provider_details == snapshot({'finish_reason': 'MAX_TOKENS'})

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -29,6 +29,7 @@ from pydantic_ai import (
 )
 from pydantic_ai.capabilities import NativeTool
 from pydantic_ai.exceptions import UserError
+from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.native_tools import WebSearchTool
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RequestUsage, RunUsage
@@ -71,7 +72,7 @@ with try_import() as imports_successful:
     )
     from cohere.core.api_error import ApiError
 
-    from pydantic_ai.models.cohere import CohereModel
+    from pydantic_ai.models.cohere import CohereModel, CohereStreamedResponse
     from pydantic_ai.providers.cohere import CohereProvider
 
     MockChatResponse = ChatResponse | Exception
@@ -108,7 +109,7 @@ class MockClientWrapper:
 @dataclass
 class MockAsyncClientV2:
     completions: MockChatResponse | Sequence[MockChatResponse] | None = None
-    stream: Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]] | None = None
+    stream: Exception | Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]] | None = None
     index: int = 0
     chat_kwargs: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
     _client_wrapper: MockClientWrapper = None  # type: ignore
@@ -122,7 +123,7 @@ class MockAsyncClientV2:
 
     @classmethod
     def create_stream_mock(
-        cls, stream: Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]]
+        cls, stream: Exception | Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]]
     ) -> AsyncClientV2:
         return cast(AsyncClientV2, cls(stream=stream))
 
@@ -141,6 +142,8 @@ class MockAsyncClientV2:
     def chat_stream(self, *_args: Any, **kwargs: Any) -> MockAsyncStream[MockStreamEvent]:
         self.chat_kwargs.append(kwargs)
         assert self.stream is not None
+        raise_if_exception(self.stream)
+        assert not isinstance(self.stream, Exception)
         if isinstance(self.stream[0], Sequence):
             response = MockAsyncStream(iter(cast(list[MockStreamEvent], self.stream[self.index])))
         else:
@@ -959,3 +962,160 @@ async def test_stream_thinking(allow_model_requests: None):
     assert len(text_parts) == 1
     assert text_parts[0].content == snapshot('The answer is 42.')
     assert result.usage == snapshot(RunUsage(requests=1, input_tokens=5, output_tokens=4))
+
+
+async def test_stream_request_status_error(allow_model_requests: None) -> None:
+    mock_client = MockAsyncClientV2.create_stream_mock(
+        ApiError(status_code=500, body={'error': 'test error'}),
+    )
+    m = CohereModel('command-r', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+    with pytest.raises(ModelHTTPError) as exc_info:
+        async with agent.run_stream('hello'):
+            pass  # pragma: no cover
+    assert str(exc_info.value) == snapshot("status_code: 500, model_name: command-r, body: {'error': 'test error'}")
+
+
+async def test_stream_request_non_http_error(allow_model_requests: None) -> None:
+    mock_client = MockAsyncClientV2.create_stream_mock(
+        ApiError(status_code=None, body={'error': 'connection error'}),
+    )
+    m = CohereModel('command-r', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+    with pytest.raises(ModelAPIError) as exc_info:
+        async with agent.run_stream('hello'):
+            pass  # pragma: no cover
+    assert exc_info.value.model_name == 'command-r'
+
+
+async def test_stream_event_edge_cases():
+    """Regression: boundary conditions in `_get_event_iterator` that must yield no part event."""
+    events: list[Any] = [
+        # A real Cohere stream begins with a message-start event, which this model doesn't yet
+        # handle: it must fall through the isinstance chain without raising or yielding.
+        cohere.MessageStartV2ChatStreamResponse(type='message-start'),
+        # ContentStart with no index: guard clause skips content-type tracking.
+        ContentStartV2ChatStreamResponse(
+            index=None,
+            delta=ChatContentStartEventDelta(
+                message=ChatContentStartEventDeltaMessage(
+                    content=ChatContentStartEventDeltaMessageContent(type='thinking')
+                )
+            ),
+        ),
+        # ContentDelta with no index: guard clause skips entirely.
+        ContentDeltaV2ChatStreamResponse(
+            index=None,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(
+                    content=ChatContentDeltaEventDeltaMessageContent(text='ignored')
+                )
+            ),
+        ),
+        # A real thinking index registered, then a delta with empty thinking content (falsy).
+        ContentStartV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentStartEventDelta(
+                message=ChatContentStartEventDeltaMessage(
+                    content=ChatContentStartEventDeltaMessageContent(type='thinking')
+                )
+            ),
+        ),
+        ContentDeltaV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(content=ChatContentDeltaEventDeltaMessageContent(thinking=''))
+            ),
+        ),
+        # A real (non-thinking) index, then a delta with empty text content (falsy).
+        ContentDeltaV2ChatStreamResponse(
+            index=1,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(content=ChatContentDeltaEventDeltaMessageContent(text=''))
+            ),
+        ),
+        # ToolCallStart with no tool_calls on the message: guard clause skips.
+        ToolCallStartV2ChatStreamResponse(
+            index=2,
+            delta=ChatToolCallStartEventDelta(message=ChatToolCallStartEventDeltaMessage(tool_calls=None)),
+        ),
+        # ToolCallStart that produces no part-start event (no name yet).
+        ToolCallStartV2ChatStreamResponse(
+            index=3,
+            delta=ChatToolCallStartEventDelta(
+                message=ChatToolCallStartEventDeltaMessage(
+                    tool_calls=ToolCallV2(id='tc-noname', type='function', function=None)
+                )
+            ),
+        ),
+        # ToolCallDelta with no tool_calls on the message: guard clause skips.
+        ToolCallDeltaV2ChatStreamResponse(
+            index=3,
+            delta=ChatToolCallDeltaEventDelta(message=ChatToolCallDeltaEventDeltaMessage(tool_calls=None)),
+        ),
+        # ToolCallDelta that passes the guard but carries no new args: still incomplete, no event.
+        ToolCallDeltaV2ChatStreamResponse(
+            index=3,
+            delta=ChatToolCallDeltaEventDelta(
+                message=ChatToolCallDeltaEventDeltaMessage(
+                    tool_calls=ChatToolCallDeltaEventDeltaMessageToolCalls(function=None)
+                )
+            ),
+        ),
+        # MessageEnd with no delta: guard clause skips entirely.
+        MessageEndV2ChatStreamResponse(delta=None),
+        # MessageEnd with a delta but no finish_reason and no usage.
+        MessageEndV2ChatStreamResponse(delta=ChatMessageEndEventDelta(finish_reason=None, usage=None)),
+    ]
+    response = CohereStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='command-r7b-12-2024',
+        _provider_name='cohere',
+        _provider_url='https://api.cohere.com',
+        _response=cast(Any, MockAsyncStream(iter(events))),
+    )
+
+    part_events = [e async for e in response._get_event_iterator()]  # pyright: ignore[reportPrivateUsage]
+
+    assert part_events == []
+    assert response.finish_reason is None
+    assert response.provider_details is None
+
+
+@pytest.mark.parametrize(
+    ('error_message', 'raises'),
+    [
+        ('async generator is already running', False),
+        ('boom', True),
+    ],
+)
+async def test_close_stream_only_suppresses_async_generator_race(error_message: str, raises: bool):
+    class FailingStream:
+        async def aclose(self) -> None:
+            raise RuntimeError(error_message)
+
+    response = CohereStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='command-r7b-12-2024',
+        _provider_name='cohere',
+        _provider_url='https://api.cohere.com',
+        _response=cast(Any, FailingStream()),
+    )
+
+    if raises:
+        with pytest.raises(RuntimeError, match='boom'):
+            await response.close_stream()
+    else:
+        await response.close_stream()
+
+
+async def test_close_stream_no_aclose():
+    """`close_stream` is a no-op when the underlying response has no `aclose` method."""
+    response = CohereStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='command-r7b-12-2024',
+        _provider_name='cohere',
+        _provider_url='https://api.cohere.com',
+        _response=cast(Any, iter([])),
+    )
+    await response.close_stream()

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -42,14 +42,14 @@ with try_import() as imports_successful:
     from cohere import (
         AssistantMessageResponse,
         AsyncClientV2,
-        ChatMessageEndEventDelta,
-        ChatResponse,
         ChatContentDeltaEventDelta,
         ChatContentDeltaEventDeltaMessage,
         ChatContentDeltaEventDeltaMessageContent,
         ChatContentStartEventDelta,
         ChatContentStartEventDeltaMessage,
         ChatContentStartEventDeltaMessageContent,
+        ChatMessageEndEventDelta,
+        ChatResponse,
         ChatToolCallDeltaEventDelta,
         ChatToolCallDeltaEventDeltaMessage,
         ChatToolCallDeltaEventDeltaMessageToolCalls,
@@ -121,7 +121,9 @@ class MockAsyncClientV2:
         return cast(AsyncClientV2, cls(completions=completions))
 
     @classmethod
-    def create_stream_mock(cls, stream: Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]]) -> AsyncClientV2:
+    def create_stream_mock(
+        cls, stream: Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]]
+    ) -> AsyncClientV2:
         return cast(AsyncClientV2, cls(stream=stream))
 
     async def chat(self, *_args: Any, **kwargs: Any) -> ChatResponse:
@@ -766,9 +768,7 @@ def _text_stream_events(chunks: list[str], *, finish_reason: str = 'COMPLETE') -
         ContentStartV2ChatStreamResponse(
             index=0,
             delta=ChatContentStartEventDelta(
-                message=ChatContentStartEventDeltaMessage(
-                    content=ChatContentStartEventDeltaMessageContent(type='text')
-                )
+                message=ChatContentStartEventDeltaMessage(content=ChatContentStartEventDeltaMessageContent(type='text'))
             ),
         )
     ]
@@ -864,9 +864,7 @@ async def test_stream_tool_call(allow_model_requests: None):
             )
         ),
     ]
-    mock_client = MockAsyncClientV2.create_stream_mock(
-        [tool_call_events, _text_stream_events(['Sunny in London'])]
-    )
+    mock_client = MockAsyncClientV2.create_stream_mock([tool_call_events, _text_stream_events(['Sunny in London'])])
     m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
 
     agent = Agent(m, output_type=str)
@@ -926,9 +924,7 @@ async def test_stream_thinking(allow_model_requests: None):
         ContentStartV2ChatStreamResponse(
             index=1,
             delta=ChatContentStartEventDelta(
-                message=ChatContentStartEventDeltaMessage(
-                    content=ChatContentStartEventDeltaMessageContent(type='text')
-                )
+                message=ChatContentStartEventDeltaMessage(content=ChatContentStartEventDeltaMessageContent(type='text'))
             ),
         ),
         ContentDeltaV2ChatStreamResponse(

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -73,7 +73,7 @@ with try_import() as imports_successful:
     )
     from cohere.core.api_error import ApiError
 
-    from pydantic_ai.models.cohere import CohereModel, CohereStreamedResponse
+    from pydantic_ai.models.cohere import CohereModel
     from pydantic_ai.providers.cohere import CohereProvider
 
     MockChatResponse = ChatResponse | Exception
@@ -1166,3 +1166,72 @@ async def test_stream_finish_reason(allow_model_requests: None):
     last_response = next(msg for msg in reversed(messages) if isinstance(msg, ModelResponse))
     assert last_response.finish_reason == snapshot('length')
     assert last_response.provider_details == snapshot({'finish_reason': 'MAX_TOKENS'})
+
+
+async def test_stream_thinking(allow_model_requests: None):
+    """Regression: thinking-block streaming (index tracking + handle_thinking_delta)."""
+    thinking_events: list[MockStreamEvent] = [
+        ContentStartV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentStartEventDelta(
+                message=ChatContentStartEventDeltaMessage(
+                    content=ChatContentStartEventDeltaMessageContent(type='thinking')
+                )
+            ),
+        ),
+        ContentDeltaV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(
+                    content=ChatContentDeltaEventDeltaMessageContent(thinking='I am thinking...')
+                )
+            ),
+        ),
+        ContentDeltaV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(
+                    content=ChatContentDeltaEventDeltaMessageContent(thinking=' carefully.')
+                )
+            ),
+        ),
+        ContentStartV2ChatStreamResponse(
+            index=1,
+            delta=ChatContentStartEventDelta(
+                message=ChatContentStartEventDeltaMessage(
+                    content=ChatContentStartEventDeltaMessageContent(type='text')
+                )
+            ),
+        ),
+        ContentDeltaV2ChatStreamResponse(
+            index=1,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(
+                    content=ChatContentDeltaEventDeltaMessageContent(text='The answer is 42.')
+                )
+            ),
+        ),
+        MessageEndV2ChatStreamResponse(
+            delta=ChatMessageEndEventDelta(
+                finish_reason='COMPLETE',
+                usage=Usage(tokens=UsageTokens(input_tokens=5, output_tokens=4)),
+            )
+        ),
+    ]
+    mock_client = MockAsyncClientV2.create_stream_mock(thinking_events)
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('think about it') as result:
+        chunks = [c async for c in result.stream_text(debounce_by=None)]
+
+    assert chunks == snapshot(['The answer is 42.'])
+    messages = result.all_messages()
+    last_response = next(msg for msg in reversed(messages) if isinstance(msg, ModelResponse))
+    thinking_parts = [p for p in last_response.parts if isinstance(p, ThinkingPart)]
+    text_parts = [p for p in last_response.parts if isinstance(p, TextPart)]
+    assert len(thinking_parts) == 1
+    assert thinking_parts[0].content == snapshot('I am thinking... carefully.')
+    assert len(text_parts) == 1
+    assert text_parts[0].content == snapshot('The answer is 42.')
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=5, output_tokens=4))

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -2,12 +2,13 @@ from __future__ import annotations as _annotations
 
 import json
 import re
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, cast
 
+import anyio
 import pytest
 
 from pydantic_ai import (
@@ -28,6 +29,7 @@ from pydantic_ai import (
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai._utils import PeekableAsyncStream
 from pydantic_ai.capabilities import NativeTool
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import ModelRequestParameters, ToolDefinition
@@ -1390,40 +1392,78 @@ async def test_stream_event_edge_cases():
     assert response.provider_details is None
 
 
-@pytest.mark.parametrize(
-    ('error_message', 'raises'),
-    [
-        ('async generator is already running', False),
-        ('boom', True),
-    ],
-)
-async def test_close_stream_only_suppresses_async_generator_race(error_message: str, raises: bool):
-    class FailingStream:
-        async def aclose(self) -> None:
-            raise RuntimeError(error_message)
+async def test_close_stream_closes_underlying_source():
+    """`close_stream` must close the provider stream, not silently no-op."""
+    closed = anyio.Event()
 
+    async def source() -> AsyncIterator[Any]:
+        try:
+            yield MessageEndV2ChatStreamResponse(delta=None)
+            await anyio.sleep_forever()  # pragma: no cover
+        finally:
+            closed.set()
+
+    peekable: PeekableAsyncStream[Any, AsyncIterator[Any]] = PeekableAsyncStream(source())
     response = CohereStreamedResponse(
         model_request_parameters=ModelRequestParameters(),
         _model_name='command-r7b-12-2024',
         _provider_name='cohere',
         _provider_url='https://api.cohere.com',
-        _response=cast(Any, FailingStream()),
+        _response=peekable,
     )
 
-    if raises:
-        with pytest.raises(RuntimeError, match='boom'):
-            await response.close_stream()
-    else:
-        await response.close_stream()
-
-
-async def test_close_stream_no_aclose():
-    """`close_stream` is a no-op when the underlying response has no `aclose` method."""
-    response = CohereStreamedResponse(
-        model_request_parameters=ModelRequestParameters(),
-        _model_name='command-r7b-12-2024',
-        _provider_name='cohere',
-        _provider_url='https://api.cohere.com',
-        _response=cast(Any, iter([])),
-    )
+    assert await anext(aiter(peekable)) is not None
     await response.close_stream()
+    assert closed.is_set()
+
+
+async def test_request_stream_closes_source_on_early_exit(allow_model_requests: None):
+    """Abandoning the stream without consuming it must still tear down the connection.
+
+    `chat_stream` wraps the SDK's `async with` on the HTTP response, so leaving
+    `request_stream`'s context early has to close it or the connection leaks.
+    """
+    closed = anyio.Event()
+
+    async def source() -> AsyncIterator[Any]:
+        try:
+            yield ContentStartV2ChatStreamResponse(
+                index=0,
+                delta=ChatContentStartEventDelta(
+                    message=ChatContentStartEventDeltaMessage(content=ChatContentStartEventDeltaMessageContent(text=''))
+                ),
+            )
+            yield ContentDeltaV2ChatStreamResponse(
+                index=0,
+                delta=ChatContentDeltaEventDelta(
+                    message=ChatContentDeltaEventDeltaMessage(
+                        content=ChatContentDeltaEventDeltaMessageContent(text='hello')
+                    )
+                ),
+            )
+            await anyio.sleep_forever()  # pragma: no cover
+        finally:
+            closed.set()
+
+    stream = source()
+
+    class _GeneratorClient:
+        """`chat_stream` returns an async generator, as the real `AsyncClientV2` does."""
+
+        _client_wrapper = MockClientWrapper()
+
+        def chat_stream(self, *_args: Any, **_kwargs: Any) -> AsyncIterator[Any]:
+            return stream
+
+    m = CohereModel(
+        'command-r7b-12-2024',
+        provider=CohereProvider(cohere_client=cast(Any, _GeneratorClient())),
+    )
+
+    async with m.request_stream(
+        [ModelRequest(parts=[UserPromptPart('hello')])], None, ModelRequestParameters()
+    ) as response:
+        async for _ in response:
+            break  # abandon mid-stream, leaving the connection live
+
+    assert closed.is_set()

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -44,14 +44,14 @@ with try_import() as imports_successful:
     from cohere import (
         AssistantMessageResponse,
         AsyncClientV2,
-        ChatMessageEndEventDelta,
-        ChatResponse,
         ChatContentDeltaEventDelta,
         ChatContentDeltaEventDeltaMessage,
         ChatContentDeltaEventDeltaMessageContent,
         ChatContentStartEventDelta,
         ChatContentStartEventDeltaMessage,
         ChatContentStartEventDeltaMessageContent,
+        ChatMessageEndEventDelta,
+        ChatResponse,
         ChatToolCallDeltaEventDelta,
         ChatToolCallDeltaEventDeltaMessage,
         ChatToolCallDeltaEventDeltaMessageToolCalls,
@@ -1198,9 +1198,7 @@ async def test_stream_thinking(allow_model_requests: None):
         ContentStartV2ChatStreamResponse(
             index=1,
             delta=ChatContentStartEventDelta(
-                message=ChatContentStartEventDeltaMessage(
-                    content=ChatContentStartEventDeltaMessageContent(type='text')
-                )
+                message=ChatContentStartEventDeltaMessage(content=ChatContentStartEventDeltaMessageContent(type='text'))
             ),
         ),
         ContentDeltaV2ChatStreamResponse(

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -37,25 +37,54 @@ from pydantic_ai.usage import RequestUsage, RunUsage
 
 from .._inline_snapshot import snapshot
 from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, raise_if_exception, try_import
+from .mock_async_stream import MockAsyncStream
 
 with try_import() as imports_successful:
     import cohere
     from cohere import (
         AssistantMessageResponse,
         AsyncClientV2,
+        ChatMessageEndEventDelta,
         ChatResponse,
+        ChatContentDeltaEventDelta,
+        ChatContentDeltaEventDeltaMessage,
+        ChatContentDeltaEventDeltaMessageContent,
+        ChatContentStartEventDelta,
+        ChatContentStartEventDeltaMessage,
+        ChatContentStartEventDeltaMessageContent,
+        ChatToolCallDeltaEventDelta,
+        ChatToolCallDeltaEventDeltaMessage,
+        ChatToolCallDeltaEventDeltaMessageToolCalls,
+        ChatToolCallDeltaEventDeltaMessageToolCallsFunction,
+        ChatToolCallStartEventDelta,
+        ChatToolCallStartEventDeltaMessage,
+        ContentDeltaV2ChatStreamResponse,
+        ContentStartV2ChatStreamResponse,
+        MessageEndV2ChatStreamResponse,
         TextAssistantMessageResponseContentItem,
         TextContent as CohereTextContent,
+        ToolCallDeltaV2ChatStreamResponse,
+        ToolCallStartV2ChatStreamResponse,
         ToolCallV2,
         ToolCallV2Function,
+        Usage,
+        UsageTokens,
         UserChatMessageV2,
     )
     from cohere.core.api_error import ApiError
 
-    from pydantic_ai.models.cohere import CohereModel
+    from pydantic_ai.models.cohere import CohereModel, CohereStreamedResponse
     from pydantic_ai.providers.cohere import CohereProvider
 
     MockChatResponse = ChatResponse | Exception
+    MockStreamEvent = (
+        ContentStartV2ChatStreamResponse
+        | ContentDeltaV2ChatStreamResponse
+        | ToolCallStartV2ChatStreamResponse
+        | ToolCallDeltaV2ChatStreamResponse
+        | MessageEndV2ChatStreamResponse
+        | Exception
+    )
 
 pytestmark = [
     pytest.mark.skipif(not imports_successful(), reason='cohere not installed'),
@@ -102,7 +131,8 @@ class MockClientWrapper:
 @dataclass
 class MockAsyncClientV2:
     completions: MockChatResponse | Sequence[MockChatResponse] | None = None
-    index = 0
+    stream: Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]] | None = None
+    index: int = 0
     chat_kwargs: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
     _client_wrapper: MockClientWrapper = None  # pyright: ignore[reportAssignmentType]
 
@@ -113,6 +143,12 @@ class MockAsyncClientV2:
     def create_mock(cls, completions: MockChatResponse | Sequence[MockChatResponse]) -> AsyncClientV2:
         return cast(AsyncClientV2, cls(completions=completions))
 
+    @classmethod
+    def create_stream_mock(
+        cls, stream: Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]]
+    ) -> AsyncClientV2:
+        return cast(AsyncClientV2, cls(stream=stream))
+
     async def chat(self, *_args: Any, **kwargs: Any) -> ChatResponse:
         self.chat_kwargs.append(kwargs)
         assert self.completions is not None
@@ -122,6 +158,16 @@ class MockAsyncClientV2:
         else:
             raise_if_exception(self.completions)
             response = cast(ChatResponse, self.completions)
+        self.index += 1
+        return response
+
+    def chat_stream(self, *_args: Any, **kwargs: Any) -> MockAsyncStream[MockStreamEvent]:
+        self.chat_kwargs.append(kwargs)
+        assert self.stream is not None
+        if isinstance(self.stream[0], Sequence):
+            response = MockAsyncStream(iter(cast(list[MockStreamEvent], self.stream[self.index])))
+        else:
+            response = MockAsyncStream(iter(cast(list[MockStreamEvent], self.stream)))
         self.index += 1
         return response
 
@@ -987,3 +1033,136 @@ async def test_tool_call_without_function_skipped(allow_model_requests: None):
     assert result.output == 'hello back'
     parts = [part for message in result.all_messages() for part in message.parts]
     assert not any(isinstance(part, ToolCallPart) for part in parts)
+
+
+def _text_stream_events(chunks: list[str], *, finish_reason: str = 'COMPLETE') -> list[MockStreamEvent]:
+    events: list[MockStreamEvent] = [
+        ContentStartV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentStartEventDelta(
+                message=ChatContentStartEventDeltaMessage(content=ChatContentStartEventDeltaMessageContent(type='text'))
+            ),
+        )
+    ]
+    for chunk in chunks:
+        events.append(
+            ContentDeltaV2ChatStreamResponse(
+                index=0,
+                delta=ChatContentDeltaEventDelta(
+                    message=ChatContentDeltaEventDeltaMessage(
+                        content=ChatContentDeltaEventDeltaMessageContent(text=chunk)
+                    )
+                ),
+            )
+        )
+    events.append(
+        MessageEndV2ChatStreamResponse(
+            delta=ChatMessageEndEventDelta(
+                finish_reason=finish_reason,
+                usage=Usage(tokens=UsageTokens(input_tokens=10, output_tokens=len(chunks))),
+            )
+        )
+    )
+    return events
+
+
+async def test_stream_text(allow_model_requests: None):
+    mock_client = MockAsyncClientV2.create_stream_mock(_text_stream_events(['hello ', 'world']))
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('hi') as result:
+        chunks = [c async for c in result.stream_text(debounce_by=None)]
+
+    assert chunks == snapshot(['hello ', 'hello world'])
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=10, output_tokens=2, cost=Decimal('6.75E-7')))
+
+
+async def test_stream_text_multiple_calls(allow_model_requests: None):
+    mock_client = MockAsyncClientV2.create_stream_mock(
+        [
+            _text_stream_events(['first ', 'call']),
+            _text_stream_events(['second ', 'call']),
+        ]
+    )
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('first') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(['first ', 'first call'])
+
+    async with agent.run_stream('second') as result:
+        assert [c async for c in result.stream_text(debounce_by=None)] == snapshot(['second ', 'second call'])
+
+
+async def test_stream_tool_call(allow_model_requests: None):
+    tool_call_events: list[MockStreamEvent] = [
+        ToolCallStartV2ChatStreamResponse(
+            index=0,
+            delta=ChatToolCallStartEventDelta(
+                message=ChatToolCallStartEventDeltaMessage(
+                    tool_calls=ToolCallV2(
+                        id='tc-1',
+                        type='function',
+                        function=ToolCallV2Function(name='get_weather', arguments=None),
+                    )
+                )
+            ),
+        ),
+        ToolCallDeltaV2ChatStreamResponse(
+            index=0,
+            delta=ChatToolCallDeltaEventDelta(
+                message=ChatToolCallDeltaEventDeltaMessage(
+                    tool_calls=ChatToolCallDeltaEventDeltaMessageToolCalls(
+                        function=ChatToolCallDeltaEventDeltaMessageToolCallsFunction(arguments='{"city"')
+                    )
+                )
+            ),
+        ),
+        ToolCallDeltaV2ChatStreamResponse(
+            index=0,
+            delta=ChatToolCallDeltaEventDelta(
+                message=ChatToolCallDeltaEventDeltaMessage(
+                    tool_calls=ChatToolCallDeltaEventDeltaMessageToolCalls(
+                        function=ChatToolCallDeltaEventDeltaMessageToolCallsFunction(arguments=': "London"}')
+                    )
+                )
+            ),
+        ),
+        MessageEndV2ChatStreamResponse(
+            delta=ChatMessageEndEventDelta(
+                finish_reason='TOOL_CALL',
+                usage=Usage(tokens=UsageTokens(input_tokens=5, output_tokens=8)),
+            )
+        ),
+    ]
+    mock_client = MockAsyncClientV2.create_stream_mock([tool_call_events, _text_stream_events(['Sunny in London'])])
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+
+    agent = Agent(m, output_type=str)
+
+    @agent.tool_plain
+    async def get_weather(city: str) -> str:
+        return f'Sunny in {city}'
+
+    async with agent.run_stream('Weather in London?') as result:
+        output = await result.get_output()
+
+    assert output == snapshot('Sunny in London')
+    assert result.usage == snapshot(
+        RunUsage(requests=2, input_tokens=15, output_tokens=9, cost=Decimal('0.0000019125'), tool_calls=1)
+    )
+
+
+async def test_stream_finish_reason(allow_model_requests: None):
+    mock_client = MockAsyncClientV2.create_stream_mock(_text_stream_events(['done'], finish_reason='MAX_TOKENS'))
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('hi') as result:
+        _ = [c async for c in result.stream_text(debounce_by=None)]
+
+    messages = result.all_messages()
+    last_response = next(msg for msg in reversed(messages) if isinstance(msg, ModelResponse))
+    assert last_response.finish_reason == snapshot('length')
+    assert last_response.provider_details == snapshot({'finish_reason': 'MAX_TOKENS'})

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -73,7 +73,7 @@ with try_import() as imports_successful:
     )
     from cohere.core.api_error import ApiError
 
-    from pydantic_ai.models.cohere import CohereModel
+    from pydantic_ai.models.cohere import CohereModel, CohereStreamedResponse
     from pydantic_ai.providers.cohere import CohereProvider
 
     MockChatResponse = ChatResponse | Exception
@@ -131,7 +131,7 @@ class MockClientWrapper:
 @dataclass
 class MockAsyncClientV2:
     completions: MockChatResponse | Sequence[MockChatResponse] | None = None
-    stream: Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]] | None = None
+    stream: Exception | Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]] | None = None
     index: int = 0
     chat_kwargs: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
     _client_wrapper: MockClientWrapper = None  # pyright: ignore[reportAssignmentType]
@@ -145,7 +145,7 @@ class MockAsyncClientV2:
 
     @classmethod
     def create_stream_mock(
-        cls, stream: Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]]
+        cls, stream: Exception | Sequence[MockStreamEvent] | Sequence[Sequence[MockStreamEvent]]
     ) -> AsyncClientV2:
         return cast(AsyncClientV2, cls(stream=stream))
 
@@ -164,6 +164,8 @@ class MockAsyncClientV2:
     def chat_stream(self, *_args: Any, **kwargs: Any) -> MockAsyncStream[MockStreamEvent]:
         self.chat_kwargs.append(kwargs)
         assert self.stream is not None
+        raise_if_exception(self.stream)
+        assert not isinstance(self.stream, Exception)
         if isinstance(self.stream[0], Sequence):
             response = MockAsyncStream(iter(cast(list[MockStreamEvent], self.stream[self.index])))
         else:
@@ -1233,3 +1235,160 @@ async def test_stream_thinking(allow_model_requests: None):
     assert len(text_parts) == 1
     assert text_parts[0].content == snapshot('The answer is 42.')
     assert result.usage == snapshot(RunUsage(requests=1, input_tokens=5, output_tokens=4))
+
+
+async def test_stream_request_status_error(allow_model_requests: None) -> None:
+    mock_client = MockAsyncClientV2.create_stream_mock(
+        ApiError(status_code=500, body={'error': 'test error'}),
+    )
+    m = CohereModel('command-r', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+    with pytest.raises(ModelHTTPError) as exc_info:
+        async with agent.run_stream('hello'):
+            pass  # pragma: no cover
+    assert str(exc_info.value) == snapshot("status_code: 500, model_name: command-r, body: {'error': 'test error'}")
+
+
+async def test_stream_request_non_http_error(allow_model_requests: None) -> None:
+    mock_client = MockAsyncClientV2.create_stream_mock(
+        ApiError(status_code=None, body={'error': 'connection error'}),
+    )
+    m = CohereModel('command-r', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+    with pytest.raises(ModelAPIError) as exc_info:
+        async with agent.run_stream('hello'):
+            pass  # pragma: no cover
+    assert exc_info.value.model_name == 'command-r'
+
+
+async def test_stream_event_edge_cases():
+    """Regression: boundary conditions in `_get_event_iterator` that must yield no part event."""
+    events: list[Any] = [
+        # A real Cohere stream begins with a message-start event, which this model doesn't yet
+        # handle: it must fall through the isinstance chain without raising or yielding.
+        cohere.MessageStartV2ChatStreamResponse(type='message-start'),
+        # ContentStart with no index: guard clause skips content-type tracking.
+        ContentStartV2ChatStreamResponse(
+            index=None,
+            delta=ChatContentStartEventDelta(
+                message=ChatContentStartEventDeltaMessage(
+                    content=ChatContentStartEventDeltaMessageContent(type='thinking')
+                )
+            ),
+        ),
+        # ContentDelta with no index: guard clause skips entirely.
+        ContentDeltaV2ChatStreamResponse(
+            index=None,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(
+                    content=ChatContentDeltaEventDeltaMessageContent(text='ignored')
+                )
+            ),
+        ),
+        # A real thinking index registered, then a delta with empty thinking content (falsy).
+        ContentStartV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentStartEventDelta(
+                message=ChatContentStartEventDeltaMessage(
+                    content=ChatContentStartEventDeltaMessageContent(type='thinking')
+                )
+            ),
+        ),
+        ContentDeltaV2ChatStreamResponse(
+            index=0,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(content=ChatContentDeltaEventDeltaMessageContent(thinking=''))
+            ),
+        ),
+        # A real (non-thinking) index, then a delta with empty text content (falsy).
+        ContentDeltaV2ChatStreamResponse(
+            index=1,
+            delta=ChatContentDeltaEventDelta(
+                message=ChatContentDeltaEventDeltaMessage(content=ChatContentDeltaEventDeltaMessageContent(text=''))
+            ),
+        ),
+        # ToolCallStart with no tool_calls on the message: guard clause skips.
+        ToolCallStartV2ChatStreamResponse(
+            index=2,
+            delta=ChatToolCallStartEventDelta(message=ChatToolCallStartEventDeltaMessage(tool_calls=None)),
+        ),
+        # ToolCallStart that produces no part-start event (no name yet).
+        ToolCallStartV2ChatStreamResponse(
+            index=3,
+            delta=ChatToolCallStartEventDelta(
+                message=ChatToolCallStartEventDeltaMessage(
+                    tool_calls=ToolCallV2(id='tc-noname', type='function', function=None)
+                )
+            ),
+        ),
+        # ToolCallDelta with no tool_calls on the message: guard clause skips.
+        ToolCallDeltaV2ChatStreamResponse(
+            index=3,
+            delta=ChatToolCallDeltaEventDelta(message=ChatToolCallDeltaEventDeltaMessage(tool_calls=None)),
+        ),
+        # ToolCallDelta that passes the guard but carries no new args: still incomplete, no event.
+        ToolCallDeltaV2ChatStreamResponse(
+            index=3,
+            delta=ChatToolCallDeltaEventDelta(
+                message=ChatToolCallDeltaEventDeltaMessage(
+                    tool_calls=ChatToolCallDeltaEventDeltaMessageToolCalls(function=None)
+                )
+            ),
+        ),
+        # MessageEnd with no delta: guard clause skips entirely.
+        MessageEndV2ChatStreamResponse(delta=None),
+        # MessageEnd with a delta but no finish_reason and no usage.
+        MessageEndV2ChatStreamResponse(delta=ChatMessageEndEventDelta(finish_reason=None, usage=None)),
+    ]
+    response = CohereStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='command-r7b-12-2024',
+        _provider_name='cohere',
+        _provider_url='https://api.cohere.com',
+        _response=cast(Any, MockAsyncStream(iter(events))),
+    )
+
+    part_events = [e async for e in response._get_event_iterator()]  # pyright: ignore[reportPrivateUsage]
+
+    assert part_events == []
+    assert response.finish_reason is None
+    assert response.provider_details is None
+
+
+@pytest.mark.parametrize(
+    ('error_message', 'raises'),
+    [
+        ('async generator is already running', False),
+        ('boom', True),
+    ],
+)
+async def test_close_stream_only_suppresses_async_generator_race(error_message: str, raises: bool):
+    class FailingStream:
+        async def aclose(self) -> None:
+            raise RuntimeError(error_message)
+
+    response = CohereStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='command-r7b-12-2024',
+        _provider_name='cohere',
+        _provider_url='https://api.cohere.com',
+        _response=cast(Any, FailingStream()),
+    )
+
+    if raises:
+        with pytest.raises(RuntimeError, match='boom'):
+            await response.close_stream()
+    else:
+        await response.close_stream()
+
+
+async def test_close_stream_no_aclose():
+    """`close_stream` is a no-op when the underlying response has no `aclose` method."""
+    response = CohereStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='command-r7b-12-2024',
+        _provider_name='cohere',
+        _provider_url='https://api.cohere.com',
+        _response=cast(Any, iter([])),
+    )
+    await response.close_stream()

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -1234,7 +1234,7 @@ async def test_stream_thinking(allow_model_requests: None):
     assert thinking_parts[0].content == snapshot('I am thinking... carefully.')
     assert len(text_parts) == 1
     assert text_parts[0].content == snapshot('The answer is 42.')
-    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=5, output_tokens=4))
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=5, output_tokens=4, cost=Decimal('7.875E-7')))
 
 
 async def test_stream_request_status_error(allow_model_requests: None) -> None:
@@ -1258,6 +1258,41 @@ async def test_stream_request_non_http_error(allow_model_requests: None) -> None
     with pytest.raises(ModelAPIError) as exc_info:
         async with agent.run_stream('hello'):
             pass  # pragma: no cover
+    assert exc_info.value.model_name == 'command-r'
+
+
+async def test_stream_request_status_error_mid_stream(allow_model_requests: None) -> None:
+    """Regression: `chat_stream()` returns an async iterator without making any request, so an
+    `ApiError` from the underlying HTTP call only ever surfaces once the stream is iterated, not
+    when it's opened. It must still be mapped to `ModelHTTPError` like the call-opening case above.
+    """
+    events: list[MockStreamEvent] = [
+        *_text_stream_events(['hello '])[:-1],  # content-start + content-delta, no message-end yet
+        ApiError(status_code=500, body={'error': 'test error'}),
+    ]
+    mock_client = MockAsyncClientV2.create_stream_mock(events)
+    m = CohereModel('command-r', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+    with pytest.raises(ModelHTTPError) as exc_info:
+        async with agent.run_stream('hello') as result:
+            async for _ in result.stream_text(debounce_by=None):
+                pass
+    assert str(exc_info.value) == snapshot("status_code: 500, model_name: command-r, body: {'error': 'test error'}")
+
+
+async def test_stream_request_non_http_error_mid_stream(allow_model_requests: None) -> None:
+    """Same as above but for the non-HTTP (`status_code=None`) branch of the error mapping."""
+    events: list[MockStreamEvent] = [
+        *_text_stream_events(['hello '])[:-1],
+        ApiError(status_code=None, body={'error': 'connection error'}),
+    ]
+    mock_client = MockAsyncClientV2.create_stream_mock(events)
+    m = CohereModel('command-r', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+    with pytest.raises(ModelAPIError) as exc_info:
+        async with agent.run_stream('hello') as result:
+            async for _ in result.stream_text(debounce_by=None):
+                pass
     assert exc_info.value.model_name == 'command-r'
 
 

--- a/tests/models/test_stream_close.py
+++ b/tests/models/test_stream_close.py
@@ -18,10 +18,12 @@ from ..conftest import IsDatetime, IsStr, try_import
 
 with try_import() as imports_successful:
     import xai_sdk.chat as xai_chat
+    from cohere import ContentDeltaV2ChatStreamResponse, V2ChatStreamResponse
     from google.genai.types import GenerateContentResponse
     from huggingface_hub import AsyncInferenceClient, ChatCompletionStreamOutput
     from xai_sdk.proto import chat_pb2
 
+    from pydantic_ai.models.cohere import CohereStreamedResponse
     from pydantic_ai.models.google import GeminiStreamedResponse, GoogleModel
     from pydantic_ai.models.huggingface import HuggingFaceModel, HuggingFaceStreamedResponse
     from pydantic_ai.models.xai import XaiModel, XaiStreamedResponse
@@ -181,18 +183,34 @@ async def _assert_close_cancels_active_pull(
     assert finalization_started.is_set()
 
 
-@pytest.mark.parametrize('provider', ['google', 'huggingface', 'xai'])
-async def test_provider_close_stream_cancels_active_pull(provider: Literal['google', 'huggingface', 'xai']):
+@pytest.mark.parametrize('provider', ['cohere', 'google', 'huggingface', 'xai'])
+async def test_provider_close_stream_cancels_active_pull(
+    provider: Literal['cohere', 'google', 'huggingface', 'xai'],
+):
     """Provider shutdown must synchronize with an active pull through `PeekableAsyncStream`."""
     pull_started = anyio.Event()
     finalization_started = anyio.Event()
 
-    if provider == 'google':
+    if provider == 'cohere':
+        first = ContentDeltaV2ChatStreamResponse(index=0)
+        cohere_source: AsyncIterator[V2ChatStreamResponse] = _active_stream(first, pull_started, finalization_started)
+        cohere_stream: PeekableAsyncStream[V2ChatStreamResponse, AsyncIterator[V2ChatStreamResponse]] = (
+            PeekableAsyncStream(cohere_source)
+        )
+        response: StreamedResponse = CohereStreamedResponse(
+            model_request_parameters=ModelRequestParameters(),
+            _model_name='command-r7b-12-2024',
+            _provider_name='cohere',
+            _provider_url='https://api.cohere.com',
+            _response=cohere_stream,
+        )
+        stream: _ClosableStream = cohere_stream
+    elif provider == 'google':
         first = GenerateContentResponse()
         google_stream: PeekableAsyncStream[GenerateContentResponse, AsyncIterator[GenerateContentResponse]] = (
             PeekableAsyncStream(_active_stream(first, pull_started, finalization_started))
         )
-        response: StreamedResponse = GeminiStreamedResponse(
+        response = GeminiStreamedResponse(
             model_request_parameters=ModelRequestParameters(),
             _model_name='gemini-2.0-flash',
             _response=google_stream,
@@ -200,7 +218,7 @@ async def test_provider_close_stream_cancels_active_pull(provider: Literal['goog
             _model_id_namespace='google',
             _provider_url='https://generativelanguage.googleapis.com',
         )
-        stream: _ClosableStream = google_stream
+        stream = google_stream
     elif provider == 'huggingface':
         first = ChatCompletionStreamOutput(
             choices=[], created=0, id='response-id', model='model', system_fingerprint='fingerprint'


### PR DESCRIPTION
Closes #5954.

## Problem

`CohereModel` never overrode `request_stream`, so every call to `agent.iter()` / `agent.run_stream()` on a Cohere-backed agent raised the generic `NotImplementedError('Streamed requests not supported by this CohereModel')` from the base class. The Cohere v2 SDK does support streaming via `client.chat_stream(...)`, so this is a pure adapter gap.

## Fix

- **`request_stream`** added to `CohereModel` (decorated with `@asynccontextmanager`) that calls `client.chat_stream(...)` with the same settings forwarded by `_chat`, and yields a `CohereStreamedResponse`.
- **`CohereStreamedResponse(StreamedResponse)`** translates the Cohere v2 SSE events into pydantic-ai stream events:
  - `content-start` — tracks which block index is `text` vs `thinking`
  - `content-delta` — emits `TextPartDelta` (via `handle_text_delta`) or thinking delta (via `handle_thinking_delta`)
  - `tool-call-start` — creates a `ToolCallPart` via `handle_tool_call_delta` (name + id)
  - `tool-call-delta` — appends args via `handle_tool_call_delta`
  - `message-end` — records finish reason and `RequestUsage`
- **`_map_cohere_usage`** extracted from `_map_usage` so both non-streaming and streaming paths share the same implementation.

## Tests

Four new streaming tests added to `tests/models/test_cohere.py`, all exercising `MockAsyncClientV2.chat_stream`:
- `test_stream_text` — basic text streaming, checks debounced output and usage
- `test_stream_text_multiple_calls` — sequential `run_stream` calls, verifying index tracking
- `test_stream_tool_call` — tool call arg streaming followed by a text turn, full round-trip
- `test_stream_finish_reason` — `MAX_TOKENS` finish reason maps to `'length'` in `ModelResponse`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

