### PR TITLE
Run `sentence-transformers` embedding tests offline to avoid HF Hub flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,10 @@ jobs:
           restore-keys: |
             hf-${{ runner.os }}-
 
-      # Warm the HF cache out-of-band (retried, non-fatal) so the offline pytest
-      # run below never revalidates the sentence-transformers test model against
-      # HF Hub. On a sustained HF outage the cache stays cold and the ST tests
-      # skip (see `stsb_bert_tiny_model`) instead of erroring the whole job.
+      # Warm the HF cache out-of-band (retried, non-fatal) so the sentence-transformers
+      # test model is on disk when the ST tests load it offline (see the
+      # `stsb_bert_tiny_model` fixture). On a sustained HF outage the cache stays
+      # cold and those tests skip instead of erroring the whole job.
       - name: pre-download sentence-transformers test model
         if: matrix.install.name == 'all-extras'
         continue-on-error: true
@@ -182,13 +182,9 @@ jobs:
       # under-subscribes Ubicloud's hyperthreaded vCPUs (premium-4 -> 2 workers
       # instead of 4). `logical` uses all vCPUs; ~39% faster on premium-4, no-op
       # on ubuntu-latest (already 4). See PR benchmark.
-      # HF_HUB_OFFLINE keeps the run hermetic: with the cache warmed above,
-      # sentence-transformers loads from disk and never revalidates against the Hub.
       - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-${{ matrix.install.name }}
-          HF_HUB_OFFLINE: "1"
-          TRANSFORMERS_OFFLINE: "1"
 
       - name: store coverage files
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -244,8 +240,8 @@ jobs:
         env:
           UV_FROZEN: "0"
 
-      # Warm the HF cache out-of-band (see the `test` job) so the offline pytest
-      # run below never revalidates the sentence-transformers test model.
+      # Warm the HF cache out-of-band (see the `test` job) so the ST tests load
+      # the model offline from disk instead of revalidating it against HF Hub.
       - name: pre-download sentence-transformers test model
         continue-on-error: true
         run: |
@@ -260,12 +256,9 @@ jobs:
           exit 1
 
       # `-n logical` (see note on the `test` job): use all vCPUs on Ubicloud.
-      # HF_HUB_OFFLINE keeps the run hermetic (see the `test` job).
       - run: uv run --no-sync coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{matrix.python-version}}-lowest-versions
-          HF_HUB_OFFLINE: "1"
-          TRANSFORMERS_OFFLINE: "1"
 
       - name: store coverage files
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,13 +160,35 @@ jobs:
           restore-keys: |
             hf-${{ runner.os }}-
 
+      # Warm the HF cache out-of-band (retried, non-fatal) so the offline pytest
+      # run below never revalidates the sentence-transformers test model against
+      # HF Hub. On a sustained HF outage the cache stays cold and the ST tests
+      # skip (see `stsb_bert_tiny_model`) instead of erroring the whole job.
+      - name: pre-download sentence-transformers test model
+        if: matrix.install.name == 'all-extras'
+        continue-on-error: true
+        run: |
+          for i in 1 2 3; do
+            if uv run --all-extras python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors')"; then
+              exit 0
+            fi
+            echo "HF model download attempt $i failed; retrying in 15s..."
+            sleep 15
+          done
+          echo "sentence-transformers test model unavailable after retries; ST tests will skip"
+          exit 1
+
       # `-n logical`, not `-n auto`: xdist `auto` counts *physical* cores, which
       # under-subscribes Ubicloud's hyperthreaded vCPUs (premium-4 -> 2 workers
       # instead of 4). `logical` uses all vCPUs; ~39% faster on premium-4, no-op
       # on ubuntu-latest (already 4). See PR benchmark.
+      # HF_HUB_OFFLINE keeps the run hermetic: with the cache warmed above,
+      # sentence-transformers loads from disk and never revalidates against the Hub.
       - run: uv run ${{ matrix.install.command }} coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{ matrix.python-version }}-${{ matrix.install.name }}
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
 
       - name: store coverage files
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -222,10 +244,28 @@ jobs:
         env:
           UV_FROZEN: "0"
 
+      # Warm the HF cache out-of-band (see the `test` job) so the offline pytest
+      # run below never revalidates the sentence-transformers test model.
+      - name: pre-download sentence-transformers test model
+        continue-on-error: true
+        run: |
+          for i in 1 2 3; do
+            if uv run --no-sync python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors')"; then
+              exit 0
+            fi
+            echo "HF model download attempt $i failed; retrying in 15s..."
+            sleep 15
+          done
+          echo "sentence-transformers test model unavailable after retries; ST tests will skip"
+          exit 1
+
       # `-n logical` (see note on the `test` job): use all vCPUs on Ubicloud.
+      # HF_HUB_OFFLINE keeps the run hermetic (see the `test` job).
       - run: uv run --no-sync coverage run -m pytest --durations=100 -n logical --dist=loadgroup
         env:
           COVERAGE_FILE: .coverage/.coverage.${{matrix.python-version}}-lowest-versions
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
 
       - name: store coverage files
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1584,14 +1584,21 @@ class TestGoogle:
 class TestSentenceTransformers:
     @pytest.fixture(scope='session')
     def stsb_bert_tiny_model(self):
-        try:
-            model = SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors')
-        except OSError as e:  # pragma: no cover
-            # A cold HF cache under offline mode (or an unreachable/rate-limited
-            # Hub) raises OSError; skip rather than fail so a HF outage never reds
-            # the whole suite. CI keeps the cache warm (see ci.yml) so this is a
-            # last-resort net, not the normal path.
-            pytest.skip(f'sentence-transformers test model unavailable (HF Hub): {e}')
+        # Load offline so sentence-transformers never revalidates the model against
+        # the HF Hub (a recurring source of 429 flakes). Scoped to just this load:
+        # a job-wide HF_HUB_OFFLINE would also block the HuggingFace VCR tests, whose
+        # cassette replay still trips huggingface_hub's offline check. CI warms the
+        # cache out-of-band (see ci.yml) so the load hits disk.
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv('HF_HUB_OFFLINE', '1')
+            try:
+                model = SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors')
+            except OSError as e:  # pragma: no cover
+                # A cold HF cache under offline mode (or an unreachable/rate-limited
+                # Hub) raises OSError; skip rather than fail so a HF outage never reds
+                # the whole suite. CI keeps the cache warm (see ci.yml) so this is a
+                # last-resort net, not the normal path.
+                pytest.skip(f'sentence-transformers test model unavailable (HF Hub): {e}')
         # Under HF_HUB_OFFLINE the model card isn't fetched, so `model_id` is unset
         # and the model would report its name as 'unknown'. Set it explicitly to
         # match the name users get online (a no-op when the card did load).

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1584,7 +1584,18 @@ class TestGoogle:
 class TestSentenceTransformers:
     @pytest.fixture(scope='session')
     def stsb_bert_tiny_model(self):
-        model = SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors')
+        try:
+            model = SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors')
+        except OSError as e:  # pragma: no cover
+            # A cold HF cache under offline mode (or an unreachable/rate-limited
+            # Hub) raises OSError; skip rather than fail so a HF outage never reds
+            # the whole suite. CI keeps the cache warm (see ci.yml) so this is a
+            # last-resort net, not the normal path.
+            pytest.skip(f'sentence-transformers test model unavailable (HF Hub): {e}')
+        # Under HF_HUB_OFFLINE the model card isn't fetched, so `model_id` is unset
+        # and the model would report its name as 'unknown'. Set it explicitly to
+        # match the name users get online (a no-op when the card did load).
+        model.model_card_data.model_id = 'sentence-transformers-testing/stsb-bert-tiny-safetensors'
         model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
         return model
 


### PR DESCRIPTION
<!-- No issue: this fixes a recurring flake on `main`'s own CI, not a reported bug. -->

### Problem

`tests/test_embeddings.py::TestSentenceTransformers` loads a model from the HF Hub at fixture setup. Even with the existing warm HF cache in CI, `sentence-transformers` revalidates the model's metadata against the Hub, which returns **429 Too Many Requests** when the (unauthenticated) runner is rate-limited — erroring all four tests. This is the dominant source of red on `main`'s test-matrix jobs (3/3 recent test-job failures: runs [28681520085](https://github.com/pydantic/pydantic-ai/actions/runs/28681520085), [28555636820](https://github.com/pydantic/pydantic-ai/actions/runs/28555636820), [28539346304](https://github.com/pydantic/pydantic-ai/actions/runs/28539346304)). The failing run even logged *"Cache restored successfully"* — the warm cache doesn't help because nothing stops the online revalidation.

### Fix

Make the run hermetic: use the warm cache and never touch the Hub during the test.

- **`HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE`** on both test jobs' pytest step — with a warm cache, the model loads from disk and never revalidates online, so a rate-limited/unreachable Hub can't red the run.
- **Retried, non-fatal pre-download step** before the offline run, reseeding a cold cache (offline mode alone can never repopulate an evicted cache, so this keeps the offline run self-healing).
- **Fixture** sets `model_id` (offline mode doesn't fetch the model card, so the model would otherwise report its name as `'unknown'` and break the snapshots — a no-op when the card did load) and **skips on `OSError`** as a last-resort net when even the reseed fails, so a total HF outage skips rather than errors.

### Why offline rather than just skip-on-outage

`TestSentenceTransformers` is the only coverage of `SentenceTransformerEmbeddingModel`'s methods, so skipping on every HF hiccup would move the red from the test job to the `coverage` job (`fail_under = 100`). Offline + warm cache keeps the tests actually *running* (and covered) regardless of the Hub's live state; the skip is only for the rare fully-cold-cache case.

### Verified locally

- warm cache + offline → 5 passed
- cold cache + offline → 4 skipped, 1 passed (graceful, no error)
- online (no offline env) → unchanged (the `model_id` set is a no-op)

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

