### PR TITLE
fix(ag-ui): preserve request tool return order

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -581,15 +581,21 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             if converted is not None:
                                 user_content.append(converted)
             elif isinstance(part, ToolReturnPart):
-                result.append(
-                    ToolMessage(
-                        id=_new_message_id(),
-                        content=part.model_response_str(),
-                        tool_call_id=part.tool_call_id,
-                    )
-                )
+                if user_content:
+                    if len(user_content) == 1 and isinstance(user_content[0], TextInputContent):
+                        result.append(UserMessage(id=_new_message_id(), content=user_content[0].text))
+                    else:
+                        result.append(UserMessage(id=_new_message_id(), content=user_content))
+                    user_content = []
+                result.append(ToolMessage(id=_new_message_id(), content=part.model_response_str(), tool_call_id=part.tool_call_id))
             elif isinstance(part, RetryPromptPart):
                 if part.tool_name:
+                    if user_content:
+                        if len(user_content) == 1 and isinstance(user_content[0], TextInputContent):
+                            result.append(UserMessage(id=_new_message_id(), content=user_content[0].text))
+                        else:
+                            result.append(UserMessage(id=_new_message_id(), content=user_content))
+                        user_content = []
                     result.append(
                         ToolMessage(
                             id=_new_message_id(),

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1728,6 +1728,37 @@ def test_dump_load_roundtrip_builtin_tool_return() -> None:
     assert reloaded == original
 
 
+def test_dump_preserves_tool_return_before_user_prompt() -> None:
+    """Tool returns in a request should stay before later user prompts when dumped."""
+    original: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name='suggest_answer',
+                    args='{"suggestions":["Yes","No"]}',
+                    tool_call_id='toolu_1',
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='suggest_answer',
+                    content="['Yes', 'No'] suggested.",
+                    tool_call_id='toolu_1',
+                ),
+                UserPromptPart(content='Yes, I confirm.'),
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+
+    assert [type(msg).__name__ for msg in ag_ui_msgs] == snapshot(['AssistantMessage', 'ToolMessage', 'UserMessage'])
+    assert ag_ui_msgs[1].tool_call_id == 'toolu_1'  # type: ignore[attr-defined]
+    assert ag_ui_msgs[2].content == 'Yes, I confirm.'  # type: ignore[attr-defined]
+
+
 def test_dump_builtin_tool_call_without_return() -> None:
     """Test that NativeToolCallPart without a matching NativeToolReturnPart still dumps correctly."""
     messages: list[ModelMessage] = [


### PR DESCRIPTION
## Summary

  Fix `AGUIAdapter.dump_messages()` so `ToolReturnPart` keeps its original order relative to `UserPromptPart` inside a
  `ModelRequest`.

  Previously, tool returns were appended after user prompts during dump, which could reorder message history and break
  providers that require tool results to immediately follow tool use.

  ## Testing

  - `python -m compileall pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Closes https://github.com/pydantic/pydantic-ai/issues/5964