### PR TITLE
Validate `Tool.from_schema` JSON schemas at creation

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -31,6 +31,7 @@ from typing import (
     Generic,
     TypeAlias,
     TypeGuard,
+    cast,
     get_args,
     get_origin,
     overload,
@@ -159,6 +160,7 @@ def check_object_json_schema(schema: JsonSchemaValue) -> ObjectJsonSchema:
     from .exceptions import UserError
 
     if schema.get('type') == 'object':
+        _check_required_properties(schema)
         return schema
     elif ref := schema.get('$ref'):
         prefix = '#/$defs/'
@@ -169,10 +171,27 @@ def check_object_json_schema(schema: JsonSchemaValue) -> ObjectJsonSchema:
             and resolved.get('type') == 'object'
             and not _contains_ref(resolved)
         ):
+            _check_required_properties(resolved)
             return resolved
         return schema
     else:
         raise UserError('Schema must be an object')
+
+
+def _check_required_properties(schema: JsonSchemaValue) -> None:
+    from .exceptions import UserError
+
+    required = schema.get('required')
+    if not isinstance(required, list):
+        return
+
+    properties = schema.get('properties', {})
+
+    for required_property in cast(list[object], required):
+        if isinstance(required_property, str) and (
+            not isinstance(properties, dict) or required_property not in properties
+        ):
+            raise UserError(f'Schema `required` property {required_property!r} is not defined in `properties`')
 
 
 def _contains_ref(obj: JsonSchemaValue | list[JsonSchemaValue]) -> bool:

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -614,6 +614,7 @@ class Tool(Generic[ToolAgentDepsT]):
         Returns:
             A Pydantic tool that calls the function
         """
+        json_schema = _utils.check_object_json_schema(json_schema)
         function_schema = _function_schema.FunctionSchema(
             function=function,
             name=name,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1432,6 +1432,39 @@ def test_function_tool_inconsistent_with_schema():
     assert result == 'Coverage made me call this'
 
 
+def test_function_tool_from_schema_rejects_non_object_schema():
+    def function(*args: Any, **kwargs: Any) -> str:  # pragma: no cover
+        return 'unreachable'
+
+    with pytest.raises(UserError, match='Schema must be an object'):
+        Tool.from_schema(function, name='foobar', description='does foobar stuff', json_schema={'type': 'string'})
+
+
+def test_function_tool_from_schema_rejects_unknown_required_property():
+    def function(*args: Any, **kwargs: Any) -> str:  # pragma: no cover
+        return 'unreachable'
+
+    with pytest.raises(UserError, match="Schema `required` property 'known' is not defined in `properties`"):
+        Tool.from_schema(
+            function,
+            name='foobar',
+            description='does foobar stuff',
+            json_schema={'type': 'object', 'required': ['known']},
+        )
+
+    with pytest.raises(UserError, match="Schema `required` property 'missing' is not defined in `properties`"):
+        Tool.from_schema(
+            function,
+            name='foobar',
+            description='does foobar stuff',
+            json_schema={
+                'type': 'object',
+                'properties': {'known': {'type': 'string'}},
+                'required': ['known', 'missing'],
+            },
+        )
+
+
 def test_async_function_tool_consistent_with_schema():
     async def function(*args: Any, **kwargs: Any) -> str:
         assert len(args) == 0


### PR DESCRIPTION
- Closes #6218

### Summary

- validate raw `Tool.from_schema()` JSON schemas when the tool is created
- reject non-object schemas before they reach runtime tool-call processing
- reject `required` entries that do not have matching `properties` entries

### Why

`Tool.from_schema()` is the public entry point for user-supplied tool argument schemas. Before this change, invalid schemas could be accepted during tool construction and fail later during model/tool-call processing, wasting a run and making the error harder to connect to the user-provided schema.

### Validation

- `uv run pytest tests/test_tools.py::test_function_tool_from_schema_rejects_non_object_schema tests/test_tools.py::test_function_tool_from_schema_rejects_unknown_required_property tests/test_tools.py::test_function_tool_consistent_with_schema tests/test_tools.py::test_function_tool_from_schema_with_ctx tests/test_tools.py::test_function_tool_inconsistent_with_schema tests/test_tools.py::test_async_function_tool_consistent_with_schema tests/test_tools.py::test_args_validator_tool_from_schema -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_utils.py pydantic_ai_slim/pydantic_ai/tools.py tests/test_tools.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/_utils.py pydantic_ai_slim/pydantic_ai/tools.py tests/test_tools.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/_utils.py pydantic_ai_slim/pydantic_ai/tools.py tests/test_tools.py`
- `git diff --check HEAD~1 HEAD`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

