### PR TITLE
Handle JSON-encoded span attributes in `SpanQuery`

### DIFF
--- a/pydantic_evals/pydantic_evals/otel/span_tree.py
+++ b/pydantic_evals/pydantic_evals/otel/span_tree.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
@@ -20,6 +21,17 @@ AttributeValue = str | bool | int | float | Sequence[str] | Sequence[bool] | Seq
 
 
 __all__ = 'SpanNode', 'SpanTree', 'SpanQuery'
+
+
+def _attribute_matches(actual: AttributeValue | None, expected: Any) -> bool:
+    if actual == expected:
+        return True
+    if isinstance(actual, str) and isinstance(expected, (dict, list)):
+        try:
+            return json.loads(actual) == expected
+        except ValueError:
+            return False
+    return False
 
 
 class SpanQuery(TypedDict, total=False):
@@ -267,7 +279,7 @@ class SpanNode:
 
         # Attribute conditions
         if (has_attributes := query.get('has_attributes')) and not all(
-            self.attributes.get(key) == value for key, value in has_attributes.items()
+            _attribute_matches(self.attributes.get(key), value) for key, value in has_attributes.items()
         ):
             return False
         if (has_attributes_keys := query.get('has_attribute_keys')) and not all(

--- a/tests/evals/test_otel.py
+++ b/tests/evals/test_otel.py
@@ -230,6 +230,24 @@ async def test_span_node_matches(span_tree: SpanTree):
     assert not child1_node.matches(SpanQuery(name_equals='child1', has_attributes={'type': 'normal'}))
 
 
+async def test_span_query_matches_json_encoded_attributes(span_tree: SpanTree):
+    root_node = span_tree.roots[0]
+    root_node.attributes.update(
+        {
+            'serialized_dict': '{"tool": {"name": "search"}, "ids": [1, 2]}',
+            'serialized_list': '["alpha", {"score": 1}]',
+            'malformed_json': '{"tool":',
+            'json_string': '"plain"',
+        }
+    )
+
+    assert root_node.matches({'has_attributes': {'serialized_dict': {'tool': {'name': 'search'}, 'ids': [1, 2]}}})
+    assert root_node.matches({'has_attributes': {'serialized_list': ['alpha', {'score': 1}]}})
+    assert not root_node.matches({'has_attributes': {'serialized_dict': {'tool': {'name': 'search'}, 'ids': [1, 3]}}})
+    assert not root_node.matches({'has_attributes': {'malformed_json': {'tool': {'name': 'search'}}}})
+    assert not root_node.matches({'has_attributes': {'json_string': 'plain'}})
+
+
 async def test_span_tree_repr(span_tree: SpanTree):
     assert repr(SpanTree()) == snapshot('<SpanTree />')
     assert str(span_tree) == snapshot('<SpanTree num_roots=1 total_spans=6 />')


### PR DESCRIPTION
- Closes #4448

This keeps the existing exact attribute comparison first, then parses JSON-encoded span attribute strings when the query value is a `dict` or `list`. That covers complex OTel attributes stored as strings without changing ordinary string matching.

Tests:

- `uv run pytest tests/evals/test_otel.py`
- `uv run ruff check pydantic_evals/pydantic_evals/otel/span_tree.py tests/evals/test_otel.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_evals/pydantic_evals/otel/span_tree.py tests/evals/test_otel.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

