### PR TITLE
fix(groq): map unified `thinking` to `reasoning_effort`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -48,8 +48,9 @@ from ..messages import (
 from ..native_tools import AbstractNativeTool, WebSearchTool
 from ..output import OutputObjectDefinition
 from ..profiles import DEFAULT_THINKING_TAGS, ModelProfile, ModelProfileSpec
+from ..profiles.groq import GroqModelProfile, GroqReasoningEffort
 from ..providers import Provider, infer_provider
-from ..settings import ModelSettings
+from ..settings import ModelSettings, ThinkingLevel
 from ..tools import ToolDefinition
 from . import (
     Model,
@@ -127,6 +128,24 @@ _FINISH_REASON_MAP: dict[Literal['stop', 'length', 'tool_calls', 'content_filter
     'content_filter': 'content_filter',
     'function_call': 'tool_call',
 }
+
+_GROQ_REASONING_EFFORT_MAP: dict[ThinkingLevel, GroqReasoningEffort | None] = {
+    True: None,
+    False: 'none',
+    'minimal': 'low',
+    'low': 'low',
+    'medium': 'medium',
+    'high': 'high',
+    'xhigh': 'high',
+}
+"""Maps unified thinking values to Groq `reasoning_effort` strings."""
+
+
+def _map_reasoning_effort(thinking: ThinkingLevel, profile: GroqModelProfile) -> GroqReasoningEffort | None:
+    """Map unified thinking values to Groq `reasoning_effort` values the model accepts."""
+    supported_efforts = profile.get('groq_reasoning_efforts', frozenset())
+    effort = _GROQ_REASONING_EFFORT_MAP[thinking]
+    return effort if effort in supported_efforts else None
 
 
 class GroqModelSettings(ModelSettings, total=False):
@@ -346,9 +365,6 @@ class GroqModel(Model[AsyncGroq]):
         )
 
         extra_body = model_settings.get('extra_body')
-        # `reasoning_effort` value sets are family-specific on Groq (qwen3: none/default; gpt-oss: low/medium/high),
-        # so we don't map the unified `thinking` level here — only the explicit `groq_reasoning_effort` setting, plus
-        # the qwen3 disable signal (`'none'`), which wins. Unified thinking still controls `reasoning_format` above.
         groq_reasoning_effort = model_settings.get('groq_reasoning_effort')
         if disable_via_effort and groq_reasoning_effort is not None:
             warnings.warn(
@@ -357,6 +373,11 @@ class GroqModel(Model[AsyncGroq]):
                 UserWarning,
             )
         effort = 'none' if disable_via_effort else groq_reasoning_effort
+        if effort is None and model_request_parameters.thinking is not None:
+            effort = _map_reasoning_effort(
+                model_request_parameters.thinking,
+                cast(GroqModelProfile, self.profile),
+            )
         if effort is not None:
             # `reasoning_effort` isn't a named param in the Groq SDK, so it's passed via `extra_body`.
             # `ModelSettings.extra_body` is typed `object`, so narrowing it for the merge reads back as `Unknown`.

--- a/pydantic_ai_slim/pydantic_ai/profiles/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/groq.py
@@ -1,6 +1,11 @@
 from __future__ import annotations as _annotations
 
+from typing import Literal, TypeAlias
+
 from . import ModelProfile
+
+GroqReasoningEffort: TypeAlias = Literal['none', 'default', 'low', 'medium', 'high']
+"""Native Groq `reasoning_effort` values."""
 
 
 class GroqModelProfile(ModelProfile, total=False):
@@ -19,6 +24,9 @@ class GroqModelProfile(ModelProfile, total=False):
     *output* via `reasoning_format='hidden'` while still reasoning internally.
     """
 
+    groq_reasoning_efforts: frozenset[GroqReasoningEffort]
+    """Native `reasoning_effort` values supported by the Groq model. Default: empty (`frozenset()`)."""
+
 
 def groq_model_profile(model_name: str) -> ModelProfile:
     """Get the model profile for a Groq model."""
@@ -30,13 +38,24 @@ def groq_model_profile(model_name: str) -> ModelProfile:
             'qwen-qwq',  # legacy (deprecated)
             'deepseek-r1',  # legacy (deprecated)
             'llama-4-maverick',  # legacy (deprecated)
+            'openai/gpt-oss',
         )
     )
     is_qwen3 = model_name.startswith('qwen/qwen3')
-    return GroqModelProfile(
+    is_gpt_oss = model_name.startswith('openai/gpt-oss')
+    if is_qwen3:
+        reasoning_efforts = frozenset[GroqReasoningEffort]({'none', 'default'})
+    elif is_gpt_oss:
+        reasoning_efforts = frozenset[GroqReasoningEffort]({'low', 'medium', 'high'})
+    else:
+        reasoning_efforts = frozenset[GroqReasoningEffort]()
+    profile = GroqModelProfile(
         groq_always_has_web_search_builtin_tool=model_name.startswith('compound-'),
         supports_thinking=is_reasoning_model,
         # qwen3 can disable reasoning with reasoning_effort='none'; legacy models can't
         thinking_always_enabled=is_reasoning_model and not is_qwen3,
         groq_supports_reasoning_disable=is_qwen3,
     )
+    if reasoning_efforts:
+        profile['groq_reasoning_efforts'] = reasoning_efforts
+    return profile

--- a/pydantic_ai_slim/pydantic_ai/providers/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/groq.py
@@ -92,11 +92,21 @@ class GroqProvider(Provider[AsyncGroq]):
         # profile must never claim reasoning support (`supports_thinking` / `thinking_always_enabled`)
         # for a model Groq doesn't actually expose reasoning controls for — it would silently override
         # the Groq base and reintroduce the mismatch this overlay fixes.
-        return merge_profile(
-            groq_model_profile(model_name),
+        groq_profile = groq_model_profile(model_name)
+        merged_profile = merge_profile(
+            groq_profile,
             profile,
             ModelProfile(supports_inline_system_prompts=True),
         )
+        if reasoning_efforts := groq_profile.get('groq_reasoning_efforts'):
+            merged_profile = merge_profile(
+                merged_profile,
+                ModelProfile(
+                    supports_thinking=True,
+                    thinking_always_enabled='none' not in reasoning_efforts,
+                ),
+            )
+        return merged_profile
 
     @overload
     def __init__(self, *, groq_client: AsyncGroq | None = None) -> None: ...

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 import json
 import os
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import cached_property
 from typing import Any, Literal, cast
@@ -45,6 +45,7 @@ from pydantic_ai import (
 from pydantic_ai.capabilities import NativeTool
 from pydantic_ai.native_tools import WebSearchTool
 from pydantic_ai.output import NativeOutput, PromptedOutput
+from pydantic_ai.settings import ModelSettings, ThinkingLevel
 from pydantic_ai.usage import RequestUsage, RunUsage
 
 from .._inline_snapshot import snapshot
@@ -88,10 +89,15 @@ def test_init():
     assert m.base_url == 'https://api.groq.com'
 
 
+def _create_kwargs_factory() -> list[dict[str, Any]]:
+    return []
+
+
 @dataclass
 class MockGroq:
     completions: MockChatCompletion | Sequence[MockChatCompletion] | None = None
     stream: Sequence[MockChatCompletionChunk] | Sequence[Sequence[MockChatCompletionChunk]] | None = None
+    create_kwargs: list[dict[str, Any]] = field(default_factory=_create_kwargs_factory)
     index: int = 0
     base_url: str = 'https://api.groq.com'
 
@@ -114,6 +120,7 @@ class MockGroq:
     async def chat_completions_create(
         self, *_args: Any, stream: bool = False, **_kwargs: Any
     ) -> chat.ChatCompletion | MockAsyncStream[MockChatCompletionChunk]:
+        self.create_kwargs.append(_kwargs)
         if stream:
             assert self.stream is not None, 'you can only used `stream=True` if `stream` is provided'
             if isinstance(self.stream[0], Sequence):
@@ -220,6 +227,57 @@ async def test_request_simple_usage(allow_model_requests: None):
 
     result = await agent.run('Hello')
     assert result.output == 'world'
+
+
+@pytest.mark.parametrize(
+    ('thinking', 'expected_extra_body'),
+    [
+        (True, {'service_tier': 'on_demand'}),
+        ('minimal', {'reasoning_effort': 'low', 'service_tier': 'on_demand'}),
+        ('low', {'reasoning_effort': 'low', 'service_tier': 'on_demand'}),
+        ('medium', {'reasoning_effort': 'medium', 'service_tier': 'on_demand'}),
+        ('high', {'reasoning_effort': 'high', 'service_tier': 'on_demand'}),
+        ('xhigh', {'reasoning_effort': 'high', 'service_tier': 'on_demand'}),
+    ],
+)
+async def test_groq_gpt_oss_unified_thinking_maps_to_reasoning_effort(
+    allow_model_requests: None, thinking: ThinkingLevel, expected_extra_body: dict[str, object]
+):
+    c = completion_message(ChatCompletionMessage(content='ok', role='assistant'))
+    mock_client = MockGroq(completions=c)
+    m = GroqModel('openai/gpt-oss-120b', provider=GroqProvider(groq_client=cast(AsyncGroq, mock_client)))
+    agent = Agent(
+        m,
+        model_settings=ModelSettings(
+            thinking=thinking,
+            extra_body={'service_tier': 'on_demand'},
+        ),
+    )
+
+    result = await agent.run('Hello')
+
+    assert result.output == 'ok'
+    assert mock_client.create_kwargs[0]['extra_body'] == expected_extra_body
+
+
+async def test_groq_qwen3_unified_effort_level_does_not_send_unsupported_reasoning_effort(
+    allow_model_requests: None,
+):
+    c = completion_message(ChatCompletionMessage(content='ok', role='assistant'))
+    mock_client = MockGroq(completions=c)
+    m = GroqModel('qwen/qwen3-32b', provider=GroqProvider(groq_client=cast(AsyncGroq, mock_client)))
+    agent = Agent(
+        m,
+        model_settings=ModelSettings(
+            thinking='low',
+            extra_body={'service_tier': 'on_demand'},
+        ),
+    )
+
+    result = await agent.run('Hello')
+
+    assert result.output == 'ok'
+    assert mock_client.create_kwargs[0]['extra_body'] == {'service_tier': 'on_demand'}
 
 
 async def test_request_structured_response(allow_model_requests: None):


### PR DESCRIPTION
- Closes #5796

This wires Groq GPT-OSS models into the unified `thinking` setting by mapping the supported effort levels to Groq's native `extra_body.reasoning_effort` values.

The mapping is profile-gated so only model families that declare compatible Groq effort values receive them:

- `openai/gpt-oss-*`: `minimal`/`low` -> `low`, `medium` -> `medium`, `high`/`xhigh` -> `high`
- `qwen/qwen3-*`: keeps unsupported unified effort levels off the wire, while preserving the existing `thinking=False` -> `reasoning_effort=none` behavior

It also preserves user-provided `extra_body` entries when injecting `reasoning_effort`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Tests

- `uv run --extra groq pytest tests/models/test_groq.py::test_groq_gpt_oss_unified_thinking_maps_to_reasoning_effort tests/models/test_groq.py::test_groq_qwen3_unified_effort_level_does_not_send_unsupported_reasoning_effort -q`
- `uv run --extra groq pytest tests/test_thinking_wire_contract.py -k groq -q`
- `uv run --extra groq pytest tests/models/test_groq.py -k "unified_thinking or reasoning_effort" -q`
- `uv run --extra groq pytest tests/models/test_groq.py -q`
- `uv run --extra groq pytest tests/profiles/test_resolution_matrix.py::test_groq_moonshotai_kimi tests/profiles/test_resolution_matrix.py::test_groq_meta_llama4_maverick tests/profiles/test_resolution_matrix.py::test_groq_meta_llama3_no_overlay tests/profiles/test_resolution_matrix.py::test_groq_deepseek -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/groq.py pydantic_ai_slim/pydantic_ai/profiles/groq.py pydantic_ai_slim/pydantic_ai/providers/groq.py tests/models/test_groq.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/models/groq.py pydantic_ai_slim/pydantic_ai/profiles/groq.py pydantic_ai_slim/pydantic_ai/providers/groq.py tests/models/test_groq.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/models/groq.py pydantic_ai_slim/pydantic_ai/profiles/groq.py pydantic_ai_slim/pydantic_ai/providers/groq.py tests/models/test_groq.py`