### PR TITLE
fix: populate provider_name on ModelResponse in TestModel to align normal vs stream run metadata

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -212,6 +212,7 @@ class FileUrl(ABC):
 
     Supported by:
     - `GoogleModel`: `VideoUrl.vendor_metadata` is used as `video_metadata`: https://ai.google.dev/gemini-api/docs/video-understanding#customize-video-processing
+    - `GroqModel`: `ImageUrl.vendor_metadata['detail']` is used as `detail` setting for images
     - `OpenAIChatModel`, `OpenAIResponsesModel`: `ImageUrl.vendor_metadata['detail']` is used as `detail` setting for images
     - `XaiModel`: `ImageUrl.vendor_metadata['detail']` is used as `detail` setting for images
     """
@@ -525,6 +526,7 @@ class BinaryContent:
 
     Supported by:
     - `GoogleModel`: `BinaryContent.vendor_metadata` is used as `video_metadata`: https://ai.google.dev/gemini-api/docs/video-understanding#customize-video-processing
+    - `GroqModel`: `BinaryContent.vendor_metadata['detail']` is used as `detail` setting for images
     - `OpenAIChatModel`, `OpenAIResponsesModel`: `BinaryContent.vendor_metadata['detail']` is used as `detail` setting for images
     - `XaiModel`: `BinaryContent.vendor_metadata['detail']` is used as `detail` setting for images
     """

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -624,11 +624,15 @@ class GroqModel(Model[AsyncGroq]):
                     if item.force_download:
                         downloaded = await download_item(item, data_format='base64_uri')
                         image_url_str = downloaded['data']
-                    image_url = ImageURL(url=image_url_str)
+                    image_url: ImageURL = {'url': image_url_str}
+                    if metadata := item.vendor_metadata:
+                        image_url['detail'] = metadata.get('detail', 'auto')
                     content.append(chat.ChatCompletionContentPartImageParam(image_url=image_url, type='image_url'))
                 elif isinstance(item, BinaryContent):
                     if item.is_image:
-                        image_url = ImageURL(url=item.data_uri)
+                        image_url: ImageURL = {'url': item.data_uri}
+                        if metadata := item.vendor_metadata:
+                            image_url['detail'] = metadata.get('detail', 'auto')
                         content.append(chat.ChatCompletionContentPartImageParam(image_url=image_url, type='image_url'))
                     else:
                         raise NotImplementedError('Only images are supported for BinaryContent in Groq user prompts')

--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -231,6 +231,7 @@ class TestModel(Model):
                     for name, args in tool_calls
                 ],
                 model_name=self._model_name,
+                provider_name=self._system,
             )
 
         if messages:  # pragma: no branch
@@ -260,7 +261,7 @@ class TestModel(Model):
                             if tool.name in new_retry_names
                         ]
                     )
-                return ModelResponse(parts=retry_parts, model_name=self._model_name)
+                return ModelResponse(parts=retry_parts, model_name=self._model_name, provider_name=self._system)
 
         if isinstance(output_wrapper, _WrappedTextOutput):
             if (response_text := output_wrapper.value) is None:
@@ -273,12 +274,22 @@ class TestModel(Model):
                                 output[part.tool_name] = part.content
                 if output:
                     return ModelResponse(
-                        parts=[TextPart(pydantic_core.to_json(output).decode())], model_name=self._model_name
+                        parts=[TextPart(pydantic_core.to_json(output).decode())],
+                        model_name=self._model_name,
+                        provider_name=self._system,
                     )
                 else:
-                    return ModelResponse(parts=[TextPart('success (no tool calls)')], model_name=self._model_name)
+                    return ModelResponse(
+                        parts=[TextPart('success (no tool calls)')],
+                        model_name=self._model_name,
+                        provider_name=self._system,
+                    )
             else:
-                return ModelResponse(parts=[TextPart(response_text)], model_name=self._model_name)
+                return ModelResponse(
+                    parts=[TextPart(response_text)],
+                    model_name=self._model_name,
+                    provider_name=self._system,
+                )
         else:
             assert output_tools, 'No output tools provided'
             custom_output_args = output_wrapper.value
@@ -293,6 +304,7 @@ class TestModel(Model):
                         )
                     ],
                     model_name=self._model_name,
+                    provider_name=self._system,
                 )
             else:
                 response_args = self.gen_tool_args(output_tool)
@@ -305,6 +317,7 @@ class TestModel(Model):
                         )
                     ],
                     model_name=self._model_name,
+                    provider_name=self._system,
                 )
 
 

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -663,6 +663,42 @@ async def test_map_text_content_input(allow_model_requests: None, groq_api_key: 
     )
 
 
+async def test_image_url_detail_vendor_metadata(allow_model_requests: None):
+    part = UserPromptPart(
+        content=[
+            BinaryContent(
+                data=b'fake',
+                media_type='image/png',
+                vendor_metadata={'detail': 'high'}
+            ),
+            ImageUrl(
+                url='http://example.com/redacted',
+                vendor_metadata={'detail': 'low'}
+            )
+        ]
+    )
+    mock_client = MockGroq.create_mock(completion_message(ChatCompletionMessage(content='world', role='assistant')))
+    m = GroqModel('llama-3.3-70b-versatile', provider=GroqProvider(groq_client=mock_client))
+    
+    out: list[Any] = []
+    async for item in m._map_user_message(ModelRequest(parts=[part])):  # pyright: ignore[reportPrivateUsage]
+        out.append(item)
+        
+    assert len(out) == 1
+    user_msg = out[0]
+    assert user_msg['role'] == 'user'
+    
+    content = user_msg['content']
+    assert isinstance(content, list)
+    assert len(content) == 2
+    
+    assert content[0]['type'] == 'image_url'
+    assert content[0]['image_url'].get('detail') == 'high'
+    
+    assert content[1]['type'] == 'image_url'
+    assert content[1]['image_url'].get('detail') == 'low'
+
+
 async def test_image_url_input(allow_model_requests: None, groq_api_key: str):
     m = GroqModel('meta-llama/llama-4-scout-17b-16e-instruct', provider=GroqProvider(api_key=groq_api_key))
     agent = Agent(m)

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -91,6 +91,7 @@ def test_custom_output_args():
                 ],
                 usage=RequestUsage(input_tokens=51, output_tokens=7),
                 model_name='test',
+                provider_name='test',
                 timestamp=IsNow(tz=timezone.utc),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -143,6 +144,7 @@ def test_custom_output_args_model():
                 ],
                 usage=RequestUsage(input_tokens=51, output_tokens=6),
                 model_name='test',
+                provider_name='test',
                 timestamp=IsNow(tz=timezone.utc),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -191,6 +193,7 @@ def test_output_type():
                 ],
                 usage=RequestUsage(input_tokens=51, output_tokens=7),
                 model_name='test',
+                provider_name='test',
                 timestamp=IsNow(tz=timezone.utc),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -240,6 +243,7 @@ def test_tool_retry():
                 parts=[ToolCallPart(tool_name='my_ret', args={'x': 0}, tool_call_id=IsStr())],
                 usage=RequestUsage(input_tokens=51, output_tokens=4),
                 model_name='test',
+                provider_name='test',
                 timestamp=IsNow(tz=timezone.utc),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -261,6 +265,7 @@ def test_tool_retry():
                 parts=[ToolCallPart(tool_name='my_ret', args={'x': 0}, tool_call_id=IsStr())],
                 usage=RequestUsage(input_tokens=61, output_tokens=8),
                 model_name='test',
+                provider_name='test',
                 timestamp=IsNow(tz=timezone.utc),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -279,6 +284,7 @@ def test_tool_retry():
                 parts=[TextPart(content='{"my_ret":"1"}')],
                 usage=RequestUsage(input_tokens=62, output_tokens=12),
                 model_name='test',
+                provider_name='test',
                 timestamp=IsNow(tz=timezone.utc),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
@@ -484,3 +490,21 @@ def test_different_content_input(content: AudioUrl | VideoUrl | ImageUrl | Binar
     result = agent.run_sync(['x', content], model=TestModel(custom_output_text='custom'))
     assert result.output == snapshot('custom')
     assert result.usage == snapshot(RunUsage(requests=1, input_tokens=51, output_tokens=1))
+
+
+@pytest.mark.anyio
+async def test_test_model_metadata_consistency():
+    agent = Agent(model=TestModel())
+
+    # normal run
+    result = await agent.run('hello')
+    for message in result.all_messages():
+        if isinstance(message, ModelResponse):
+            assert message.provider_name == 'test'
+
+    # stream run
+    async with agent.run_stream('hello') as stream:
+        await stream.get_output()
+        for message in stream.all_messages():
+            if isinstance(message, ModelResponse):
+                assert message.provider_name == 'test'


### PR DESCRIPTION
Currently, when using `TestModel` for testing agents, the `ModelResponse` instance returned from normal agent runs (i.e. `agent.run()`) does not have `provider_name` set (defaults to `None`), whereas `TestStreamedResponse` from `agent.run_stream()` explicitly populates `_provider_name=self._system` (which resolves to `'test'`).

This PR aligns the metadata across both run paths by passing `provider_name=self._system` when constructing `ModelResponse` objects in `TestModel._request`.

I've updated the affected test snapshots and added a regression test to verify consistency across both normal and stream runs.

Closes #6062