### PR TITLE
Round-trip TextContent.metadata through the Vercel AI adapter

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -278,7 +278,14 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                 user_prompt_content: str | list[UserContent] = []
                 for part in msg.parts:
                     if isinstance(part, TextUIPart):
-                        user_prompt_content.append(part.text)
+                        # Restoring client-supplied `TextContent.metadata` is intentional, like
+                        # `vendor_metadata` below (#5571/#5772): it carries only data the requester
+                        # attached to their own prompt, and `TextContent.metadata` is typed `Any`.
+                        metadata = load_provider_metadata(part.provider_metadata).get('metadata')
+                        if metadata is not None:
+                            user_prompt_content.append(TextContent(content=part.text, metadata=metadata))
+                        else:
+                            user_prompt_content.append(part.text)
                     elif isinstance(part, FileUIPart):
                         provider_meta = load_provider_metadata(part.provider_metadata)
                         # Restoring client-supplied `vendor_metadata` is intentional (as the `UploadedFile` branch
@@ -976,7 +983,15 @@ def _convert_user_prompt_part(part: UserPromptPart) -> list[UIMessagePart]:
             if isinstance(item, str):
                 ui_parts.append(TextUIPart(text=item, state='done'))
             elif isinstance(item, TextContent):
-                ui_parts.append(TextUIPart(text=item.content, state='done'))
+                ui_parts.append(
+                    TextUIPart(
+                        text=item.content,
+                        state='done',
+                        # Round-trip `TextContent.metadata` (e.g. MCP source attribution);
+                        # see `TextContent.metadata` and #5679.
+                        provider_metadata=dump_provider_metadata(metadata=item.metadata),
+                    )
+                )
             elif isinstance(item, BinaryContent):
                 ui_parts.append(
                     FileUIPart(

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -4979,6 +4979,37 @@ async def test_adapter_dump_load_roundtrip_without_timestamps():
     assert reloaded_messages == original_messages
 
 
+async def test_adapter_dump_load_roundtrip_text_content_metadata():
+    """`TextContent.metadata` (e.g. MCP source attribution) survives the dump/load round-trip (#5679)."""
+    original_messages: list[ModelRequest | ModelResponse] = [
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        'Hello',
+                        TextContent(content='World', metadata={'source': 'mcp', 'part_id': 'abc123'}),
+                    ]
+                ),
+            ]
+        ),
+    ]
+
+    ui_messages = VercelAIAdapter.dump_messages(original_messages)
+    text_parts = [part for msg in ui_messages for part in msg.parts if isinstance(part, TextUIPart)]
+    assert text_parts[0].provider_metadata is None
+    assert text_parts[1].provider_metadata == {'pydantic_ai': {'metadata': {'source': 'mcp', 'part_id': 'abc123'}}}
+
+    reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
+    _sync_timestamps(original_messages, reloaded_messages)
+    assert reloaded_messages == original_messages
+
+    # A `TextContent` without metadata carries nothing to restore, so it flattens to plain text
+    flattened = VercelAIAdapter.load_messages(
+        VercelAIAdapter.dump_messages([ModelRequest(parts=[UserPromptPart(content=[TextContent(content='Bare')])])])
+    )
+    assert flattened[0].parts[0].content == 'Bare'
+
+
 async def test_adapter_dump_load_roundtrip_with_message_metadata():
     """`timestamp` and application `metadata` survive the dump/load round-trip; server fields don't.
 
@@ -6067,7 +6098,12 @@ async def test_convert_user_prompt_part_text_content():
     part = UserPromptPart(content=['Just some text', TextContent(content='More text', metadata={'key': 'value'})])
     ui_parts = _convert_user_prompt_part(part)
     assert ui_parts == snapshot(
-        [TextUIPart(text='Just some text', state='done'), TextUIPart(text='More text', state='done')]
+        [
+            TextUIPart(text='Just some text', state='done'),
+            TextUIPart(
+                text='More text', state='done', provider_metadata={'pydantic_ai': {'metadata': {'key': 'value'}}}
+            ),
+        ]
     )
 
 


### PR DESCRIPTION
Fixes #5679

`VercelAIAdapter.dump_messages` converted a `TextContent` user-content item to a bare `TextUIPart`, so `metadata` (e.g. the MCP source attribution attached by `_mcp_part_metadata`) was silently dropped, and `load_messages` reloaded the item as a plain `str`. Resumed/conversational workflows that round-trip history through the adapter lost MCP protocol metadata permanently.

## Change

- **Dump:** `_convert_user_prompt_part` now carries `TextContent.metadata` in `TextUIPart.provider_metadata` under the existing `pydantic_ai` wrapper key — the same mechanism as `vendor_metadata` on file parts. A `TextContent` without metadata still dumps with `provider_metadata=None` (wire format unchanged for that case).
- **Load:** the user-role `TextUIPart` branch rebuilds `TextContent(content=..., metadata=...)` when the key is present; otherwise it stays a plain `str` as before. Restoring the client-supplied value follows the same trust rationale as `vendor_metadata` (#5571/#5772): it carries only data the requester attached to their own prompt, and `TextContent.metadata` is typed `Any`.

Scoped to the Vercel AI adapter: the AG-UI side has no extension point on `TextInputContent` and belongs with the carrier mechanism being worked out in #5937/#6127.

## Tests

- New `test_adapter_dump_load_roundtrip_text_content_metadata`: exact round-trip equality for the issue's repro (mixed `str` + `TextContent` content), wire-format assertion, and the no-metadata flattening case.
- `test_convert_user_prompt_part_text_only` snapshot updated: it previously pinned the lossy behavior (`provider_metadata=None` for a `TextContent` that had `metadata={'key': 'value'}`).
- `tests/test_vercel_ai.py`: 186 passed; ruff and pyright clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

