### PR TITLE
fix(google): handle list content in code execution tool return parts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -1661,7 +1661,7 @@ def _native_tool_return_part_dict(
 ) -> PartDict | None:
     if item.provider_name not in accepted_provider_names:
         return None
-    if item.tool_name == CodeExecutionTool.kind and isinstance(item.content, dict):
+    if item.tool_name == CodeExecutionTool.kind and isinstance(item.content, dict | list):
         return _attach_signature(
             {'code_execution_result': cast(CodeExecutionResultDict, item.content)},  # pyright: ignore[reportUnknownMemberType]
             signature,

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -70,6 +70,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import DEFAULT_HTTP_TIMEOUT, ModelRequestParameters
 from pydantic_ai.native_tools import (
+    CodeExecutionTool,
     FileSearchTool,
     ImageGenerationTool,
     WebFetchTool,
@@ -6677,3 +6678,61 @@ async def test_google_top_k_propagation(
     assert mock_generate.call_count == 1
     _, kwargs = mock_generate.call_args
     assert kwargs['config']['top_k'] == 40
+
+
+def test_native_tool_return_part_dict_code_execution_list_content():
+    """Test that _native_tool_return_part_dict handles list content for code execution tools."""
+    from pydantic_ai.models.google import _native_tool_return_part_dict  # pyright: ignore[reportPrivateUsage]
+
+    list_content = [
+        {
+            'return_code': 0,
+            'stderr': '',
+            'stdout': 'hello\n',
+            'type': 'bash_code_execution_result',
+        }
+    ]
+
+    item = NativeToolReturnPart(
+        provider_name='google',
+        tool_name=CodeExecutionTool.kind,
+        content=list_content,
+        tool_call_id='test_id',
+    )
+
+    result = _native_tool_return_part_dict(
+        item,
+        frozenset({'google'}),
+        None,
+        supports_tool_combination=True,
+    )
+
+    assert result is not None
+    assert result['code_execution_result'] == list_content
+
+
+def test_native_tool_return_part_dict_code_execution_dict_content():
+    """Test that _native_tool_return_part_dict still handles dict content for code execution tools."""
+    from pydantic_ai.models.google import _native_tool_return_part_dict  # pyright: ignore[reportPrivateUsage]
+
+    dict_content = {
+        'outcome': 'OUTCOME_OK',
+        'output': 'hello\n',
+    }
+
+    item = NativeToolReturnPart(
+        provider_name='google',
+        tool_name=CodeExecutionTool.kind,
+        content=dict_content,
+        tool_call_id='test_id',
+    )
+
+    result = _native_tool_return_part_dict(
+        item,
+        frozenset({'google'}),
+        None,
+        supports_tool_combination=True,
+    )
+
+    assert result is not None
+    assert result['code_execution_result'] == dict_content


### PR DESCRIPTION

  ## Summary

  Fix Google native tool return mapping so `CodeExecutionTool` results are handled when the provider
  returns list-shaped content instead of only dict-shaped content.

  This prevents code execution responses with list payloads from failing to map into
  `code_execution_result`, which could break model response processing.

  ## Changes

  - Support both list and dict content when mapping `code_execution_result` parts.
  - Add regression tests for both list-shaped and dict-shaped code execution results.

  ## Verification

  - `pytest tests/models/test_google.py -k code_execution_list_content -q`
  - `pytest tests/models/test_google.py -k code_execution_dict_content -q`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

