### PR TITLE
Guard `TogetherProvider.model_profile` against model names without a `/`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -55,9 +55,10 @@ class TogetherProvider(Provider[AsyncOpenAI]):
         profile = None
 
         model_name = model_name.lower()
-        provider, model_name = model_name.split('/', 1)
-        if provider in provider_to_profile:
-            profile = provider_to_profile[provider](model_name)
+        if '/' in model_name:
+            provider, model_name = model_name.split('/', 1)
+            if provider in provider_to_profile:
+                profile = provider_to_profile[provider](model_name)
 
         # As the Together API is OpenAI-compatible, let's assume we also need OpenAIJsonSchemaTransformer,
         # unless json_schema_transformer is set explicitly

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -285,7 +285,9 @@ def test_parse_model_id(model_id: str, expected: tuple[str | None, str]):
         pytest.param('nebius:model-without-slash', False, id='provider-unknown-model'),
         pytest.param('google:gemini-2.0-flash', False, id='google-shorthand'),
         pytest.param('openrouter:model-without-slash', True, id='openrouter-no-slash'),
-        pytest.param('together:model-without-slash', True, id='together-no-slash'),
+        # Together (OpenAI-compatible) returns the OpenAI default profile for a slashless name
+        # rather than crashing — like `nebius` above — so it's not `DEFAULT_PROFILE`.
+        pytest.param('together:model-without-slash', False, id='together-no-slash'),
     ],
 )
 def test_infer_model_profile(model_id: str, is_default: bool):

--- a/tests/providers/test_together.py
+++ b/tests/providers/test_together.py
@@ -98,3 +98,9 @@ def test_together_provider_model_profile(mocker: MockerFixture):
     unknown_profile = provider.model_profile('unknown/model')
     assert unknown_profile is not None
     assert unknown_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    # A model name without a `/` must not crash (regression for the unguarded `split('/', 1)`
+    # unpack); it falls back to the OpenAI-compatible default like the other providers.
+    no_slash_profile = provider.model_profile('gpt-4o-mini')
+    assert no_slash_profile is not None
+    assert no_slash_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer


### PR DESCRIPTION
Fixes #6112.

### Problem

`TogetherProvider.model_profile` split the model name on `/` and unpacked into two variables **without first checking a `/` was present**:

```python
model_name = model_name.lower()
provider, model_name = model_name.split('/', 1)  # ValueError when there's no '/'
```

For a slashless name, `split('/', 1)` returns a one-element list and the two-target unpack raises `ValueError: not enough values to unpack (expected 2, got 1)`. Because `model_profile` runs during model construction, this is a user-facing crash:

```python
OpenAIChatModel('gpt-4o-mini', provider='together')
# ValueError: not enough values to unpack (expected 2, got 1)
```

A vendor-prefixed name (e.g. `meta-llama/Llama-3.3-70B`) works fine — only slashless names break. Every sibling provider with the same `<vendor>/<model>` scheme already guards against this (`github`, `nebius`, `vercel` via `if '/' not in model_name`; `litellm`, `huggingface` via `if '/' in model_name`); `together` was the lone outlier.

### Fix

Only split when a `/` is present; otherwise leave `profile = None` and return the existing OpenAI-compatible default — matching the other providers.

### Tests

Added a slashless-name (`gpt-4o-mini`) case to `test_together_provider_model_profile` asserting it returns the OpenAI-compatible default instead of raising.

`tests/providers/test_together.py` passes (5 tests); `ruff format`/`ruff check` and `pyright` are clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

