### PR TITLE
Suppress closed sender errors during graph cancellation

### DIFF
--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -30,7 +30,7 @@ from typing import (
     overload,
 )
 
-from anyio import BrokenResourceError, CancelScope, create_memory_object_stream, create_task_group
+from anyio import BrokenResourceError, CancelScope, ClosedResourceError, create_memory_object_stream, create_task_group
 from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from typing_extensions import Never, TypeAliasType, TypeVar, assert_never
@@ -862,7 +862,7 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                 # or ExceptionGroup). This preserves the original exception for the caller.
                 try:
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, [], error=exc))
-                except BrokenResourceError:
+                except (BrokenResourceError, ClosedResourceError):
                     pass  # pragma: no cover
                 return
             try:
@@ -872,7 +872,7 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, []))
                 else:
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, result))
-            except BrokenResourceError:
+            except (BrokenResourceError, ClosedResourceError):
                 # Can happen when an asyncio task is cancelled mid-send.
                 pass
 

--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -863,7 +863,7 @@ class _GraphIterator(Generic[StateT, DepsT, OutputT]):
                 try:
                     await self.iter_stream_sender.send(_GraphTaskResult(t_, [], error=exc))
                 except (BrokenResourceError, ClosedResourceError):
-                    pass  # pragma: no cover
+                    pass
                 return
             try:
                 if isinstance(result, _GraphTaskAsyncIterable):

--- a/tests/graph/builder/test_graph_execution.py
+++ b/tests/graph/builder/test_graph_execution.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import pytest
+from anyio import ClosedResourceError, create_task_group
 
 from pydantic_graph import GraphBuilder, StepContext
+from pydantic_graph.graph_builder import GraphTask, _GraphIterator
+from pydantic_graph.id_types import TaskID
 from pydantic_graph.join import ReduceFirstValue, reduce_list_append, reduce_list_extend
 
 pytestmark = pytest.mark.anyio
@@ -16,6 +19,67 @@ pytestmark = pytest.mark.anyio
 class ExecutionState:
     log: list[str] = field(default_factory=list[str])
     counter: int = 0
+
+
+class _ClosedSender:
+    async def send(self, item: object) -> None:
+        raise ClosedResourceError
+
+
+async def test_run_tracked_task_suppresses_closed_resource_error_for_result_send():
+    """Cancellation cleanup may close the sender while a finished task reports its result."""
+    g = GraphBuilder(state_type=ExecutionState, output_type=int)
+
+    @g.step
+    async def produce(ctx: StepContext[ExecutionState, None, None]) -> int:
+        return 1
+
+    g.add(g.edge_from(g.start_node).to(produce), g.edge_from(produce).to(g.end_node))
+    graph = g.build()
+
+    async with create_task_group() as task_group:
+        iterator = _GraphIterator(
+            graph=graph,
+            state=ExecutionState(),
+            deps=None,
+            task_group=task_group,
+            get_next_node_run_id=lambda: None,  # type: ignore[arg-type]
+            get_next_task_id=lambda: TaskID('unused'),
+        )
+        iterator.iter_stream_sender.close()
+        iterator.iter_stream_receiver.close()
+        iterator.iter_stream_sender = _ClosedSender()  # type: ignore[assignment]
+
+        task = GraphTask(produce.id, None, (), TaskID('task:1'))
+        await iterator._run_tracked_task(task)
+
+
+async def test_run_tracked_task_suppresses_closed_resource_error_for_error_send():
+    """Cancellation cleanup may close the sender while a failing task reports its error."""
+    g = GraphBuilder(state_type=ExecutionState, output_type=int)
+
+    @g.step
+    async def fail(ctx: StepContext[ExecutionState, None, None]) -> int:
+        raise RuntimeError('boom')
+
+    g.add(g.edge_from(g.start_node).to(fail), g.edge_from(fail).to(g.end_node))
+    graph = g.build()
+
+    async with create_task_group() as task_group:
+        iterator = _GraphIterator(
+            graph=graph,
+            state=ExecutionState(),
+            deps=None,
+            task_group=task_group,
+            get_next_node_run_id=lambda: None,  # type: ignore[arg-type]
+            get_next_task_id=lambda: TaskID('unused'),
+        )
+        iterator.iter_stream_sender.close()
+        iterator.iter_stream_receiver.close()
+        iterator.iter_stream_sender = _ClosedSender()  # type: ignore[assignment]
+
+        task = GraphTask(fail.id, None, (), TaskID('task:1'))
+        await iterator._run_tracked_task(task)
 
 
 async def test_map_to_end_node_cancels_pending():

--- a/tests/graph/builder/test_graph_execution.py
+++ b/tests/graph/builder/test_graph_execution.py
@@ -8,7 +8,7 @@ import pytest
 from anyio import ClosedResourceError, create_task_group
 
 from pydantic_graph import GraphBuilder, StepContext
-from pydantic_graph.graph_builder import GraphTask, _GraphIterator
+from pydantic_graph.graph_builder import GraphTask, _GraphIterator  # pyright: ignore[reportPrivateUsage]
 from pydantic_graph.id_types import TaskID
 from pydantic_graph.join import ReduceFirstValue, reduce_list_append, reduce_list_extend
 
@@ -51,7 +51,7 @@ async def test_run_tracked_task_suppresses_closed_resource_error_for_result_send
         iterator.iter_stream_sender = _ClosedSender()  # type: ignore[assignment]
 
         task = GraphTask(produce.id, None, (), TaskID('task:1'))
-        await iterator._run_tracked_task(task)
+        await iterator._run_tracked_task(task)  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_run_tracked_task_suppresses_closed_resource_error_for_error_send():
@@ -79,7 +79,7 @@ async def test_run_tracked_task_suppresses_closed_resource_error_for_error_send(
         iterator.iter_stream_sender = _ClosedSender()  # type: ignore[assignment]
 
         task = GraphTask(fail.id, None, (), TaskID('task:1'))
-        await iterator._run_tracked_task(task)
+        await iterator._run_tracked_task(task)  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_map_to_end_node_cancels_pending():


### PR DESCRIPTION
## Summary
- catch `ClosedResourceError` alongside `BrokenResourceError` when graph task cleanup races with cancellation
- cover both result and error send paths in `_run_tracked_task`
- keep graph cancellations surfacing as normal cancellation instead of leaking `ClosedResourceError`

## Testing
- python -m pytest -q tests/graph/builder/test_graph_execution.py -k closed_resource_error
- python -m pytest -q tests/graph/builder/test_graph_execution.py

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

