### PR TITLE
Emit an `execute_tool` span for tool calls that fail validation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/abstract.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias
 from pydantic import ValidationError
 
 from pydantic_ai._instructions import AgentInstructions
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, ToolRetryError
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.tools import (
     AgentDepsT,
@@ -713,6 +713,28 @@ class AbstractCapability(ABC, Generic[AgentDepsT]):
         to intercept retries.
         """
         raise error
+
+    async def on_tool_execute_skipped(
+        self,
+        ctx: RunContext[AgentDepsT],
+        *,
+        call: ToolCallPart,
+        error: ToolRetryError,
+    ) -> None:
+        """Observe a tool call that failed argument validation and is therefore not executed.
+
+        Unlike [`on_tool_validate_error`][pydantic_ai.capabilities.AbstractCapability.on_tool_validate_error]
+        (which fires *during* validation and may recover by returning valid args), this fires later —
+        when a call whose arguments already failed validation reaches the execute stage and its
+        [`ToolRetryError`][pydantic_ai.exceptions.ToolRetryError] is about to be surfaced to the model.
+        It also covers hallucinated tool names (an unknown tool never reaches `wrap_tool_validate`).
+
+        Observe-only: the `error` is raised regardless of what this hook does. The
+        [`Instrumentation`][pydantic_ai.capabilities.Instrumentation] capability uses it to emit an
+        `execute_tool` span for the failed call, so validation failures appear in traces alongside
+        the spans that successful and execution-failed calls produce. Default: do nothing.
+        """
+        return None
 
     # --- Output validate lifecycle hooks ---
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/combined.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 
 from pydantic_ai._instructions import AgentInstructions, normalize_instructions
 from pydantic_ai._utils import gather
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, ToolRetryError
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.settings import ModelSettings, merge_model_settings
 from pydantic_ai.tools import (
@@ -534,6 +534,17 @@ class CombinedCapability(AbstractCapability[AgentDepsT]):
             except Exception as new_error:
                 error = new_error
         raise error
+
+    async def on_tool_execute_skipped(
+        self,
+        ctx: RunContext[AgentDepsT],
+        *,
+        call: ToolCallPart,
+        error: ToolRetryError,
+    ) -> None:
+        for capability in self.capabilities:
+            if (cap_ctx := _ctx_for_available_cap(capability, ctx)) is not None:
+                await capability.on_tool_execute_skipped(cap_ctx, call=call, error=error)
 
     # --- Output validate lifecycle hooks ---
 

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -404,6 +404,32 @@ class Instrumentation(AbstractCapability[Any]):
             handle_tool_control_flow=True,
         )
 
+    async def on_tool_execute_skipped(
+        self,
+        ctx: RunContext[AgentDepsT],
+        *,
+        call: ToolCallPart,
+        error: ToolRetryError,
+    ) -> None:
+        """Emit an `execute_tool` span for a call skipped because its arguments failed validation.
+
+        The call never runs (so there's nothing to wrap in `wrap_tool_execute`), but we still want it
+        to show up in traces. Mirrors the `ToolRetryError` branch of `_run_tool_span`: record the retry
+        prompt the model will see as the tool result, then mark the span `ERROR`.
+        """
+        settings = self.settings
+        names = self._instrumentation_names
+        with settings.tracer.start_as_current_span(
+            names.get_tool_span_name(call.tool_name),
+            attributes=self._tool_span_attributes(call),
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            if settings.include_content and span.is_recording():
+                span.set_attribute(names.tool_result_attr, error.tool_retry.model_response())
+            span.record_exception(error, escaped=True)
+            span.set_status(StatusCode.ERROR)
+
     # ------------------------------------------------------------------
     # wrap_output_process — output tool execution span (tool-mode only)
     # ------------------------------------------------------------------

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -411,7 +411,11 @@ class Instrumentation(AbstractCapability[Any]):
         call: ToolCallPart,
         error: ToolRetryError,
     ) -> None:
-        """Emit an `execute_tool` span for a call skipped because its arguments failed validation.
+        """Emit an `execute_tool` span for a call skipped before execution.
+
+        Fires when a tool call can't run and its `ToolRetryError` is about to be surfaced to the
+        model — either its arguments failed validation, or it named an unknown/hallucinated tool
+        (rejected during validation and wrapped as a `ToolRetryError`).
 
         The call never runs (so there's nothing to wrap in `wrap_tool_execute`), but we still want it
         to show up in traces. Mirrors the `ToolRetryError` branch of `_run_tool_span`: record the retry

--- a/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/wrapper.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import ValidationError
 
 from pydantic_ai._instructions import AgentInstructions
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, ToolRetryError
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse, ToolCallPart
 from pydantic_ai.tools import (
     AgentDepsT,
@@ -331,6 +331,15 @@ class WrapperCapability(AbstractCapability[AgentDepsT]):
         error: Exception,
     ) -> Any:
         return await self.wrapped.on_tool_execute_error(ctx, call=call, tool_def=tool_def, args=args, error=error)
+
+    async def on_tool_execute_skipped(
+        self,
+        ctx: RunContext[AgentDepsT],
+        *,
+        call: ToolCallPart,
+        error: ToolRetryError,
+    ) -> None:
+        return await self.wrapped.on_tool_execute_skipped(ctx, call=call, error=error)
 
     # --- Output validate lifecycle hooks ---
 

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -714,6 +714,13 @@ class ToolManager(Generic[AgentDepsT]):
         # Asserts narrow types for pyright; invariants guaranteed by ValidatedToolCall construction
         if not validated.args_valid:
             assert validated.validation_error is not None
+            # The call failed validation and won't execute, so no `wrap_tool_execute` span is opened.
+            # Give capabilities (e.g. Instrumentation) a chance to record the failure — this is what
+            # makes a validation-failed call still surface an `execute_tool` span — before raising.
+            if self.root_capability is not None:
+                await self.root_capability.on_tool_execute_skipped(
+                    validated.ctx, call=validated.call, error=validated.validation_error
+                )
             raise validated.validation_error
 
         assert validated.tool is not None

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -58,6 +58,7 @@ from pydantic_ai.exceptions import (
     SkipModelRequest,
     SkipToolExecution,
     SkipToolValidation,
+    ToolRetryError,
     UndrainedPendingMessagesError,
     UnexpectedModelBehavior,
     UserError,
@@ -4109,6 +4110,7 @@ _DEFERRED_HOOK_NAMES = {
     'on_model_request_error',
     'on_tool_validate_error',
     'on_tool_execute_error',
+    'on_tool_execute_skipped',
     'before_output_validate',
     'after_output_validate',
     'wrap_output_validate',
@@ -4162,6 +4164,9 @@ async def test_combined_capability_skips_unloaded_deferred_forward_hooks() -> No
         )
         is None
     )
+    skip_call = ToolCallPart('tool', {}, tool_call_id='skip-call')
+    skip_error = ToolRetryError(RetryPromptPart(tool_name='tool', content='bad', tool_call_id='skip-call'))
+    assert await combined.on_tool_execute_skipped(ctx, call=skip_call, error=skip_error) is None
 
 
 async def test_combined_capability_skips_unloaded_deferred_reverse_hooks() -> None:
@@ -11363,6 +11368,38 @@ async def test_wrapper_capability_delegates_on_tool_execute_error():
 
     result = await agent.run('call tool')
     assert result.output == 'final response'
+
+
+async def test_wrapper_capability_delegates_on_tool_execute_skipped():
+    """WrapperCapability delegates on_tool_execute_skipped to the wrapped capability."""
+
+    @dataclass
+    class SkipObserverCap(AbstractCapability[Any]):
+        log: list[str] = field(default_factory=list[str])
+
+        async def on_tool_execute_skipped(
+            self, ctx: RunContext[Any], *, call: ToolCallPart, error: ToolRetryError
+        ) -> None:
+            self.log.append(f'on_tool_execute_skipped:{call.tool_name}')
+
+    def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        for msg in messages:
+            for part in msg.parts:
+                if isinstance(part, RetryPromptPart):
+                    return ModelResponse(parts=[TextPart(content='done')])
+        # Call the tool with args that fail schema validation, so it's skipped before execution.
+        return ModelResponse(parts=[ToolCallPart(tool_name='my_tool', args={'x': 'not-an-int'})])
+
+    observer = SkipObserverCap()
+    agent = Agent(FunctionModel(model_fn), capabilities=[WrapperCapability(wrapped=observer)])
+
+    @agent.tool_plain
+    def my_tool(x: int) -> str:  # pragma: no cover — never executes, args fail validation
+        return f'result: {x}'
+
+    result = await agent.run('call tool')
+    assert result.output == 'done'
+    assert observer.log == ['on_tool_execute_skipped:my_tool']
 
 
 # --- Tests for double-execution bug fix (streaming + before_node_run replacement) ---

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -1406,6 +1406,59 @@ Fix the errors and try again.\
             )
 
 
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+@pytest.mark.parametrize('include_content', [True, False])
+def test_failed_tool_call_emits_execute_tool_span(
+    get_logfire_summary: Callable[[], LogfireSummary], include_content: bool
+) -> None:
+    """A tool call that fails argument validation (or names an unknown tool) still emits an
+    `execute_tool` span, marked ERROR, just like a call that fails during execution."""
+
+    def call_failing_tools(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart('add', {'x': 'not-an-int', 'y': 2}),  # fails schema validation
+                    ToolCallPart('does_not_exist', {}),  # hallucinated tool name
+                ]
+            )
+        return ModelResponse(parts=[TextPart('done')])
+
+    my_agent = Agent(
+        model=FunctionModel(call_failing_tools),
+        capabilities=[Instrumentation(settings=InstrumentationSettings(include_content=include_content))],
+    )
+
+    @my_agent.tool_plain
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    my_agent.run_sync('go')
+
+    summary = get_logfire_summary()
+    tool_spans = {
+        attrs['gen_ai.tool.name']: attrs
+        for attrs in summary.attributes.values()
+        if attrs.get('gen_ai.operation.name') == 'execute_tool'
+    }
+
+    # Both the bad-args call and the unknown-tool call produce an ERROR-level execute_tool span
+    # (logfire.level_num 17 == error), even though neither tool body ran.
+    assert set(tool_spans) == {'add', 'does_not_exist'}
+    assert tool_spans['add']['logfire.level_num'] == 17
+    assert tool_spans['does_not_exist']['logfire.level_num'] == 17
+
+    if include_content:
+        # The retry prompt the model will see is recorded as the tool result.
+        assert 'validation error' in tool_spans['add']['gen_ai.tool.call.result']
+        assert 'Fix the errors and try again.' in tool_spans['add']['gen_ai.tool.call.result']
+        assert 'Unknown tool name' in tool_spans['does_not_exist']['gen_ai.tool.call.result']
+    else:
+        # Content is excluded, so the result/args are never recorded on the span.
+        assert 'gen_ai.tool.call.result' not in tool_spans['add']
+        assert 'gen_ai.tool.call.arguments' not in tool_spans['add']
+
+
 class WeatherInfo(BaseModel):
     temperature: float
     description: str


### PR DESCRIPTION
## Problem

Only tool calls that fail **during execution** produce an `execute_tool` span (marked ERROR). Calls that fail at the **validation** stage — bad arguments, or an unknown/hallucinated tool name — raise their `ToolRetryError` before any span-creating hook runs, so they never show up in traces. This was reported internally ("why don't failed tool calls generate a `running tool` span?"), and confirmed with a repro:

| Scenario | Before | After |
|---|---|---|
| Bad arguments (schema validation fails) | ❌ no span | ✅ `execute_tool` span, ERROR |
| Unknown / hallucinated tool name | ❌ no span | ✅ `execute_tool` span, ERROR |
| Failure during execution (`ModelRetry`) | ✅ span, ERROR | ✅ span, ERROR |

### Before / after in Logfire

The same run — a tool called with **invalid arguments** (schema validation fails). Identical except for the fix.

**Before** — the failed call produces no span; `agent run` has only the two `chat` spans:

<img width="1568" height="116" alt="image-1782912770965" src="https://github.com/user-attachments/assets/072b7465-22bb-4902-995d-7884b3aba93b" />

**After** — the failed call now produces a `running tool: add` span, marked with an `exception` (ERROR) status:

<img width="1565" height="148" alt="image-1782912762688" src="https://github.com/user-attachments/assets/577b5386-d30b-40c4-bbb2-e36fd2f7909b" />

## Fix

The tool span is opened inside `wrap_tool_execute`, which only runs on the execute path. A validation-failed call raises in `_execute_tool_call_impl` **before** that hook — so no span.

This adds a small capability hook, `on_tool_execute_skipped`, invoked at the single choke point where a validation-failed call is about to raise its `ToolRetryError`. `Instrumentation` implements it to emit the `execute_tool` span (recording the retry prompt as the result and marking the span ERROR), mirroring the `ToolRetryError` branch of `_run_tool_span`. Every other capability inherits a no-op default; `CombinedCapability`/`WrapperCapability` dispatch it.

## Why a new hook rather than `wrap_tool_validate`

Implementing this in `wrap_tool_validate` was considered, but firing at the post-validation choke point is more robust:

1. **Unknown tools bypass `wrap_tool_validate`.** They're rejected in `_resolve_tool` *before* the validate hooks run, so a `wrap_tool_validate` implementation wouldn't produce a span for them.
2. **No spurious spans on recovery.** A `ValidationError`/`ModelRetry` from `wrap_tool_validate` can be recovered by `on_tool_validate_error` (the call then executes and gets a normal span). `on_tool_execute_skipped` fires only *after* recovery is exhausted, so it never marks a span ERROR for a call that ultimately succeeds.
3. **No double spans** for successful calls (`wrap_tool_validate` runs on every validation).

The tradeoff is a new (no-op-by-default) hook on `AbstractCapability`. Feedback welcome on that vs. reusing `wrap_tool_validate` — happy to switch if preferred.

## Tests

- `test_failed_tool_call_emits_execute_tool_span` (parametrized on `include_content`) — asserts bad-args and unknown-tool calls each emit an ERROR `execute_tool` span, with/without content.
- `test_wrapper_capability_delegates_on_tool_execute_skipped` and coverage of the combined-capability skip path.
- All changed modules at 100% coverage; ruff/pyright/affected suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


