### PR TITLE
fix(ag-ui): preserve ToolReturnPart.outcome on dump/load round-trip

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -475,7 +475,10 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     # slot, so client-built ToolMessages usually carry no `encrypted_value`. Error
                     # results stay untyped — typed return parts imply success to their readers.
                     tool_kind = None
-                    if tool_msg.error is None:
+                    outcome: Literal['success', 'failed', 'denied'] = 'success'
+                    if tool_msg.error is not None:
+                        outcome = 'failed'
+                    elif use_encrypted_value:
                         encrypted_tool_kind = (
                             parse_encrypted_tool_kind(tool_msg.encrypted_value) if use_encrypted_value else None
                         )
@@ -491,6 +494,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 tool_call_id=original_id,
                                 provider_name=provider_name,
                                 tool_kind=tool_kind,
+                                outcome=outcome,
                             )
                         )
                     else:
@@ -503,6 +507,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 content=content,
                                 tool_call_id=tool_call_id,
                                 tool_kind=tool_kind,
+                                outcome=outcome,
                             )
                         )
 
@@ -658,12 +663,16 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
             elif isinstance(part, ToolReturnPart):
                 flush_user_content()
                 # Tool-return files ride inline in `ToolMessage.content` (see `dump_tool_return_content`).
+                is_error_return = part.outcome in ('failed', 'denied')
                 result.append(
                     ToolMessage(
                         id=_new_message_id(),
                         content=dump_tool_return_content(part.content),
                         tool_call_id=part.tool_call_id,
-                        **tool_kind_encrypted_value_kwargs(part.tool_kind, supported=use_encrypted_value),
+                        error=part.model_response_str() if is_error_return else None,
+                        **tool_kind_encrypted_value_kwargs(
+                            part.tool_kind if not is_error_return else None, supported=use_encrypted_value
+                        ),
                     )
                 )
             elif isinstance(part, RetryPromptPart):
@@ -766,12 +775,17 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                 )
                 if builtin_return := builtin_returns.get(part.tool_call_id):
                     # Built-in tool-return files also ride inline in `ToolMessage.content` (see above).
+                    is_error_return = builtin_return.outcome in ('failed', 'denied')
                     tool_messages.append(
                         ToolMessage(
                             id=_new_message_id(),
                             content=dump_tool_return_content(builtin_return.content),
                             tool_call_id=prefixed_id,
-                            **tool_kind_encrypted_value_kwargs(builtin_return.tool_kind, supported=use_encrypted_value),
+                            error=builtin_return.model_response_str() if is_error_return else None,
+                            **tool_kind_encrypted_value_kwargs(
+                                builtin_return.tool_kind if not is_error_return else None,
+                                supported=use_encrypted_value,
+                            ),
                         )
                     )
             elif isinstance(part, NativeToolReturnPart):
@@ -830,7 +844,8 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
         - `tool_kind` is lost when `ag_ui_version < '0.1.11'` (before its `encrypted_value` carrier
           existed), so typed tool parts reload as their base classes.
         - `tool_kind` is not restored on error/denied tool returns (a typed return implies
-          success to its readers), so those reload as plain `ToolReturnPart`.
+          success to its readers), so those reload as plain `ToolReturnPart` with
+          `outcome='failed'` when `ToolMessage.error` is set.
         - `RetryPromptPart` becomes `ToolReturnPart` (or `UserPromptPart`) on reload.
         - `CachePoint` and `UploadedFile` content items are dropped (unless `preserve_file_data=True`).
         - `ThinkingPart` is dropped when `ag_ui_version='0.1.10'`.

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1782,7 +1782,81 @@ def test_load_tool_kind_error_result_stays_plain() -> None:
     )
 
     assert type(loaded[1].parts[0]) is ToolReturnPart
+    assert loaded[1].parts[0].outcome == 'failed'
     assert parse_loaded_capabilities(loaded) == set()
+
+
+def test_dump_tool_return_failed_sets_tool_message_error() -> None:
+    """Failed `ToolReturnPart`s encode their error state in `ToolMessage.error` on dump."""
+    req = ModelRequest(
+        parts=[ToolReturnPart(tool_name='foo', content='err', tool_call_id='call-1', outcome='failed')]
+    )
+    dumped = AGUIAdapter._dump_request_parts(req)
+    assert dumped[0].error == 'err'
+
+
+def test_load_tool_message_error_sets_outcome_failed() -> None:
+    """`ToolMessage.error` reloads as `ToolReturnPart(outcome='failed')`, not success."""
+    am = AssistantMessage(
+        id='a1',
+        tool_calls=[
+            ToolCall(id='call-1', type='function', function=FunctionCall(name='foo', arguments='{}'))
+        ],
+    )
+    tm = ToolMessage(id='m1', content='err', tool_call_id='call-1', error='err')
+    loaded = AGUIAdapter.load_messages([am, tm])
+    assert loaded[-1].parts[-1].outcome == 'failed'
+
+
+def test_dump_load_roundtrip_failed_tool_return() -> None:
+    """`ToolReturnPart.outcome='failed'` survives dump -> load."""
+    original: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Call tool')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='my_tool', tool_call_id='call_abc', args='{}')]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='my_tool',
+                    tool_call_id='call_abc',
+                    content='Something went wrong',
+                    outcome='failed',
+                )
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    _sync_timestamps(original, reloaded)
+
+    tool_return = reloaded[2].parts[0]
+    assert isinstance(tool_return, ToolReturnPart)
+    assert tool_return.outcome == 'failed'
+    assert tool_return.content == 'Something went wrong'
+
+
+def test_dump_load_roundtrip_retry_prompt_with_tool_preserves_failed_outcome() -> None:
+    """`RetryPromptPart` round-trips through `ToolMessage.error` with `outcome='failed'`."""
+    original: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content='Call tool')]),
+        ModelResponse(parts=[ToolCallPart(tool_name='my_tool', tool_call_id='call_1', args='{}')]),
+        ModelRequest(
+            parts=[
+                RetryPromptPart(
+                    tool_name='my_tool',
+                    tool_call_id='call_1',
+                    content='Invalid args',
+                )
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+
+    retry_part = reloaded[2].parts[0]
+    assert isinstance(retry_part, ToolReturnPart)
+    assert retry_part.outcome == 'failed'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Preserve failed tool return state across AG-UI `dump_messages` → `load_messages` round-trips by encoding non-success `ToolReturnPart` outcomes in `ToolMessage.error` and restoring `outcome='failed'` on reload.

## Motivation

Fixes #5870. When a Pydantic AI agent run produced a failed or denied tool return, `ToolReturnPart.outcome` was silently dropped during AG-UI history serialization. After reload, the model saw the tool return as successful and could not adapt to the failure.

The Vercel AI adapter already handles this correctly via `ToolOutputErrorPart` / `ToolOutputDeniedPart`; AG-UI has the `ToolMessage.error` field available but the adapter was not using it symmetrically.

## Changes

- **Load** (`load_messages`): when `ToolMessage.error` is set, construct `ToolReturnPart` / `NativeToolReturnPart` with `outcome='failed'` and no `tool_kind`
- **Dump request** (`_dump_request_parts`): for `ToolReturnPart` with `outcome in ('failed', 'denied')`, set `ToolMessage.error` and omit `tool_kind`
- **Dump response** (`_dump_response_parts`): same for paired builtin `NativeToolReturnPart` values
- Update `dump_messages` docstring to document the intentional lossiness
- Add regression tests for dump, load, full round-trip, and `RetryPromptPart` paths

## Tests

- `uv run pytest tests/test_ag_ui.py -q` — 176 passed
- `uv run ruff check pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py` — clean

## Notes

- AG-UI `ToolMessage` has no separate denied carrier (unlike Vercel AI's `ToolOutputDeniedPart`), so `outcome='denied'` round-trips as `outcome='failed'` via `error`. This is still correct vs the previous silent `success` reload.
- Reviewed with composer-2.5 — APPROVE.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

