### PR TITLE
Single-source `BinaryContent` → `BinaryImage` narrowing in `MultiModalContent` validation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -860,7 +860,13 @@ class UploadedFile:
 
 
 MultiModalContent = Annotated[
-    ImageUrl | AudioUrl | DocumentUrl | VideoUrl | BinaryContent | UploadedFile, pydantic.Discriminator('kind')
+    ImageUrl
+    | AudioUrl
+    | DocumentUrl
+    | VideoUrl
+    | Annotated[BinaryContent, pydantic.AfterValidator(BinaryImage.narrow_type)]
+    | UploadedFile,
+    pydantic.Discriminator('kind'),
 ]
 """Union of all multi-modal content types with a discriminator for Pydantic validation."""
 

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -864,7 +864,7 @@ MultiModalContent = Annotated[
     | AudioUrl
     | DocumentUrl
     | VideoUrl
-    | Annotated[BinaryContent, pydantic.AfterValidator(BinaryImage.narrow_type)]
+    | Annotated[BinaryContent, pydantic.AfterValidator(BinaryContent.narrow_type)]
     | UploadedFile,
     pydantic.Discriminator('kind'),
 ]
@@ -1784,7 +1784,7 @@ class CompactionPart:
 class FilePart:
     """A file response from a model."""
 
-    content: Annotated[BinaryContent, pydantic.AfterValidator(BinaryImage.narrow_type)]
+    content: Annotated[BinaryContent, pydantic.AfterValidator(BinaryContent.narrow_type)]
     """The file content of the response."""
 
     _: KW_ONLY

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1303,9 +1303,6 @@ def test_multi_modal_content_types_matches_union():
 def test_binary_image_narrowed_wherever_multimodal_content_is_validated(mode: str):
     """An image `BinaryContent` narrows to `BinaryImage` on validation of any `MultiModalContent`
     (here via `UserPromptPart`), not just `FilePart.content`; non-image `BinaryContent` is left as-is.
-
-    Single-sources the narrowing that UI adapters and the Temporal `CallToolResult` path previously
-    applied by hand, so every `MultiModalContent`/`ToolReturnContent` consumer gets it for free.
     """
     image = BinaryContent(data=b'\x89PNG', media_type='image/png')
     audio = BinaryContent(data=b'\x00\x01', media_type='audio/mpeg')

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,7 +1,7 @@
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast, get_args
+from typing import Annotated, Any, cast, get_args, get_origin
 
 import pytest
 from pydantic import TypeAdapter
@@ -1279,7 +1279,11 @@ def test_tool_return_content_nested_multimodal():
 def test_multi_modal_content_types_matches_union():
     """Validate that MULTI_MODAL_CONTENT_TYPES matches the MultiModalContent union members,
     and that is_multi_modal_content correctly narrows types."""
-    union_members = set(get_args(get_args(MultiModalContent)[0]))
+    # Unwrap any `Annotated` wrappers (e.g. `BinaryContent` carries an `AfterValidator` that narrows
+    # image content to `BinaryImage`) so the comparison is against the underlying content types.
+    union_members = {
+        get_args(m)[0] if get_origin(m) is Annotated else m for m in get_args(get_args(MultiModalContent)[0])
+    }
     assert set(MULTI_MODAL_CONTENT_TYPES) == union_members
 
     # Positive cases: each multimodal type is recognized
@@ -1293,6 +1297,33 @@ def test_multi_modal_content_types_matches_union():
     assert not is_multi_modal_content('a string')
     assert not is_multi_modal_content({'key': 'value'})
     assert not is_multi_modal_content(42)
+
+
+@pytest.mark.parametrize('mode', ['json', 'python'])
+def test_binary_image_narrowed_wherever_multimodal_content_is_validated(mode: str):
+    """An image `BinaryContent` narrows to `BinaryImage` on validation of any `MultiModalContent`
+    (here via `UserPromptPart`), not just `FilePart.content`; non-image `BinaryContent` is left as-is.
+
+    Single-sources the narrowing that UI adapters and the Temporal `CallToolResult` path previously
+    applied by hand, so every `MultiModalContent`/`ToolReturnContent` consumer gets it for free.
+    """
+    image = BinaryContent(data=b'\x89PNG', media_type='image/png')
+    audio = BinaryContent(data=b'\x00\x01', media_type='audio/mpeg')
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(content=[image, audio])])]
+
+    if mode == 'json':
+        loaded = ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(messages))
+    else:
+        loaded = ModelMessagesTypeAdapter.validate_python(ModelMessagesTypeAdapter.dump_python(messages, mode='json'))
+
+    part = loaded[0].parts[0]
+    assert isinstance(part, UserPromptPart)
+    assert isinstance(part.content, list)
+    reloaded_image, reloaded_audio = part.content
+    assert type(reloaded_image) is BinaryImage
+    assert reloaded_image.data == image.data and reloaded_image.media_type == image.media_type
+    # Non-image content is not narrowed.
+    assert type(reloaded_audio) is BinaryContent
 
 
 def test_tool_return_part_binary_content_serialization():

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -4184,7 +4184,7 @@ async def test_multimodal_content_serialization_in_workflow(client: Client):
                         UserPromptPart(
                             content=[
                                 'Process these files and call the tool',
-                                BinaryContent(data=b'\x89PNG', media_type='image/png', _identifier='4effda'),
+                                BinaryImage(data=b'\x89PNG', media_type='image/png', identifier='4effda'),
                                 DocumentUrl(
                                     url='https://example.com/doc/12345',
                                     _media_type='application/pdf',
@@ -4219,7 +4219,7 @@ async def test_multimodal_content_serialization_in_workflow(client: Client):
                             tool_name='get_multimodal_content',
                             content=[
                                 'test',
-                                BinaryContent(data=b'\x89PNG', media_type='image/png', _identifier='4effda'),
+                                BinaryImage(data=b'\x89PNG', media_type='image/png', identifier='4effda'),
                                 DocumentUrl(
                                     url='https://example.com/doc/12345',
                                     _media_type='application/pdf',
@@ -4266,11 +4266,13 @@ async def test_multimodal_content_serialization_in_workflow(client: Client):
                     for content in part.content_items():
                         if isinstance(content, (BinaryContent, DocumentUrl)):
                             media_types.append((type(content).__name__, content.media_type))
-        # Should have 4 items: 2 from user input, 2 from tool return
+        # Should have 4 items: 2 from user input, 2 from tool return.
+        # The image `BinaryContent` round-trips as `BinaryImage`: narrowing is applied during
+        # `MultiModalContent` validation, so it now survives the Temporal serialization boundary too.
         assert media_types == [
-            ('BinaryContent', 'image/png'),
+            ('BinaryImage', 'image/png'),
             ('DocumentUrl', 'application/pdf'),
-            ('BinaryContent', 'image/png'),
+            ('BinaryImage', 'image/png'),
             ('DocumentUrl', 'application/pdf'),
         ]
 


### PR DESCRIPTION
- Closes #5801

The rule *"an image-typed `BinaryContent` should be narrowed to the `BinaryImage` subclass on deserialization"* is currently applied from scattered call sites — `FilePart.content` (via an `AfterValidator`), and, in #5255, the AG-UI and Vercel adapters (a recursive `_narrow_binary_images` walk and an inline narrow). The rule is single-sourced (all delegate to `BinaryContent.narrow_type`) but wired up per-site, so every new `MultiModalContent` consumer has to remember to re-apply it.

This pushes the narrowing into the `MultiModalContent` union itself, via an `AfterValidator` on the `BinaryContent` arm:

```python
MultiModalContent = Annotated[
    ImageUrl | AudioUrl | DocumentUrl | VideoUrl
    | Annotated[BinaryContent, pydantic.AfterValidator(BinaryImage.narrow_type)]
    | UploadedFile,
    pydantic.Discriminator('kind'),
]
```

`BinaryImage` shares `kind='binary'` with `BinaryContent`, so the `Discriminator('kind')` still dispatches to the `BinaryContent` arm and the `AfterValidator` then narrows image content (a no-op for non-image content, which never raises). Every `MultiModalContent` / `ToolReturnContent` consumer — both UI adapters, the Temporal `CallToolResult` round-trip, and future integrations — now narrows for free.

Scope note: this is the *add* half of #5801 and stands alone on `main`. The adapter-local narrowing it obsoletes lives in #5255, so that code is deleted when #5255 rebases onto this (and onto #6191). `FilePart.content` keeps its own `AfterValidator` — it's a `BinaryContent` field, not a `MultiModalContent` field, so it isn't covered by the union narrowing.

Blast radius is minimal: narrowing only triggers on validation, and most code either works with live objects or (like `FilePart`) already narrowed. The full test suite passes (5177) with a single one-line adjustment to `test_multi_modal_content_types_matches_union` to unwrap the `Annotated` member.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

