### PR TITLE
Align LLMJudge `_build_prompt` section order with its few-shot examples

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
+++ b/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
@@ -250,16 +250,22 @@ def _build_prompt(
     inputs: Any | None = None,
     expected_output: Any | None = None,
 ) -> str | Sequence[str | UserContent]:
-    """Build a prompt that includes input, output, expected output, and rubric."""
+    """Build a prompt that includes input, expected output, output, and rubric.
+
+    Sections are emitted in the same order the judge agents' system-prompt few-shot
+    examples demonstrate — `Input → ExpectedOutput → Output → Rubric` — so the runtime
+    prompt matches the format the model was primed with and the rubric (the instruction)
+    comes last, after all the context it applies to.
+    """
     sections: list[str | UserContent] = []
     if inputs is not None:
         sections.extend(_make_section(inputs, 'Input'))
 
-    sections.extend(_make_section(output, 'Output'))
-    sections.extend(_make_section(rubric, 'Rubric'))
-
     if expected_output is not None:
         sections.extend(_make_section(expected_output, 'ExpectedOutput'))
+
+    sections.extend(_make_section(output, 'Output'))
+    sections.extend(_make_section(rubric, 'Rubric'))
     if all(isinstance(section, str) for section in sections):
         return '\n'.join(sections)  # type: ignore[arg-type]
     return sections

--- a/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
+++ b/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
@@ -121,14 +121,14 @@ _judge_input_output_expected_agent = Agent(
         Examples:
 
         <Input>What color is the sky?</Input>
-        <ExpectedOutput>Blue</ExpectedOutput>
         <Output>Cerulean</Output>
+        <ExpectedOutput>Blue</ExpectedOutput>
         <Rubric>The output is consistent with the expected output but doesn't have to match exactly</Rubric>
         {"reason": "'Cerulean' is a shade of blue", "pass": true, "score": 1.0}
 
         <Input>How many legs does a spider have?</Input>
-        <ExpectedOutput>8</ExpectedOutput>
         <Output>Six</Output>
+        <ExpectedOutput>8</ExpectedOutput>
         <Rubric>The output is factually consistent with the expected output</Rubric>
         {"reason": "Spiders have 8 legs", "pass": false, "score": 0.0}
         """
@@ -167,13 +167,13 @@ _judge_output_expected_agent = Agent(
 
         Examples:
 
-        <ExpectedOutput>Blue</ExpectedOutput>
         <Output>Cerulean</Output>
+        <ExpectedOutput>Blue</ExpectedOutput>
         <Rubric>The output should be a shade of the expected output color</Rubric>
         {"reason": "'Cerulean' is a shade of blue", "pass": true, "score": 1.0}
 
-        <ExpectedOutput>8</ExpectedOutput>
         <Output>Six</Output>
+        <ExpectedOutput>8</ExpectedOutput>
         <Rubric>The output should be a number written in words which matches the number written in digits in the expected output</Rubric>
         {"reason": "The output is 'Six' which is a different number than 8", "pass": false, "score": 0.0}
         """
@@ -250,21 +250,23 @@ def _build_prompt(
     inputs: Any | None = None,
     expected_output: Any | None = None,
 ) -> str | Sequence[str | UserContent]:
-    """Build a prompt that includes input, expected output, output, and rubric.
+    """Build a prompt that includes input, output, expected output, and rubric.
 
     Sections are emitted in the same order the judge agents' system-prompt few-shot
-    examples demonstrate — `Input → ExpectedOutput → Output → Rubric` — so the runtime
-    prompt matches the format the model was primed with and the rubric (the instruction)
-    comes last, after all the context it applies to.
+    examples demonstrate — `Input → Output → ExpectedOutput → Rubric`, matching the
+    `judge_input_output_expected` naming — so the runtime prompt matches the format the
+    model was primed with and the rubric (the instruction) comes last, after all the
+    context it applies to.
     """
     sections: list[str | UserContent] = []
     if inputs is not None:
         sections.extend(_make_section(inputs, 'Input'))
 
+    sections.extend(_make_section(output, 'Output'))
+
     if expected_output is not None:
         sections.extend(_make_section(expected_output, 'ExpectedOutput'))
 
-    sections.extend(_make_section(output, 'Output'))
     sections.extend(_make_section(rubric, 'Rubric'))
     if all(isinstance(section, str) for section in sections):
         return '\n'.join(sections)  # type: ignore[arg-type]

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -1,5 +1,7 @@
 from __future__ import annotations as _annotations
 
+import re
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -10,6 +12,7 @@ with try_import() as imports_successful:
     from pydantic_ai.settings import ModelSettings
     from pydantic_evals.evaluators.llm_as_a_judge import (
         GradingOutput,
+        _build_prompt,  # pyright: ignore[reportPrivateUsage]
         _stringify,  # pyright: ignore[reportPrivateUsage]
         judge_input_output,
         judge_input_output_expected,
@@ -67,6 +70,27 @@ def test_stringify():
 
     obj = NonSerializable()
     assert _stringify(obj) == 'NonSerializable()'
+
+
+@pytest.mark.parametrize(
+    'kwargs,expected_tags',
+    [
+        ({'output': 'O', 'rubric': 'R'}, ['Output', 'Rubric']),
+        ({'output': 'O', 'rubric': 'R', 'inputs': 'I'}, ['Input', 'Output', 'Rubric']),
+        ({'output': 'O', 'rubric': 'R', 'expected_output': 'E'}, ['ExpectedOutput', 'Output', 'Rubric']),
+        (
+            {'output': 'O', 'rubric': 'R', 'inputs': 'I', 'expected_output': 'E'},
+            ['Input', 'ExpectedOutput', 'Output', 'Rubric'],
+        ),
+    ],
+)
+def test_build_prompt_section_order_matches_few_shot_examples(kwargs: dict[str, str], expected_tags: list[str]) -> None:
+    """`_build_prompt` must emit sections in the same order the judge system-prompt few-shot
+    examples demonstrate: `Input → ExpectedOutput → Output → Rubric`, with the rubric (the
+    instruction) last, after all the context it applies to. See issue #6110."""
+    prompt = _build_prompt(**kwargs)
+    assert isinstance(prompt, str)
+    assert re.findall(r'<(\w+)>', prompt) == expected_tags
 
 
 @pytest.mark.anyio
@@ -263,15 +287,15 @@ async def test_judge_input_output_expected_mock(mocker: MockerFixture, image_con
 <Input>
 Hello
 </Input>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Output>
 Hello world
 </Output>
 <Rubric>
 Output contains input
-</Rubric>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>\
+</Rubric>\
 """,
         )
     )
@@ -289,15 +313,15 @@ Hello
                 '<Input>',
                 image_content,
                 '</Input>',
+                '<ExpectedOutput>',
+                'Hello',
+                '</ExpectedOutput>',
                 '<Output>',
                 'Hello world',
                 '</Output>',
                 '<Rubric>',
                 'Output contains input',
                 '</Rubric>',
-                '<ExpectedOutput>',
-                'Hello',
-                '</ExpectedOutput>',
             ],
         )
     )
@@ -333,15 +357,15 @@ async def test_judge_input_output_expected_with_model_settings_mock(
 <Input>
 Hello settings
 </Input>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Output>
 Hello world with settings
 </Output>
 <Rubric>
 Output contains input with settings
-</Rubric>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>\
+</Rubric>\
 """,
         )
     )
@@ -369,15 +393,15 @@ Hello
                 '<Input>',
                 image_content,
                 '</Input>',
+                '<ExpectedOutput>',
+                'Hello',
+                '</ExpectedOutput>',
                 '<Output>',
                 'Hello world with settings',
                 '</Output>',
                 '<Rubric>',
                 'Output contains input with settings',
                 '</Rubric>',
-                '<ExpectedOutput>',
-                'Hello',
-                '</ExpectedOutput>',
             ],
         )
     )
@@ -406,15 +430,15 @@ Hello
 <Input>
 123
 </Input>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Output>
 Hello world with settings
 </Output>
 <Rubric>
 Output contains input with settings
-</Rubric>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>\
+</Rubric>\
 """,
         )
     )
@@ -440,15 +464,15 @@ Hello
 <Input>
 123
 </Input>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Output>
 Hello world with settings
 </Output>
 <Rubric>
 Output contains input with settings
-</Rubric>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>\
+</Rubric>\
 """,
         )
     )
@@ -522,15 +546,15 @@ async def test_judge_output_expected_with_model_settings_mock(mocker: MockerFixt
     assert call_args == snapshot(
         (
             [
+                '<ExpectedOutput>',
+                'Hello',
+                '</ExpectedOutput>',
                 '<Output>',
                 image_content,
                 '</Output>',
                 '<Rubric>',
                 'Output contains input with settings',
                 '</Rubric>',
-                '<ExpectedOutput>',
-                'Hello',
-                '</ExpectedOutput>',
             ],
         )
     )

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -9,10 +9,15 @@ from .._inline_snapshot import snapshot
 from ..conftest import BinaryContent, try_import
 
 with try_import() as imports_successful:
+    from pydantic_ai import Agent
     from pydantic_ai.settings import ModelSettings
     from pydantic_evals.evaluators.llm_as_a_judge import (
         GradingOutput,
         _build_prompt,  # pyright: ignore[reportPrivateUsage]
+        _judge_input_output_agent,  # pyright: ignore[reportPrivateUsage]
+        _judge_input_output_expected_agent,  # pyright: ignore[reportPrivateUsage]
+        _judge_output_agent,  # pyright: ignore[reportPrivateUsage]
+        _judge_output_expected_agent,  # pyright: ignore[reportPrivateUsage]
         _stringify,  # pyright: ignore[reportPrivateUsage]
         judge_input_output,
         judge_input_output_expected,
@@ -73,25 +78,49 @@ def test_stringify():
 
 
 @pytest.mark.parametrize(
-    'kwargs,expected_tags',
+    'variant,kwargs,expected_tags',
     [
-        ({'output': 'O', 'rubric': 'R'}, ['Output', 'Rubric']),
-        ({'output': 'O', 'rubric': 'R', 'inputs': 'I'}, ['Input', 'Output', 'Rubric']),
-        ({'output': 'O', 'rubric': 'R', 'expected_output': 'E'}, ['Output', 'ExpectedOutput', 'Rubric']),
+        ('output', {'output': 'O', 'rubric': 'R'}, ['Output', 'Rubric']),
+        ('input_output', {'output': 'O', 'rubric': 'R', 'inputs': 'I'}, ['Input', 'Output', 'Rubric']),
         (
+            'output_expected',
+            {'output': 'O', 'rubric': 'R', 'expected_output': 'E'},
+            ['Output', 'ExpectedOutput', 'Rubric'],
+        ),
+        (
+            'input_output_expected',
             {'output': 'O', 'rubric': 'R', 'inputs': 'I', 'expected_output': 'E'},
             ['Input', 'Output', 'ExpectedOutput', 'Rubric'],
         ),
     ],
 )
-def test_build_prompt_section_order_matches_few_shot_examples(kwargs: dict[str, str], expected_tags: list[str]) -> None:
-    """`_build_prompt` must emit sections in the same order the judge system-prompt few-shot
-    examples demonstrate: `Input → Output → ExpectedOutput → Rubric` (matching the
+def test_build_prompt_section_order_matches_few_shot_examples(
+    variant: str, kwargs: dict[str, str], expected_tags: list[str]
+) -> None:
+    """The runtime prompt and every few-shot example in the matching judge's system prompt must
+    share the same section order: `Input → Output → ExpectedOutput → Rubric` (matching the
     `judge_input_output_expected` naming), with the rubric (the instruction) last, after all
     the context it applies to. See issue #6110."""
+    # Resolve the agent inside the test body so the module-level skip applies when the optional
+    # `pydantic-evals` dependency is missing (the agents only exist on a successful import).
+    agent: Agent[None, GradingOutput] = {
+        'output': _judge_output_agent,
+        'input_output': _judge_input_output_agent,
+        'output_expected': _judge_output_expected_agent,
+        'input_output_expected': _judge_input_output_expected_agent,
+    }[variant]
+
     prompt = _build_prompt(**kwargs)
     assert isinstance(prompt, str)
     assert re.findall(r'<(\w+)>', prompt) == expected_tags
+
+    system_prompt = agent._system_prompts[0]  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(system_prompt, str)
+    # Check every example block, not the deduped set, so a single drifting example is caught.
+    example_tags = re.findall(r'<(\w+)>', system_prompt)
+    assert example_tags and len(example_tags) % len(expected_tags) == 0
+    for start in range(0, len(example_tags), len(expected_tags)):
+        assert example_tags[start : start + len(expected_tags)] == expected_tags
 
 
 @pytest.mark.anyio

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -77,17 +77,18 @@ def test_stringify():
     [
         ({'output': 'O', 'rubric': 'R'}, ['Output', 'Rubric']),
         ({'output': 'O', 'rubric': 'R', 'inputs': 'I'}, ['Input', 'Output', 'Rubric']),
-        ({'output': 'O', 'rubric': 'R', 'expected_output': 'E'}, ['ExpectedOutput', 'Output', 'Rubric']),
+        ({'output': 'O', 'rubric': 'R', 'expected_output': 'E'}, ['Output', 'ExpectedOutput', 'Rubric']),
         (
             {'output': 'O', 'rubric': 'R', 'inputs': 'I', 'expected_output': 'E'},
-            ['Input', 'ExpectedOutput', 'Output', 'Rubric'],
+            ['Input', 'Output', 'ExpectedOutput', 'Rubric'],
         ),
     ],
 )
 def test_build_prompt_section_order_matches_few_shot_examples(kwargs: dict[str, str], expected_tags: list[str]) -> None:
     """`_build_prompt` must emit sections in the same order the judge system-prompt few-shot
-    examples demonstrate: `Input → ExpectedOutput → Output → Rubric`, with the rubric (the
-    instruction) last, after all the context it applies to. See issue #6110."""
+    examples demonstrate: `Input → Output → ExpectedOutput → Rubric` (matching the
+    `judge_input_output_expected` naming), with the rubric (the instruction) last, after all
+    the context it applies to. See issue #6110."""
     prompt = _build_prompt(**kwargs)
     assert isinstance(prompt, str)
     assert re.findall(r'<(\w+)>', prompt) == expected_tags
@@ -287,12 +288,12 @@ async def test_judge_input_output_expected_mock(mocker: MockerFixture, image_con
 <Input>
 Hello
 </Input>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>
 <Output>
 Hello world
 </Output>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Rubric>
 Output contains input
 </Rubric>\
@@ -313,12 +314,12 @@ Output contains input
                 '<Input>',
                 image_content,
                 '</Input>',
-                '<ExpectedOutput>',
-                'Hello',
-                '</ExpectedOutput>',
                 '<Output>',
                 'Hello world',
                 '</Output>',
+                '<ExpectedOutput>',
+                'Hello',
+                '</ExpectedOutput>',
                 '<Rubric>',
                 'Output contains input',
                 '</Rubric>',
@@ -357,12 +358,12 @@ async def test_judge_input_output_expected_with_model_settings_mock(
 <Input>
 Hello settings
 </Input>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>
 <Output>
 Hello world with settings
 </Output>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Rubric>
 Output contains input with settings
 </Rubric>\
@@ -393,12 +394,12 @@ Output contains input with settings
                 '<Input>',
                 image_content,
                 '</Input>',
-                '<ExpectedOutput>',
-                'Hello',
-                '</ExpectedOutput>',
                 '<Output>',
                 'Hello world with settings',
                 '</Output>',
+                '<ExpectedOutput>',
+                'Hello',
+                '</ExpectedOutput>',
                 '<Rubric>',
                 'Output contains input with settings',
                 '</Rubric>',
@@ -430,12 +431,12 @@ Output contains input with settings
 <Input>
 123
 </Input>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>
 <Output>
 Hello world with settings
 </Output>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Rubric>
 Output contains input with settings
 </Rubric>\
@@ -464,12 +465,12 @@ Output contains input with settings
 <Input>
 123
 </Input>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>
 <Output>
 Hello world with settings
 </Output>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Rubric>
 Output contains input with settings
 </Rubric>\
@@ -546,12 +547,12 @@ async def test_judge_output_expected_with_model_settings_mock(mocker: MockerFixt
     assert call_args == snapshot(
         (
             [
-                '<ExpectedOutput>',
-                'Hello',
-                '</ExpectedOutput>',
                 '<Output>',
                 image_content,
                 '</Output>',
+                '<ExpectedOutput>',
+                'Hello',
+                '</ExpectedOutput>',
                 '<Rubric>',
                 'Output contains input with settings',
                 '</Rubric>',


### PR DESCRIPTION
Fixes #6110.

### Problem

The default `LLMJudge` evaluator builds its prompt with `_build_prompt`, and each expected-output judge agent primes the model with a section layout via few-shot examples. The two were inconsistent: the few-shot examples put `ExpectedOutput` before `Output`, while `_build_prompt` emitted `ExpectedOutput` after the `Rubric`. So the model saw a layout it was never primed on, and the rubric (the instruction) came before the expected output it has to reason about.

### Fix

Following maintainer feedback, the section order is aligned to the function names (`judge_input_output_expected`): `Input → Output → ExpectedOutput → Rubric`, with the rubric last so the instruction follows all the context it applies to. Both the few-shot examples (in `judge_input_output_expected` and `judge_output_expected`) and `_build_prompt` were reordered to that layout. The `judge_output` / `judge_input_output` variants (no expected output) were already correct and are unchanged.

### Tests

- Updated the affected snapshot tests in `test_llm_as_a_judge.py` to the new order.
- Added `test_build_prompt_section_order_matches_few_shot_examples`, a parametrized regression test pinning `_build_prompt`'s section order for all four variants.

`tests/evals/test_llm_as_a_judge.py` + `tests/evals/test_evaluator_common.py` pass; `ruff format`/`ruff check` and `pyright` are clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
