### PR TITLE
chore: add testing helpers for tool calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/testing.py
+++ b/pydantic_ai_slim/pydantic_ai/testing.py
@@ -1,0 +1,79 @@
+from __future__ import annotations as _annotations
+
+from collections.abc import Sequence
+from typing import Any, TypeAlias
+
+from .messages import ModelResponse, ToolCallPart
+from .run import AgentRunResult
+
+ToolCallSource: TypeAlias = AgentRunResult[Any] | ModelResponse
+
+_UNSET = object()
+
+
+def tool_calls(source: ToolCallSource, *, across_history: bool = False) -> list[ToolCallPart]:
+    """Return function tool calls from a model response or agent run result.
+
+    By default this reads the final response, matching `result.response.tool_calls`.
+    Set `across_history=True` to collect calls from every model response in an
+    agent run's message history.
+    """
+    if isinstance(source, ModelResponse):
+        return source.tool_calls
+
+    if not across_history:
+        return source.response.tool_calls
+
+    return [
+        call for message in source.all_messages() if isinstance(message, ModelResponse) for call in message.tool_calls
+    ]
+
+
+def assert_tool_call(
+    source: ToolCallSource,
+    tool_name: str,
+    *,
+    args: Any = _UNSET,
+    across_history: bool = False,
+) -> ToolCallPart:
+    """Assert that a tool call with `tool_name` and optional `args` exists."""
+    calls = tool_calls(source, across_history=across_history)
+    for call in calls:
+        if call.tool_name != tool_name:
+            continue
+        if args is _UNSET or call.args == args:
+            return call
+
+    if not calls:
+        raise AssertionError(f'No tool calls found; expected {tool_name!r}.')
+
+    available = _format_tool_calls(calls)
+    if args is _UNSET:
+        raise AssertionError(f'Expected tool call {tool_name!r}; available tool calls: {available}.')
+    raise AssertionError(f'Expected tool call {tool_name!r} with args {args!r}; available tool calls: {available}.')
+
+
+def assert_tool_call_sequence(
+    source: ToolCallSource,
+    expected_tool_names: Sequence[str],
+    *,
+    across_history: bool = False,
+) -> list[ToolCallPart]:
+    """Assert that tool calls were emitted in exactly the expected order."""
+    calls = tool_calls(source, across_history=across_history)
+    actual_tool_names = [call.tool_name for call in calls]
+    expected_tool_names = list(expected_tool_names)
+
+    if actual_tool_names == expected_tool_names:
+        return calls
+
+    if not calls:
+        raise AssertionError(f'No tool calls found; expected sequence {expected_tool_names!r}.')
+    raise AssertionError(f'Expected tool call sequence {expected_tool_names!r}; got {actual_tool_names!r}.')
+
+
+def _format_tool_calls(calls: Sequence[ToolCallPart]) -> str:
+    return ', '.join(f'{call.tool_name}({call.args!r})' for call in calls)
+
+
+__all__ = ('ToolCallSource', 'assert_tool_call', 'assert_tool_call_sequence', 'tool_calls')

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -30,6 +30,8 @@ def test_tool_call_helpers_can_scan_agent_run_history() -> None:
 
     assert result.response.tool_calls == []
     with pytest.raises(AssertionError, match='No tool calls found'):
+        assert_tool_call(result, 'lookup')
+    with pytest.raises(AssertionError, match='No tool calls found'):
         assert_tool_call_sequence(result, ['lookup'])
     assert [call.tool_name for call in tool_calls(result, across_history=True)] == ['lookup']
     assert_tool_call(result, 'lookup', args={'key': 'weather'}, across_history=True)
@@ -47,3 +49,10 @@ def test_assert_tool_call_checks_args() -> None:
 
     with pytest.raises(AssertionError, match='with args'):
         assert_tool_call(response, 'search', args={'q': 'tools'})
+
+
+def test_assert_tool_call_sequence_reports_mismatch() -> None:
+    response = ModelResponse(parts=[ToolCallPart('search', {'q': 'agents'}, tool_call_id='call-1')])
+
+    with pytest.raises(AssertionError, match='Expected tool call sequence'):
+        assert_tool_call_sequence(response, ['lookup'])

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,49 @@
+import pytest
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.testing import assert_tool_call, assert_tool_call_sequence, tool_calls
+
+
+def test_assert_tool_call_checks_final_response_tool_args() -> None:
+    response = ModelResponse(parts=[ToolCallPart('search', {'q': 'agents'}, tool_call_id='call-1')])
+
+    assert tool_calls(response) == response.tool_calls
+    assert assert_tool_call(response, 'search', args={'q': 'agents'}) is response.tool_calls[0]
+    assert assert_tool_call_sequence(response, ['search']) == response.tool_calls
+
+
+def test_tool_call_helpers_can_scan_agent_run_history() -> None:
+    def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+            return ModelResponse(parts=[TextPart('done')])
+        return ModelResponse(parts=[ToolCallPart('lookup', {'key': 'weather'}, tool_call_id='call-1')])
+
+    agent = Agent(FunctionModel(model_logic))
+
+    @agent.tool_plain
+    def lookup(key: str) -> str:
+        return f'{key}: sunny'
+
+    result = agent.run_sync('check weather')
+
+    assert result.response.tool_calls == []
+    with pytest.raises(AssertionError, match='No tool calls found'):
+        assert_tool_call_sequence(result, ['lookup'])
+    assert [call.tool_name for call in tool_calls(result, across_history=True)] == ['lookup']
+    assert_tool_call(result, 'lookup', args={'key': 'weather'}, across_history=True)
+
+
+def test_assert_tool_call_reports_available_calls() -> None:
+    response = ModelResponse(parts=[ToolCallPart('search', {'q': 'agents'}, tool_call_id='call-1')])
+
+    with pytest.raises(AssertionError, match="Expected tool call 'lookup'"):
+        assert_tool_call(response, 'lookup')
+
+
+def test_assert_tool_call_checks_args() -> None:
+    response = ModelResponse(parts=[ToolCallPart('search', {'q': 'agents'}, tool_call_id='call-1')])
+
+    with pytest.raises(AssertionError, match='with args'):
+        assert_tool_call(response, 'search', args={'q': 'tools'})


### PR DESCRIPTION
- Refs #3138

### Summary

This adds a small `pydantic_ai.testing` helper module for deterministic assertions over function tool calls without introducing fixture files, recording/replay, or snapshot machinery.

The first slice is intentionally narrow:

- `tool_calls(source, across_history=False)` collects `ToolCallPart`s from either a `ModelResponse` or an `AgentRunResult`
- `assert_tool_call(source, name, args=...)` asserts that a call exists and returns the matching part for further checks
- `assert_tool_call_sequence(source, [...])` asserts exact tool-call order
- `across_history=True` scans all `ModelResponse`s in an `AgentRunResult` when the final response no longer contains the tool call

This follows the issue discussion direction of staying Python-native and building on `result.response.tool_calls` / `result.all_messages()` rather than adding YAML fixtures or new snapshot behavior.

### Tests

- `uv run pytest tests/test_testing.py tests/test_messages.py::test_model_response_convenience_methods -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/testing.py tests/test_testing.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/testing.py tests/test_testing.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/testing.py tests/test_testing.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

