### PR TITLE
fix(vercel-ai): preserve `FilePart.content.vendor_metadata` in adapter round-trip

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -348,6 +348,9 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                                 'Vercel AI integration can currently only handle assistant file parts with data URIs.'
                             ) from e
                         provider_meta = load_provider_metadata(part.provider_metadata)
+                        vendor_metadata = provider_meta.get('vendor_metadata')
+                        if vendor_metadata is not None:
+                            file.vendor_metadata = vendor_metadata
                         builder.add(
                             FilePart(
                                 content=file,
@@ -581,7 +584,10 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                         url=part.content.data_uri,
                         media_type=part.content.media_type,
                         provider_metadata=dump_provider_metadata(
-                            id=part.id, provider_name=part.provider_name, provider_details=part.provider_details
+                            id=part.id,
+                            provider_name=part.provider_name,
+                            provider_details=part.provider_details,
+                            vendor_metadata=part.content.vendor_metadata,
                         ),
                     )
                 )

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -6469,6 +6469,63 @@ async def test_adapter_load_messages_file_with_provider_metadata():
     )
 
 
+async def test_adapter_dump_load_roundtrip_filepart_vendor_metadata():
+    """FilePart vendor_metadata survives Vercel AI adapter dump/load round-trip."""
+    messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                FilePart(
+                    content=BinaryContent(
+                        data=b'fake video bytes',
+                        media_type='video/mp4',
+                        vendor_metadata={
+                            'fps': 24,
+                            'start_offset': '12.5s',
+                            'end_offset': '67.0s',
+                        },
+                    ),
+                    provider_name='google',
+                    provider_details={'model': 'gemini-2.5-flash'},
+                ),
+            ]
+        ),
+    ]
+
+    ui_messages = VercelAIAdapter.dump_messages(messages)
+    reloaded = VercelAIAdapter.load_messages(ui_messages)
+
+    reloaded_part = reloaded[0].parts[0]
+    assert isinstance(reloaded_part, FilePart)
+    assert reloaded_part.content.vendor_metadata == {
+        'fps': 24,
+        'start_offset': '12.5s',
+        'end_offset': '67.0s',
+    }
+
+
+async def test_adapter_dump_filepart_carries_vendor_metadata_in_provider_metadata():
+    """Dumped FileUIPart carries vendor_metadata in provider_metadata for wire-format round-trip."""
+    messages: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                FilePart(
+                    content=BinaryContent(
+                        data=b'fake video bytes',
+                        media_type='video/mp4',
+                        vendor_metadata={'detail': 'high'},
+                    ),
+                ),
+            ]
+        ),
+    ]
+
+    ui_messages = VercelAIAdapter.dump_messages(messages)
+    file_ui_part = ui_messages[0].parts[0]
+    assert isinstance(file_ui_part, FileUIPart)
+    provider_meta = load_provider_metadata(file_ui_part.provider_metadata)
+    assert provider_meta.get('vendor_metadata') == {'detail': 'high'}
+
+
 async def test_adapter_builtin_tool_part_with_provider_metadata():
     """Test NativeToolCallPart with id, provider_name, provider_details and roundtrips."""
     # Use JSON string for content since that's what load_messages produces


### PR DESCRIPTION
## Summary

Preserve `BinaryContent.vendor_metadata` when round-tripping model-response `FilePart` messages through the Vercel AI adapter.

## Motivation

`FilePart.content.vendor_metadata` carries load-bearing provider settings on the model-response side (e.g. Gemini `video_metadata`, OpenAI image `detail`). The Vercel AI adapter already round-trips `vendor_metadata` for user-prompt `BinaryContent` / `UploadedFile` (#5790), but the response-side `FilePart` branch omitted it. This causes provider hints to be silently lost when a Vercel AI client resumes a run from `message_history`.

Fixes #6102. Symmetric with AG-UI adapter fix in #6095.

## Changes

- **Dump** (`_dump_response_message`): include `vendor_metadata=part.content.vendor_metadata` in `dump_provider_metadata()` for `FilePart`.
- **Load** (assistant `FileUIPart` → `FilePart`): restore `vendor_metadata` from `provider_metadata` after `BinaryContent.from_data_uri`.
- **Tests**: add round-trip and wire-format regression tests.

## Tests

```bash
uv run pytest tests/test_vercel_ai.py::test_adapter_dump_load_roundtrip_filepart_vendor_metadata \
  tests/test_vercel_ai.py::test_adapter_dump_filepart_carries_vendor_metadata_in_provider_metadata \
  tests/test_vercel_ai.py::test_adapter_file_part_with_provider_metadata -v
```

Result: **3 passed**

## Notes

- Event-stream `FileChunk` path is unchanged; this PR targets `dump_messages` / `load_messages` only, matching the scope of #6102.
- Happy to adjust if maintainers prefer a different wire format.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

