### PR TITLE
Add media_qc example: fix-and-verify loop over a stdio MCP toolset

### DIFF
--- a/docs/examples/media-qc.md
+++ b/docs/examples/media-qc.md
@@ -1,0 +1,52 @@
+Media QC agent — a fix-and-verify loop over a local stdio MCP server.
+
+Demonstrates:
+
+* [MCP toolsets over stdio](../mcp/client.md#stdio)
+* [structured `output_type`](../output.md)
+* mixing MCP tools with a native [tool](../tools.md) in one agent
+
+The agent checks a media file for loudness compliance against a formal
+broadcast standard (EBU R 128) using the
+[loudcheck](https://github.com/chaoz23/loudcheck) MCP server (spawned with
+`uvx`, no install step), applies the exact gain correction the verdict
+recommends via a native `ffmpeg` tool, and re-checks until the file passes —
+returning a structured QC report.
+
+The interesting shape here is the loop: the MCP tool's output (a verdict
+with an exact remediation delta) feeds a native tool (`apply_gain`), whose
+output feeds the MCP tool again. The model plans the loop; each measurement
+is deterministic.
+
+## Running the Example
+
+Requires `ffmpeg` >= 5 on `PATH` and [`uv`](https://docs.astral.sh/uv/).
+With [dependencies installed and environment variables set](./setup.md#usage), run:
+
+```bash
+python/uv-run -m pydantic_ai_examples.media_qc
+```
+
+With no argument it generates an intentionally too-loud test tone, so the
+run is fully self-contained; pass a path to check your own file:
+
+```bash
+python/uv-run -m pydantic_ai_examples.media_qc path/to/master.wav
+```
+
+Output looks like:
+
+```json
+{
+  "file": "/tmp/.../master.fixed.wav",
+  "standard": "EBU R 128",
+  "verdict": "pass",
+  "integrated_lufs": -23.0,
+  "corrections_applied": ["applied -3.6 dB gain"],
+  "summary": "master.wav was 3.6 LU over target; corrected copy passes EBU R 128."
+}
+```
+
+## Example Code
+
+```snippet {path="/examples/pydantic_ai_examples/media_qc.py"}```

--- a/examples/pydantic_ai_examples/media_qc.py
+++ b/examples/pydantic_ai_examples/media_qc.py
@@ -1,0 +1,90 @@
+"""Media QC agent — a fix-and-verify loop over a local stdio MCP server.
+
+An agent that checks a media file for loudness compliance against a formal
+broadcast standard (EBU R 128) using the loudcheck MCP server, applies the
+exact gain correction the verdict recommends via a native tool, and
+re-checks until the file passes — returning a structured QC report.
+
+Requires ffmpeg >= 5 on PATH and `uv` (the MCP server is fetched with uvx
+on first run, no install step). If no file is given, an intentionally
+too-loud test tone is generated so the example is fully self-contained.
+
+Run with:
+
+    uv run -m pydantic_ai_examples.media_qc [path/to/file.wav]
+"""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from fastmcp.client.transports import StdioTransport
+from pydantic import BaseModel
+
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPToolset
+
+
+class QCReport(BaseModel):
+    """Structured result of the compliance check."""
+
+    file: str
+    standard: str
+    verdict: str
+    """pass | fail — the final verdict after any corrections."""
+    integrated_lufs: float
+    corrections_applied: list[str]
+    summary: str
+
+
+# loudcheck's MCP server exposes check_loudness(path, standard) and
+# list_standards(); uvx fetches it from PyPI on first run.
+loudcheck = MCPToolset(
+    StdioTransport(
+        command='uvx', args=['--from', 'loudcheck[mcp]', 'loudcheck', '--mcp']
+    )
+)
+
+agent = Agent(
+    'openai:gpt-5.2',
+    output_type=QCReport,
+    toolsets=[loudcheck],
+    instructions=(
+        'You are a media QC operator. Check the file for EBU R 128 loudness '
+        'compliance with check_loudness. If it fails, the verdict includes a '
+        'remediation with the exact gain delta — apply it with apply_gain, '
+        'then re-check the corrected file. Report the final state.'
+    ),
+)
+
+
+@agent.tool_plain
+def apply_gain(path: str, gain_db: float) -> str:
+    """Apply a gain correction to a media file with ffmpeg.
+
+    Writes a corrected copy next to the original and returns its path.
+    """
+    src = Path(path)
+    dst = src.with_name(f'{src.stem}.fixed{src.suffix}')
+    subprocess.run(
+        ['ffmpeg', '-y', '-loglevel', 'error', '-i', str(src), '-af', f'volume={gain_db}dB', str(dst)],
+        check=True,
+    )
+    return str(dst)
+
+
+def demo_file() -> str:
+    """Generate a test tone ~3.6 LU louder than the EBU R 128 target."""
+    path = Path(tempfile.mkdtemp()) / 'master.wav'
+    subprocess.run(
+        ['ffmpeg', '-y', '-loglevel', 'error', '-f', 'lavfi', '-i', 'sine=frequency=997:duration=5', '-af', 'volume=1.7dB', str(path)],
+        check=True,
+    )
+    return str(path)
+
+
+if __name__ == '__main__':
+    media = sys.argv[1] if len(sys.argv) > 1 else demo_file()
+    result = agent.run_sync(f'Run loudness QC on {media}')
+    print(result.output.model_dump_json(indent=2))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
           - examples/stream-whales.md
       - Complex Workflows:
           - examples/flight-booking.md
+          - examples/media-qc.md
       - Business Applications:
           - examples/slack-lead-qualifier.md
       - UI Examples:


### PR DESCRIPTION
## Summary

Adds a **media QC** example demonstrating a pattern the examples don't cover yet: **an agent looping between an MCP toolset and a native tool** — measure (MCP) → correct (native ffmpeg tool) → re-measure (MCP) → structured report.

- `MCPToolset(StdioTransport(...))` spawning a PyPI-published MCP server via `uvx` (no install step, no API key for the tool side)
- structured `output_type` (`QCReport`)
- a native `@agent.tool_plain` (`apply_gain`) whose output feeds back into the MCP tool

The domain is broadcast loudness compliance (EBU R 128) via [loudcheck](https://github.com/chaoz23/loudcheck): the verdict includes an exact remediation delta, so the loop converges deterministically — the model plans, the tools measure. With no argument the example generates its own intentionally-too-loud test tone with ffmpeg, so it's fully self-contained (needs ffmpeg >= 5 and uv on PATH).

Disclosure: I'm the author of loudcheck. It's MIT, zero-dependency, and chosen here because a verdict-with-exact-fix tool is what makes the fix-and-verify loop demonstrable; happy to swap in a different server if you'd prefer.

## Changes
- `examples/pydantic_ai_examples/media_qc.py` — the example
- `docs/examples/media-qc.md` — docs page (snippet include, matching existing pages)
- `mkdocs.yml` — registered under Examples → Complex Workflows

Verified locally: `MCPToolset` + `StdioTransport('uvx', ...)` spawns the server and lists `check_loudness` / `list_standards`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

