### PR TITLE
fix(huggingface): reject file content in tool returns

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -462,11 +462,14 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
             elif isinstance(part, UserPromptPart):
                 yield await self._map_user_prompt(part)
             elif isinstance(part, ToolReturnPart):
+                tool_text, tool_file_content = part.model_response_str_and_user_content()
+                if tool_file_content:
+                    raise NotImplementedError('File content is not supported for Hugging Face')
                 yield ChatCompletionOutputMessage.parse_obj_as_instance(  # type: ignore
                     {
                         'role': 'tool',
                         'tool_call_id': _guard_tool_call_id(t=part),
-                        'content': part.model_response_str(),
+                        'content': tool_text,
                     }
                 )
             elif isinstance(part, RetryPromptPart):

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -1011,6 +1011,23 @@ async def test_unsupported_media_types(allow_model_requests: None, content_item:
         await agent.run(['hello', content_item])
 
 
+async def test_tool_return_file_content_is_rejected():
+    model = HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=Mock(), api_key='x'))
+    request = ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name='get_location',
+                content=[UploadedFile(file_id='file-123', provider_name='anthropic')],
+                tool_call_id='call-123',
+            )
+        ]
+    )
+
+    with pytest.raises(NotImplementedError, match='File content is not supported for Hugging Face'):
+        async for _ in model._map_user_message(request):  # pyright: ignore[reportPrivateUsage]
+            pass
+
+
 @pytest.mark.vcr()
 async def test_hf_model_thinking_part(allow_model_requests: None, huggingface_api_key: str):
     m = HuggingFaceModel(


### PR DESCRIPTION
 ## Summary

  Fix `HuggingFaceModel` so tool returns containing file content are no longer silently dropped.

  Previously, `ToolReturnPart` values with multimodal/file content were converted with `model_response_str()`, which
  discarded file parts without any warning. This made the Hugging Face adapter inconsistent with other providers and could
  lead to silent data loss.

  ## Changes

  - Detect file content in Hugging Face tool returns.
  - Raise `NotImplementedError` instead of silently dropping unsupported file content.
  - Add a regression test covering tool returns with `UploadedFile`.

  ## Verification

  - `python -m compileall pydantic_ai_slim/pydantic_ai/models/huggingface.py tests/models/test_huggingface.py`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Closes https://github.com/pydantic/pydantic-ai/issues/5879