### PR TITLE
Mention GEMINI_API_KEY in GoogleProvider missing key error

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -108,7 +108,8 @@ class GoogleProvider(BaseGoogleProvider):
 
         Args:
             api_key: The [API key](https://ai.google.dev/gemini-api/docs/api-key) to
-                use for authentication. It can also be set via the `GOOGLE_API_KEY` environment variable.
+                use for authentication. It can also be set via the `GOOGLE_API_KEY` or `GEMINI_API_KEY`
+                environment variable.
             client: A pre-initialized client to use.
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
             base_url: The base URL for the Gemini API.
@@ -121,8 +122,8 @@ class GoogleProvider(BaseGoogleProvider):
         api_key = api_key or os.getenv('GOOGLE_API_KEY') or os.getenv('GEMINI_API_KEY')
         if api_key is None:
             raise UserError(
-                'Set the `GOOGLE_API_KEY` environment variable or pass it via `GoogleProvider(api_key=...)`'
-                ' to use the Gemini API.'
+                'Set the `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable '
+                'or pass it via `GoogleProvider(api_key=...)` to use the Gemini API.'
             )
         http_options = self._build_http_options(http_client=http_client, base_url=base_url)
         self._client = Client(vertexai=False, api_key=api_key, http_options=http_options)

--- a/tests/providers/test_google.py
+++ b/tests/providers/test_google.py
@@ -1,0 +1,28 @@
+from __future__ import annotations as _annotations
+
+import re
+
+import pytest
+
+from pydantic_ai.exceptions import UserError
+
+from ..conftest import TestEnv, try_import
+
+with try_import() as imports_successful:
+    from pydantic_ai.providers.google import GoogleProvider
+
+
+pytestmark = pytest.mark.skipif(not imports_successful(), reason='google-genai not installed')
+
+
+def test_google_provider_need_api_key_mentions_supported_env_vars(env: TestEnv) -> None:
+    env.remove('GOOGLE_API_KEY')
+    env.remove('GEMINI_API_KEY')
+    with pytest.raises(
+        UserError,
+        match=re.escape(
+            'Set the `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable '
+            'or pass it via `GoogleProvider(api_key=...)` to use the Gemini API.'
+        ),
+    ):
+        GoogleProvider()  # pyright: ignore[reportCallIssue]


### PR DESCRIPTION
﻿## Summary

- Add coverage for the `GoogleProvider` missing API key error.
- Update the error message and constructor docs to mention both `GOOGLE_API_KEY` and backwards-compatible `GEMINI_API_KEY`.

## Why

`GoogleProvider` reads the API key from `GOOGLE_API_KEY` or `GEMINI_API_KEY`, keeping the Gemini variable for backwards compatibility. When neither variable is present, the missing-key error only mentioned `GOOGLE_API_KEY`, which could mislead users who still use the compatible `GEMINI_API_KEY` configuration.

## Tests

- `python -m pytest tests/providers/test_google.py -q`
- `python -m pytest tests/providers/test_google.py tests/providers/test_provider_names.py -k "google" -q`
- `python -m ruff check pydantic_ai_slim\pydantic_ai\providers\google.py tests\providers\test_google.py`
- `python -m py_compile pydantic_ai_slim\pydantic_ai\providers\google.py tests\providers\test_google.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

