### PR TITLE
Avoid mutable default argument in `process_tool_calls`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -142,11 +142,6 @@ async def process_tool_calls(
     `output_final_result` as output arguments.
     """
     if output_final_result is None:
-        # `output_final_result` is an output argument that is appended to, and at
-        # least one caller relies on this default rather than passing its own. A
-        # shared module-level `deque(maxlen=1)` would be reused across every such
-        # run, retaining the previous run's final result (a mutable-default / B006
-        # footgun). Give each call that omits the argument its own deque.
         output_final_result = deque(maxlen=1)
     end_strategy = ctx.deps.end_strategy
     if end_strategy == 'exhaustive':

--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -106,7 +106,7 @@ async def process_tool_calls(
     final_result: result.FinalResult[NodeRunEndT] | None,
     ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]],
     output_parts: list[_messages.ModelRequestPart],
-    output_final_result: deque[result.FinalResult[NodeRunEndT]] = deque(maxlen=1),
+    output_final_result: deque[result.FinalResult[NodeRunEndT]] | None = None,
 ) -> AsyncIterator[_messages.HandleResponseEvent]:
     """Process a model response's tool calls, honoring the `end_strategy`.
 
@@ -141,6 +141,13 @@ async def process_tool_calls(
     Because async iterators can't have return values, we use `output_parts` and
     `output_final_result` as output arguments.
     """
+    if output_final_result is None:
+        # `output_final_result` is an output argument that is appended to, and at
+        # least one caller relies on this default rather than passing its own. A
+        # shared module-level `deque(maxlen=1)` would be reused across every such
+        # run, retaining the previous run's final result (a mutable-default / B006
+        # footgun). Give each call that omits the argument its own deque.
+        output_final_result = deque(maxlen=1)
     end_strategy = ctx.deps.end_strategy
     if end_strategy == 'exhaustive':
         processor_class: type[_ToolCallProcessor[DepsT, NodeRunEndT]] = _ExhaustiveProcessor


### PR DESCRIPTION
## Problem

`process_tool_calls` in `_tool_execution.py` uses a mutable default argument for its `output_final_result` output parameter:

```python
output_final_result: deque[result.FinalResult[NodeRunEndT]] = deque(maxlen=1),
```

Default values are evaluated once, at function definition time, so every call that omits the argument (the `run_stream` `on_complete` path in `agent/abstract.py`) shares a single module-level deque.

This is not a behavioral bug today: the function only ever appends to `output_final_result`, and the only caller that reads the result back (`CallToolsNode._handle_tool_calls` in `_agent_graph.py`) always passes its own fresh deque. Nothing ever reads the shared default, so no run's result can leak into another and no released version is affected.

It is still worth removing:

- The shared deque keeps the most recent streamed run's final result (and its output object) alive at module level.
- It is a latent trap: if a future edit made the function read the parameter (for example, an early exit when it is non-empty), state would leak between streamed runs in long-lived processes, silently skipping tool calls and leaving dangling tool calls in message history, with the failure only surfacing a run later.

## Fix

Default the parameter to `None` and create a fresh deque inside the function, so each call that omits the argument gets isolated state. Callers that pass their own deque are unaffected. No user-visible behavior changes, so no test is added.
