### PR TITLE
fix: write relative `$schema` for local `AgentSpec.to_file` schemas

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/spec.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/spec.py
@@ -133,7 +133,9 @@ class AgentSpec(BaseModel):
             if not schema_path.is_absolute():
                 schema_ref = str(schema_path)
                 schema_path = path.parent / schema_path
-            else:  # pragma: no cover
+            elif schema_path.is_relative_to(path.parent):
+                schema_ref = str(schema_path.relative_to(path.parent))
+            else:
                 schema_ref = str(schema_path)
             self._save_schema(schema_path, custom_capability_types)
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -2127,6 +2127,20 @@ def test_to_file_json(tmp_path: str):
     assert schema_path.exists()
 
 
+def test_to_file_json_with_absolute_schema_path(tmp_path: str):
+    import json
+
+    spec = AgentSpec(model='test', name='my-agent')
+    spec_path = Path(tmp_path) / 'agent.json'
+    schema_path = Path(tmp_path) / 'agent_schema.json'
+
+    spec.to_file(spec_path, schema_path=schema_path)
+
+    data = json.loads(spec_path.read_text(encoding='utf-8'))
+    assert data['$schema'] == 'agent_schema.json'
+    assert schema_path.exists()
+
+
 def test_to_file_no_schema(tmp_path: str):
     spec = AgentSpec(model='test')
     spec_path = Path(tmp_path) / 'agent.yaml'


### PR DESCRIPTION
﻿﻿Keep `AgentSpec.to_file()` schema references portable when callers pass an absolute schema path that lives beside the saved spec.

## What Problem This Solves

`AgentSpec.to_file()` currently writes an absolute `$schema` reference when `schema_path` is passed as an absolute path, even if that schema file is in the same directory as the generated `agent.json` or `agent.yaml`.

A minimal local reproduction before this change produced:

```text
schema_path= C:\Users\MiaoXing\AppData\Local\Temp\tmpe0wvnupc\agent_schema.json
schema_ref= C:\Users\MiaoXing\AppData\Local\Temp\tmpe0wvnupc\agent_schema.json
schema_exists= True
is_absolute_ref= True
```

That makes generated spec files machine-specific: a file that should be safe to move, commit, or share can carry a local temp path or username in its schema reference.

This is also inconsistent with `Dataset.to_file()`, which already converts an absolute schema path under the target file directory into a relative schema reference.

## Change

- Relativize `AgentSpec.to_file()` schema references when `schema_path` is absolute and located under the saved spec file's directory.
- Preserve existing behavior for relative `schema_path` values.
- Preserve absolute schema references when the schema file is outside the spec file directory.
- Add regression coverage for same-directory absolute `schema_path` serialization.

## Evidence

Before this change, saving an agent spec with an absolute schema path in the same directory writes the absolute local path into `$schema`:

```python
from pathlib import Path
from tempfile import TemporaryDirectory
import json

from pydantic_ai.agent.spec import AgentSpec

with TemporaryDirectory() as td:
    root = Path(td)
    spec_path = root / 'agent.json'
    schema_path = root / 'agent_schema.json'

    AgentSpec(model='test', name='demo').to_file(
        spec_path,
        schema_path=schema_path,
        fmt='json',
    )

    data = json.loads(spec_path.read_text(encoding='utf-8'))
    print(data['$schema'])
    print(Path(data['$schema']).is_absolute())
```

Observed before the fix:

```text
C:\Users\MiaoXing\AppData\Local\Temp\...\agent_schema.json
True
```

Expected after the fix:

```text
agent_schema.json
False
```

## Possible call chain / impact

```text
User/tooling calls AgentSpec.to_file(...)
  -> schema_path is an absolute Path under spec_path.parent
  -> current AgentSpec.to_file() absolute-path branch
  -> schema_ref = str(schema_path)
  -> JSON "$schema" or YAML yaml-language-server comment receives local absolute path
```

This PR only changes the generated schema reference text for schema files located under the saved spec directory. It does not change schema generation, spec validation, `AgentSpec.from_file()`, capability schema generation, or external absolute schema paths.

## Validation

- `PYTHONUTF8=1 uv run --project D:\ZXY\Github\pydantic-ai\pydantic_ai_slim pytest D:\ZXY\Github\pydantic-ai\tests\test_capabilities.py::test_to_file_json_with_absolute_schema_path` - passed, 1 test
- `PYTHONUTF8=1 uv run --project D:\ZXY\Github\pydantic-ai ruff check pydantic_ai_slim\pydantic_ai\agent\spec.py tests\test_capabilities.py` - passed
- `git -C D:\ZXY\Github\pydantic-ai diff --check` - passed

- Fixes #6250

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


