### PR TITLE
fix(temporal): pass through genai_prices and httpx2 for workflow cost()

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -109,6 +109,12 @@ def _workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner:
             # Imported inside `logfire._internal.json_schema` when running `logfire.info` inside an activity with attributes to serialize
             'numpy',
             'pandas',
+            # `response.cost()` lazily imports `genai_prices` (and its `httpx2` dependency) on first call.
+            # When cost is calculated inside a workflow, the sandbox re-imports that chain and `httpx2._models`
+            # subclasses `urllib.request.Request`, which is restricted unless `genai_prices`/`httpx2` are passed
+            # through alongside the rest of the HTTP stack.
+            'genai_prices',
+            'httpx2',
         ),
     )
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1785,6 +1785,37 @@ async def test_model_construction_in_workflow_passes_sandbox(
     assert result == expected_model_class
 
 
+# Regression test for the `genai_prices`/`httpx2` passthrough entries in `_workflow_runner`.
+# `ModelResponse.cost()` lazily imports genai-prices on first call; inside a workflow that trips the
+# sandbox unless those modules are passed through (see #6215).
+@workflow.defn
+class CalculateCostInWorkflow:
+    @workflow.run
+    async def run(self) -> float:
+        response = ModelResponse(
+            parts=[TextPart('ok')],
+            usage=RequestUsage(input_tokens=100, output_tokens=10),
+            model_name='claude-sonnet-4-5',
+            provider_name='anthropic',
+        )
+        return float(response.cost().total_price)
+
+
+async def test_response_cost_in_workflow_passes_sandbox(client: Client):
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[CalculateCostInWorkflow],
+        workflow_failure_exception_types=[Exception],
+    ):
+        result = await client.execute_workflow(
+            CalculateCostInWorkflow.run,
+            id='calculate_cost_in_workflow',
+            task_queue=TASK_QUEUE,
+        )
+    assert result > 0
+
+
 async def test_temporal_agent():
     assert isinstance(complex_temporal_agent.model, TemporalModel)
     assert complex_temporal_agent.model.wrapped == complex_agent.model


### PR DESCRIPTION
## Summary

Add `genai_prices` and `httpx2` to the Temporal workflow sandbox passthrough list so `ModelResponse.cost()` can be called inside workflows without tripping sandbox restrictions.

## Motivation

When `response.cost()` runs inside a Temporal workflow, genai-prices lazily loads its price data and imports `httpx2`. The sandbox re-imports that chain and `httpx2._models` subclasses `urllib.request.Request`, which raises `RestrictedWorkflowAccessError` unless those modules are passed through. This silently drops `operation.cost` from Temporal runs (#6215).

Fixes #6215

## Changes

- `pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py`: add `genai_prices` and `httpx2` to `_workflow_runner` passthrough modules (alongside existing `httpx`/`httpcore`/`certifi` entries)
- `tests/test_temporal.py`: add `CalculateCostInWorkflow` regression test exercising `cost()` inside a sandboxed workflow

## Tests

- `uv run pytest tests/test_temporal.py::test_response_cost_in_workflow_passes_sandbox -xvs` — PASSED
- `uv run ruff check` on changed files — PASSED

## Notes

- Follows the same passthrough pattern used for `anthropic`, `google.auth`, and `certifi` sandbox regressions.
- Composer-2.5 review: APPROVE

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

