### PR TITLE
Exclude first-class token counts from `gen_ai.usage.details.*` OTel attributes to fix double-counting

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -13,10 +13,6 @@ from .exceptions import UsageLimitExceeded
 
 __all__ = 'RequestUsage', 'RunUsage', 'UsageLimits'
 
-_FIRST_CLASS_TOKEN_DETAIL_KEYS = frozenset({'input_tokens', 'output_tokens'})
-"""`details` keys whose names collide with first-class `gen_ai.usage.*` token attributes, so they must not
-also be emitted under the `gen_ai.usage.details.*` namespace."""
-
 
 @dataclass(repr=False, kw_only=True)
 class UsageBase:
@@ -90,13 +86,18 @@ class UsageBase:
         if self.output_audio_tokens:
             details['output_audio_tokens'] = self.output_audio_tokens
         if details:
+            # A first-class token attribute (e.g. `gen_ai.usage.output_tokens`) and its same-named `details`
+            # entry map to the same value only when the entry is an exact copy of the first-class field.
+            first_class_token_values = {'input_tokens': self.input_tokens, 'output_tokens': self.output_tokens}
             prefix = 'gen_ai.usage.details.'
             for key, value in details.items():
-                # Skip keys that duplicate a first-class token attribute (e.g. some adapters copy the raw
-                # `input_tokens`/`output_tokens` into `details`). Emitting them here too would report the same
-                # value under both `gen_ai.usage.{input,output}_tokens` and `gen_ai.usage.details.*`, which
-                # consumers like Langfuse sum, double-counting tokens and cost.
-                if key in _FIRST_CLASS_TOKEN_DETAIL_KEYS:
+                # Skip a `details` entry only when it exactly duplicates a first-class token attribute (e.g.
+                # Anthropic copies the raw `input_tokens`/`output_tokens` into `details` as a streaming
+                # carry-forward carrier). Emitting the same value under both `gen_ai.usage.{input,output}_tokens`
+                # and `gen_ai.usage.details.*` makes consumers like Langfuse sum them, double-counting tokens
+                # and cost. An entry carrying a *different* value (e.g. Cohere's billed units) is genuine extra
+                # telemetry and is kept.
+                if first_class_token_values.get(key) == value:
                     continue
                 # Skipping check for value since spec implies all detail values are relevant
                 if value:

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -13,6 +13,13 @@ from .exceptions import UsageLimitExceeded
 
 __all__ = 'RequestUsage', 'RunUsage', 'UsageLimits'
 
+_FIRST_CLASS_TOKEN_DETAIL_KEYS = frozenset({'input_tokens', 'output_tokens'})
+"""`details` keys whose names collide with the first-class `gen_ai.usage.{input,output}_tokens`
+attributes. They must never be emitted under `gen_ai.usage.details.*` too: doing so reports the same
+conceptual quantity under two attributes that consumers like Langfuse then sum, double-counting tokens
+and cost. Adapters that stash these keys in `details` (e.g. Anthropic's streaming carry-forward, Cohere's
+billed units) keep them accessible on `RequestUsage.details`; only the ambiguous OTel emission is dropped."""
+
 
 @dataclass(repr=False, kw_only=True)
 class UsageBase:
@@ -86,18 +93,12 @@ class UsageBase:
         if self.output_audio_tokens:
             details['output_audio_tokens'] = self.output_audio_tokens
         if details:
-            # A first-class token attribute (e.g. `gen_ai.usage.output_tokens`) and its same-named `details`
-            # entry map to the same value only when the entry is an exact copy of the first-class field.
-            first_class_token_values = {'input_tokens': self.input_tokens, 'output_tokens': self.output_tokens}
             prefix = 'gen_ai.usage.details.'
             for key, value in details.items():
-                # Skip a `details` entry only when it exactly duplicates a first-class token attribute (e.g.
-                # Anthropic copies the raw `input_tokens`/`output_tokens` into `details` as a streaming
-                # carry-forward carrier). Emitting the same value under both `gen_ai.usage.{input,output}_tokens`
-                # and `gen_ai.usage.details.*` makes consumers like Langfuse sum them, double-counting tokens
-                # and cost. An entry carrying a *different* value (e.g. Cohere's billed units) is genuine extra
-                # telemetry and is kept.
-                if first_class_token_values.get(key) == value:
+                # Never emit a `details` entry whose name collides with a first-class token attribute: the
+                # value is already reported as `gen_ai.usage.{input,output}_tokens`, and emitting it again
+                # under `gen_ai.usage.details.*` makes consumers like Langfuse sum the two and double-count.
+                if key in _FIRST_CLASS_TOKEN_DETAIL_KEYS:
                     continue
                 # Skipping check for value since spec implies all detail values are relevant
                 if value:

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -13,6 +13,10 @@ from .exceptions import UsageLimitExceeded
 
 __all__ = 'RequestUsage', 'RunUsage', 'UsageLimits'
 
+_FIRST_CLASS_TOKEN_DETAIL_KEYS = frozenset({'input_tokens', 'output_tokens'})
+"""`details` keys whose names collide with first-class `gen_ai.usage.*` token attributes, so they must not
+also be emitted under the `gen_ai.usage.details.*` namespace."""
+
 
 @dataclass(repr=False, kw_only=True)
 class UsageBase:
@@ -88,6 +92,12 @@ class UsageBase:
         if details:
             prefix = 'gen_ai.usage.details.'
             for key, value in details.items():
+                # Skip keys that duplicate a first-class token attribute (e.g. some adapters copy the raw
+                # `input_tokens`/`output_tokens` into `details`). Emitting them here too would report the same
+                # value under both `gen_ai.usage.{input,output}_tokens` and `gen_ai.usage.details.*`, which
+                # consumers like Langfuse sum, double-counting tokens and cost.
+                if key in _FIRST_CLASS_TOKEN_DETAIL_KEYS:
+                    continue
                 # Skipping check for value since spec implies all detail values are relevant
                 if value:
                     result[prefix + key] = value

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -4440,6 +4440,59 @@ def test_usage(
     assert _map_usage(message_callback(), 'anthropic', '', 'unknown') == usage
 
 
+def test_usage_otel_attributes_omit_first_class_token_details_with_compaction():
+    """With compaction, `details['input_tokens']` (raw, pre-compaction) diverges from the first-class
+    `input_tokens` (raw + compaction totals), yet both name the same conceptual quantity. The colliding
+    `input_tokens`/`output_tokens` detail keys must not be emitted under `gen_ai.usage.details.*`, or a
+    Langfuse-style consumer summing them double-counts. `compaction_*` keys don't collide and are kept.
+    """
+    message = anth_msg(
+        BetaUsage(
+            input_tokens=23,
+            output_tokens=1,
+            iterations=[
+                BetaCompactionIterationUsage(
+                    type='compaction',
+                    input_tokens=180,
+                    output_tokens=3,
+                    cache_creation_input_tokens=4,
+                    cache_read_input_tokens=5,
+                ),
+                BetaMessageIterationUsage(
+                    type='message',
+                    model='claude-sonnet-4-5',
+                    input_tokens=23,
+                    output_tokens=1,
+                    cache_creation_input_tokens=0,
+                    cache_read_input_tokens=0,
+                ),
+            ],
+        )
+    )
+    mapped = _map_usage(message, 'anthropic', '', 'unknown')
+    assert mapped.input_tokens == 212
+    assert mapped.details['input_tokens'] == 23  # still accessible on `details`
+    attributes = mapped.opentelemetry_attributes()
+    assert 'gen_ai.usage.details.input_tokens' not in attributes
+    assert 'gen_ai.usage.details.output_tokens' not in attributes
+    assert attributes == snapshot(
+        {
+            'gen_ai.usage.input_tokens': 212,
+            'gen_ai.usage.output_tokens': 4,
+            'gen_ai.usage.cache_creation.input_tokens': 4,
+            'gen_ai.usage.cache_read.input_tokens': 5,
+            'gen_ai.usage.details.compaction_iterations': 1,
+            'gen_ai.usage.details.message_iterations': 1,
+            'gen_ai.usage.details.compaction_input_tokens': 180,
+            'gen_ai.usage.details.compaction_output_tokens': 3,
+            'gen_ai.usage.details.compaction_cache_creation_input_tokens': 4,
+            'gen_ai.usage.details.compaction_cache_read_input_tokens': 5,
+            'gen_ai.usage.details.cache_write_tokens': 4,
+            'gen_ai.usage.details.cache_read_tokens': 5,
+        }
+    )
+
+
 def test_streaming_usage():
     start = BetaRawMessageStartEvent(message=anth_msg(BetaUsage(input_tokens=1, output_tokens=1)), type='message_start')
     initial_usage = _map_usage(start, 'anthropic', '', 'unknown')

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -419,9 +419,7 @@ async def test_request_tool_call(allow_model_requests: None):
     # `gen_ai.usage.details.*` too would let consumers like Langfuse sum billed + actual and double-count.
     # They must be dropped from the OTel attributes (only the first-class counts remain) while staying
     # accessible on `usage.details`.
-    tool_call_usage = next(
-        m.usage for m in result.all_messages() if isinstance(m, ModelResponse) and m.usage.details
-    )
+    tool_call_usage = next(m.usage for m in result.all_messages() if isinstance(m, ModelResponse) and m.usage.details)
     assert tool_call_usage.details == {'input_tokens': 4, 'output_tokens': 2}
     assert tool_call_usage.opentelemetry_attributes() == snapshot(
         {

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -414,6 +414,22 @@ async def test_request_tool_call(allow_model_requests: None):
         )
     )
 
+    # Cohere stores billed units under `details['input_tokens']`/`details['output_tokens']`, which differ
+    # from the first-class token counts (from `usage.tokens`). These are genuine extra telemetry, not
+    # duplicates, so `opentelemetry_attributes()` must still emit them under `gen_ai.usage.details.*`
+    # rather than dropping them as it does for exact duplicates (see the Anthropic double-count fix).
+    tool_call_usage = next(
+        m.usage for m in result.all_messages() if isinstance(m, ModelResponse) and m.usage.details
+    )
+    assert tool_call_usage.opentelemetry_attributes() == snapshot(
+        {
+            'gen_ai.usage.input_tokens': 5,
+            'gen_ai.usage.output_tokens': 3,
+            'gen_ai.usage.details.input_tokens': 4,
+            'gen_ai.usage.details.output_tokens': 2,
+        }
+    )
+
 
 def test_text_content_in_request(allow_model_requests: None):
     req = ModelRequest(

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -414,19 +414,19 @@ async def test_request_tool_call(allow_model_requests: None):
         )
     )
 
-    # Cohere stores billed units under `details['input_tokens']`/`details['output_tokens']`, which differ
-    # from the first-class token counts (from `usage.tokens`). These are genuine extra telemetry, not
-    # duplicates, so `opentelemetry_attributes()` must still emit them under `gen_ai.usage.details.*`
-    # rather than dropping them as it does for exact duplicates (see the Anthropic double-count fix).
+    # Cohere stores billed units under `details['input_tokens']`/`details['output_tokens']`. Those names
+    # collide with the first-class `gen_ai.usage.{input,output}_tokens` attributes, so emitting them under
+    # `gen_ai.usage.details.*` too would let consumers like Langfuse sum billed + actual and double-count.
+    # They must be dropped from the OTel attributes (only the first-class counts remain) while staying
+    # accessible on `usage.details`.
     tool_call_usage = next(
         m.usage for m in result.all_messages() if isinstance(m, ModelResponse) and m.usage.details
     )
+    assert tool_call_usage.details == {'input_tokens': 4, 'output_tokens': 2}
     assert tool_call_usage.opentelemetry_attributes() == snapshot(
         {
             'gen_ai.usage.input_tokens': 5,
             'gen_ai.usage.output_tokens': 3,
-            'gen_ai.usage.details.input_tokens': 4,
-            'gen_ai.usage.details.output_tokens': 2,
         }
     )
 

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -324,6 +324,27 @@ async def test_multi_agent_usage_no_incr():
     }
 
 
+def test_opentelemetry_attributes_excludes_first_class_token_details():
+    """Detail keys that duplicate a first-class token attribute must not be emitted twice.
+
+    Some adapters (e.g. Anthropic) copy the raw `input_tokens`/`output_tokens` into `details` as a
+    streaming carry-forward carrier. Emitting those under `gen_ai.usage.details.*` as well as the
+    first-class `gen_ai.usage.{input,output}_tokens` makes consumers like Langfuse sum them and
+    double-count tokens and cost. Not reachable through the public API since it depends on an adapter
+    leaving these keys in `details`, so pinned directly on the OTel attribute mapping.
+    """
+    usage = RequestUsage(
+        input_tokens=100,
+        output_tokens=50,
+        details={'input_tokens': 100, 'output_tokens': 50, 'reasoning_tokens': 10},
+    )
+    assert usage.opentelemetry_attributes() == {
+        'gen_ai.usage.input_tokens': 100,
+        'gen_ai.usage.output_tokens': 50,
+        'gen_ai.usage.details.reasoning_tokens': 10,
+    }
+
+
 async def test_multi_agent_usage_sync():
     """As in `test_multi_agent_usage_async`, with a sync tool."""
     controller_agent = Agent(TestModel())

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -324,23 +324,28 @@ async def test_multi_agent_usage_no_incr():
     }
 
 
-def test_opentelemetry_attributes_excludes_first_class_token_details():
-    """Detail keys that duplicate a first-class token attribute must not be emitted twice.
+def test_opentelemetry_attributes_excludes_duplicated_first_class_token_details():
+    """A `details` entry that exactly duplicates a first-class token attribute must not be emitted twice.
 
     Some adapters (e.g. Anthropic) copy the raw `input_tokens`/`output_tokens` into `details` as a
     streaming carry-forward carrier. Emitting those under `gen_ai.usage.details.*` as well as the
     first-class `gen_ai.usage.{input,output}_tokens` makes consumers like Langfuse sum them and
-    double-count tokens and cost. Not reachable through the public API since it depends on an adapter
-    leaving these keys in `details`, so pinned directly on the OTel attribute mapping.
+    double-count tokens and cost. An entry sharing the name but carrying a *different* value (e.g.
+    Cohere's billed units vs actual tokens) is genuine extra telemetry and must be preserved. Not
+    reachable through the public API since it depends on an adapter leaving these keys in `details`,
+    so pinned directly on the OTel attribute mapping.
     """
     usage = RequestUsage(
         input_tokens=100,
         output_tokens=50,
-        details={'input_tokens': 100, 'output_tokens': 50, 'reasoning_tokens': 10},
+        # `input_tokens` duplicates the first-class value (Anthropic case) → dropped;
+        # `output_tokens` differs from the first-class value (Cohere billed-units case) → kept.
+        details={'input_tokens': 100, 'output_tokens': 42, 'reasoning_tokens': 10},
     )
     assert usage.opentelemetry_attributes() == {
         'gen_ai.usage.input_tokens': 100,
         'gen_ai.usage.output_tokens': 50,
+        'gen_ai.usage.details.output_tokens': 42,
         'gen_ai.usage.details.reasoning_tokens': 10,
     }
 

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -324,28 +324,27 @@ async def test_multi_agent_usage_no_incr():
     }
 
 
-def test_opentelemetry_attributes_excludes_duplicated_first_class_token_details():
-    """A `details` entry that exactly duplicates a first-class token attribute must not be emitted twice.
+def test_opentelemetry_attributes_excludes_first_class_token_details():
+    """`details` entries named like a first-class token attribute must never be emitted under `details.*`.
 
-    Some adapters (e.g. Anthropic) copy the raw `input_tokens`/`output_tokens` into `details` as a
-    streaming carry-forward carrier. Emitting those under `gen_ai.usage.details.*` as well as the
-    first-class `gen_ai.usage.{input,output}_tokens` makes consumers like Langfuse sum them and
-    double-count tokens and cost. An entry sharing the name but carrying a *different* value (e.g.
-    Cohere's billed units vs actual tokens) is genuine extra telemetry and must be preserved. Not
-    reachable through the public API since it depends on an adapter leaving these keys in `details`,
-    so pinned directly on the OTel attribute mapping.
+    Adapters stash `input_tokens`/`output_tokens` in `details` for different reasons (Anthropic's
+    streaming carry-forward and pre-compaction raw counts, Cohere's billed units), but the name
+    collides with the first-class `gen_ai.usage.{input,output}_tokens` attributes. Emitting the value
+    under both makes consumers like Langfuse sum them and double-count tokens and cost, regardless of
+    whether the two values happen to match. They stay accessible on `RequestUsage.details`; only the
+    ambiguous OTel emission is dropped. Not reachable through the public API since it depends on an
+    adapter leaving these keys in `details`, so pinned directly on the OTel attribute mapping.
     """
     usage = RequestUsage(
         input_tokens=100,
         output_tokens=50,
-        # `input_tokens` duplicates the first-class value (Anthropic case) → dropped;
-        # `output_tokens` differs from the first-class value (Cohere billed-units case) → kept.
+        # A matching value (Anthropic exact-copy case) and a differing one (Cohere billed-units /
+        # Anthropic compaction case) are both dropped: the colliding name is what makes them ambiguous.
         details={'input_tokens': 100, 'output_tokens': 42, 'reasoning_tokens': 10},
     )
     assert usage.opentelemetry_attributes() == {
         'gen_ai.usage.input_tokens': 100,
         'gen_ai.usage.output_tokens': 50,
-        'gen_ai.usage.details.output_tokens': 42,
         'gen_ai.usage.details.reasoning_tokens': 10,
     }
 


### PR DESCRIPTION
Closes #6131

## Summary

`opentelemetry_attributes()` emitted `input_tokens`/`output_tokens` twice: once as the first-class `gen_ai.usage.{input,output}_tokens` and again under `gen_ai.usage.details.*` whenever an adapter left same-named keys in `RequestUsage.details`. Consumers like Langfuse sum both and double-count tokens and cost (2.0x on direct Anthropic, per the evidence in #6131).

## Approach

Fixed at the OTel layer, so it covers every provider generically rather than patching each adapter: `opentelemetry_attributes()` never emits `details` entries whose names collide with a first-class token attribute (`input_tokens`, `output_tokens`). The colliding name is what makes the emission ambiguous, so the drop is unconditional (not value-based).

This matters for two cases that both use these key names in `details`:
- **Anthropic**, including the compaction path where the first-class `input_tokens` includes compaction totals but `details['input_tokens']` stays raw. A value-based guard would miss this and keep double-counting; the unconditional drop covers it. `compaction_*` keys don't collide and are preserved.
- **Cohere**, which stores billed units under these names (a latent double-count on `main`: actual + billed).

The keys stay accessible on `RequestUsage.details`; only the ambiguous `gen_ai.usage.details.*` emission is dropped. No adapter changes, no `details` shape changes.

### Behavior change

Cohere's billed-unit breakdown (`details.input_tokens`/`details.output_tokens`) is no longer emitted under `gen_ai.usage.details.*`. It was emitted under a name identical to the first-class attribute, which is itself ambiguous, and it remains available on `usage.details`.

## Tests

- `test_opentelemetry_attributes_excludes_first_class_token_details` (usage): colliding detail keys dropped whether or not their value matches the first-class field.
- `test_usage_otel_attributes_omit_first_class_token_details_with_compaction` (anthropic): pinned on the documented compaction fixture; asserts no `gen_ai.usage.details.{input,output}_tokens`, first-class counts emitted once, `compaction_*` kept.
- `test_request_tool_call` (cohere): billed units absent from OTel attributes, still present on `usage.details`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
