### PR TITLE
Add prompt-cache prefix-stability conventions to `tests/AGENTS.md` and `models/AGENTS.md`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/AGENTS.md
+++ b/pydantic_ai_slim/pydantic_ai/models/AGENTS.md
@@ -14,6 +14,7 @@
 - Verify provider limitations through testing before implementing workarounds in `pydantic_ai/models/` — defer validation to runtime API responses rather than preemptive client-side checks — Prevents degrading functionality with unnecessary workarounds based on outdated assumptions, and lets the underlying API return clear error messages about actual incompatibilities
 <!-- rule:478 -->
 - Token counting must mirror actual request parameters (`tools`, `system_prompt`, configs) and use identical message formatting — Ensures token count estimates match actual API usage, preventing billing surprises and quota errors
+- Per-request injections or mutations of request content (message blocks, tool defs, instructions, cache breakpoints) must anchor to a position that doesn't move with history length (e.g. the first user message or a fixed index), never the last message or a length-based index — anchoring to a moving position shifts the cacheable prefix every turn, so the provider silently re-processes the tail instead of reading from cache, a cost/latency regression that surfaces no error
 
 ## Error Handling
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -202,6 +202,7 @@ async def test_something(model: Model):
 - Remove stale test docstrings, comments, and historical provider bug notes when behavior changes
 - Prefer `instructions=` over `system_prompt=` when the test doesn't specifically need the system-prompt code path — `instructions=` is the canonical entry point for non-system-prompt-specific behavior (cacheable prefix, persona priming, format guidance), and reserving `system_prompt=` for tests that exercise the system-prompt machinery keeps intent legible
 - Never reference line numbers in test docstrings or comments (`lines 872-873`, `L42`, `line 100`) — they go stale on the next edit to the referenced file. Describe the condition or behavior instead
+- When testing prompt caching, assert prefix stability, not just a cache hit — `cache_read_tokens > 0` only proves that some prefix was reused, not that the prefix you intended stayed stable as history grows; pin it by asserting the cacheable region (serialized leading blocks up to the breakpoint) is byte-identical across consecutive requests and/or that the cache read covers the full prior prefix, since a per-request injection or serialization that moves with history length silently busts the cache with no error
 
 ## Directory Structure
 


### PR DESCRIPTION
Adds two short author-facing conventions to the agent guides, both targeting a silent prompt-cache failure mode that recently nearly shipped (a per-request injection anchored to the *last* user message moved the cacheable prefix every turn, and the test only asserted `cache_read_tokens > 0`, which proves a hit but not prefix stability):

- `tests/AGENTS.md` (Best Practices): when testing prompt caching, assert prefix **stability** (cacheable region byte-identical across consecutive requests and/or read covering the full prior prefix), not just a hit.
- `pydantic_ai_slim/pydantic_ai/models/AGENTS.md` (API Design): per-request injections/mutations of request content must anchor to a position that doesn't move with history length (first message / fixed index), never the last message or a length-based index.

`CLAUDE.md` in each directory is a symlink to the respective `AGENTS.md`, so the mirror follows automatically; no code or behavior changes.

<!-- Trivial conventions-only change; no issue. -->

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

