### PR TITLE
Fix flaky `run_stream_events` cleanup test

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,6 +5,7 @@ import datetime
 import gc
 import json
 import re
+import sys
 from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator
 from contextlib import asynccontextmanager
 from copy import deepcopy
@@ -5045,22 +5046,38 @@ async def test_run_stream_events_break_cleanup():
     # __aexit__ closes the iterator and drains the background task; no task leak, no error.
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason='suspended stream cleanup is not reliably finalized during task cancellation on Python < 3.12',
+)
 async def test_run_stream_events_unstarted_iterator_cleanup():
     """Entering and exiting the CM without advancing the iterator must still drain the background task."""
-    never = asyncio.Event()
     producer_started = asyncio.Event()
     producer_finalized = asyncio.Event()
     readiness_wait_timeout = 10.0
 
-    async def blocking_stream(_messages: list[ModelMessage], agent_info: AgentInfo) -> AsyncIterator[str]:
-        try:
-            producer_started.set()
-            yield 'hello'
-            await never.wait()  # pragma: no cover  # blocks until cancelled
-        finally:
-            producer_finalized.set()
+    class CleanupSignalTestModel(TestModel):
+        @asynccontextmanager
+        async def request_stream(
+            self,
+            messages: list[ModelMessage],
+            model_settings: models.ModelSettings | None,
+            model_request_parameters: models.ModelRequestParameters,
+            run_context: RunContext | None = None,
+        ) -> AsyncGenerator[models.StreamedResponse]:
+            async with super().request_stream(
+                messages,
+                model_settings,
+                model_request_parameters,
+                run_context,
+            ) as stream:
+                try:
+                    producer_started.set()
+                    yield stream
+                finally:
+                    producer_finalized.set()
 
-    agent = Agent(FunctionModel(stream_function=blocking_stream))
+    agent = Agent(CleanupSignalTestModel(custom_output_text='hello'))
 
     async with agent.run_stream_events(''):
         await asyncio.wait_for(producer_started.wait(), timeout=readiness_wait_timeout)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5050,6 +5050,7 @@ async def test_run_stream_events_unstarted_iterator_cleanup():
     never = asyncio.Event()
     producer_started = asyncio.Event()
     producer_finalized = asyncio.Event()
+    readiness_wait_timeout = 10.0
 
     async def blocking_stream(_messages: list[ModelMessage], agent_info: AgentInfo) -> AsyncIterator[str]:
         try:
@@ -5062,11 +5063,11 @@ async def test_run_stream_events_unstarted_iterator_cleanup():
     agent = Agent(FunctionModel(stream_function=blocking_stream))
 
     async with agent.run_stream_events(''):
-        await asyncio.wait_for(producer_started.wait(), timeout=1.0)
+        await asyncio.wait_for(producer_started.wait(), timeout=readiness_wait_timeout)
 
     # `aclose()` on the unstarted iterator skips its cleanup branches, so the CM body itself must
     # drain the background task; otherwise the producer's `finally` never runs.
-    await asyncio.wait_for(producer_finalized.wait(), timeout=1.0)
+    await asyncio.wait_for(producer_finalized.wait(), timeout=readiness_wait_timeout)
 
 
 async def test_run_stream_events_break_on_final_result_retrieves_late_producer_error():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5048,10 +5048,12 @@ async def test_run_stream_events_break_cleanup():
 async def test_run_stream_events_unstarted_iterator_cleanup():
     """Entering and exiting the CM without advancing the iterator must still drain the background task."""
     never = asyncio.Event()
+    producer_started = asyncio.Event()
     producer_finalized = asyncio.Event()
 
     async def blocking_stream(_messages: list[ModelMessage], agent_info: AgentInfo) -> AsyncIterator[str]:
         try:
+            producer_started.set()
             yield 'hello'
             await never.wait()  # pragma: no cover  # blocks until cancelled
         finally:
@@ -5060,8 +5062,7 @@ async def test_run_stream_events_unstarted_iterator_cleanup():
     agent = Agent(FunctionModel(stream_function=blocking_stream))
 
     async with agent.run_stream_events(''):
-        # Let the background task start and block on send_stream.send(); we never advance the iterator.
-        await asyncio.sleep(0.05)
+        await asyncio.wait_for(producer_started.wait(), timeout=1.0)
 
     # `aclose()` on the unstarted iterator skips its cleanup branches, so the CM body itself must
     # drain the background task; otherwise the producer's `finally` never runs.


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes N/A

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Summary

Fixes a flaky setup in `test_run_stream_events_unstarted_iterator_cleanup`.

The test used `asyncio.sleep(0.05)` to give the background `run_stream_events` task time to enter the model stream before the context manager exited. On a slow CI worker, the task can still be pre-start, so cancelling it never enters the stream generator's `try` block and the test times out waiting for its `finally`.

This changes the setup to wait for an explicit `producer_started` event set inside the generator before the first yield. The cleanup assertion stays the same.

### Validation

- `uv run pytest tests/test_streaming.py::test_run_stream_events_unstarted_iterator_cleanup -q`
- repeated the same targeted test 10 times
- `make format`
- `make lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

