### PR TITLE
fix: set `TestModel` provider name

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/test.py
+++ b/pydantic_ai_slim/pydantic_ai/models/test.py
@@ -231,6 +231,7 @@ class TestModel(Model):
                     for name, args in tool_calls
                 ],
                 model_name=self._model_name,
+                provider_name=self._system,
             )
 
         if messages:  # pragma: no branch
@@ -260,7 +261,7 @@ class TestModel(Model):
                             if tool.name in new_retry_names
                         ]
                     )
-                return ModelResponse(parts=retry_parts, model_name=self._model_name)
+                return ModelResponse(parts=retry_parts, model_name=self._model_name, provider_name=self._system)
 
         if isinstance(output_wrapper, _WrappedTextOutput):
             if (response_text := output_wrapper.value) is None:
@@ -273,12 +274,22 @@ class TestModel(Model):
                                 output[part.tool_name] = part.content
                 if output:
                     return ModelResponse(
-                        parts=[TextPart(pydantic_core.to_json(output).decode())], model_name=self._model_name
+                        parts=[TextPart(pydantic_core.to_json(output).decode())],
+                        model_name=self._model_name,
+                        provider_name=self._system,
                     )
                 else:
-                    return ModelResponse(parts=[TextPart('success (no tool calls)')], model_name=self._model_name)
+                    return ModelResponse(
+                        parts=[TextPart('success (no tool calls)')],
+                        model_name=self._model_name,
+                        provider_name=self._system,
+                    )
             else:
-                return ModelResponse(parts=[TextPart(response_text)], model_name=self._model_name)
+                return ModelResponse(
+                    parts=[TextPart(response_text)],
+                    model_name=self._model_name,
+                    provider_name=self._system,
+                )
         else:
             assert output_tools, 'No output tools provided'
             custom_output_args = output_wrapper.value
@@ -293,6 +304,7 @@ class TestModel(Model):
                         )
                     ],
                     model_name=self._model_name,
+                    provider_name=self._system,
                 )
             else:
                 response_args = self.gen_tool_args(output_tool)
@@ -305,6 +317,7 @@ class TestModel(Model):
                         )
                     ],
                     model_name=self._model_name,
+                    provider_name=self._system,
                 )
 
 

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -64,6 +64,21 @@ def test_custom_output_text():
         agent.run_sync('x', model=TestModel(custom_output_text='custom'))
 
 
+@pytest.mark.anyio
+async def test_provider_name_matches_streamed_response():
+    agent = Agent(model=TestModel(custom_output_text='done'))
+
+    result = await agent.run('hello')
+    run_provider_names = [m.provider_name for m in result.all_messages() if isinstance(m, ModelResponse)]
+
+    async with agent.run_stream('hello') as stream:
+        await stream.get_output()
+        stream_provider_names = [m.provider_name for m in stream.all_messages() if isinstance(m, ModelResponse)]
+
+    assert run_provider_names == ['test']
+    assert stream_provider_names == ['test']
+
+
 def test_custom_output_args():
     agent = Agent(output_type=tuple[str, str])
     result = agent.run_sync('x', model=TestModel(custom_output_args=['a', 'b']))
@@ -92,6 +107,7 @@ def test_custom_output_args():
                 usage=RequestUsage(input_tokens=51, output_tokens=7),
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
+                provider_name='test',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
@@ -144,6 +160,7 @@ def test_custom_output_args_model():
                 usage=RequestUsage(input_tokens=51, output_tokens=6),
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
+                provider_name='test',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
@@ -192,6 +209,7 @@ def test_output_type():
                 usage=RequestUsage(input_tokens=51, output_tokens=7),
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
+                provider_name='test',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
@@ -241,6 +259,7 @@ def test_tool_retry():
                 usage=RequestUsage(input_tokens=51, output_tokens=4),
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
+                provider_name='test',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
@@ -262,6 +281,7 @@ def test_tool_retry():
                 usage=RequestUsage(input_tokens=61, output_tokens=8),
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
+                provider_name='test',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
@@ -280,6 +300,7 @@ def test_tool_retry():
                 usage=RequestUsage(input_tokens=62, output_tokens=12),
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
+                provider_name='test',
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),


### PR DESCRIPTION
- Closes #6062

This sets `provider_name=self._system` on every `ModelResponse` returned by `TestModel._request()`, so `agent.run()` now reports the same provider metadata as `agent.run_stream()`.

I added a regression test that runs `TestModel` through both paths and checks the `ModelResponse.provider_name` values.

Validation:

- `uv run pytest tests/models/test_model_test.py -q`
- `uv run pytest tests/test_streaming.py::test_streamed_text_response -q`
- `uv run ruff format pydantic_ai_slim/pydantic_ai/models/test.py tests/models/test_model_test.py --check`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/test.py tests/models/test_model_test.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/models/test.py tests/models/test_model_test.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

