### PR TITLE
Exclude first-class token counts from Anthropic `RequestUsage.details` to fix OTel double-counting

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2195,10 +2195,16 @@ class AnthropicCompaction(AbstractCapability[AgentDepsT]):
 
 
 _COMPACTION_TOKEN_KEYS = ('input_tokens', 'output_tokens', 'cache_creation_input_tokens', 'cache_read_input_tokens')
-# The same raw Anthropic token fields all map onto first-class `RequestUsage` fields, so they're
-# excluded from the exposed `RequestUsage.details` to stop OTel consumers double-counting them against
-# the `gen_ai.usage.*` attributes (see `_map_usage` and <https://github.com/pydantic/pydantic-ai/issues/6131>).
-_FIRST_CLASS_TOKEN_KEYS = frozenset(_COMPACTION_TOKEN_KEYS)
+# Raw Anthropic token fields that map onto first-class `RequestUsage` fields, so they're excluded from the
+# exposed `RequestUsage.details` to stop OTel consumers double-counting them against the `gen_ai.usage.*`
+# attributes (see `_map_usage` and <https://github.com/pydantic/pydantic-ai/issues/6131>). Kept as its own
+# literal rather than `frozenset(_COMPACTION_TOKEN_KEYS)`: the two sets share these four keys only because the
+# compaction iteration totals happen to cover exactly the first-class token fields today, but they answer
+# independent questions ("which keys need compaction summing" vs "which keys duplicate a first-class field")
+# and must be free to diverge if Anthropic's usage schema grows.
+_FIRST_CLASS_TOKEN_KEYS = frozenset(
+    {'input_tokens', 'output_tokens', 'cache_creation_input_tokens', 'cache_read_input_tokens'}
+)
 
 
 def _extract_usage_details(response_usage: BetaUsage | BetaMessageDeltaUsage) -> dict[str, int]:
@@ -2278,8 +2284,11 @@ def _map_usage(
     # Note: genai-prices already extracts cache_creation_input_tokens and cache_read_input_tokens
     # from the Anthropic response and maps them to cache_write_tokens and cache_read_tokens.
     # The raw token counts are summed into the first-class `RequestUsage` fields above, so they're
-    # excluded from `details` (see docstring); `compaction_*`/`*_iterations` keys stay as they're
-    # supplementary information not represented by any first-class field.
+    # excluded from `details` (see docstring). The `compaction_iterations`/`message_iterations` counts
+    # stay as they're genuinely supplementary. The `compaction_*` token sub-totals also stay for
+    # transparency, but note they ARE folded into the first-class totals above, so a consumer summing
+    # them against `gen_ai.usage.*` still double-counts under compaction — a known, narrower residual
+    # scoped out of this fix.
     request_usage = usage.RequestUsage.extract(
         dict(model=model, usage=usage_for_extraction),
         provider=provider,

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2195,13 +2195,12 @@ class AnthropicCompaction(AbstractCapability[AgentDepsT]):
 
 
 _COMPACTION_TOKEN_KEYS = ('input_tokens', 'output_tokens', 'cache_creation_input_tokens', 'cache_read_input_tokens')
-# Raw Anthropic token fields that map onto first-class `RequestUsage` fields, so they're excluded from the
-# exposed `RequestUsage.details` to stop OTel consumers double-counting them against the `gen_ai.usage.*`
-# attributes (see `_map_usage` and <https://github.com/pydantic/pydantic-ai/issues/6131>). Kept as its own
-# literal rather than `frozenset(_COMPACTION_TOKEN_KEYS)`: the two sets share these four keys only because the
-# compaction iteration totals happen to cover exactly the first-class token fields today, but they answer
-# independent questions ("which keys need compaction summing" vs "which keys duplicate a first-class field")
-# and must be free to diverge if Anthropic's usage schema grows.
+# Raw Anthropic token fields that a consumer normalizes onto a first-class `RequestUsage` metric (input,
+# output, cache read/write). Excluded from the exposed `RequestUsage.details` so consumers don't add them
+# on top of the canonical `gen_ai.usage.*` totals and double-count (see `_map_usage` and #6131). Kept as
+# its own literal rather than `frozenset(_COMPACTION_TOKEN_KEYS)`: the two sets answer independent questions
+# ("which keys need compaction summing" vs "which keys duplicate a first-class metric") and must be free to
+# diverge if Anthropic's usage schema grows.
 _FIRST_CLASS_TOKEN_KEYS = frozenset(
     {'input_tokens', 'output_tokens', 'cache_creation_input_tokens', 'cache_read_input_tokens'}
 )
@@ -2283,15 +2282,13 @@ def _map_usage(
 
     # Note: genai-prices already extracts cache_creation_input_tokens and cache_read_input_tokens
     # from the Anthropic response and maps them to cache_write_tokens and cache_read_tokens.
-    # The raw token counts are summed into the first-class `RequestUsage` fields above and are excluded
-    # from `details` because their detail keys share the first-class attribute names: e.g.
-    # `gen_ai.usage.details.output_tokens` collides with `gen_ai.usage.output_tokens`, so a consumer
-    # records both against the same metric and double-counts it (#6131).
-    # The `compaction_*` token sub-totals are also folded into the first-class totals, but they are kept:
-    # their `gen_ai.usage.details.compaction_*` attribute names do not collide with any first-class
-    # `gen_ai.usage.*` attribute, so a consumer records them as their own usage-breakdown metric rather
-    # than adding them onto `input_tokens`/`output_tokens` (no double-count of the canonical totals). The
-    # `compaction_iterations`/`message_iterations` counts likewise stay as they're genuinely supplementary.
+    # The raw token counts are summed into the first-class `RequestUsage` fields above and excluded from
+    # `details`: consumers (e.g. Langfuse) map a detail key like `output_tokens`, or the well-known Anthropic
+    # cache field names, back onto the canonical usage metric and add them on top of `gen_ai.usage.*`,
+    # double-counting (#6131). The `compaction_*` sub-totals are also folded into the first-class totals but
+    # kept, because their key names have no canonical metric to collide with — a consumer records them as
+    # their own breakdown rather than re-adding them. `compaction_iterations`/`message_iterations` stay too,
+    # as genuinely supplementary counts.
     request_usage = usage.RequestUsage.extract(
         dict(model=model, usage=usage_for_extraction),
         provider=provider,

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -1034,9 +1034,10 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             provider_details = provider_details or {}
             provider_details['container_id'] = response.container.id
 
+        response_usage, _ = _map_usage(response, self._provider.name, self._provider.base_url, self._model_name)
         return ModelResponse(
             parts=items,
-            usage=_map_usage(response, self._provider.name, self._provider.base_url, self._model_name),
+            usage=response_usage,
             model_name=response.model,
             provider_response_id=response.id,
             provider_name=self._provider.name,
@@ -2194,6 +2195,10 @@ class AnthropicCompaction(AbstractCapability[AgentDepsT]):
 
 
 _COMPACTION_TOKEN_KEYS = ('input_tokens', 'output_tokens', 'cache_creation_input_tokens', 'cache_read_input_tokens')
+# The same raw Anthropic token fields all map onto first-class `RequestUsage` fields, so they're
+# excluded from the exposed `RequestUsage.details` to stop OTel consumers double-counting them against
+# the `gen_ai.usage.*` attributes (see `_map_usage` and <https://github.com/pydantic/pydantic-ai/issues/6131>).
+_FIRST_CLASS_TOKEN_KEYS = frozenset(_COMPACTION_TOKEN_KEYS)
 
 
 def _extract_usage_details(response_usage: BetaUsage | BetaMessageDeltaUsage) -> dict[str, int]:
@@ -2232,8 +2237,17 @@ def _map_usage(
     provider: str,
     provider_url: str,
     model: str,
-    existing_usage: usage.RequestUsage | None = None,
-) -> usage.RequestUsage:
+    existing_details: dict[str, int] | None = None,
+) -> tuple[usage.RequestUsage, dict[str, int]]:
+    """Map an Anthropic usage payload to a `RequestUsage`, alongside the raw token counts to carry forward.
+
+    The returned `dict` retains the raw Anthropic token counts (`input_tokens`, `output_tokens`,
+    `cache_*`) keyed by their API names so that streaming delta events — which may omit input/cache
+    tokens — can inherit them from the `message_start` event by passing it back as `existing_details`.
+    Those raw keys are excluded from the returned `RequestUsage.details`, since they duplicate the
+    first-class `RequestUsage` fields and OTel consumers would otherwise double-count them against the
+    `gen_ai.usage.*` attributes (see <https://github.com/pydantic/pydantic-ai/issues/6131>).
+    """
     if isinstance(message, BetaMessage):
         response_usage = message.usage
     elif isinstance(message, BetaRawMessageStartEvent):
@@ -2243,7 +2257,7 @@ def _map_usage(
             # into `BetaRawMessageStartEvent(message=None)`, violating the type annotation.
             # The metrics chunk's token counts duplicate the canonical `message_start` /
             # `message_delta` usage, so dropping them here avoids double-counting.
-            return existing_usage or usage.RequestUsage()
+            return usage.RequestUsage(), existing_details or {}
         response_usage = message.message.usage
     elif isinstance(message, BetaRawMessageDeltaEvent):
         response_usage = message.usage
@@ -2252,24 +2266,28 @@ def _map_usage(
 
     # In streaming, usage appears in different events.
     # The values are cumulative, meaning new values should replace existing ones entirely.
-    details = (existing_usage.details if existing_usage else {}) | _extract_usage_details(response_usage)
+    raw_details = (existing_details or {}) | _extract_usage_details(response_usage)
 
     # Anthropic reports top-level tokens excluding compaction iteration usage; add the
     # compaction totals back in so the extracted `RequestUsage` reflects the real request cost.
-    usage_for_extraction = dict(details)
+    usage_for_extraction = dict(raw_details)
     for key in _COMPACTION_TOKEN_KEYS:
-        if compaction_value := details.get(f'compaction_{key}'):
+        if compaction_value := raw_details.get(f'compaction_{key}'):
             usage_for_extraction[key] = usage_for_extraction.get(key, 0) + compaction_value
 
     # Note: genai-prices already extracts cache_creation_input_tokens and cache_read_input_tokens
-    # from the Anthropic response and maps them to cache_write_tokens and cache_read_tokens
-    return usage.RequestUsage.extract(
+    # from the Anthropic response and maps them to cache_write_tokens and cache_read_tokens.
+    # The raw token counts are summed into the first-class `RequestUsage` fields above, so they're
+    # excluded from `details` (see docstring); `compaction_*`/`*_iterations` keys stay as they're
+    # supplementary information not represented by any first-class field.
+    request_usage = usage.RequestUsage.extract(
         dict(model=model, usage=usage_for_extraction),
         provider=provider,
         provider_url=provider_url,
         provider_fallback='anthropic',
-        details=details,
+        details={key: value for key, value in raw_details.items() if key not in _FIRST_CLASS_TOKEN_KEYS},
     )
+    return request_usage, raw_details
 
 
 @dataclass
@@ -2281,6 +2299,10 @@ class AnthropicStreamedResponse(StreamedResponse):
     _provider_name: str
     _provider_url: str
     _timestamp: datetime = field(default_factory=_utils.now_utc)
+    # Raw Anthropic token counts carried across `message_start`/`message_delta` events so deltas that
+    # omit input/cache tokens inherit them. Kept separate from `self._usage`, whose `details` excludes
+    # these raw keys to avoid OTel double-counting (see `_map_usage`).
+    _raw_usage_details: dict[str, int] = field(default_factory=dict[str, int], init=False)
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
         with _map_api_errors(self._model_name):
@@ -2294,7 +2316,9 @@ class AnthropicStreamedResponse(StreamedResponse):
                         # as `BetaRawMessageStartEvent(message=None)`. Skip them entirely so we
                         # don't dereference `event.message.id` / `.container` below.
                         continue
-                    self._usage = _map_usage(event, self._provider_name, self._provider_url, self._model_name)
+                    self._usage, self._raw_usage_details = _map_usage(
+                        event, self._provider_name, self._provider_url, self._model_name
+                    )
                     self.provider_response_id = event.message.id
                     if event.message.container:
                         self.provider_details = self.provider_details or {}
@@ -2447,8 +2471,8 @@ class AnthropicStreamedResponse(StreamedResponse):
                         pass
 
                 elif isinstance(event, BetaRawMessageDeltaEvent):
-                    self._usage = _map_usage(
-                        event, self._provider_name, self._provider_url, self._model_name, self._usage
+                    self._usage, self._raw_usage_details = _map_usage(
+                        event, self._provider_name, self._provider_url, self._model_name, self._raw_usage_details
                     )
                     if raw_finish_reason := event.delta.stop_reason:  # pragma: no branch
                         self.provider_details = self.provider_details or {}

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -2283,12 +2283,15 @@ def _map_usage(
 
     # Note: genai-prices already extracts cache_creation_input_tokens and cache_read_input_tokens
     # from the Anthropic response and maps them to cache_write_tokens and cache_read_tokens.
-    # The raw token counts are summed into the first-class `RequestUsage` fields above, so they're
-    # excluded from `details` (see docstring). The `compaction_iterations`/`message_iterations` counts
-    # stay as they're genuinely supplementary. The `compaction_*` token sub-totals also stay for
-    # transparency, but note they ARE folded into the first-class totals above, so a consumer summing
-    # them against `gen_ai.usage.*` still double-counts under compaction — a known, narrower residual
-    # scoped out of this fix.
+    # The raw token counts are summed into the first-class `RequestUsage` fields above and are excluded
+    # from `details` because their detail keys share the first-class attribute names: e.g.
+    # `gen_ai.usage.details.output_tokens` collides with `gen_ai.usage.output_tokens`, so a consumer
+    # records both against the same metric and double-counts it (#6131).
+    # The `compaction_*` token sub-totals are also folded into the first-class totals, but they are kept:
+    # their `gen_ai.usage.details.compaction_*` attribute names do not collide with any first-class
+    # `gen_ai.usage.*` attribute, so a consumer records them as their own usage-breakdown metric rather
+    # than adding them onto `input_tokens`/`output_tokens` (no double-count of the canonical totals). The
+    # `compaction_iterations`/`message_iterations` counts likewise stay as they're genuinely supplementary.
     request_usage = usage.RequestUsage.extract(
         dict(model=model, usage=usage_for_extraction),
         provider=provider,

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -4309,6 +4309,12 @@ def test_streaming_usage():
     delta = BetaRawMessageDeltaEvent(delta=Delta(), usage=BetaMessageDeltaUsage(output_tokens=5), type='message_delta')
     final_usage, _ = _map_usage(delta, 'anthropic', '', 'unknown', existing_details=raw_details)
     assert final_usage == snapshot(RequestUsage(input_tokens=1, output_tokens=5))
+    # Assert the carry-forward explicitly (a snapshot refresh could silently rewrite the line above to
+    # `RequestUsage()`): the delta omits `input_tokens`, so it must be inherited from `message_start` (=1).
+    # Without it, genai-prices — which requires `input_tokens` for Anthropic — zeroes the whole RequestUsage.
+    assert final_usage.input_tokens == 1
+    # #6131: the first-class counts must not leak back into `details` (they would double-count in OTel).
+    assert 'input_tokens' not in final_usage.details and 'output_tokens' not in final_usage.details
 
 
 def test_map_usage_bedrock_start_event_without_message():
@@ -4326,9 +4332,11 @@ def test_map_usage_bedrock_start_event_without_message():
     # A `message=None` event contributes no usage of its own but must not drop the raw token counts
     # carried forward for the next delta event.
     existing_details = {'input_tokens': 7, 'output_tokens': 3}
-    assert _map_usage(start, 'anthropic', '', 'unknown', existing_details=existing_details) == snapshot(
-        (RequestUsage(), {'input_tokens': 7, 'output_tokens': 3})
-    )
+    request_usage, carried = _map_usage(start, 'anthropic', '', 'unknown', existing_details=existing_details)
+    assert (request_usage, carried) == snapshot((RequestUsage(), {'input_tokens': 7, 'output_tokens': 3}))
+    # Explicitly: the `message=None` chunk yields empty usage of its own, but the carried raw counts pass
+    # through untouched so the following delta can still inherit them.
+    assert carried == {'input_tokens': 7, 'output_tokens': 3}
 
 
 async def test_streaming_bedrock_start_event_without_message_is_skipped(allow_model_requests: None):
@@ -4371,6 +4379,10 @@ async def test_streaming_bedrock_start_event_without_message_is_skipped(allow_mo
     response = result.all_messages()[-1]
     assert isinstance(response, ModelResponse)
     assert response.usage == snapshot(RequestUsage(input_tokens=4, output_tokens=2))
+    # Carry-forward across the real `run_stream` path, asserted explicitly so a snapshot refresh can't zero
+    # it: `input_tokens` comes from the real `message_start` (=4) and survives the `message_delta` that
+    # carries only `output_tokens`. A carry-forward regression would zero both.
+    assert (response.usage.input_tokens, response.usage.output_tokens) == (4, 2)
     assert response.provider_response_id == 'x'
     assert response.model_name == 'claude-haiku-4-5'
 
@@ -4425,6 +4437,11 @@ def test_streaming_usage_with_compaction():
             },
         )
     )
+    # Assert the summed totals explicitly: the compaction iteration set on `message_start` (input 180,
+    # output 3, cache 4/5) must survive the delta (which carries no `iterations`) and be added back into the
+    # first-class fields — 23+180+4+5=212 input, 500+3=503 output. A snapshot refresh could otherwise hide it.
+    assert (final_usage.input_tokens, final_usage.output_tokens) == (212, 503)
+    assert (final_usage.cache_write_tokens, final_usage.cache_read_tokens) == (4, 5)
 
 
 def test_usage_otel_attributes_have_no_first_class_token_duplicates():
@@ -11139,6 +11156,10 @@ async def test_anthropic_compaction_usage_with_cache_streaming(allow_model_reque
             requests=1,
         )
     )
+    # The test's whole point, asserted explicitly: the ~55k compaction cache survives the delta resetting
+    # top-level `cache_creation_input_tokens` to 0. A snapshot refresh could otherwise silently drop it to 0.
+    assert usage.cache_write_tokens == 55096
+    assert usage.input_tokens == 55368
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -10259,12 +10259,6 @@ async def test_anthropic_cache_bedrock_real_api(allow_model_requests: None):
             input_tokens=9514,
             cache_read_tokens=9511,
             output_tokens=1944,
-            details={
-                'cache_creation_input_tokens': 0,
-                'cache_read_input_tokens': 9511,
-                'input_tokens': 3,
-                'output_tokens': 1944,
-            },
             requests=1,
         )
     )
@@ -10276,12 +10270,6 @@ async def test_anthropic_cache_bedrock_real_api(allow_model_requests: None):
             cache_write_tokens=1956,
             cache_read_tokens=9511,
             output_tokens=44,
-            details={
-                'cache_creation_input_tokens': 1956,
-                'cache_read_input_tokens': 9511,
-                'input_tokens': 3,
-                'output_tokens': 44,
-            },
             requests=1,
         )
     )

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -309,27 +309,13 @@ async def test_sync_request_text_response(allow_model_requests: None):
 
     result = await agent.run('hello')
     assert result.output == 'world'
-    assert result.usage == snapshot(
-        RunUsage(
-            requests=1,
-            input_tokens=5,
-            output_tokens=10,
-            details={'input_tokens': 5, 'output_tokens': 10},
-        )
-    )
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=5, output_tokens=10))
     # reset the index so we get the same response again
     mock_client.index = 0  # type: ignore
 
     result = await agent.run('hello', message_history=result.new_messages())
     assert result.output == 'world'
-    assert result.usage == snapshot(
-        RunUsage(
-            requests=1,
-            input_tokens=5,
-            output_tokens=10,
-            details={'input_tokens': 5, 'output_tokens': 10},
-        )
-    )
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=5, output_tokens=10))
     assert result.all_messages() == snapshot(
         [
             ModelRequest(
@@ -340,7 +326,7 @@ async def test_sync_request_text_response(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[TextPart(content='world')],
-                usage=RequestUsage(input_tokens=5, output_tokens=10, details={'input_tokens': 5, 'output_tokens': 10}),
+                usage=RequestUsage(input_tokens=5, output_tokens=10),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -359,7 +345,7 @@ async def test_sync_request_text_response(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[TextPart(content='world')],
-                usage=RequestUsage(input_tokens=5, output_tokens=10, details={'input_tokens': 5, 'output_tokens': 10}),
+                usage=RequestUsage(input_tokens=5, output_tokens=10),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -391,19 +377,7 @@ async def test_async_request_prompt_caching(allow_model_requests: None):
     result = await agent.run('hello')
     assert result.output == 'world'
     assert result.usage == snapshot(
-        RunUsage(
-            requests=1,
-            input_tokens=13,
-            cache_write_tokens=4,
-            cache_read_tokens=6,
-            output_tokens=5,
-            details={
-                'input_tokens': 3,
-                'output_tokens': 5,
-                'cache_creation_input_tokens': 4,
-                'cache_read_input_tokens': 6,
-            },
-        )
+        RunUsage(requests=1, input_tokens=13, cache_write_tokens=4, cache_read_tokens=6, output_tokens=5)
     )
     last_message = result.all_messages()[-1]
     assert isinstance(last_message, ModelResponse)
@@ -1853,14 +1827,7 @@ async def test_async_request_text_response(allow_model_requests: None):
 
     result = await agent.run('hello')
     assert result.output == 'world'
-    assert result.usage == snapshot(
-        RunUsage(
-            requests=1,
-            input_tokens=3,
-            output_tokens=5,
-            details={'input_tokens': 3, 'output_tokens': 5},
-        )
-    )
+    assert result.usage == snapshot(RunUsage(requests=1, input_tokens=3, output_tokens=5))
 
 
 async def test_request_stream_fallback_for_high_max_tokens(
@@ -1891,16 +1858,7 @@ async def test_request_stream_fallback_for_high_max_tokens(
             ),
             ModelResponse(
                 parts=[TextPart(content='2')],
-                usage=RequestUsage(
-                    input_tokens=20,
-                    output_tokens=5,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 20,
-                        'output_tokens': 5,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=20, output_tokens=5),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -1943,7 +1901,7 @@ async def test_request_structured_response(allow_model_requests: None):
                         tool_call_id='123',
                     )
                 ],
-                usage=RequestUsage(input_tokens=3, output_tokens=5, details={'input_tokens': 3, 'output_tokens': 5}),
+                usage=RequestUsage(input_tokens=3, output_tokens=5),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -2019,7 +1977,7 @@ async def test_request_tool_call(allow_model_requests: None):
                         tool_call_id='1',
                     )
                 ],
-                usage=RequestUsage(input_tokens=2, output_tokens=1, details={'input_tokens': 2, 'output_tokens': 1}),
+                usage=RequestUsage(input_tokens=2, output_tokens=1),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -2052,7 +2010,7 @@ async def test_request_tool_call(allow_model_requests: None):
                         tool_call_id='2',
                     )
                 ],
-                usage=RequestUsage(input_tokens=3, output_tokens=2, details={'input_tokens': 3, 'output_tokens': 2}),
+                usage=RequestUsage(input_tokens=3, output_tokens=2),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -2079,7 +2037,7 @@ async def test_request_tool_call(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[TextPart(content='final response')],
-                usage=RequestUsage(input_tokens=3, output_tokens=5, details={'input_tokens': 3, 'output_tokens': 5}),
+                usage=RequestUsage(input_tokens=3, output_tokens=5),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='anthropic',
@@ -2420,21 +2378,12 @@ async def test_stream_structured(allow_model_requests: None):
         # the block starts and once when it ends.
         assert chunks == snapshot(['FINAL_PAYLOAD', 'FINAL_PAYLOAD'])
         assert result.is_complete
-        assert result.usage == snapshot(
-            RunUsage(
-                requests=2,
-                input_tokens=20,
-                output_tokens=5,
-                tool_calls=1,
-                details={'input_tokens': 20, 'output_tokens': 5},
-            )
-        )
+        assert result.usage == snapshot(RunUsage(requests=2, input_tokens=20, output_tokens=5, tool_calls=1))
         assert tool_called
         async for response in result.stream_response(debounce_by=None):
             assert response == snapshot(
                 ModelResponse(
                     parts=[TextPart(content='FINAL_PAYLOAD')],
-                    usage=RequestUsage(details={'input_tokens': 0, 'output_tokens': 0}),
                     model_name='claude-3-5-haiku-123',
                     timestamp=IsDatetime(),
                     provider_name='anthropic',
@@ -2972,16 +2921,7 @@ async def test_anthropic_model_instructions(allow_model_requests: None, anthropi
             ),
             ModelResponse(
                 parts=[TextPart(content='The capital of France is Paris.')],
-                usage=RequestUsage(
-                    input_tokens=20,
-                    output_tokens=10,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 20,
-                        'output_tokens': 10,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=20, output_tokens=10),
                 model_name='claude-3-opus-20240229',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3019,16 +2959,7 @@ async def test_anthropic_model_thinking_part(allow_model_requests: None, anthrop
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=43,
-                    output_tokens=321,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 43,
-                        'output_tokens': 321,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=43, output_tokens=321),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3088,16 +3019,7 @@ I should provide practical advice for different methods of crossing a river.\
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=354,
-                    output_tokens=525,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 354,
-                        'output_tokens': 525,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=354, output_tokens=525),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3143,16 +3065,7 @@ async def test_anthropic_model_thinking_part_redacted(allow_model_requests: None
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=92,
-                    output_tokens=196,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 92,
-                        'output_tokens': 196,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=92, output_tokens=196),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3193,16 +3106,7 @@ async def test_anthropic_model_thinking_part_redacted(allow_model_requests: None
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=168,
-                    output_tokens=232,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 168,
-                        'output_tokens': 232,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=168, output_tokens=232),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3262,16 +3166,7 @@ async def test_anthropic_model_thinking_part_redacted_stream(allow_model_request
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=92,
-                    output_tokens=189,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 92,
-                        'output_tokens': 189,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=92, output_tokens=189),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3478,16 +3373,7 @@ async def test_anthropic_model_thinking_part_from_other_model(
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=1343,
-                    output_tokens=538,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 1343,
-                        'output_tokens': 538,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=1343, output_tokens=538),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -3538,16 +3424,7 @@ async def test_anthropic_model_thinking_part_stream(allow_model_requests: None, 
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=43,
-                    output_tokens=282,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 43,
-                        'output_tokens': 282,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=43, output_tokens=282),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -4356,27 +4233,14 @@ def anth_msg(usage: BetaUsage) -> BetaMessage:
     [
         pytest.param(
             lambda: anth_msg(BetaUsage(input_tokens=1, output_tokens=1)),
-            snapshot(RequestUsage(input_tokens=1, output_tokens=1, details={'input_tokens': 1, 'output_tokens': 1})),
+            snapshot(RequestUsage(input_tokens=1, output_tokens=1)),
             id='AnthropicMessage',
         ),
         pytest.param(
             lambda: anth_msg(
                 BetaUsage(input_tokens=1, output_tokens=1, cache_creation_input_tokens=2, cache_read_input_tokens=3)
             ),
-            snapshot(
-                RequestUsage(
-                    input_tokens=6,
-                    cache_write_tokens=2,
-                    cache_read_tokens=3,
-                    output_tokens=1,
-                    details={
-                        'cache_creation_input_tokens': 2,
-                        'cache_read_input_tokens': 3,
-                        'input_tokens': 1,
-                        'output_tokens': 1,
-                    },
-                )
-            ),
+            snapshot(RequestUsage(input_tokens=6, cache_write_tokens=2, cache_read_tokens=3, output_tokens=1)),
             id='AnthropicMessage-cached',
         ),
         pytest.param(
@@ -4410,8 +4274,6 @@ def anth_msg(usage: BetaUsage) -> BetaMessage:
                     cache_write_tokens=4,
                     cache_read_tokens=5,
                     details={
-                        'input_tokens': 23,
-                        'output_tokens': 1,
                         'compaction_iterations': 1,
                         'message_iterations': 1,
                         'compaction_input_tokens': 180,
@@ -4427,7 +4289,7 @@ def anth_msg(usage: BetaUsage) -> BetaMessage:
             lambda: BetaRawMessageStartEvent(
                 message=anth_msg(BetaUsage(input_tokens=1, output_tokens=1)), type='message_start'
             ),
-            snapshot(RequestUsage(input_tokens=1, output_tokens=1, details={'input_tokens': 1, 'output_tokens': 1})),
+            snapshot(RequestUsage(input_tokens=1, output_tokens=1)),
             id='RawMessageStartEvent',
         ),
     ],
@@ -4435,17 +4297,18 @@ def anth_msg(usage: BetaUsage) -> BetaMessage:
 def test_usage(
     message_callback: Callable[[], BetaMessage | BetaRawMessageStartEvent | BetaRawMessageDeltaEvent], usage: RunUsage
 ):
-    assert _map_usage(message_callback(), 'anthropic', '', 'unknown') == usage
+    request_usage, _ = _map_usage(message_callback(), 'anthropic', '', 'unknown')
+    assert request_usage == usage
 
 
 def test_streaming_usage():
+    """A delta event without `input_tokens` must inherit it from the `message_start` event, while the
+    exposed `details` excludes the raw token keys that duplicate first-class fields (#6131)."""
     start = BetaRawMessageStartEvent(message=anth_msg(BetaUsage(input_tokens=1, output_tokens=1)), type='message_start')
-    initial_usage = _map_usage(start, 'anthropic', '', 'unknown')
+    _, raw_details = _map_usage(start, 'anthropic', '', 'unknown')
     delta = BetaRawMessageDeltaEvent(delta=Delta(), usage=BetaMessageDeltaUsage(output_tokens=5), type='message_delta')
-    final_usage = _map_usage(delta, 'anthropic', '', 'unknown', existing_usage=initial_usage)
-    assert final_usage == snapshot(
-        RequestUsage(input_tokens=1, output_tokens=5, details={'input_tokens': 1, 'output_tokens': 5})
-    )
+    final_usage, _ = _map_usage(delta, 'anthropic', '', 'unknown', existing_details=raw_details)
+    assert final_usage == snapshot(RequestUsage(input_tokens=1, output_tokens=5))
 
 
 def test_map_usage_bedrock_start_event_without_message():
@@ -4458,10 +4321,14 @@ def test_map_usage_bedrock_start_event_without_message():
     """
     # `model_construct` skips validation, mirroring the SDK's `construct_type` on Bedrock.
     start = BetaRawMessageStartEvent.model_construct(type='message_start', message=None)
-    assert _map_usage(start, 'anthropic', '', 'unknown') == snapshot(RequestUsage())
+    assert _map_usage(start, 'anthropic', '', 'unknown') == snapshot((RequestUsage(), {}))
 
-    existing = RequestUsage(input_tokens=7, output_tokens=3)
-    assert _map_usage(start, 'anthropic', '', 'unknown', existing_usage=existing) == existing
+    # A `message=None` event contributes no usage of its own but must not drop the raw token counts
+    # carried forward for the next delta event.
+    existing_details = {'input_tokens': 7, 'output_tokens': 3}
+    assert _map_usage(start, 'anthropic', '', 'unknown', existing_details=existing_details) == snapshot(
+        (RequestUsage(), {'input_tokens': 7, 'output_tokens': 3})
+    )
 
 
 async def test_streaming_bedrock_start_event_without_message_is_skipped(allow_model_requests: None):
@@ -4503,9 +4370,7 @@ async def test_streaming_bedrock_start_event_without_message_is_skipped(allow_mo
     # name falls back to the configured id because the peeked-first chunk carried no `message.model`.
     response = result.all_messages()[-1]
     assert isinstance(response, ModelResponse)
-    assert response.usage == snapshot(
-        RequestUsage(input_tokens=4, output_tokens=2, details={'input_tokens': 4, 'output_tokens': 2})
-    )
+    assert response.usage == snapshot(RequestUsage(input_tokens=4, output_tokens=2))
     assert response.provider_response_id == 'x'
     assert response.model_name == 'claude-haiku-4-5'
 
@@ -4539,11 +4404,11 @@ def test_streaming_usage_with_compaction():
         ),
         type='message_start',
     )
-    initial_usage = _map_usage(start, 'anthropic', '', 'unknown')
+    _, raw_details = _map_usage(start, 'anthropic', '', 'unknown')
     delta = BetaRawMessageDeltaEvent(
         delta=Delta(), usage=BetaMessageDeltaUsage(input_tokens=23, output_tokens=500), type='message_delta'
     )
-    final_usage = _map_usage(delta, 'anthropic', '', 'unknown', existing_usage=initial_usage)
+    final_usage, _ = _map_usage(delta, 'anthropic', '', 'unknown', existing_details=raw_details)
     assert final_usage == snapshot(
         RequestUsage(
             input_tokens=212,
@@ -4551,8 +4416,6 @@ def test_streaming_usage_with_compaction():
             cache_write_tokens=4,
             cache_read_tokens=5,
             details={
-                'input_tokens': 23,
-                'output_tokens': 500,
                 'compaction_iterations': 1,
                 'message_iterations': 1,
                 'compaction_input_tokens': 180,
@@ -4562,6 +4425,32 @@ def test_streaming_usage_with_compaction():
             },
         )
     )
+
+
+def test_usage_otel_attributes_have_no_first_class_token_duplicates():
+    """The raw Anthropic token counts must not leak into `details`, otherwise `opentelemetry_attributes()`
+    emits them under both `gen_ai.usage.*` and `gen_ai.usage.details.*`, and consumers like Langfuse
+    double-count tokens and cost (https://github.com/pydantic/pydantic-ai/issues/6131)."""
+    message = anth_msg(
+        BetaUsage(input_tokens=10, output_tokens=20, cache_creation_input_tokens=2, cache_read_input_tokens=3)
+    )
+    request_usage, _ = _map_usage(message, 'anthropic', '', 'unknown')
+    attributes = request_usage.opentelemetry_attributes()
+    assert attributes == snapshot(
+        {
+            'gen_ai.usage.input_tokens': 15,
+            'gen_ai.usage.output_tokens': 20,
+            'gen_ai.usage.cache_creation.input_tokens': 2,
+            'gen_ai.usage.cache_read.input_tokens': 3,
+            'gen_ai.usage.details.cache_write_tokens': 2,
+            'gen_ai.usage.details.cache_read_tokens': 3,
+        }
+    )
+    # The raw token counts appear only as first-class attributes, never duplicated under `details.*`.
+    assert 'gen_ai.usage.details.input_tokens' not in attributes
+    assert 'gen_ai.usage.details.output_tokens' not in attributes
+    assert 'gen_ai.usage.details.cache_creation_input_tokens' not in attributes
+    assert 'gen_ai.usage.details.cache_read_input_tokens' not in attributes
 
 
 async def test_anthropic_model_empty_message_on_history(allow_model_requests: None, anthropic_api_key: str):
@@ -4779,16 +4668,7 @@ Overall, it's a pleasant day in San Francisco with mild temperatures and mostly 
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=8984,
-                    output_tokens=520,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 8984,
-                        'output_tokens': 520,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=8984, output_tokens=520),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -4982,16 +4862,7 @@ Mexico City is experiencing typical rainy season weather with moderate temperatu
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=19859,
-                    output_tokens=544,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 19859,
-                        'output_tokens': 544,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=19859, output_tokens=544),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -5269,16 +5140,7 @@ So for today, you can expect partly sunny to sunny skies with a high around 76°
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=22397,
-                    output_tokens=637,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 22397,
-                        'output_tokens': 637,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=22397, output_tokens=637),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -5932,16 +5794,7 @@ Let me fetch the page first.\
                         content='Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications and workflows with Generative AI.'
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=7262,
-                    output_tokens=171,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 7262,
-                        'output_tokens': 171,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=7262, output_tokens=171),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -6017,16 +5870,7 @@ Let me fetch the page first.\
                         content='Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications and workflows with Generative AI.'
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=7262,
-                    output_tokens=171,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 7262,
-                        'output_tokens': 171,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=7262, output_tokens=171),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -6081,16 +5925,7 @@ It notes that "virtually every Python agent framework and LLM library" uses Pyda
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=6346,
-                    output_tokens=354,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 6346,
-                        'output_tokens': 354,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=6346, output_tokens=354),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -6186,16 +6021,7 @@ async def test_anthropic_web_fetch_tool_stream(
                         content='Pydantic AI is a Python agent framework designed to help you quickly, confidently, and painlessly build production grade applications and workflows with Generative AI.'
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=7244,
-                    output_tokens=153,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 7244,
-                        'output_tokens': 153,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=7244, output_tokens=153),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -6855,16 +6681,7 @@ The repo is organized as a monorepo with core packages like `pydantic-ai-slim` (
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=2674,
-                    output_tokens=373,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 2674,
-                        'output_tokens': 373,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=2674, output_tokens=373),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -6996,16 +6813,7 @@ Pydantic ensures runtime data integrity through type hints and is foundational t
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=5262,
-                    output_tokens=369,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 5262,
-                        'output_tokens': 369,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=5262, output_tokens=369),
                 model_name='claude-sonnet-4-20250514',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -7111,16 +6919,7 @@ It's designed to simplify building robust, production-ready AI agents while abst
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=3042,
-                    output_tokens=354,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 3042,
-                        'output_tokens': 354,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=3042, output_tokens=354),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -7365,16 +7164,7 @@ async def test_anthropic_code_execution_tool(allow_model_requests: None, anthrop
                     ),
                     TextPart(content='The result of **3 × 12,390 = 37,170**.'),
                 ],
-                usage=RequestUsage(
-                    input_tokens=4692,
-                    output_tokens=106,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 4692,
-                        'output_tokens': 106,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=4692, output_tokens=106),
                 model_name='claude-sonnet-4-6',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -7432,16 +7222,7 @@ async def test_anthropic_code_execution_tool(allow_model_requests: None, anthrop
                     ),
                     TextPart(content='**4 × 12,390 = 49,560**'),
                 ],
-                usage=RequestUsage(
-                    input_tokens=4690,
-                    output_tokens=103,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 4690,
-                        'output_tokens': 103,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=4690, output_tokens=103),
                 model_name='claude-sonnet-4-6',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -7533,16 +7314,7 @@ Following the standard **order of operations (PEMDAS/BODMAS)** — multiplicatio
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=4714,
-                    output_tokens=304,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 4714,
-                        'output_tokens': 304,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=4714, output_tokens=304),
                 model_name='claude-sonnet-4-6',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8001,16 +7773,7 @@ async def test_anthropic_tool_output(allow_model_requests: None, anthropic_api_k
                 parts=[
                     ToolCallPart(tool_name='get_user_country', args={}, tool_call_id='toolu_01X9wcHKKAZD9tBC711xipPa')
                 ],
-                usage=RequestUsage(
-                    input_tokens=445,
-                    output_tokens=23,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 445,
-                        'output_tokens': 23,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=445, output_tokens=23),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8042,16 +7805,7 @@ async def test_anthropic_tool_output(allow_model_requests: None, anthropic_api_k
                         tool_call_id='toolu_01LZABsgreMefH2Go8D5PQbW',
                     )
                 ],
-                usage=RequestUsage(
-                    input_tokens=497,
-                    output_tokens=56,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 497,
-                        'output_tokens': 56,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=497, output_tokens=56),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8118,16 +7872,7 @@ async def test_anthropic_text_output_function(allow_model_requests: None, anthro
                     ),
                     ToolCallPart(tool_name='get_user_country', args={}, tool_call_id='toolu_01JJ8TequDsrEU2pv1QFRWAK'),
                 ],
-                usage=RequestUsage(
-                    input_tokens=383,
-                    output_tokens=65,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 383,
-                        'output_tokens': 65,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=383, output_tokens=65),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8157,16 +7902,7 @@ async def test_anthropic_text_output_function(allow_model_requests: None, anthro
                         content='Based on the result, you are located in Mexico. The largest city in Mexico is Mexico City (Ciudad de México), which is both the capital and the most populous city in the country. With a population of approximately 9.2 million people in the city proper and over 21 million people in its metropolitan area, Mexico City is not only the largest city in Mexico but also one of the largest cities in the world.'
                     )
                 ],
-                usage=RequestUsage(
-                    input_tokens=460,
-                    output_tokens=91,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 460,
-                        'output_tokens': 91,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=460, output_tokens=91),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8217,16 +7953,7 @@ async def test_anthropic_prompted_output(allow_model_requests: None, anthropic_a
                 parts=[
                     ToolCallPart(tool_name='get_user_country', args={}, tool_call_id='toolu_01ArHq5f2wxRpRF2PVQcKExM')
                 ],
-                usage=RequestUsage(
-                    input_tokens=459,
-                    output_tokens=38,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 459,
-                        'output_tokens': 38,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=459, output_tokens=38),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8252,16 +7979,7 @@ async def test_anthropic_prompted_output(allow_model_requests: None, anthropic_a
             ),
             ModelResponse(
                 parts=[TextPart(content='{"city": "Mexico City", "country": "Mexico"}')],
-                usage=RequestUsage(
-                    input_tokens=510,
-                    output_tokens=17,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 510,
-                        'output_tokens': 17,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=510, output_tokens=17),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8311,16 +8029,7 @@ async def test_anthropic_prompted_output_multiple(allow_model_requests: None, an
                         content='{"result": {"kind": "CityLocation", "data": {"city": "Mexico City", "country": "Mexico"}}}'
                     )
                 ],
-                usage=RequestUsage(
-                    input_tokens=265,
-                    output_tokens=31,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 265,
-                        'output_tokens': 31,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=265, output_tokens=31),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -8630,16 +8339,7 @@ Everything looks perfect! 🎉\
 """
                     ),
                 ],
-                usage=RequestUsage(
-                    input_tokens=10490,
-                    output_tokens=469,
-                    details={
-                        'input_tokens': 10490,
-                        'output_tokens': 469,
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=10490, output_tokens=469),
                 model_name='claude-sonnet-4-6',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -10468,12 +10168,6 @@ async def test_anthropic_cache_real_api(allow_model_requests: None, anthropic_ap
             input_tokens=1114,
             cache_read_tokens=1111,
             output_tokens=406,
-            details={
-                'cache_creation_input_tokens': 0,
-                'cache_read_input_tokens': 1111,
-                'input_tokens': 3,
-                'output_tokens': 406,
-            },
             requests=1,
         )
     )
@@ -10485,12 +10179,6 @@ async def test_anthropic_cache_real_api(allow_model_requests: None, anthropic_ap
             cache_read_tokens=1111,
             cache_write_tokens=418,
             output_tokens=33,
-            details={
-                'cache_creation_input_tokens': 418,
-                'cache_read_input_tokens': 1111,
-                'input_tokens': 3,
-                'output_tokens': 33,
-            },
             requests=1,
         )
     )
@@ -10521,12 +10209,6 @@ async def test_anthropic_cache_count_tokens(allow_model_requests: None, anthropi
             input_tokens=1114,
             cache_read_tokens=1111,
             output_tokens=414,
-            details={
-                'cache_creation_input_tokens': 0,
-                'cache_read_input_tokens': 1111,
-                'input_tokens': 3,
-                'output_tokens': 414,
-            },
             requests=1,
         )
     )
@@ -10837,16 +10519,7 @@ async def test_anthropic_code_execution_tool_container_reuse(allow_model_request
                     ),
                     TextPart(content='3 * 12390 = **37,170**'),
                 ],
-                usage=RequestUsage(
-                    input_tokens=4612,
-                    output_tokens=80,
-                    details={
-                        'input_tokens': 4612,
-                        'output_tokens': 80,
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=4612, output_tokens=80),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -10889,16 +10562,7 @@ async def test_anthropic_code_execution_tool_container_reuse(allow_model_request
                     ),
                     TextPart(content='4 * 12390 = **49,560**'),
                 ],
-                usage=RequestUsage(
-                    input_tokens=4840,
-                    output_tokens=80,
-                    details={
-                        'input_tokens': 4840,
-                        'output_tokens': 80,
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=4840, output_tokens=80),
                 model_name='claude-sonnet-4-5-20250929',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -11036,7 +10700,7 @@ async def test_anthropic_malformed_tool_args_no_crash(allow_model_requests: None
             ),
             ModelResponse(
                 parts=[TextPart(content='Here is the corrected result.')],
-                usage=RequestUsage(input_tokens=10, output_tokens=5, details={'input_tokens': 10, 'output_tokens': 5}),
+                usage=RequestUsage(input_tokens=10, output_tokens=5),
                 model_name='claude-3-5-haiku-123',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -11148,7 +10812,7 @@ async def test_stream_cancel(allow_model_requests: None):
             ),
             ModelResponse(
                 parts=[TextPart(content='hello ')],
-                usage=RequestUsage(input_tokens=5, details={'input_tokens': 5, 'output_tokens': 0}),
+                usage=RequestUsage(input_tokens=5),
                 model_name='claude-haiku-4-5-123',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',
@@ -11442,10 +11106,6 @@ async def test_anthropic_compaction_usage_with_cache(allow_model_requests: None,
             cache_write_tokens=55096,
             output_tokens=90,
             details={
-                'input_tokens': 180,
-                'output_tokens': 8,
-                'cache_creation_input_tokens': 0,
-                'cache_read_input_tokens': 0,
                 'compaction_iterations': 1,
                 'message_iterations': 1,
                 'compaction_input_tokens': 100,
@@ -11482,10 +11142,6 @@ async def test_anthropic_compaction_usage_with_cache_streaming(allow_model_reque
             cache_write_tokens=55096,
             output_tokens=76,
             details={
-                'input_tokens': 172,
-                'output_tokens': 5,
-                'cache_creation_input_tokens': 0,
-                'cache_read_input_tokens': 0,
                 'compaction_iterations': 1,
                 'message_iterations': 1,
                 'compaction_input_tokens': 100,

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -3388,16 +3388,7 @@ async def test_openai_responses_thinking_part_from_other_model(
                     ),
                     TextPart(content=IsStr()),
                 ],
-                usage=RequestUsage(
-                    input_tokens=42,
-                    output_tokens=291,
-                    details={
-                        'cache_creation_input_tokens': 0,
-                        'cache_read_input_tokens': 0,
-                        'input_tokens': 42,
-                        'output_tokens': 291,
-                    },
-                ),
+                usage=RequestUsage(input_tokens=42, output_tokens=291),
                 model_name='claude-sonnet-4-6',
                 timestamp=IsDatetime(),
                 provider_name='anthropic',


### PR DESCRIPTION
- Closes #6131

## Summary

The Anthropic adapter's `_map_usage` copied the raw API token fields (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`) into `RequestUsage.details`. Since these duplicate the first-class `RequestUsage` fields, `opentelemetry_attributes()` emitted each value twice — once as `gen_ai.usage.output_tokens` and once as `gen_ai.usage.details.output_tokens` — so consumers like Langfuse summed them and doubled reported output tokens and cost. (`RunUsage.incr`, which sums `details`, was affected too.)

The OpenAI adapter already filters these keys; this brings Anthropic in line.

## Why it's not a one-line strip

`details` did double duty as the **streaming merge carrier**: Anthropic `message_delta` events may omit `input_tokens`, so the raw counts were carried forward from `message_start` via `existing_usage.details` (added in #3111). Simply stripping the stored `details` regresses that carry-forward (the existing `test_streaming_usage`, where the delta has no `input_tokens`, would drop to `input_tokens=0`). genai-prices also folds cache tokens into `input_tokens`, so the raw per-event values can't be reliably reconstructed from the first-class fields.

So the fix **decouples the two roles**: `_map_usage` now returns the `RequestUsage` (with the raw token keys excluded from `details`) alongside the raw counts, and `AnthropicStreamedResponse` threads those raw counts in a separate field. `self._usage.details` is always clean, while streaming carry-forward still works. Pricing is unaffected — it reads the `usage=` field, not `details`. Compaction/iteration keys remain in `details` as they're genuinely supplementary.

## Tests

- New `test_usage_otel_attributes_have_no_first_class_token_duplicates` asserts `opentelemetry_attributes()` (the method emitted on the model-request span) no longer contains `gen_ai.usage.details.{input,output}_tokens`.
- Updated the direct `_map_usage` unit tests; `test_streaming_usage` now explicitly pins carry-forward (delta without `input_tokens` → result keeps `input_tokens=1`, `details` empty).
- Public-API snapshots updated to drop the duplicated detail keys; first-class token counts are unchanged. The end-to-end `agent.run_stream` test `test_streaming_bedrock_start_event_without_message_is_skipped` covers the real streaming path.

Scoped to Anthropic only — OpenAI already filters these keys and Bedrock builds `RequestUsage` directly.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

