### PR TITLE
docs: add pydantic-ai-perseus-vault to third-party toolsets (memory)

### DIFF
--- a/docs/toolsets.md
+++ b/docs/toolsets.md
@@ -898,6 +898,12 @@ Toolsets for task planning and progress tracking help agents organize complex wo
 
 * [`pydantic-ai-todo`](https://github.com/vstorm-co/pydantic-ai-todo) - `TodoToolset` with `read_todos` and `write_todos` tools. Included in the third-party [`pydantic-deep`](https://github.com/vstorm-co/pydantic-deepagents) [deep agent](multi-agent-applications.md#deep-agents) framework.
 
+### Memory
+
+Toolsets that give agents durable, cross-run memory:
+
+* [`pydantic-ai-perseus-vault`](https://pypi.org/project/pydantic-ai-perseus-vault/) - `PerseusVaultToolset` subclasses [`MCPToolset`][pydantic_ai.mcp.MCPToolset] to give an agent persistent, local-first memory backed by [Perseus Vault](https://github.com/Perseus-Computing-LLC/perseus-vault) (a single-binary MCP memory server). Exposes `perseus_vault_remember`/`perseus_vault_recall` and related tools with full-text + semantic search over a local SQLite database, with optional AES-256-GCM encryption at rest.
+
 ### File Operations
 
 Toolsets for file operations help agents read, write, and edit files:


### PR DESCRIPTION
Adds a "Memory" subsection under **Third-Party Toolsets** in `docs/toolsets.md` listing `pydantic-ai-perseus-vault`.

`PerseusVaultToolset` is an `MCPToolset` subclass that gives a Pydantic AI agent persistent, local-first memory backed by [Perseus Vault](https://github.com/Perseus-Computing-LLC/perseus-vault), a single-binary MCP memory server (SQLite + FTS5 + vector search, optional AES-256-GCM encryption, fully offline). It follows the recommended `pydantic-ai-<name>` self-published package convention and depends on `pydantic-ai-slim[mcp]`.

- Package: https://pypi.org/project/pydantic-ai-perseus-vault/ (v0.1.0)
- Docs entry follows the existing one-line bullet format used by the other third-party toolset entries.

This is a docs-only, single-entry addition.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

