### PR TITLE
Suppress `ClosedResourceError` when cancelling a graph run mid-send

### DIFF
--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -30,7 +30,7 @@ from typing import (
     overload,
 )
 
-from anyio import BrokenResourceError, CancelScope, create_memory_object_stream, create_task_group
+from anyio import BrokenResourceError, CancelScope, ClosedResourceError, create_memory_object_stream, create_task_group
 from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from typing_extensions import Never, TypeAliasType, TypeVar, assert_never
@@ -862,7 +862,7 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                 # or ExceptionGroup). This preserves the original exception for the caller.
                 try:
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, [], error=exc))
-                except BrokenResourceError:
+                except (BrokenResourceError, ClosedResourceError):
                     pass  # pragma: no cover
                 return
             try:
@@ -872,8 +872,13 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, []))
                 else:
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, result))
-            except BrokenResourceError:
-                # Can happen when an asyncio task is cancelled mid-send.
+            except (BrokenResourceError, ClosedResourceError):
+                # Can happen when an asyncio task is cancelled mid-send: the run's
+                # cleanup closes ``iter_stream_sender`` in another task while this
+                # task is still in-flight on ``send``. Closing the sender raises
+                # ``ClosedResourceError`` (closing the receiver would raise
+                # ``BrokenResourceError``); both are benign here — the result/error
+                # is no longer needed because the run is being torn down.
                 pass
 
     async def _run_task(


### PR DESCRIPTION
- Closes #6146

Follow-up to #3655 / #3675. #3675 added `except BrokenResourceError` at the two `iter_stream_sender.send(...)` sites in `_GraphIterator._run_tracked_task` to swallow the benign error from sending into a stream closed during run teardown. But run cleanup closes the memory-object-stream **sender**, so an in-flight send raises the sibling `anyio.ClosedResourceError`, which the narrow `except` misses — leaving runs cancelled before completion to crash out of `GraphRun.__aexit__` instead of cancelling cleanly. This broadens both excepts to `(BrokenResourceError, ClosedResourceError)`.

**Validation:** the minimal repro in #6146 leaks ~40 `ClosedResourceError` per 2000 cancelled runs on `main`; with this change, **0** (every cancellation surfaces cleanly as `TimeoutError`/`CancelledError`). No deterministic unit test is added: this is the same hard-to-trigger teardown race the sibling `BrokenResourceError` branch already carries (and which #3675 marked `# pragma: no cover`), so the repro in the linked issue is the validation.

A matching backport against `v1` is in #6148.

🤖 Prepared with Claude Code and validated against the repro; opened by @conradlee.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
