### PR TITLE
Fix absolute `schema_path` handling in `Dataset.to_file`

### DIFF
--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -925,11 +925,11 @@ def _get_relative_path_reference(target: Path, source: Path, _prefix: str = '') 
     # This is useful for creating a relative path reference from a source file to a target file.
     # For example, if source is '/a/b/c.py' and target is '/a/d/e.py', the relative path reference
     # would be '../../d/e.py'.
-    if not target.is_absolute():
-        target = target.resolve()
+    if not target.is_absolute():  # pragma: no branch
+        target = target.resolve()  # pragma: no cover
     try:
         return Path(f'{_prefix}{Path(target).relative_to(source)}')
-    except ValueError:
+    except ValueError:  # pragma: no cover
         return _get_relative_path_reference(target, source.parent, _prefix=f'{_prefix}../')
 
 

--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -903,7 +903,7 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
             return nxt(self)
 
 
-def _get_relative_path_reference(target: Path, source: Path, _prefix: str = '') -> Path:  # pragma: no cover
+def _get_relative_path_reference(target: Path, source: Path, _prefix: str = '') -> Path:
     """Get a relative path reference from source to target.
 
     Recursively resolve a relative path to target from source, adding '..' as needed.

--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -764,8 +764,8 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
             if not schema_path.is_absolute():
                 schema_ref = str(schema_path)
                 schema_path = path.parent / schema_path
-            elif schema_path.is_relative_to(path):  # pragma: no cover
-                schema_ref = str(_get_relative_path_reference(schema_path, path))
+            elif schema_path.is_relative_to(path.parent):
+                schema_ref = str(_get_relative_path_reference(schema_path, path.parent))
             else:  # pragma: no cover
                 schema_ref = str(schema_path)
             self._save_schema(schema_path, custom_evaluator_types, custom_report_evaluator_types)

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -949,6 +949,19 @@ async def test_serialization_to_json(example_dataset: Dataset[TaskInput, TaskOut
     assert (tmp_path / schema).exists()
 
 
+def test_serialization_to_json_with_absolute_schema_path(
+    example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata], tmp_path: Path
+):
+    json_path = tmp_path / 'test_cases.json'
+    schema_path = tmp_path / 'test_cases_schema.json'
+
+    example_dataset.to_file(json_path, schema_path=schema_path, fmt='json')
+
+    raw = json.loads(json_path.read_text(encoding='utf-8'))
+    assert raw['$schema'] == 'test_cases_schema.json'
+    assert schema_path.exists()
+
+
 def test_serializing_parts_with_discriminators(tmp_path: Path):
     class Foo(BaseModel):
         foo: str

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -19,7 +19,7 @@ from .utils import render_table
 
 with try_import() as imports_successful:
     from pydantic_evals import Case, Dataset
-    from pydantic_evals.dataset import _get_relative_path_reference, increment_eval_metric, set_eval_attribute
+    from pydantic_evals.dataset import increment_eval_metric, set_eval_attribute
     from pydantic_evals.evaluators import (
         EvaluationReason,
         EvaluationResult,
@@ -960,15 +960,6 @@ def test_serialization_to_json_with_absolute_schema_path(
     raw = json.loads(json_path.read_text(encoding='utf-8'))
     assert raw['$schema'] == 'test_cases_schema.json'
     assert schema_path.exists()
-
-
-def test_get_relative_path_reference_with_relative_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.chdir(tmp_path)
-
-    source = tmp_path / 'datasets' / 'nested'
-    target = Path('schemas/test_cases_schema.json')
-
-    assert _get_relative_path_reference(target, source) == Path('../../schemas/test_cases_schema.json')
 
 
 def test_serializing_parts_with_discriminators(tmp_path: Path):

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -19,7 +19,7 @@ from .utils import render_table
 
 with try_import() as imports_successful:
     from pydantic_evals import Case, Dataset
-    from pydantic_evals.dataset import increment_eval_metric, set_eval_attribute
+    from pydantic_evals.dataset import _get_relative_path_reference, increment_eval_metric, set_eval_attribute
     from pydantic_evals.evaluators import (
         EvaluationReason,
         EvaluationResult,
@@ -960,6 +960,15 @@ def test_serialization_to_json_with_absolute_schema_path(
     raw = json.loads(json_path.read_text(encoding='utf-8'))
     assert raw['$schema'] == 'test_cases_schema.json'
     assert schema_path.exists()
+
+
+def test_get_relative_path_reference_with_relative_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+
+    source = tmp_path / 'datasets' / 'nested'
+    target = Path('schemas/test_cases_schema.json')
+
+    assert _get_relative_path_reference(target, source) == Path('../../schemas/test_cases_schema.json')
 
 
 def test_serializing_parts_with_discriminators(tmp_path: Path):


### PR DESCRIPTION
This keeps `Dataset.to_file()` from serializing machine-local absolute schema paths when the schema file is next to the dataset file.

## What Problem This Solves

When `Dataset.to_file()` receives an absolute `schema_path` in the same directory as the dataset file, it currently compares the schema path against the dataset file path itself:

```py
elif schema_path.is_relative_to(path):
    schema_ref = str(_get_relative_path_reference(schema_path, path))
```

Sibling files are not relative to each other, so that branch is skipped and the generated dataset stores an absolute `$schema` reference instead of a portable sibling reference.

Before this change, a local reproduction wrote a machine-local path like:

```text
"$schema": "C:\Users\MiaoXing\AppData\Local\Temp\...\cases_schema.json"
```

That makes checked-in datasets less portable and can expose local machine paths.

## Change

- Compare absolute `schema_path` against `path.parent`, the dataset directory.
- Generate the `$schema` reference relative to that directory when possible.
- Add a regression test for an absolute schema path next to the dataset JSON file.

## Evidence

After this change, the same reproduction writes a portable sibling reference:

```text
"$schema": "cases_schema.json"
```

The schema file is still written to the requested absolute path; only the serialized reference changes.

## Validation

- `uv run pytest tests/evals/test_dataset.py::test_serialization_to_json tests/evals/test_dataset.py::test_serialization_to_json_with_absolute_schema_path`
- `uv run ruff check pydantic_evals/pydantic_evals/dataset.py tests/evals/test_dataset.py`
- `uv run ruff format --check pydantic_evals/pydantic_evals/dataset.py tests/evals/test_dataset.py`
- `git diff --check`

No issue; this is a narrow regression fix for an existing code path.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).