### PR TITLE
ci: don't re-close a PR when a maintainer reopens it in `pr-guard`

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -61,6 +61,33 @@ jobs:
             exit 0
           fi
 
+          # Maintainer-reopen bypass. AUTHOR_ASSOCIATION above is the PR *author's*
+          # relationship to the repo, so a guard-closed contributor PR that a
+          # maintainer deliberately reopens would just be closed again on the
+          # `reopened` event. When someone other than the author reopens, confirm
+          # they have triage-or-higher access on *this* repo before respecting it:
+          # GitHub also lets a collaborator on the contributor's fork reopen the
+          # PR, so `sender != author` alone isn't proof of base-repo trust. We read
+          # `role_name` (not the legacy `permission`, which collapses triage into
+          # read) so a triager — who can legitimately reopen — still counts. If the
+          # role can't be determined, err toward respecting the reopen: this is a
+          # courtesy gate (trivially satisfied by linking any open issue), not a
+          # security boundary, and a deliberate reopen shouldn't be undone by a
+          # transient API hiccup. The author reopening their own PR still gets
+          # re-checked, so the issue-link policy can't be bypassed by reopening.
+          if [ "${GITHUB_EVENT_ACTION}" = "reopened" ] && [ "${GITHUB_EVENT_SENDER_LOGIN}" != "$PR_AUTHOR" ]; then
+            SENDER_ROLE=$(gh api "repos/${REPO}/collaborators/${GITHUB_EVENT_SENDER_LOGIN}/permission" --jq '.role_name' 2>/dev/null || echo "unknown")
+            case "$SENDER_ROLE" in
+              read | none)
+                echo "PR reopened by ${GITHUB_EVENT_SENDER_LOGIN} (role: ${SENDER_ROLE}, no write access); continuing checks."
+                ;;
+              *)
+                echo "PR reopened by ${GITHUB_EVENT_SENDER_LOGIN} (role: ${SENDER_ROLE}); a trusted collaborator reopened it, skipping checks."
+                exit 0
+                ;;
+            esac
+          fi
+
           # pydanty is the autonomous agent that opens PRs from issues. Its PRs are
           # never auto-closed for duplication; instead a pydanty PR supersedes a
           # competing PR opened within WINDOW_SECONDS before it (see the loop below).
@@ -340,6 +367,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
+          GITHUB_EVENT_SENDER_LOGIN: ${{ github.event.sender.login }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_EVENT_PULL_REQUEST_USER_LOGIN: ${{ github.event.pull_request.user.login }}
           GITHUB_EVENT_PULL_REQUEST_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}


### PR DESCRIPTION
The **PR Guard** workflow auto-closes external-contributor PRs that don't link an issue. But when a maintainer *reopens* such a PR, the `reopened` event re-runs the guard, which closes it again — the maintainer bypass only checks the PR *author's* association, never who reopened it.

This happened on #6208: it was auto-closed, a maintainer reopened it, and ~40s later the guard closed it a second time. See https://github.com/pydantic/pydantic-ai/pull/6208#issuecomment-4874473510.

### Fix

On a `reopened` event where the reopener isn't the PR author, look up the reopener's `role_name` on this repo and skip the guard checks when they have triage-or-higher access. Rationale:

- `sender != author` alone isn't proof of base-repo trust — a collaborator on the *contributor's fork* can also reopen the PR, so we confirm the reopener's actual role on this repo.
- We read `role_name` rather than the legacy `permission` field (which collapses `triage` into `read`) so triagers, who can legitimately reopen, still count.
- If the role can't be determined, we err toward respecting the reopen: this is a courtesy gate (trivially satisfied by linking any open issue), not a security boundary, and a deliberate reopen shouldn't be undone by a transient API hiccup.
- The author reopening their *own* PR still gets re-checked, so the issue-link policy can't be bypassed by reopening.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

