### PR TITLE
fix(google): retain file search grounding with native tool parts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -1416,6 +1416,7 @@ class GeminiStreamedResponse(StreamedResponse):
                         yield self._parts_manager.handle_part(vendor_part_id=uuid4(), part=tool_call_part)
                     elif part.tool_response:
                         tool_response_part = _map_tool_response(part.tool_response, self.provider_name)
+                        _fill_empty_file_search_return_content(tool_response_part, candidate.grounding_metadata)
                         tool_response_part.provider_details = provider_details
                         yield self._parts_manager.handle_part(vendor_part_id=uuid4(), part=tool_response_part)
                     elif part.executable_code is not None:
@@ -1786,6 +1787,8 @@ def _process_response_from_parts(
     for part in parts:
         item, code_execution_tool_call_id = _process_part(part, code_execution_tool_call_id, provider_name)
         if item is not None:
+            if isinstance(item, NativeToolReturnPart):
+                _fill_empty_file_search_return_content(item, grounding_metadata)
             items.append(item)
 
     return ModelResponse(
@@ -1936,6 +1939,18 @@ def _map_tool_response(tool_response: ToolResponse, provider_name: str) -> Nativ
         tool_call_id=tool_response.id or _utils.generate_tool_call_id(),
         content=tool_response.response,
     )
+
+
+def _fill_empty_file_search_return_content(
+    item: NativeToolReturnPart, grounding_metadata: GroundingMetadata | None
+) -> None:
+    if item.tool_name != FileSearchTool.kind or item.content is not None:
+        return
+
+    grounding_chunks = grounding_metadata.grounding_chunks if grounding_metadata else None
+    retrieved_contexts = _extract_file_search_retrieved_contexts(grounding_chunks)
+    if retrieved_contexts:
+        item.content = retrieved_contexts
 
 
 def _map_grounding_metadata(

--- a/tests/models/google/test_native_tools.py
+++ b/tests/models/google/test_native_tools.py
@@ -29,11 +29,13 @@ from pydantic_ai.native_tools import (
 from ...conftest import try_import
 
 with try_import() as imports_successful:
-    from google.genai.types import ToolType
+    from google.genai.types import GroundingMetadata, Part, ToolType
 
     from pydantic_ai.models.google import (
         _content_model_response,  # pyright: ignore[reportPrivateUsage]
+        _process_response_from_parts,  # pyright: ignore[reportPrivateUsage]
     )
+    from pydantic_ai.usage import RequestUsage
 
 pytestmark = pytest.mark.skipif(not imports_successful(), reason='google-genai not installed')
 
@@ -157,6 +159,54 @@ def test_content_model_response_drops_pyd_ai_synthesized_native_tool_ids():
     assert _content_model_response(response, frozenset({'google-gla'}), supports_tool_combination=True) == snapshot(
         {'role': 'model', 'parts': [{'text': 'hello'}]}
     )
+
+
+def test_file_search_tool_response_uses_grounding_metadata_when_response_is_empty():
+    """Gemini may return explicit file-search tool parts while keeping contexts in grounding metadata."""
+    response = _process_response_from_parts(
+        parts=[
+            Part.model_validate({'tool_call': {'id': 'file_search_call', 'tool_type': 'FILE_SEARCH', 'args': {}}}),
+            Part.model_validate({'tool_response': {'id': 'file_search_call', 'tool_type': 'FILE_SEARCH'}}),
+            Part.model_validate({'text': 'Paris is the capital of France.'}),
+        ],
+        grounding_metadata=GroundingMetadata.model_validate(
+            {
+                'grounding_chunks': [
+                    {
+                        'retrieved_context': {
+                            'text': 'Paris is the capital of France.',
+                            'file_search_store': 'fileSearchStores/test-store',
+                        },
+                    },
+                ],
+            }
+        ),
+        model_name='gemini-3.5-flash',
+        provider_name='google-gla',
+        provider_url='https://generativelanguage.googleapis.com/',
+        usage=RequestUsage(),
+        provider_response_id='response-id',
+    )
+
+    file_search_call, file_search_return, text = response.parts
+
+    assert file_search_call == NativeToolCallPart(
+        tool_name='file_search',
+        args={},
+        tool_call_id='file_search_call',
+        provider_name='google-gla',
+    )
+    assert isinstance(file_search_return, NativeToolReturnPart)
+    assert file_search_return.tool_name == 'file_search'
+    assert file_search_return.tool_call_id == 'file_search_call'
+    assert file_search_return.provider_name == 'google-gla'
+    assert file_search_return.content == [
+        {
+            'text': 'Paris is the capital of France.',
+            'file_search_store': 'fileSearchStores/test-store',
+        }
+    ]
+    assert text == TextPart(content='Paris is the capital of France.')
 
 
 @pytest.mark.parametrize('supports_tool_combination', [False, True])


### PR DESCRIPTION
Closes #6207

### Summary

When Gemini returns explicit native File Search `tool_call` / `tool_response` parts, the response mapper skips metadata-based native tool reconstruction to avoid duplicate parts. That is correct for call reconstruction, but Gemini can still leave the explicit File Search `tool_response.response` empty while putting the retrieved contexts in `grounding_metadata`.

This PR keeps the explicit native tool parts and only fills an empty File Search `NativeToolReturnPart.content` from `grounding_metadata.grounding_chunks`. It applies to both non-streaming and streaming mapping paths and does not reopen full metadata reconstruction when native tool invocations are present.

### Verification

- RED: `uv run pytest tests/models/google/test_native_tools.py::test_file_search_tool_response_uses_grounding_metadata_when_response_is_empty -q` failed with `NativeToolReturnPart.content is None`.
- GREEN: `uv run pytest tests/models/google/test_native_tools.py::test_file_search_tool_response_uses_grounding_metadata_when_response_is_empty -q`
- `uv run pytest tests/models/google/test_native_tools.py tests/models/test_google.py::test_google_model_file_search_tool tests/models/test_google.py::test_google_model_file_search_tool_stream -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/models/google.py tests/models/google/test_native_tools.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/models/google.py tests/models/google/test_native_tools.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/models/google.py tests/models/google/test_native_tools.py`
- `git diff --check`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

