### PR TITLE
Recover malformed search_tools call args

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_search.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_search.py
@@ -371,7 +371,10 @@ _TOOL_SEARCH_RETURN_CONTENT_TA: pydantic.TypeAdapter[ToolSearchReturnContent] = 
 def _narrow_native_tool_search_call(part: NativeToolCallPart) -> NativeToolSearchCallPart:
     if isinstance(part, NativeToolSearchCallPart):
         return part
-    validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    try:
+        validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    except pydantic.ValidationError:
+        return part
     return copy_dataclass_fields(part, NativeToolSearchCallPart, args=validated_args, tool_kind='tool-search')
 
 
@@ -385,7 +388,10 @@ def _narrow_native_tool_search_return(part: NativeToolReturnPart) -> NativeToolS
 def _narrow_tool_search_call(part: ToolCallPart) -> ToolSearchCallPart:
     if isinstance(part, ToolSearchCallPart):
         return part
-    validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    try:
+        validated_args = _TOOL_SEARCH_CALL_ARGS_TA.validate_python(part.args)
+    except pydantic.ValidationError:
+        return part
     return copy_dataclass_fields(part, ToolSearchCallPart, args=validated_args, tool_kind='tool-search')
 
 

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -4680,6 +4680,24 @@ def test_typed_call_part_typed_args_returns_none_for_unparsed_args() -> None:
         assert complete_part.queries == ['x']
 
 
+def test_tool_search_narrow_type_leaves_malformed_args_untyped() -> None:
+    """Malformed `search_tools` args should stay on the base part for retry handling."""
+
+    local_part = ToolCallPart(tool_name='search_tools', args={'query': 'find a tool'}, tool_call_id='c1')
+    narrowed_local = ToolCallPart.narrow_type(local_part, tool_kind='tool-search')
+    assert narrowed_local is local_part
+
+    native_part = NativeToolCallPart(
+        tool_name='tool_search',
+        tool_kind=None,
+        args={'queries': 'oops'},
+        tool_call_id='c2',
+        provider_name='openai',
+    )
+    narrowed_native = NativeToolCallPart.narrow_type(native_part, tool_kind='tool-search')
+    assert narrowed_native is native_part
+
+
 def test_builtin_tool_search_return_part_message_accessor() -> None:
     """`message` on `NativeToolSearchReturnPart` reads `content.get('message')`.
 


### PR DESCRIPTION
## Summary
- leave malformed `tool-search` call args on the base `ToolCallPart` / `NativeToolCallPart`
- avoid raising during typed-part narrowing so invalid `search_tools` args can flow into normal retry handling
- add a regression test covering malformed local and native tool-search calls

Fixes #6106.

## Testing
- `python -m pytest -q tests/test_tool_search.py -k malformed_args_untyped`
- `python -m pytest -q tests/test_tool_search.py -k 'typed_call_part_accessors_return_typed_shapes or typed_call_part_typed_args_returns_none_for_unparsed_args or malformed_args_untyped'`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

