### PR TITLE
fix: validate `ExternalToolset` parameter schemas

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/toolsets/external.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/external.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Any
+from typing import Any, cast
 
 from pydantic_core import SchemaValidator, core_schema
 
+from .. import _utils
 from .._run_context import AgentDepsT, RunContext
+from ..exceptions import UserError
 from ..tools import ToolDefinition
 from .abstract import AbstractToolset, ToolsetTool
 
@@ -22,7 +24,10 @@ class ExternalToolset(AbstractToolset[AgentDepsT]):
     _id: str | None
 
     def __init__(self, tool_defs: list[ToolDefinition], *, id: str | None = None):
-        self.tool_defs = tool_defs
+        self.tool_defs = [
+            replace(tool_def, parameters_json_schema=_validate_parameters_json_schema(tool_def))
+            for tool_def in tool_defs
+        ]
         self._id = id
 
     @property
@@ -44,3 +49,42 @@ class ExternalToolset(AbstractToolset[AgentDepsT]):
         self, name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT], tool: ToolsetTool[AgentDepsT]
     ) -> Any:
         raise NotImplementedError('External tools cannot be called directly')
+
+
+def _validate_parameters_json_schema(tool_def: ToolDefinition) -> dict[str, Any]:
+    try:
+        schema = _utils.check_object_json_schema(tool_def.parameters_json_schema)
+    except UserError as exc:
+        raise UserError(f'Invalid parameters_json_schema for external tool {tool_def.name!r}: {exc}') from exc
+
+    properties_value = schema.get('properties', {})
+    if not isinstance(properties_value, dict):
+        raise UserError(
+            f'Invalid parameters_json_schema for external tool {tool_def.name!r}: properties must be an object'
+        )
+    properties = cast(dict[str, Any], properties_value)
+
+    required_value = schema.get('required', [])
+    if not isinstance(required_value, list):
+        raise UserError(
+            f'Invalid parameters_json_schema for external tool {tool_def.name!r}: required must be a list of strings'
+        )
+
+    required: list[str] = []
+    for key in cast(list[Any], required_value):
+        if not isinstance(key, str):
+            raise UserError(
+                f'Invalid parameters_json_schema for external tool {tool_def.name!r}: '
+                'required must be a list of strings'
+            )
+        required.append(key)
+
+    missing_required = sorted(set(required) - set(properties))
+    if missing_required:
+        missing = ', '.join(repr(key) for key in missing_required)
+        raise UserError(
+            f'Invalid parameters_json_schema for external tool {tool_def.name!r}: '
+            f'required keys are missing from properties: {missing}'
+        )
+
+    return schema

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -158,7 +158,7 @@ class _AGUIFrontendToolset(ExternalToolset[AgentDepsT]):
                 ToolDefinition(
                     name=tool.name,
                     description=tool.description,
-                    parameters_json_schema=tool.parameters or {},
+                    parameters_json_schema=tool.parameters or {'type': 'object', 'properties': {}},
                 )
                 for tool in tools
             ]

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -82,6 +82,7 @@ from pydantic_ai.tools import (
     ToolDefinition,
     ToolDenied,
 )
+from pydantic_ai.toolsets import ExternalToolset
 from pydantic_ai.toolsets._tool_search import parse_discovered_tools
 
 from ._inline_snapshot import snapshot
@@ -336,6 +337,20 @@ async def test_basic_user_message() -> None:
     events = await run_and_collect_events(agent, run_input)
 
     assert events == simple_result()
+
+
+async def test_frontend_tool_without_parameters_uses_empty_object_schema() -> None:
+    agent = Agent(model=FunctionModel(stream_function=simple_stream))
+    run_input = create_input(
+        UserMessage(id='msg_1', content='Hello!'),
+        tools=[Tool(name='current_time', description='Get the current time')],
+    )
+    adapter = AGUIAdapter(agent=agent, run_input=run_input)
+
+    toolset = adapter.toolset
+
+    assert isinstance(toolset, ExternalToolset)
+    assert toolset.tool_defs[0].parameters_json_schema == {'type': 'object', 'properties': {}}
 
 
 async def test_empty_messages() -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1890,6 +1890,35 @@ async def test_deferred_tool_without_output_type():
             await result.get_output()
 
 
+def test_external_toolset_rejects_invalid_parameters_schema():
+    with pytest.raises(UserError) as exc_info:
+        ExternalToolset(
+            [
+                ToolDefinition(
+                    name='search',
+                    parameters_json_schema={'properties': {'query': {'type': 'string'}}, 'required': ['query']},
+                )
+            ]
+        )
+
+    assert str(exc_info.value) == "Invalid parameters_json_schema for external tool 'search': Schema must be an object"
+
+    with pytest.raises(UserError) as exc_info:
+        ExternalToolset(
+            [
+                ToolDefinition(
+                    name='lookup',
+                    parameters_json_schema={'type': 'object', 'required': ['id']},
+                )
+            ]
+        )
+
+    assert (
+        str(exc_info.value)
+        == "Invalid parameters_json_schema for external tool 'lookup': required keys are missing from properties: 'id'"
+    )
+
+
 def test_output_type_deferred_tool_requests_by_itself():
     with pytest.raises(UserError, match='At least one output type must be provided other than `DeferredToolRequests`.'):
         Agent(TestModel(), output_type=DeferredToolRequests)


### PR DESCRIPTION
- Closes #6218

### Summary

- Validate `ExternalToolset` parameter schemas when tool definitions are registered, using the existing object-schema check.
- Reject required keys that are not declared in `properties`, with the external tool name included in the error.
- Preserve AG-UI frontend tools with no parameters by mapping them to an empty object schema before constructing the external toolset.

### Test Plan

- [x] `uv run pytest tests/test_tools.py::test_external_toolset_rejects_invalid_parameters_schema tests/test_tools.py::test_deferred_tool_with_output_type tests/test_tools.py::test_deferred_tool_with_tool_output_type tests/test_tools.py::test_deferred_tool_without_output_type tests/test_ag_ui.py::test_frontend_tool_without_parameters_uses_empty_object_schema`
- [x] `uv run ruff check pydantic_ai_slim/pydantic_ai/toolsets/external.py pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_tools.py tests/test_ag_ui.py`
- [x] `uv run pyright pydantic_ai_slim/pydantic_ai/toolsets/external.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

