### PR TITLE
examples: add Dakera persistent memory agent

### DIFF
--- a/docs/examples/dakera-memory-agent.md
+++ b/docs/examples/dakera-memory-agent.md
@@ -30,16 +30,16 @@ Start the Dakera server with Docker:
 ```bash
 docker run -d \
   --name dakera \
-  -p 3000:3000 \
+  -p 3300:3300 \
   -e DAKERA_API_KEY=demo \
   -v dakera_data:/data \
-  dakera/dakera:latest
+  ghcr.io/dakera-ai/dakera:latest
 ```
 
 Verify it's running:
 
 ```bash
-curl http://localhost:3000/health
+curl http://localhost:3300/health
 ```
 
 ## Running the Example
@@ -75,7 +75,7 @@ OPENAI_API_KEY=your-key DAKERA_API_KEY=demo \
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DAKERA_BASE_URL` | `http://localhost:3000` | Dakera server URL |
+| `DAKERA_BASE_URL` | `http://localhost:3300` | Dakera server URL |
 | `DAKERA_API_KEY` | `demo` | Dakera API key |
 | `DAKERA_NAMESPACE` | `pydantic-ai-agent` | Namespace to isolate memories |
 | `PYDANTIC_AI_MODEL` | `openai:gpt-4o` | Model to use for the agent |

--- a/docs/examples/dakera-memory-agent.md
+++ b/docs/examples/dakera-memory-agent.md
@@ -1,0 +1,85 @@
+# Dakera Memory Agent
+
+Persistent cross-session memory agent using [Dakera](https://dakera.ai) — a self-hosted, decay-weighted vector memory server.
+
+Demonstrates:
+
+- [tool definitions](../tools.md)
+- [agent dependencies](../dependencies.md)
+- persistent memory with decay-weighted recall
+- cross-session context retention
+
+## What Dakera Provides
+
+Dakera is a self-hosted REST server that stores agent memories as embeddings in a persistent vector index. Unlike in-process memory, Dakera memories survive process restarts, container rebuilds, and horizontal scaling.
+
+**Decay-weighted scoring**: Each memory has an importance score that decays exponentially over time without access. Memories recalled frequently stay ranked higher; stale context fades naturally — matching how human memory works.
+
+**Three REST endpoints cover all operations:**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/memories` | Store text as an embedding |
+| `POST` | `/v1/memories/search` | Semantic recall with decay scoring |
+| `DELETE` | `/v1/memories` | Forget memories by filter |
+
+## Setup
+
+Start the Dakera server with Docker:
+
+```bash
+docker run -d \
+  --name dakera \
+  -p 3000:3000 \
+  -e DAKERA_API_KEY=demo \
+  -v dakera_data:/data \
+  dakera/dakera:latest
+```
+
+Verify it's running:
+
+```bash
+curl http://localhost:3000/health
+```
+
+## Running the Example
+
+Store a fact (directly, without the agent):
+
+```bash
+DAKERA_API_KEY=demo uv run -m pydantic_ai_examples.dakera_memory_agent \
+  store "My name is Alice and I prefer concise technical answers."
+```
+
+Recall semantically similar memories:
+
+```bash
+DAKERA_API_KEY=demo uv run -m pydantic_ai_examples.dakera_memory_agent \
+  recall "What do you know about my communication preferences?"
+```
+
+Chat with the agent — it automatically recalls relevant context and stores new facts:
+
+```bash
+OPENAI_API_KEY=your-key DAKERA_API_KEY=demo \
+  uv run -m pydantic_ai_examples.dakera_memory_agent \
+  chat "What are my preferences?"
+
+# New process, same memories:
+OPENAI_API_KEY=your-key DAKERA_API_KEY=demo \
+  uv run -m pydantic_ai_examples.dakera_memory_agent \
+  chat "Do you remember who I am?"
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAKERA_BASE_URL` | `http://localhost:3000` | Dakera server URL |
+| `DAKERA_API_KEY` | `demo` | Dakera API key |
+| `DAKERA_NAMESPACE` | `pydantic-ai-agent` | Namespace to isolate memories |
+| `PYDANTIC_AI_MODEL` | `openai:gpt-4o` | Model to use for the agent |
+
+## Example Code
+
+```snippet {path="/examples/pydantic_ai_examples/dakera_memory_agent.py"}```

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -348,7 +348,8 @@
         "label": "Conversational Agents",
         "items": [
           "examples/chat-app",
-          "examples/bank-support"
+          "examples/bank-support",
+          "examples/dakera-memory-agent"
         ]
       },
       {

--- a/examples/pydantic_ai_examples/dakera_memory_agent.py
+++ b/examples/pydantic_ai_examples/dakera_memory_agent.py
@@ -1,0 +1,246 @@
+"""Persistent memory agent using Dakera — self-hosted, decay-weighted vector memory.
+
+Dakera is a self-hosted REST server that gives pydantic-ai agents persistent memory
+across process restarts. Each memory is stored as an embedding; recall uses
+decay-weighted scoring so stale context fades naturally.
+
+Start the Dakera server:
+
+    docker run -d \\
+        --name dakera \\
+        -p 3000:3000 \\
+        -e DAKERA_API_KEY=demo \\
+        -v dakera_data:/data \\
+        dakera/dakera:latest
+
+Store a fact:
+
+    uv run -m pydantic_ai_examples.dakera_memory_agent store \\
+        "My name is Alice and I prefer concise technical answers."
+
+Recall with a semantic query:
+
+    uv run -m pydantic_ai_examples.dakera_memory_agent recall \\
+        "What do you know about my preferences?"
+
+Chat with the agent (memory persists across runs):
+
+    uv run -m pydantic_ai_examples.dakera_memory_agent chat \\
+        "What are my communication preferences?"
+"""
+
+from __future__ import annotations as _annotations
+
+import asyncio
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from pydantic_ai import Agent, RunContext
+
+DAKERA_URL = os.getenv("DAKERA_BASE_URL", "http://localhost:3000")
+DAKERA_KEY = os.getenv("DAKERA_API_KEY", "demo")
+DAKERA_NS = os.getenv("DAKERA_NAMESPACE", "pydantic-ai-agent")
+
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MemoryDeps:
+    """Runtime dependencies injected into all agent tools."""
+
+    client: httpx.AsyncClient
+    namespace: str = DAKERA_NS
+
+
+# ---------------------------------------------------------------------------
+# Agent definition
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    os.getenv("PYDANTIC_AI_MODEL", "openai:gpt-4o"),
+    deps_type=MemoryDeps,
+    system_prompt=(
+        "You are a helpful assistant with persistent memory. "
+        "Before answering questions that may require past context, "
+        "use `recall_memory` to search for relevant information. "
+        "When the user shares important facts about themselves or their preferences, "
+        "use `store_memory` to save those facts for future sessions. "
+        "Be concise and accurate."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Memory tools
+# ---------------------------------------------------------------------------
+
+
+@agent.tool
+async def store_memory(ctx: RunContext[MemoryDeps], content: str) -> str:
+    """Store a fact or observation in persistent memory.
+
+    Args:
+        ctx: The call context with Dakera client.
+        content: The text to store (a fact, preference, or observation).
+
+    Returns:
+        Confirmation that the memory was stored.
+    """
+    resp = await ctx.deps.client.post(
+        "/v1/memories",
+        json={"content": content, "namespace": ctx.deps.namespace},
+    )
+    resp.raise_for_status()
+    return f"Stored: {content!r}"
+
+
+@agent.tool
+async def recall_memory(
+    ctx: RunContext[MemoryDeps], query: str, limit: int = 5
+) -> list[str]:
+    """Recall relevant memories by semantic similarity.
+
+    Results are ranked by a composite score: semantic similarity + recency +
+    importance (which decays over time without access). More recently accessed
+    memories rank higher.
+
+    Args:
+        ctx: The call context with Dakera client.
+        query: Natural-language query describing what you want to recall.
+        limit: Maximum number of memories to return (default 5).
+
+    Returns:
+        List of memory contents ranked by relevance.
+    """
+    resp = await ctx.deps.client.post(
+        "/v1/memories/search",
+        json={"query": query, "namespace": ctx.deps.namespace, "limit": limit},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    memories: list[dict[str, Any]] = data.get("memories", [])
+    if not memories:
+        return ["No relevant memories found."]
+    return [m["content"] for m in memories]
+
+
+@agent.tool
+async def forget_old_memories(
+    ctx: RunContext[MemoryDeps], older_than_days: int = 90
+) -> str:
+    """Forget memories older than N days.
+
+    Use this to prune stale context that is no longer relevant.
+
+    Args:
+        ctx: The call context with Dakera client.
+        older_than_days: Delete memories older than this many days (default 90).
+
+    Returns:
+        Confirmation of how many memories were deleted.
+    """
+    resp = await ctx.deps.client.request(
+        "DELETE",
+        "/v1/memories",
+        json={"namespace": ctx.deps.namespace, "older_than_days": older_than_days},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    deleted = data.get("deleted", "some")
+    return f"Forgot {deleted} memories older than {older_than_days} days."
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
+
+
+async def _run(prompt: str) -> str:
+    async with httpx.AsyncClient(
+        base_url=DAKERA_URL,
+        headers={"Authorization": f"Bearer {DAKERA_KEY}"},
+        timeout=15.0,
+    ) as client:
+        deps = MemoryDeps(client=client)
+        result = await agent.run(prompt, deps=deps)
+        return result.output
+
+
+async def _store_direct(content: str) -> None:
+    async with httpx.AsyncClient(
+        base_url=DAKERA_URL,
+        headers={"Authorization": f"Bearer {DAKERA_KEY}"},
+        timeout=15.0,
+    ) as client:
+        resp = await client.post(
+            "/v1/memories",
+            json={"content": content, "namespace": DAKERA_NS},
+        )
+        resp.raise_for_status()
+        print(f"Stored: {content!r}")
+
+
+async def _recall_direct(query: str) -> None:
+    async with httpx.AsyncClient(
+        base_url=DAKERA_URL,
+        headers={"Authorization": f"Bearer {DAKERA_KEY}"},
+        timeout=15.0,
+    ) as client:
+        resp = await client.post(
+            "/v1/memories/search",
+            json={"query": query, "namespace": DAKERA_NS, "limit": 5},
+        )
+        resp.raise_for_status()
+        memories = resp.json().get("memories", [])
+        if not memories:
+            print("No memories found.")
+        for i, m in enumerate(memories, 1):
+            score = m.get("score", 0.0)
+            print(f"[{i}] ({score:.2f}) {m['content']}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(0)
+
+    command = sys.argv[1]
+    args = sys.argv[2:]
+
+    if command == "store":
+        content = " ".join(args)
+        if not content:
+            print("Usage: store <text>")
+            sys.exit(1)
+        asyncio.run(_store_direct(content))
+
+    elif command == "recall":
+        query = " ".join(args)
+        if not query:
+            print("Usage: recall <query>")
+            sys.exit(1)
+        asyncio.run(_recall_direct(query))
+
+    elif command == "chat":
+        prompt = " ".join(args)
+        if not prompt:
+            print("Usage: chat <prompt>")
+            sys.exit(1)
+        response = asyncio.run(_run(prompt))
+        print(response)
+
+    else:
+        print(f"Unknown command: {command!r}")
+        print("Commands: store, recall, chat")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pydantic_ai_examples/dakera_memory_agent.py
+++ b/examples/pydantic_ai_examples/dakera_memory_agent.py
@@ -1,4 +1,4 @@
-"""Persistent memory agent using Dakera — self-hosted, decay-weighted vector memory.
+r"""Persistent memory agent using Dakera — self-hosted, decay-weighted vector memory.
 
 Dakera is a self-hosted REST server that gives pydantic-ai agents persistent memory
 across process restarts. Each memory is stored as an embedding; recall uses
@@ -41,9 +41,9 @@ import httpx
 
 from pydantic_ai import Agent, RunContext
 
-DAKERA_URL = os.getenv("DAKERA_BASE_URL", "http://localhost:3300")
-DAKERA_KEY = os.getenv("DAKERA_API_KEY", "demo")
-DAKERA_NS = os.getenv("DAKERA_NAMESPACE", "pydantic-ai-agent")
+DAKERA_URL = os.getenv('DAKERA_BASE_URL', 'http://localhost:3300')
+DAKERA_KEY = os.getenv('DAKERA_API_KEY', 'demo')
+DAKERA_NS = os.getenv('DAKERA_NAMESPACE', 'pydantic-ai-agent')
 
 
 # ---------------------------------------------------------------------------
@@ -64,15 +64,15 @@ class MemoryDeps:
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    os.getenv("PYDANTIC_AI_MODEL", "openai:gpt-4o"),
+    os.getenv('PYDANTIC_AI_MODEL', 'openai:gpt-4o'),
     deps_type=MemoryDeps,
     system_prompt=(
-        "You are a helpful assistant with persistent memory. "
-        "Before answering questions that may require past context, "
-        "use `recall_memory` to search for relevant information. "
-        "When the user shares important facts about themselves or their preferences, "
-        "use `store_memory` to save those facts for future sessions. "
-        "Be concise and accurate."
+        'You are a helpful assistant with persistent memory. '
+        'Before answering questions that may require past context, '
+        'use `recall_memory` to search for relevant information. '
+        'When the user shares important facts about themselves or their preferences, '
+        'use `store_memory` to save those facts for future sessions. '
+        'Be concise and accurate.'
     ),
 )
 
@@ -94,11 +94,11 @@ async def store_memory(ctx: RunContext[MemoryDeps], content: str) -> str:
         Confirmation that the memory was stored.
     """
     resp = await ctx.deps.client.post(
-        "/v1/memories",
-        json={"content": content, "namespace": ctx.deps.namespace},
+        '/v1/memories',
+        json={'content': content, 'namespace': ctx.deps.namespace},
     )
     resp.raise_for_status()
-    return f"Stored: {content!r}"
+    return f'Stored: {content!r}'
 
 
 @agent.tool
@@ -120,15 +120,15 @@ async def recall_memory(
         List of memory contents ranked by relevance.
     """
     resp = await ctx.deps.client.post(
-        "/v1/memories/search",
-        json={"query": query, "namespace": ctx.deps.namespace, "limit": limit},
+        '/v1/memories/search',
+        json={'query': query, 'namespace': ctx.deps.namespace, 'limit': limit},
     )
     resp.raise_for_status()
     data = resp.json()
-    memories: list[dict[str, Any]] = data.get("memories", [])
+    memories: list[dict[str, Any]] = data.get('memories', [])
     if not memories:
-        return ["No relevant memories found."]
-    return [m["content"] for m in memories]
+        return ['No relevant memories found.']
+    return [m['content'] for m in memories]
 
 
 @agent.tool
@@ -147,14 +147,14 @@ async def forget_old_memories(
         Confirmation of how many memories were deleted.
     """
     resp = await ctx.deps.client.request(
-        "DELETE",
-        "/v1/memories",
-        json={"namespace": ctx.deps.namespace, "older_than_days": older_than_days},
+        'DELETE',
+        '/v1/memories',
+        json={'namespace': ctx.deps.namespace, 'older_than_days': older_than_days},
     )
     resp.raise_for_status()
     data = resp.json()
-    deleted = data.get("deleted", "some")
-    return f"Forgot {deleted} memories older than {older_than_days} days."
+    deleted = data.get('deleted', 'some')
+    return f'Forgot {deleted} memories older than {older_than_days} days.'
 
 
 # ---------------------------------------------------------------------------
@@ -165,7 +165,7 @@ async def forget_old_memories(
 async def _run(prompt: str) -> str:
     async with httpx.AsyncClient(
         base_url=DAKERA_URL,
-        headers={"Authorization": f"Bearer {DAKERA_KEY}"},
+        headers={'Authorization': f'Bearer {DAKERA_KEY}'},
         timeout=15.0,
     ) as client:
         deps = MemoryDeps(client=client)
@@ -176,34 +176,34 @@ async def _run(prompt: str) -> str:
 async def _store_direct(content: str) -> None:
     async with httpx.AsyncClient(
         base_url=DAKERA_URL,
-        headers={"Authorization": f"Bearer {DAKERA_KEY}"},
+        headers={'Authorization': f'Bearer {DAKERA_KEY}'},
         timeout=15.0,
     ) as client:
         resp = await client.post(
-            "/v1/memories",
-            json={"content": content, "namespace": DAKERA_NS},
+            '/v1/memories',
+            json={'content': content, 'namespace': DAKERA_NS},
         )
         resp.raise_for_status()
-        print(f"Stored: {content!r}")
+        print(f'Stored: {content!r}')
 
 
 async def _recall_direct(query: str) -> None:
     async with httpx.AsyncClient(
         base_url=DAKERA_URL,
-        headers={"Authorization": f"Bearer {DAKERA_KEY}"},
+        headers={'Authorization': f'Bearer {DAKERA_KEY}'},
         timeout=15.0,
     ) as client:
         resp = await client.post(
-            "/v1/memories/search",
-            json={"query": query, "namespace": DAKERA_NS, "limit": 5},
+            '/v1/memories/search',
+            json={'query': query, 'namespace': DAKERA_NS, 'limit': 5},
         )
         resp.raise_for_status()
-        memories = resp.json().get("memories", [])
+        memories = resp.json().get('memories', [])
         if not memories:
-            print("No memories found.")
+            print('No memories found.')
         for i, m in enumerate(memories, 1):
-            score = m.get("score", 0.0)
-            print(f"[{i}] ({score:.2f}) {m['content']}")
+            score = m.get('score', 0.0)
+            print(f'[{i}] ({score:.2f}) {m["content"]}')
 
 
 def main() -> None:
@@ -214,33 +214,33 @@ def main() -> None:
     command = sys.argv[1]
     args = sys.argv[2:]
 
-    if command == "store":
-        content = " ".join(args)
+    if command == 'store':
+        content = ' '.join(args)
         if not content:
-            print("Usage: store <text>")
+            print('Usage: store <text>')
             sys.exit(1)
         asyncio.run(_store_direct(content))
 
-    elif command == "recall":
-        query = " ".join(args)
+    elif command == 'recall':
+        query = ' '.join(args)
         if not query:
-            print("Usage: recall <query>")
+            print('Usage: recall <query>')
             sys.exit(1)
         asyncio.run(_recall_direct(query))
 
-    elif command == "chat":
-        prompt = " ".join(args)
+    elif command == 'chat':
+        prompt = ' '.join(args)
         if not prompt:
-            print("Usage: chat <prompt>")
+            print('Usage: chat <prompt>')
             sys.exit(1)
         response = asyncio.run(_run(prompt))
         print(response)
 
     else:
-        print(f"Unknown command: {command!r}")
-        print("Commands: store, recall, chat")
+        print(f'Unknown command: {command!r}')
+        print('Commands: store, recall, chat')
         sys.exit(1)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/examples/pydantic_ai_examples/dakera_memory_agent.py
+++ b/examples/pydantic_ai_examples/dakera_memory_agent.py
@@ -8,10 +8,10 @@ Start the Dakera server:
 
     docker run -d \\
         --name dakera \\
-        -p 3000:3000 \\
+        -p 3300:3300 \\
         -e DAKERA_API_KEY=demo \\
         -v dakera_data:/data \\
-        dakera/dakera:latest
+        ghcr.io/dakera-ai/dakera:latest
 
 Store a fact:
 
@@ -41,7 +41,7 @@ import httpx
 
 from pydantic_ai import Agent, RunContext
 
-DAKERA_URL = os.getenv("DAKERA_BASE_URL", "http://localhost:3000")
+DAKERA_URL = os.getenv("DAKERA_BASE_URL", "http://localhost:3300")
 DAKERA_KEY = os.getenv("DAKERA_API_KEY", "demo")
 DAKERA_NS = os.getenv("DAKERA_NAMESPACE", "pydantic-ai-agent")
 


### PR DESCRIPTION
## Summary

Adds a working example of a pydantic-ai agent with persistent cross-session memory backed by [Dakera](https://dakera.ai) — a self-hosted, decay-weighted vector memory server.

Closes #6173

## What Changed

- **New example**: `examples/pydantic_ai_examples/dakera_memory_agent.py`
- **New doc**: `docs/examples/dakera-memory-agent.md`
- **Navigation**: Added entry in `docs/nav.json` under "Conversational Agents"

## Quick Start

```bash
# Start Dakera
docker run -d --name dakera -p 3000:3000 -e DAKERA_API_KEY=demo \
  -v dakera_data:/data dakera/dakera:latest

# Store a fact
DAKERA_API_KEY=demo uv run -m pydantic_ai_examples.dakera_memory_agent \
  store "My name is Alice and I prefer concise technical answers."

# Chat (agent recalls from memory automatically)
OPENAI_API_KEY=your-key DAKERA_API_KEY=demo \
  uv run -m pydantic_ai_examples.dakera_memory_agent \
  chat "What are my communication preferences?"

# New process — same memories persist
OPENAI_API_KEY=your-key DAKERA_API_KEY=demo \
  uv run -m pydantic_ai_examples.dakera_memory_agent \
  chat "Do you remember who I am?"
```

## Agent Design

The agent uses three tools registered via `@agent.tool` with typed `RunContext[MemoryDeps]` dependency injection:

```python
@dataclass
class MemoryDeps:
    client: httpx.AsyncClient
    namespace: str = "pydantic-ai-agent"

@agent.tool
async def store_memory(ctx: RunContext[MemoryDeps], content: str) -> str: ...

@agent.tool
async def recall_memory(ctx: RunContext[MemoryDeps], query: str, limit: int = 5) -> list[str]: ...

@agent.tool
async def forget_old_memories(ctx: RunContext[MemoryDeps], older_than_days: int = 90) -> str: ...
```

The `httpx.AsyncClient` is created once per run and injected via `MemoryDeps`, keeping connections efficient.

## Why Dakera vs In-Process Memory

- **Persistent**: Survives process restarts, container rebuilds, deployments
- **Decay-weighted**: Old unaccessed memories lose importance score naturally
- **Self-hosted**: `docker run` — no managed cloud service required
- **REST-auditable**: Inspect or delete memories with `curl` from outside the agent

## Test Plan

- [ ] `docker run -p 3000:3000 -e DAKERA_API_KEY=demo dakera/dakera:latest`
- [ ] `uv run -m pydantic_ai_examples.dakera_memory_agent store "..."` succeeds
- [ ] `uv run -m pydantic_ai_examples.dakera_memory_agent recall "..."` returns results
- [ ] `uv run -m pydantic_ai_examples.dakera_memory_agent chat "..."` recalls context from previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

