### PR TITLE
docs: fix `supported_builtin_tools` → `supported_native_tools` and br…

### DIFF
--- a/docs/tools-advanced.md
+++ b/docs/tools-advanced.md
@@ -747,7 +747,7 @@ Available strategy values:
 
 The execution mode (server-executed, client-executed-native, or local fallback) is auto-derived from the chosen algorithm and the current provider — users don't pick it directly. Native execution is preferred whenever available because it keeps the model-facing tool list stable across discovery rounds, which preserves Anthropic and OpenAI prompt caching.
 
-To force the local `keywords` algorithm on a provider that natively supports tool search, override [`ModelProfile.supported_builtin_tools`][pydantic_ai.profiles.ModelProfile.supported_builtin_tools] to exclude `ToolSearchTool` — the capability then falls through to the local `search_tools` function tool.
+To force the local `keywords` algorithm on a provider that natively supports tool search, override [`ModelProfile.supported_native_tools`][pydantic_ai.profiles.ModelProfile.supported_native_tools] to exclude `ToolSearchTool` — the capability then falls through to the local `search_tools` function tool.
 
 !!! note "Cross-provider history replay"
     A turn can run on one provider and the next on another (e.g. via [`FallbackModel`][pydantic_ai.models.fallback.FallbackModel] or by switching `model=` between runs). Discovered-tool state is preserved across the switch:

--- a/docs/ui/ag-ui.md
+++ b/docs/ui/ag-ui.md
@@ -23,7 +23,7 @@ pip/uv-add 'pydantic-ai-slim[ag-ui]'
 
 To run the examples you'll also need:
 
-- [uvicorn](https://www.uvicorn.org/) or another ASGI compatible server
+- [uvicorn](https://uvicorn.dev) or another ASGI compatible server
 
 ```bash
 pip/uv-add uvicorn

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_model.py
@@ -350,7 +350,7 @@ class TemporalModel(WrapperModel):
         Mirrors `prepare_request`: when `using_model()` overrides the runtime model, we
         delegate to that model's profile (or to the grandparent default for unregistered
         model strings) so cross-provider history shapes are translated against the right
-        `supported_builtin_tools`.
+        `supported_native_tools`.
         """
         current = self._current_model()
         if isinstance(current, str):


### PR DESCRIPTION
…oken uvicorn link

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

Closes #6121
Closes #6125

### Checklist

- [ x ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ x ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ x ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

