### PR TITLE
chore(ci): stop `pydantic-ai-roundtrip-sweep` from filing auto failure-issues

### DIFF
--- a/.github/workflows/pydantic-ai-roundtrip-sweep.lock.yml
+++ b/.github/workflows/pydantic-ai-roundtrip-sweep.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6048371439005d7e588d0d252c829ff1c8868eb561f09a78c7908fece8fbe57e","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8efbdd972baaea6f35576752770d63badfe538198ea4d2ff45945e8b2b38c98a","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_READ_EXTERNAL_VARIABLES","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -210,20 +210,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_51b877f03a920b92_EOF'
+          cat << 'GH_AW_PROMPT_b70163c48d17fd92_EOF'
           <system>
-          GH_AW_PROMPT_51b877f03a920b92_EOF
+          GH_AW_PROMPT_b70163c48d17fd92_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_51b877f03a920b92_EOF'
+          cat << 'GH_AW_PROMPT_b70163c48d17fd92_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_51b877f03a920b92_EOF
+          GH_AW_PROMPT_b70163c48d17fd92_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_51b877f03a920b92_EOF'
+          cat << 'GH_AW_PROMPT_b70163c48d17fd92_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -255,9 +255,9 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_51b877f03a920b92_EOF
+          GH_AW_PROMPT_b70163c48d17fd92_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_51b877f03a920b92_EOF'
+          cat << 'GH_AW_PROMPT_b70163c48d17fd92_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/network-vendor-domains.md}}
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
@@ -269,7 +269,7 @@ jobs:
           {{#runtime-import .github/workflows/shared/pre-steps.md}}
           {{#runtime-import .github/workflows/shared/pre-agent-steps.md}}
           {{#runtime-import .github/workflows/pydantic-ai-roundtrip-sweep.md}}
-          GH_AW_PROMPT_51b877f03a920b92_EOF
+          GH_AW_PROMPT_b70163c48d17fd92_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -489,9 +489,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_52a072226961aac3_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_ffdbc014405dadfb_EOF'
           {"create_issue":{"close_older_issues":false,"close_older_key":"[roundtrip-sweep]","expires":168,"footer":false,"max":1,"title_prefix":"[roundtrip-sweep] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_52a072226961aac3_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ffdbc014405dadfb_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -695,7 +695,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_741c65d78a7b476e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b2866682a18f812a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -725,7 +725,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_741c65d78a7b476e_EOF
+          GH_AW_MCP_CONFIG_b2866682a18f812a_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1165,7 +1165,7 @@ jobs:
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_SAFE_OUTPUT_MESSAGES: "{\"activationComments\":\"false\"}"
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "30"

--- a/.github/workflows/pydantic-ai-roundtrip-sweep.md
+++ b/.github/workflows/pydantic-ai-roundtrip-sweep.md
@@ -17,6 +17,10 @@ tools:
 safe-outputs:
   footer: false
   activation-comments: false
+  # Engine/model failures are tracked as ERROR spans in Logfire (service_name
+  # `gh-aw.pydantic-ai-roundtrip-sweep`) via the otel-logfire import + the shim's
+  # `instrument_pydantic_ai`, so we don't also file an auto-generated failure issue.
+  report-failure-as-issue: false
   noop:
   create-issue:
     max: 1


### PR DESCRIPTION
- Closes #6060

### What

Set `safe-outputs.report-failure-as-issue: false` on the **Pydantic AI Round-Trip Sweep** workflow so its agent-engine failures no longer file an auto-generated `[aw] … failed` issue. Recompiled the lock (`gh aw compile`); the only semantic change is `GH_AW_FAILURE_REPORT_AS_ISSUE: "true" → "false"` (the rest of the `.lock.yml` diff is deterministic heredoc-delimiter re-hashing from the compiler).

### Why

The sweep's MiniMax-backed agent engine intermittently terminates mid-run — e.g. `MiniMax-M3` emits malformed `TodoWrite` tool calls, which Pydantic AI correctly rejects with `UnexpectedModelBehavior: Tool 'TodoWrite' exceeded max retries` (working as designed; `TodoWrite` is a harness tool, not a library tool). This produces recurring failure issues that need no code change: #6060 plus the already-closed #5996 / #5963 / #5858 / #5755 / #5603.

This **only** silences the auto-generated *failure* issue. The workflow's productive `create-issue` output — the real round-trip bug reports it files on successful runs (e.g. #6087, #5913) — is unchanged, and the workflow itself keeps running.

### Why this is safe — failures stay tracked in Logfire

Engine/run failures are already recorded as **ERROR-status spans** in Logfire (`service_name = gh-aw.pydantic-ai-roundtrip-sweep`), via two independent layers, so the reliability signal is preserved without the GitHub-issue noise:

1. **gh-aw OTLP export** — the `shared/otel-logfire.md` import wires `OTEL_EXPORTER_OTLP_*` + `LOGFIRE_TOKEN`.
2. **Shim instrumentation** — `.github/scripts/pydantic_ai_gh_aw_shim/cli.py` calls `logfire.configure(...)` + `logfire.instrument_pydantic_ai(...)`; the `'agent run'` span uses OTel's default `record_exception=True`/`set_status_on_exception=True`, so the `UnexpectedModelBehavior` lands as an ERROR span with the full traceback before the shim catches it.

### Follow-up (optional, not in this PR)

The error span relies on the interpreter's `atexit` flush (which runs on the clean `rc=1` failure path — including the MiniMax `TodoWrite` failures). A `SIGKILL` (e.g. the 30-min `timeout-minutes` hard-kill or OOM) would skip the flush. If we want *every* failure class guaranteed in Logfire once the issues are off, a `finally: logfire.force_flush()` around the run in `cli.py` would harden it — separable from this change.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** — CI/workflow config only.
- [x] **PR title** is fit for the release changelog.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

