### PR TITLE
fix: write relative schema refs for AgentSpec files

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/spec.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/spec.py
@@ -133,7 +133,9 @@ class AgentSpec(BaseModel):
             if not schema_path.is_absolute():
                 schema_ref = str(schema_path)
                 schema_path = path.parent / schema_path
-            else:  # pragma: no cover
+            elif schema_path.is_relative_to(path.parent):
+                schema_ref = str(schema_path.relative_to(path.parent))
+            else:
                 schema_ref = str(schema_path)
             self._save_schema(schema_path, custom_capability_types)
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -2153,6 +2153,24 @@ def test_to_file_yaml_with_absolute_schema_path(tmp_path: Path):
     assert schema_path.exists()
 
 
+def test_to_file_json_with_external_absolute_schema_path(tmp_path: Path):
+    import json
+
+    spec = AgentSpec(model='test', name='my-agent')
+    spec_dir = tmp_path / 'specs'
+    schema_dir = tmp_path / 'schemas'
+    spec_dir.mkdir()
+    schema_dir.mkdir()
+    spec_path = spec_dir / 'agent.json'
+    schema_path = schema_dir / 'agent_schema.json'
+
+    spec.to_file(spec_path, schema_path=schema_path)
+
+    data = json.loads(spec_path.read_text(encoding='utf-8'))
+    assert data['$schema'] == str(schema_path)
+    assert schema_path.exists()
+
+
 def test_to_file_no_schema(tmp_path: str):
     spec = AgentSpec(model='test')
     spec_path = Path(tmp_path) / 'agent.yaml'

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -2127,6 +2127,20 @@ def test_to_file_json(tmp_path: str):
     assert schema_path.exists()
 
 
+def test_to_file_json_with_absolute_schema_path(tmp_path: str):
+    import json
+
+    spec = AgentSpec(model='test', name='my-agent')
+    spec_path = Path(tmp_path) / 'agent.json'
+    schema_path = Path(tmp_path) / 'agent_schema.json'
+
+    spec.to_file(spec_path, schema_path=schema_path)
+
+    data = json.loads(spec_path.read_text(encoding='utf-8'))
+    assert data['$schema'] == 'agent_schema.json'
+    assert schema_path.exists()
+
+
 def test_to_file_no_schema(tmp_path: str):
     spec = AgentSpec(model='test')
     spec_path = Path(tmp_path) / 'agent.yaml'

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -2127,7 +2127,7 @@ def test_to_file_json(tmp_path: str):
     assert schema_path.exists()
 
 
-def test_to_file_json_with_absolute_schema_path(tmp_path: str):
+def test_to_file_json_with_absolute_schema_path(tmp_path: Path):
     import json
 
     spec = AgentSpec(model='test', name='my-agent')
@@ -2138,6 +2138,18 @@ def test_to_file_json_with_absolute_schema_path(tmp_path: str):
 
     data = json.loads(spec_path.read_text(encoding='utf-8'))
     assert data['$schema'] == 'agent_schema.json'
+    assert schema_path.exists()
+
+
+def test_to_file_yaml_with_absolute_schema_path(tmp_path: Path):
+    spec = AgentSpec(model='test', name='my-agent')
+    spec_path = Path(tmp_path) / 'agent.yaml'
+    schema_path = Path(tmp_path) / 'agent_schema.json'
+
+    spec.to_file(spec_path, schema_path=schema_path)
+
+    content = spec_path.read_text(encoding='utf-8')
+    assert content.startswith('# yaml-language-server: $schema=agent_schema.json')
     assert schema_path.exists()
 
 


### PR DESCRIPTION
Keep AgentSpec.to_file schema references portable when callers pass an absolute schema path that lives beside the saved spec.

## What Problem This Solves

`AgentSpec.to_file()` accepts `schema_path` so callers can emit a JSON Schema file alongside the generated `agent.json` or `agent.yaml`. A common way to call this API is to build both paths from the same output directory, which means `schema_path` may be an absolute `Path` even though it points to a sibling file beside the generated spec.

Today that absolute-path input is serialized back into the generated spec unchanged. If the caller passes an absolute `schema_path` located in the same directory as the generated spec, the saved schema reference still becomes a machine-local absolute path instead of a portable sibling reference.

For example, a caller may write both files into the same output directory:

```text
spec_path   = /repo/agents/weather/agent.json
schema_path = /repo/agents/weather/agent_schema.json
```

Before this change, `agent.json` stores the machine-local path as the schema reference:

```json
{"$schema": "/repo/agents/weather/agent_schema.json", "...": "..."}
```

After this change, it stores the portable sibling reference instead:

```json
{"$schema": "agent_schema.json", "...": "..."}
```

The same rule applies to YAML output:

```text
spec_path   = /repo/agents/weather/agent.yaml
schema_path = /repo/agents/weather/agent_schema.json
```

After this change, the YAML language-server comment uses the same relative sibling reference:

```yaml
# yaml-language-server: $schema=agent_schema.json
```

This PR intentionally does not relativize schema files outside the generated spec directory. For example, `/shared/schemas/agent_schema.json` remains an absolute reference because it is not a sibling artifact of the generated spec.
A minimal local reproduction before this change produced:

```text
schema_path= C:\Users\MiaoXing\AppData\Local\Temp\tmpe0wvnupc\agent_schema.json
schema_ref= C:\Users\MiaoXing\AppData\Local\Temp\tmpe0wvnupc\agent_schema.json
schema_exists= True
is_absolute_ref= True
```

That makes the generated spec file depend on the machine where it was produced. The spec may work locally, but once it is moved to another directory, committed to a repository, shared with another developer, or consumed by tooling in a different workspace, the schema reference can point back to a private temp directory that does not exist there.

It can also leak local path details, such as usernames or temporary build directories, into files that otherwise look safe to publish. The issue is only the serialized reference text; the schema file itself is still written to the requested location.

This behavior is inconsistent with the sibling `Dataset.to_file()` path handling. `Dataset.to_file()` already treats an absolute schema path under the target file directory as a local schema file and serializes it as a relative reference. `AgentSpec.to_file()` should follow the same portability rule for colocated schema files while preserving absolute references for schema files outside the generated spec directory.

## Change

- Relativize AgentSpec.to_file schema references when schema_path is absolute and located under the saved spec file directory.
- Preserve existing behavior for relative schema_path values.
- Preserve absolute schema references when the schema file is outside the spec file directory.
- Add regression coverage for same-directory absolute schema_path serialization.

## Evidence

Before this change, saving an agent spec with an absolute schema path in the same directory writes the absolute local path into the schema reference:

```python
from pathlib import Path
from tempfile import TemporaryDirectory
import json

from pydantic_ai.agent.spec import AgentSpec

with TemporaryDirectory() as td:
    root = Path(td)
    spec_path = root / 'agent.json'
    schema_path = root / 'agent_schema.json'

    AgentSpec(model='test', name='demo').to_file(
        spec_path,
        schema_path=schema_path,
        fmt='json',
    )

    data = json.loads(spec_path.read_text(encoding='utf-8'))
    print(data['$schema'])
    print(Path(data['$schema']).is_absolute())
```

Observed before the fix:

```text
C:\Users\MiaoXing\AppData\Local\Temp\...\agent_schema.json
True
```

Expected after the fix:

```text
agent_schema.json
False
```

## Possible call chain / impact

```text
User/tooling calls AgentSpec.to_file(...)
  -> schema_path is an absolute Path under spec_path.parent
  -> current AgentSpec.to_file absolute-path branch
  -> schema_ref = str(schema_path)
  -> JSON schema field or YAML language-server comment receives local absolute path
```

This PR only changes the generated schema reference text for schema files located under the saved spec directory. It does not change schema generation, spec validation, AgentSpec.from_file, capability schema generation, or external absolute schema paths.

## Validation

- PYTHONUTF8=1 uv run --project D:\ZXY\Github\pydantic-ai\pydantic_ai_slim pytest D:\ZXY\Github\pydantic-ai\tests\test_capabilities.py::test_to_file_json_with_absolute_schema_path D:\ZXY\Github\pydantic-ai\tests\test_capabilities.py::test_to_file_yaml_with_absolute_schema_path D:\ZXY\Github\pydantic-ai\tests\test_capabilities.py::test_to_file_json_with_external_absolute_schema_path - passed, 3 tests
- PYTHONUTF8=1 uv run --project D:\ZXY\Github\pydantic-ai ruff check pydantic_ai_slim\pydantic_ai\agent\spec.py tests\test_capabilities.py - passed
- git -C D:\ZXY\Github\pydantic-ai diff --check - passed

Fixes #6250

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




