### PR TITLE
fix(bedrock): emit non-empty toolResult content for empty tool returns

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -1018,6 +1018,14 @@ class BedrockConverseModel(Model[BaseClient]):
                             else:
                                 tool_result_content.append({'json': item})
 
+                        if not tool_result_content:
+                            # An empty tool return (e.g. a lookup that found no rows) still
+                            # has to produce a non-empty content block: Bedrock Converse
+                            # rejects a toolResult whose `content` is an empty array.
+                            tool_result_content.append(
+                                {'text': str(part.content)} if content_mode == 'str' else {'json': part.content}
+                            )
+
                         user_content: list[ContentBlockUnionTypeDef] = [
                             {
                                 'toolResult': {

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -2648,6 +2648,48 @@ async def test_bedrock_mistral_tool_result_format(bedrock_provider: BedrockProvi
     )
 
 
+async def test_bedrock_empty_tool_result_content(bedrock_provider: BedrockProvider):
+    """An empty tool return (e.g. a lookup with no rows) must still map to a non-empty
+    toolResult.content — Bedrock Converse rejects `content: []`."""
+    now = datetime.now()
+    req = [
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name='lookup', content=[], tool_call_id='id1', timestamp=now),
+            ],
+            timestamp=IsDatetime(),
+        ),
+    ]
+
+    # Text-format model: the empty list is rendered as a text block, never `content: []`.
+    model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
+    _, bedrock_messages = await model._map_messages(req, ModelRequestParameters(), BedrockModelSettings())  # type: ignore[reportPrivateUsage]
+    assert bedrock_messages == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {'toolResult': {'toolUseId': 'id1', 'content': [{'text': '[]'}], 'status': 'success'}},
+                ],
+            },
+        ]
+    )
+
+    # JSON-format model (Mistral): the empty list is preserved as a json block.
+    model = BedrockConverseModel('mistral.mistral-7b-instruct-v0:2', provider=bedrock_provider)
+    _, bedrock_messages = await model._map_messages(req, ModelRequestParameters(), BedrockModelSettings())  # type: ignore[reportPrivateUsage]
+    assert bedrock_messages == snapshot(
+        [
+            {
+                'role': 'user',
+                'content': [
+                    {'toolResult': {'toolUseId': 'id1', 'content': [{'json': []}], 'status': 'success'}},
+                ],
+            },
+        ]
+    )
+
+
 async def test_bedrock_no_tool_choice(bedrock_provider: BedrockProvider):
     my_tool = ToolDefinition(
         name='my_tool',


### PR DESCRIPTION
## Summary

An empty-list tool return (e.g. a DB/catalog lookup that finds no rows — a normal, common result) was serialized to a Bedrock Converse `toolResult` with an empty `content` array. Bedrock rejects `toolResult.content: []` with a `ValidationException`, so the next model turn 400s. The same agent code works on OpenAI/Anthropic, which tolerate empty tool content.

Fixes #6115.

## Change

In `BedrockConverseModel._map_messages`, when the mapped `tool_result_content` is empty, append a single content block representing the empty value:

- `{'json': part.content}` for json-format models (e.g. Mistral)
- `{'text': str(part.content)}` for text-format models (e.g. Nova/Claude)

so `content` is never an empty array.

## Test

`tests/models/test_bedrock.py::test_bedrock_empty_tool_result_content` asserts an empty-list `ToolReturnPart` maps to `content: [{'text': '[]'}]` (text-format) and `content: [{'json': []}]` (json-format).

Full `tests/models/test_bedrock.py` passes (138), `ruff` and `pyright` clean on the changed files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

