### PR TITLE
[codex] Fix Anthropic usage details duplication

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2194,6 +2194,7 @@ class AnthropicCompaction(AbstractCapability[AgentDepsT]):
 
 
 _COMPACTION_TOKEN_KEYS = ('input_tokens', 'output_tokens', 'cache_creation_input_tokens', 'cache_read_input_tokens')
+_FIRST_CLASS_USAGE_DETAIL_KEYS = frozenset(_COMPACTION_TOKEN_KEYS)
 
 
 def _extract_usage_details(response_usage: BetaUsage | BetaMessageDeltaUsage) -> dict[str, int]:
@@ -2227,6 +2228,37 @@ def _extract_usage_details(response_usage: BetaUsage | BetaMessageDeltaUsage) ->
     return details
 
 
+def _details_from_existing_usage(existing_usage: usage.RequestUsage) -> dict[str, int]:
+    """Reconstruct Anthropic raw usage keys from a filtered `RequestUsage`.
+
+    Streaming deltas can omit fields that were reported by `message_start`, so `_map_usage`
+    needs those raw keys internally even though they are no longer exposed in `details`.
+    """
+    details = existing_usage.details.copy()
+
+    def add_detail(key: str, value: int) -> None:
+        if key not in details and value > 0:
+            details[key] = value
+
+    add_detail(
+        'input_tokens',
+        existing_usage.input_tokens
+        - existing_usage.cache_write_tokens
+        - existing_usage.cache_read_tokens
+        - details.get('compaction_input_tokens', 0),
+    )
+    add_detail('output_tokens', existing_usage.output_tokens - details.get('compaction_output_tokens', 0))
+    add_detail(
+        'cache_creation_input_tokens',
+        existing_usage.cache_write_tokens - details.get('compaction_cache_creation_input_tokens', 0),
+    )
+    add_detail(
+        'cache_read_input_tokens',
+        existing_usage.cache_read_tokens - details.get('compaction_cache_read_input_tokens', 0),
+    )
+    return details
+
+
 def _map_usage(
     message: BetaMessage | BetaRawMessageStartEvent | BetaRawMessageDeltaEvent,
     provider: str,
@@ -2252,7 +2284,9 @@ def _map_usage(
 
     # In streaming, usage appears in different events.
     # The values are cumulative, meaning new values should replace existing ones entirely.
-    details = (existing_usage.details if existing_usage else {}) | _extract_usage_details(response_usage)
+    details = (_details_from_existing_usage(existing_usage) if existing_usage else {}) | _extract_usage_details(
+        response_usage
+    )
 
     # Anthropic reports top-level tokens excluding compaction iteration usage; add the
     # compaction totals back in so the extracted `RequestUsage` reflects the real request cost.
@@ -2268,7 +2302,7 @@ def _map_usage(
         provider=provider,
         provider_url=provider_url,
         provider_fallback='anthropic',
-        details=details,
+        details={k: v for k, v in details.items() if k not in _FIRST_CLASS_USAGE_DETAIL_KEYS},
     )
 
 

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -309,27 +309,13 @@ async def test_sync_request_text_response(allow_model_requests: None):
 
     result = await agent.run('hello')
     assert result.output == 'world'
-    assert result.usage == snapshot(
-        RunUsage(
-            requests=1,
-            input_tokens=5,
-            output_tokens=10,
-            details={'input_tokens': 5, 'output_tokens': 10},
-        )
-    )
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=5, output_tokens=10))
     # reset the index so we get the same response again
     mock_client.index = 0  # type: ignore
 
     result = await agent.run('hello', message_history=result.new_messages())
     assert result.output == 'world'
-    assert result.usage == snapshot(
-        RunUsage(
-            requests=1,
-            input_tokens=5,
-            output_tokens=10,
-            details={'input_tokens': 5, 'output_tokens': 10},
-        )
-    )
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=5, output_tokens=10))
     assert result.all_messages() == snapshot(
         [
             ModelRequest(
@@ -340,7 +326,7 @@ async def test_sync_request_text_response(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[TextPart(content='world')],
-                usage=RequestUsage(input_tokens=5, output_tokens=10, details={'input_tokens': 5, 'output_tokens': 10}),
+                usage=RequestUsage(input_tokens=5, output_tokens=10),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -359,7 +345,7 @@ async def test_sync_request_text_response(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[TextPart(content='world')],
-                usage=RequestUsage(input_tokens=5, output_tokens=10, details={'input_tokens': 5, 'output_tokens': 10}),
+                usage=RequestUsage(input_tokens=5, output_tokens=10),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -391,19 +377,7 @@ async def test_async_request_prompt_caching(allow_model_requests: None):
     result = await agent.run('hello')
     assert result.output == 'world'
     assert result.usage == snapshot(
-        RunUsage(
-            requests=1,
-            input_tokens=13,
-            cache_write_tokens=4,
-            cache_read_tokens=6,
-            output_tokens=5,
-            details={
-                'input_tokens': 3,
-                'output_tokens': 5,
-                'cache_creation_input_tokens': 4,
-                'cache_read_input_tokens': 6,
-            },
-        )
+        RunUsage(requests=1, input_tokens=13, cache_write_tokens=4, cache_read_tokens=6, output_tokens=5)
     )
     last_message = result.all_messages()[-1]
     assert isinstance(last_message, ModelResponse)
@@ -1853,14 +1827,7 @@ async def test_async_request_text_response(allow_model_requests: None):
 
     result = await agent.run('hello')
     assert result.output == 'world'
-    assert result.usage == snapshot(
-        RunUsage(
-            requests=1,
-            input_tokens=3,
-            output_tokens=5,
-            details={'input_tokens': 3, 'output_tokens': 5},
-        )
-    )
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=3, output_tokens=5))
 
 
 async def test_request_stream_fallback_for_high_max_tokens(
@@ -1891,16 +1858,7 @@ async def test_request_stream_fallback_for_high_max_tokens(
             ),
             ModelResponse(
                 parts=[TextPart(content='2')],
-                usage=RequestUsage(
-                    input_tokens=20,
-                    output_tokens=5,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 20,
-                        'output_tokens': 5,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=20, output_tokens=5),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -1943,7 +1901,7 @@ async def test_request_structured_response(allow_model_requests: None):
                         tool_call_id='123',
                     )
                 ],
-                usage=RequestUsage(input_tokens=3, output_tokens=5, details={'input_tokens': 3, 'output_tokens': 5}),
+                usage=RequestUsage(input_tokens=3, output_tokens=5),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -2019,7 +1977,7 @@ async def test_request_tool_call(allow_model_requests: None):
                         tool_call_id='1',
                     )
                 ],
-                usage=RequestUsage(input_tokens=2, output_tokens=1, details={'input_tokens': 2, 'output_tokens': 1}),
+                usage=RequestUsage(input_tokens=2, output_tokens=1),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -2052,7 +2010,7 @@ async def test_request_tool_call(allow_model_requests: None):
                         tool_call_id='2',
                     )
                 ],
-                usage=RequestUsage(input_tokens=3, output_tokens=2, details={'input_tokens': 3, 'output_tokens': 2}),
+                usage=RequestUsage(input_tokens=3, output_tokens=2),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -2079,7 +2037,7 @@ async def test_request_tool_call(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[TextPart(content='final response')],
-                usage=RequestUsage(input_tokens=3, output_tokens=5, details={'input_tokens': 3, 'output_tokens': 5}),
+                usage=RequestUsage(input_tokens=3, output_tokens=5),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -2420,21 +2378,12 @@ async def test_stream_structured(allow_model_requests: None):
         # the block starts and once when it ends.
         assert chunks == snapshot(['FINAL_PAYLOAD', 'FINAL_PAYLOAD'])
         assert result.is_complete
-        assert result.usage == snapshot(
-            RunUsage(
-                requests=2,
-                input_tokens=20,
-                output_tokens=5,
-                tool_calls=1,
-                details={'input_tokens': 20, 'output_tokens': 5},
-            )
-        )
+        assert result.usage == snapshot(RunUsage(requests=2, input_tokens=20, output_tokens=5, tool_calls=1))
         assert tool_called
         async for response in result.stream_response(debounce_by=None):
             assert response == snapshot(
                 ModelResponse(
                     parts=[TextPart(content='FINAL_PAYLOAD')],
-                    usage=RequestUsage(details={'input_tokens': 0, 'output_tokens': 0}),
                     model_name='claude-3-5-haiku-123',
                     timestamp=IsDatetime(),
                     provider_name='anthropic',
@@ -2972,16 +2921,7 @@ async def test_anthropic_model_instructions(allow_model_requests: None, anthropi
             ),
             ModelResponse(
                 parts=[TextPart(content='The capital of France is Paris.')],
-                usage=RequestUsage(
-                    input_tokens=20,
-                    output_tokens=10,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 20,
-                        'output_tokens': 10,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=20, output_tokens=10),
                 model_name='claude-3-opus-20240229',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3019,16 +2959,7 @@ async def test_anthropic_model_thinking_part(allow_model_requests: None, anthrop
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=43,
-                    output_tokens=321,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 43,
-                        'output_tokens': 321,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=43, output_tokens=321),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3088,16 +3019,7 @@ I should provide practical advice for different methods of crossing a river.\
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=354,
-                    output_tokens=525,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 354,
-                        'output_tokens': 525,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=354, output_tokens=525),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3143,16 +3065,7 @@ async def test_anthropic_model_thinking_part_redacted(allow_model_requests: None
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=92,
-                    output_tokens=196,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 92,
-                        'output_tokens': 196,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=92, output_tokens=196),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3193,16 +3106,7 @@ async def test_anthropic_model_thinking_part_redacted(allow_model_requests: None
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=168,
-                    output_tokens=232,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 168,
-                        'output_tokens': 232,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=168, output_tokens=232),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3262,16 +3166,7 @@ async def test_anthropic_model_thinking_part_redacted_stream(allow_model_request
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=92,
-                    output_tokens=189,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 92,
-                        'output_tokens': 189,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=92, output_tokens=189),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3478,16 +3373,7 @@ async def test_anthropic_model_thinking_part_from_other_model(
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=1343,
-                    output_tokens=538,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 1343,
-                        'output_tokens': 538,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=1343, output_tokens=538),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3538,16 +3424,7 @@ async def test_anthropic_model_thinking_part_stream(allow_model_requests: None, 
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=43,
-                    output_tokens=282,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 43,
-                        'output_tokens': 282,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=43, output_tokens=282),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -4356,7 +4233,7 @@ def anth_msg(usage: BetaUsage) -> BetaMessage:
     [
         pytest.param(
             lambda: anth_msg(BetaUsage(input_tokens=1, output_tokens=1)),
-            snapshot(RequestUsage(input_tokens=1, output_tokens=1, details={'input_tokens': 1, 'output_tokens': 1})),
+            snapshot(RequestUsage(input_tokens=1, output_tokens=1)),
             id='AnthropicMessage',
         ),
         pytest.param(
@@ -4369,12 +4246,6 @@ def anth_msg(usage: BetaUsage) -> BetaMessage:
                     cache_write_tokens=2,
                     cache_read_tokens=3,
                     output_tokens=1,
-                    details={
-                        'cache_creation_input_tokens': 2,
-                        'cache_read_input_tokens': 3,
-                        'input_tokens': 1,
-                        'output_tokens': 1,
-                    },
                 )
             ),
             id='AnthropicMessage-cached',
@@ -4410,8 +4281,6 @@ def anth_msg(usage: BetaUsage) -> BetaMessage:
                     cache_write_tokens=4,
                     cache_read_tokens=5,
                     details={
-                        'input_tokens': 23,
-                        'output_tokens': 1,
                         'compaction_iterations': 1,
                         'message_iterations': 1,
                         'compaction_input_tokens': 180,
@@ -4427,7 +4296,7 @@ def anth_msg(usage: BetaUsage) -> BetaMessage:
             lambda: BetaRawMessageStartEvent(
                 message=anth_msg(BetaUsage(input_tokens=1, output_tokens=1)), type='message_start'
             ),
-            snapshot(RequestUsage(input_tokens=1, output_tokens=1, details={'input_tokens': 1, 'output_tokens': 1})),
+            snapshot(RequestUsage(input_tokens=1, output_tokens=1)),
             id='RawMessageStartEvent',
         ),
     ],
@@ -4443,8 +4312,17 @@ def test_streaming_usage():
     initial_usage = _map_usage(start, 'anthropic', '', 'unknown')
     delta = BetaRawMessageDeltaEvent(delta=Delta(), usage=BetaMessageDeltaUsage(output_tokens=5), type='message_delta')
     final_usage = _map_usage(delta, 'anthropic', '', 'unknown', existing_usage=initial_usage)
-    assert final_usage == snapshot(
-        RequestUsage(input_tokens=1, output_tokens=5, details={'input_tokens': 1, 'output_tokens': 5})
+    assert final_usage == snapshot(RequestUsage(input_tokens=1, output_tokens=5))
+
+
+def test_anthropic_usage_otel_attrs_do_not_duplicate_first_class_token_counts():
+    mapped_usage = _map_usage(anth_msg(BetaUsage(input_tokens=12, output_tokens=3946)), 'anthropic', '', 'unknown')
+    assert mapped_usage.details == {}
+    assert mapped_usage.opentelemetry_attributes() == snapshot(
+        {
+            'gen_ai.usage.input_tokens': 12,
+            'gen_ai.usage.output_tokens': 3946,
+        }
     )
 
 
@@ -4503,9 +4381,7 @@ async def test_streaming_bedrock_start_event_without_message_is_skipped(allow_mo
     # name falls back to the configured id because the peeked-first chunk carried no `message.model`.
     response = result.all_messages()[-1]
     assert isinstance(response, ModelResponse)
-    assert response.usage == snapshot(
-        RequestUsage(input_tokens=4, output_tokens=2, details={'input_tokens': 4, 'output_tokens': 2})
-    )
+    assert response.usage == snapshot(RequestUsage(input_tokens=4, output_tokens=2))
     assert response.provider_response_id == 'x'
     assert response.model_name == 'claude-haiku-4-5'
 
@@ -4551,8 +4427,6 @@ def test_streaming_usage_with_compaction():
             cache_write_tokens=4,
             cache_read_tokens=5,
             details={
-                'input_tokens': 23,
-                'output_tokens': 500,
                 'compaction_iterations': 1,
                 'message_iterations': 1,
                 'compaction_input_tokens': 180,
@@ -4779,16 +4653,7 @@ Overall, it's a pleasant day in San Francisco with mild temperatures and mostly 
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=8984,
-                    output_tokens=520,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 8984,
-                        'output_tokens': 520,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=8984, output_tokens=520),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -4982,16 +4847,7 @@ Mexico City is experiencing typical rainy season weather with moderate temperatu
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=19859,
-                    output_tokens=544,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 19859,
-                        'output_tokens': 544,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=19859, output_tokens=544),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -5269,16 +5125,7 @@ So for today, you can expect partly sunny to sunny skies with a high around 76°
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=22397,
-                    output_tokens=637,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 22397,
-                        'output_tokens': 637,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=22397, output_tokens=637),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -5932,16 +5779,7 @@ Let me fetch the page first.\
                         content='Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications and workflows with Generative AI.'
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=7262,
-                    output_tokens=171,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 7262,
-                        'output_tokens': 171,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=7262, output_tokens=171),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -6017,16 +5855,7 @@ Let me fetch the page first.\
                         content='Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications and workflows with Generative AI.'
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=7262,
-                    output_tokens=171,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 7262,
-                        'output_tokens': 171,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=7262, output_tokens=171),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -6081,16 +5910,7 @@ It notes that "virtually every Python agent framework and LLM library" uses Pyda
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=6346,
-                    output_tokens=354,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 6346,
-                        'output_tokens': 354,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=6346, output_tokens=354),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -6186,16 +6006,7 @@ async def test_anthropic_web_fetch_tool_stream(
                         content='Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications and workflows with Generative AI.'
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=7244,
-                    output_tokens=153,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 7244,
-                        'output_tokens': 153,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=7244, output_tokens=153),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -6855,16 +6666,7 @@ The repo is organized as a monorepo with core packages like `pydantic-ai-slim` (
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=2674,
-                    output_tokens=373,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 2674,
-                        'output_tokens': 373,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=2674, output_tokens=373),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -6996,16 +6798,7 @@ Pydantic ensures runtime data integrity through type hints and is foundational t
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=5262,
-                    output_tokens=369,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 5262,
-                        'output_tokens': 369,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=5262, output_tokens=369),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -7111,16 +6904,7 @@ It's designed to simplify building robust, production-ready AI agents while abst
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=3042,
-                    output_tokens=354,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 3042,
-                        'output_tokens': 354,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=3042, output_tokens=354),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -7365,16 +7149,7 @@ async def test_anthropic_code_execution_tool(allow_model_requests: None, anthrop
                     ),
                     TextPart(content='The result of **3 × 12,390 = 37,170**.'),
                 ],
-                usage=RequestUsage(
-                    input_tokens=4692,
-                    output_tokens=106,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 4692,
-                        'output_tokens': 106,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=4692, output_tokens=106),
                 model_name='claude-sonnet-4-6',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -7432,16 +7207,7 @@ async def test_anthropic_code_execution_tool(allow_model_requests: None, anthrop
                     ),
                     TextPart(content='**4 × 12,390 = 49,560**'),
                 ],
-                usage=RequestUsage(
-                    input_tokens=4690,
-                    output_tokens=103,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 4690,
-                        'output_tokens': 103,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=4690, output_tokens=103),
                 model_name='claude-sonnet-4-6',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -7533,16 +7299,7 @@ Following the standard **order of operations (PEMDAS/BODMAS)** — multiplicatio
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=4714,
-                    output_tokens=304,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 4714,
-                        'output_tokens': 304,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=4714, output_tokens=304),
                 model_name='claude-sonnet-4-6',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8001,16 +7758,7 @@ async def test_anthropic_tool_output(allow_model_requests: None, anthropic_api_k
                 parts=[
                     ToolCallPart(tool_name='get_user_country', args={}, tool_call_id='toolu_01X9wcHKKAZD9tBC711xipPa')
                 ],
-                usage=RequestUsage(
-                    input_tokens=445,
-                    output_tokens=23,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 445,
-                        'output_tokens': 23,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=445, output_tokens=23),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8042,16 +7790,7 @@ async def test_anthropic_tool_output(allow_model_requests: None, anthropic_api_k
                         tool_call_id='toolu_01LZABsgreMefH2Go8D5PQbW',
                     )
                 ],
-                usage=RequestUsage(
-                    input_tokens=497,
-                    output_tokens=56,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 497,
-                        'output_tokens': 56,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=497, output_tokens=56),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8118,16 +7857,7 @@ async def test_anthropic_text_output_function(allow_model_requests: None, anthro
                     ),
                     ToolCallPart(tool_name='get_user_country', args={}, tool_call_id='toolu_01JJ8TequDsrEU2pv1QFRWAK'),
                 ],
-                usage=RequestUsage(
-                    input_tokens=383,
-                    output_tokens=65,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 383,
-                        'output_tokens': 65,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=383, output_tokens=65),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8157,16 +7887,7 @@ async def test_anthropic_text_output_function(allow_model_requests: None, anthro
                         content='Based on the result, you are located in Mexico. The largest city in Mexico is Mexico City (Ciudad de México), which is both the capital and the most populous city in the country. With a population of approximately 9.2 million people in the city proper and over 21 million people in its metropolitan area, Mexico City is not only the largest city in Mexico but also one of the largest cities in the world.'
                     )
                 ],
-                usage=RequestUsage(
-                    input_tokens=460,
-                    output_tokens=91,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 460,
-                        'output_tokens': 91,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=460, output_tokens=91),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8217,16 +7938,7 @@ async def test_anthropic_prompted_output(allow_model_requests: None, anthropic_a
                 parts=[
                     ToolCallPart(tool_name='get_user_country', args={}, tool_call_id='toolu_01ArHq5f2wxRpRF2PVQcKExM')
                 ],
-                usage=RequestUsage(
-                    input_tokens=459,
-                    output_tokens=38,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 459,
-                        'output_tokens': 38,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=459, output_tokens=38),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8252,16 +7964,7 @@ async def test_anthropic_prompted_output(allow_model_requests: None, anthropic_a
             ),
             ModelResponse(
                 parts=[TextPart(content='{"city": "Mexico City", "country": "Mexico"}')],
-                usage=RequestUsage(
-                    input_tokens=510,
-                    output_tokens=17,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 510,
-                        'output_tokens': 17,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=510, output_tokens=17),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8311,16 +8014,7 @@ async def test_anthropic_prompted_output_multiple(allow_model_requests: None, an
                         content='{"result": {"kind": "CityLocation", "data": {"city": "Mexico City", "country": "Mexico"}}}'
                     )
                 ],
-                usage=RequestUsage(
-                    input_tokens=265,
-                    output_tokens=31,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 265,
-                        'output_tokens': 31,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=265, output_tokens=31),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8630,16 +8324,7 @@ Everything looks perfect! 🎉\
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=10490,
-                    output_tokens=469,
-                    details={
-                        'input_tokens': 10490,
-                        'output_tokens': 469,
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=10490, output_tokens=469),
                 model_name='claude-sonnet-4-6',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -10468,12 +10153,6 @@ async def test_anthropic_cache_real_api(allow_model_requests: None, anthropic_ap
             input_tokens=1114,
             cache_read_tokens=1111,
             output_tokens=406,
-            details={
-                'cache_creation_input_tokens': 0,
-                'cache_read_input_tokens': 1111,
-                'input_tokens': 3,
-                'output_tokens': 406,
-            },
             requests=1,
         )
     )
@@ -10485,12 +10164,6 @@ async def test_anthropic_cache_real_api(allow_model_requests: None, anthropic_ap
             cache_read_tokens=1111,
             cache_write_tokens=418,
             output_tokens=33,
-            details={
-                'cache_creation_input_tokens': 418,
-                'cache_read_input_tokens': 1111,
-                'input_tokens': 3,
-                'output_tokens': 33,
-            },
             requests=1,
         )
     )
@@ -10521,12 +10194,6 @@ async def test_anthropic_cache_count_tokens(allow_model_requests: None, anthropi
             input_tokens=1114,
             cache_read_tokens=1111,
             output_tokens=414,
-            details={
-                'cache_creation_input_tokens': 0,
-                'cache_read_input_tokens': 1111,
-                'input_tokens': 3,
-                'output_tokens': 414,
-            },
             requests=1,
         )
     )
@@ -10577,12 +10244,6 @@ async def test_anthropic_cache_bedrock_real_api(allow_model_requests: None):
             input_tokens=9514,
             cache_read_tokens=9511,
             output_tokens=1944,
-            details={
-                'cache_creation_input_tokens': 0,
-                'cache_read_input_tokens': 9511,
-                'input_tokens': 3,
-                'output_tokens': 1944,
-            },
             requests=1,
         )
     )
@@ -10594,12 +10255,6 @@ async def test_anthropic_cache_bedrock_real_api(allow_model_requests: None):
             cache_write_tokens=1956,
             cache_read_tokens=9511,
             output_tokens=44,
-            details={
-                'cache_creation_input_tokens': 1956,
-                'cache_read_input_tokens': 9511,
-                'input_tokens': 3,
-                'output_tokens': 44,
-            },
             requests=1,
         )
     )
@@ -10837,16 +10492,7 @@ async def test_anthropic_code_execution_tool_container_reuse(allow_model_request
                     ),
                     TextPart(content='3 * 12390 = **37,170**'),
                 ],
-                usage=RequestUsage(
-                    input_tokens=4612,
-                    output_tokens=80,
-                    details={
-                        'input_tokens': 4612,
-                        'output_tokens': 80,
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=4612, output_tokens=80),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -10889,16 +10535,7 @@ async def test_anthropic_code_execution_tool_container_reuse(allow_model_request
                     ),
                     TextPart(content='4 * 12390 = **49,560**'),
                 ],
-                usage=RequestUsage(
-                    input_tokens=4840,
-                    output_tokens=80,
-                    details={
-                        'input_tokens': 4840,
-                        'output_tokens': 80,
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=4840, output_tokens=80),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -11036,7 +10673,7 @@ async def test_anthropic_malformed_tool_args_no_crash(allow_model_requests: None
             ),
             ModelResponse(
                 parts=[TextPart(content='Here is the corrected result.')],
-                usage=RequestUsage(input_tokens=10, output_tokens=5, details={'input_tokens': 10, 'output_tokens': 5}),
+                usage=RequestUsage(input_tokens=10, output_tokens=5),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -11148,7 +10785,7 @@ async def test_stream_cancel(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[TextPart(content='hello ')],
-                usage=RequestUsage(input_tokens=5, details={'input_tokens': 5, 'output_tokens': 0}),
+                usage=RequestUsage(input_tokens=5),
                 model_name='claude-haiku-4-5-123',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -11442,10 +11079,6 @@ async def test_anthropic_compaction_usage_with_cache(allow_model_requests: None,
             cache_write_tokens=55096,
             output_tokens=90,
             details={
-                'input_tokens': 180,
-                'output_tokens': 8,
-                'cache_creation_input_tokens': 0,
-                'cache_read_input_tokens': 0,
                 'compaction_iterations': 1,
                 'message_iterations': 1,
                 'compaction_input_tokens': 100,
@@ -11482,10 +11115,6 @@ async def test_anthropic_compaction_usage_with_cache_streaming(allow_model_reque
             cache_write_tokens=55096,
             output_tokens=76,
             details={
-                'input_tokens': 172,
-                'output_tokens': 5,
-                'cache_creation_input_tokens': 0,
-                'cache_read_input_tokens': 0,
                 'compaction_iterations': 1,
                 'message_iterations': 1,
                 'compaction_input_tokens': 100,


### PR DESCRIPTION
Fixes #6131.

## Summary

This PR stops the Anthropic adapter from exposing first-class token counts in `RequestUsage.details` while still keeping those raw Anthropic usage keys available internally for extraction and compaction accounting.

The root cause was that `_extract_usage_details()` copied Anthropic raw usage fields such as `input_tokens` and `output_tokens` into `details`, and `_map_usage()` also used those same values to populate the first-class `RequestUsage` fields via `genai-prices`. `opentelemetry_attributes()` then emitted both `gen_ai.usage.output_tokens` and `gen_ai.usage.details.output_tokens`, which downstream OTel consumers could count twice.

## Changes

- Filter Anthropic first-class usage fields out of the public `RequestUsage.details` payload.
- Preserve streaming behavior by reconstructing raw Anthropic usage keys from the existing filtered `RequestUsage` when later stream events omit fields from `message_start`.
- Keep compaction iteration details in `details` so compaction-specific accounting remains visible.
- Update Anthropic usage snapshots and add an OTel regression test for duplicate output token attributes.

## Validation

- `uv run pytest tests/models/test_anthropic.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/anthropic.py tests/models/test_anthropic.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/models/anthropic.py tests/models/test_anthropic.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

