### PR TITLE
Clean up the pending task and streams on `KeyboardInterrupt` in synchronous `run_until_complete` wrappers

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -410,11 +410,11 @@ def sync_async_iterator(async_iter: AsyncIterator[T]) -> Iterator[T]:
         # Close the underlying async iterator so its `async with`/`finally` blocks (which close
         # model streams and HTTP connections) run even when the consumer breaks out early or is
         # interrupted (Ctrl-C closing this generator with `GeneratorExit`), not just when the
-        # stream is exhausted.
-        aclose: Callable[[], Awaitable[None]] | None = getattr(async_iter, 'aclose', None)
-        if aclose is not None:  # pragma: no branch
+        # stream is exhausted. The `stream_*` methods always return async generators at runtime even
+        # though they're typed as `AsyncIterator`, so this narrows to the closable case.
+        if isinstance(async_iter, AsyncGenerator):  # pragma: no branch
             with suppress(BaseException):
-                run_until_complete(aclose())
+                run_until_complete(async_iter.aclose())
 
 
 def now_utc() -> datetime:

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -45,7 +45,10 @@ from typing_extensions import ParamSpec, TypeIs, TypeVar, is_typeddict
 from typing_inspection import typing_objects
 from typing_inspection.introspection import is_union_origin
 
-from pydantic_graph._utils import AbstractSpan, run_until_complete
+from pydantic_graph._utils import (
+    AbstractSpan,
+    run_until_complete as run_until_complete,  # re-exported for the sync wrappers
+)
 from pydantic_graph.util import get_callable_name
 
 from .exceptions import UserError

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -45,7 +45,7 @@ from typing_extensions import ParamSpec, TypeIs, TypeVar, is_typeddict
 from typing_inspection import typing_objects
 from typing_inspection.introspection import is_union_origin
 
-from pydantic_graph._utils import AbstractSpan
+from pydantic_graph._utils import AbstractSpan, run_until_complete
 from pydantic_graph.util import get_callable_name
 
 from .exceptions import UserError
@@ -817,31 +817,6 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
     return event_loop
-
-
-def run_until_complete(coro: Awaitable[T]) -> T:
-    """Run `coro` to completion on the event loop, cleaning up after itself if interrupted.
-
-    If the caller interrupts `loop.run_until_complete()` (e.g. by pressing Ctrl-C, raising
-    `KeyboardInterrupt`) while `coro` is suspended, asyncio leaves its task pending with its
-    `async with`/`finally` blocks un-run, leaking the task and any open model streams and HTTP
-    connections. We cancel *our own* task and drive its cleanup to completion before re-raising,
-    so those blocks close their resources. Unlike cancelling every task via `asyncio.all_tasks()`,
-    this never touches other tasks on the (caller-owned) loop.
-    """
-    loop = get_event_loop()
-    task = asyncio.ensure_future(coro, loop=loop)
-    try:
-        return loop.run_until_complete(task)
-    except BaseException:
-        if not task.done():
-            task.cancel()
-            # Run the loop again to let the cancellation propagate through `coro`'s cleanup.
-            # Suppress everything (including a second Ctrl-C): we're only finishing cleanup and
-            # retrieving the task's exception, not replacing the one we're about to re-raise.
-            with suppress(BaseException):
-                loop.run_until_complete(task)
-        raise
 
 
 def is_str_dict(obj: Any) -> TypeGuard[dict[str, Any]]:

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -397,12 +397,21 @@ def sync_anext(iterator: Iterator[T]) -> T:
 
 
 def sync_async_iterator(async_iter: AsyncIterator[T]) -> Iterator[T]:
-    loop = get_event_loop()
-    while True:
-        try:
-            yield loop.run_until_complete(anext(async_iter))
-        except StopAsyncIteration:
-            break
+    try:
+        while True:
+            try:
+                yield run_until_complete(anext(async_iter))
+            except StopAsyncIteration:
+                break
+    finally:
+        # Close the underlying async iterator so its `async with`/`finally` blocks (which close
+        # model streams and HTTP connections) run even when the consumer breaks out early or is
+        # interrupted (Ctrl-C closing this generator with `GeneratorExit`), not just when the
+        # stream is exhausted.
+        aclose: Callable[[], Awaitable[None]] | None = getattr(async_iter, 'aclose', None)
+        if aclose is not None:  # pragma: no branch
+            with suppress(BaseException):
+                run_until_complete(aclose())
 
 
 def now_utc() -> datetime:
@@ -808,6 +817,31 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
     return event_loop
+
+
+def run_until_complete(coro: Awaitable[T]) -> T:
+    """Run `coro` to completion on the event loop, cleaning up after itself if interrupted.
+
+    If the caller interrupts `loop.run_until_complete()` (e.g. by pressing Ctrl-C, raising
+    `KeyboardInterrupt`) while `coro` is suspended, asyncio leaves its task pending with its
+    `async with`/`finally` blocks un-run, leaking the task and any open model streams and HTTP
+    connections. We cancel *our own* task and drive its cleanup to completion before re-raising,
+    so those blocks close their resources. Unlike cancelling every task via `asyncio.all_tasks()`,
+    this never touches other tasks on the (caller-owned) loop.
+    """
+    loop = get_event_loop()
+    task = asyncio.ensure_future(coro, loop=loop)
+    try:
+        return loop.run_until_complete(task)
+    except BaseException:
+        if not task.done():
+            task.cancel()
+            # Run the loop again to let the cancellation propagate through `coro`'s cleanup.
+            # Suppress everything (including a second Ctrl-C): we're only finishing cleanup and
+            # retrieving the task's exception, not replacing the one we're about to re-raise.
+            with suppress(BaseException):
+                loop.run_until_complete(task)
+        raise
 
 
 def is_str_dict(obj: Any) -> TypeGuard[dict[str, Any]]:

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -548,7 +548,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         if infer_name and self.name is None:
             self._infer_name(inspect.currentframe())
 
-        return _utils.get_event_loop().run_until_complete(
+        return _utils.run_until_complete(
             self.run(
                 user_prompt,
                 output_type=output_type,
@@ -1022,7 +1022,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             ) as stream_result:
                 yield stream_result
 
-        async_result = _utils.get_event_loop().run_until_complete(anext(_consume_stream()))
+        async_result = _utils.run_until_complete(anext(_consume_stream()))
         return result.StreamedRunResultSync(async_result)
 
     @overload
@@ -1617,7 +1617,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         agent.to_cli_sync(prog_name='assistant')
         ```
         """
-        return _utils.get_event_loop().run_until_complete(
+        return _utils.run_until_complete(
             self.to_cli(
                 deps=deps,
                 prog_name=prog_name,

--- a/pydantic_ai_slim/pydantic_ai/direct.py
+++ b/pydantic_ai_slim/pydantic_ai/direct.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from types import TracebackType
 
 from pydantic_ai.usage import RequestUsage
-from pydantic_graph._utils import get_event_loop as _get_event_loop
+from pydantic_graph._utils import get_event_loop as _get_event_loop, run_until_complete as _run_until_complete
 
 from . import agent, messages, models, settings
 from .models import StreamedResponse, instrumented as instrumented_models
@@ -153,7 +153,7 @@ def model_request_sync(
     Returns:
         The model response and token usage associated with the request.
     """
-    return _get_event_loop().run_until_complete(
+    return _run_until_complete(
         model_request(
             model,
             list(messages),

--- a/pydantic_ai_slim/pydantic_ai/embeddings/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/__init__.py
@@ -350,27 +350,27 @@ class Embedder:
         self, query: str | Sequence[str], *, settings: EmbeddingSettings | None = None
     ) -> EmbeddingResult:
         """Synchronous version of [`embed_query()`][pydantic_ai.embeddings.Embedder.embed_query]."""
-        return _utils.get_event_loop().run_until_complete(self.embed_query(query, settings=settings))
+        return _utils.run_until_complete(self.embed_query(query, settings=settings))
 
     def embed_documents_sync(
         self, documents: str | Sequence[str], *, settings: EmbeddingSettings | None = None
     ) -> EmbeddingResult:
         """Synchronous version of [`embed_documents()`][pydantic_ai.embeddings.Embedder.embed_documents]."""
-        return _utils.get_event_loop().run_until_complete(self.embed_documents(documents, settings=settings))
+        return _utils.run_until_complete(self.embed_documents(documents, settings=settings))
 
     def embed_sync(
         self, inputs: str | Sequence[str], *, input_type: EmbedInputType, settings: EmbeddingSettings | None = None
     ) -> EmbeddingResult:
         """Synchronous version of [`embed()`][pydantic_ai.embeddings.Embedder.embed]."""
-        return _utils.get_event_loop().run_until_complete(self.embed(inputs, input_type=input_type, settings=settings))
+        return _utils.run_until_complete(self.embed(inputs, input_type=input_type, settings=settings))
 
     def max_input_tokens_sync(self) -> int | None:
         """Synchronous version of [`max_input_tokens()`][pydantic_ai.embeddings.Embedder.max_input_tokens]."""
-        return _utils.get_event_loop().run_until_complete(self.max_input_tokens())
+        return _utils.run_until_complete(self.max_input_tokens())
 
     def count_tokens_sync(self, text: str) -> int:
         """Synchronous version of [`count_tokens()`][pydantic_ai.embeddings.Embedder.count_tokens]."""
-        return _utils.get_event_loop().run_until_complete(self.count_tokens(text))
+        return _utils.run_until_complete(self.count_tokens(text))
 
     def _get_model(self) -> EmbeddingModel:
         """Create a model configured for this embedder.

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -839,7 +839,7 @@ class StreamedRunResultSync(Generic[AgentDepsT, OutputDataT]):
 
     def get_output(self) -> OutputDataT:
         """Stream the whole response, validate and return it."""
-        return _utils.get_event_loop().run_until_complete(self._streamed_run_result.get_output())
+        return _utils.run_until_complete(self._streamed_run_result.get_output())
 
     @property
     def response(self) -> _messages.ModelResponse:
@@ -877,7 +877,7 @@ class StreamedRunResultSync(Generic[AgentDepsT, OutputDataT]):
 
     def validate_response_output(self, message: _messages.ModelResponse, *, allow_partial: bool = False) -> OutputDataT:
         """Validate a structured result message."""
-        return _utils.get_event_loop().run_until_complete(
+        return _utils.run_until_complete(
             self._streamed_run_result.validate_response_output(message, allow_partial=allow_partial)
         )
 

--- a/pydantic_evals/pydantic_evals/_utils.py
+++ b/pydantic_evals/pydantic_evals/_utils.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import warnings
 from collections.abc import Awaitable, Callable, Generator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -86,6 +86,27 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
     return event_loop
+
+
+def run_until_complete(coro: Awaitable[T]) -> T:
+    """Run `coro` to completion on the event loop, cleaning up after itself if interrupted.
+
+    If the caller interrupts `loop.run_until_complete()` (e.g. by pressing Ctrl-C, raising
+    `KeyboardInterrupt`) while `coro` is suspended, asyncio leaves its task pending with its
+    `async with`/`finally` blocks un-run, leaking the task and any open connections. We cancel
+    *our own* task and drive its cleanup to completion before re-raising, without touching any
+    other tasks on the (caller-owned) loop.
+    """
+    loop = get_event_loop()
+    task = asyncio.ensure_future(coro, loop=loop)
+    try:
+        return loop.run_until_complete(task)
+    except BaseException:
+        if not task.done():
+            task.cancel()
+            with suppress(BaseException):
+                loop.run_until_complete(task)
+        raise
 
 
 async def task_group_gather(tasks: Sequence[Callable[[], Awaitable[T]]]) -> list[T]:

--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -32,7 +32,7 @@ from rich.progress import Progress
 from typing_extensions import Self, TypeVar
 
 from pydantic_ai._spec import build_registry, build_schema_types, load_from_registry
-from pydantic_evals._utils import get_event_loop
+from pydantic_evals._utils import run_until_complete
 
 from . import _task_run
 from ._utils import get_unwrapped_function_name, logfire_span, task_group_gather
@@ -455,7 +455,7 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
         Returns:
             A report containing the results of the evaluation.
         """
-        return get_event_loop().run_until_complete(
+        return run_until_complete(
             self.evaluate(
                 task,
                 name=name,

--- a/pydantic_evals/pydantic_evals/evaluators/evaluator.py
+++ b/pydantic_evals/pydantic_evals/evaluators/evaluator.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, Generic, cast
 from pydantic import Field
 from typing_extensions import TypeVar
 
-from .._utils import get_event_loop
+from .._utils import run_until_complete
 from ._base import BaseEvaluator
 from .context import EvaluatorContext
 from .spec import EvaluatorSpec
@@ -226,7 +226,7 @@ class Evaluator(BaseEvaluator, Generic[InputsT, OutputT, MetadataT]):
         """
         output = self.evaluate(ctx)
         if inspect.iscoroutine(output):  # pragma: no cover
-            return get_event_loop().run_until_complete(output)
+            return run_until_complete(output)
         else:
             return cast(EvaluatorOutput, output)
 

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -4,9 +4,9 @@ import asyncio
 import inspect
 import types
 import warnings
-from collections.abc import Generator
-from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, TypeAlias, get_args, get_origin
+from collections.abc import Awaitable, Generator
+from contextlib import contextmanager, suppress
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, get_args, get_origin
 
 from logfire_api import Logfire, LogfireSpan
 from typing_inspection import typing_objects
@@ -55,6 +55,30 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
     return event_loop
+
+
+_T = TypeVar('_T')
+
+
+def run_until_complete(coro: Awaitable[_T]) -> _T:
+    """Run `coro` to completion on the event loop, cleaning up after itself if interrupted.
+
+    If the caller interrupts `loop.run_until_complete()` (e.g. by pressing Ctrl-C, raising
+    `KeyboardInterrupt`) while `coro` is suspended, asyncio leaves its task pending with its
+    `async with`/`finally` blocks un-run, leaking the task and any open connections. We cancel
+    *our own* task and drive its cleanup to completion before re-raising, without touching any
+    other tasks on the (caller-owned) loop.
+    """
+    loop = get_event_loop()
+    task = asyncio.ensure_future(coro, loop=loop)
+    try:
+        return loop.run_until_complete(task)
+    except BaseException:
+        if not task.done():
+            task.cancel()
+            with suppress(BaseException):
+                loop.run_until_complete(task)
+        raise
 
 
 def get_union_args(tp: Any) -> tuple[Any, ...]:

--- a/pydantic_graph/pydantic_graph/graph_builder.py
+++ b/pydantic_graph/pydantic_graph/graph_builder.py
@@ -307,9 +307,7 @@ class Graph(Generic[StateT, DepsT, InputT, OutputT]):
             inferred_name = infer_obj_name(self, depth=2)
             if inferred_name is not None:  # pragma: no branch
                 self.name = inferred_name
-        return _utils.get_event_loop().run_until_complete(
-            self.run(state=state, deps=deps, inputs=inputs, span=span, infer_name=False)
-        )
+        return _utils.run_until_complete(self.run(state=state, deps=deps, inputs=inputs, span=span, infer_name=False))
 
     @asynccontextmanager
     async def iter(

--- a/tests/evals/test_utils.py
+++ b/tests/evals/test_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import asyncio
 import functools
 import sys
 from collections.abc import Callable
@@ -21,12 +22,53 @@ with try_import() as imports_successful:
     from pydantic_evals._utils import (
         UNSET,
         Unset,
+        get_event_loop,
         get_unwrapped_function_name,
         is_set,
+        run_until_complete,
         task_group_gather,
     )
 
 pytestmark = [pytest.mark.skipif(not imports_successful(), reason='pydantic-evals not installed'), pytest.mark.anyio]
+
+
+def test_run_until_complete_cleans_up_own_task_on_interrupt():
+    """A `KeyboardInterrupt` during `run_until_complete` must cancel only its own task and drive its
+    cleanup, leaving no pending task and not touching other tasks on the caller-owned loop.
+
+    Simulated by patching the loop because a real interrupt mid-`run_until_complete` while the
+    coroutine is suspended can't be triggered reliably through the public API.
+    """
+    cleaned: list[str] = []
+
+    async def coro() -> None:
+        try:
+            await asyncio.Event().wait()  # suspends forever
+        finally:
+            cleaned.append('cleaned')
+
+    loop = get_event_loop()
+    tasks_before = asyncio.all_tasks(loop)
+    real_run_until_complete = loop.run_until_complete
+    calls = 0
+
+    def interrupt_once(future: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            # Let our task start and suspend, then simulate Ctrl-C reaching the caller.
+            loop.call_soon(loop.stop)
+            loop.run_forever()
+            raise KeyboardInterrupt
+        return real_run_until_complete(future)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(loop, 'run_until_complete', interrupt_once)
+        with pytest.raises(KeyboardInterrupt):
+            run_until_complete(coro())
+
+    assert cleaned == ['cleaned']  # our coroutine's cleanup ran
+    assert asyncio.all_tasks(loop) == tasks_before  # our task didn't leak, nothing else was touched
 
 
 def test_unset():

--- a/tests/evals/test_utils.py
+++ b/tests/evals/test_utils.py
@@ -71,6 +71,17 @@ def test_run_until_complete_cleans_up_own_task_on_interrupt():
     assert asyncio.all_tasks(loop) == tasks_before  # our task didn't leak, nothing else was touched
 
 
+def test_run_until_complete_propagates_coroutine_error():
+    """When the coroutine itself raises, the task is already done so no cleanup is attempted and the
+    exception propagates unchanged."""
+
+    async def coro() -> None:
+        raise ValueError('boom')
+
+    with pytest.raises(ValueError, match='boom'):
+        run_until_complete(coro())
+
+
 def test_unset():
     """Test Unset singleton."""
     assert isinstance(UNSET, Unset)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -239,33 +239,43 @@ def test_run_until_complete_cleans_up_own_task_on_interrupt():
         loop.run_until_complete(bystander_task)
 
 
-def test_sync_async_iterator_closes_source_on_early_break():
-    """Breaking out of the sync stream early must close the underlying async iterator so its
-    `async with`/`finally` blocks (which close model streams and connections) run, not only when
-    the stream is exhausted."""
-    closed: list[str] = []
+def test_sync_async_iterator_closes_source():
+    """`sync_async_iterator` must close the underlying async iterator so its `async with`/`finally`
+    blocks (which close model streams and connections) run both when the stream is exhausted and when
+    the consumer breaks out early, rather than leaking until garbage collection."""
+    # Full exhaustion closes the source.
+    exhausted_closed: list[str] = []
 
-    async def agen() -> AsyncIterator[int]:
+    async def finite() -> AsyncIterator[int]:
+        try:
+            for i in range(3):
+                yield i
+        finally:
+            exhausted_closed.append('closed')
+
+    assert list(utils_module.sync_async_iterator(finite())) == [0, 1, 2]
+    assert exhausted_closed == ['closed']
+
+    # Breaking out early (before exhaustion) closes the source too.
+    broken_closed: list[str] = []
+
+    async def infinite() -> AsyncIterator[int]:
         try:
             i = 0
             while True:
                 yield i
                 i += 1
         finally:
-            closed.append('closed')
+            broken_closed.append('closed')
 
-    iterator = utils_module.sync_async_iterator(agen())
-    collected: list[int] = []
-    for value in iterator:
-        collected.append(value)
-        if value == 2:
-            break
+    iterator = utils_module.sync_async_iterator(infinite())
+    collected = [next(iterator), next(iterator), next(iterator)]
     # Tearing down the consumer's frame sends `GeneratorExit` into the sync iterator; do it explicitly
     # here so the test is deterministic instead of relying on garbage collection.
     cast('Generator[int, None, None]', iterator).close()
 
     assert collected == [0, 1, 2]
-    assert closed == ['closed']
+    assert broken_closed == ['closed']
 
 
 def test_package_versions(capsys: pytest.CaptureFixture[str]):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,17 @@
 from __future__ import annotations as _annotations
 
 import asyncio
+import contextlib
 import contextvars
 import functools
 import importlib
 import os
 import sys
 import threading
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Generator
 from concurrent.futures import ThreadPoolExecutor
 from importlib.metadata import distributions
+from typing import Any, cast
 
 import pytest
 
@@ -180,6 +182,90 @@ async def test_peekable_async_stream_aclose_before_iteration():
     await peekable_async_stream.aclose()
 
     assert await peekable_async_stream.is_exhausted()
+
+
+def test_run_until_complete_cleans_up_own_task_on_interrupt():
+    """A `KeyboardInterrupt` during `run_until_complete` must drive our own coroutine's cleanup
+    (closing model streams and HTTP connections via its `async with`/`finally` blocks) and leave no
+    pending task, without cancelling other tasks on the caller-owned loop.
+
+    This is a unit test rather than a public-API/VCR test because it requires a real interrupt to
+    arrive mid-`run_until_complete` while the coroutine is suspended, which can't be triggered
+    reliably through the public API; we simulate the interrupt by patching the loop.
+    """
+    cleaned: list[str] = []
+
+    async def coro() -> None:
+        try:
+            await asyncio.Event().wait()  # suspends forever
+        finally:
+            cleaned.append('cleaned')
+
+    loop = utils_module.get_event_loop()
+
+    # An unrelated task on the (caller-owned) loop that must survive: the reporter's `all_tasks()`
+    # sledgehammer would cancel this, ours must not.
+    async def bystander() -> None:
+        await asyncio.Event().wait()
+
+    bystander_task = loop.create_task(bystander())
+    tasks_before = asyncio.all_tasks(loop)
+
+    real_run_until_complete = loop.run_until_complete
+    calls = 0
+
+    def interrupt_once(future: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            # Let our task (and the bystander) start and suspend, then simulate Ctrl-C reaching the
+            # caller of `run_until_complete`.
+            loop.call_soon(loop.stop)
+            loop.run_forever()
+            raise KeyboardInterrupt
+        return real_run_until_complete(future)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(loop, 'run_until_complete', interrupt_once)
+        with pytest.raises(KeyboardInterrupt):
+            utils_module.run_until_complete(coro())
+
+    assert cleaned == ['cleaned']  # our coroutine's cleanup ran
+    assert not bystander_task.cancelled()  # the unrelated task was left alone
+    assert asyncio.all_tasks(loop) == tasks_before  # our task didn't leak, nothing else was touched
+
+    bystander_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        loop.run_until_complete(bystander_task)
+
+
+def test_sync_async_iterator_closes_source_on_early_break():
+    """Breaking out of the sync stream early must close the underlying async iterator so its
+    `async with`/`finally` blocks (which close model streams and connections) run, not only when
+    the stream is exhausted."""
+    closed: list[str] = []
+
+    async def agen() -> AsyncIterator[int]:
+        try:
+            i = 0
+            while True:
+                yield i
+                i += 1
+        finally:
+            closed.append('closed')
+
+    iterator = utils_module.sync_async_iterator(agen())
+    collected: list[int] = []
+    for value in iterator:
+        collected.append(value)
+        if value == 2:
+            break
+    # Tearing down the consumer's frame sends `GeneratorExit` into the sync iterator; do it explicitly
+    # here so the test is deterministic instead of relying on garbage collection.
+    cast('Generator[int, None, None]', iterator).close()
+
+    assert collected == [0, 1, 2]
+    assert closed == ['closed']
 
 
 def test_package_versions(capsys: pytest.CaptureFixture[str]):


### PR DESCRIPTION
- Closes #5975

## Problem

When a `KeyboardInterrupt` (e.g. pressing Ctrl-C) interrupts `loop.run_until_complete(coro)`, asyncio leaves the coroutine's task suspended with its `async with`/`finally` blocks un-run. The task lingers on the loop and any open model streams and HTTP connections are never closed — exactly the "event loop remains stuffed with old events and open sockets" the reporter hit with `run_stream_sync`.

The reporter's own workaround cancels *every* task on the loop via `asyncio.all_tasks()` and calls `shutdown_asyncgens()`. That's unsafe for a library: it runs on a loop it doesn't own and would cancel the user's unrelated tasks and every async generator in the process.

## Fix

Add `_utils.run_until_complete(coro)` that wraps the coroutine in its own task and, on any `BaseException`, cancels **only that task** and drives its cleanup to completion before re-raising — so the coroutine's `async with`/`finally` blocks close their streams and connections, without touching any other task on the loop.

Route the synchronous wrappers through it:
- `Agent.run_sync`, `run_stream_sync`, `to_cli_sync`, `StreamedRunResultSync.get_output`/`validate_response_output`
- `direct.model_request_sync`
- `Embedder.*_sync`
- `Graph.run_sync` (helper copied into `pydantic_graph._utils`)
- `Dataset.evaluate_sync`, `Evaluator.evaluate_sync` (helper copied into `pydantic_evals._utils`)

`sync_async_iterator` now also `aclose()`s the underlying async iterator in a `finally`, so breaking out of a synchronous stream early closes the model stream and connection instead of leaking them until garbage collection.

The threaded `direct.model_request_stream_sync` is intentionally left as-is: it runs its loop in a background thread, so a main-thread `KeyboardInterrupt` never interrupts its `run_until_complete` and this defect doesn't apply.

## Follow-up

This fixes interrupts that land *inside* a synchronous call. `run_stream_sync` additionally keeps the `run_stream(...)` context open on a suspended `_consume_stream()` generator between calls, which is only closed at GC; making `StreamedRunResultSync` a proper (context-manager) owner of that stream is tracked separately in #3716.

## Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

