### PR TITLE
fix(ui): round-trip CompactionPart through Vercel AI & AG-UI adapters

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -81,6 +81,7 @@ try:
     )
     from ._utils import (
         BUILTIN_TOOL_CALL_ID_PREFIX,
+        COMPACTION_ACTIVITY_TYPE,
         DEFAULT_AG_UI_VERSION,
         FILE_ACTIVITY_TYPE,
         MULTIMODAL_VERSION,
@@ -517,6 +518,16 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 ]
                             )
                         )
+                    elif activity_msg.activity_type == COMPACTION_ACTIVITY_TYPE:
+                        activity_content = activity_msg.content
+                        builder.add(
+                            CompactionPart(
+                                content=activity_content.get('content'),
+                                id=activity_content.get('id'),
+                                provider_name=activity_content.get('provider_name'),
+                                provider_details=activity_content.get('provider_details'),
+                            )
+                        )
 
                 case _:
                     if TYPE_CHECKING:
@@ -715,8 +726,28 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             content=file_content,
                         )
                     )
-            elif isinstance(part, CompactionPart):  # pragma: no cover
-                pass  # Compaction parts are not rendered in AG-UI
+            elif isinstance(part, CompactionPart):
+                # AG-UI has no native compaction message type, but compaction data must be
+                # round-tripped back to the same provider (e.g. OpenAI's `encrypted_content`
+                # chain token), so we repurpose ActivityMessage with a reserved
+                # `pydantic_ai_*` activity_type for round-trip fidelity. See CompactionActivityContent.
+                flush()
+                compaction_content: dict[str, Any] = {}
+                if part.content is not None:
+                    compaction_content['content'] = part.content
+                if part.id is not None:
+                    compaction_content['id'] = part.id
+                if part.provider_name is not None:
+                    compaction_content['provider_name'] = part.provider_name
+                if part.provider_details is not None:
+                    compaction_content['provider_details'] = part.provider_details
+                result.append(
+                    ActivityMessage(
+                        id=_new_message_id(),
+                        activity_type=COMPACTION_ACTIVITY_TYPE,
+                        content=compaction_content,
+                    )
+                )
             else:
                 assert_never(part)
 

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
@@ -42,6 +42,14 @@ FILE_ACTIVITY_TYPE: Final[str] = 'pydantic_ai_file'
 UPLOADED_FILE_ACTIVITY_TYPE: Final[str] = 'pydantic_ai_uploaded_file'
 """Activity type for uploaded files stored as AG-UI ActivityMessages."""
 
+COMPACTION_ACTIVITY_TYPE: Final[str] = 'pydantic_ai_compaction'
+"""Activity type for `CompactionPart`s stored as AG-UI ActivityMessages.
+
+Compaction data must be round-tripped back to the same provider in subsequent
+requests (e.g. the OpenAI Responses-API `encrypted_content` chain token), so it is
+preserved as a reserved `pydantic_ai_*` ActivityMessage rather than dropped.
+"""
+
 
 class FileActivityContent(TypedDict, total=False):
     """Content schema for `ActivityMessage` with `activity_type=pydantic_ai_file`."""
@@ -61,6 +69,15 @@ class UploadedFileActivityContent(TypedDict, total=False):
     media_type: str
     identifier: str
     vendor_metadata: Any
+
+
+class CompactionActivityContent(TypedDict, total=False):
+    """Content schema for `ActivityMessage` with `activity_type=pydantic_ai_compaction`."""
+
+    content: str
+    id: str
+    provider_name: str
+    provider_details: dict[str, Any]
 
 
 _AG_UI_VERSION_RE = re.compile(r'(\d+(?:\.\d+)*)')

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -47,6 +47,7 @@ from ...tools import AgentDepsT, DeferredToolResults, ToolDenied
 from .. import MessagesBuilder, UIAdapter
 from ._event_stream import VercelAIEventStream
 from ._utils import (
+    COMPACTION_DATA_TYPE,
     apply_message_metadata,
     dump_message_metadata,
     dump_provider_metadata,
@@ -474,9 +475,10 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                                         outcome='denied',
                                     )
                                 )
-                    elif isinstance(part, DataUIPart):  # pragma: no cover
-                        # Contains custom data that shouldn't be sent to the model
-                        pass
+                    elif isinstance(part, DataUIPart):
+                        if part.type == COMPACTION_DATA_TYPE:
+                            builder.add(cls._load_compaction_data_part(part))
+                        # else: contains custom data that shouldn't be sent to the model
                     elif isinstance(part, SourceUrlUIPart):  # pragma: no cover
                         # TODO: Once we support citations: https://github.com/pydantic/pydantic-ai/issues/3126
                         pass
@@ -684,12 +686,41 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                         )
             elif isinstance(part, ToolCallPart):
                 ui_parts.extend(cls._dump_tool_call_part(part, tool_results, sdk_version))
-            elif isinstance(part, CompactionPart):  # pragma: no cover
-                pass  # Compaction parts are not rendered in the UI
+            elif isinstance(part, CompactionPart):
+                ui_parts.append(cls._dump_compaction_part(part))
             else:
                 assert_never(part)
 
         return ui_parts
+
+    @staticmethod
+    def _load_compaction_data_part(part: DataUIPart) -> CompactionPart:
+        """Reconstruct a `CompactionPart` from a reserved `data-*` `DataUIPart`."""
+        data: dict[str, Any] = part.data if _is_str_dict(part.data) else {}
+        return CompactionPart(
+            content=data.get('content'),
+            id=part.id,
+            provider_name=data.get('provider_name'),
+            provider_details=data.get('provider_details'),
+        )
+
+    @staticmethod
+    def _dump_compaction_part(part: CompactionPart) -> DataUIPart:
+        """Convert a `CompactionPart` into a reserved `data-*` `DataUIPart`.
+
+        Vercel AI has no native compaction message type, but compaction data must be
+        round-tripped back to the same provider (e.g. OpenAI's `encrypted_content` chain
+        token), so we preserve it as a reserved `data-*` part rather than drop it. `data-*`
+        parts are not sent to the model. See COMPACTION_DATA_TYPE.
+        """
+        compaction_data: dict[str, Any] = {}
+        if part.content is not None:
+            compaction_data['content'] = part.content
+        if part.provider_name is not None:
+            compaction_data['provider_name'] = part.provider_name
+        if part.provider_details is not None:
+            compaction_data['provider_details'] = part.provider_details
+        return DataUIPart(type=COMPACTION_DATA_TYPE, id=part.id, data=compaction_data)
 
     @staticmethod
     def _dump_tool_call_part(

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_utils.py
@@ -43,6 +43,15 @@ __all__ = []
 
 PROVIDER_METADATA_KEY = 'pydantic_ai'
 
+COMPACTION_DATA_TYPE = 'data-pydantic-ai-compaction'
+"""Reserved Vercel AI `DataUIPart` type for round-tripping `CompactionPart`s.
+
+Vercel AI has no native compaction message type, but compaction data must be
+round-tripped back to the same provider in subsequent requests (e.g. OpenAI's
+`encrypted_content` chain token), so it is preserved as a reserved `data-*` part
+rather than dropped. Such `data-*` parts are not sent to the model.
+"""
+
 
 class _PydanticAIMessageMetadata(BaseModel):
     """Schema for the `pydantic_ai` key in `UIMessage.metadata`.

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -19,6 +19,7 @@ from pydantic_ai import (
     BinaryContent,
     BinaryImage,
     CachePoint,
+    CompactionPart,
     DocumentUrl,
     FilePart,
     FunctionToolCallEvent,
@@ -1688,6 +1689,52 @@ def test_dump_load_roundtrip_file_part(original: list[ModelMessage]) -> None:
     """
     ag_ui_msgs = AGUIAdapter.dump_messages(original, preserve_file_data=True)
     reloaded = AGUIAdapter.load_messages(ag_ui_msgs, preserve_file_data=True)
+    _sync_timestamps(original, reloaded)
+
+    assert reloaded == original
+
+
+@pytest.mark.parametrize(
+    'original',
+    [
+        pytest.param(
+            [
+                ModelRequest(parts=[UserPromptPart(content='Hello')]),
+                ModelResponse(
+                    parts=[
+                        CompactionPart(
+                            content=None,
+                            id='cmp-1',
+                            provider_name='openai',
+                            provider_details={'encrypted_content': 'opaque-chain-token'},
+                        )
+                    ]
+                ),
+            ],
+            id='openai-encrypted',
+        ),
+        pytest.param(
+            [
+                ModelRequest(parts=[UserPromptPart(content='Hello')]),
+                ModelResponse(
+                    parts=[
+                        CompactionPart(content='Readable summary of prior messages.', provider_name='anthropic'),
+                        TextPart(content='Continuing the conversation.'),
+                    ]
+                ),
+            ],
+            id='anthropic-text-plus-following-part',
+        ),
+    ],
+)
+def test_dump_load_roundtrip_compaction_part(original: list[ModelMessage]) -> None:
+    """`CompactionPart` survives dump_messages -> load_messages intact.
+
+    Regression test for the UI-adapter layer silently dropping `CompactionPart`
+    (and with it OpenAI's `provider_details['encrypted_content']` chain token).
+    """
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
     _sync_timestamps(original, reloaded)
 
     assert reloaded == original

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1725,6 +1725,13 @@ def test_dump_load_roundtrip_file_part(original: list[ModelMessage]) -> None:
             ],
             id='anthropic-text-plus-following-part',
         ),
+        pytest.param(
+            [
+                ModelRequest(parts=[UserPromptPart(content='Hello')]),
+                ModelResponse(parts=[CompactionPart(content='Summary only, no provider metadata.')]),
+            ],
+            id='content-only-no-provider-metadata',
+        ),
     ],
 )
 def test_dump_load_roundtrip_compaction_part(original: list[ModelMessage]) -> None:

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -20,6 +20,7 @@ from pydantic_ai.messages import (
     AudioUrl,
     BinaryContent,
     BinaryImage,
+    CompactionPart,
     DocumentUrl,
     FilePart,
     FunctionToolCallEvent,
@@ -3883,6 +3884,60 @@ async def test_adapter_dump_messages():
             },
         ]
     )
+
+
+@pytest.mark.parametrize(
+    'original',
+    [
+        pytest.param(
+            [
+                ModelRequest(parts=[UserPromptPart(content='Hello')]),
+                ModelResponse(
+                    parts=[
+                        CompactionPart(
+                            content=None,
+                            id='cmp-1',
+                            provider_name='openai',
+                            provider_details={'encrypted_content': 'opaque-chain-token'},
+                        )
+                    ]
+                ),
+            ],
+            id='openai-encrypted',
+        ),
+        pytest.param(
+            [
+                ModelRequest(parts=[UserPromptPart(content='Hello')]),
+                ModelResponse(
+                    parts=[
+                        CompactionPart(content='Readable summary of prior messages.', provider_name='anthropic'),
+                        TextPart(content='Continuing the conversation.'),
+                    ]
+                ),
+            ],
+            id='anthropic-text-plus-following-part',
+        ),
+    ],
+)
+async def test_adapter_round_trips_compaction_part(original: list[ModelMessage]) -> None:
+    """`CompactionPart` survives dump_messages -> load_messages intact.
+
+    Regression test for the UI-adapter layer silently dropping `CompactionPart`
+    (and with it OpenAI's `provider_details['encrypted_content']` chain token).
+    """
+    ui_messages = VercelAIAdapter.dump_messages(original)
+    reloaded = VercelAIAdapter.load_messages(ui_messages)
+
+    # Normalise timestamps, which are regenerated on reload.
+    for original_msg, reloaded_msg in zip(original, reloaded):
+        if isinstance(original_msg, ModelResponse) and isinstance(reloaded_msg, ModelResponse):
+            reloaded_msg.timestamp = original_msg.timestamp
+        for original_part, reloaded_part in zip(original_msg.parts, reloaded_msg.parts):
+            original_ts = getattr(original_part, 'timestamp', None)
+            if original_ts is not None and hasattr(reloaded_part, 'timestamp'):
+                reloaded_part.timestamp = original_ts
+
+    assert reloaded == original
 
 
 async def test_adapter_dump_messages_with_tools():

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3809,6 +3809,11 @@ async def test_adapter_load_messages_with_data_ui_part_in_user_message():
                         text='Hello',
                         state='streaming',
                     ),
+                    DataUIPart(
+                        id='custom-assistant-data',
+                        type='data-custom',
+                        data={'key': 'value'},
+                    ),
                 ],
             ),
         ],
@@ -3917,6 +3922,13 @@ async def test_adapter_dump_messages():
             ],
             id='anthropic-text-plus-following-part',
         ),
+        pytest.param(
+            [
+                ModelRequest(parts=[UserPromptPart(content='Hello')]),
+                ModelResponse(parts=[CompactionPart(content='Summary only, no provider metadata.')]),
+            ],
+            id='content-only-no-provider-metadata',
+        ),
     ],
 )
 async def test_adapter_round_trips_compaction_part(original: list[ModelMessage]) -> None:
@@ -3935,7 +3947,7 @@ async def test_adapter_round_trips_compaction_part(original: list[ModelMessage])
         for original_part, reloaded_part in zip(original_msg.parts, reloaded_msg.parts):
             original_ts = getattr(original_part, 'timestamp', None)
             if original_ts is not None and hasattr(reloaded_part, 'timestamp'):
-                reloaded_part.timestamp = original_ts
+                setattr(reloaded_part, 'timestamp', original_ts)
 
     assert reloaded == original
 


### PR DESCRIPTION
## Summary

- The Vercel AI and AG-UI UI adapters silently dropped `CompactionPart` on `dump_messages`, so a paused/resumed chat lost the OpenAI Responses-API compaction chain (`encrypted_content`), forcing a costly re-compaction on the next request.
- This PR preserves and reconstructs `CompactionPart` through both adapters' `dump_messages` → `load_messages` round-trip.

## Motivation

Closes #6123.

Both adapters' `_dump_part` contained `elif isinstance(part, CompactionPart): pass` (marked `# pragma: no cover`). On reload the `CompactionPart` was gone — `provider_details['encrypted_content']`, `id`, and `provider_name` all lost. This breaks the documented invariant in `messages.py` that compaction parts *"must be round-tripped back to the same provider in subsequent requests"* and silently inflates cost/latency on resumed sessions.

## Root Cause

**Symptom** — `VercelAIAdapter`/`AGUIAdapter` `dump_messages` returns an empty list (or silently skips the part when mixed with others) for a `ModelResponse` whose `parts=[CompactionPart(...)]`; `load_messages` can never recover it.

**Root cause** — `VercelAIAdapter._dump_response_message` and `AGUIAdapter._dump_response_parts` explicitly `pass` on `CompactionPart` (vercel `_adapter.py:687`, ag_ui `_adapter.py:718`) on the assumption it "isn't rendered in the UI." But compaction data isn't UI content — it's an opaque provider chain token that must survive the round-trip. The dump methods are the only layer that drops it; `ModelMessagesTypeAdapter` round-trips it correctly.

**Evidence** — the issue's repro (`dump_messages` → `load_messages` of a `ModelResponse` carrying a `CompactionPart` with `provider_details['encrypted_content']`) returns `dumped=[] reloaded=[]`. Confirmed on `origin/main` before the fix; the two new parametrized tests fail without it.

**Fix + why this level** — fix at the dump/load boundary (where the loss occurs) using each format's *existing* reserved-carrier convention rather than inventing a new message type:
- **AG-UI** — a reserved `pydantic_ai_compaction` `ActivityMessage` (new `COMPACTION_ACTIVITY_TYPE` + `CompactionActivityContent`), mirroring the existing `FILE_ACTIVITY_TYPE`/`UPLOADED_FILE_ACTIVITY_TYPE` pattern.
- **Vercel AI** — a reserved `data-pydantic-ai-compaction` `DataUIPart`; `data-*` parts are explicitly *not* sent to the model, so it's the natural side-channel.
Both `load_messages` paths reconstruct the `CompactionPart`. Unlike `FilePart` (gated on `preserve_file_data`), compaction is round-tripped **unconditionally** because losing it is a correctness/cost bug, not a cosmetic one.

**Scope / risk** — touches only the two UI adapters + their `_utils` constants. `ModelMessagesTypeAdapter` is unchanged. `CompactionPart` is already in `ModelResponsePart`, so `MessagesBuilder.add()` routes the reloaded part back into `ModelResponse` correctly. Empty/`None` fields are omitted from the carrier so a content-less Anthropic-style part round-trips just as cleanly.

## Tests

- `tests/test_ag_ui.py::test_dump_load_roundtrip_compaction_part` (parametrized: OpenAI encrypted `provider_details`; Anthropic readable summary + following `TextPart`).
- `tests/test_vercel_ai.py::test_adapter_round_trips_compaction_part` (same parametrization).
- Both assert `load_messages(dump_messages(msgs)) == msgs` and FAIL without the fix (dump drops the part).

## Verification

- `uv run pytest tests/test_ag_ui.py tests/test_vercel_ai.py` — 297 passed.
- `uv run pytest tests/test_capabilities.py` — passes (CompactionPart serialization suite unaffected).
- `uv run ruff format` / `uv run ruff check` — clean.
- `uv run pyright <ui adapter + utils files>` — 0 errors.

### Real behavior proof (captured on this branch, py3.12)

Repro from the issue, after the fix:

```
vercel: dumped_len=2 reloaded_compaction=[CompactionPart(id='cmp-1', provider_name='openai', provider_details={'encrypted_content': 'SECRET_TOKEN'})] OK=True
ag_ui:  dumped_len=2 reloaded_compaction=[CompactionPart(id='cmp-1', provider_name='openai', provider_details={'encrypted_content': 'SECRET_TOKEN'})] OK=True
```

(`OK=True` asserts the `encrypted_content` chain token survives the full round-trip; both reported empty lists before the fix.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

