### PR TITLE
fix(evals): reject non-positive `OnlineEvaluator.max_concurrency`

### DIFF
--- a/pydantic_evals/pydantic_evals/online.py
+++ b/pydantic_evals/pydantic_evals/online.py
@@ -259,6 +259,8 @@ class OnlineEvaluator:
     """
 
     def __post_init__(self) -> None:
+        if self.max_concurrency < 1:
+            raise ValueError(f'max_concurrency must be >= 1, got {self.max_concurrency}')
         self.semaphore = threading.Semaphore(self.max_concurrency)
 
 

--- a/tests/evals/test_online.py
+++ b/tests/evals/test_online.py
@@ -234,6 +234,13 @@ async def test_online_evaluator_custom_config():
     assert online.max_concurrency == 5
 
 
+@pytest.mark.parametrize('max_concurrency', [0, -1])
+def test_online_evaluator_invalid_max_concurrency(max_concurrency: int):
+    """OnlineEvaluator rejects non-positive concurrency limits."""
+    with pytest.raises(ValueError, match=f'max_concurrency must be >= 1, got {max_concurrency}'):
+        OnlineEvaluator(evaluator=AlwaysTrue(), max_concurrency=max_concurrency)
+
+
 @pytest.mark.anyio
 async def test_run_evaluators_success():
     """run_evaluators returns results from all evaluators."""


### PR DESCRIPTION
﻿<!-- Thank you for contributing to Pydantic AI! -->



<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->



<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->

<!-- and assigned to you. Unassigned PRs may be auto-closed. -->

<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->



<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->

<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->



- Closes #6266



This rejects invalid non-positive `OnlineEvaluator.max_concurrency` values before they create a semaphore that cannot run evaluations.



## What Problem This Solves



`OnlineEvaluator.max_concurrency` is a user-facing configuration value for bounding how many online evaluations may run at the same time. A positive value has a clear meaning: `1` allows one in-flight evaluation, `2` allows two, and so on. `0`, however, does not provide a useful concurrency budget for this API.



Today, `OnlineEvaluator.__post_init__` passes the value directly into `threading.Semaphore(self.max_concurrency)`. That creates two different failure modes for the same class of invalid input:



- `max_concurrency=-1` fails immediately with Python's low-level `ValueError: semaphore initial value must be >= 0`.

- `max_concurrency=0` is accepted because `threading.Semaphore(0)` is valid, but it starts with zero available permits.



The second case is the confusing one. Once the evaluator is attached, the online evaluation dispatch path checks capacity with:



```python

online_eval.semaphore.acquire(blocking=False)

```



For a zero-permit semaphore, that call always returns `False`. As a result, every sampled evaluation for that `OnlineEvaluator` is treated as if the evaluator is already at its concurrency limit. The run does not fail at configuration time; it simply follows the documented ?limit reached? path.



That makes the bug easy to miss in real usage. If an `on_max_concurrency` callback is configured, users may see every evaluation reported as dropped even though there is no real concurrency pressure. If no callback is configured, those evaluations are silently ignored, which can make online evaluation appear to be installed while producing no results.



This is different from intentionally disabling evaluation. The API already has an explicit sampling control for that: `sample_rate=0.0`. By contrast, `max_concurrency` should describe the positive number of evaluations that may run concurrently after an evaluation has been sampled.



This change also aligns `OnlineEvaluator` with the existing validation in `Dataset.evaluate(..., max_concurrency<=0)`, which already rejects non-positive concurrency limits before constructing a semaphore.



## Change

This change adds explicit validation for `OnlineEvaluator.max_concurrency` inside `OnlineEvaluator.__post_init__`, before the class creates its internal `threading.Semaphore`.

That placement is intentional. `__post_init__` is the point where the dataclass turns user-supplied configuration into runtime state, so it is the narrowest place to reject invalid concurrency settings before they become background-dispatch behavior. A positive value still means the same thing as before: the number of online evaluations that may run at the same time. Values below `1` now fail fast because they do not represent a useful concurrency limit for this API.

The new guard is intentionally small:

```python
if self.max_concurrency < 1:
    raise ValueError(f'max_concurrency must be >= 1, got {self.max_concurrency}')
```

This gives the two invalid boundaries the same user-facing treatment:

- `max_concurrency=0` now raises immediately instead of creating a zero-permit semaphore. Without the guard, every later `acquire(blocking=False)` call fails and every sampled online evaluation looks like it hit a real concurrency limit.
- `max_concurrency=-1` now raises the same `OnlineEvaluator` validation error instead of leaking Python's lower-level `threading.Semaphore` validation message.

Positive concurrency limits are unchanged. The default `10`, the single-worker case `1`, and higher limits still create the same semaphore-backed limiter. The existing `on_max_concurrency` path is still used when a valid positive limit is reached by real concurrent demand.

The test update covers both invalid inputs, `0` and `-1`, so the API now has one consistent rule: `OnlineEvaluator.max_concurrency` must be a positive integer, while intentional disabling remains represented by the existing sampling control such as `sample_rate=0.0`.
## Evidence



Before this change, the underlying semaphore behavior is:



```text

threading.Semaphore(0) constructed=True first_acquire=False

threading.Semaphore(-1) error=ValueError: semaphore initial value must be >= 0

threading.Semaphore(1) constructed=True first_acquire=True

```



That means `max_concurrency=0` is accepted at construction time but can never acquire a permit in the online evaluation dispatch path.



After this change, `OnlineEvaluator(..., max_concurrency=0)` and `OnlineEvaluator(..., max_concurrency=-1)` fail eagerly with:



```text

ValueError: max_concurrency must be >= 1, got <value>

```



## Possible call chain / impact



```text

OnlineEvaluator(max_concurrency=0)

  -> OnlineEvaluator.__post_init__()

  -> threading.Semaphore(0)

  -> online evaluation dispatch

  -> online_eval.semaphore.acquire(blocking=False)

  -> False every time

  -> on_max_concurrency callback or silent drop

```



This PR only changes invalid `OnlineEvaluator` configuration. It does not change sampling, sink emission, `on_max_concurrency` behavior for real concurrency pressure, or positive concurrency limits.



## Validation



- `uv run --project D:\ZXY\Github\pydantic-ai\pydantic_evals pytest D:\ZXY\Github\pydantic-ai\tests\evals\test_online.py -k "online_evaluator_invalid_max_concurrency or online_evaluator_custom_config or max_concurrency_respected"` - passed, 4 tests

- `git diff --check` - passed



### Checklist



- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.

- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).

- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).






<!-- This is an auto-generated description by cubic. -->

<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



