### PR TITLE
fix(agent): keep replaced resumed request out of new messages

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -942,13 +942,17 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         # Fill in framework metadata the history processors may have left unset on a new `ModelRequest`.
         fill_run_metadata(messages[-1], run_id=ctx.state.run_id, conversation_id=ctx.state.conversation_id)
 
+        resumed_request_index = len(request_context.messages) - 1 if self.is_resuming_without_prompt else None
         if self.is_resuming_without_prompt:
             ctx.deps.resumed_request = self.request
         # `ctx.state.message_history` is the same list used by `capture_run_messages`, so we should replace its contents, not the reference
         ctx.state.message_history[:] = messages
         # Update the new message index to ensure `result.new_messages()` returns the correct messages
         ctx.deps.new_message_index = _first_new_message_index(
-            messages, ctx.state.run_id, resumed_request=ctx.deps.resumed_request
+            messages,
+            ctx.state.run_id,
+            resumed_request=ctx.deps.resumed_request,
+            resumed_request_index=resumed_request_index,
         )
 
         # Merge possible consecutive trailing `ModelRequest`s into one, with tool call parts before user parts,
@@ -1674,8 +1678,15 @@ def _first_new_message_index(
     run_id: str,
     *,
     resumed_request: _messages.ModelRequest | None,
+    resumed_request_index: int | None = None,
 ) -> int:
-    """Return the first index that should be included in `new_messages()`."""
+    """Return the first index that should be included in `new_messages()`.
+
+    When `resumed_request_index` is provided, it marks the original position of
+    the resumed request before any `before_model_request` capability mutates it.
+    The identity and field-equality checks still run first so processors that
+    insert messages before the resumed request keep the correct boundary.
+    """
     if resumed_request is not None:
         for index, message in enumerate(messages):
             if message is resumed_request:
@@ -1687,6 +1698,8 @@ def _first_new_message_index(
         for index in range(len(messages) - 1, -1, -1):
             if _is_same_request(messages[index], resumed_request):
                 return index + 1
+        if resumed_request_index is not None and 0 <= resumed_request_index < len(messages):
+            return resumed_request_index + 1
     return _first_run_id_index(messages, run_id)
 
 

--- a/tests/test_history_processor.py
+++ b/tests/test_history_processor.py
@@ -1672,13 +1672,13 @@ async def test_history_processor_rebuild_resuming_without_prompt(
     assert result.new_messages() == result.all_messages()[-1:]
 
 
-async def test_history_processor_replace_resumed_request_falls_through(
+async def test_history_processor_replace_resumed_request_excluded(
     function_model: FunctionModel, received_messages: list[ModelMessage]
 ):
     """
     When a history processor replaces the resumed request with completely
-    different content, new_messages() falls back to run_id-based detection
-    to determine which messages belong to the current run.
+    different content, new_messages() should still exclude the resumed request
+    because its position was captured before the processor replaced it.
     """
 
     def replace_all_requests(messages: list[ModelMessage]) -> list[ModelMessage]:
@@ -1744,9 +1744,9 @@ async def test_history_processor_replace_resumed_request_falls_through(
         ]
     )
 
-    # Falls back to run_id-based detection: the replaced request got run_id from
-    # the framework, so new_messages includes both it and the model response
-    assert result.new_messages() == result.all_messages()[-2:]
+    # The resumed request's original position is the boundary, so only the
+    # model response is considered new.
+    assert result.new_messages() == result.all_messages()[-1:]
 
 
 def test_takes_ctx_returns_false_for_untyped_processor():


### PR DESCRIPTION

 ## Summary

  Fix `new_messages()` so a resumed request that gets replaced by a `before_model_request` capability
  is still excluded from the returned new messages.

  ## Verification

  - `pytest tests/test_history_processor.py -k replace_resumed_request_excluded -q`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

