### PR TITLE
fix(ag-ui): preserve ToolReturnPart outcome on message round-trip

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -452,11 +452,15 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             )
                         )
                     else:
+                        outcome: Literal['success', 'failed', 'denied'] = (
+                            'failed' if tool_msg.error is not None else 'success'
+                        )
                         builder.add(
                             ToolReturnPart(
                                 tool_name=tool_name,
                                 content=tool_msg.content,
                                 tool_call_id=tool_call_id,
+                                outcome=outcome,
                             )
                         )
 
@@ -581,11 +585,13 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             if converted is not None:
                                 user_content.append(converted)
             elif isinstance(part, ToolReturnPart):
+                tool_error = part.model_response_str() if part.outcome in ('failed', 'denied') else None
                 result.append(
                     ToolMessage(
                         id=_new_message_id(),
                         content=part.model_response_str(),
                         tool_call_id=part.tool_call_id,
+                        error=tool_error,
                     )
                 )
             elif isinstance(part, RetryPromptPart):

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1580,6 +1580,62 @@ def test_dump_load_roundtrip_thinking() -> None:
     assert reloaded == original
 
 
+def test_dump_load_roundtrip_tool_return_failed_outcome() -> None:
+    """Failed tool returns should preserve outcome via ToolMessage.error."""
+    original: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Call tool')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='my_tool', tool_call_id='call_abc', args='{}')]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='my_tool',
+                    tool_call_id='call_abc',
+                    content='execution failed',
+                    outcome='failed',
+                )
+            ]
+        ),
+        ModelResponse(parts=[TextPart(content='Done')]),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+    dumped_tool_msg = next(msg for msg in ag_ui_msgs if isinstance(msg, ToolMessage))
+    assert dumped_tool_msg.error == 'execution failed'
+
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    _sync_timestamps(original, reloaded)
+
+    assert reloaded == original
+
+
+def test_dump_load_roundtrip_tool_return_denied_outcome() -> None:
+    """Denied tool returns should round-trip with a failed outcome (AG-UI has no denied discriminator)."""
+    original: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Call tool')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='my_tool', tool_call_id='call_abc', args='{}')]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='my_tool',
+                    tool_call_id='call_abc',
+                    content='denied by user',
+                    outcome='denied',
+                )
+            ]
+        ),
+        ModelResponse(parts=[TextPart(content='Done')]),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+    dumped_tool_msg = next(msg for msg in ag_ui_msgs if isinstance(msg, ToolMessage))
+    assert dumped_tool_msg.error == 'denied by user'
+
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    return_part = reloaded[2].parts[0]
+    assert isinstance(return_part, ToolReturnPart)
+    assert return_part.outcome == 'failed'
+
+
 def test_dump_load_roundtrip_tools() -> None:
     """Test full round-trip for tool calls and returns."""
     original: list[ModelMessage] = [
@@ -1828,6 +1884,7 @@ def test_dump_load_roundtrip_retry_prompt_with_tool() -> None:
     assert isinstance(retry_part, ToolReturnPart)
     assert retry_part.tool_name == 'my_tool'
     assert retry_part.tool_call_id == 'call_1'
+    assert retry_part.outcome == 'failed'
 
 
 def test_dump_load_roundtrip_retry_prompt_without_tool() -> None:


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

- Closes #5870

### Summary

The AG-UI adapter now encodes failed/denied `ToolReturnPart` outcomes in `ToolMessage.error` during `dump_messages`, and restores `outcome='failed'` on `load_messages` when `error` is set. This prevents tool failures from silently reloading as successful returns in AG-UI message history.

### Motivation

AG-UI clients that round-trip message history (frontend state, persisted runs, multi-turn resumption) were losing tool failure state. The Vercel AI adapter already preserves outcome; AG-UI was the outlier.

### Changes

- `_dump_request_parts`: set `ToolMessage.error` when `ToolReturnPart.outcome` is `failed` or `denied`
- `load_messages`: set `ToolReturnPart.outcome='failed'` when `ToolMessage.error` is not `None`
- Regression tests for failed round-trip, denied dump/reload semantics, and retry-prompt reload

### Tests

```bash
uv run pytest tests/test_ag_ui.py::test_dump_load_roundtrip_tool_return_failed_outcome \
                 tests/test_ag_ui.py::test_dump_load_roundtrip_tool_return_denied_outcome \
                 tests/test_ag_ui.py::test_dump_load_roundtrip_retry_prompt_with_tool \
                 tests/test_ag_ui.py::test_dump_load_roundtrip_tools -q
# 4 passed

uv run ruff check pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py
uv run ruff format --check pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py
# all passed
```

### Notes

- AG-UI `ToolMessage` has no denied discriminator, so `outcome='denied'` reloads as `failed` (documented in test). This still fixes the critical success-default bug.
- `NativeToolReturnPart` outcome handling is unchanged and out of scope for #5870.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

