### PR TITLE
feat(instrumentation): opt-in `gen_ai.agent.name` on client metrics

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -247,13 +247,18 @@ def open_model_request_span(
                 price_calculation = None
 
                 def _record_metrics() -> None:
-                    metric_attributes = {
+                    metric_attributes: dict[str, AttributeValue] = {
                         GEN_AI_PROVIDER_NAME_ATTRIBUTE: system,
                         GEN_AI_SYSTEM_ATTRIBUTE: system,
                         'gen_ai.operation.name': operation,
                         'gen_ai.request.model': request_model,
                         'gen_ai.response.model': response_model,
                     }
+                    if (
+                        settings.include_agent_name_in_metric_attributes
+                        and (agent_name := attributes.get(AGENT_NAME_BAGGAGE_KEY)) is not None
+                    ):
+                        metric_attributes[AGENT_NAME_BAGGAGE_KEY] = agent_name
                     settings.record_metrics(response, price_calculation, metric_attributes)
 
                 record_metrics = _record_metrics

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -66,6 +66,7 @@ class InstrumentationSettings:
     include_content: bool = True
     version: Literal[2, 3, 4, 5] = DEFAULT_INSTRUMENTATION_VERSION
     use_aggregated_usage_attribute_names: bool = True
+    include_agent_name_in_metric_attributes: bool = False
 
     def __init__(
         self,
@@ -76,6 +77,7 @@ class InstrumentationSettings:
         include_content: bool = True,
         version: Literal[2, 3, 4, 5] = DEFAULT_INSTRUMENTATION_VERSION,
         use_aggregated_usage_attribute_names: bool = True,
+        include_agent_name_in_metric_attributes: bool = False,
     ):
         """Create instrumentation options.
 
@@ -110,6 +112,15 @@ class InstrumentationSettings:
                 attributes across parent and child spans.
                 Note: `gen_ai.aggregated_usage.*` is a custom namespace, not part of the OpenTelemetry
                 Semantic Conventions. It may be updated if OTel introduces an official convention.
+            include_agent_name_in_metric_attributes: Whether to stamp the `gen_ai.agent.name` attribute
+                (read from OpenTelemetry baggage) on the GenAI client metric data points, such as
+                `gen_ai.client.token.usage` and `operation.cost`. Defaults to False.
+                The OpenTelemetry GenAI semantic conventions currently specify `gen_ai.agent.name` only for
+                spans (`invoke_agent`), not for client metrics, so it is not emitted by default. Enable this
+                to break metrics down by agent (e.g. in metrics-only backends like Prometheus/Grafana that
+                have no span pipeline). Note that enabling it adds a dimension that splits existing metric
+                series keyed on the current attributes. The attribute is only added when the request is made
+                on behalf of a named agent; it is omitted for direct model use and unnamed agents.
         """
         from pydantic_ai import __version__
 
@@ -131,6 +142,7 @@ class InstrumentationSettings:
             )
         self.version = version
         self.use_aggregated_usage_attribute_names = use_aggregated_usage_attribute_names
+        self.include_agent_name_in_metric_attributes = include_agent_name_in_metric_attributes
 
         # As specified in the OpenTelemetry GenAI metrics spec:
         # https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -2133,3 +2133,69 @@ async def test_instrumented_model_request_error(capfire: CaptureLogfire):
     # finish() was never called, so response-specific attributes are absent
     assert 'gen_ai.response.id' not in spans[0]['attributes']
     assert 'gen_ai.usage.input_tokens' not in spans[0]['attributes']
+
+
+def _metric_attribute_sets(capfire: CaptureLogfire) -> list[dict[str, object]]:
+    """Collect the attribute dicts of every metric data point that was recorded."""
+    attribute_sets: list[dict[str, object]] = []
+    for metric in capfire.get_collected_metrics():
+        for data_point in metric['data']['data_points']:
+            attribute_sets.append(data_point['attributes'])
+    return attribute_sets
+
+
+async def test_metrics_omit_agent_name_by_default(capfire: CaptureLogfire):
+    """By default, `gen_ai.agent.name` is not stamped on client metric data points."""
+    from opentelemetry import context
+    from opentelemetry.baggage import set_baggage
+
+    from pydantic_ai._instrumentation import AGENT_NAME_BAGGAGE_KEY
+
+    model = InstrumentedModel(MyModel(), InstrumentationSettings())
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('Hello')], timestamp=IsDatetime())]
+
+    token = context.attach(set_baggage(AGENT_NAME_BAGGAGE_KEY, 'planner'))
+    try:
+        await model.request(messages, model_settings=None, model_request_parameters=ModelRequestParameters())
+    finally:
+        context.detach(token)
+
+    attribute_sets = _metric_attribute_sets(capfire)
+    assert attribute_sets  # sanity: metrics were recorded
+    assert all(AGENT_NAME_BAGGAGE_KEY not in attrs for attrs in attribute_sets)
+
+
+async def test_metrics_include_agent_name_when_enabled(capfire: CaptureLogfire):
+    """When opted in, `gen_ai.agent.name` from baggage is stamped on client metric data points."""
+    from opentelemetry import context
+    from opentelemetry.baggage import set_baggage
+
+    from pydantic_ai._instrumentation import AGENT_NAME_BAGGAGE_KEY
+
+    model = InstrumentedModel(MyModel(), InstrumentationSettings(include_agent_name_in_metric_attributes=True))
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('Hello')], timestamp=IsDatetime())]
+
+    token = context.attach(set_baggage(AGENT_NAME_BAGGAGE_KEY, 'planner'))
+    try:
+        await model.request(messages, model_settings=None, model_request_parameters=ModelRequestParameters())
+    finally:
+        context.detach(token)
+
+    attribute_sets = _metric_attribute_sets(capfire)
+    # Both the token-usage (input/output) and cost data points carry the agent name.
+    assert attribute_sets
+    assert all(attrs.get(AGENT_NAME_BAGGAGE_KEY) == 'planner' for attrs in attribute_sets)
+
+
+async def test_metrics_omit_agent_name_when_enabled_but_unnamed(capfire: CaptureLogfire):
+    """With the flag on but no agent name in baggage, the attribute is omitted (direct model use)."""
+    from pydantic_ai._instrumentation import AGENT_NAME_BAGGAGE_KEY
+
+    model = InstrumentedModel(MyModel(), InstrumentationSettings(include_agent_name_in_metric_attributes=True))
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('Hello')], timestamp=IsDatetime())]
+
+    await model.request(messages, model_settings=None, model_request_parameters=ModelRequestParameters())
+
+    attribute_sets = _metric_attribute_sets(capfire)
+    assert attribute_sets
+    assert all(AGENT_NAME_BAGGAGE_KEY not in attrs for attrs in attribute_sets)

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator, AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from typing import Literal
 
@@ -2144,21 +2144,30 @@ def _metric_attribute_sets(capfire: CaptureLogfire) -> list[dict[str, object]]:
     return attribute_sets
 
 
-async def test_metrics_omit_agent_name_by_default(capfire: CaptureLogfire):
-    """By default, `gen_ai.agent.name` is not stamped on client metric data points."""
+@contextmanager
+def _agent_name_baggage(name: str):
+    """Attach an agent name to OTel baggage for the duration of the block."""
     from opentelemetry import context
     from opentelemetry.baggage import set_baggage
 
     from pydantic_ai._instrumentation import AGENT_NAME_BAGGAGE_KEY
 
+    token = context.attach(set_baggage(AGENT_NAME_BAGGAGE_KEY, name))
+    try:
+        yield
+    finally:
+        context.detach(token)
+
+
+async def test_metrics_omit_agent_name_by_default(capfire: CaptureLogfire):
+    """By default, `gen_ai.agent.name` is not stamped on client metric data points."""
+    from pydantic_ai._instrumentation import AGENT_NAME_BAGGAGE_KEY
+
     model = InstrumentedModel(MyModel(), InstrumentationSettings())
     messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('Hello')], timestamp=IsDatetime())]
 
-    token = context.attach(set_baggage(AGENT_NAME_BAGGAGE_KEY, 'planner'))
-    try:
+    with _agent_name_baggage('planner'):
         await model.request(messages, model_settings=None, model_request_parameters=ModelRequestParameters())
-    finally:
-        context.detach(token)
 
     attribute_sets = _metric_attribute_sets(capfire)
     assert attribute_sets  # sanity: metrics were recorded
@@ -2167,19 +2176,13 @@ async def test_metrics_omit_agent_name_by_default(capfire: CaptureLogfire):
 
 async def test_metrics_include_agent_name_when_enabled(capfire: CaptureLogfire):
     """When opted in, `gen_ai.agent.name` from baggage is stamped on client metric data points."""
-    from opentelemetry import context
-    from opentelemetry.baggage import set_baggage
-
     from pydantic_ai._instrumentation import AGENT_NAME_BAGGAGE_KEY
 
     model = InstrumentedModel(MyModel(), InstrumentationSettings(include_agent_name_in_metric_attributes=True))
     messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('Hello')], timestamp=IsDatetime())]
 
-    token = context.attach(set_baggage(AGENT_NAME_BAGGAGE_KEY, 'planner'))
-    try:
+    with _agent_name_baggage('planner'):
         await model.request(messages, model_settings=None, model_request_parameters=ModelRequestParameters())
-    finally:
-        context.detach(token)
 
     attribute_sets = _metric_attribute_sets(capfire)
     # Both the token-usage (input/output) and cost data points carry the agent name.


### PR DESCRIPTION
## Summary

- Adds an opt-in `include_agent_name_in_metric_attributes` flag to `InstrumentationSettings`.
- When enabled, `gen_ai.agent.name` (read from OTel baggage) is stamped on the GenAI **client metric** data points — `gen_ai.client.token.usage` and `operation.cost` — so users can break cost/usage metrics down by agent.

## Motivation

Closes #6204.

GenAI client metric data points currently carry only the semconv metric attribute set (`gen_ai.operation.name`, provider, request/response model). That means metrics can be sliced by model/provider/service/environment but **not by agent** — in a multi-agent app, a planner and a summarizer calling the same model are indistinguishable in the metric series.

OTel Views can drop metric attributes downstream but can never add them, so a metrics-only consumer (Prometheus/Grafana with no span pipeline) has no path to per-agent series unless the SDK stamps the attribute. This makes the SDK the only place the option can live.

## Fix

`open_model_request_span` already captures the agent-run baggage (`gen_ai.agent.name`) into the span `attributes` dict. The new flag reuses that captured value in the shared `metric_attributes` dict passed to `record_metrics`, so every client histogram recorded through that path picks it up consistently.

Design choices (matching the issue and semconv guidance):
- **Off by default** — the current OTel GenAI semconv specifies `gen_ai.agent.name` only for spans (`invoke_agent`), not client metrics. Enabling by default would split every existing user's token/cost series and add cardinality not everyone wants. Precedent: `use_aggregated_usage_attribute_names`.
- **Omitted for direct model use and unnamed agents** — the attribute is only added when the request runs on behalf of a named agent (present in baggage).
- Low-cardinality logical label (bounded by code, not user input), opted into knowingly.

## Tests

- `test_metrics_omit_agent_name_by_default` — flag off + baggage set → attribute absent on all data points.
- `test_metrics_include_agent_name_when_enabled` — flag on + baggage set → `gen_ai.agent.name` present on token-usage and cost data points.
- `test_metrics_omit_agent_name_when_enabled_but_unnamed` — flag on, no agent name in baggage → attribute omitted (direct model use).

## Verification

- `uv run pytest tests/models/test_instrumented.py` — 48 passed
- `uv run ruff format --check` / `ruff check` — clean on changed files
- `uv run pyright` — 0 errors on the changed files
- Did NOT change default behavior: the attribute is only emitted when the new flag is explicitly enabled AND an agent name is present in baggage.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

