### PR TITLE
Suppress `ClosedResourceError` when cancelling a graph run mid-send

### DIFF
--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -874,10 +874,10 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, result))
             except (BrokenResourceError, ClosedResourceError):
                 # Can happen when an asyncio task is cancelled mid-send: the run's
-                # cleanup closes ``iter_stream_sender`` in another task while this
-                # task is still in-flight on ``send``. Closing the sender raises
-                # ``ClosedResourceError`` (closing the receiver would raise
-                # ``BrokenResourceError``); both are benign here — the result/error
+                # cleanup closes `iter_stream_sender` in another task while this
+                # task is still in-flight on `send`. Closing the sender raises
+                # `ClosedResourceError` (closing the receiver would raise
+                # `BrokenResourceError`); both are benign here — the result/error
                 # is no longer needed because the run is being torn down.
                 pass
 

--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -30,7 +30,7 @@ from typing import (
     overload,
 )
 
-from anyio import BrokenResourceError, CancelScope, create_memory_object_stream, create_task_group
+from anyio import BrokenResourceError, CancelScope, ClosedResourceError, create_memory_object_stream, create_task_group
 from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from typing_extensions import Never, TypeAliasType, TypeVar, assert_never
@@ -862,7 +862,7 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                 # or ExceptionGroup). This preserves the original exception for the caller.
                 try:
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, [], error=exc))
-                except BrokenResourceError:
+                except (BrokenResourceError, ClosedResourceError):
                     pass  # pragma: no cover
                 return
             try:
@@ -872,8 +872,13 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, []))
                 else:
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, result))
-            except BrokenResourceError:
-                # Can happen when an asyncio task is cancelled mid-send.
+            except (BrokenResourceError, ClosedResourceError):
+                # Can happen when an asyncio task is cancelled mid-send: the run's
+                # cleanup closes ``iter_stream_sender`` in another task while this
+                # task is still in-flight on ``send``. Closing the sender raises
+                # ``ClosedResourceError`` (closing the receiver would raise
+                # ``BrokenResourceError``); both are benign here — the result/error
+                # is no longer needed because the run is being torn down.
                 pass
 
     async def _run_task(

--- a/tests/graph/builder/test_graph_execution.py
+++ b/tests/graph/builder/test_graph_execution.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import pytest
+from anyio import create_task_group
 
 from pydantic_graph import GraphBuilder, StepContext
+from pydantic_graph.graph_builder import GraphTask, _GraphIterator  # pyright: ignore[reportPrivateUsage]
+from pydantic_graph.id_types import NodeRunID, TaskID
 from pydantic_graph.join import ReduceFirstValue, reduce_list_append, reduce_list_extend
 
 pytestmark = pytest.mark.anyio
@@ -397,6 +400,63 @@ async def test_early_termination_from_nested_generator():
     async for _ in gen:  # pragma: no branch
         break
     await gen.aclose()
+
+
+async def test_tracked_task_send_after_sender_closed_is_swallowed():
+    """A node task whose `send` lands after the run's stream sender is closed must not crash the run.
+
+    When a run is cancelled before reaching its end node, teardown closes
+    `iter_stream_sender` while node tasks may still be in flight. An in-flight
+    `send` to a closed sender raises `anyio.ClosedResourceError` (a closed
+    *receiver* would instead raise `BrokenResourceError`); both are benign during
+    teardown and must be swallowed rather than escape into the task group.
+
+    The real-world trigger is a teardown race that can't be reproduced reliably
+    through the public API, so this drives `_run_tracked_task` directly: closing
+    the sender up front guarantees the deterministic equivalent of the race (the
+    task finishing its `send` against an already-closed sender). Regression test
+    for #6146; without the fix this leaks `ClosedResourceError` out of the group.
+    """
+    g = GraphBuilder(output_type=int)
+
+    ran = False
+
+    @g.step
+    async def produce(ctx: StepContext[None, None, None]) -> int:
+        nonlocal ran
+        ran = True
+        return 42
+
+    g.add(
+        g.edge_from(g.start_node).to(produce),
+        g.edge_from(produce).to(g.end_node),
+    )
+    graph = g.build()
+
+    next_task_id_counter = 0
+
+    def next_task_id() -> TaskID:
+        nonlocal next_task_id_counter
+        next_task_id_counter += 1
+        return TaskID(f'task:{next_task_id_counter}')
+
+    def next_node_run_id() -> NodeRunID:  # pragma: no cover
+        # Not reached for a single leaf step, but required to construct the iterator.
+        return NodeRunID('node-run:0')
+
+    async with create_task_group() as task_group:
+        iterator = _GraphIterator(graph, None, None, task_group, next_node_run_id, next_task_id)
+        # Simulate run teardown closing the streams while a node task is still in flight.
+        # `send_nowait` checks the sender's own closed flag before the receiver's, so the
+        # in-flight `send` raises `ClosedResourceError` (not `BrokenResourceError`) here.
+        iterator.iter_stream_sender.close()
+        iterator.iter_stream_receiver.close()
+        task = GraphTask(produce.id, None, (), next_task_id())
+        task_group.start_soon(iterator._run_tracked_task, task)  # pyright: ignore[reportPrivateUsage]
+
+    # Reaching here means the task group exited cleanly; the `ClosedResourceError`
+    # from the closed-sender `send` was swallowed instead of propagating.
+    assert ran, 'the node task should have run and attempted to send its result'
 
 
 def test_run_sync():


### PR DESCRIPTION
- Closes #6146

Follow-up to #3655 / #3675. #3675 added `except BrokenResourceError` at the two `iter_stream_sender.send(...)` sites in `_GraphIterator._run_tracked_task` to swallow the benign error from sending into a stream closed during run teardown. But run cleanup closes the memory-object-stream **sender**, so an in-flight send raises the sibling `anyio.ClosedResourceError`, which the narrow `except` misses — leaving runs cancelled before completion to crash out of `GraphRun.__aexit__` instead of cancelling cleanly. This broadens both excepts to `(BrokenResourceError, ClosedResourceError)`.

**Validation:** the minimal repro in #6146 leaks ~40 `ClosedResourceError` per 2000 cancelled runs on `main`; with this change, **0** (every cancellation surfaces cleanly as `TimeoutError`/`CancelledError`). No deterministic unit test is added: this is the same hard-to-trigger teardown race the sibling `BrokenResourceError` branch already carries (and which #3675 marked `# pragma: no cover`), so the repro in the linked issue is the validation.

A matching backport against `v1` is in #6148.

🤖 Prepared with Claude Code and validated against the repro; opened by @conradlee.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

