### PR TITLE
Handle malformed tool search call args

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_search.py
@@ -368,10 +368,13 @@ _TOOL_SEARCH_RETURN_CONTENT_TA: pydantic.TypeAdapter[ToolSearchReturnContent] = 
 )
 
 
-def _narrow_native_tool_search_call(part: NativeToolCallPart) -> NativeToolSearchCallPart:
+def _narrow_native_tool_search_call(part: NativeToolCallPart) -> NativeToolCallPart:
     if isinstance(part, NativeToolSearchCallPart):
         return part
-    validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    try:
+        validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    except pydantic_core.ValidationError:
+        return part
     return copy_dataclass_fields(part, NativeToolSearchCallPart, args=validated_args, tool_kind='tool-search')
 
 
@@ -382,10 +385,13 @@ def _narrow_native_tool_search_return(part: NativeToolReturnPart) -> NativeToolS
     return copy_dataclass_fields(part, NativeToolSearchReturnPart, content=validated_content, tool_kind='tool-search')
 
 
-def _narrow_tool_search_call(part: ToolCallPart) -> ToolSearchCallPart:
+def _narrow_tool_search_call(part: ToolCallPart) -> ToolCallPart:
     if isinstance(part, ToolSearchCallPart):
         return part
-    validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    try:
+        validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    except pydantic_core.ValidationError:
+        return part
     return copy_dataclass_fields(part, ToolSearchCallPart, args=validated_args, tool_kind='tool-search')
 
 

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3619,6 +3619,20 @@ def test_narrow_type_promotes_builtin_call_to_tool_search() -> None:
     assert NativeToolCallPart.narrow_type(already_narrowed) is already_narrowed
 
 
+@pytest.mark.parametrize('args', [{'query': 'find a tool'}, {'queries': 'noop'}])
+def test_narrow_type_builtin_call_with_invalid_args_returns_input_unchanged(args: Any) -> None:
+    """Malformed tool-search args should not fail during typed narrowing."""
+    base = NativeToolCallPart(
+        tool_name='tool_search',
+        args=args,
+        tool_call_id='c1',
+        tool_kind='tool-search',
+        provider_name='anthropic',
+    )
+
+    assert NativeToolCallPart.narrow_type(base) is base
+
+
 def test_narrow_type_promotes_builtin_return_to_tool_search() -> None:
     """Direct construction of `NativeToolReturnPart` with `tool_kind='tool-search'`
     promotes to `NativeToolSearchReturnPart` via the narrowing registry."""
@@ -4125,6 +4139,19 @@ def test_narrow_type_local_promotes_with_tool_kind_set() -> None:
     narrowed = ToolCallPart.narrow_type(part)
     assert isinstance(narrowed, ToolSearchCallPart)
     assert narrowed.args == {'queries': ['mortgage']}
+
+
+@pytest.mark.parametrize('args', [{'query': 'find a tool'}, {'queries': 'noop'}])
+def test_narrow_type_local_with_invalid_args_returns_input_unchanged(args: Any) -> None:
+    """Malformed local search_tools args should reach normal tool arg validation."""
+    part = ToolCallPart(
+        tool_name='search_tools',
+        args=args,
+        tool_call_id='c1',
+        tool_kind='tool-search',
+    )
+
+    assert ToolCallPart.narrow_type(part) is part
 
 
 def test_narrow_type_local_passthrough_when_already_narrowed() -> None:


### PR DESCRIPTION
- Closes #6106

### Summary

- Keep malformed tool-search call args as the original base call part during typed narrowing instead of raising a ValidationError.
- Apply the same fallback to local search_tools calls and native tool_search calls.
- Add regression coverage for malformed args shaped as {"query": ...} and {"queries": "noop"}.

### Checklist

- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No breaking changes in accordance with the version policy.
- [x] PR title is fit for the release changelog.

### Tests

- .venv/bin/python -m pytest tests/test_tool_search.py::test_narrow_type_promotes_builtin_call_to_tool_search tests/test_tool_search.py::test_narrow_type_builtin_call_with_invalid_args_returns_input_unchanged tests/test_tool_search.py::test_narrow_type_local_promotes_with_tool_kind_set tests/test_tool_search.py::test_narrow_type_local_with_invalid_args_returns_input_unchanged -q
- .venv/bin/python -m pytest tests/test_tool_search.py -k narrow_type -q
- .venv/bin/python -m ruff check pydantic_ai_slim/pydantic_ai/_tool_search.py tests/test_tool_search.py
- .venv/bin/python -m ruff format --check pydantic_ai_slim/pydantic_ai/_tool_search.py tests/test_tool_search.py

Note: full tests/test_tool_search.py -q was not run successfully in this minimal local environment because optional test dependencies/types are missing (brotli, ResponseToolSearchCall).