### PR TITLE
fix: reconstruct multimodal `ToolReturnPart.content` via a `ToolReturnContent` discriminator

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1111,6 +1111,35 @@ def _tool_return_content_discriminator(value: Any) -> str:
     return 'any'
 
 
+def _validate_multimodal_or_passthrough(value: Any, handler: pydantic.ValidatorFunctionWrapHandler) -> Any:
+    """Validate a `multimodal`-tagged value as `MultiModalContent`, falling back to the raw value.
+
+    The discriminator gates a dict into the `multimodal` branch on a matching `kind` plus a
+    type-specific field, but that's a heuristic: a user tool-return dict that merely reuses one of
+    our `kind` values and happens to carry a `media_type`/`url`/`file_id` key (e.g.
+    `{'kind': 'binary', 'media_type': 'text/plain'}`) would otherwise raise a hard `ValidationError`.
+    Returning it unchanged keeps such dicts as plain mappings, matching the pre-discriminator behavior
+    where they fell through to the `Any` arm rather than being force-validated as multimodal content.
+    """
+    try:
+        return handler(value)
+    except pydantic.ValidationError:
+        return value
+
+
+def _serialize_multimodal_or_passthrough(value: Any, handler: pydantic.SerializerFunctionWrapHandler) -> Any:
+    """Serialize a `multimodal`-tagged value, passing non-`MultiModalContent` values through as-is.
+
+    Mirror of `_validate_multimodal_or_passthrough`: a passthrough dict left as a plain mapping (see
+    there) is still routed to the `multimodal` branch by the discriminator on serialization, where the
+    `MultiModalContent` serializer would emit a spurious `PydanticSerializationUnexpectedValue` warning.
+    Serializing it as a plain value avoids that while real `MultiModalContent` instances dump normally.
+    """
+    if isinstance(value, MULTI_MODAL_CONTENT_TYPES):
+        return handler(value)
+    return value
+
+
 if TYPE_CHECKING:
     # Simpler type for static analysis - recursive TypeAliasType with Any produces spurious Unknown types
     ToolReturnContent: TypeAlias = MultiModalContent | Sequence[Any] | Mapping[str, Any] | Any
@@ -1122,7 +1151,12 @@ else:
     ToolReturnContent = TypeAliasType(
         'ToolReturnContent',
         Annotated[
-            Annotated[MultiModalContent, pydantic.Tag('multimodal')]
+            Annotated[
+                MultiModalContent,
+                pydantic.WrapValidator(_validate_multimodal_or_passthrough),
+                pydantic.WrapSerializer(_serialize_multimodal_or_passthrough),
+                pydantic.Tag('multimodal'),
+            ]
             | Annotated[Mapping[str, 'ToolReturnContent'], pydantic.Tag('mapping')]
             | Annotated[Sequence['ToolReturnContent'], pydantic.Tag('sequence')]
             | Annotated[Any, pydantic.Tag('any')],

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1069,15 +1069,65 @@ tool_return_ta: pydantic.TypeAdapter[Any] = pydantic.TypeAdapter(
     Any, config=pydantic.ConfigDict(defer_build=True, ser_json_bytes='base64', val_json_bytes='base64')
 )
 
+# Derived from the union members (pinned by `test_multi_modal_content_types_matches_union`) so it can't drift.
+_MULTIMODAL_KINDS: frozenset[str] = frozenset(t.__dataclass_fields__['kind'].default for t in MULTI_MODAL_CONTENT_TYPES)
+
+# Type-specific fields that, alongside a matching `kind`, mark a dict as a real `MultiModalContent`
+# rather than a user dict reusing one of our `kind` values: `url` (`FileUrl` types), `media_type`
+# (every dumped item), `file_id` (`UploadedFile`).
+_MULTIMODAL_FIELDS: frozenset[str] = frozenset({'url', 'media_type', 'file_id'})
+
+
+def _tool_return_content_discriminator(value: Any) -> str:
+    """Route a `ToolReturnContent` value to one of the tagged union branches.
+
+    Pydantic's smart-union resolution would otherwise pick `Mapping[str, ToolReturnContent]`
+    for a dumped `MultiModalContent` dict (e.g. `{'kind': 'binary', 'data': '...'}`) and skip
+    the discriminated `MultiModalContent` branch in `validate_python`, leaving multimodal
+    leaves as plain dicts.
+
+    A matching `kind` alone is not enough: this alias is wired into the core `ToolReturnContent`
+    type, so `ModelMessagesTypeAdapter` runs the discriminator on every tool return everywhere.
+    A type-specific field must also be present — `url` for the `FileUrl` types, `media_type`
+    (carried by every dumped `MultiModalContent`), or `file_id` for `UploadedFile` — so a user
+    dict that merely reuses one of our `kind` values (e.g. `{'kind': 'binary', 'label': 'foo'}`)
+    stays a plain mapping instead of being forced through multimodal validation.
+    """
+    if isinstance(value, MULTI_MODAL_CONTENT_TYPES):
+        return 'multimodal'
+    if isinstance(value, Mapping):
+        if (
+            'kind' in value
+            and isinstance(value['kind'], str)
+            and value['kind'] in _MULTIMODAL_KINDS
+            and any(field in value for field in _MULTIMODAL_FIELDS)
+        ):
+            return 'multimodal'
+        return 'mapping'
+    if isinstance(value, (str, bytes, bytearray)):
+        return 'any'
+    if isinstance(value, Sequence):
+        return 'sequence'
+    return 'any'
+
+
 if TYPE_CHECKING:
     # Simpler type for static analysis - recursive TypeAliasType with Any produces spurious Unknown types
     ToolReturnContent: TypeAlias = MultiModalContent | Sequence[Any] | Mapping[str, Any] | Any
 else:
     # Recursive type for runtime Pydantic validation - enables automatic reconstruction of
-    # BinaryContent/FileUrl objects nested inside dicts/lists during deserialization
+    # BinaryContent/FileUrl objects nested inside dicts/lists during deserialization.
+    # The explicit `Discriminator` is required because smart-union resolution otherwise picks
+    # `Mapping`/`Any` over the inner-discriminated `MultiModalContent` branch in python mode.
     ToolReturnContent = TypeAliasType(
         'ToolReturnContent',
-        MultiModalContent | Sequence['ToolReturnContent'] | Mapping[str, 'ToolReturnContent'] | Any,
+        Annotated[
+            Annotated[MultiModalContent, pydantic.Tag('multimodal')]
+            | Annotated[Mapping[str, 'ToolReturnContent'], pydantic.Tag('mapping')]
+            | Annotated[Sequence['ToolReturnContent'], pydantic.Tag('sequence')]
+            | Annotated[Any, pydantic.Tag('any')],
+            pydantic.Discriminator(_tool_return_content_discriminator),
+        ],
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -687,6 +687,17 @@ def text_document_content(assets_path: Path) -> BinaryContent:
     return bin_content
 
 
+# `tiny_*` fixtures: opaque 3-byte payloads for roundtrip / serialization tests where the bytes
+# are never decoded by a model and assertions only check structure (e.g. `IsStr()` on base64).
+# Prefer these whenever a real, decodable image is not required: keeps inline-snapshot diffs
+# small and avoids CI errors that explode when failure traces include large base64 payloads.
+# When the model has to actually see the content (e.g. VCR tests against provider APIs), use
+# the KB-scale session fixtures above (`image_content`, `audio_content`, `video_content`).
+@pytest.fixture
+def tiny_audio() -> BinaryContent:
+    return BinaryContent(data=b'\x10\x11\x12', media_type='audio/mpeg')
+
+
 os.environ.pop('OPENAI_BASE_URL', None)
 os.environ.pop('ANTHROPIC_BASE_URL', None)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -687,12 +687,11 @@ def text_document_content(assets_path: Path) -> BinaryContent:
     return bin_content
 
 
-# `tiny_*` fixtures: opaque 3-byte payloads for roundtrip / serialization tests where the bytes
-# are never decoded by a model and assertions only check structure (e.g. `IsStr()` on base64).
-# Prefer these whenever a real, decodable image is not required: keeps inline-snapshot diffs
-# small and avoids CI errors that explode when failure traces include large base64 payloads.
-# When the model has to actually see the content (e.g. VCR tests against provider APIs), use
-# the KB-scale session fixtures above (`image_content`, `audio_content`, `video_content`).
+# Opaque 3-byte payload for roundtrip / serialization tests where the bytes are never decoded by a
+# model and assertions only check structure (e.g. `IsStr()` on base64): keeps inline-snapshot diffs
+# small and avoids CI errors that explode when failure traces include large base64 payloads. When the
+# model has to actually see the content (e.g. VCR tests against provider APIs), use the KB-scale
+# session fixtures above (`image_content`, `audio_content`, `video_content`).
 @pytest.fixture
 def tiny_audio() -> BinaryContent:
     return BinaryContent(data=b'\x10\x11\x12', media_type='audio/mpeg')

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -35,7 +35,12 @@ from pydantic_ai import (
     UserPromptPart,
     VideoUrl,
 )
-from pydantic_ai.messages import INVALID_JSON_KEY, MULTI_MODAL_CONTENT_TYPES, is_multi_modal_content
+from pydantic_ai.messages import (
+    INVALID_JSON_KEY,
+    MULTI_MODAL_CONTENT_TYPES,
+    ToolReturnContent,
+    is_multi_modal_content,
+)
 from pydantic_ai.models.test import TestModel
 
 from ._inline_snapshot import snapshot
@@ -1295,11 +1300,135 @@ def test_multi_modal_content_types_matches_union():
     assert not is_multi_modal_content(42)
 
 
+def test_every_multimodal_type_rehydrates_as_tool_return_content():
+    """Every `MultiModalContent` type, dumped as scalar `ToolReturnPart.content`, must rehydrate to
+    its own subclass through `ModelMessagesTypeAdapter` — not collapse to a plain dict.
+
+    Guards the `ToolReturnContent` discriminator's type-specific-field gate (`_MULTIMODAL_FIELDS`):
+    if a future `MultiModalContent` type serialized without a `url`/`media_type`/`file_id` key, the
+    gate would route its dumped dict to the `mapping` branch and silently stop rehydrating it. The
+    factory must cover exactly `MULTI_MODAL_CONTENT_TYPES`, so a new type forces a deliberate update.
+    `BinaryContent` uses a non-image media type so it isn't narrowed to `BinaryImage`.
+    """
+    samples: dict[type, MultiModalContent] = {
+        ImageUrl: ImageUrl(url='https://example.com/a.png'),
+        AudioUrl: AudioUrl(url='https://example.com/a.mp3'),
+        VideoUrl: VideoUrl(url='https://example.com/a.mp4'),
+        DocumentUrl: DocumentUrl(url='https://example.com/a.pdf'),
+        BinaryContent: BinaryContent(data=b'x', media_type='application/pdf'),
+        UploadedFile: UploadedFile(file_id='f1', provider_name='openai', media_type='image/png'),
+    }
+    assert set(samples) == set(MULTI_MODAL_CONTENT_TYPES)
+
+    for cls, instance in samples.items():
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[ToolReturnPart(tool_name='t', content=instance, tool_call_id='c')])
+        ]
+        reloaded = ModelMessagesTypeAdapter.validate_python(ModelMessagesTypeAdapter.dump_python(messages, mode='json'))
+        part = reloaded[0].parts[0]
+        assert isinstance(part, ToolReturnPart)
+        assert type(part.content) is cls, (
+            f'{cls.__name__} did not rehydrate through the discriminator gate '
+            f'(got {type(part.content).__name__}) — a `_MULTIMODAL_FIELDS` mismatch would cause this'
+        )
+
+
 def test_tool_return_part_binary_content_serialization():
     png_data = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc```\x00\x00\x00\x04\x00\x01\xf6\x178\x00\x00\x00\x00IEND\xaeB`\x82'
     binary_content = BinaryContent(png_data, media_type='image/png')
     tool_return = ToolReturnPart(tool_name='test_tool', content=binary_content, tool_call_id='test_call_123')
     assert tool_return.model_response_object() == snapshot({})
+
+
+@pytest.mark.parametrize('case_id', ['scalar', 'list-with-binary', 'dict-with-nested-binary'])
+def test_tool_return_part_binary_content_round_trip(case_id: str, tiny_audio: BinaryContent):
+    """`ToolReturnPart.content` containing `BinaryContent` (scalar, in a list, or in a dict)
+    must round-trip via `ModelMessagesTypeAdapter` in both `validate_json` (the wire path)
+    and `validate_python` (the replay path used by UI adapters that already parsed JSON).
+
+    Without the explicit `Discriminator` on `ToolReturnContent`, smart-union resolution picks
+    `Mapping`/`Sequence`/`Any` over the discriminated `MultiModalContent` branch in
+    `validate_python`, leaving binary leaves as plain dicts.
+
+    Uses `tiny_audio` (non-image `BinaryContent`) to focus on rehydration, not the
+    `BinaryImage` narrowing applied by UI adapters.
+    """
+    contents: dict[str, ToolReturnContent] = {
+        'scalar': tiny_audio,
+        'list-with-binary': ['hello', tiny_audio],
+        'dict-with-nested-binary': {'caption': 'see audio', 'attachment': tiny_audio},
+    }
+    content = contents[case_id]
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[ToolReturnPart(tool_name='t', content=content, tool_call_id='c')])
+    ]
+
+    json_loaded = ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(messages))
+    json_part = json_loaded[0].parts[0]
+    assert isinstance(json_part, ToolReturnPart)
+    assert json_part.content == content
+
+    python_loaded = ModelMessagesTypeAdapter.validate_python(
+        ModelMessagesTypeAdapter.dump_python(messages, mode='json')
+    )
+    python_part = python_loaded[0].parts[0]
+    assert isinstance(python_part, ToolReturnPart)
+    assert python_part.content == content
+
+
+@pytest.mark.parametrize(
+    'content',
+    [
+        pytest.param({'kind': 'binary', 'label': 'foo'}, id='kind-binary-no-media-type'),
+        pytest.param({'kind': 'image-url', 'note': 'not a real url part'}, id='kind-url-no-media-type'),
+    ],
+)
+def test_tool_return_dict_reusing_kind_without_type_field_stays_mapping(content: dict[str, str]):
+    """A user dict that reuses one of our `kind` values but lacks a type-specific field
+    (`media_type`/`file_id`) is left as a plain mapping rather than forced through
+    `MultiModalContent` validation (which would raise a hard `ValidationError`).
+
+    The discriminator is wired into core `ToolReturnContent`, so this guards every
+    `ModelMessagesTypeAdapter` round trip, not just the UI adapters.
+    """
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[ToolReturnPart(tool_name='t', content=content, tool_call_id='c')])
+    ]
+
+    loaded = ModelMessagesTypeAdapter.validate_python(ModelMessagesTypeAdapter.dump_python(messages, mode='json'))
+    part = loaded[0].parts[0]
+    assert isinstance(part, ToolReturnPart)
+    assert part.content == content
+
+
+@pytest.mark.parametrize(
+    'kind',
+    [
+        pytest.param([1, 2], id='kind-list'),
+        pytest.param({'x': 'y'}, id='kind-dict'),
+        pytest.param(bytearray(b'binary'), id='kind-bytearray'),
+    ],
+)
+@pytest.mark.parametrize('nested', [False, True], ids=['top-level', 'nested-in-sequence'])
+def test_tool_return_dict_unhashable_kind_stays_mapping(kind: object, nested: bool):
+    """A client dict whose `kind` is unhashable must not crash the discriminator with a `TypeError`.
+
+    The discriminator's `kind in _MULTIMODAL_KINDS` membership test raises `TypeError` on an unhashable
+    `kind` (`list`/`dict`/`bytearray`); the `isinstance(kind, str)` guard routes it to the `mapping`
+    branch instead, where it round-trips as a plain mapping — the same graceful handling of malformed
+    client input as the `_js_binary_to_bytes` hardening.
+    """
+    inner: dict[str, Any] = {'kind': kind, 'media_type': 'image/png', 'data': 'YWJj'}
+    content: Any = [inner] if nested else inner
+    dumped = {
+        'parts': [{'tool_name': 't', 'content': content, 'tool_call_id': 'c', 'part_kind': 'tool-return'}],
+        'kind': 'request',
+    }
+
+    loaded = ModelMessagesTypeAdapter.validate_python([dumped])
+    part = loaded[0].parts[0]
+    assert isinstance(part, ToolReturnPart)
+    assert part.content == content
 
 
 def test_tool_return_part_list_structure_preserved():

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast, get_args
@@ -1396,6 +1397,45 @@ def test_tool_return_dict_reusing_kind_without_type_field_stays_mapping(content:
     ]
 
     loaded = ModelMessagesTypeAdapter.validate_python(ModelMessagesTypeAdapter.dump_python(messages, mode='json'))
+    part = loaded[0].parts[0]
+    assert isinstance(part, ToolReturnPart)
+    assert part.content == content
+
+
+@pytest.mark.parametrize(
+    'content',
+    [
+        # Reserved `kind` + a type-specific field, but not a valid instance of that type:
+        pytest.param({'kind': 'binary', 'media_type': 'text/plain', 'text': 'hello'}, id='binary-without-data'),
+        pytest.param(
+            {'kind': 'uploaded-file', 'file_id': 'abc', 'status': 'ready'}, id='uploaded-file-without-provider'
+        ),
+        pytest.param({'kind': 'image-url', 'media_type': 'image/png', 'note': 'x'}, id='image-url-without-url'),
+    ],
+)
+@pytest.mark.parametrize('mode', ['json', 'python'])
+def test_tool_return_dict_reusing_kind_with_type_field_stays_mapping(content: dict[str, str], mode: str):
+    """A user dict that reuses a `kind` value AND carries a type field (`media_type`/`url`/`file_id`)
+    but isn't a valid instance of that type must stay a plain mapping, not raise.
+
+    The discriminator gates such a dict into the `multimodal` branch on the `kind`+field heuristic;
+    `_validate_multimodal_or_passthrough` falls back to the raw dict when `MultiModalContent` validation
+    fails, and `_serialize_multimodal_or_passthrough` dumps it without a spurious serializer warning —
+    together matching the pre-discriminator behavior where these fell through to the `Any` arm.
+    """
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[ToolReturnPart(tool_name='t', content=content, tool_call_id='c')])
+    ]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')  # a `PydanticSerializationUnexpectedValue` warning would fail here
+        if mode == 'json':
+            loaded = ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(messages))
+        else:
+            loaded = ModelMessagesTypeAdapter.validate_python(
+                ModelMessagesTypeAdapter.dump_python(messages, mode='json')
+            )
+
     part = loaded[0].parts[0]
     assert isinstance(part, ToolReturnPart)
     assert part.content == content


### PR DESCRIPTION
- Closes #5811

A `BinaryContent` (or any `MultiModalContent`) placed in `ToolReturnPart.content` was silently demoted to a plain `dict` when messages round-tripped through `ModelMessagesTypeAdapter.dump_python(mode='json')` + `validate_python` (the boundary used by `to_jsonable_python` and many AG-UI / Vercel AI / OTel-instrumentation paths). After round-trip, `content` was a `dict` with base64 `data` as a `str`, so `.data`/`.media_type`/`.files` etc. no longer worked.

The cause: `ToolReturnContent` is a recursive `TypeAliasType` whose `Mapping`/`Any` arms won Pydantic's smart-union resolution over the `Discriminator('kind')`-tagged `MultiModalContent` branch on the `validate_python` path (the `dump_json`/`validate_json` path worked). This wires the union to an explicit `Discriminator` that routes a dumped `MultiModalContent` dict to the multimodal branch — gated on a matching `kind` **plus** a type-specific field (`url`/`media_type`/`file_id`) so a user dict that merely reuses one of our `kind` values stays a plain mapping.

Extracted from #5255 as the narrow bug fix. The UI-adapter multimodal support (`preserve_file_data`, sidecar activity messages, explicit rehydration) stays in that PR. Note this fix reconstructs `BinaryContent` but does not yet narrow image `BinaryContent` to `BinaryImage` on this path — that narrowing is single-sourced separately in #5801.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

