### PR TITLE
docs: fix `agent_docs` topic guide links

### DIFF
--- a/agent_docs/index.md
+++ b/agent_docs/index.md
@@ -127,8 +127,8 @@
 
 Check these when working in specific areas:
 
-- **[Code Simplification & Idioms](agent_docs/code-simplification.md)**: When refactoring code for clarity or looking to simplify complex patterns
-- **[Documentation](agent_docs/documentation.md)**: When writing or updating documentation, comments, or docstrings
-- **[API Design & Interfaces](agent_docs/api-design.md)**: When designing or modifying public APIs, parameters, or class interfaces
-- **[Pydantic AI Slim Architecture](agent_docs/pydantic-ai-slim.md)**: When changing agents, tools, output, message history, providers, profiles, capabilities, toolsets, UI adapters, or durable execution
+- **[Code Simplification & Idioms](code-simplification.md)**: When refactoring code for clarity or looking to simplify complex patterns
+- **[Documentation](documentation.md)**: When writing or updating documentation, comments, or docstrings
+- **[API Design & Interfaces](api-design.md)**: When designing or modifying public APIs, parameters, or class interfaces
+- **[Pydantic AI Slim Architecture](pydantic-ai-slim.md)**: When changing agents, tools, output, message history, providers, profiles, capabilities, toolsets, UI adapters, or durable execution
 <!-- /braindump -->


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

Fix four topic-guide links in `agent_docs/index.md` so they resolve relative to the `agent_docs` directory.

This is a trivial broken-link documentation fix and does not close an issue.

### Checklist

- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

### Validation

- `git diff --check`
- Targeted local Markdown link check for `agent_docs/index.md`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

