### PR TITLE
fix(gateway): avoid duplicating provider route in `base_url`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/gateway.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/gateway.py
@@ -237,7 +237,11 @@ def _merge_url_path(base_url: str, path: str) -> str:
         base_url: The base URL to merge.
         path: The path to merge.
     """
-    return base_url.rstrip('/') + '/' + path.lstrip('/')
+    base_url = base_url.rstrip('/')
+    path = path.strip('/')
+    if base_url.endswith(f'/{path}'):
+        return base_url + '/'
+    return base_url + '/' + path
 
 
 # Wire-value remaps for the PAIG URL route. Keyed by canonical class-lookup names

--- a/tests/providers/test_gateway.py
+++ b/tests/providers/test_gateway.py
@@ -55,6 +55,12 @@ def test_init_with_base_url(
     assert provider.client.api_key == 'foobar'
 
 
+@pytest.mark.parametrize('base_url', ['https://example.com/openai', 'https://example.com/openai/'])
+def test_init_with_base_url_already_including_route(base_url: str):
+    provider = gateway_provider('openai', base_url=base_url, api_key='foobar')
+    assert provider.base_url == 'https://example.com/openai/'
+
+
 def test_init_gateway_without_api_key_raises_error(env: TestEnv):
     env.remove('PYDANTIC_AI_GATEWAY_API_KEY')
     with pytest.raises(


### PR DESCRIPTION
Prevent `gateway_provider()` from appending the same provider route twice when `base_url` already points at that route.

No issue; small focused bug fix.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

## What Problem This Solves

`gateway_provider()` accepts a user-provided `base_url` directly, either through the explicit function argument or through `PYDANTIC_AI_GATEWAY_BASE_URL`. That value is meant to describe the Gateway endpoint the provider client should use.

The current merge logic treats every `base_url` as a Gateway proxy root and unconditionally appends the selected provider route. That is correct for inputs such as:

```text
https://example.com
https://example.com/
```

because those should become:

```text
https://example.com/openai/
```

However, it is also natural for users to configure the already-routed provider endpoint, especially when copying a working proxy URL from logs, infrastructure config, or documentation:

```text
https://example.com/openai
https://example.com/openai/
```

Before this change, those already-routed values are treated as if they were still proxy roots and become:

```text
https://example.com/openai/openai/
```

That produces requests to the wrong path. The resulting failure can look like a Gateway outage, authentication issue, provider route mismatch, or model availability problem, even though the user's configured endpoint already contained the correct route. This is a small URL normalization bug, but it can send both humans and agents down the wrong diagnostic path because the configured `base_url` appears plausible while the actual request URL is silently shifted.

The affected path is only the merge between a configured Gateway base URL and the default provider route. Provider selection, API key handling, region-based Gateway URL inference, explicit custom `route=...` values, and normal proxy-root inputs are not the problem being changed here.

## Change

Make `_merge_url_path()` idempotent when the normalized `base_url` already ends with the route being appended.

Normal Gateway proxy root behavior is unchanged:

```text
https://example.com -> https://example.com/openai/
```

Only the already-routed case changes:

```text
https://example.com/openai -> https://example.com/openai/
```

## Evidence

Local behavior proof after the patch:

```text
https://example.com -> https://example.com/openai/ expected=https://example.com/openai/ pass=True
https://example.com/ -> https://example.com/openai/ expected=https://example.com/openai/ pass=True
https://example.com/openai -> https://example.com/openai/ expected=https://example.com/openai/ pass=True
https://example.com/openai/ -> https://example.com/openai/ expected=https://example.com/openai/ pass=True
```

Regression coverage was added for `base_url` values that already include the `openai` route, with and without a trailing slash.

## Possible call chain / impact

```text
User config / PYDANTIC_AI_GATEWAY_BASE_URL
  -> gateway_provider(..., base_url=...)
  -> _merge_url_path(base_url, route)
  -> provider client base_url
  -> Gateway request path
```

This PR only changes Gateway URL path merging. It does not change provider selection, API key handling, inferred Gateway base URLs, HTTP client setup, or normal proxy-root inputs.

## Validation

- `uv run ruff check pydantic_ai_slim/pydantic_ai/providers/gateway.py tests/providers/test_gateway.py` - passed
- `git diff --check` - passed
- Local direct behavior proof shown above - passed

Note: the focused pytest target in `tests/providers/test_gateway.py` was module-skipped locally because provider optional dependencies were not installed. A follow-up `uv run --all-extras ...` attempt was blocked by local Windows build tooling while building `numpy`, so the PR evidence uses the direct public `gateway_provider()` behavior proof plus lint/diff checks.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



