### PR TITLE
fix: de-duplicate `output_audio_tokens` accumulation in `_incr_usage_tokens`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -236,7 +236,6 @@ def _incr_usage_tokens(slf: RunUsage | RequestUsage, incr_usage: RunUsage | Requ
     slf.cache_audio_read_tokens += incr_usage.cache_audio_read_tokens
     slf.output_audio_tokens += incr_usage.output_audio_tokens
     slf.output_tokens += incr_usage.output_tokens
-    slf.output_audio_tokens += incr_usage.output_audio_tokens
 
     for key, value in incr_usage.details.items():
         # Note: value can be None at runtime from model responses despite the type annotation


### PR DESCRIPTION
`_incr_usage_tokens` was applying `output_audio_tokens` twice, double-counting audio output tokens in every `RequestUsage`/`RunUsage` accumulation (e.g. `incr(15)` then `incr(8)` produced `31` instead of `23`).

The duplicate line was introduced by two PRs that independently fixed the same "missing `output_audio_tokens` accumulation" bug, unaware of each other:

- https://github.com/pydantic/pydantic-ai/pull/4594 added the accumulation grouped with the other audio fields
- https://github.com/pydantic/pydantic-ai/pull/5904 added an identical accumulation line after `output_tokens`

Each was green in isolation, but once both merged `_incr_usage_tokens` summed `output_audio_tokens` twice, turning `main` red repo-wide. This PR removes the orphaned duplicate (keeping the one grouped with the other audio fields).

The existing tests `test_output_audio_tokens_increment` and `test_add_usages` now pass with no snapshot change — their assertions already encode the correct single-count semantics (`15 + 8 = 23`, `output_audio_tokens=140`), so they serve as the regression guard and no new test is needed. This unblocks CI on all open PRs.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

