### PR TITLE
Suppress `ClosedResourceError` when cancelling a graph run mid-send (v1)

### DIFF
--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -38,7 +38,7 @@ from typing import (
     overload,
 )
 
-from anyio import BrokenResourceError, CancelScope, create_memory_object_stream, create_task_group
+from anyio import BrokenResourceError, CancelScope, ClosedResourceError, create_memory_object_stream, create_task_group
 from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from typing_extensions import Never, TypeAliasType, TypeVar, assert_never
@@ -848,7 +848,7 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                 # or ExceptionGroup). This preserves the original exception for the caller.
                 try:
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, [], error=exc))
-                except BrokenResourceError:
+                except (BrokenResourceError, ClosedResourceError):
                     pass  # pragma: no cover
                 return
             try:
@@ -858,8 +858,13 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, []))
                 else:
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, result))
-            except BrokenResourceError:
-                # Can happen when an asyncio task is cancelled mid-send.
+            except (BrokenResourceError, ClosedResourceError):
+                # Can happen when an asyncio task is cancelled mid-send: the run's
+                # cleanup closes ``iter_stream_sender`` in another task while this
+                # task is still in-flight on ``send``. Closing the sender raises
+                # ``ClosedResourceError`` (closing the receiver would raise
+                # ``BrokenResourceError``); both are benign here — the result/error
+                # is no longer needed because the run is being torn down.
                 pass
 
     async def _run_task(


### PR DESCRIPTION
**v1 backport of #6149** (do not auto-close — this targets the maintained 1.x line, a different base branch than #6149).

#3675 added `except BrokenResourceError` at the two `iter_stream_sender.send(...)` sites in `_GraphIterator._run_tracked_task`, but run cleanup closes the memory-object-stream **sender**, so an in-flight send raises the sibling `anyio.ClosedResourceError` (not `BrokenResourceError`), which the narrow `except` misses — leaving runs cancelled before completion to crash out of `GraphRun.__aexit__` instead of cancelling cleanly. This broadens both excepts to `(BrokenResourceError, ClosedResourceError)`.

The `_run_tracked_task` teardown is byte-identical on `v1` and `main`, so this is the same one-line change as #6149, targeted at the 1.x line (where many users — including us — are still pinned). Validated with the repro from the linked issue: ~40 `ClosedResourceError` per 2000 cancelled runs on `v1` (1.107) → **0** with this change.

🤖 Prepared with Claude Code and validated against the repro; opened by @conradlee.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
