### PR TITLE
Recover from malformed `search_tools` args via `ModelRetry` instead of crashing (#6106)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_search.py
@@ -368,10 +368,17 @@ _TOOL_SEARCH_RETURN_CONTENT_TA: pydantic.TypeAdapter[ToolSearchReturnContent] = 
 )
 
 
-def _narrow_native_tool_search_call(part: NativeToolCallPart) -> NativeToolSearchCallPart:
+def _narrow_native_tool_search_call(part: NativeToolCallPart) -> NativeToolCallPart:
     if isinstance(part, NativeToolSearchCallPart):
         return part
-    validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    try:
+        validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    except pydantic.ValidationError:
+        # A model can emit the wrong arg shape (e.g. singular `query` instead of `queries`, or a
+        # bare string where a `list[str]` is expected). Leaving the part un-narrowed keeps it a base
+        # call part so the normal tool-arg validation recovers it with a `ModelRetry`, rather than the
+        # `ValidationError` propagating out of response assembly and crashing the run (see #6106).
+        return part
     return copy_dataclass_fields(part, NativeToolSearchCallPart, args=validated_args, tool_kind='tool-search')
 
 
@@ -382,10 +389,15 @@ def _narrow_native_tool_search_return(part: NativeToolReturnPart) -> NativeToolS
     return copy_dataclass_fields(part, NativeToolSearchReturnPart, content=validated_content, tool_kind='tool-search')
 
 
-def _narrow_tool_search_call(part: ToolCallPart) -> ToolSearchCallPart:
+def _narrow_tool_search_call(part: ToolCallPart) -> ToolCallPart:
     if isinstance(part, ToolSearchCallPart):
         return part
-    validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    try:
+        validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    except pydantic.ValidationError:
+        # See `_narrow_native_tool_search_call`: malformed `search_tools` args stay un-narrowed so the
+        # regular tool-arg validation surfaces a `ModelRetry` instead of crashing the run (see #6106).
+        return part
     return copy_dataclass_fields(part, ToolSearchCallPart, args=validated_args, tool_kind='tool-search')
 
 

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -50,6 +50,7 @@ from pydantic_ai.messages import (
     NativeToolSearchCallPart,
     NativeToolSearchReturnPart,
     PartStartEvent,
+    RetryPromptPart,
     TextPart,
     ToolPartKind,
     ToolReturnPart,
@@ -3473,6 +3474,50 @@ async def test_tool_search_keywords_agent_run_falls_back_on_unsupported_model():
     assert result.output
 
 
+async def test_malformed_search_tools_call_recovers_via_model_retry():
+    """A model that emits the wrong `search_tools` arg shape (singular `query` instead of
+    `queries: list[str]`) must recover via the normal `ModelRetry` path rather than crashing
+    the run with an uncaught `ValidationError` during response assembly (see #6106).
+
+    The first response carries a malformed call; the agent should answer it with a
+    `RetryPromptPart` and let the model correct itself, so the run completes normally.
+    """
+
+    def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        retries = [
+            part
+            for message in messages
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+            if isinstance(part, RetryPromptPart)
+        ]
+        if not retries:
+            # Malformed: singular `query` where `queries: list[str]` is required.
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name=_SEARCH_TOOLS_NAME, args={'query': 'mortgage'}, tool_call_id='bad-1')]
+            )
+        return ModelResponse(parts=[TextPart(content='recovered')])
+
+    agent = Agent(NoNativeToolSearchModel(model_fn), capabilities=[ToolSearch(strategy='keywords')])
+
+    @agent.tool_plain(defer_loading=True)
+    def calculate_mortgage(principal: float, rate: float, years: int) -> str:  # pragma: no cover
+        """Calculate monthly mortgage payment for a loan."""
+        return 'Mortgage calculated'
+
+    result = await agent.run('calculate my mortgage')
+
+    assert result.output == 'recovered'
+    retry_prompts = [
+        part
+        for message in result.all_messages()
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+        if isinstance(part, RetryPromptPart) and part.tool_name == _SEARCH_TOOLS_NAME
+    ]
+    assert len(retry_prompts) == 1
+
+
 @pytest.mark.parametrize('strategy', ['bm25', 'regex'])
 async def test_tool_search_named_strategy_skips_local_search_tools_emission(strategy: str):
     """Named-native strategies (`'bm25'`/`'regex'`) construct the toolset with
@@ -3662,6 +3707,26 @@ def test_narrow_type_no_tool_kind_returns_input_unchanged() -> None:
     local_collision = ToolCallPart(tool_name='search_tools', args={'query': 'x'}, tool_call_id='c2')
     assert local_collision.tool_kind is None
     assert ToolCallPart.narrow_type(local_collision) is local_collision
+
+
+@pytest.mark.parametrize('args', [{'query': 'find a tool'}, {'queries': 'noop'}, {}])
+def test_narrow_type_malformed_tool_search_call_args_left_unnarrowed(args: dict[str, Any]) -> None:
+    """A malformed `search_tools` call (wrong arg shape) must not raise during narrowing.
+
+    Narrowing runs while the model response is assembled — before tool execution — so a
+    `ValidationError` here would crash the run and bypass the `ModelRetry` recovery that handles
+    bad arguments for ordinary tools. Instead the part is left as a base call part so the normal
+    tool-arg validation path engages (see #6106).
+    """
+    local = ToolCallPart(tool_name='search_tools', args=args, tool_call_id='c1')
+    narrowed_local = ToolCallPart.narrow_type(local, tool_kind='tool-search')
+    assert not isinstance(narrowed_local, ToolSearchCallPart)
+    assert narrowed_local.args == args
+
+    builtin = NativeToolCallPart(tool_name='tool_search', args=args, tool_call_id='c2')
+    narrowed_builtin = NativeToolCallPart.narrow_type(builtin, tool_kind='tool-search')
+    assert not isinstance(narrowed_builtin, NativeToolSearchCallPart)
+    assert narrowed_builtin.args == args
 
 
 def test_model_response_dict_round_trip_promotes_typed_subclasses() -> None:


### PR DESCRIPTION
Fixes #6106.

### Problem

When a model emits a `search_tools` (tool-search) call with the wrong argument shape, pydantic-ai raised an uncaught `pydantic_core.ValidationError` during **response-part narrowing**, aborting the whole run. Narrowing happens while the model response is assembled — *before* tool execution — so the normal "invalid tool args → `ModelRetry` / `ToolRetryPromptPart`" recovery never engaged, and a recoverable model slip became a fatal error shown to the end user.

This is easy for a model to hit: `search_tools` takes `queries: list[str]`, but most ordinary tools take `query: str`, so models frequently emit `{"query": "..."}` (singular) or `{"queries": "noop"}` (a bare string instead of a list).

### Fix

`_narrow_tool_search_call` and `_narrow_native_tool_search_call` now catch `ValidationError` and leave the part **un-narrowed** (option 1 from the issue). A malformed call then flows into the regular tool-arg validation path, so the model gets a retry prompt describing the expected `queries: list[str]` shape instead of the run crashing — matching how bad arguments to any other tool are handled.

The OpenAI native server-side normalization path (`_normalize_tool_search_args`) is intentionally left untouched: there a malformed shape means provider/SDK drift and should still surface loudly.

### Tests

- Parametrized unit test asserting both narrowers don't raise and don't promote on `{"query": ...}`, `{"queries": "noop"}`, and `{}`.
- End-to-end agent test proving recovery: a model emits a malformed `search_tools` call, the agent answers with a single `RetryPromptPart`, the model corrects, and the run completes normally.

`tests/test_tool_search.py` passes (158 tests); `ruff format`/`ruff check` and `pyright` are clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

