### PR TITLE
Handle None metadata in Gradio weather agent example

### DIFF
--- a/examples/pydantic_ai_examples/weather_agent_gradio.py
+++ b/examples/pydantic_ai_examples/weather_agent_gradio.py
@@ -45,10 +45,9 @@ async def stream_from_agent(prompt: str, chatbot: list[dict], past_messages: lis
                     chatbot.append(gr_message)
                 if isinstance(call, ToolReturnPart):
                     for gr_message in chatbot:
-                        if (
-                            gr_message.get('metadata', {}).get('id', '')
-                            == call.tool_call_id
-                        ):
+                        if (gr_message.get('metadata') or {}).get(
+                            'id', ''
+                        ) == call.tool_call_id:
                             if isinstance(call.content, BaseModel):
                                 json_content = call.content.model_dump_json()
                             else:


### PR DESCRIPTION
Fixes the last of the three crashes reported in #1546 for the Gradio weather-agent example.

On a **second query**, the chatbot history contains plain assistant messages that carry no `metadata`. The existing `gr_message.get('metadata', {}).get('id', '')` only guards the *missing-key* case — if `metadata` is present but `None`, `.get('metadata', {})` returns `None` and `.get('id')` raises:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

This changes it to `(gr_message.get('metadata') or {}).get('id', '')`, so both missing and explicitly-`None` metadata fall back to an empty dict.

### Notes
- The other two issues from #1546 (`args_dict` on a `str`, and the `{call.tool_call_id}` set-literal id) were already resolved on `main`; this covers the remaining one.
- Verified the formatting logic against constructed tool-call / tool-return messages (str **and** dict args, missing metadata, `None` metadata) — all three scenarios now run without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

