### PR TITLE
docs(mcp): warn that load_mcp_toolsets runs local commands from config

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -149,6 +149,9 @@ Instead of constructing `MCPToolset` instances individually, you can load multip
 
 This is particularly useful when you need to manage multiple MCP servers or want to configure servers externally without modifying code.
 
+!!! warning "Only load configuration files you trust"
+    A `command` server entry is spawned as a local process when the toolset connects, and `${VAR}` references are expanded from the current process environment (see [Environment variables](#environment-variables) below). Loading a configuration file from an untrusted or attacker-influenced source can therefore run arbitrary local commands and leak environment variables (such as API keys) into command arguments, headers, or URLs. Only pass [`load_mcp_toolsets()`][pydantic_ai.mcp.load_mcp_toolsets] configuration files from trusted sources, the same way you would treat a shell script or any other executable input.
+
 ### Configuration format
 
 The configuration file should be a JSON file with an `mcpServers` object containing server definitions. Each server is identified by a unique key and contains the configuration for that server:

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -1651,6 +1651,14 @@ def load_mcp_toolsets(config_path: str | Path) -> list[AbstractToolset[Any]]:
     wrapped in a [`PrefixedToolset`][pydantic_ai.toolsets.PrefixedToolset] using the server's name
     as prefix to disambiguate tools across multiple servers.
 
+    !!! warning "Only load configuration files you trust"
+        A `command` server entry is spawned as a local process when the toolset connects, and
+        `${VAR}` references are expanded from the current process environment. Loading a config
+        file from an untrusted or attacker-influenced source can therefore run arbitrary local
+        commands and leak environment variables (e.g. API keys) into command arguments, headers,
+        or URLs. Only call `load_mcp_toolsets` with configuration files from trusted sources, the
+        same way you would treat a shell script or any other executable input.
+
     Environment variables can be referenced in the configuration file using:
 
     - `${VAR_NAME}` syntax — expands to the value of `VAR_NAME`, raises if not defined


### PR DESCRIPTION
## Summary

- Adds a security warning to `load_mcp_toolsets` (docstring + MCP client docs page) telling users to only load configuration files from trusted sources.
- Docs-only change; no runtime behavior is altered.

## Motivation

Closes #6058.

`load_mcp_toolsets()` builds a `StdioTransport(command, args, env, cwd)` directly from a JSON config file. A `command` entry is spawned as a local process when the toolset connects, and `_expand_env_vars` resolves `${VAR}` references from `os.environ` into command args / headers / URLs. If an integrating application feeds an attacker-influenced config to this function, the result is local command execution and/or exfiltration of process env vars (e.g. API keys).

## Root Cause

**Symptom** — an app that loads an untrusted `mcpServers` config via `load_mcp_toolsets` can be made to spawn an arbitrary local command and/or send its environment variables (API keys) to an attacker-controlled destination, with no warning to the developer.

**Root cause** — this is *not* an upstream/shell-injection bug: fastmcp/mcp pass `[command, *args]` as argv with `shell=False`, so there is no shell amplification. The gap is purely that pydantic-ai forwards untrusted config to a process-spawning + env-expanding path (`mcp.py` `load_mcp_toolsets` / `_expand_env_vars`) **without documenting that the input is effectively executable**, so callers don't know they must treat the config like a shell script.

**Evidence** — `command` is forwarded verbatim into `StdioTransport(command=server['command'], ...)` and `_expand_env_vars` reads `os.environ[var_name]` into any string field (args/env/headers/url). The reporter's non-destructive repro (`{"mcpServers":{"x":{"command":"python","args":["-c","print(1)"]}}}`) spawns the process on connect.

**Fix + why this level** — the issue author lists three options; option 1 (document the trust requirement) is the one explicitly called out as acceptable and is the correct first-line fix here because the spawn behavior itself is intentional and matches the Claude Desktop / Cursor `mcpServers` contract. A hard opt-in flag or env-expansion allowlist (options 2/3) would change established behavior and is better discussed separately — this PR deliberately does **not** change behavior, only surfaces the trust boundary so developers can reason about it. The warning is added in **both** surfaces a developer might read: the API docstring and the prose docs page.

**Scope / risk** — docs/docstring only. No code path, signature, or default changes; zero behavioral risk. The docs anchor `#environment-variables` resolves to the existing "Environment variables" subsection on the same page.

## Verification

- `uv run ruff check pydantic_ai_slim/pydantic_ai/mcp.py` — All checks passed
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/mcp.py` — already formatted
- `uv run python -c "from pydantic_ai.mcp import load_mcp_toolsets; assert 'Only load configuration files you trust' in load_mcp_toolsets.__doc__"` — passes (docstring renders)
- Did NOT change: any runtime behavior, function signatures, or the `_expand_env_vars` / `StdioTransport` logic.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

