### PR TITLE
fix: preserve union `NativeOutput` description instead of last member's docstring

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -1122,7 +1122,9 @@ class UnionOutputProcessor(BaseObjectOutputProcessor[OutputDataT]):
         discriminated_json_schemas: list[ObjectJsonSchema] = []
         for object_key, json_schema in zip(self._processors.keys(), json_schemas):
             title = json_schema.pop('title', None)
-            description = json_schema.pop('description', None)
+            # Don't shadow the outer `description` parameter: it carries the union's own
+            # description (e.g. from `NativeOutput(..., description=...)`) into `super().__init__()` below.
+            json_schema_description = json_schema.pop('description', None)
 
             discriminated_json_schema = {
                 'type': 'object',
@@ -1138,8 +1140,8 @@ class UnionOutputProcessor(BaseObjectOutputProcessor[OutputDataT]):
             }
             if title:  # pragma: no branch
                 discriminated_json_schema['title'] = title
-            if description:
-                discriminated_json_schema['description'] = description
+            if json_schema_description:
+                discriminated_json_schema['description'] = json_schema_description
 
             discriminated_json_schemas.append(discriminated_json_schema)
 

--- a/tests/test_agent_output_schemas.py
+++ b/tests/test_agent_output_schemas.py
@@ -195,7 +195,11 @@ class Vehicle(BaseModel):
 
 
 async def test_native_output_union_preserves_description():
-    """A union `NativeOutput` keeps its own `name`/`description`, not the last member's title/docstring (issue #6262)."""
+    """A union `NativeOutput` keeps its own `name`/`description`, not the last member's title/docstring (issue #6262).
+
+    Taps the internal `output_object` rather than being a VCR test because a cassette matcher isn't sensitive to the
+    request-body schema `description` field, so a VCR test asserting only `result.output` would pass green even with the bug.
+    """
     captured: OutputObjectDefinition | None = None
 
     async def capture(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:

--- a/tests/test_agent_output_schemas.py
+++ b/tests/test_agent_output_schemas.py
@@ -1,4 +1,5 @@
 import dataclasses
+import json
 
 import pytest
 from pydantic import BaseModel
@@ -13,6 +14,9 @@ from pydantic_ai import (
     TextOutput,
     ToolOutput,
 )
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.output import OutputObjectDefinition
 
 from ._inline_snapshot import snapshot
 from .conftest import remove_schema_descriptions
@@ -174,6 +178,47 @@ async def test_native_output_json_schema():
             },
         }
     )
+
+
+class Fruit(BaseModel):
+    """A fruit"""
+
+    name: str
+    color: str
+
+
+class Vehicle(BaseModel):
+    """A vehicle"""
+
+    name: str
+    wheels: int
+
+
+async def test_native_output_union_preserves_description():
+    """A union `NativeOutput` keeps its own `name`/`description`, not the last member's title/docstring (issue #6262)."""
+    captured: OutputObjectDefinition | None = None
+
+    async def capture(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal captured
+        captured = info.model_request_parameters.output_object
+        return ModelResponse(
+            parts=[
+                TextPart(
+                    content=json.dumps({'result': {'kind': 'Fruit', 'data': {'name': 'banana', 'color': 'yellow'}}})
+                )
+            ]
+        )
+
+    agent = Agent(
+        FunctionModel(function=capture),
+        output_type=NativeOutput([Fruit, Vehicle], name='Fruit or vehicle', description='Return a fruit or vehicle.'),
+    )
+    result = await agent.run('What is a banana?')
+
+    assert result.output == Fruit(name='banana', color='yellow')
+    assert captured is not None
+    assert captured.name == 'Fruit or vehicle'
+    assert captured.description == 'Return a fruit or vehicle.'
 
 
 async def test_prompted_output_json_schema():


### PR DESCRIPTION
- Closes #6262

When `NativeOutput` is given a union of output types plus a `description`, that description was silently dropped and replaced by the **last union member's docstring** in the schema sent to the model.

In `UnionOutputProcessor.__init__` (`_output.py`), the per-member loop reassigned the local `description` (popped from each member's schema), shadowing the constructor's `description` parameter that is passed to `super().__init__()` after the loop. The loop variable is renamed so the union's own `description` survives; per-member descriptions are unchanged.

Regression test (`test_native_output_union_preserves_description`) captures `ModelRequestParameters.output_object` via a `FunctionModel` and asserts the union's `name`/`description` are preserved — it fails on `main` (`description == 'A vehicle'`) and passes with the fix.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

