### PR TITLE
fix: preserve AG-UI `ToolReturnPart` error outcomes

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -457,6 +457,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 tool_name=tool_name,
                                 content=tool_msg.content,
                                 tool_call_id=tool_call_id,
+                                outcome='failed' if tool_msg.error is not None else 'success',
                             )
                         )
 
@@ -581,11 +582,13 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             if converted is not None:
                                 user_content.append(converted)
             elif isinstance(part, ToolReturnPart):
+                content = part.model_response_str()
                 result.append(
                     ToolMessage(
                         id=_new_message_id(),
-                        content=part.model_response_str(),
+                        content=content,
                         tool_call_id=part.tool_call_id,
+                        error=content if part.outcome != 'success' else None,
                     )
                 )
             elif isinstance(part, RetryPromptPart):

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1596,6 +1596,80 @@ def test_dump_load_roundtrip_tools() -> None:
     assert reloaded == original
 
 
+def test_dump_load_roundtrip_failed_tool_return() -> None:
+    """Test that failed tool returns survive an AG-UI round-trip."""
+    original: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Call tool')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='my_tool', tool_call_id='call_abc', args='{"x": 1}')]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='my_tool',
+                    tool_call_id='call_abc',
+                    content='error from tool',
+                    outcome='failed',
+                )
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    _sync_timestamps(original, reloaded)
+
+    assert reloaded == original
+
+
+@pytest.mark.parametrize('outcome', ['failed', 'denied'])
+def test_dump_unsuccessful_tool_return_sets_ag_ui_error(outcome: Literal['failed', 'denied']) -> None:
+    """Test that unsuccessful tool returns are not emitted as clean AG-UI tool messages."""
+    ag_ui_msgs = AGUIAdapter.dump_messages(
+        [
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name='my_tool',
+                        tool_call_id='call_abc',
+                        content='tool did not complete',
+                        outcome=outcome,
+                    )
+                ]
+            )
+        ]
+    )
+
+    assert len(ag_ui_msgs) == 1
+    tool_msg = ag_ui_msgs[0]
+    assert isinstance(tool_msg, ToolMessage)
+    assert tool_msg.error == 'tool did not complete'
+
+
+def test_load_tool_message_error_sets_failed_outcome() -> None:
+    """Test that AG-UI tool messages with error state reload as failed tool returns."""
+    reloaded = AGUIAdapter.load_messages(
+        [
+            AssistantMessage(
+                id='assistant_1',
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id='call_abc',
+                        type='function',
+                        function=FunctionCall(name='my_tool', arguments='{}'),
+                    )
+                ],
+            ),
+            ToolMessage(id='tool_1', content='error from tool', tool_call_id='call_abc', error='error from tool'),
+        ]
+    )
+
+    assert len(reloaded) == 2
+    assert isinstance(reloaded[1], ModelRequest)
+    tool_return = reloaded[1].parts[0]
+    assert isinstance(tool_return, ToolReturnPart)
+    assert tool_return.outcome == 'failed'
+
+
 def test_dump_load_roundtrip_multiple_thinking_parts() -> None:
     """Test round-trip preserves multiple ThinkingParts with their metadata."""
     original: list[ModelMessage] = [
@@ -1828,6 +1902,7 @@ def test_dump_load_roundtrip_retry_prompt_with_tool() -> None:
     assert isinstance(retry_part, ToolReturnPart)
     assert retry_part.tool_name == 'my_tool'
     assert retry_part.tool_call_id == 'call_1'
+    assert retry_part.outcome == 'failed'
 
 
 def test_dump_load_roundtrip_retry_prompt_without_tool() -> None:


### PR DESCRIPTION
- Closes #5870

### Summary

- Preserve AG-UI `ToolMessage.error` when dumping failed or denied `ToolReturnPart` values.
- Load AG-UI tool messages with `error` set as failed `ToolReturnPart` values.
- Add AG-UI round-trip coverage for failed tool returns, direct error messages, and retry prompts.

### Validation

- `uv run --extra ag-ui pytest tests/test_ag_ui.py -k 'dump_load_roundtrip_tools or dump_load_roundtrip_failed_tool_return or dump_unsuccessful_tool_return_sets_ag_ui_error or load_tool_message_error_sets_failed_outcome or dump_load_roundtrip_retry_prompt_with_tool'`
- `uv run --extra ag-ui pytest tests/test_ag_ui.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

