### PR TITLE
Enable ruff RUF043 and fix ambiguous `pytest.raises` patterns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ extend-select = [
     "Q",
     "RUF100",
     "RUF018", # https://docs.astral.sh/ruff/rules/assignment-in-assert/
+    "RUF043", # https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern/
     "C90",
     "UP",
     "I",

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -2105,7 +2105,7 @@ cases:
 report_evaluators:
   - NonExistentEvaluator
 """
-    with pytest.raises(ExceptionGroup, match='error.*loading evaluators'):
+    with pytest.raises(ExceptionGroup, match=r'error.*loading evaluators'):
         Dataset[TaskInput, TaskOutput, TaskMetadata].from_text(yaml_text)
 
 
@@ -2120,7 +2120,7 @@ report_evaluators:
   - ConfusionMatrixEvaluator:
       nonexistent_param: true
 """
-    with pytest.raises(ExceptionGroup, match='error.*loading evaluators'):
+    with pytest.raises(ExceptionGroup, match=r'error.*loading evaluators'):
         Dataset[TaskInput, TaskOutput, TaskMetadata].from_text(yaml_text)
 
 

--- a/tests/evals/test_evaluator_base.py
+++ b/tests/evals/test_evaluator_base.py
@@ -82,20 +82,20 @@ def test_strict_abc_meta():
     from pydantic_evals.evaluators.report_evaluator import ReportEvaluator
 
     # Subclasses that don't implement inherited abstract methods are rejected at definition time
-    with pytest.raises(TypeError, match="must implement all abstract methods.*'evaluate'"):
+    with pytest.raises(TypeError, match=r"must implement all abstract methods.*'evaluate'"):
 
         @dataclass
         class InvalidEvaluator(Evaluator[Any, Any, Any]):  # pyright: ignore[reportUnusedClass]
             pass
 
-    with pytest.raises(TypeError, match="must implement all abstract methods.*'evaluate'"):
+    with pytest.raises(TypeError, match=r"must implement all abstract methods.*'evaluate'"):
 
         @dataclass
         class InvalidReportEvaluator(ReportEvaluator[Any, Any, Any]):  # pyright: ignore[reportUnusedClass]
             pass
 
     # Subclasses that add new abstract methods but don't implement inherited ones are also rejected
-    with pytest.raises(TypeError, match="must implement all abstract methods.*'evaluate'"):
+    with pytest.raises(TypeError, match=r"must implement all abstract methods.*'evaluate'"):
 
         @dataclass
         class PartialAbstract(Evaluator[Any, Any, Any]):  # pyright: ignore[reportUnusedClass]

--- a/tests/evals/test_evaluators.py
+++ b/tests/evals/test_evaluators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -594,31 +595,35 @@ async def test_span_query_evaluator(
 async def test_import_errors():
     with pytest.raises(
         ImportError,
-        match='The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.',
+        match=re.escape(
+            'The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.'
+        ),
     ):
         from pydantic_evals.evaluators import Python  # pyright: ignore[reportUnusedImport]
 
     with pytest.raises(
         ImportError,
-        match='The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.',
+        match=re.escape(
+            'The `Python` evaluator has been removed for security reasons. See https://github.com/pydantic/pydantic-ai/pull/2808 for more details and a workaround.'
+        ),
     ):
         from pydantic_evals.evaluators.common import Python  # pyright: ignore[reportUnusedImport] # noqa: F401
 
     with pytest.raises(
         ImportError,
-        match="cannot import name 'Foo' from 'pydantic_evals.evaluators'",
+        match=re.escape("cannot import name 'Foo' from 'pydantic_evals.evaluators'"),
     ):
         from pydantic_evals.evaluators import Foo  # pyright: ignore[reportUnusedImport]
 
     with pytest.raises(
         ImportError,
-        match="cannot import name 'Foo' from 'pydantic_evals.evaluators.common'",
+        match=re.escape("cannot import name 'Foo' from 'pydantic_evals.evaluators.common'"),
     ):
         from pydantic_evals.evaluators.common import Foo  # pyright: ignore[reportUnusedImport] # noqa: F401
 
     with pytest.raises(
         AttributeError,
-        match="module 'pydantic_evals.evaluators' has no attribute 'Foo'",
+        match=re.escape("module 'pydantic_evals.evaluators' has no attribute 'Foo'"),
     ):
         import pydantic_evals.evaluators as _evaluators
 
@@ -626,7 +631,7 @@ async def test_import_errors():
 
     with pytest.raises(
         AttributeError,
-        match="module 'pydantic_evals.evaluators.common' has no attribute 'Foo'",
+        match=re.escape("module 'pydantic_evals.evaluators.common' has no attribute 'Foo'"),
     ):
         import pydantic_evals.evaluators.common as _common
 

--- a/tests/graph/builder/test_edge_cases.py
+++ b/tests/graph/builder/test_edge_cases.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -292,7 +293,9 @@ async def test_multiple_joins_same_fork():
     join_b = g.join(reduce_list_append, initial_factory=list[int], node_id='join_b')
     collect = g.join(reduce_sum, initial=0, node_id='collect')
 
-    with pytest.raises(NotImplementedError, match='Map is not currently supported with multiple source nodes.'):
+    with pytest.raises(
+        NotImplementedError, match=re.escape('Map is not currently supported with multiple source nodes.')
+    ):
         g.edge_from(join_a, join_b).map().to(collect)
 
     g.add(

--- a/tests/graph/builder/test_parent_forks.py
+++ b/tests/graph/builder/test_parent_forks.py
@@ -1,5 +1,7 @@
 """Tests for parent fork identification and dominator analysis."""
 
+import re
+
 import pytest
 
 from pydantic_graph.exceptions import GraphBuildingError
@@ -269,7 +271,9 @@ def test_parent_fork_explicit_fail_with_cycle():
 
     with pytest.raises(
         GraphBuildingError,
-        match="There is a cycle in the graph passing through 'J' that does not include 'F'. Parent forks of a join must be a part of any cycles involving that join.",
+        match=re.escape(
+            "There is a cycle in the graph passing through 'J' that does not include 'F'. Parent forks of a join must be a part of any cycles involving that join."
+        ),
     ):
         finder.find_parent_fork(join_id, parent_fork_id='F')
 

--- a/tests/models/anthropic/test_output.py
+++ b/tests/models/anthropic/test_output.py
@@ -11,6 +11,7 @@ Test organization:
 
 from __future__ import annotations as _annotations
 
+import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Annotated
 
@@ -268,7 +269,7 @@ def test_no_tools_native_output_strict_false(
 
     with pytest.raises(
         UserError,
-        match='Setting `strict=False` on `output_type=NativeOutput\\(\\.\\.\\.\\)` is not allowed for Anthropic models.',
+        match=r'Setting `strict=False` on `output_type=NativeOutput\(\.\.\.\)` is not allowed for Anthropic models.',
     ):
         agent.run_sync('Tell me about Rome')
 
@@ -520,5 +521,5 @@ def test_unsupported_native_output_raises(
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
 
-    with pytest.raises(UserError, match='Native structured output is not supported by this model.'):
+    with pytest.raises(UserError, match=re.escape('Native structured output is not supported by this model.')):
         agent.run_sync('Tell me about Berlin')

--- a/tests/models/bedrock/test_native_output.py
+++ b/tests/models/bedrock/test_native_output.py
@@ -8,6 +8,7 @@ error path.
 
 from __future__ import annotations as _annotations
 
+import re
 from enum import Enum
 from typing import Annotated
 
@@ -91,7 +92,7 @@ def test_bedrock_native_output_unsupported_model_raises(
 
     agent = Agent(model, output_type=NativeOutput(CityInfo))
 
-    with pytest.raises(UserError, match='Native structured output is not supported by this model.'):
+    with pytest.raises(UserError, match=re.escape('Native structured output is not supported by this model.')):
         agent.run_sync('Tell me about Berlin')
 
 

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -483,7 +483,9 @@ async def test_cache_point_as_first_content_raises_error(allow_model_requests: N
 
     with pytest.raises(
         UserError,
-        match='CachePoint cannot be the first content in a user message - there must be previous content to attach the CachePoint to.',
+        match=re.escape(
+            'CachePoint cannot be the first content in a user message - there must be previous content to attach the CachePoint to.'
+        ),
     ):
         await agent.run([CachePoint(), 'This should fail'])
 
@@ -2915,7 +2917,7 @@ async def test_uploaded_file_wrong_provider(allow_model_requests: None) -> None:
     m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
     agent = Agent(m)
 
-    with pytest.raises(UserError, match="provider_name='openai'.*cannot be used with AnthropicModel"):
+    with pytest.raises(UserError, match=r"provider_name='openai'.*cannot be used with AnthropicModel"):
         await agent.run(['Analyze this file', UploadedFile(file_id='file-abc123', provider_name='openai')])
 
 
@@ -2929,7 +2931,7 @@ async def test_uploaded_file_unsupported_media_type(allow_model_requests: None) 
     m = AnthropicModel('claude-haiku-4-5', provider=AnthropicProvider(anthropic_client=mock_client))
     agent = Agent(m)
 
-    with pytest.raises(UserError, match='Unsupported media type.*audio/mpeg'):
+    with pytest.raises(UserError, match=r'Unsupported media type.*audio/mpeg'):
         await agent.run(
             [
                 'Analyze this file',
@@ -10120,7 +10122,7 @@ async def test_anthropic_memory_tool(allow_model_requests: None, anthropic_api_k
     )
     agent = Agent(anthropic_model, capabilities=[NativeTool(MemoryTool())])
 
-    with pytest.raises(UserError, match="Native `MemoryTool` requires a 'memory' tool to be defined."):
+    with pytest.raises(UserError, match=re.escape("Native `MemoryTool` requires a 'memory' tool to be defined.")):
         await agent.run('Where do I live?')
 
     class FakeMemoryTool(BetaAbstractMemoryTool):

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -4278,7 +4278,7 @@ async def test_uploaded_file_wrong_provider(allow_model_requests: None, bedrock_
     model = BedrockConverseModel('us.amazon.nova-pro-v1:0', provider=bedrock_provider)
     agent = Agent(model)
 
-    with pytest.raises(UserError, match="provider_name='openai'.*cannot be used with BedrockConverseModel"):
+    with pytest.raises(UserError, match=r"provider_name='openai'.*cannot be used with BedrockConverseModel"):
         await agent.run(['Analyze this file', UploadedFile(file_id='s3://bucket/file.pdf', provider_name='openai')])
 
 

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import json
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -461,7 +462,7 @@ async def test_multimodal(allow_model_requests: None):
     m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
     agent = Agent(m)
 
-    with pytest.raises(RuntimeError, match='Cohere does not yet support multi-modal inputs.'):
+    with pytest.raises(RuntimeError, match=re.escape('Cohere does not yet support multi-modal inputs.')):
         await agent.run(
             [
                 'hello',

--- a/tests/models/test_download_item.py
+++ b/tests/models/test_download_item.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from pydantic_ai import AudioUrl, DocumentUrl, ImageUrl, VideoUrl
@@ -40,7 +42,7 @@ async def test_download_item_raises_user_error_with_unsupported_protocol(
 
 
 async def test_download_item_raises_user_error_with_youtube_url() -> None:
-    with pytest.raises(UserError, match='Downloading YouTube videos is not supported.'):
+    with pytest.raises(UserError, match=re.escape('Downloading YouTube videos is not supported.')):
         _ = await download_item(VideoUrl(url='https://youtu.be/lCdaVNyHtjU'), data_format='bytes')
 
 

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -5,6 +5,7 @@ import datetime
 import json
 import os
 import random
+import re
 import tempfile
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
@@ -589,7 +590,7 @@ async def test_google_model_gla_labels_raises_value_error(allow_model_requests: 
     agent = Agent(model=model, instructions='You are a helpful chatbot.', model_settings=settings)
 
     # Raises before any request is made.
-    with pytest.raises(ValueError, match='labels parameter is not supported in Gemini API.'):
+    with pytest.raises(ValueError, match=re.escape('labels parameter is not supported in Gemini API.')):
         await agent.run('What is the capital of France?')
 
 
@@ -936,7 +937,7 @@ async def test_google_model_safety_settings(allow_model_requests: None, google_p
 
     with pytest.raises(
         ContentFilterError,
-        match="Content filter triggered. Finish reason: 'SAFETY'",
+        match=re.escape("Content filter triggered. Finish reason: 'SAFETY'"),
     ) as exc_info:
         await agent.run('Tell me a joke about a Brazilians.')
 
@@ -2420,7 +2421,9 @@ async def test_google_timeout(allow_model_requests: None, google_provider: Googl
     result = await agent.run('Hello!', model_settings={'timeout': 10})
     assert result.output == snapshot('Hello there! How can I help you today?\n')
 
-    with pytest.raises(UserError, match='Google does not support setting ModelSettings.timeout to a httpx.Timeout'):
+    with pytest.raises(
+        UserError, match=re.escape('Google does not support setting ModelSettings.timeout to a httpx.Timeout')
+    ):
         await agent.run('Hello!', model_settings={'timeout': Timeout(10)})
 
 
@@ -3396,7 +3399,7 @@ async def test_google_image_generation_with_tool_output(allow_model_requests: No
     model = GoogleModel('gemini-2.5-flash-image', provider=google_provider)
     agent = Agent(model=model, output_type=Animal)
 
-    with pytest.raises(UserError, match='Tool output is not supported by this model.'):
+    with pytest.raises(UserError, match=re.escape('Tool output is not supported by this model.')):
         await agent.run('Generate an image of an axolotl.')
 
 
@@ -3408,7 +3411,7 @@ async def test_google_image_generation_with_native_output(allow_model_requests: 
     model = GoogleModel('gemini-2.5-flash-image', provider=google_provider)
     agent = Agent(model=model, output_type=NativeOutput(Animal))
 
-    with pytest.raises(UserError, match='Native structured output is not supported by this model.'):
+    with pytest.raises(UserError, match=re.escape('Native structured output is not supported by this model.')):
         await agent.run('Generate an image of an axolotl.')
 
     model = GoogleModel('gemini-3-pro-image-preview', provider=google_provider)
@@ -3506,7 +3509,7 @@ async def test_google_image_generation_with_prompted_output(
     model = GoogleModel('gemini-2.5-flash-image', provider=google_provider)
     agent = Agent(model=model, output_type=PromptedOutput(Animal))
 
-    with pytest.raises(UserError, match='JSON output is not supported by this model.'):
+    with pytest.raises(UserError, match=re.escape('JSON output is not supported by this model.')):
         await agent.run('Generate an image of an axolotl.')
 
 
@@ -3518,7 +3521,7 @@ async def test_google_image_generation_with_tools(allow_model_requests: None, go
     async def get_animal() -> str:
         return 'axolotl'  # pragma: no cover
 
-    with pytest.raises(UserError, match='Tools are not supported by this model.'):
+    with pytest.raises(UserError, match=re.escape('Tools are not supported by this model.')):
         await agent.run('Generate an image of an animal returned by the get_animal tool.')
 
 
@@ -3605,7 +3608,9 @@ async def test_google_image_generation_tool(allow_model_requests: None, google_p
 
     with pytest.raises(
         UserError,
-        match="`ImageGenerationTool` is not supported by this model. Use a model with 'image' in the name instead.",
+        match=re.escape(
+            "`ImageGenerationTool` is not supported by this model. Use a model with 'image' in the name instead."
+        ),
     ):
         await agent.run('Generate an image of an axolotl.')
 
@@ -4780,7 +4785,7 @@ async def test_uploaded_file_wrong_provider(allow_model_requests: None):
     model = GoogleModel('gemini-1.5-flash', provider=GoogleProvider(api_key='test-key'))
     agent = Agent(model)
 
-    with pytest.raises(UserError, match="provider_name='anthropic'.*cannot be used with GoogleModel"):
+    with pytest.raises(UserError, match=r"provider_name='anthropic'.*cannot be used with GoogleModel"):
         await agent.run(['Analyze this file', UploadedFile(file_id='file-abc123', provider_name='anthropic')])
 
 
@@ -6241,7 +6246,7 @@ async def test_google_prompt_feedback_non_streaming(
     agent = Agent(model=model)
 
     with pytest.raises(
-        ContentFilterError, match="Content filter triggered. Block reason: 'PROHIBITED_CONTENT'"
+        ContentFilterError, match=re.escape("Content filter triggered. Block reason: 'PROHIBITED_CONTENT'")
     ) as exc_info:
         await agent.run('prohibited content')
 
@@ -6297,7 +6302,7 @@ async def test_google_prompt_feedback_streaming(
     agent = Agent(model=model)
 
     with pytest.raises(
-        ContentFilterError, match="Content filter triggered. Block reason: 'PROHIBITED_CONTENT'"
+        ContentFilterError, match=re.escape("Content filter triggered. Block reason: 'PROHIBITED_CONTENT'")
     ) as exc_info:
         async with agent.run_stream('prohibited content'):
             pass

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 import json
 import os
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -5827,7 +5828,7 @@ async def test_tool_regular_error(allow_model_requests: None, groq_api_key: str)
     agent = Agent(m)
 
     with pytest.raises(
-        ModelHTTPError, match='The model `non-existent` does not exist or you do not have access to it.'
+        ModelHTTPError, match=re.escape('The model `non-existent` does not exist or you do not have access to it.')
     ):
         await agent.run('hello')
 

--- a/tests/models/test_model_function.py
+++ b/tests/models/test_model_function.py
@@ -330,7 +330,9 @@ def test_model_arg():
     result = agent.run_sync('Hello', model=FunctionModel(return_last))
     assert result.output == snapshot("content='Hello' part_kind='user-prompt' message_count=1")
 
-    with pytest.raises(RuntimeError, match='`model` must either be set on the agent or included when calling it.'):
+    with pytest.raises(
+        RuntimeError, match=re.escape('`model` must either be set on the agent or included when calling it.')
+    ):
         agent.run_sync('Hello')
 
 

--- a/tests/models/test_model_test.py
+++ b/tests/models/test_model_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 import asyncio
 import dataclasses
+import re
 from datetime import timezone
 from typing import Annotated, Any, Literal
 
@@ -89,7 +90,7 @@ def test_custom_output_text():
     result = agent.run_sync('x', model=TestModel(custom_output_text='custom'))
     assert result.output == snapshot('custom')
     agent = Agent(output_type=tuple[str, str])
-    with pytest.raises(AssertionError, match='Plain response not allowed, but `custom_output_text` is set.'):
+    with pytest.raises(AssertionError, match=re.escape('Plain response not allowed, but `custom_output_text` is set.')):
         agent.run_sync('x', model=TestModel(custom_output_text='custom'))
 
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -1837,7 +1837,7 @@ async def test_uploaded_file_wrong_provider_chat(allow_model_requests: None) -> 
     m = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
     agent = Agent(m)
 
-    with pytest.raises(UserError, match="provider_name='anthropic'.*cannot be used with OpenAIChatModel"):
+    with pytest.raises(UserError, match=r"provider_name='anthropic'.*cannot be used with OpenAIChatModel"):
         await agent.run(['Analyze this file', UploadedFile(file_id='file-abc123', provider_name='anthropic')])
 
 
@@ -1857,7 +1857,7 @@ async def test_uploaded_file_wrong_provider_responses(allow_model_requests: None
     m = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
     agent = Agent(m)
 
-    with pytest.raises(UserError, match="provider_name='anthropic'.*cannot be used with OpenAIResponsesModel"):
+    with pytest.raises(UserError, match=r"provider_name='anthropic'.*cannot be used with OpenAIResponsesModel"):
         await agent.run(['Analyze this file', UploadedFile(file_id='file-xyz789', provider_name='anthropic')])
 
 

--- a/tests/models/test_tool_choice_unit.py
+++ b/tests/models/test_tool_choice_unit.py
@@ -364,7 +364,7 @@ async def test_unsupported_profile_with_forced_tool_choice_raises(
         m = OpenAIChatModel('gpt-4o-mini', provider=provider, profile=profile)
 
     params = ModelRequestParameters(function_tools=[make_tool('my_tool')], allow_text_output=True)
-    with pytest.raises(UserError, match='tool_choice=.* is not supported by model'):
+    with pytest.raises(UserError, match=r'tool_choice=.* is not supported by model'):
         await m.request([ModelRequest.user_text_prompt('test')], {'tool_choice': tool_choice}, params)
 
 
@@ -727,7 +727,7 @@ async def test_anthropic_no_forcing_model_explicit_forcing_raises(
     m = AnthropicModel(model_name, provider=AnthropicProvider(api_key='test-key'))
     params = ModelRequestParameters(function_tools=[make_tool('tool_a')], allow_text_output=True)
     settings: AnthropicModelSettings = {'tool_choice': tool_choice}
-    with pytest.raises(UserError, match='Anthropic does not support .* for this model'):
+    with pytest.raises(UserError, match=r'Anthropic does not support .* for this model'):
         m._prepare_tools_and_tool_choice(settings, params)  # pyright: ignore[reportPrivateUsage]
 
 

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -1651,7 +1651,7 @@ async def test_uploaded_file_wrong_provider_xai(allow_model_requests: None):
     m = XaiModel(XAI_NON_REASONING_MODEL, provider=XaiProvider(xai_client=mock_client))
     agent = Agent(m)
 
-    with pytest.raises(UserError, match="provider_name='anthropic'.*cannot be used with XaiModel"):
+    with pytest.raises(UserError, match=r"provider_name='anthropic'.*cannot be used with XaiModel"):
         await agent.run(['Analyze this file', UploadedFile(file_id='file-abc123', provider_name='anthropic')])
 
 

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -7,6 +7,7 @@ Tests verify model profile detection for different OpenAI models, particularly:
 
 from __future__ import annotations as _annotations
 
+import re
 from dataclasses import dataclass
 from typing import Annotated, Any
 
@@ -103,7 +104,9 @@ class TestEncryptedReasoningContent:
 def test_send_back_thinking_parts_field_requires_thinking_field():
     with pytest.raises(
         UserError,
-        match='If `openai_chat_send_back_thinking_parts` is "field", `openai_chat_thinking_field` must be set to a non-None value.',
+        match=re.escape(
+            'If `openai_chat_send_back_thinking_parts` is "field", `openai_chat_thinking_field` must be set to a non-None value.'
+        ),
     ):
         validate_openai_profile(OpenAIModelProfile(openai_chat_send_back_thinking_parts='field'))
 

--- a/tests/providers/test_azure.py
+++ b/tests/providers/test_azure.py
@@ -168,7 +168,7 @@ async def test_azure_document_input_not_supported(allow_model_requests: None):
 
     with pytest.raises(
         UserError,
-        match="Azure's Chat Completions API does not support document input.*OpenAIResponsesModel",
+        match=r"Azure's Chat Completions API does not support document input.*OpenAIResponsesModel",
     ):
         await agent.run(
             [
@@ -189,7 +189,7 @@ async def test_azure_document_url_input_not_supported(allow_model_requests: None
 
     with pytest.raises(
         UserError,
-        match="Azure's Chat Completions API does not support document input.*OpenAIResponsesModel",
+        match=r"Azure's Chat Completions API does not support document input.*OpenAIResponsesModel",
     ):
         await agent.run(['Summarize this document', DocumentUrl(url='https://example.com/test.pdf')])
 

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -34,7 +34,7 @@ def test_init_of_openai_without_api_key_raises_error(env: TestEnv):
     env.remove('OPENAI_API_KEY')
     with pytest.raises(
         OpenAIError,
-        match='^The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable$',
+        match=r'^The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable$',
     ):
         OpenAIProvider()
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1863,7 +1863,7 @@ def test_output_type_text_output_function_with_retry():
     [[str, str], [str, TextOutput(upcase)], [TextOutput(upcase), TextOutput(upcase)]],
 )
 def test_output_type_multiple_text_output(output_type: OutputSpec[str]):
-    with pytest.raises(UserError, match='Only one `str` or `TextOutput` is allowed.'):
+    with pytest.raises(UserError, match=re.escape('Only one `str` or `TextOutput` is allowed.')):
         Agent('test', output_type=output_type)
 
 
@@ -1878,7 +1878,7 @@ def test_output_type_text_output_invalid():
 
 def test_output_type_native_output_must_be_only():
     """Test that NativeOutput must be the only output type."""
-    with pytest.raises(UserError, match='`NativeOutput` must be the only output type.'):
+    with pytest.raises(UserError, match=re.escape('`NativeOutput` must be the only output type.')):
         Agent('test', output_type=[NativeOutput(str), str])
 
 
@@ -1896,7 +1896,7 @@ def test_output_type_native_output_with_binary_image():
 
 def test_output_type_prompted_output_must_be_only():
     """Test that PromptedOutput must be the only output type."""
-    with pytest.raises(UserError, match='`PromptedOutput` must be the only output type.'):
+    with pytest.raises(UserError, match=re.escape('`PromptedOutput` must be the only output type.')):
         Agent('test', output_type=[PromptedOutput(str), str])
 
 
@@ -3535,7 +3535,7 @@ def test_run_with_history_ending_on_model_response_with_tool_calls_and_user_prom
 
     with pytest.raises(
         UserError,
-        match='Cannot provide a new user prompt when the message history contains unprocessed tool calls.',
+        match=re.escape('Cannot provide a new user prompt when the message history contains unprocessed tool calls.'),
     ):
         agent.run_sync(user_prompt='New question', message_history=message_history)
 
@@ -8291,17 +8291,17 @@ def test_unsupported_output_mode():
 
     agent = Agent(model, output_type=NativeOutput(Foo))
 
-    with pytest.raises(UserError, match='Native structured output is not supported by this model.'):
+    with pytest.raises(UserError, match=re.escape('Native structured output is not supported by this model.')):
         agent.run_sync('Hello')
 
     agent = Agent(model, output_type=ToolOutput(Foo))
 
-    with pytest.raises(UserError, match='Tool output is not supported by this model.'):
+    with pytest.raises(UserError, match=re.escape('Tool output is not supported by this model.')):
         agent.run_sync('Hello')
 
     agent = Agent(model, output_type=BinaryImage)
 
-    with pytest.raises(UserError, match='Image output is not supported by this model.'):
+    with pytest.raises(UserError, match=re.escape('Image output is not supported by this model.')):
         agent.run_sync('Hello')
 
 
@@ -8508,7 +8508,9 @@ def test_many_multimodal_tool_response():
 
     with pytest.raises(
         UserError,
-        match="The return value of tool 'analyze_data' contains invalid nested `ToolReturn` objects. `ToolReturn` should be used directly.",
+        match=re.escape(
+            "The return value of tool 'analyze_data' contains invalid nested `ToolReturn` objects. `ToolReturn` should be used directly."
+        ),
     ):
         agent.run_sync('Please analyze the data')
 
@@ -8937,7 +8939,7 @@ def test_set_mcp_sampling_model():
     toolset = CombinedToolset([server1, PrefixedToolset(server2, 'prefix')])
     agent = Agent(None, toolsets=[toolset])
 
-    with pytest.raises(UserError, match='No sampling model provided and no model set on the agent.'):
+    with pytest.raises(UserError, match=re.escape('No sampling model provided and no model set on the agent.')):
         agent.set_mcp_sampling_model()
     assert server1.sampling_model is None
     assert server2.sampling_model is test_model
@@ -9873,7 +9875,7 @@ async def test_run_with_deferred_tool_results_errors():
 
     with pytest.raises(
         UserError,
-        match='Tool call results were provided, but the message history does not contain a `ModelResponse`.',
+        match=re.escape('Tool call results were provided, but the message history does not contain a `ModelResponse`.'),
     ):
         await agent.run(
             'Hello again',
@@ -9888,7 +9890,9 @@ async def test_run_with_deferred_tool_results_errors():
 
     with pytest.raises(
         UserError,
-        match='Tool call results were provided, but the message history does not contain any unprocessed tool calls.',
+        match=re.escape(
+            'Tool call results were provided, but the message history does not contain any unprocessed tool calls.'
+        ),
     ):
         await agent.run(
             'Hello again',
@@ -9902,17 +9906,22 @@ async def test_run_with_deferred_tool_results_errors():
     ]
 
     with pytest.raises(
-        UserError, match='Cannot provide a new user prompt when the message history contains unprocessed tool calls.'
+        UserError,
+        match=re.escape('Cannot provide a new user prompt when the message history contains unprocessed tool calls.'),
     ):
         await agent.run('Hello', message_history=message_history)
 
-    with pytest.raises(UserError, match='Tool call results need to be provided for all deferred tool calls.'):
+    with pytest.raises(
+        UserError, match=re.escape('Tool call results need to be provided for all deferred tool calls.')
+    ):
         await agent.run(
             message_history=message_history,
             deferred_tool_results=DeferredToolResults(),
         )
 
-    with pytest.raises(UserError, match='Tool call results were provided, but the message history is empty.'):
+    with pytest.raises(
+        UserError, match=re.escape('Tool call results were provided, but the message history is empty.')
+    ):
         await agent.run(
             'Hello again',
             deferred_tool_results=DeferredToolResults(approvals={'create_file': True}),
@@ -9935,7 +9944,9 @@ async def test_run_with_deferred_tool_results_errors():
         ),
     ]
 
-    with pytest.raises(UserError, match="Tool call 'run_me' was already executed and its result cannot be overridden."):
+    with pytest.raises(
+        UserError, match=re.escape("Tool call 'run_me' was already executed and its result cannot be overridden.")
+    ):
         await agent.run(
             message_history=message_history,
             deferred_tool_results=DeferredToolResults(
@@ -9944,7 +9955,7 @@ async def test_run_with_deferred_tool_results_errors():
         )
 
     with pytest.raises(
-        UserError, match="Tool call 'run_me_too' was already executed and its result cannot be overridden."
+        UserError, match=re.escape("Tool call 'run_me_too' was already executed and its result cannot be overridden.")
     ):
         await agent.run(
             message_history=message_history,
@@ -10889,7 +10900,9 @@ async def test_central_content_filter_handling():
     model = FunctionModel(function=filtered_response, model_name='test-model')
     agent = Agent(model)
 
-    with pytest.raises(ContentFilterError, match="Content filter triggered. Finish reason: 'content_filter'"):
+    with pytest.raises(
+        ContentFilterError, match=re.escape("Content filter triggered. Finish reason: 'content_filter'")
+    ):
         await agent.run('Trigger filter')
 
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import re
 import threading
 import warnings
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
@@ -4104,7 +4105,7 @@ def test_infer_fmt_unknown_extension():
     """_infer_fmt raises ValueError for unknown extension without explicit fmt."""
     from pydantic_ai.agent.spec import _infer_fmt  # pyright: ignore[reportPrivateUsage]
 
-    with pytest.raises(ValueError, match="Could not infer format for filename 'agent.txt'"):
+    with pytest.raises(ValueError, match=re.escape("Could not infer format for filename 'agent.txt'")):
         _infer_fmt(Path('agent.txt'), None)
 
 
@@ -19445,11 +19446,11 @@ def test_deferred_tool_requests_build_results_validates_ids():
     )
 
     # Mis-routed ID: tool-result provided for something in the approvals list.
-    with pytest.raises(ValueError, match='calls.*not in.*DeferredToolRequests.calls'):
+    with pytest.raises(ValueError, match=r'calls.*not in.*DeferredToolRequests.calls'):
         requests.build_results(calls={'approval_1': 'oops'})
 
     # Unknown ID entirely.
-    with pytest.raises(ValueError, match='approvals.*not in.*DeferredToolRequests.approvals'):
+    with pytest.raises(ValueError, match=r'approvals.*not in.*DeferredToolRequests.approvals'):
         requests.build_results(approvals={'unknown_id': True})
 
     # Happy path still works.

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -726,7 +726,9 @@ async def test_agent_name_collision(allow_model_requests: None, dbos: DBOS):
 async def test_agent_without_name():
     with pytest.raises(
         UserError,
-        match="An agent needs to have a unique `name` in order to be used with DBOS. The name will be used to identify the agent's workflows and steps.",
+        match=re.escape(
+            "An agent needs to have a unique `name` in order to be used with DBOS. The name will be used to identify the agent's workflows and steps."
+        ),
     ):
         DBOSAgent(Agent())
 
@@ -734,7 +736,9 @@ async def test_agent_without_name():
 async def test_agent_without_model():
     with pytest.raises(
         UserError,
-        match='An agent needs to have a `model` in order to be used with DBOS, it cannot be set at agent run time.',
+        match=re.escape(
+            'An agent needs to have a `model` in order to be used with DBOS, it cannot be set at agent run time.'
+        ),
     ):
         DBOSAgent(Agent(name='test_agent'))
 

--- a/tests/test_history_processor.py
+++ b/tests/test_history_processor.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from collections.abc import AsyncIterator
 from copy import deepcopy
@@ -813,7 +814,7 @@ async def test_history_processor_empty_history(function_model: FunctionModel, re
 
     agent = Agent(function_model, capabilities=[ProcessHistory(return_new_history)])
 
-    with pytest.raises(UserError, match='Processed history cannot be empty.'):
+    with pytest.raises(UserError, match=re.escape('Processed history cannot be empty.')):
         await agent.run('foobar')
 
 
@@ -825,7 +826,7 @@ async def test_history_processor_history_ending_in_response(
 
     agent = Agent(function_model, capabilities=[ProcessHistory(return_new_history)])
 
-    with pytest.raises(UserError, match='Processed history must end with a `ModelRequest`.'):
+    with pytest.raises(UserError, match=re.escape('Processed history must end with a `ModelRequest`.')):
         await agent.run('foobar')
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -134,7 +135,7 @@ class TestMCPToolsetConstruction:
 
     def test_pre_built_client_with_handler_kwargs_raises(self):
         client = Client('https://example.com/mcp')
-        with pytest.raises(ValueError, match='pre-built `fastmcp.Client`'):
+        with pytest.raises(ValueError, match=re.escape('pre-built `fastmcp.Client`')):
             MCPToolset(client, headers={'X-Key': 'foo'})
 
     def test_pre_built_client_with_overridden_init_timeout_raises(self):
@@ -153,7 +154,7 @@ class TestMCPToolsetConstruction:
         assert toolset.client is client
 
     def test_sampling_model_and_handler_conflict(self):
-        with pytest.raises(ValueError, match='sampling_model.*sampling_handler'):
+        with pytest.raises(ValueError, match=r'sampling_model.*sampling_handler'):
             MCPToolset(
                 'https://example.com/mcp',
                 sampling_model=models.infer_model('test'),

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import warnings
 from dataclasses import replace
@@ -217,7 +218,7 @@ def test_audio_url(audio_url: AudioUrl, media_type: str, format: str):
 
 
 def test_audio_url_invalid():
-    with pytest.raises(ValueError, match='Could not infer media type from audio URL: foobar.potato'):
+    with pytest.raises(ValueError, match=re.escape('Could not infer media type from audio URL: foobar.potato')):
         AudioUrl('foobar.potato').media_type
 
 
@@ -237,10 +238,10 @@ def test_image_url_formats(image_url: ImageUrl, media_type: str, format: str):
 
 
 def test_image_url_invalid():
-    with pytest.raises(ValueError, match='Could not infer media type from image URL: foobar.potato'):
+    with pytest.raises(ValueError, match=re.escape('Could not infer media type from image URL: foobar.potato')):
         ImageUrl('foobar.potato').media_type
 
-    with pytest.raises(ValueError, match='Could not infer media type from image URL: foobar.potato'):
+    with pytest.raises(ValueError, match=re.escape('Could not infer media type from image URL: foobar.potato')):
         ImageUrl('foobar.potato').format
 
 
@@ -278,7 +279,7 @@ def test_document_url_formats(document_url: DocumentUrl, media_type: str, format
 
 
 def test_document_url_invalid():
-    with pytest.raises(ValueError, match='Could not infer media type from document URL: foobar.potato'):
+    with pytest.raises(ValueError, match=re.escape('Could not infer media type from document URL: foobar.potato')):
         DocumentUrl('foobar.potato').media_type
 
     with pytest.raises(ValueError, match='Unknown document media type: text/x-python'):
@@ -384,7 +385,7 @@ def test_video_url_formats(video_url: VideoUrl, media_type: str, format: str):
 
 
 def test_video_url_invalid():
-    with pytest.raises(ValueError, match='Could not infer media type from video URL: foobar.potato'):
+    with pytest.raises(ValueError, match=re.escape('Could not infer media type from video URL: foobar.potato')):
         VideoUrl('foobar.potato').media_type
 
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1349,7 +1349,9 @@ async def test_agent_name_collision(allow_model_requests: None, client: Client):
 async def test_agent_without_name():
     with pytest.raises(
         UserError,
-        match="An agent needs to have a unique `name` in order to be used with Temporal. The name will be used to identify the agent's activities within the workflow.",
+        match=re.escape(
+            "An agent needs to have a unique `name` in order to be used with Temporal. The name will be used to identify the agent's activities within the workflow."
+        ),
     ):
         TemporalAgent(Agent())
 
@@ -1357,7 +1359,9 @@ async def test_agent_without_name():
 async def test_agent_without_model():
     with pytest.raises(
         UserError,
-        match="The wrapped agent's `model` or the TemporalAgent's `models` parameter must provide at least one Model instance to be used with Temporal. Models cannot be set at agent run time.",
+        match=re.escape(
+            "The wrapped agent's `model` or the TemporalAgent's `models` parameter must provide at least one Model instance to be used with Temporal. Models cannot be set at agent run time."
+        ),
     ):
         TemporalAgent(Agent(name='test_agent'))
 

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from collections.abc import AsyncIterable, AsyncIterator, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -766,7 +767,7 @@ async def test_tool_search_toolset_search_empty_query():
     tools = await searchable.get_tools(ctx)
     search_tool = tools[_SEARCH_TOOLS_NAME]
 
-    with pytest.raises(ModelRetry, match='Please provide at least one non-empty search query.'):
+    with pytest.raises(ModelRetry, match=re.escape('Please provide at least one non-empty search query.')):
         await searchable.call_tool(_SEARCH_TOOLS_NAME, {'queries': ['']}, ctx, search_tool)
 
 
@@ -780,7 +781,7 @@ async def test_tool_search_toolset_search_non_tokenizable_query(query: str):
     tools = await searchable.get_tools(ctx)
     search_tool = tools[_SEARCH_TOOLS_NAME]
 
-    with pytest.raises(ModelRetry, match='Please provide at least one non-empty search query.'):
+    with pytest.raises(ModelRetry, match=re.escape('Please provide at least one non-empty search query.')):
         await searchable.call_tool(_SEARCH_TOOLS_NAME, {'queries': [query]}, ctx, search_tool)
 
 
@@ -3562,7 +3563,7 @@ async def test_tool_search_named_strategy_agent_run_raises_on_unsupported_model(
     def get_weather(city: str) -> str:  # pragma: no cover
         return f'Weather in {city}'
 
-    with pytest.raises(UserError, match='ToolSearchTool.*not supported by this model'):
+    with pytest.raises(UserError, match=r'ToolSearchTool.*not supported by this model'):
         await agent.run('what should I wear?')
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -737,7 +737,7 @@ def test_repeat_tool():
     def bar(x: int, y: str) -> str:  # pragma: no cover
         return f'{x} {y}'
 
-    with pytest.raises(UserError, match="Tool name conflicts with previously renamed tool: 'bar'."):
+    with pytest.raises(UserError, match=re.escape("Tool name conflicts with previously renamed tool: 'bar'.")):
         agent.run_sync('')
 
 
@@ -1425,7 +1425,7 @@ def test_function_tool_inconsistent_with_schema():
     pydantic_tool = Tool.from_schema(function, name='foobar', description='does foobar stuff', json_schema=json_schema)
 
     agent = Agent('test', tools=[pydantic_tool], retries={'tools': 0, 'output': 0})
-    with pytest.raises(TypeError, match=".* got an unexpected keyword argument 'one'"):
+    with pytest.raises(TypeError, match=r".* got an unexpected keyword argument 'one'"):
         agent.run_sync('foobar')
 
     result = function('three', 4)
@@ -1891,12 +1891,14 @@ async def test_deferred_tool_without_output_type():
 
 
 def test_output_type_deferred_tool_requests_by_itself():
-    with pytest.raises(UserError, match='At least one output type must be provided other than `DeferredToolRequests`.'):
+    with pytest.raises(
+        UserError, match=re.escape('At least one output type must be provided other than `DeferredToolRequests`.')
+    ):
         Agent(TestModel(), output_type=DeferredToolRequests)
 
 
 def test_output_type_empty():
-    with pytest.raises(UserError, match='At least one output type must be provided.'):
+    with pytest.raises(UserError, match=re.escape('At least one output type must be provided.')):
         Agent(TestModel(), output_type=[])
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,7 +140,7 @@ def test_check_object_json_schema():
     }
 
     array_schema = {'type': 'array', 'items': {'type': 'string'}}
-    with pytest.raises(UserError, match='^Schema must be an object$'):
+    with pytest.raises(UserError, match=r'^Schema must be an object$'):
         check_object_json_schema(array_schema)
 
 


### PR DESCRIPTION
## Summary

Enables the ruff rule [`RUF043`](https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern/) (*pytest-raises-ambiguous-pattern*) and fixes all pre-existing violations across the test suite.

`pytest.raises(match=...)` / `pytest.warns(match=...)` treat the pattern as a **regex** (`re.search`). RUF043 flags patterns that contain regex metacharacters (`.`, backticks, `(`, `)`, `[`, `]`, `+`, `$`, `*`, …) but are neither raw strings nor escaped, so the literal-vs-regex intent is ambiguous — e.g. `match='must be the only output type.'` silently lets the trailing `.` match *any* character.

## Background

This came up in #5209, where CodeRabbit flagged two new `match=` assertions as RUF043 violations ([comment](https://github.com/pydantic/pydantic-ai/pull/5209#discussion_r3513307906)). At the time the rule wasn't enabled and there were already 15+ pre-existing violations in the same file, so fixing only those two would have been inconsistent. As noted in that thread, the proper fix is to enable RUF043 repo-wide in a separate change — this is that change.

## What changed

- **`pyproject.toml`**: add `RUF043` to `[tool.ruff.lint] extend-select`.
- **87 violations fixed** across 31 test files, using two strategies:
  - **Literal** error/warning messages → wrapped in `re.escape(...)` (with `import re` added where missing).
  - **Intentional regex** patterns (`.*`, `^`/`$` anchors, already-escaped metacharacters) → converted to raw strings (`r'...'`), pattern text unchanged.

## No behavior change

`re.escape` of a literal still substring-matches via `re.search`, and raw-prefixing an existing regex is byte-identical. Verified locally: `ruff check` and `ruff format --check` are clean, and the affected test files show identical pass/skip results with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

