### PR TITLE
messages: add ToolReturnPart to ModelResponsePart discriminated union

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2038,6 +2038,7 @@ ModelResponsePart = Annotated[
     | Annotated[ToolSearchCallPart, pydantic.Tag('tool-search-call')]
     | Annotated[LoadCapabilityCallPart, pydantic.Tag('capability-load-call')]
     | Annotated[ToolCallPart, pydantic.Tag('tool-call')]
+    | Annotated[ToolReturnPart, pydantic.Tag('tool-return')]
     | Annotated[NativeToolSearchCallPart, pydantic.Tag('builtin-tool-search-call')]
     | Annotated[NativeToolCallPart, pydantic.Tag('builtin-tool-call')]
     | Annotated[NativeToolSearchReturnPart, pydantic.Tag('builtin-tool-search-return')]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -745,6 +745,28 @@ def test_model_messages_type_adapter_preserves_user_text_prompt_metadata():
     assert deserialized[0].parts[0].content[0].metadata == snapshot({'foo': 'bar'})  # type: ignore[reportUnknownMemberType]
 
 
+def test_tool_return_part_in_model_response_roundtrip():
+    from pydantic_ai.messages import ModelMessagesTypeAdapter, ModelResponse, ToolReturnPart
+
+    messages = [
+        ModelResponse(
+            parts=[
+                ToolReturnPart(
+                    tool_name='my_tool',
+                    content={'result': 'success'},
+                    tool_call_id='call-abc',
+                )
+            ]
+        )
+    ]
+    py_serialized = ModelMessagesTypeAdapter.dump_python(messages, mode='python')
+    py_deserialized = ModelMessagesTypeAdapter.validate_python(py_serialized)
+    assert py_deserialized == messages
+    js_serialized = ModelMessagesTypeAdapter.dump_json(messages)
+    js_deserialized = ModelMessagesTypeAdapter.validate_json(js_serialized)
+    assert js_deserialized == messages
+
+
 def test_model_response_convenience_methods():
     response = ModelResponse(parts=[])
     assert response.text == snapshot(None)


### PR DESCRIPTION
Fixes #6171

## Problem
`ToolReturnPart` was missing from the `ModelResponsePart` discriminated union. Any message history containing a tool return silently failed to deserialize (raised `union_tag_invalid`), breaking `result.all_messages_json()` round-trips.

The discriminator function `_model_response_part_discriminator` correctly returns `'tool-return'` for `ToolReturnPart` instances, but no member of the union carried `pydantic.Tag('tool-return')`.

## Fix
One-line addition to the `ModelResponsePart` union in `pydantic_ai_slim/pydantic_ai/messages.py`:
```python
| Annotated[ToolReturnPart, pydantic.Tag('tool-return')]
```
Placed adjacent to the other `ToolCallPart` entry, mirroring the pattern already used in `ModelRequestPart`.

## Testing
Added regression test `test_tool_return_part_in_model_response_roundtrip` in `tests/test_messages.py` covering both `validate_python` and `validate_json` round-trips. Full `tests/test_messages.py` suite passes (141 tests).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

