### PR TITLE
Don't send `defer_loading` without `tool_search` on models without native tool search

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -504,6 +504,12 @@ class Model(ABC, Generic[InterfaceClient]):
             # Rule 3: drop undiscovered corpus members when the native tool is unsupported.
             if t.with_native and t.with_native not in supported_ids and t.defer_loading:
                 continue
+            # A discovered corpus member (Rule 3 kept it) whose native tool is unsupported must
+            # shed `with_native`: with no native tool on the wire, an adapter that derives a
+            # native flag from it (e.g. OpenAI's `defer_loading`) would emit it unpaired and the
+            # provider would reject the request. It stays callable as a plain function tool.
+            if t.with_native and t.with_native not in supported_ids:
+                t = replace(t, with_native=None)
             # Rules 2 + 4: keep.
             function_tools.append(t)
 

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -443,9 +443,13 @@ class Model(ABC, Generic[InterfaceClient]):
         2. `with_native` matches a supported native tool → keep on wire; the adapter
            applies any native-tool-specific format (e.g. Anthropic / OpenAI's wire-side
            `defer_loading` flag for `ToolSearchTool`).
-        3. `with_native` matches an *unsupported* native tool AND `defer_loading=True`
-           → drop from wire (the corpus member is currently undiscovered, so the model has
-           no way to call it on this provider).
+        3. `with_native` matches an *unsupported* native tool → the corpus member can't be
+           paired with its native tool on this provider, so its fate turns on discovery:
+           if `defer_loading=True` it's still undiscovered and is dropped from wire (the
+           model has no way to call it); otherwise it's already discovered and stays on wire
+           as a plain function tool, but sheds `with_native` — with no native tool present, an
+           adapter that derives a native flag from it (e.g. OpenAI's `defer_loading`) would
+           emit it unpaired and the provider would reject the request.
         4. Otherwise → keep.
 
         On top of the four-rule filter, two narrower drops apply, kept independent:
@@ -501,14 +505,16 @@ class Model(ABC, Generic[InterfaceClient]):
             if t.unless_native and t.unless_native in supported_ids:
                 if not (tool_search_kept_local and t.unless_native == ToolSearchTool.kind):
                     continue
-            # Rule 3: drop undiscovered corpus members when the native tool is unsupported.
-            if t.with_native and t.with_native not in supported_ids and t.defer_loading:
-                continue
-            # A discovered corpus member (Rule 3 kept it) whose native tool is unsupported must
-            # shed `with_native`: with no native tool on the wire, an adapter that derives a
-            # native flag from it (e.g. OpenAI's `defer_loading`) would emit it unpaired and the
-            # provider would reject the request. It stays callable as a plain function tool.
+            # Rule 3: a corpus member whose native tool is unsupported can't be paired with that
+            # native tool on this provider; its fate turns on whether it's been discovered yet.
             if t.with_native and t.with_native not in supported_ids:
+                # Still undiscovered → drop: the model has no way to call it on this provider.
+                if t.defer_loading:
+                    continue
+                # Already discovered → keep it callable as a plain function tool, but shed
+                # `with_native`: with no native tool on the wire, an adapter that derives a native
+                # flag from it (e.g. OpenAI's `defer_loading`) would emit it unpaired and the
+                # provider would reject the request.
                 t = replace(t, with_native=None)
             # Rules 2 + 4: keep.
             function_tools.append(t)

--- a/tests/cassettes/test_tool_search/test_openai_deferred_capability_runs_on_model_without_native_tool_search.yaml
+++ b/tests/cassettes/test_tool_search/test_openai_deferred_capability_runs_on_model_without_native_tool_search.yaml
@@ -1,0 +1,679 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '1640'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: Use foo with x=1.
+        role: user
+      instructions: |-
+        First load capability id 'foo', then call bar.
+
+        The following capabilities are deferred and can be loaded using the `load_capability` tool:
+        - foo: Use this capability when the user asks for foo.
+      model: gpt-5.2
+      stream: false
+      tool_choice: auto
+      tools:
+      - description: Load a capability to access its full instructions and tools.
+        name: load_capability
+        parameters:
+          additionalProperties: false
+          description: Typed arguments for a `load_capability` tool call.
+          properties:
+            id:
+              description: The id of the capability to load.
+              type: string
+          required:
+          - id
+          type: object
+        strict: true
+        type: function
+      - description: There are additional tools not yet visible to you. When you need a capability not provided by your current
+          tools, search here by providing one or more queries to discover and activate relevant tools. Each query is tokenized
+          into words; tool names and descriptions are scored by token overlap. If no tools are found, they do not exist --
+          do not retry.
+        name: search_tools
+        parameters:
+          additionalProperties: false
+          properties:
+            queries:
+              description: List of search queries to match against tool names and descriptions. Use specific words likely
+                to appear in tool names or descriptions to narrow down relevant tools. Each query is independently tokenized;
+                matches across queries are unioned.
+              items:
+                type: string
+              type: array
+          required:
+          - queries
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      access-control-expose-headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '3019'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '1213'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1782791167
+      created_at: 1782791166
+      error: null
+      frequency_penalty: 0.0
+      id: resp_0f19077ea087b45d006a433bfe77f881a1949df593e5aa66b7
+      incomplete_details: null
+      instructions: |-
+        First load capability id 'foo', then call bar.
+
+        The following capabilities are deferred and can be loaded using the `load_capability` tool:
+        - foo: Use this capability when the user asks for foo.
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.2-2025-12-11
+      moderation: null
+      object: response
+      output:
+      - arguments: '{"id":"foo"}'
+        call_id: call_oD98mk1GikNahiJd9ld4gNMk
+        id: fc_0f19077ea087b45d006a433bff503481a19d056b1d5d2deb5a
+        name: load_capability
+        status: completed
+        type: function_call
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        context: current_turn
+        effort: none
+        mode: standard
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools:
+      - description: Load a capability to access its full instructions and tools.
+        name: load_capability
+        parameters:
+          additionalProperties: false
+          description: Typed arguments for a `load_capability` tool call.
+          properties:
+            id:
+              description: The id of the capability to load.
+              type: string
+          required:
+          - id
+          type: object
+        strict: true
+        type: function
+      - description: There are additional tools not yet visible to you. When you need a capability not provided by your current
+          tools, search here by providing one or more queries to discover and activate relevant tools. Each query is tokenized
+          into words; tool names and descriptions are scored by token overlap. If no tools are found, they do not exist --
+          do not retry.
+        name: search_tools
+        parameters:
+          additionalProperties: false
+          properties:
+            queries:
+              description: List of search queries to match against tool names and descriptions. Use specific words likely
+                to appear in tool names or descriptions to narrow down relevant tools. Each query is independently tokenized;
+                matches across queries are unioned.
+              items:
+                type: string
+              type: array
+          required:
+          - queries
+          type: object
+        strict: true
+        type: function
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 251
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 19
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 270
+      user: null
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '2429'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: Use foo with x=1.
+        role: user
+      - arguments: '{"id":"foo"}'
+        call_id: call_oD98mk1GikNahiJd9ld4gNMk
+        id: fc_0f19077ea087b45d006a433bff503481a19d056b1d5d2deb5a
+        name: load_capability
+        type: function_call
+      - call_id: call_oD98mk1GikNahiJd9ld4gNMk
+        output: '{}'
+        type: function_call_output
+      - arguments: '{"queries":["foo"]}'
+        call_id: auto_load_d85fe7a9a0e51eb3
+        name: search_tools
+        type: function_call
+      - call_id: auto_load_d85fe7a9a0e51eb3
+        output: '{"discovered_tools":[{"name":"bar","description":"Return x."}]}'
+        type: function_call_output
+      instructions: |-
+        First load capability id 'foo', then call bar.
+
+        The following capabilities are deferred and can be loaded using the `load_capability` tool:
+        - foo: Use this capability when the user asks for foo.
+      model: gpt-5.2
+      stream: false
+      tool_choice: auto
+      tools:
+      - description: Load a capability to access its full instructions and tools.
+        name: load_capability
+        parameters:
+          additionalProperties: false
+          description: Typed arguments for a `load_capability` tool call.
+          properties:
+            id:
+              description: The id of the capability to load.
+              type: string
+          required:
+          - id
+          type: object
+        strict: true
+        type: function
+      - description: Return x.
+        name: bar
+        parameters:
+          additionalProperties: false
+          properties:
+            x:
+              type: integer
+          required:
+          - x
+          type: object
+        strict: true
+        type: function
+      - description: There are additional tools not yet visible to you. When you need a capability not provided by your current
+          tools, search here by providing one or more queries to discover and activate relevant tools. Each query is tokenized
+          into words; tool names and descriptions are scored by token overlap. If no tools are found, they do not exist --
+          do not retry.
+        name: search_tools
+        parameters:
+          additionalProperties: false
+          properties:
+            queries:
+              description: List of search queries to match against tool names and descriptions. Use specific words likely
+                to appear in tool names or descriptions to narrow down relevant tools. Each query is independently tokenized;
+                matches across queries are unioned.
+              items:
+                type: string
+              type: array
+          required:
+          - queries
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      access-control-expose-headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '3207'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '672'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1782791168
+      created_at: 1782791168
+      error: null
+      frequency_penalty: 0.0
+      id: resp_0f19077ea087b45d006a433c00216481a1bf2c90a8dbb786b1
+      incomplete_details: null
+      instructions: |-
+        First load capability id 'foo', then call bar.
+
+        The following capabilities are deferred and can be loaded using the `load_capability` tool:
+        - foo: Use this capability when the user asks for foo.
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.2-2025-12-11
+      moderation: null
+      object: response
+      output:
+      - arguments: '{"x":1}'
+        call_id: call_BUmPMEwNfrp69Ou8ELM3TaAG
+        id: fc_0f19077ea087b45d006a433c00992c81a1a4f0d94323b767af
+        name: bar
+        status: completed
+        type: function_call
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        context: current_turn
+        effort: none
+        mode: standard
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools:
+      - description: Load a capability to access its full instructions and tools.
+        name: load_capability
+        parameters:
+          additionalProperties: false
+          description: Typed arguments for a `load_capability` tool call.
+          properties:
+            id:
+              description: The id of the capability to load.
+              type: string
+          required:
+          - id
+          type: object
+        strict: true
+        type: function
+      - description: Return x.
+        name: bar
+        parameters:
+          additionalProperties: false
+          properties:
+            x:
+              type: integer
+          required:
+          - x
+          type: object
+        strict: true
+        type: function
+      - description: There are additional tools not yet visible to you. When you need a capability not provided by your current
+          tools, search here by providing one or more queries to discover and activate relevant tools. Each query is tokenized
+          into words; tool names and descriptions are scored by token overlap. If no tools are found, they do not exist --
+          do not retry.
+        name: search_tools
+        parameters:
+          additionalProperties: false
+          properties:
+            queries:
+              description: List of search queries to match against tool names and descriptions. Use specific words likely
+                to appear in tool names or descriptions to narrow down relevant tools. Each query is independently tokenized;
+                matches across queries are unioned.
+              items:
+                type: string
+              type: array
+          required:
+          - queries
+          type: object
+        strict: true
+        type: function
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 343
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 17
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 360
+      user: null
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '2697'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: Use foo with x=1.
+        role: user
+      - arguments: '{"id":"foo"}'
+        call_id: call_oD98mk1GikNahiJd9ld4gNMk
+        id: fc_0f19077ea087b45d006a433bff503481a19d056b1d5d2deb5a
+        name: load_capability
+        type: function_call
+      - call_id: call_oD98mk1GikNahiJd9ld4gNMk
+        output: '{}'
+        type: function_call_output
+      - arguments: '{"queries":["foo"]}'
+        call_id: auto_load_d85fe7a9a0e51eb3
+        name: search_tools
+        type: function_call
+      - call_id: auto_load_d85fe7a9a0e51eb3
+        output: '{"discovered_tools":[{"name":"bar","description":"Return x."}]}'
+        type: function_call_output
+      - arguments: '{"x":1}'
+        call_id: call_BUmPMEwNfrp69Ou8ELM3TaAG
+        id: fc_0f19077ea087b45d006a433c00992c81a1a4f0d94323b767af
+        name: bar
+        type: function_call
+      - call_id: call_BUmPMEwNfrp69Ou8ELM3TaAG
+        output: '1'
+        type: function_call_output
+      instructions: |-
+        First load capability id 'foo', then call bar.
+
+        The following capabilities are deferred and can be loaded using the `load_capability` tool:
+        - foo: Use this capability when the user asks for foo.
+      model: gpt-5.2
+      stream: false
+      tool_choice: auto
+      tools:
+      - description: Load a capability to access its full instructions and tools.
+        name: load_capability
+        parameters:
+          additionalProperties: false
+          description: Typed arguments for a `load_capability` tool call.
+          properties:
+            id:
+              description: The id of the capability to load.
+              type: string
+          required:
+          - id
+          type: object
+        strict: true
+        type: function
+      - description: Return x.
+        name: bar
+        parameters:
+          additionalProperties: false
+          properties:
+            x:
+              type: integer
+          required:
+          - x
+          type: object
+        strict: true
+        type: function
+      - description: There are additional tools not yet visible to you. When you need a capability not provided by your current
+          tools, search here by providing one or more queries to discover and activate relevant tools. Each query is tokenized
+          into words; tool names and descriptions are scored by token overlap. If no tools are found, they do not exist --
+          do not retry.
+        name: search_tools
+        parameters:
+          additionalProperties: false
+          properties:
+            queries:
+              description: List of search queries to match against tool names and descriptions. Use specific words likely
+                to appear in tool names or descriptions to narrow down relevant tools. Each query is independently tokenized;
+                matches across queries are unioned.
+              items:
+                type: string
+              type: array
+          required:
+          - queries
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      access-control-expose-headers:
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '3223'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '846'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1782791169
+      created_at: 1782791169
+      error: null
+      frequency_penalty: 0.0
+      id: resp_0f19077ea087b45d006a433c0142b881a1bf0d33fdd891acee
+      incomplete_details: null
+      instructions: |-
+        First load capability id 'foo', then call bar.
+
+        The following capabilities are deferred and can be loaded using the `load_capability` tool:
+        - foo: Use this capability when the user asks for foo.
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.2-2025-12-11
+      moderation: null
+      object: response
+      output:
+      - content:
+        - annotations: []
+          logprobs: []
+          text: '1'
+          type: output_text
+        id: msg_0f19077ea087b45d006a433c01e73081a18220ab277dbb89c5
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        context: current_turn
+        effort: none
+        mode: standard
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools:
+      - description: Load a capability to access its full instructions and tools.
+        name: load_capability
+        parameters:
+          additionalProperties: false
+          description: Typed arguments for a `load_capability` tool call.
+          properties:
+            id:
+              description: The id of the capability to load.
+              type: string
+          required:
+          - id
+          type: object
+        strict: true
+        type: function
+      - description: Return x.
+        name: bar
+        parameters:
+          additionalProperties: false
+          properties:
+            x:
+              type: integer
+          required:
+          - x
+          type: object
+        strict: true
+        type: function
+      - description: There are additional tools not yet visible to you. When you need a capability not provided by your current
+          tools, search here by providing one or more queries to discover and activate relevant tools. Each query is tokenized
+          into words; tool names and descriptions are scored by token overlap. If no tools are found, they do not exist --
+          do not retry.
+        name: search_tools
+        parameters:
+          additionalProperties: false
+          properties:
+            queries:
+              description: List of search queries to match against tool names and descriptions. Use specific words likely
+                to appear in tool names or descriptions to narrow down relevant tools. Each query is independently tokenized;
+                matches across queries are unioned.
+              items:
+                type: string
+              type: array
+          required:
+          - queries
+          type: object
+        strict: true
+        type: function
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 371
+        input_tokens_details:
+          cached_tokens: 0
+        output_tokens: 5
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 376
+      user: null
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -2230,73 +2230,22 @@ async def test_openai_deferred_capability_tool_reveal_uses_client_tool_search(al
     assert replay_outputs and all(item.get('execution') == 'client' for item in replay_outputs)
 
 
-async def test_openai_discovered_tool_without_native_tool_search_omits_defer_loading(
-    allow_model_requests: None,
-):
-    """A tool-search tool discovered in a prior turn must not carry the wire-side `defer_loading`
-    flag on a model without native `tool_search` (e.g. `gpt-5.2`).
-
-    `defer_loading` only travels alongside a native `tool_search` tool; without one, pydantic-ai
-    falls back to local search and OpenAI rejects a lone `defer_loading`. Minimal form of #5938;
-    the deferred-capability path is covered by
-    `test_openai_deferred_capability_runs_on_model_without_native_tool_search`.
-    """
-    pytest.importorskip('openai')
-
-    final = response_message(
-        [
-            ResponseOutputMessage(
-                id='msg',
-                content=[ResponseOutputText(text='Sunny.', type='output_text', annotations=[])],
-                role='assistant',
-                status='completed',
-                type='message',
-            )
-        ]
-    )
-    mock_client = MockOpenAIResponses.create_mock(final)
-    model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(openai_client=mock_client))
-    agent: Agent[None, str] = Agent(model=model, capabilities=[ToolSearch()])
-
-    @agent.tool_plain(defer_loading=True)
-    def get_weather(city: str) -> str:  # pragma: no cover
-        return f'Weather in {city}.'
-
-    # `get_weather` was discovered last turn, so it now rides along as a callable tool
-    # (`defer_loading=False`, but `with_native='tool_search'` still set).
-    history: list[ModelMessage] = [
-        ModelRequest(parts=[UserPromptPart(content='I might want the weather later.')]),
-        ModelResponse(parts=[ToolSearchCallPart(args={'queries': ['weather']}, tool_call_id='loc_1')]),
-        ModelRequest(
-            parts=[
-                ToolSearchReturnPart(
-                    content={'discovered_tools': [{'name': 'get_weather', 'description': None}]},
-                    tool_call_id='loc_1',
-                )
-            ]
-        ),
-    ]
-
-    await agent.run('Weather in Paris?', message_history=history)
-
-    [request] = get_mock_responses_kwargs(mock_client)
-    request_tools = cast(list[dict[str, Any]], request['tools'])
-    assert not any(tool['type'] == 'tool_search' for tool in request_tools)
-    [weather_tool] = [tool for tool in request_tools if tool.get('name') == 'get_weather']
-    assert 'defer_loading' not in weather_tool
-
-
 @pytest.mark.vcr
 async def test_openai_deferred_capability_runs_on_model_without_native_tool_search(
-    allow_model_requests: None, openai_api_key: str, vcr: Any
+    allow_model_requests: None, openai_api_key: str
 ) -> None:
-    """#5938 end-to-end against live `gpt-5.2` (no native `tool_search`): loading a deferred
-    `Capability` and calling its tool must complete, not 400.
+    """Loading a deferred `Capability` and calling its tool must complete on a model
+    *without* native `tool_search` (#5938).
 
-    After `load_capability` reveals `bar`, it carries `with_native='tool_search'`. Before the fix
-    the revealed tool shipped with `defer_loading: true` and no `tool_search` tool, and OpenAI
-    rejected it. The wire contract is pinned by the mock
-    `test_openai_discovered_tool_without_native_tool_search_omits_defer_loading`.
+    `gpt-5.2` predates OpenAI's native `tool_search`, so search falls back to local and no
+    `tool_search` builtin is on the wire. The tool revealed by `load_capability` still carries
+    `with_native='tool_search'`, which the base-class filter sheds so no adapter emits a
+    wire-side `defer_loading` flag with no native `tool_search` tool to pair it with — which
+    OpenAI rejects. The invariant is simply that the run completes and `bar` returns.
+
+    This is the tool-search-*unsupported* half of the matrix. OpenAI is the only provider it
+    can be recorded against: every non-deprecated Anthropic (and Google) model supports native
+    tool search, so there is no equivalent no-native-`tool_search` model to exercise.
     """
     foo = Capability[None](id='foo', description='Use this capability when the user asks for foo.', defer_loading=True)
 
@@ -2316,18 +2265,12 @@ async def test_openai_deferred_capability_runs_on_model_without_native_tool_sear
     result = await agent.run('Use foo with x=1.')
 
     # The capability loaded and `bar` returned, so the follow-up request carrying the revealed
-    # `bar` (the one that used to 400) was sent and accepted.
+    # `bar` (the one that used to 400) was accepted and the run finished.
     assert any(isinstance(p, LoadCapabilityReturnPart) for m in result.all_messages() for p in m.parts)
     bar_returns = [
         p for m in result.all_messages() for p in m.parts if isinstance(p, ToolReturnPart) and p.tool_name == 'bar'
     ]
     assert [p.content for p in bar_returns] == [1]
-
-    # gpt-5.2 runs the local fallback: no request may carry `defer_loading` or a `tool_search` tool.
-    for request in vcr.requests:
-        request_tools = cast(list[dict[str, Any]], json.loads(request.body).get('tools', []))
-        assert not any(tool.get('type') == 'tool_search' for tool in request_tools)
-        assert not any('defer_loading' in tool for tool in request_tools)
 
 
 async def test_cross_provider_history_replay_anthropic_to_openai(allow_model_requests: None):

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -2230,6 +2230,125 @@ async def test_openai_deferred_capability_tool_reveal_uses_client_tool_search(al
     assert replay_outputs and all(item.get('execution') == 'client' for item in replay_outputs)
 
 
+async def test_openai_discovered_tool_without_native_tool_search_omits_defer_loading(
+    allow_model_requests: None,
+):
+    """A discovered tool-search tool must NOT carry the wire-side `defer_loading` flag on a
+    model without native `tool_search` (e.g. `gpt-5.2`).
+
+    `defer_loading` is the native-tool-search knob: it only travels alongside a `tool_search`
+    tool, which the provider then uses to reveal the deferred tool. Without native support,
+    pydantic-ai falls back to local search — undiscovered tools are simply omitted and revealed
+    via a plain `search_tools` function — so there is no `tool_search` tool to pair with, and
+    OpenAI rejects a lone `defer_loading`:
+
+        Invalid Value: 'tools.defer_loading'. Deferred tools require tools.tool_search.
+
+    This is the minimal form of #5938: a plain `ToolSearch()` corpus tool that was discovered in
+    a prior turn (so `defer_loading` flipped to `False`, but `with_native='tool_search'` stuck).
+    Deferred capabilities reach the same defect through `load_capability` — see
+    `test_openai_deferred_capability_reveal_without_native_tool_search_omits_defer_loading`. The
+    native-supported path (`defer_loading` + `tool_search` together) is covered on `gpt-5.4` by
+    `test_openai_promotes_local_search_history_round_trip`.
+    """
+    pytest.importorskip('openai')
+
+    final = response_message(
+        [
+            ResponseOutputMessage(
+                id='msg_done',
+                content=[ResponseOutputText(text='Sunny.', type='output_text', annotations=[])],
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(final)
+    model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(openai_client=mock_client))
+    agent: Agent[None, str] = Agent(model=model, capabilities=[ToolSearch()])
+
+    @agent.tool_plain(defer_loading=True)
+    def get_weather(city: str) -> str:  # pragma: no cover
+        """Look up the weather for a city."""
+        return f'Weather in {city}.'
+
+    # Prior turn already discovered `get_weather` via local tool search, so on the next request
+    # it rides along as a now-callable tool (`defer_loading=False`, `with_native='tool_search'`).
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='I might want the weather later.')]),
+        ModelResponse(parts=[ToolSearchCallPart(args={'queries': ['weather']}, tool_call_id='loc_1')]),
+        ModelRequest(
+            parts=[
+                ToolSearchReturnPart(
+                    content={'discovered_tools': [{'name': 'get_weather', 'description': None}]},
+                    tool_call_id='loc_1',
+                )
+            ]
+        ),
+    ]
+
+    result = await agent.run('Weather in Paris?', message_history=history)
+    assert result.output == 'Sunny.'
+
+    [request] = get_mock_responses_kwargs(mock_client)
+    request_tools = cast(list[dict[str, Any]], request['tools'])
+    # gpt-5.2 has no native tool search: the corpus is searched locally via `search_tools`.
+    assert not any(tool['type'] == 'tool_search' for tool in request_tools)
+    # The discovered tool is still sent (callable), but as a plain function — no `defer_loading`.
+    [weather_tool] = [tool for tool in request_tools if tool.get('name') == 'get_weather']
+    assert 'defer_loading' not in weather_tool
+
+
+@pytest.mark.vcr
+async def test_openai_deferred_capability_runs_on_model_without_native_tool_search(
+    allow_model_requests: None, openai_api_key: str, vcr: Any
+) -> None:
+    """The #5938 repro end-to-end against live `gpt-5.2`, which has no native `tool_search`:
+    loading a deferred `Capability` and calling its tool must complete, not 400.
+
+    `Capability(defer_loading=True)` is built on the tool-search corpus, so after `load_capability`
+    reveals `bar` it carries `with_native='tool_search'`. Before the fix, the revealed tool shipped
+    with `defer_loading: true` and no `tool_search` tool, and OpenAI rejected the request:
+    `Invalid Value: 'tools.defer_loading'. Deferred tools require tools.tool_search.` Here we
+    confirm the live model accepts the request the fix produces; the wire contract itself is pinned
+    by the mock `test_openai_discovered_tool_without_native_tool_search_omits_defer_loading`, since
+    the cassette matcher isn't sensitive to the request body.
+    """
+    foo = Capability[None](
+        id='foo',
+        description='Use this capability when the user asks for foo.',
+        defer_loading=True,
+    )
+
+    @foo.tool_plain
+    def bar(x: int) -> int:
+        """Return x."""
+        return x
+
+    model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(api_key=openai_api_key))
+    agent: Agent[None, str] = Agent(
+        model, instructions="First load capability id 'foo', then call bar.", capabilities=[foo]
+    )
+
+    result = await agent.run('Use foo with x=1.')
+
+    # The capability loaded, so the follow-up request — the one carrying the revealed `bar`, which
+    # used to 400 — was actually sent and accepted, and the revealed tool was usable.
+    assert any(isinstance(p, LoadCapabilityReturnPart) for m in result.all_messages() for p in m.parts)
+    bar_returns = [
+        p for m in result.all_messages() for p in m.parts if isinstance(p, ToolReturnPart) and p.tool_name == 'bar'
+    ]
+    assert [p.content for p in bar_returns] == [1]
+
+    # Wire-level: gpt-5.2 runs the local fallback, so no request may carry the native-only
+    # `defer_loading` flag or a `tool_search` tool.
+    for request in vcr.requests:
+        request_tools = cast(list[dict[str, Any]], json.loads(request.body).get('tools', []))
+        assert not any(tool.get('type') == 'tool_search' for tool in request_tools)
+        assert not any('defer_loading' in tool for tool in request_tools)
+
+
 async def test_cross_provider_history_replay_anthropic_to_openai(allow_model_requests: None):
     """A model switch between turns (Anthropic → OpenAI) should replay cleanly: the
     provider-specific Builtin* tool search parts are skipped by the mismatched provider,

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -2307,7 +2307,10 @@ async def test_openai_deferred_capability_runs_on_model_without_native_tool_sear
 
     model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(api_key=openai_api_key))
     agent: Agent[None, str] = Agent(
-        model, instructions="First load capability id 'foo', then call bar.", capabilities=[foo]
+        model,
+        deps_type=type(None),
+        instructions="First load capability id 'foo', then call bar.",
+        capabilities=[foo],
     )
 
     result = await agent.run('Use foo with x=1.')

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -2233,30 +2233,20 @@ async def test_openai_deferred_capability_tool_reveal_uses_client_tool_search(al
 async def test_openai_discovered_tool_without_native_tool_search_omits_defer_loading(
     allow_model_requests: None,
 ):
-    """A discovered tool-search tool must NOT carry the wire-side `defer_loading` flag on a
-    model without native `tool_search` (e.g. `gpt-5.2`).
+    """A tool-search tool discovered in a prior turn must not carry the wire-side `defer_loading`
+    flag on a model without native `tool_search` (e.g. `gpt-5.2`).
 
-    `defer_loading` is the native-tool-search knob: it only travels alongside a `tool_search`
-    tool, which the provider then uses to reveal the deferred tool. Without native support,
-    pydantic-ai falls back to local search — undiscovered tools are simply omitted and revealed
-    via a plain `search_tools` function — so there is no `tool_search` tool to pair with, and
-    OpenAI rejects a lone `defer_loading`:
-
-        Invalid Value: 'tools.defer_loading'. Deferred tools require tools.tool_search.
-
-    This is the minimal form of #5938: a plain `ToolSearch()` corpus tool that was discovered in
-    a prior turn (so `defer_loading` flipped to `False`, but `with_native='tool_search'` stuck).
-    Deferred capabilities reach the same defect through `load_capability` — see
-    `test_openai_deferred_capability_reveal_without_native_tool_search_omits_defer_loading`. The
-    native-supported path (`defer_loading` + `tool_search` together) is covered on `gpt-5.4` by
-    `test_openai_promotes_local_search_history_round_trip`.
+    `defer_loading` only travels alongside a native `tool_search` tool; without one, pydantic-ai
+    falls back to local search and OpenAI rejects a lone `defer_loading`. Minimal form of #5938;
+    the deferred-capability path is covered by
+    `test_openai_deferred_capability_runs_on_model_without_native_tool_search`.
     """
     pytest.importorskip('openai')
 
     final = response_message(
         [
             ResponseOutputMessage(
-                id='msg_done',
+                id='msg',
                 content=[ResponseOutputText(text='Sunny.', type='output_text', annotations=[])],
                 role='assistant',
                 status='completed',
@@ -2270,11 +2260,10 @@ async def test_openai_discovered_tool_without_native_tool_search_omits_defer_loa
 
     @agent.tool_plain(defer_loading=True)
     def get_weather(city: str) -> str:  # pragma: no cover
-        """Look up the weather for a city."""
         return f'Weather in {city}.'
 
-    # Prior turn already discovered `get_weather` via local tool search, so on the next request
-    # it rides along as a now-callable tool (`defer_loading=False`, `with_native='tool_search'`).
+    # `get_weather` was discovered last turn, so it now rides along as a callable tool
+    # (`defer_loading=False`, but `with_native='tool_search'` still set).
     history: list[ModelMessage] = [
         ModelRequest(parts=[UserPromptPart(content='I might want the weather later.')]),
         ModelResponse(parts=[ToolSearchCallPart(args={'queries': ['weather']}, tool_call_id='loc_1')]),
@@ -2288,14 +2277,11 @@ async def test_openai_discovered_tool_without_native_tool_search_omits_defer_loa
         ),
     ]
 
-    result = await agent.run('Weather in Paris?', message_history=history)
-    assert result.output == 'Sunny.'
+    await agent.run('Weather in Paris?', message_history=history)
 
     [request] = get_mock_responses_kwargs(mock_client)
     request_tools = cast(list[dict[str, Any]], request['tools'])
-    # gpt-5.2 has no native tool search: the corpus is searched locally via `search_tools`.
     assert not any(tool['type'] == 'tool_search' for tool in request_tools)
-    # The discovered tool is still sent (callable), but as a plain function — no `defer_loading`.
     [weather_tool] = [tool for tool in request_tools if tool.get('name') == 'get_weather']
     assert 'defer_loading' not in weather_tool
 
@@ -2304,22 +2290,15 @@ async def test_openai_discovered_tool_without_native_tool_search_omits_defer_loa
 async def test_openai_deferred_capability_runs_on_model_without_native_tool_search(
     allow_model_requests: None, openai_api_key: str, vcr: Any
 ) -> None:
-    """The #5938 repro end-to-end against live `gpt-5.2`, which has no native `tool_search`:
-    loading a deferred `Capability` and calling its tool must complete, not 400.
+    """#5938 end-to-end against live `gpt-5.2` (no native `tool_search`): loading a deferred
+    `Capability` and calling its tool must complete, not 400.
 
-    `Capability(defer_loading=True)` is built on the tool-search corpus, so after `load_capability`
-    reveals `bar` it carries `with_native='tool_search'`. Before the fix, the revealed tool shipped
-    with `defer_loading: true` and no `tool_search` tool, and OpenAI rejected the request:
-    `Invalid Value: 'tools.defer_loading'. Deferred tools require tools.tool_search.` Here we
-    confirm the live model accepts the request the fix produces; the wire contract itself is pinned
-    by the mock `test_openai_discovered_tool_without_native_tool_search_omits_defer_loading`, since
-    the cassette matcher isn't sensitive to the request body.
+    After `load_capability` reveals `bar`, it carries `with_native='tool_search'`. Before the fix
+    the revealed tool shipped with `defer_loading: true` and no `tool_search` tool, and OpenAI
+    rejected it. The wire contract is pinned by the mock
+    `test_openai_discovered_tool_without_native_tool_search_omits_defer_loading`.
     """
-    foo = Capability[None](
-        id='foo',
-        description='Use this capability when the user asks for foo.',
-        defer_loading=True,
-    )
+    foo = Capability[None](id='foo', description='Use this capability when the user asks for foo.', defer_loading=True)
 
     @foo.tool_plain
     def bar(x: int) -> int:
@@ -2333,16 +2312,15 @@ async def test_openai_deferred_capability_runs_on_model_without_native_tool_sear
 
     result = await agent.run('Use foo with x=1.')
 
-    # The capability loaded, so the follow-up request — the one carrying the revealed `bar`, which
-    # used to 400 — was actually sent and accepted, and the revealed tool was usable.
+    # The capability loaded and `bar` returned, so the follow-up request carrying the revealed
+    # `bar` (the one that used to 400) was sent and accepted.
     assert any(isinstance(p, LoadCapabilityReturnPart) for m in result.all_messages() for p in m.parts)
     bar_returns = [
         p for m in result.all_messages() for p in m.parts if isinstance(p, ToolReturnPart) and p.tool_name == 'bar'
     ]
     assert [p.content for p in bar_returns] == [1]
 
-    # Wire-level: gpt-5.2 runs the local fallback, so no request may carry the native-only
-    # `defer_loading` flag or a `tool_search` tool.
+    # gpt-5.2 runs the local fallback: no request may carry `defer_loading` or a `tool_search` tool.
     for request in vcr.requests:
         request_tools = cast(list[dict[str, Any]], json.loads(request.body).get('tools', []))
         assert not any(tool.get('type') == 'tool_search' for tool in request_tools)

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -2230,6 +2230,68 @@ async def test_openai_deferred_capability_tool_reveal_uses_client_tool_search(al
     assert replay_outputs and all(item.get('execution') == 'client' for item in replay_outputs)
 
 
+async def test_openai_discovered_tool_without_native_tool_search_omits_defer_loading(
+    allow_model_requests: None,
+):
+    """A tool-search corpus member discovered in a prior turn must not carry the wire-side
+    `defer_loading` flag on a model without native `tool_search` (e.g. `gpt-5.2`).
+
+    OpenAI's `defer_loading` only travels alongside a native `tool_search` tool; without one the
+    provider rejects a lone `defer_loading` (#5938). Once discovered, the corpus member stays
+    callable as a plain function tool but must shed its `with_native='tool_search'` marker, so the
+    adapter (which derives `defer_loading` purely from `with_native`) stops stamping it.
+
+    This is a unit test, not VCR: the cassette matcher keys only on method and path, so a request
+    that regained a stale `defer_loading` (or an over-eager native-tool swap) would still match the
+    existing recording and pass green. Only a direct assertion on the emitted payload pins the wire
+    invariant the fix is responsible for. The end-to-end deferred-capability flow is covered by
+    `test_openai_deferred_capability_runs_on_model_without_native_tool_search`.
+    """
+    pytest.importorskip('openai')
+
+    final = response_message(
+        [
+            ResponseOutputMessage(
+                id='msg',
+                content=[ResponseOutputText(text='Sunny.', type='output_text', annotations=[])],
+                role='assistant',
+                status='completed',
+                type='message',
+            )
+        ]
+    )
+    mock_client = MockOpenAIResponses.create_mock(final)
+    model = OpenAIResponsesModel('gpt-5.2', provider=OpenAIProvider(openai_client=mock_client))
+    agent: Agent[None, str] = Agent(model=model, capabilities=[ToolSearch()])
+
+    @agent.tool_plain(defer_loading=True)
+    def get_weather(city: str) -> str:  # pragma: no cover
+        return f'Weather in {city}.'
+
+    # `get_weather` was discovered last turn, so it now rides along as a callable tool
+    # (`defer_loading=False`, but `with_native='tool_search'` still set).
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='I might want the weather later.')]),
+        ModelResponse(parts=[ToolSearchCallPart(args={'queries': ['weather']}, tool_call_id='loc_1')]),
+        ModelRequest(
+            parts=[
+                ToolSearchReturnPart(
+                    content={'discovered_tools': [{'name': 'get_weather', 'description': None}]},
+                    tool_call_id='loc_1',
+                )
+            ]
+        ),
+    ]
+
+    await agent.run('Weather in Paris?', message_history=history)
+
+    [request] = get_mock_responses_kwargs(mock_client)
+    request_tools = cast(list[dict[str, Any]], request['tools'])
+    assert not any(tool['type'] == 'tool_search' for tool in request_tools)
+    [weather_tool] = [tool for tool in request_tools if tool.get('name') == 'get_weather']
+    assert 'defer_loading' not in weather_tool
+
+
 @pytest.mark.vcr
 async def test_openai_deferred_capability_runs_on_model_without_native_tool_search(
     allow_model_requests: None, openai_api_key: str
@@ -2242,6 +2304,10 @@ async def test_openai_deferred_capability_runs_on_model_without_native_tool_sear
     `with_native='tool_search'`, which the base-class filter sheds so no adapter emits a
     wire-side `defer_loading` flag with no native `tool_search` tool to pair it with — which
     OpenAI rejects. The invariant is simply that the run completes and `bar` returns.
+
+    The wire-payload shape (no `defer_loading`, no `tool_search` on the wire) is pinned directly by
+    `test_openai_discovered_tool_without_native_tool_search_omits_defer_loading`, since the cassette
+    matcher isn't body-sensitive and wouldn't catch a regression here on its own.
 
     This is the tool-search-*unsupported* half of the matrix. OpenAI is the only provider it
     can be recorded against: every non-deprecated Anthropic (and Google) model supports native


### PR DESCRIPTION
- Closes #5938

## What was going wrong

Loading a deferred capability (or discovering a `defer_loading=True` tool via tool search) on an OpenAI model that **doesn't support native tool search** (e.g. `gpt-5.2`) failed with:

```
Invalid Value: 'tools.defer_loading'. Deferred tools require tools.tool_search.
```

## Why

OpenAI's wire-side `defer_loading` flag only works **paired with** a native `tool_search` tool, and native tool search only exists on `gpt-5.4+`.

On older models we already do the right thing and fall back to Pydantic AI's **local** tool search (a plain `search_tools` function), so no `tool_search` tool goes on the wire. The bug: once a deferred tool was *discovered*, it kept an internal `with_native='tool_search'` marker, and the OpenAI adapter stamped the wire-side `defer_loading: true` flag purely off that marker, without checking whether a `tool_search` tool was actually being sent. So the request went out with `defer_loading` and nothing to pair it with, and the provider rejected it.

In short:

| | `gpt-5.4+` (native) | `gpt-5.2` (local fallback) |
|---|---|---|
| `tool_search` tool on wire | ✅ yes | ❌ no |
| `defer_loading` stamped | ✅ correct | ❌ **stamped anyway, so 400** |

## The fix

In the provider-agnostic native-tool swap, when the model doesn't support native tool search, clear the stale `with_native` marker on tools that have already been discovered (they stay callable as plain function tools). With the marker gone, the adapter no longer stamps `defer_loading`, and the request is accepted.

Models that **do** support native tool search (`gpt-5.4+`) are completely unaffected: the marker is kept and `defer_loading` + `tool_search` still go out together. The change only fires on the path that had no native tool search (and therefore no native cache) to begin with.

## Tests

- **Unit test** pinning the wire payload: a discovered tool-search tool on `gpt-5.2` ships with no `defer_loading` and no `tool_search` (the cassette matcher isn't body-sensitive, so this is the real guard).
- **VCR test** against live `gpt-5.2` reproducing the issue exactly (deferred `Capability` + `load_capability` + tool call). All three recorded requests return `200`, where the second one (carrying the revealed tool) used to `400`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
