### PR TITLE
docs: add pydantic-ai-mimir to third-party toolsets

### DIFF
--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -911,6 +911,12 @@ Toolsets for sandboxed code execution help agents run code in a sandboxed enviro
 
 * [`mcp-run-python`](https://github.com/pydantic/mcp-run-python) - MCP server by the Pydantic team that runs Python code in a sandboxed environment. Can be used as `MCPToolset(StdioTransport(command='uv', args=['run', 'mcp-run-python', 'stdio']))`.
 
+### Memory
+
+Toolsets that give agents persistent memory across runs:
+
+* [`pydantic-ai-mimir`](https://pypi.org/project/pydantic-ai-mimir/) - `MimirToolset` (an `MCPToolset` subclass) wires up [Mimir](https://github.com/Perseus-Computing-LLC/pydantic-ai-mimir), a local-first, encrypted, MIT-licensed persistent-memory MCP server, as a one-line toolset. `MimirToolset(db_path=...)` spawns `mimir serve` over an MCP `StdioTransport` and exposes Mimir's memory tools (`mimir_remember`, `mimir_recall`, etc.) to the agent.
+
 ### LangChain Tools {#langchain-tools}
 
 If you'd like to use tools or a [toolkit](https://python.langchain.com/docs/concepts/tools/#toolkits) from LangChain's [community tool library](https://python.langchain.com/docs/integrations/tools/) with Pydantic AI, you can use the [`LangChainToolset`][pydantic_ai.ext.langchain.LangChainToolset] which takes a list of LangChain tools. Note that Pydantic AI will not validate the arguments in this case -- it's up to the model to provide arguments matching the schema specified by the LangChain tool, and up to the LangChain tool to raise an error if the arguments are invalid.


### PR DESCRIPTION
Adds an entry for [`pydantic-ai-mimir`](https://pypi.org/project/pydantic-ai-mimir/) to the Third-Party Toolsets section of `docs/toolsets.md`, under a new **Memory** category (alongside the existing Task Management, File Operations, and Code Execution categories).

`pydantic-ai-mimir` provides `MimirToolset`, an `MCPToolset` subclass that wires up [Mimir](https://github.com/Perseus-Computing-LLC/pydantic-ai-mimir) — a local-first, encrypted, MIT-licensed persistent-memory MCP server — as a one-line toolset for a Pydantic AI agent.

- Package: https://pypi.org/project/pydantic-ai-mimir/ (`pip install pydantic-ai-mimir`)
- Repo: https://github.com/Perseus-Computing-LLC/pydantic-ai-mimir

Docs-only change; matches the format of the existing entries.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

