### PR TITLE
fix(ui): preserve Vercel tool return metadata chunks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -104,6 +104,8 @@ if TYPE_CHECKING:
 __all__ = ['VercelAIAdapter']
 
 request_data_ta: TypeAdapter[RequestData] = TypeAdapter(RequestData)
+_TOOL_RETURN_METADATA_KIND = 'tool_return_metadata_kind'
+_FILE_CHUNK_METADATA_KIND = 'file_chunk'
 
 
 def _generate_message_id(
@@ -373,7 +375,11 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                             )
                         )
                     elif isinstance(part, FileUIPart):
-                        if active_tool_return is not None:
+                        provider_meta = load_provider_metadata(part.provider_metadata)
+                        if (
+                            active_tool_return is not None
+                            and provider_meta.get(_TOOL_RETURN_METADATA_KIND) == _FILE_CHUNK_METADATA_KIND
+                        ):
                             _append_metadata_chunk(
                                 active_tool_return, FileChunk(url=part.url, media_type=part.media_type)
                             )
@@ -387,7 +393,6 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                             raise ValueError(
                                 'Vercel AI integration can currently only handle assistant file parts with data URIs.'
                             ) from e
-                        provider_meta = load_provider_metadata(part.provider_metadata)
                         vendor_metadata = provider_meta.get('vendor_metadata')
                         # `vendor_metadata` is client-supplied and unconstrained; assignment on the
                         # (non-`validate_assignment`) `BinaryContent` dataclass bypasses validation,
@@ -1103,7 +1108,13 @@ def _extract_metadata_ui_parts(tool_result: ToolReturnPart) -> list[UIMessagePar
                 )
             )
         elif isinstance(chunk, FileChunk):
-            parts.append(FileUIPart(url=chunk.url, media_type=chunk.media_type))
+            parts.append(
+                FileUIPart(
+                    url=chunk.url,
+                    media_type=chunk.media_type,
+                    provider_metadata=dump_provider_metadata(**{_TOOL_RETURN_METADATA_KIND: _FILE_CHUNK_METADATA_KIND}),
+                )
+            )
         else:
             assert_never(chunk)
     return parts

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -347,8 +347,10 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                     builder.add(UserPromptPart(content=user_prompt_content))
 
             elif msg.role == 'assistant':
+                active_tool_return: ToolReturnPart | None = None
                 for part in msg.parts:
                     if isinstance(part, TextUIPart):
+                        active_tool_return = None
                         provider_meta = load_provider_metadata(part.provider_metadata)
                         builder.add(
                             TextPart(
@@ -359,6 +361,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                             )
                         )
                     elif isinstance(part, ReasoningUIPart):
+                        active_tool_return = None
                         provider_meta = load_provider_metadata(part.provider_metadata)
                         builder.add(
                             ThinkingPart(
@@ -370,6 +373,13 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                             )
                         )
                     elif isinstance(part, FileUIPart):
+                        if active_tool_return is not None:
+                            _append_metadata_chunk(
+                                active_tool_return, FileChunk(url=part.url, media_type=part.media_type)
+                            )
+                            continue
+
+                        active_tool_return = None
                         try:
                             file = BinaryContent.from_data_uri(part.url)
                         except ValueError as e:  # pragma: no cover
@@ -424,6 +434,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                         tool_kind = parse_tool_kind(raw_tool_kind) if isinstance(raw_tool_kind, str) else None
 
                         if builtin_tool:
+                            active_tool_return = None
                             # For builtin tools, we need to create 2 parts (BuiltinToolCall & BuiltinToolReturn) for a single Vercel ToolOutput
                             # The call and return metadata are combined in the output part.
                             # So we extract and return them to the respective parts
@@ -509,45 +520,67 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                             )
 
                             if part.state == 'output-available':
-                                builder.add(
-                                    ToolReturnPart(
-                                        tool_name=tool_name,
-                                        tool_call_id=tool_call_id,
-                                        content=part.output,
-                                        tool_kind=tool_kind,
-                                    )
+                                active_tool_return = ToolReturnPart(
+                                    tool_name=tool_name,
+                                    tool_call_id=tool_call_id,
+                                    content=part.output,
+                                    tool_kind=tool_kind,
                                 )
+                                builder.add(active_tool_return)
                             # Error/denied returns deliberately carry no `tool_kind`: typed return
                             # subclasses only ever wrap successful, shape-valid content, and readers
                             # like `parse_loaded_capabilities` treat their presence as proof of success.
                             elif part.state == 'output-error':
-                                builder.add(
-                                    ToolReturnPart(
-                                        tool_name=tool_name,
-                                        tool_call_id=tool_call_id,
-                                        content=part.error_text,
-                                        outcome='failed',
-                                    )
+                                active_tool_return = ToolReturnPart(
+                                    tool_name=tool_name,
+                                    tool_call_id=tool_call_id,
+                                    content=part.error_text,
+                                    outcome='failed',
                                 )
+                                builder.add(active_tool_return)
                             elif part.state == 'output-denied':
-                                builder.add(
-                                    ToolReturnPart(
-                                        tool_name=tool_name,
-                                        tool_call_id=tool_call_id,
-                                        content=_denial_reason(part),
-                                        outcome='denied',
-                                    )
+                                active_tool_return = ToolReturnPart(
+                                    tool_name=tool_name,
+                                    tool_call_id=tool_call_id,
+                                    content=_denial_reason(part),
+                                    outcome='denied',
                                 )
-                    elif isinstance(part, DataUIPart):  # pragma: no cover
+                                builder.add(active_tool_return)
+                            else:
+                                active_tool_return = None
+                    elif isinstance(part, DataUIPart):
                         # Contains custom data that shouldn't be sent to the model
-                        pass
-                    elif isinstance(part, SourceUrlUIPart):  # pragma: no cover
+                        if active_tool_return is not None:
+                            _append_metadata_chunk(
+                                active_tool_return, DataChunk(type=part.type, id=part.id, data=part.data)
+                            )
+                    elif isinstance(part, SourceUrlUIPart):
                         # TODO: Once we support citations: https://github.com/pydantic/pydantic-ai/issues/3126
-                        pass
-                    elif isinstance(part, SourceDocumentUIPart):  # pragma: no cover
+                        if active_tool_return is not None:
+                            _append_metadata_chunk(
+                                active_tool_return,
+                                SourceUrlChunk(
+                                    source_id=part.source_id,
+                                    url=part.url,
+                                    title=part.title,
+                                    provider_metadata=part.provider_metadata,
+                                ),
+                            )
+                    elif isinstance(part, SourceDocumentUIPart):
                         # TODO: Once we support citations: https://github.com/pydantic/pydantic-ai/issues/3126
-                        pass
+                        if active_tool_return is not None:
+                            _append_metadata_chunk(
+                                active_tool_return,
+                                SourceDocumentChunk(
+                                    source_id=part.source_id,
+                                    media_type=part.media_type,
+                                    title=part.title,
+                                    filename=part.filename,
+                                    provider_metadata=part.provider_metadata,
+                                ),
+                            )
                     elif isinstance(part, StepStartUIPart):  # pragma: no cover
+                        active_tool_return = None
                         # Nothing to do here
                         pass
                     else:
@@ -1022,6 +1055,19 @@ def _denial_reason(part: ToolUIPart | DynamicToolUIPart) -> str:
     if isinstance(part.approval, ToolApprovalResponded) and part.approval.reason:
         return part.approval.reason
     return ToolDenied().message
+
+
+def _append_metadata_chunk(
+    tool_return: ToolReturnPart, chunk: DataChunk | SourceUrlChunk | SourceDocumentChunk | FileChunk
+) -> None:
+    """Append a persisted Vercel data chunk to a loaded tool return."""
+    metadata = tool_return.metadata
+    if metadata is None:
+        tool_return.metadata = [chunk]
+    elif isinstance(metadata, list):
+        cast(list[Any], metadata).append(chunk)
+    else:
+        tool_return.metadata = [metadata, chunk]
 
 
 def _extract_metadata_ui_parts(tool_result: ToolReturnPart) -> list[UIMessagePart]:

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -4380,6 +4380,58 @@ async def test_adapter_dump_messages_with_tool_metadata_data_chunks():
     )
 
 
+@pytest.mark.parametrize(
+    'chunks',
+    [
+        [DataChunk(type='data-sources', id='s1', data={'query': 'pydantic-ai'})],
+        [SourceUrlChunk(source_id='src_1', url='https://example.com', title='Example')],
+        [
+            SourceDocumentChunk(
+                source_id='doc_1',
+                media_type='application/pdf',
+                title='Doc',
+                filename='doc.pdf',
+                provider_metadata={'provider': {'id': 'doc-provider'}},
+            )
+        ],
+        [FileChunk(url='https://example.com/file.png', media_type='image/png')],
+    ],
+    ids=['data', 'source-url', 'source-document', 'file'],
+)
+async def test_adapter_dump_load_round_trips_tool_return_metadata_chunks(
+    chunks: list[DataChunk | SourceUrlChunk | SourceDocumentChunk | FileChunk],
+):
+    """Test loading preserves data-carrying chunks emitted from ToolReturnPart.metadata."""
+    messages: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Send data')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='send_data', args={}, tool_call_id='call_1')]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='send_data',
+                    content='Data sent',
+                    tool_call_id='call_1',
+                    metadata=chunks,
+                )
+            ]
+        ),
+    ]
+
+    ui_messages = VercelAIAdapter.dump_messages(messages)
+    reloaded = VercelAIAdapter.load_messages(ui_messages)
+
+    tool_returns = [
+        part
+        for message in reloaded
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+        if isinstance(part, ToolReturnPart)
+    ]
+    assert len(tool_returns) == 1
+    assert tool_returns[0].metadata == chunks
+    assert len(reloaded) == len(messages)
+
+
 async def test_stream_and_dump_messages_metadata_consistency():
     """Test that streaming and dump_messages produce consistent DataChunk/DataUIPart data."""
 

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -4361,7 +4361,7 @@ async def test_adapter_dump_messages_with_tool_metadata_data_chunks():
                         'media_type': 'image/png',
                         'filename': None,
                         'url': 'https://example.com/file.png',
-                        'provider_metadata': None,
+                        'provider_metadata': {'pydantic_ai': {'tool_return_metadata_kind': 'file_chunk'}},
                     },
                     {
                         'type': 'data-valid',
@@ -4430,6 +4430,40 @@ async def test_adapter_dump_load_round_trips_tool_return_metadata_chunks(
     assert len(tool_returns) == 1
     assert tool_returns[0].metadata == chunks
     assert len(reloaded) == len(messages)
+
+
+async def test_adapter_load_messages_preserves_standalone_file_after_tool_output():
+    """Test untagged file parts after tool outputs stay standalone assistant files."""
+    file_content = BinaryContent(data=b'file_data', media_type='image/png')
+    ui_messages = [
+        UIMessage(
+            id='message-1',
+            role='assistant',
+            parts=[
+                ToolOutputAvailablePart(
+                    type='tool-send_data',
+                    tool_call_id='call_1',
+                    input={},
+                    output='Data sent',
+                ),
+                FileUIPart(media_type=file_content.media_type, url=file_content.data_uri),
+            ],
+        )
+    ]
+
+    reloaded = VercelAIAdapter.load_messages(ui_messages)
+
+    assert len(reloaded) == 3
+    assert isinstance(reloaded[1], ModelRequest)
+    tool_return = reloaded[1].parts[0]
+    assert isinstance(tool_return, ToolReturnPart)
+    assert tool_return.metadata is None
+
+    assert isinstance(reloaded[2], ModelResponse)
+    file_part = reloaded[2].parts[0]
+    assert isinstance(file_part, FilePart)
+    assert file_part.content.data == file_content.data
+    assert file_part.content.media_type == file_content.media_type
 
 
 async def test_stream_and_dump_messages_metadata_consistency():


### PR DESCRIPTION
- Closes #5913

Preserves data-carrying Vercel AI metadata chunks when `dump_messages()` output is loaded back through `load_messages()`.

The dump path already emits `DataChunk`, `SourceUrlChunk`, `SourceDocumentChunk`, and `FileChunk` values from `ToolReturnPart.metadata` as adjacent UI message parts. The load path now re-bundles those adjacent parts back onto the corresponding `ToolReturnPart.metadata` instead of dropping them or converting file chunks into a separate model response.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

