### PR TITLE
feat(exa): expose developer-configured domain filters

### DIFF
--- a/docs/common-tools.md
+++ b/docs/common-tools.md
@@ -257,6 +257,29 @@ result = agent.run_sync('What are the latest developments in quantum computing?'
 print(result.output)
 ```
 
+You can also restrict or exclude domains at tool creation time via `include_domains` / `exclude_domains`.
+Because these are configured by the developer rather than the model, the search query stays free of domain
+filters (which the LLM might otherwise inject into the query text):
+
+```py {title="exa_domain_filtering.py" test="skip"}
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.exa import exa_search_tool
+
+api_key = os.getenv('EXA_API_KEY')
+assert api_key is not None
+
+agent = Agent(
+    'openai:gpt-5.2',
+    tools=[exa_search_tool(api_key, num_results=5, include_domains=['arxiv.org'])],
+    system_prompt='Search the web for information using Exa.',
+)
+
+result = agent.run_sync('What are the latest developments in quantum computing?')
+print(result.output)
+```
+
 #### Using ExaToolset
 
 For better efficiency when using multiple Exa tools, use [`ExaToolset`][pydantic_ai.common_tools.exa.ExaToolset]

--- a/pydantic_ai_slim/pydantic_ai/common_tools/exa.py
+++ b/pydantic_ai_slim/pydantic_ai/common_tools/exa.py
@@ -100,6 +100,12 @@ class ExaSearchTool:
     max_characters: int | None
     """Maximum characters of text content per result, or None for no limit."""
 
+    include_domains: list[str] | None = None
+    """Developer-configured domains to restrict results to, or None for no restriction."""
+
+    exclude_domains: list[str] | None = None
+    """Developer-configured domains to exclude from results, or None for no exclusion."""
+
     async def __call__(
         self,
         query: str,
@@ -126,6 +132,8 @@ class ExaSearchTool:
             num_results=self.num_results,
             type=search_type,
             contents=contents,
+            include_domains=self.include_domains,
+            exclude_domains=self.exclude_domains,
         )
 
         return [
@@ -150,6 +158,12 @@ class ExaFindSimilarTool:
     num_results: int
     """The number of results to return."""
 
+    include_domains: list[str] | None = None
+    """Developer-configured domains to restrict results to, or None for no restriction."""
+
+    exclude_domains: list[str] | None = None
+    """Developer-configured domains to exclude from results, or None for no exclusion."""
+
     async def __call__(
         self,
         url: str,
@@ -171,6 +185,8 @@ class ExaFindSimilarTool:
             num_results=self.num_results,
             exclude_source_domain=exclude_source_domain,
             contents=contents,
+            include_domains=self.include_domains,
+            exclude_domains=self.exclude_domains,
         )
 
         return [
@@ -258,6 +274,8 @@ def exa_search_tool(
     *,
     num_results: int = 5,
     max_characters: int | None = None,
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
 ) -> Tool[Any]: ...
 
 
@@ -267,6 +285,8 @@ def exa_search_tool(
     client: AsyncExa,
     num_results: int = 5,
     max_characters: int | None = None,
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
 ) -> Tool[Any]: ...
 
 
@@ -276,6 +296,8 @@ def exa_search_tool(
     client: AsyncExa | None = None,
     num_results: int = 5,
     max_characters: int | None = None,
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
 ) -> Tool[Any]:
     """Creates an Exa search tool.
 
@@ -288,6 +310,10 @@ def exa_search_tool(
         num_results: The number of results to return. Defaults to 5.
         max_characters: Maximum characters of text content per result. Use this to limit
             token usage. Defaults to None (no limit).
+        include_domains: Domains to restrict results to. Set by the developer rather than the
+            model, so the search query stays free of domain filters. Defaults to None (no restriction).
+        exclude_domains: Domains to exclude from results. Set by the developer rather than the
+            model. Defaults to None (no exclusion).
     """
     if client is None:
         if api_key is None:
@@ -298,6 +324,8 @@ def exa_search_tool(
             client=client,
             num_results=num_results,
             max_characters=max_characters,
+            include_domains=include_domains,
+            exclude_domains=exclude_domains,
         ).__call__,
         name='exa_search',
         description='Searches Exa for the given query and returns the results with content. Exa is a neural search engine that finds high-quality, relevant results.',
@@ -309,6 +337,8 @@ def exa_find_similar_tool(
     api_key: str,
     *,
     num_results: int = 5,
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
 ) -> Tool[Any]: ...
 
 
@@ -317,6 +347,8 @@ def exa_find_similar_tool(
     *,
     client: AsyncExa,
     num_results: int = 5,
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
 ) -> Tool[Any]: ...
 
 
@@ -325,6 +357,8 @@ def exa_find_similar_tool(
     *,
     client: AsyncExa | None = None,
     num_results: int = 5,
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
 ) -> Tool[Any]:
     """Creates an Exa find similar tool.
 
@@ -335,13 +369,22 @@ def exa_find_similar_tool(
         client: An existing AsyncExa client. If provided, `api_key` is ignored.
             This is useful for sharing a client across multiple tools.
         num_results: The number of similar results to return. Defaults to 5.
+        include_domains: Domains to restrict results to. Set by the developer rather than the
+            model. Defaults to None (no restriction).
+        exclude_domains: Domains to exclude from results. Set by the developer rather than the
+            model. Defaults to None (no exclusion).
     """
     if client is None:
         if api_key is None:
             raise ValueError('Either api_key or client must be provided')
         client = AsyncExa(api_key=api_key)
     return Tool[Any](
-        ExaFindSimilarTool(client=client, num_results=num_results).__call__,
+        ExaFindSimilarTool(
+            client=client,
+            num_results=num_results,
+            include_domains=include_domains,
+            exclude_domains=exclude_domains,
+        ).__call__,
         name='exa_find_similar',
         description='Finds web pages similar to a given URL. Useful for discovering related content, competitors, or alternative sources.',
     )
@@ -435,6 +478,8 @@ class ExaToolset(FunctionToolset):
         *,
         num_results: int = 5,
         max_characters: int | None = None,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
         include_search: bool = True,
         include_find_similar: bool = True,
         include_get_contents: bool = True,
@@ -450,6 +495,10 @@ class ExaToolset(FunctionToolset):
             num_results: The number of results to return for search and find_similar. Defaults to 5.
             max_characters: Maximum characters of text content per result. Use this to limit
                 token usage. Defaults to None (no limit).
+            include_domains: Domains to restrict search/find_similar results to. Set by the developer
+                rather than the model, so the query stays free of domain filters. Defaults to None.
+            exclude_domains: Domains to exclude from search/find_similar results. Set by the developer
+                rather than the model. Defaults to None.
             include_search: Whether to include the search tool. Defaults to True.
             include_find_similar: Whether to include the find_similar tool. Defaults to True.
             include_get_contents: Whether to include the get_contents tool. Defaults to True.
@@ -460,10 +509,25 @@ class ExaToolset(FunctionToolset):
         tools: list[Tool[Any]] = []
 
         if include_search:
-            tools.append(exa_search_tool(client=client, num_results=num_results, max_characters=max_characters))
+            tools.append(
+                exa_search_tool(
+                    client=client,
+                    num_results=num_results,
+                    max_characters=max_characters,
+                    include_domains=include_domains,
+                    exclude_domains=exclude_domains,
+                )
+            )
 
         if include_find_similar:
-            tools.append(exa_find_similar_tool(client=client, num_results=num_results))
+            tools.append(
+                exa_find_similar_tool(
+                    client=client,
+                    num_results=num_results,
+                    include_domains=include_domains,
+                    exclude_domains=exclude_domains,
+                )
+            )
 
         if include_get_contents:
             tools.append(exa_get_contents_tool(client=client))

--- a/tests/test_exa.py
+++ b/tests/test_exa.py
@@ -1,0 +1,125 @@
+"""Tests for the Exa common tools.
+
+These tests avoid hitting the network by injecting a fake `AsyncExa` client that
+records the keyword arguments passed to `search` / `find_similar`, so we can assert
+the developer-configured domain filters are forwarded to the Exa SDK.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from pydantic_ai.common_tools.exa import (
+    ExaFindSimilarTool,
+    ExaSearchTool,
+    ExaToolset,
+)
+
+pytest.importorskip('exa_py', reason='exa extra not installed')
+
+pytestmark = pytest.mark.anyio
+
+
+@dataclass
+class _FakeResult:
+    title: str | None = 'Title'
+    url: str = 'https://example.com'
+    published_date: str | None = None
+    author: str | None = None
+    text: str | None = 'body'
+
+
+@dataclass
+class _FakeResponse:
+    results: list[_FakeResult] = field(default_factory=lambda: [_FakeResult()])
+
+
+class _FakeExaClient:
+    """Records the kwargs passed to `search` / `find_similar`."""
+
+    def __init__(self) -> None:
+        self.search_kwargs: dict[str, Any] = {}
+        self.find_similar_kwargs: dict[str, Any] = {}
+
+    async def search(self, query: str, **kwargs: Any) -> _FakeResponse:
+        self.search_kwargs = {'query': query, **kwargs}
+        return _FakeResponse()
+
+    async def find_similar(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.find_similar_kwargs = {'url': url, **kwargs}
+        return _FakeResponse()
+
+
+async def test_search_forwards_domain_filters() -> None:
+    client = _FakeExaClient()
+    tool = ExaSearchTool(
+        client=client,  # type: ignore[arg-type]
+        num_results=3,
+        max_characters=None,
+        include_domains=['arxiv.org'],
+        exclude_domains=['spam.example'],
+    )
+
+    results = await tool('quantum computing')
+
+    assert results == [
+        {
+            'title': 'Title',
+            'url': 'https://example.com',
+            'published_date': None,
+            'author': None,
+            'text': 'body',
+        }
+    ]
+    assert client.search_kwargs['include_domains'] == ['arxiv.org']
+    assert client.search_kwargs['exclude_domains'] == ['spam.example']
+
+
+async def test_search_defaults_domain_filters_to_none() -> None:
+    client = _FakeExaClient()
+    tool = ExaSearchTool(client=client, num_results=5, max_characters=None)  # type: ignore[arg-type]
+
+    await tool('hello')
+
+    assert client.search_kwargs['include_domains'] is None
+    assert client.search_kwargs['exclude_domains'] is None
+
+
+async def test_find_similar_forwards_domain_filters() -> None:
+    client = _FakeExaClient()
+    tool = ExaFindSimilarTool(
+        client=client,  # type: ignore[arg-type]
+        num_results=2,
+        include_domains=['arxiv.org'],
+        exclude_domains=['spam.example'],
+    )
+
+    await tool('https://example.com/article')
+
+    assert client.find_similar_kwargs['include_domains'] == ['arxiv.org']
+    assert client.find_similar_kwargs['exclude_domains'] == ['spam.example']
+    assert client.find_similar_kwargs['exclude_source_domain'] is True
+
+
+def test_toolset_threads_domain_filters_to_search_and_find_similar() -> None:
+    toolset = ExaToolset(
+        api_key='test-key',
+        include_domains=['arxiv.org'],
+        exclude_domains=['spam.example'],
+        include_get_contents=False,
+        include_answer=False,
+    )
+
+    search_impl = toolset.tools['exa_search'].function.__self__  # type: ignore[attr-defined]
+    find_similar_impl = toolset.tools['exa_find_similar'].function.__self__  # type: ignore[attr-defined]
+
+    assert isinstance(search_impl, ExaSearchTool)
+    assert search_impl.include_domains == ['arxiv.org']
+    assert search_impl.exclude_domains == ['spam.example']
+
+    assert isinstance(find_similar_impl, ExaFindSimilarTool)
+    assert find_similar_impl.include_domains == ['arxiv.org']
+    assert find_similar_impl.exclude_domains == ['spam.example']


### PR DESCRIPTION
Closes #6082

## Problem

The Exa `search` and `find_similar` common tools gave developers no way to restrict or exclude result domains. The only way to bias results toward specific domains was to rely on the model injecting a domain filter into the query text — which is unreliable and, as noted in the issue, causes the LLM to pollute the query with domain filters instead of keeping them as a configuration concern.

## Fix

Add `include_domains` / `exclude_domains` parameters to:

- `exa_search_tool` and `exa_find_similar_tool` factory functions (+ overloads)
- the underlying `ExaSearchTool` / `ExaFindSimilarTool` dataclasses
- `ExaToolset` (threaded through to both search and find_similar)

They are set by the developer at tool-creation time and forwarded to the Exa SDK's `search` / `find_similar` calls, mirroring the existing Tavily tool's domain-filtering ergonomics. Both parameters default to `None`, so existing callers are unaffected.

## Tests

`tests/test_exa.py` (new) uses a fake `AsyncExa` client (no network) to assert:
- `include_domains` / `exclude_domains` are forwarded to `search` and `find_similar`
- they default to `None` when unset
- `ExaToolset` threads the filters through to both underlying tools

## Verification

- `ruff check` / `ruff format --check`: clean
- `pyright`: 0 errors (against exa-py 2.15)
- new tests: 4/4 pass

Scope is intentionally minimal — the domain-filter exposure that the issue explicitly motivates (developer-configured filters rather than model-injected ones). The broader exa-py 2.15 modernization items in the issue (highlights content type, deprecated `search_type` values) can follow separately.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

