### PR TITLE
fix(evals): align LLMJudge expected-output prompt order

### DIFF
--- a/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
+++ b/pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py
@@ -255,11 +255,11 @@ def _build_prompt(
     if inputs is not None:
         sections.extend(_make_section(inputs, 'Input'))
 
-    sections.extend(_make_section(output, 'Output'))
-    sections.extend(_make_section(rubric, 'Rubric'))
-
     if expected_output is not None:
         sections.extend(_make_section(expected_output, 'ExpectedOutput'))
+
+    sections.extend(_make_section(output, 'Output'))
+    sections.extend(_make_section(rubric, 'Rubric'))
     if all(isinstance(section, str) for section in sections):
         return '\n'.join(sections)  # type: ignore[arg-type]
     return sections

--- a/tests/evals/test_llm_as_a_judge.py
+++ b/tests/evals/test_llm_as_a_judge.py
@@ -263,15 +263,15 @@ async def test_judge_input_output_expected_mock(mocker: MockerFixture, image_con
 <Input>
 Hello
 </Input>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Output>
 Hello world
 </Output>
 <Rubric>
 Output contains input
-</Rubric>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>\
+</Rubric>\
 """,
         )
     )
@@ -289,15 +289,15 @@ Hello
                 '<Input>',
                 image_content,
                 '</Input>',
+                '<ExpectedOutput>',
+                'Hello',
+                '</ExpectedOutput>',
                 '<Output>',
                 'Hello world',
                 '</Output>',
                 '<Rubric>',
                 'Output contains input',
                 '</Rubric>',
-                '<ExpectedOutput>',
-                'Hello',
-                '</ExpectedOutput>',
             ],
         )
     )
@@ -333,15 +333,15 @@ async def test_judge_input_output_expected_with_model_settings_mock(
 <Input>
 Hello settings
 </Input>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Output>
 Hello world with settings
 </Output>
 <Rubric>
 Output contains input with settings
-</Rubric>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>\
+</Rubric>\
 """,
         )
     )
@@ -369,15 +369,15 @@ Hello
                 '<Input>',
                 image_content,
                 '</Input>',
+                '<ExpectedOutput>',
+                'Hello',
+                '</ExpectedOutput>',
                 '<Output>',
                 'Hello world with settings',
                 '</Output>',
                 '<Rubric>',
                 'Output contains input with settings',
                 '</Rubric>',
-                '<ExpectedOutput>',
-                'Hello',
-                '</ExpectedOutput>',
             ],
         )
     )
@@ -406,15 +406,15 @@ Hello
 <Input>
 123
 </Input>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Output>
 Hello world with settings
 </Output>
 <Rubric>
 Output contains input with settings
-</Rubric>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>\
+</Rubric>\
 """,
         )
     )
@@ -440,15 +440,15 @@ Hello
 <Input>
 123
 </Input>
+<ExpectedOutput>
+Hello
+</ExpectedOutput>
 <Output>
 Hello world with settings
 </Output>
 <Rubric>
 Output contains input with settings
-</Rubric>
-<ExpectedOutput>
-Hello
-</ExpectedOutput>\
+</Rubric>\
 """,
         )
     )
@@ -522,15 +522,15 @@ async def test_judge_output_expected_with_model_settings_mock(mocker: MockerFixt
     assert call_args == snapshot(
         (
             [
+                '<ExpectedOutput>',
+                'Hello',
+                '</ExpectedOutput>',
                 '<Output>',
                 image_content,
                 '</Output>',
                 '<Rubric>',
                 'Output contains input with settings',
                 '</Rubric>',
-                '<ExpectedOutput>',
-                'Hello',
-                '</ExpectedOutput>',
             ],
         )
     )


### PR DESCRIPTION
- Closes #6110

This keeps the runtime `LLMJudge` prompt layout aligned with the judge agents' few-shot examples when `expected_output` is present.

The expected-output variants currently teach these layouts in the system prompt examples:

- `judge_input_output_expected`: `Input -> ExpectedOutput -> Output -> Rubric`
- `judge_output_expected`: `ExpectedOutput -> Output -> Rubric`

But `_build_prompt()` emitted `ExpectedOutput` after `Rubric`. This PR moves `ExpectedOutput` before `Output`, leaving `Rubric` last so the instruction follows the full context it applies to.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Tests

RED before the fix:

- `uv run pytest tests/evals/test_llm_as_a_judge.py -q -k 'judge_input_output_expected or judge_output_expected'`
- Failed with snapshot mismatches showing runtime prompts still emitted `Input -> Output -> Rubric -> ExpectedOutput` and `Output -> Rubric -> ExpectedOutput`.

GREEN after the fix:

- `uv run pytest tests/evals/test_llm_as_a_judge.py -q -k 'judge_input_output_expected or judge_output_expected'`
- `uv run pytest tests/evals/test_llm_as_a_judge.py tests/evals/test_evaluator_common.py -q`
- `uv run ruff check pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py tests/evals/test_llm_as_a_judge.py`
- `uv run ruff format --check pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py tests/evals/test_llm_as_a_judge.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_evals/pydantic_evals/evaluators/llm_as_a_judge.py tests/evals/test_llm_as_a_judge.py`
- `git diff --check`

AI assistance: This draft PR was prepared by an AI agent on behalf of @Sehlani042; the first checklist item is intentionally left unchecked for human review.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

