### PR TITLE
Reject duplicate deferred tool call IDs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -252,7 +252,9 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
             # was already handled in a prior step. The check below relies on that convention.
             self.executable_function_kinds = ('function', 'unknown', 'external', 'unapproved')
             eligible_calls = [
-                call for call, kind in zip(self.tool_calls, call_kinds) if kind in self.executable_function_kinds
+                call
+                for call, kind in zip(self.tool_calls, call_kinds, strict=True)
+                if kind in self.executable_function_kinds
             ]
             # Results are matched back to calls by `tool_call_id`, so duplicate ids make the binding
             # ambiguous: one supplied result would bind to more than one call. Fail closed here rather

--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -37,6 +37,17 @@ _OUTPUT_VALIDATION_FAILED = 'Output tool not used - output failed validation.'
 _TOOL_SKIPPED_FINAL_ALREADY_PROCESSED = 'Tool not executed - a final result was already processed.'
 
 
+def _duplicate_tool_call_ids(calls: Sequence[_messages.ToolCallPart]) -> list[str]:
+    """Return duplicate tool call ids, preserving the order in which each duplicate first appears."""
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for call in calls:
+        if call.tool_call_id in seen and call.tool_call_id not in duplicates:
+            duplicates.append(call.tool_call_id)
+        seen.add(call.tool_call_id)
+    return duplicates
+
+
 def _emit_output_tool_events(
     call: _messages.ToolCallPart,
     part: _messages.ToolReturnPart | _messages.RetryPromptPart,
@@ -240,12 +251,19 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
             # including `'unknown'` (hallucinated) ones, using the `'skip'` sentinel for any call that
             # was already handled in a prior step. The check below relies on that convention.
             self.executable_function_kinds = ('function', 'unknown', 'external', 'unapproved')
+            eligible_calls = [
+                call for call, kind in zip(self.tool_calls, call_kinds) if kind in self.executable_function_kinds
+            ]
+            # Results are matched back to calls by `tool_call_id`, so duplicate ids make the binding
+            # ambiguous: one supplied result would bind to more than one call. Fail closed here rather
+            # than silently mis-binding (the set comparison below would otherwise collapse duplicates).
+            if duplicate_ids := _duplicate_tool_call_ids(eligible_calls):
+                raise exceptions.UserError(
+                    'Tool call results cannot be matched unambiguously because the message history contains '
+                    f'duplicate tool_call_id values: {duplicate_ids}'
+                )
             result_tool_call_ids = set(self.tool_call_results.keys())
-            eligible_call_ids = {
-                call.tool_call_id
-                for call, kind in zip(self.tool_calls, call_kinds)
-                if kind in self.executable_function_kinds
-            }
+            eligible_call_ids = {call.tool_call_id for call in eligible_calls}
             if eligible_call_ids != result_tool_call_ids:
                 raise exceptions.UserError(
                     'Tool call results need to be provided for all deferred tool calls. '
@@ -780,6 +798,15 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
 
     async def _resolve_deferred_calls(self) -> AsyncIterator[_messages.HandleResponseEvent]:
         """Resolve collected deferred calls via capability handlers, else set the `DeferredToolRequests` result."""
+        # Deferred calls are returned to the caller and later matched back to results by `tool_call_id`.
+        # Duplicate ids would make that matching ambiguous, so reject them before handing the requests out.
+        if duplicate_ids := _duplicate_tool_call_ids(
+            [*self.deferred_calls['external'], *self.deferred_calls['unapproved']]
+        ):
+            raise exceptions.UnexpectedModelBehavior(
+                f'Deferred tool calls must have unique tool_call_id values; duplicate ids: {duplicate_ids}'
+            )
+
         deferred_tool_requests: DeferredToolRequests | None = DeferredToolRequests(
             calls=self.deferred_calls['external'],
             approvals=self.deferred_calls['unapproved'],

--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -38,7 +38,7 @@ _TOOL_SKIPPED_FINAL_ALREADY_PROCESSED = 'Tool not executed - a final result was 
 
 
 def _duplicate_tool_call_ids(calls: Sequence[_messages.ToolCallPart]) -> list[str]:
-    """Return duplicate tool call ids, preserving the order in which each duplicate first appears."""
+    """Return duplicate `tool_call_id` values, in the order each ID is first encountered as a duplicate."""
     seen: set[str] = set()
     duplicates: list[str] = []
     for call in calls:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -9965,6 +9965,62 @@ async def test_run_with_deferred_tool_results_errors():
         )
 
 
+async def test_deferred_tool_requests_reject_duplicate_tool_call_ids():
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(tool_name='safe_tool', args={'item': 'visible-safe'}, tool_call_id='duplicate-id'),
+                ToolCallPart(tool_name='danger_tool', args={'item': 'hidden-danger'}, tool_call_id='duplicate-id'),
+            ]
+        )
+
+    agent = Agent(FunctionModel(model_function), output_type=[str, DeferredToolRequests])
+
+    def safe_tool(item: str) -> str:
+        return f'safe:{item}'  # pragma: no cover
+
+    def danger_tool(item: str) -> str:
+        return f'danger:{item}'  # pragma: no cover
+
+    agent.tool_plain(requires_approval=True)(safe_tool)
+    agent.tool_plain(requires_approval=True)(danger_tool)
+
+    with pytest.raises(UnexpectedModelBehavior, match='duplicate ids'):
+        await agent.run('approve the safe operation')
+
+
+async def test_deferred_tool_results_reject_duplicate_tool_call_ids_in_history():
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart('done')])  # pragma: no cover
+
+    agent = Agent(FunctionModel(model_function), output_type=[str, DeferredToolRequests])
+
+    def safe_tool(item: str) -> str:
+        return f'safe:{item}'  # pragma: no cover
+
+    def danger_tool(item: str) -> str:
+        return f'danger:{item}'  # pragma: no cover
+
+    agent.tool_plain(requires_approval=True)(safe_tool)
+    agent.tool_plain(requires_approval=True)(danger_tool)
+
+    message_history = [
+        ModelRequest(parts=[UserPromptPart(content='approve the safe operation')]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(tool_name='safe_tool', args={'item': 'visible-safe'}, tool_call_id='duplicate-id'),
+                ToolCallPart(tool_name='danger_tool', args={'item': 'hidden-danger'}, tool_call_id='duplicate-id'),
+            ]
+        ),
+    ]
+
+    with pytest.raises(UserError, match='duplicate tool_call_id'):
+        await agent.run(
+            message_history=message_history,
+            deferred_tool_results=DeferredToolResults(approvals={'duplicate-id': True}),
+        )
+
+
 async def test_user_prompt_with_deferred_tool_results():
     """Test that user_prompt can be provided alongside deferred_tool_results."""
     from pydantic_ai.exceptions import ApprovalRequired


### PR DESCRIPTION
## Summary

Reject duplicate `tool_call_id` values in deferred tool calls, which otherwise produce ambiguous result binding.

This is a rebase of @White-Mouse's #5761 onto the V2 tool-execution refactor. The original PR targeted `process_tool_calls` in `_agent_graph.py`, which has since moved to `_tool_execution.py`, so the branch no longer merged cleanly. The guards, helper, and regression tests are re-applied to the current structure with the original authorship preserved.

Closes #5761.

## Why

Deferred tool results are matched back to pending calls by `tool_call_id`. When two calls share an id, the binding is ambiguous — one supplied result would bind to more than one call. Previously this failed **silently and mis-executed**: a single approval bound to both calls, running the wrong tool. For example, a model (or hand-built message history) with two `requires_approval` calls sharing `tool_call_id='dup'`, resumed with `approvals={'dup': True}`, would execute the *unintended* tool (twice) while the intended one never ran — an authorization hazard.

This change fails closed before that ambiguous state is consumed:

- **`UnexpectedModelBehavior`** — when a model response yields deferred calls with duplicate ids, raised before returning `DeferredToolRequests` (`_resolve_deferred_calls`).
- **`UserError`** — when resuming from message history whose eligible calls contain duplicate ids, raised before the result-matching set comparison in `_ToolCallProcessor.__post_init__` (which would otherwise collapse the duplicates).

## Tests

- `test_deferred_tool_requests_reject_duplicate_tool_call_ids`
- `test_deferred_tool_results_reject_duplicate_tool_call_ids_in_history`
- Full `tests/test_agent.py`: 342 passed, 3 skipped; `ruff` + `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

