### PR TITLE
docs: clarify `end_strategy` values in agent spec

### DIFF
--- a/docs/agent-spec.md
+++ b/docs/agent-spec.md
@@ -131,7 +131,7 @@ The [`AgentSpec`][pydantic_ai.agent.spec.AgentSpec] model represents the full sp
 | `deps_schema` | `dict \| None` | JSON Schema for [template string](#template-strings) validation (see below) |
 | `output_schema` | `dict \| None` | JSON Schema for [structured output](output.md) (see below) |
 | `retries` | `int \| AgentRetries \| None` | Retry budgets for [tools](tools-advanced.md#tool-retries) and [output validation](output.md#output-validator-functions). Pass an integer to use the same budget for both, or [`AgentRetries`][pydantic_ai.agent.AgentRetries] to configure them separately. |
-| `end_strategy` | `EndStrategy` | When to stop (`'early'` or `'exhaustive'`) |
+| `end_strategy` | `EndStrategy` | When to stop (`'early'`, `'graceful'`, or `'exhaustive'`) |
 | `tool_timeout` | `float \| None` | Default [tool](tools.md) timeout in seconds |
 | `instrument` | `bool \| None` | Enable [Logfire](logfire.md) instrumentation |
 | `metadata` | `dict \| None` | Agent [metadata](agent.md#run-metadata) |


### PR DESCRIPTION
This keeps agents and spec-driven readers from making decisions from stale docs and carrying an outdated `end_strategy` assumption into their context.

## What Problem This Solves

`docs/agent-spec.md` documented `end_strategy` as accepting only `'early'` or `'exhaustive'`.

The actual `EndStrategy` type is `Literal['early', 'graceful', 'exhaustive']`, and `AgentSpec.end_strategy` defaults to `'graceful'`. Leaving the agent spec docs behind the code can mislead readers and spec-driven agent/context configuration into treating the default strategy as unavailable.

## Recommendation

This should be updated because `agent-spec.md` acts as the declarative contract readers use when configuring agents from specs. If it omits the current default, downstream examples, generated configs, or agent-context setup can incorrectly treat `'graceful'` as invalid or unsupported, creating avoidable context/configuration confusion even though the runtime already supports it.

## Change

- Add `'graceful'` to the `end_strategy` values listed in the `AgentSpec` field table.

## Evidence

- `pydantic_ai_slim/pydantic_ai/_agent_graph.py` defines `EndStrategy = Literal['early', 'graceful', 'exhaustive']`.
- `pydantic_ai_slim/pydantic_ai/agent/spec.py` sets `end_strategy: EndStrategy = 'graceful'`.

## Validation

- `rg -n "end_strategy|EndStrategy|graceful|exhaustive" docs/agent-spec.md pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/agent/spec.py`
- `git diff --check`

`uv run pre-commit run no-rst-syntax --files docs/agent-spec.md` was attempted, but `pre-commit` is not installed in the current environment (`program not found`).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

