### PR TITLE
Preserve UNSET sentinel identity across importlib.reload of _utils

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -268,7 +268,14 @@ class Unset:
     pass
 
 
-UNSET = Unset()
+# Preserve the singleton's identity across `importlib.reload(pydantic_ai._utils)`.
+# `is_set()` below compares by identity (`is not UNSET`), and many callers capture
+# `UNSET` as a default argument value at import time (e.g. `Agent.override(retries=UNSET)`).
+# A reload re-executes this module into its existing namespace without clearing it, so
+# reusing the current instance keeps those captured defaults matching `UNSET`; otherwise a
+# reload would rebind `UNSET` to a fresh object and `is_set()` would wrongly report every
+# previously-captured default as *set*.
+UNSET: Unset = globals().get('UNSET') or Unset()
 
 
 def is_set(t_or_unset: T | Unset) -> TypeGuard[T]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -307,6 +307,32 @@ async def test_run_in_executor_runs_inline_by_default_on_emscripten(monkeypatch:
         importlib.reload(utils_module)
 
 
+def test_unset_singleton_survives_reload():
+    """`UNSET` must keep its identity across `importlib.reload(_utils)`.
+
+    `is_set()` compares by identity, and callers across the codebase capture `UNSET`
+    as a default argument value at import time (e.g. `Agent.override(retries=UNSET)`).
+    Other tests in this module reload `_utils` to re-evaluate a platform-derived default;
+    if that reload rebound `UNSET` to a fresh object, every already-captured default would
+    start reading as *set*, so e.g. `agent.override(deps=...)` would treat its unset
+    `retries` sentinel as a real value and raise `AttributeError: 'Unset' object has no
+    attribute 'copy'`. Regression guard for that cross-test leak.
+    """
+    original_unset = utils_module.UNSET
+    original_unset_type = utils_module.Unset
+
+    importlib.reload(utils_module)
+    try:
+        assert utils_module.UNSET is original_unset
+        # A value captured against the pre-reload sentinel must still read as unset.
+        assert not utils_module.is_set(original_unset)
+        assert utils_module.is_set('something')
+    finally:
+        # Restore the type identity so later reloads/tests see a consistent module.
+        utils_module.Unset = original_unset_type
+        importlib.reload(utils_module)
+
+
 def test_is_async_callable():
     def sync_func(): ...  # pragma: no branch
 


### PR DESCRIPTION
## Summary

`pydantic_ai._utils.is_set()` decides whether an argument was supplied by comparing **by identity** against the module-level `UNSET` sentinel:

```python
UNSET = Unset()

def is_set(t_or_unset: T | Unset) -> TypeGuard[T]:
    return t_or_unset is not UNSET
```

Callers all over the package capture `UNSET` as a **default argument value at import time**, e.g. `Agent.override(retries=_utils.UNSET, ...)`.

`tests/test_utils.py` reloads the module with `importlib.reload(pydantic_ai._utils)` in two platform tests (`test_disable_threads_defaults_false_on_non_emscripten`, `test_run_in_executor_runs_inline_by_default_on_emscripten`) to re-evaluate the `sys.platform`-derived `_disable_threads` `ContextVar` default. Each reload **rebinds `UNSET` to a brand-new `Unset()` instance**, so every default captured *before* the reload no longer matches the current `UNSET`. `is_set()` then reports those unset sentinels as **set**.

Concretely, once `test_utils.py` has run, `agent.override(deps=...)` (with `retries` left at its captured `UNSET` default) flows into `_normalize_agent_retry_overrides(UNSET)` and calls `UNSET.copy()`:

```
AttributeError: 'Unset' object has no attribute 'copy'
  pydantic_ai_slim/pydantic_ai/agent/__init__.py:165: return retries.copy()
```

This showed up as **order-dependent** failures in the serial suite:

- `tests/test_deps.py::test_deps_override`
- `tests/test_tools.py::test_dynamic_tools_agent_wide`

CI runs `pytest -n auto --dist=loadgroup`, which distributes these files onto separate xdist workers, so the pollution rarely lands in the same worker and the bug stays hidden. It reproduces deterministically when the files share a worker / run serially.

## Reproduce (on `main`)

```console
$ python -m pytest -p no:randomly tests/test_utils.py tests/test_deps.py::test_deps_override
...
E   AttributeError: 'Unset' object has no attribute 'copy'
pydantic_ai_slim/pydantic_ai/agent/__init__.py:165: AttributeError
1 failed, 25 passed
```

Minimal mechanism:

```python
import importlib, pydantic_ai._utils as u
old = u.UNSET
importlib.reload(u)
assert u.UNSET is old            # FAILS on main: identity lost
assert not u.is_set(old)         # FAILS on main: old sentinel now reads as "set"
```

## Fix

Make the sentinel reload-safe by reusing the existing instance when the module is re-executed. A reload runs module-level code into the module's existing namespace without clearing it, so the previous `UNSET` is still visible via `globals()`; an `Unset()` is truthy, so the `or` guard is safe:

```python
UNSET: Unset = globals().get('UNSET') or Unset()
```

This preserves `UNSET`'s identity across `importlib.reload`, so every captured default keeps matching and `is_set()` stays correct. No behavioral change on a normal (non-reload) import.

## Tests

Added `tests/test_utils.py::test_unset_singleton_survives_reload`, asserting the singleton keeps its identity across `importlib.reload` and that a value captured pre-reload still reads as unset.

Proof it guards the bug (stash the source fix, keep the test):

```console
# without src fix
$ python -m pytest tests/test_utils.py::test_unset_singleton_survives_reload
E   assert <Unset object at 0x...540> is <Unset object at 0x...420>
1 failed

# with src fix
$ python -m pytest tests/test_utils.py::test_unset_singleton_survives_reload
1 passed
```

The originally order-dependent failures now pass, and so does the wider affected surface:

```console
$ python -m pytest -p no:randomly tests/test_utils.py tests/test_deps.py tests/test_tools.py tests/test_agent.py
496 passed, 3 skipped
```

## Lint / type-check (changed files only)

- `ruff check` — All checks passed
- `ruff format --check` — already formatted
- `pyright pydantic_ai_slim/pydantic_ai/_utils.py` — 0 errors, 0 warnings
- `mypy` single-file: 4 errors, all pre-existing and unrelated (identical count with the change stashed; they are at lines 172/360/539/540, far from the change at line 271, and are single-file cross-module-context artifacts — `make typecheck` uses pyright).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

