### PR TITLE
Retain dropped usage fields across OpenAI and xAI streaming chunks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -100,6 +100,7 @@ from ..profiles.openai import (
 from ..providers import Provider, infer_provider
 from ..settings import ModelSettings
 from ..tools import AgentDepsT, ToolDefinition
+from ..usage import merge_cumulative_usage
 from . import (
     Model,
     ModelRequestContext,
@@ -3178,8 +3179,9 @@ class OpenAIStreamedResponse(StreamedResponse):
                 chunk_usage = self._map_usage(chunk)
                 if self._model_settings and self._model_settings.get('openai_continuous_usage_stats'):
                     # When continuous_usage_stats is enabled, each chunk contains cumulative usage,
-                    # so we replace rather than increment to avoid double-counting.
-                    self._usage = chunk_usage
+                    # so we replace rather than increment to avoid double-counting. Merge with the usage
+                    # so far to retain any field a later cumulative chunk dropped (#5889, same shape as #5886).
+                    self._usage = merge_cumulative_usage(self._usage, chunk_usage)
                 else:
                     self._usage += chunk_usage
 

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -58,7 +58,7 @@ from ..profiles.grok import GrokModelProfile, GrokReasoningEffort
 from ..providers import Provider, infer_provider
 from ..settings import ModelSettings, ThinkingLevel
 from ..tools import ToolDefinition
-from ..usage import RequestUsage
+from ..usage import RequestUsage, merge_cumulative_usage
 from ._tool_choice import resolve_tool_choice
 
 try:
@@ -949,8 +949,11 @@ class XaiStreamedResponse(StreamedResponse):
 
     def _update_response_state(self, response: chat_types.Response) -> None:
         """Update response state including usage, response ID, and finish reason."""
-        # Update usage (SDK Response always provides a usage object)
-        self._usage = _extract_usage(response, self._model_name, self._provider.name, self._provider.base_url)
+        # Update usage (SDK Response always provides a usage object). xAI streams cumulative
+        # snapshots, so merge with the usage so far to retain any field a later chunk dropped
+        # (#5889, same shape as #5886).
+        latest_usage = _extract_usage(response, self._model_name, self._provider.name, self._provider.base_url)
+        self._usage = merge_cumulative_usage(self._usage, latest_usage)
 
         # Set provider response ID (only set once)
         if response.id and self.provider_response_id is None:

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -243,6 +243,30 @@ def _incr_usage_tokens(slf: RunUsage | RequestUsage, incr_usage: RunUsage | Requ
             slf.details[key] = slf.details.get(key, 0) + value
 
 
+def merge_cumulative_usage(previous: RequestUsage, latest: RequestUsage) -> RequestUsage:
+    """Merge a cumulative-snapshot `latest` usage with the usage accumulated so far.
+
+    Some providers stream usage as cumulative snapshots where each chunk's usage supersedes the previous
+    one (rather than being a delta to sum). Because the per-chunk usage is built with `exclude_none`/
+    conditional includes, a sub-field reported on an earlier chunk (e.g. `reasoning_tokens` or
+    `cache_read_tokens`) can be absent from a later one, which would zero the typed field when the later
+    snapshot replaces the accumulated usage. Backfill any token field or `details` entry that `latest`
+    dropped from `previous`, so those values survive. Safe because cumulative snapshots are monotonic: a
+    real drop to zero never overwrites a prior non-zero. See #5886.
+
+    `latest` is mutated in place and returned (callers build it fresh from each chunk).
+    """
+    latest.details = {**previous.details, **latest.details}
+    latest.input_tokens = latest.input_tokens or previous.input_tokens
+    latest.cache_write_tokens = latest.cache_write_tokens or previous.cache_write_tokens
+    latest.cache_read_tokens = latest.cache_read_tokens or previous.cache_read_tokens
+    latest.output_tokens = latest.output_tokens or previous.output_tokens
+    latest.input_audio_tokens = latest.input_audio_tokens or previous.input_audio_tokens
+    latest.cache_audio_read_tokens = latest.cache_audio_read_tokens or previous.cache_audio_read_tokens
+    latest.output_audio_tokens = latest.output_audio_tokens or previous.output_audio_tokens
+    return latest
+
+
 @dataclass(repr=False, kw_only=True)
 class UsageLimits:
     """Limits on model usage.

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -85,7 +85,7 @@ with try_import() as imports_successful:
     from openai.types.chat.chat_completion_message_function_tool_call import ChatCompletionMessageFunctionToolCall
     from openai.types.chat.chat_completion_message_tool_call import Function
     from openai.types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob
-    from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
+    from openai.types.completion_usage import CompletionTokensDetails, CompletionUsage, PromptTokensDetails
 
     from pydantic_ai.models.google import GoogleModel
     from pydantic_ai.models.openai import (
@@ -5449,6 +5449,76 @@ async def test_stream_with_continuous_usage_stats(allow_model_requests: None):
     # Final usage should be from the last chunk (15 output tokens)
     # NOT the sum of all chunks (5+10+15+15 = 45 output tokens)
     assert result.usage == snapshot(RunUsage(requests=1, input_tokens=10, output_tokens=15))
+
+
+async def test_stream_continuous_usage_stats_retains_dropped_fields(allow_model_requests: None):
+    """`continuous_usage_stats` cumulative snapshots must not drop a field a later chunk omits (#5889).
+
+    Not a VCR test: it pins a defensive branch that needs an intermediate chunk to report a sub-field
+    (`reasoning_tokens`, `cached_tokens`) that a later cumulative chunk then omits — behavior a recorded
+    stream doesn't reliably produce. Same shape as the `GoogleModel` fix in #5886.
+    """
+
+    def usage_chunk(
+        delta: list[ChoiceDelta],
+        *,
+        completion_tokens: int,
+        prompt_tokens: int,
+        reasoning_tokens: int | None = None,
+        cached_tokens: int | None = None,
+        finish_reason: FinishReason | None = None,
+    ) -> chat.ChatCompletionChunk:
+        return chat.ChatCompletionChunk(
+            id='123',
+            choices=[ChunkChoice(index=0, delta=d, finish_reason=finish_reason) for d in delta],
+            created=1704067200,
+            model='gpt-5-123',
+            object='chat.completion.chunk',
+            usage=CompletionUsage(
+                completion_tokens=completion_tokens,
+                prompt_tokens=prompt_tokens,
+                total_tokens=completion_tokens + prompt_tokens,
+                completion_tokens_details=CompletionTokensDetails(reasoning_tokens=reasoning_tokens)
+                if reasoning_tokens is not None
+                else None,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=cached_tokens)
+                if cached_tokens is not None
+                else None,
+            ),
+        )
+
+    # An intermediate chunk reports reasoning_tokens=50 and cached_tokens=30; the later chunks omit both.
+    stream = [
+        usage_chunk(
+            [ChoiceDelta(content='hello ', role='assistant')],
+            completion_tokens=5,
+            prompt_tokens=20,
+            reasoning_tokens=50,
+            cached_tokens=30,
+        ),
+        usage_chunk([ChoiceDelta(content='world')], completion_tokens=10, prompt_tokens=20),
+        usage_chunk([], completion_tokens=12, prompt_tokens=20, finish_reason='stop'),
+    ]
+    mock_client = MockOpenAI.create_mock_stream(stream)
+    m = OpenAIChatModel('gpt-5', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    settings = cast(OpenAIChatModelSettings, {'openai_continuous_usage_stats': True})
+    async with agent.run_stream('', model_settings=settings) as result:
+        async for _ in result.stream_text(debounce_by=None):
+            pass
+
+    # `reasoning_tokens` (details) and `cache_read_tokens` (typed, from `cached_tokens`) survive the
+    # later chunks that dropped them, instead of being zeroed by the replacing snapshot.
+    assert result.usage == snapshot(
+        RunUsage(
+            requests=1,
+            input_tokens=20,
+            cache_read_tokens=30,
+            output_tokens=12,
+            details={'reasoning_tokens': 50},
+        )
+    )
 
 
 async def test_openai_chat_refusal_non_streaming(allow_model_requests: None):

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -1154,6 +1154,54 @@ async def test_xai_stream_text_finish_reason(allow_model_requests: None):
             )
 
 
+async def test_xai_stream_usage_retains_dropped_fields(allow_model_requests: None):
+    """xAI cumulative usage snapshots must not drop a field a later chunk omits (#5889).
+
+    Not a VCR test (xAI is gRPC, so these paths use mock proto objects): it pins a defensive branch
+    that needs an intermediate `Response` to report a sub-field (`reasoning_tokens`,
+    `cached_prompt_text_tokens`) that a later cumulative `Response` then omits — behavior a recorded
+    stream doesn't reliably produce. Same shape as the `GoogleModel` fix in #5886.
+    """
+
+    def usage_chunk(text: str, usage: Any, finish_reason: str = '') -> tuple[Any, Any]:
+        chunk = create_stream_chunk(content=text, finish_reason=finish_reason or None)  # type: ignore[arg-type]
+        response = create_response(content=text, finish_reason=finish_reason or 'stop', usage=usage)  # type: ignore[arg-type]
+        return (response, chunk)
+
+    # An intermediate snapshot reports reasoning_tokens=50 and cached_prompt_text_tokens=30; the final
+    # cumulative snapshot omits both.
+    stream = [
+        usage_chunk(
+            'hello ',
+            create_usage(prompt_tokens=20, completion_tokens=5, reasoning_tokens=50, cached_prompt_text_tokens=30),
+        ),
+        usage_chunk(
+            'world',
+            create_usage(prompt_tokens=20, completion_tokens=12),
+            finish_reason='stop',
+        ),
+    ]
+    mock_client = MockXai.create_mock_stream([stream])
+    m = XaiModel(XAI_REASONING_MODEL, provider=XaiProvider(xai_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('') as result:
+        async for _ in result.stream_text(debounce_by=None):
+            pass
+
+    # `reasoning_tokens` (details) and `cache_read_tokens` (typed, from `cached_prompt_text_tokens`)
+    # survive the final snapshot that dropped them, instead of being zeroed by the replacement.
+    assert result.usage == snapshot(
+        RunUsage(
+            requests=1,
+            input_tokens=20,
+            cache_read_tokens=30,
+            output_tokens=12,
+            details={'reasoning_tokens': 50},
+        )
+    )
+
+
 class MyTypedDict(TypedDict, total=False):
     first: str
     second: str


### PR DESCRIPTION
- Closes #5889

## Summary

#5886 fixed a streaming usage-retention bug in `GoogleModel`: the streamed response overwrote `self._usage` on every cumulative snapshot, so when a later chunk dropped a sub-field an earlier chunk had reported (e.g. cached tokens through a gateway), the typed field was zeroed. #5889 asks to verify the same overwrite-then-rebuild shape in the OpenAI and xAI streamed paths.

Both share the defect:

- `OpenAIStreamedResponse` (with `openai_continuous_usage_stats`) does `self._usage = chunk_usage`
- `XaiStreamedResponse._update_response_state` does `self._usage = _extract_usage(...)`

Because each per-chunk usage is built with `exclude_none`/conditional includes, a field reported on an earlier cumulative chunk (e.g. `reasoning_tokens` or `cache_read_tokens`) is lost when a later snapshot omits it.

## Change

- Add a small provider-agnostic `merge_cumulative_usage` helper in `usage.py` that keeps the latest cumulative snapshot but backfills any typed token field or `details` entry the latest snapshot dropped, from the usage accumulated so far. Safe because cumulative snapshots are monotonic — a real drop to zero never overwrites a prior non-zero.
- Use it in the OpenAI `continuous_usage_stats` branch and in xAI's `_update_response_state`.
- Add a regression test for each provider: an intermediate cumulative chunk reports `reasoning_tokens` and cached tokens; later chunks drop them; the test asserts both survive. Each is red on `main` and green with the fix.

## Notes

The regression tests demonstrate the data loss with synthetic cumulative chunks — mirroring #5886's own tests (a later chunk with `cached=None`) rather than a live recording, since the field-drop is a defensive branch a recorded stream doesn't reliably produce. The fix is the same shape #5886 applied to `GoogleModel`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

