### PR TITLE
fix(evals): reject non-positive `max_concurrency`

### DIFF
--- a/pydantic_evals/pydantic_evals/dataset.py
+++ b/pydantic_evals/pydantic_evals/dataset.py
@@ -324,6 +324,8 @@ class Dataset(BaseModel, Generic[InputsT, OutputT, MetadataT], extra='forbid', a
         """
         if repeat < 1:
             raise ValueError(f'repeat must be >= 1, got {repeat}')
+        if max_concurrency is not None and max_concurrency < 1:
+            raise ValueError(f'max_concurrency must be >= 1, got {max_concurrency}')
 
         task_name = task_name or get_unwrapped_function_name(task)
         name = name or task_name

--- a/tests/evals/test_dataset.py
+++ b/tests/evals/test_dataset.py
@@ -505,6 +505,17 @@ async def test_evaluate_with_concurrency(
     )
 
 
+@pytest.mark.parametrize('max_concurrency', [0, -1])
+async def test_evaluate_with_invalid_max_concurrency(
+    example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata], max_concurrency: int
+):
+    async def mock_task(inputs: TaskInput) -> TaskOutput:  # pragma: no cover
+        return TaskOutput(answer=inputs.query)
+
+    with pytest.raises(ValueError, match=f'max_concurrency must be >= 1, got {max_concurrency}'):
+        await example_dataset.evaluate(mock_task, max_concurrency=max_concurrency)
+
+
 async def test_evaluate_with_failing_task(
     example_dataset: Dataset[TaskInput, TaskOutput, TaskMetadata],
     simple_evaluator: type[Evaluator[TaskInput, TaskOutput, TaskMetadata]],


### PR DESCRIPTION
Make `Dataset.evaluate()` fail fast for non-positive `max_concurrency` values instead of hanging on an impossible semaphore acquisition.

No issue; small focused bug fix.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

## What Problem This Solves

`Dataset.evaluate()` exposes `max_concurrency` as a user-facing limit for how many case evaluations may run at the same time. The valid meanings are:

- `None`: no explicit limit; run all cases concurrently as before.
- a positive integer: allow at most that many concurrent evaluations.

`0` is neither of those meanings. It does not mean unbounded concurrency, because that is already represented by `None`; and it does not mean “run zero evaluations”, because `Dataset.evaluate()` still builds the case tasks and tries to execute them.

Today, `max_concurrency=0` is passed directly into `anyio.Semaphore(0)`. Once evaluation starts, every case task waits for a permit, but no permit can ever become available. The result is not a clear configuration error; the evaluation simply makes no progress until something external times out.

A minimal local reproduction before this change timed out:

```text
TimeoutError
```

That failure mode is especially confusing because the apparent symptom is a hung evaluation, slow task, stuck evaluator, retry issue, or event-loop problem. The actual root cause is much simpler: a non-positive concurrency limit cannot schedule any work. Failing fast at the `Dataset.evaluate()` boundary gives the caller an immediate and actionable error before any tasks, evaluators, lifecycle hooks, or progress reporting are started.

This PR only rejects explicit non-positive integer limits. It does not change the existing unbounded `max_concurrency=None` behavior, positive concurrency limits such as `1`, task execution, evaluator execution, retries, lifecycle handling, or result aggregation.

## Change

Add an early validation guard in `Dataset.evaluate()`:

```text
max_concurrency must be >= 1
```

The existing `None` behavior remains unchanged and still means all cases can run concurrently. Positive integer limits, including `1`, continue to work as before.

## Evidence

Before this change, this call hung until wrapped by an external timeout:

```python
await dataset.evaluate(task, max_concurrency=0, progress=False)
```

After this change, invalid values fail fast:

```text
0: ValueError: max_concurrency must be >= 1, got 0
-1: ValueError: max_concurrency must be >= 1, got -1
```

Regression coverage was added for both `0` and `-1`.

## Possible call chain / impact

```text
User calls Dataset.evaluate(..., max_concurrency=0)
  -> Dataset.evaluate()
  -> anyio.Semaphore(0)
  -> per-case task waits for a permit
  -> evaluation never progresses
```

This PR only validates explicit non-positive integer limits. It does not change task execution, evaluator execution, retry behavior, lifecycle hooks, `repeat`, progress rendering, or the `max_concurrency=None` unbounded path.

## Validation

- `uv run pytest tests/evals/test_dataset.py::test_evaluate_with_concurrency tests/evals/test_dataset.py::test_evaluate_with_invalid_max_concurrency -p no:cacheprovider` - passed, 3 tests
- `uv run ruff check pydantic_evals/pydantic_evals/dataset.py tests/evals/test_dataset.py` - passed
- `git diff --check` - passed
- Direct behavior proof for `0` and `-1` - passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



