### PR TITLE
Add `message` and `message_part` test helpers to collapse history-narrowing ladders

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,8 @@ from pydantic_ai.models import DEFAULT_HTTP_TIMEOUT, Model
 
 from ._inline_snapshot import Builder, Custom, customize
 
+T = TypeVar('T')
+
 __all__ = (
     'IsDatetime',
     'IsFloat',
@@ -61,6 +63,8 @@ __all__ = (
     'SNAPSHOT_BYTES_COLLAPSE_THRESHOLD',
     'strip_logfire_metrics',
     'remove_schema_descriptions',
+    'message',
+    'message_part',
 )
 
 # Configure VCR logger to WARNING as it is too verbose by default
@@ -79,8 +83,6 @@ if TYPE_CHECKING:
 
     from pydantic_ai.providers.bedrock import BedrockProvider
     from pydantic_ai.providers.xai import XaiProvider
-
-    T = TypeVar('T')
 
     def IsInstance(arg: type[T]) -> T: ...
     def IsDatetime(*args: Any, **kwargs: Any) -> datetime: ...
@@ -1066,6 +1068,23 @@ def iter_message_parts(
             for part in msg.parts:
                 if isinstance(part, part_type):
                     yield part
+
+
+def message(messages: Sequence[ModelMessage], message_type: type[T], *, index: int = 0) -> T:
+    """Return `messages[index]`, asserting it is an instance of `message_type`."""
+    msg = messages[index]
+    assert isinstance(msg, message_type)
+    return msg
+
+
+def message_part(
+    messages: Sequence[ModelMessage], part_type: type[T], *, message_index: int = 0, part_index: int = 0
+) -> T:
+    """Return `messages[message_index].parts[part_index]`, asserting it is an instance of `part_type`."""
+    msg = messages[message_index]
+    part = msg.parts[part_index]
+    assert isinstance(part, part_type)
+    return part
 
 
 # endregion

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -77,7 +77,7 @@ from pydantic_ai.usage import RequestUsage, UsageLimits
 
 from .._inline_snapshot import snapshot
 from ..cassette_utils import single_request_body
-from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, TestEnv, raise_if_exception, try_import
+from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, TestEnv, message, raise_if_exception, try_import
 from ..parts_from_messages import part_types_from_messages
 from .mock_async_stream import MockAsyncStream
 
@@ -405,8 +405,7 @@ async def test_async_request_prompt_caching(allow_model_requests: None):
             },
         )
     )
-    last_message = result.all_messages()[-1]
-    assert isinstance(last_message, ModelResponse)
+    last_message = message(result.all_messages(), ModelResponse, index=-1)
     assert last_message.cost().total_price == snapshot(Decimal('0.00002688'))
 
 
@@ -3872,8 +3871,7 @@ async def test_anthropic_opus_46_features(
     agent = Agent(m, model_settings=settings_map[case_id])
 
     result = await agent.run('What is 2+2?')
-    response = result.all_messages()[-1]
-    assert isinstance(response, ModelResponse)
+    response = message(result.all_messages(), ModelResponse, index=-1)
     assert response.model_name == 'claude-opus-4-6'
 
     if has_thinking:
@@ -3890,8 +3888,7 @@ async def test_anthropic_opus_47_features(allow_model_requests: None, anthropic_
     agent = Agent(m, model_settings=settings)
 
     result = await agent.run('What is 2+2?')
-    response = result.all_messages()[-1]
-    assert isinstance(response, ModelResponse)
+    response = message(result.all_messages(), ModelResponse, index=-1)
     assert response.model_name == 'claude-opus-4-7'
     request_body = single_request_body(vcr)
     assert {k: request_body[k] for k in ('model', 'thinking', 'output_config')} == snapshot(
@@ -3913,8 +3910,7 @@ async def test_anthropic_opus_48_features(allow_model_requests: None, anthropic_
     agent = Agent(m, model_settings=settings)
 
     result = await agent.run('What is 2+2?')
-    response = result.all_messages()[-1]
-    assert isinstance(response, ModelResponse)
+    response = message(result.all_messages(), ModelResponse, index=-1)
     assert response.model_name == 'claude-opus-4-8'
     request_body = single_request_body(vcr)
     assert {k: request_body[k] for k in ('model', 'thinking', 'output_config')} == snapshot(
@@ -4556,8 +4552,7 @@ async def test_streaming_bedrock_start_event_without_message_is_skipped(allow_mo
     # The skipped `message=None` chunk contributes no usage and no response id: usage comes from the
     # real `message_start` (input) + `message_delta` (output), and the id from the real event. The model
     # name falls back to the configured id because the peeked-first chunk carried no `message.model`.
-    response = result.all_messages()[-1]
-    assert isinstance(response, ModelResponse)
+    response = message(result.all_messages(), ModelResponse, index=-1)
     assert response.usage == snapshot(
         RequestUsage(input_tokens=4, output_tokens=2, details={'input_tokens': 4, 'output_tokens': 2})
     )
@@ -10811,8 +10806,7 @@ async def test_anthropic_container_id_from_stream_response(allow_model_requests:
 
     # Check that container_id was captured in the response
     messages = result.all_messages()
-    model_response = messages[-1]
-    assert isinstance(model_response, ModelResponse)
+    model_response = message(messages, ModelResponse, index=-1)
     assert model_response.provider_details is not None
     assert model_response.provider_details.get('container_id') == 'container_from_stream'
     assert model_response.provider_details.get('finish_reason') == 'end_turn'
@@ -10846,8 +10840,7 @@ async def test_anthropic_code_execution_tool_container_reuse(allow_model_request
     )
 
     first = await agent.run('How much is 3 * 12390?')
-    first_response = first.all_messages()[-1]
-    assert isinstance(first_response, ModelResponse)
+    first_response = message(first.all_messages(), ModelResponse, index=-1)
     assert first_response.provider_details is not None
     container_id = first_response.provider_details.get('container_id')
     assert isinstance(container_id, str) and container_id.startswith('container_')

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -42,7 +42,7 @@ from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RequestUsage
 
 from .._inline_snapshot import snapshot
-from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, raise_if_exception, try_import
+from ..conftest import IsDatetime, IsInstance, IsNow, IsStr, message, raise_if_exception, try_import
 from .mock_async_stream import MockAsyncStream
 
 with try_import() as imports_successful:
@@ -855,8 +855,7 @@ async def test_process_response_no_created_timestamp(allow_model_requests: None)
     agent = Agent(model)
     result = await agent.run('Hello')
     messages = result.all_messages()
-    response_message = messages[1]
-    assert isinstance(response_message, ModelResponse)
+    response_message = message(messages, ModelResponse, index=1)
     assert response_message.timestamp == IsNow(tz=timezone.utc)
 
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -61,7 +61,7 @@ from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage
 
 from .._inline_snapshot import snapshot
-from ..conftest import IsDatetime, IsNow, IsStr, TestEnv, try_import
+from ..conftest import IsDatetime, IsNow, IsStr, TestEnv, message, try_import
 from .mock_openai import (
     MockOpenAI,
     MockOpenAIResponses,
@@ -4257,8 +4257,7 @@ async def test_process_response_no_created_timestamp(allow_model_requests: None)
     agent = Agent(m)
     result = await agent.run('Hello')
     messages = result.all_messages()
-    response_message = messages[1]
-    assert isinstance(response_message, ModelResponse)
+    response_message = message(messages, ModelResponse, index=1)
     assert response_message.timestamp == IsNow(tz=timezone.utc)
 
 
@@ -4273,8 +4272,7 @@ async def test_process_response_no_finish_reason(allow_model_requests: None):
     agent = Agent(m)
     result = await agent.run('Hello')
     messages = result.all_messages()
-    response_message = messages[1]
-    assert isinstance(response_message, ModelResponse)
+    response_message = message(messages, ModelResponse, index=1)
     assert response_message.finish_reason == 'stop'
 
 

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -55,7 +55,7 @@ from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 
 from .._inline_snapshot import snapshot
-from ..conftest import IsDatetime, IsFloat, IsInstance, IsInt, IsNow, IsStr, TestEnv, try_import
+from ..conftest import IsDatetime, IsFloat, IsInstance, IsInt, IsNow, IsStr, TestEnv, message, try_import
 from .mock_openai import MockOpenAIResponses, get_mock_responses_kwargs, response_message
 
 with try_import() as imports_successful:
@@ -2847,8 +2847,7 @@ async def test_openai_previous_response_id_seed_auto_chains_through_retries(
 
     # Turn 1 establishes a stored response we can seed from.
     result1 = await agent.run('Say hi in one word, no punctuation.')
-    last = result1.all_messages()[-1]
-    assert isinstance(last, ModelResponse)
+    last = message(result1.all_messages(), ModelResponse, index=-1)
     seed_response_id = last.provider_response_id
     assert seed_response_id is not None
 
@@ -2995,8 +2994,7 @@ async def test_openai_conversation_id_explicit_and_auto(allow_model_requests: No
         )
 
         assert result.output == snapshot('stored')
-        response = result.all_messages()[-1]
-        assert isinstance(response, ModelResponse)
+        response = message(result.all_messages(), ModelResponse, index=-1)
         assert response.provider_details is not None
         assert response.provider_details['conversation_id'] == conversation_id
 
@@ -3007,8 +3005,7 @@ async def test_openai_conversation_id_explicit_and_auto(allow_model_requests: No
         )
 
         assert result.output == snapshot('CONV-PAI-5222')
-        response = result.all_messages()[-1]
-        assert isinstance(response, ModelResponse)
+        response = message(result.all_messages(), ModelResponse, index=-1)
         assert response.provider_details is not None
         assert response.provider_details['conversation_id'] == conversation_id
 
@@ -3025,8 +3022,7 @@ async def test_openai_conversation_id_auto_respects_pydantic_ai_conversation_id(
             model_settings=OpenAIResponsesModelSettings(openai_conversation_id=conversation_id),
         )
 
-        response = result.all_messages()[-1]
-        assert isinstance(response, ModelResponse)
+        response = message(result.all_messages(), ModelResponse, index=-1)
         assert response.provider_details is not None
         assert response.provider_details['conversation_id'] == conversation_id
         original_pydantic_ai_conversation_id = response.conversation_id
@@ -3040,11 +3036,9 @@ async def test_openai_conversation_id_auto_respects_pydantic_ai_conversation_id(
         )
 
         assert forked.output == snapshot('forked')
-        request = forked.all_messages()[-2]
-        assert isinstance(request, ModelRequest)
+        request = message(forked.all_messages(), ModelRequest, index=-2)
         assert request.conversation_id != original_pydantic_ai_conversation_id
-        response = forked.all_messages()[-1]
-        assert isinstance(response, ModelResponse)
+        response = message(forked.all_messages(), ModelResponse, index=-1)
         assert response.provider_details is not None
         assert 'conversation_id' not in response.provider_details
 
@@ -3079,8 +3073,7 @@ async def test_openai_conversation_id_preserves_mismatched_history(allow_model_r
         )
 
         assert result.output == snapshot('LOCAL-PAI-5222')
-        response = result.all_messages()[-1]
-        assert isinstance(response, ModelResponse)
+        response = message(result.all_messages(), ModelResponse, index=-1)
         assert response.provider_details is not None
         assert response.provider_details['conversation_id'] == conversation_id
 
@@ -3095,8 +3088,7 @@ async def test_openai_conversation_id_auto_without_history(allow_model_requests:
     )
 
     assert result.output == snapshot('no conversation')
-    response = result.all_messages()[-1]
-    assert isinstance(response, ModelResponse)
+    response = message(result.all_messages(), ModelResponse, index=-1)
     assert response.provider_details is not None
     assert 'conversation_id' not in response.provider_details
 
@@ -3119,8 +3111,7 @@ async def test_openai_conversation_id_tool_call_continuation(allow_model_request
         )
 
         assert result.output == snapshot('TOOL-PAI-5222')
-        response = result.all_messages()[-1]
-        assert isinstance(response, ModelResponse)
+        response = message(result.all_messages(), ModelResponse, index=-1)
         assert response.provider_details is not None
         assert response.provider_details['conversation_id'] == conversation_id
 
@@ -3158,8 +3149,7 @@ async def test_openai_conversation_id_streaming_provider_details(allow_model_req
             output = await result.get_output()
 
         assert output == snapshot('streamed')
-        response = result.all_messages()[-1]
-        assert isinstance(response, ModelResponse)
+        response = message(result.all_messages(), ModelResponse, index=-1)
         assert response.provider_details is not None
         assert response.provider_details['conversation_id'] == conversation_id
 
@@ -3913,8 +3903,7 @@ async def test_openai_responses_thinking_with_modified_history(allow_model_reque
         ]
     )
 
-    response = messages[-1]
-    assert isinstance(response, ModelResponse)
+    response = message(messages, ModelResponse, index=-1)
     assert isinstance(response.parts, list)
     response.parts[1] = TextPart(content='The meaning of life is 42')
 
@@ -12028,8 +12017,7 @@ async def test_openai_responses_phase_non_streamed(allow_model_requests: None):
     agent = Agent(model=model)
 
     result = await agent.run('What is the capital of France?')
-    response = result.all_messages()[-1]
-    assert isinstance(response, ModelResponse)
+    response = message(result.all_messages(), ModelResponse, index=-1)
     text_parts = [p for p in response.parts if isinstance(p, TextPart)]
     assert [(p.id, p.content, (p.provider_details or {}).get('phase')) for p in text_parts] == snapshot(
         [
@@ -12121,8 +12109,7 @@ async def test_openai_responses_phase_streamed(allow_model_requests: None):
     async with agent.run_stream('What is the capital of France?') as result:
         await result.get_output()
 
-    response = result.all_messages()[-1]
-    assert isinstance(response, ModelResponse)
+    response = message(result.all_messages(), ModelResponse, index=-1)
     text_parts = [p for p in response.parts if isinstance(p, TextPart)]
     assert len(text_parts) == 1
     assert text_parts[0].provider_details == snapshot({'phase': 'final_answer'})

--- a/tests/models/test_openrouter.py
+++ b/tests/models/test_openrouter.py
@@ -32,7 +32,7 @@ from pydantic_ai.native_tools import WebSearchTool
 
 from .._inline_snapshot import snapshot
 from ..cassette_utils import single_request_body
-from ..conftest import IsDatetime, IsStr, try_import
+from ..conftest import IsDatetime, IsStr, message, try_import
 
 with try_import() as imports_successful:
     from openai.types.chat import ChatCompletion
@@ -534,9 +534,7 @@ async def test_openrouter_usage(allow_model_requests: None, openrouter_api_key: 
         )
     )
 
-    last_message = result.all_messages()[-1]
-
-    assert isinstance(last_message, ModelResponse)
+    last_message = message(result.all_messages(), ModelResponse, index=-1)
     assert last_message.provider_details == snapshot(
         {
             'finish_reason': 'completed',

--- a/tests/models/test_xai.py
+++ b/tests/models/test_xai.py
@@ -74,7 +74,7 @@ from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import RunUsage
 
 from .._inline_snapshot import snapshot
-from ..conftest import IsDatetime, IsNow, IsStr, try_import
+from ..conftest import IsDatetime, IsNow, IsStr, message, message_part, try_import
 from .mock_xai import (
     MockXai,
     create_code_execution_response,
@@ -222,8 +222,7 @@ async def test_xai_cost_calculation(allow_model_requests: None):
     assert result.output == 'world'
 
     # Verify cost is calculated via genai-prices
-    last_message = result.all_messages()[-1]
-    assert isinstance(last_message, ModelResponse)
+    last_message = message(result.all_messages(), ModelResponse, index=-1)
     assert last_message.cost().total_price == snapshot(Decimal('0.000045'))
 
 
@@ -1917,10 +1916,7 @@ async def test_xai_response_with_logprobs(allow_model_requests: None):
 
     result = await agent.run('What is the capital of Minas Gerais?')
     messages = result.all_messages()
-    response_msg = messages[1]
-    assert isinstance(response_msg, ModelResponse)
-    text_part = response_msg.parts[0]
-    assert isinstance(text_part, TextPart)
+    text_part = message_part(messages, TextPart, message_index=1)
     assert text_part.provider_details is not None
     assert 'logprobs' in text_part.provider_details
     assert text_part.provider_details['logprobs'] == snapshot(
@@ -3863,8 +3859,8 @@ Fix the errors and try again.\
     # Verify the retry prompt was sent as a user message
     messages = result.all_messages()
     assert len(messages) == 4  # UserPrompt, ModelResponse, RetryPrompt, ModelResponse
-    assert isinstance(messages[2].parts[0], RetryPromptPart)
-    assert messages[2].parts[0].tool_name is None
+    part = message_part(messages, RetryPromptPart, message_index=2)
+    assert part.tool_name is None
 
 
 async def test_xai_thinking_part_in_message_history(allow_model_requests: None):

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -85,7 +85,7 @@ from pydantic_ai.tools import (
 from pydantic_ai.toolsets._tool_search import parse_discovered_tools
 
 from ._inline_snapshot import snapshot
-from .conftest import IsDatetime, IsInt, IsSameStr, IsStr, try_import
+from .conftest import IsDatetime, IsInt, IsSameStr, IsStr, message, message_part, try_import
 
 with try_import() as imports_successful:
     from ag_ui.core import (
@@ -1653,8 +1653,7 @@ def test_dump_load_roundtrip_load_capability_invalid_args() -> None:
     ag_ui_msgs = AGUIAdapter.dump_messages(original, ag_ui_version='0.1.13')
     reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
 
-    reloaded_call = reloaded[0].parts[0]
-    assert isinstance(reloaded_call, LoadCapabilityCallPart)
+    reloaded_call = message_part(reloaded, LoadCapabilityCallPart)
     assert reloaded_call.capability_id is None
     assert parse_loaded_capabilities(reloaded) == set()
 
@@ -2240,9 +2239,7 @@ def test_dump_load_roundtrip_retry_prompt_with_tool() -> None:
 
     # RetryPromptPart becomes ToolReturnPart on reload (same tool_call_id mapping)
     assert len(reloaded) == 4
-    assert isinstance(reloaded[2], ModelRequest)
-    retry_part = reloaded[2].parts[0]
-    assert isinstance(retry_part, ToolReturnPart)
+    retry_part = message_part(reloaded, ToolReturnPart, message_index=2)
     assert retry_part.tool_name == 'my_tool'
     assert retry_part.tool_call_id == 'call_1'
 
@@ -2263,9 +2260,7 @@ def test_dump_load_roundtrip_retry_prompt_without_tool() -> None:
     # RetryPromptPart without tool becomes UserPromptPart on reload
     # Content is formatted by RetryPromptPart.model_response()
     assert len(reloaded) == 4
-    assert isinstance(reloaded[2], ModelRequest)
-    retry_part = reloaded[2].parts[0]
-    assert isinstance(retry_part, UserPromptPart)
+    retry_part = message_part(reloaded, UserPromptPart, message_index=2)
     assert 'Please try again' in str(retry_part.content)
 
 
@@ -2880,8 +2875,8 @@ async def test_callback_sync() -> None:
     # Verify we can access messages
     messages = run_result.all_messages()
     assert len(messages) >= 1
-    assert isinstance(messages[0], ModelRequest)
-    assert messages[0].run_id == run_result.run_id
+    req = message(messages, ModelRequest)
+    assert req.run_id == run_result.run_id
 
     # Verify events were still streamed normally
     assert len(events) > 0
@@ -3262,11 +3257,7 @@ async def test_builtin_tool_return_json_string_content_parsed() -> None:
     ]
 
     result = AGUIAdapter.load_messages(messages)
-    response = result[0]
-    assert isinstance(response, ModelResponse)
-
-    return_part = response.parts[1]
-    assert isinstance(return_part, NativeToolReturnPart)
+    return_part = message_part(result, NativeToolReturnPart, part_index=1)
     assert return_part.tool_name == 'web_fetch'
     assert return_part.tool_call_id == 'srvtoolu_abc123'
     assert return_part.provider_name == 'anthropic'
@@ -3297,11 +3288,7 @@ async def test_builtin_tool_return_plain_string_content_preserved() -> None:
     ]
 
     result = AGUIAdapter.load_messages(messages)
-    response = result[0]
-    assert isinstance(response, ModelResponse)
-
-    return_part = response.parts[1]
-    assert isinstance(return_part, NativeToolReturnPart)
+    return_part = message_part(result, NativeToolReturnPart, part_index=1)
     assert return_part.content == 'just a plain string, not JSON'
 
 
@@ -3329,11 +3316,7 @@ async def test_builtin_tool_return_non_string_content_passthrough() -> None:
     ]
 
     result = AGUIAdapter.load_messages(messages)
-    response = result[0]
-    assert isinstance(response, ModelResponse)
-
-    return_part = response.parts[1]
-    assert isinstance(return_part, NativeToolReturnPart)
+    return_part = message_part(result, NativeToolReturnPart, part_index=1)
     assert return_part.content == {'type': 'web_fetch_result', 'url': 'https://example.com'}
 
 
@@ -3362,11 +3345,7 @@ async def test_builtin_tool_return_non_string_scalar_content_passthrough() -> No
     ]
 
     result = AGUIAdapter.load_messages(messages)
-    response = result[0]
-    assert isinstance(response, ModelResponse)
-
-    return_part = response.parts[1]
-    assert isinstance(return_part, NativeToolReturnPart)
+    return_part = message_part(result, NativeToolReturnPart, part_index=1)
     assert return_part.content == 42
 
 
@@ -4924,11 +4903,9 @@ def test_load_multimodal_url_sources(
     """Test that typed multimodal URL input content is converted to the correct Pydantic AI URL type."""
     messages = AGUIAdapter.load_messages([UserMessage(id='msg-1', content=[input_content])])
     assert len(messages) == 1
-    request = messages[0]
-    assert isinstance(request, ModelRequest)
+    request = message(messages, ModelRequest)
     assert len(request.parts) == 1
-    part = request.parts[0]
-    assert isinstance(part, UserPromptPart)
+    part = message_part(messages, UserPromptPart)
     assert isinstance(part.content, list)
     assert len(part.content) == 1
     assert part.content[0] == expected_type
@@ -5183,10 +5160,7 @@ def test_multimodal_roundtrip_file_without_vendor_metadata_stays_none() -> None:
     )
 
     loaded = AGUIAdapter.load_messages(ag_ui_msgs)
-    request = loaded[0]
-    assert isinstance(request, ModelRequest)
-    user_part = request.parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(loaded, UserPromptPart)
     assert isinstance(user_part.content, list)
     for item in user_part.content:
         assert getattr(item, 'vendor_metadata', None) is None
@@ -5848,10 +5822,7 @@ async def test_client_submitted_file_url_disallowed_scheme_stripped() -> None:
         sanitized = adapter.sanitize_messages(crafted)
 
     assert len(sanitized) == 1
-    request = sanitized[0]
-    assert isinstance(request, ModelRequest)
-    user_part = request.parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(sanitized, UserPromptPart)
     assert user_part.content == ['See attached', ImageUrl(url='https://example.com/ok.png')]
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -157,7 +157,7 @@ else:
         MistralProvider = None
 
 from ._inline_snapshot import snapshot
-from .conftest import IsDatetime, IsInstance, IsNow, IsStr, TestEnv
+from .conftest import IsDatetime, IsInstance, IsNow, IsStr, TestEnv, message, message_part
 
 pytestmark = pytest.mark.anyio
 
@@ -376,10 +376,7 @@ def test_result_pydantic_model_validation_error():
         ]
     )
 
-    user_retry = result.all_messages()[2]
-    assert isinstance(user_retry, ModelRequest)
-    retry_prompt = user_retry.parts[0]
-    assert isinstance(retry_prompt, RetryPromptPart)
+    retry_prompt = message_part(result.all_messages(), RetryPromptPart, message_index=2)
     assert retry_prompt.model_response() == snapshot("""\
 1 validation error:
 ```json
@@ -6468,8 +6465,7 @@ class TestMultipleToolCalls:
             with pytest.raises(RuntimeError, match='tool-failure'):
                 agent.run_sync('test')
 
-        interrupted = messages[-1]
-        assert isinstance(interrupted, ModelRequest)
+        interrupted = message(messages, ModelRequest, index=-1)
         assert interrupted.state == 'interrupted'
         # The completed tool's return part and its user-content part both surface.
         assert interrupted.parts == snapshot(
@@ -7247,8 +7243,7 @@ def test_dynamic_system_prompt_none_return():
     with capture_run_messages() as base_messages:
         agent.run_sync('Hi', model=TestModel(custom_output_text='baseline'))
 
-    base_req = base_messages[0]
-    assert isinstance(base_req, ModelRequest)
+    base_req = message(base_messages, ModelRequest)
     sys_texts = [p.content for p in base_req.parts if isinstance(p, SystemPromptPart)]
     # The None value should have a '' placeholder due to keeping a reference to the dynamic prompt
     assert '' in sys_texts
@@ -7258,8 +7253,7 @@ def test_dynamic_system_prompt_none_return():
     with capture_run_messages() as messages:
         agent.run_sync('Hi', model=TestModel(custom_output_text='baseline'))
 
-    req = messages[0]
-    assert isinstance(req, ModelRequest)
+    req = message(messages, ModelRequest)
     sys_texts = [p.content for p in req.parts if isinstance(p, SystemPromptPart)]
     # The None value should have a '' placeholder due to keep a reference to the dynamic prompt
     assert '' not in sys_texts
@@ -7277,8 +7271,7 @@ def test_system_prompt_none_return_are_omitted():
     with capture_run_messages() as base_messages:
         agent.run_sync('Hi', model=TestModel(custom_output_text='baseline'))
 
-    base_req = base_messages[0]
-    assert isinstance(base_req, ModelRequest)
+    base_req = message(base_messages, ModelRequest)
     sys_texts = [p.content for p in base_req.parts if isinstance(p, SystemPromptPart)]
     # The None value should be omitted
     assert 'STATIC' in sys_texts
@@ -7524,8 +7517,7 @@ def test_image_url_serializable_missing_media_type():
 
     # We also need to be able to round trip the serialized messages.
     messages = ModelMessagesTypeAdapter.validate_json(serialized)
-    part = messages[0].parts[0]
-    assert isinstance(part, UserPromptPart)
+    part = message_part(messages, UserPromptPart)
     content = part.content[1]
     assert isinstance(content, ImageUrl)
     assert content.media_type == 'image/jpeg'
@@ -7605,8 +7597,7 @@ def test_image_url_serializable():
 
     # We also need to be able to round trip the serialized messages.
     messages = ModelMessagesTypeAdapter.validate_json(serialized)
-    part = messages[0].parts[0]
-    assert isinstance(part, UserPromptPart)
+    part = message_part(messages, UserPromptPart)
     content = part.content[1]
     assert isinstance(content, ImageUrl)
     assert content.media_type == 'image/jpeg'
@@ -10038,8 +10029,7 @@ async def test_user_prompt_with_deferred_tool_results():
         # Second call: model responds to tool results and user prompt
         else:
             # Verify we received both tool results and user prompt
-            last_request = messages[-1]
-            assert isinstance(last_request, ModelRequest)
+            last_request = message(messages, ModelRequest, index=-1)
             has_tool_return = any(isinstance(p, ToolReturnPart) for p in last_request.parts)
             has_user_prompt = any(isinstance(p, UserPromptPart) for p in last_request.parts)
             assert has_tool_return, 'Expected tool return part in request'
@@ -10258,16 +10248,14 @@ def test_override_instructions_basic():
     with capture_run_messages() as base_messages:
         agent.run_sync('Hello', model=TestModel(custom_output_text='baseline'))
 
-    base_req = base_messages[0]
-    assert isinstance(base_req, ModelRequest)
+    base_req = message(base_messages, ModelRequest)
     assert base_req.instructions == 'SHOULD_BE_IGNORED'
 
     with agent.override(instructions='OVERRIDE'):
         with capture_run_messages() as messages:
             agent.run_sync('Hello', model=TestModel(custom_output_text='ok'))
 
-    req = messages[0]
-    assert isinstance(req, ModelRequest)
+    req = message(messages, ModelRequest)
     assert req.instructions == 'OVERRIDE'
 
 
@@ -10282,10 +10270,8 @@ def test_override_reset_after_context():
     with capture_run_messages() as messages_orig:
         agent.run_sync('Hi', model=TestModel(custom_output_text='ok'))
 
-    req_new = messages_new[0]
-    assert isinstance(req_new, ModelRequest)
-    req_orig = messages_orig[0]
-    assert isinstance(req_orig, ModelRequest)
+    req_new = message(messages_new, ModelRequest)
+    req_orig = message(messages_orig, ModelRequest)
     assert req_new.instructions == 'NEW'
     assert req_orig.instructions == 'ORIG'
 
@@ -10302,8 +10288,7 @@ def test_override_none_clears_instructions():
         with capture_run_messages() as messages:
             agent.run_sync('Hello', model=TestModel(custom_output_text='ok'))
 
-    req = messages[0]
-    assert isinstance(req, ModelRequest)
+    req = message(messages, ModelRequest)
     assert req.instructions is None
 
 
@@ -10321,8 +10306,7 @@ def test_override_instructions_callable_replaces_functions():
     with capture_run_messages() as base_messages:
         agent.run_sync('Hello', model=TestModel(custom_output_text='baseline'))
 
-    base_req = base_messages[0]
-    assert isinstance(base_req, ModelRequest)
+    base_req = message(base_messages, ModelRequest)
     assert base_req.instructions is not None
     assert 'BASE_FN' in base_req.instructions
 
@@ -10330,8 +10314,7 @@ def test_override_instructions_callable_replaces_functions():
         with capture_run_messages() as messages:
             agent.run_sync('Hello', model=TestModel(custom_output_text='ok'))
 
-    req = messages[0]
-    assert isinstance(req, ModelRequest)
+    req = message(messages, ModelRequest)
     assert req.instructions == 'OVERRIDE_FN'
     assert 'BASE_FN' not in req.instructions
 
@@ -10348,8 +10331,7 @@ async def test_override_instructions_async_callable():
         with capture_run_messages() as messages:
             await agent.run('Hi', model=TestModel(custom_output_text='ok'))
 
-    req = messages[0]
-    assert isinstance(req, ModelRequest)
+    req = message(messages, ModelRequest)
     assert req.instructions == 'ASYNC_FN'
 
 
@@ -10367,8 +10349,7 @@ def test_override_instructions_sequence_mixed_types():
         with capture_run_messages() as messages:
             agent.run_sync('Hello', model=TestModel(custom_output_text='ok'))
 
-    req = messages[0]
-    assert isinstance(req, ModelRequest)
+    req = message(messages, ModelRequest)
     assert req.instructions == 'OVERRIDE1\nOVERRIDE2\n\nFUNC_PART\n\nFUNC_PART_2'
     assert 'BASE' not in req.instructions
 
@@ -10381,8 +10362,7 @@ async def test_override_concurrent_isolation():
         with agent.override(instructions=instr):
             with capture_run_messages() as messages:
                 await agent.run('Hi', model=TestModel(custom_output_text='ok'))
-            req = messages[0]
-            assert isinstance(req, ModelRequest)
+            req = message(messages, ModelRequest)
             return req.instructions
 
     a, b = await asyncio.gather(
@@ -10402,8 +10382,7 @@ def test_override_replaces_instructions():
         with capture_run_messages() as messages:
             agent.run_sync('Hi', model=TestModel(custom_output_text='ok'))
 
-    req = messages[0]
-    assert isinstance(req, ModelRequest)
+    req = message(messages, ModelRequest)
     assert req.instructions == 'NEW_INSTR'
 
 
@@ -10419,10 +10398,8 @@ def test_override_nested_contexts():
             with capture_run_messages() as inner_messages:
                 agent.run_sync('Hi', model=TestModel(custom_output_text='ok'))
 
-    outer_req = outer_messages[0]
-    assert isinstance(outer_req, ModelRequest)
-    inner_req = inner_messages[0]
-    assert isinstance(inner_req, ModelRequest)
+    outer_req = message(outer_messages, ModelRequest)
+    inner_req = message(inner_messages, ModelRequest)
 
     assert outer_req.instructions == 'OUTER'
     assert inner_req.instructions == 'INNER'
@@ -10436,8 +10413,7 @@ async def test_override_async_run():
         with capture_run_messages() as messages:
             await agent.run('Hi', model=TestModel(custom_output_text='ok'))
 
-    req = messages[0]
-    assert isinstance(req, ModelRequest)
+    req = message(messages, ModelRequest)
     assert req.instructions == 'ASYNC_OVERRIDE'
 
 
@@ -10458,8 +10434,7 @@ def test_override_with_dynamic_prompts():
     with capture_run_messages() as base_messages:
         agent.run_sync('Hi', model=TestModel(custom_output_text='baseline'))
 
-    base_req = base_messages[0]
-    assert isinstance(base_req, ModelRequest)
+    base_req = message(base_messages, ModelRequest)
     assert base_req.instructions == 'DYNAMIC_INSTR'
 
     # Override should take precedence over dynamic instructions but leave system prompts intact
@@ -10467,8 +10442,7 @@ def test_override_with_dynamic_prompts():
         with capture_run_messages() as messages:
             agent.run_sync('Hi', model=TestModel(custom_output_text='ok'))
 
-    req = messages[0]
-    assert isinstance(req, ModelRequest)
+    req = message(messages, ModelRequest)
     assert req.instructions == 'OVERRIDE_INSTR'
     sys_texts = [p.content for p in req.parts if isinstance(p, SystemPromptPart)]
     # The dynamic system prompt should still be present since overrides target instructions only

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -113,7 +113,7 @@ from pydantic_ai.usage import RequestUsage, RunUsage
 from pydantic_graph import End
 
 from ._inline_snapshot import snapshot
-from .conftest import IsDatetime, IsInstance, IsStr, remove_schema_descriptions
+from .conftest import IsDatetime, IsInstance, IsStr, message, remove_schema_descriptions
 
 pytestmark = [
     pytest.mark.anyio,
@@ -3460,8 +3460,8 @@ async def test_deferred_capability_synthetic_tool_search_persists_in_history() -
 
     def synthetic_pairs(messages: list[ModelMessage]) -> list[str]:
         call_ids: list[str] = []
-        for message in messages:
-            for part in message.parts:
+        for msg in messages:
+            for part in msg.parts:
                 if isinstance(part, ToolSearchCallPart) and part.tool_call_id.startswith('auto_load_'):
                     call_ids.append(part.tool_call_id)
         return call_ids
@@ -11030,8 +11030,7 @@ async def test_wrapper_over_deferred_capability_preserves_deferral_end_to_end() 
         ]
 
         if not any(part.tool_name == LOAD_CAPABILITY_TOOL_NAME for part in tool_returns):
-            first_request = messages[0]
-            assert isinstance(first_request, ModelRequest)
+            first_request = message(messages, ModelRequest)
             first_request_instructions.append(first_request.instructions)
             return ModelResponse(
                 parts=[ToolCallPart(tool_name=LOAD_CAPABILITY_TOOL_NAME, args={'id': 'refunds'}, tool_call_id='load')]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -50,7 +50,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.test import TestModel
 
 from ._inline_snapshot import snapshot
-from .conftest import IsDatetime, IsNow, IsStr
+from .conftest import IsDatetime, IsNow, IsStr, message, message_part
 
 
 def test_image_url():
@@ -1121,8 +1121,7 @@ def test_uploaded_file_custom_identifier_and_media_type_roundtrip():
     ]
     serialized = ModelMessagesTypeAdapter.dump_python(messages, mode='json')
     deserialized = ModelMessagesTypeAdapter.validate_python(serialized)
-    part = deserialized[0].parts[0]
-    assert isinstance(part, UserPromptPart)
+    part = message_part(deserialized, UserPromptPart)
     uploaded = part.content[0]
     assert isinstance(uploaded, UploadedFile)
     assert uploaded.identifier == 'my-id'
@@ -1171,8 +1170,7 @@ def test_tool_return_content_with_url_field_not_coerced_to_image_url():
     # Deserialize - the dict with 'url' should remain as a dict, not become ImageUrl
     deserialized = ModelMessagesTypeAdapter.validate_json(serialized_history)
 
-    tool_return_part = deserialized[2].parts[0]
-    assert isinstance(tool_return_part, ToolReturnPart)
+    tool_return_part = message_part(deserialized, ToolReturnPart, message_index=2)
 
     # The content should be preserved as a dict, not coerced to ImageUrl
     expected_content = {'items': [{'name': 'Example', 'url': '/some/path/12345'}]}
@@ -1182,8 +1180,7 @@ def test_tool_return_content_with_url_field_not_coerced_to_image_url():
     reserialized = ModelMessagesTypeAdapter.dump_json(deserialized)
     reloaded = ModelMessagesTypeAdapter.validate_json(reserialized)
 
-    reloaded_tool_return = reloaded[2].parts[0]
-    assert isinstance(reloaded_tool_return, ToolReturnPart)
+    reloaded_tool_return = message_part(reloaded, ToolReturnPart, message_index=2)
     assert reloaded_tool_return.content == expected_content
 
 
@@ -1216,8 +1213,7 @@ def test_tool_return_content_with_explicit_image_url():
 
     deserialized = ModelMessagesTypeAdapter.validate_json(serialized_history)
 
-    tool_return_part = deserialized[1].parts[0]
-    assert isinstance(tool_return_part, ToolReturnPart)
+    tool_return_part = message_part(deserialized, ToolReturnPart, message_index=1)
 
     # Content with explicit kind: "image-url" should become ImageUrl
     assert isinstance(tool_return_part.content, ImageUrl)
@@ -1256,8 +1252,7 @@ def test_tool_return_content_nested_multimodal():
     """
 
     deserialized = ModelMessagesTypeAdapter.validate_json(serialized_history)
-    tool_return_part = deserialized[0].parts[0]
-    assert isinstance(tool_return_part, ToolReturnPart)
+    tool_return_part = message_part(deserialized, ToolReturnPart)
 
     # `ToolReturnPart`'s typed `ToolSearchReturnPart` subclass narrows `content` to a
     # `TypedDict`; cast back to a plain dict so we can probe arbitrary keys here.
@@ -1277,8 +1272,7 @@ def test_tool_return_content_nested_multimodal():
     # Round-trip should preserve types
     reserialized = ModelMessagesTypeAdapter.dump_json(deserialized)
     reloaded = ModelMessagesTypeAdapter.validate_json(reserialized)
-    reloaded_tool_return = reloaded[0].parts[0]
-    assert isinstance(reloaded_tool_return, ToolReturnPart)
+    reloaded_tool_return = message_part(reloaded, ToolReturnPart)
     reloaded_content = cast('dict[str, Any]', reloaded_tool_return.content)
     assert isinstance(reloaded_content, dict)
 
@@ -1324,8 +1318,7 @@ def test_binary_image_narrowed_wherever_multimodal_content_is_validated(mode: st
     else:
         loaded = ModelMessagesTypeAdapter.validate_python(ModelMessagesTypeAdapter.dump_python(messages, mode='json'))
 
-    part = loaded[0].parts[0]
-    assert isinstance(part, UserPromptPart)
+    part = message_part(loaded, UserPromptPart)
     assert isinstance(part.content, list)
     reloaded_image, reloaded_audio = part.content
     assert type(reloaded_image) is BinaryImage
@@ -1359,8 +1352,7 @@ def test_every_multimodal_type_rehydrates_as_tool_return_content():
             ModelRequest(parts=[ToolReturnPart(tool_name='t', content=instance, tool_call_id='c')])
         ]
         reloaded = ModelMessagesTypeAdapter.validate_python(ModelMessagesTypeAdapter.dump_python(messages, mode='json'))
-        part = reloaded[0].parts[0]
-        assert isinstance(part, ToolReturnPart)
+        part = message_part(reloaded, ToolReturnPart)
         assert type(part.content) is cls, (
             f'{cls.__name__} did not rehydrate through the discriminator gate '
             f'(got {type(part.content).__name__}) — a `_MULTIMODAL_FIELDS` mismatch would cause this'
@@ -1398,15 +1390,13 @@ def test_tool_return_part_binary_content_round_trip(case_id: str, tiny_audio: Bi
     ]
 
     json_loaded = ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(messages))
-    json_part = json_loaded[0].parts[0]
-    assert isinstance(json_part, ToolReturnPart)
+    json_part = message_part(json_loaded, ToolReturnPart)
     assert json_part.content == content
 
     python_loaded = ModelMessagesTypeAdapter.validate_python(
         ModelMessagesTypeAdapter.dump_python(messages, mode='json')
     )
-    python_part = python_loaded[0].parts[0]
-    assert isinstance(python_part, ToolReturnPart)
+    python_part = message_part(python_loaded, ToolReturnPart)
     assert python_part.content == content
 
 
@@ -1430,8 +1420,7 @@ def test_tool_return_dict_reusing_kind_without_type_field_stays_mapping(content:
     ]
 
     loaded = ModelMessagesTypeAdapter.validate_python(ModelMessagesTypeAdapter.dump_python(messages, mode='json'))
-    part = loaded[0].parts[0]
-    assert isinstance(part, ToolReturnPart)
+    part = message_part(loaded, ToolReturnPart)
     assert part.content == content
 
 
@@ -1469,8 +1458,7 @@ def test_tool_return_dict_reusing_kind_with_type_field_stays_mapping(content: di
                 ModelMessagesTypeAdapter.dump_python(messages, mode='json')
             )
 
-    part = loaded[0].parts[0]
-    assert isinstance(part, ToolReturnPart)
+    part = message_part(loaded, ToolReturnPart)
     assert part.content == content
 
 
@@ -1499,8 +1487,7 @@ def test_tool_return_dict_unhashable_kind_stays_mapping(kind: object, nested: bo
     }
 
     loaded = ModelMessagesTypeAdapter.validate_python([dumped])
-    part = loaded[0].parts[0]
-    assert isinstance(part, ToolReturnPart)
+    part = message_part(loaded, ToolReturnPart)
     assert part.content == content
 
 
@@ -1749,8 +1736,7 @@ class TestInstructionParts:
         serialized = ModelMessagesTypeAdapter.dump_json([original])
         deserialized = ModelMessagesTypeAdapter.validate_json(serialized)
 
-        msg = deserialized[0]
-        assert isinstance(msg, ModelRequest)
+        msg = message(deserialized, ModelRequest)
         assert msg.instructions == 'static part\n\ndynamic part'
 
     def test_repr(self):

--- a/tests/test_sanitize_messages.py
+++ b/tests/test_sanitize_messages.py
@@ -23,7 +23,7 @@ from pydantic_ai import (
 from pydantic_ai.messages import sanitize_messages
 
 from ._inline_snapshot import snapshot
-from .conftest import IsDatetime
+from .conftest import IsDatetime, message, message_part
 
 
 def test_sanitize_messages_resets_force_download_from_serialized_history():
@@ -50,10 +50,7 @@ def test_sanitize_messages_resets_force_download_from_serialized_history():
     with pytest.warns(UserWarning, match=r'force_download.*allow-local.*reset to `False`'):
         sanitized = sanitize_messages(messages)
 
-    message = sanitized[0]
-    assert isinstance(message, ModelRequest)
-    part = message.parts[0]
-    assert isinstance(part, UserPromptPart)
+    part = message_part(sanitized, UserPromptPart)
     assert part.content == snapshot(
         [
             'summarize this image',
@@ -155,8 +152,7 @@ def test_sanitize_messages_strips_dangling_call_but_keeps_other_tail_parts():
     with pytest.warns(UserWarning, match=r'unresolved tool call.*delete_account'):
         sanitized = sanitize_messages(messages)
 
-    tail = sanitized[-1]
-    assert isinstance(tail, ModelResponse)
+    tail = message(sanitized, ModelResponse, index=-1)
     assert tail.parts == [messages[1].parts[0]]
 
 
@@ -181,10 +177,7 @@ def test_sanitize_messages_keeps_bytearray_tool_return_content():
         ModelRequest(parts=[ToolReturnPart(tool_name='read_bytes', content=bytearray(b'abc'), tool_call_id='call-1')]),
     ]
     sanitized = sanitize_messages(messages, resolved_tool_call_ids=['call-1'])
-    request = sanitized[1]
-    assert isinstance(request, ModelRequest)
-    part = request.parts[0]
-    assert isinstance(part, ToolReturnPart)
+    part = message_part(sanitized, ToolReturnPart, message_index=1)
     assert part.content == bytearray(b'abc')
 
 
@@ -200,13 +193,11 @@ def test_sanitize_messages_strips_client_system_prompts():
 
     with pytest.warns(UserWarning, match=r'Client-submitted system prompts were stripped'):
         sanitized = sanitize_messages(messages)
-    request = sanitized[0]
-    assert isinstance(request, ModelRequest)
+    request = message(sanitized, ModelRequest)
     assert [type(p).__name__ for p in request.parts] == snapshot(['UserPromptPart'])
 
     kept = sanitize_messages(messages, strip_system_prompts=False)
-    request = kept[0]
-    assert isinstance(request, ModelRequest)
+    request = message(kept, ModelRequest)
     assert [type(p).__name__ for p in request.parts] == snapshot(['SystemPromptPart', 'UserPromptPart'])
 
 
@@ -232,10 +223,7 @@ def test_sanitize_messages_drops_non_http_file_url_schemes():
 
     with pytest.warns(UserWarning, match=r"scheme\(s\) \['s3'\] were dropped"):
         sanitized = sanitize_messages(messages)
-    request = sanitized[0]
-    assert isinstance(request, ModelRequest)
-    part = request.parts[0]
-    assert isinstance(part, UserPromptPart)
+    part = message_part(sanitized, UserPromptPart)
     assert part.content == snapshot(['look at this', ImageUrl(url='https://example.com/ok.png')])
 
 
@@ -260,17 +248,11 @@ def test_sanitize_messages_drops_uploaded_files_by_default():
 
     with pytest.warns(UserWarning, match=r"uploaded file\(s\) for provider\(s\) \['openai'\] were dropped"):
         sanitized = sanitize_messages(messages)
-    request = sanitized[0]
-    assert isinstance(request, ModelRequest)
-    part = request.parts[0]
-    assert isinstance(part, UserPromptPart)
+    part = message_part(sanitized, UserPromptPart)
     assert part.content == snapshot(['summarize'])
 
     kept = sanitize_messages(messages, allow_uploaded_files=True)
-    request = kept[0]
-    assert isinstance(request, ModelRequest)
-    part = request.parts[0]
-    assert isinstance(part, UserPromptPart)
+    part = message_part(kept, UserPromptPart)
     assert part.content == snapshot(
         ['summarize', UploadedFile(file_id='file-abc', provider_name='openai', media_type='application/pdf')]
     )

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -66,7 +66,7 @@ from pydantic_ai.usage import RequestUsage
 from pydantic_graph import End
 
 from ._inline_snapshot import snapshot
-from .conftest import IsDatetime, IsInt, IsNow, IsStr
+from .conftest import IsDatetime, IsInt, IsNow, IsStr, message_part
 
 pytestmark = pytest.mark.anyio
 
@@ -840,21 +840,17 @@ async def test_call_tool():
             assert agent_info.function_tools is not None
             assert len(agent_info.function_tools) == 1
             name = agent_info.function_tools[0].name
-            first = messages[0]
-            assert isinstance(first, ModelRequest)
-            assert isinstance(first.parts[0], UserPromptPart)
-            json_string = json.dumps({'x': first.parts[0].content})
+            part = message_part(messages, UserPromptPart)
+            json_string = json.dumps({'x': part.content})
             yield {0: DeltaToolCall(name=name)}
             yield {0: DeltaToolCall(json_args=json_string[:3])}
             yield {0: DeltaToolCall(json_args=json_string[3:])}
         else:
-            last = messages[-1]
-            assert isinstance(last, ModelRequest)
-            assert isinstance(last.parts[0], ToolReturnPart)
+            part = message_part(messages, ToolReturnPart, message_index=-1)
             assert agent_info.output_tools is not None
             assert len(agent_info.output_tools) == 1
             name = agent_info.output_tools[0].name
-            json_data = json.dumps({'response': [last.parts[0].content, 2]})
+            json_data = json.dumps({'response': [part.content, 2]})
             yield {0: DeltaToolCall(name=name)}
             yield {0: DeltaToolCall(json_args=json_data[:5])}
             yield {0: DeltaToolCall(json_args=json_data[5:])}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -18,6 +18,8 @@ from pydantic_ai.messages import ModelRequest
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.result import RunUsage
 
+from .conftest import message
+
 
 @dataclass
 class MyDeps:
@@ -243,8 +245,7 @@ async def test_agent_run_with_template_instructions() -> None:
     )
     result = await agent.run('hi', deps=MyDeps(name='Alice', age=30))
     # The rendered instructions should appear in the first model request
-    first_request = result.all_messages()[0]
-    assert isinstance(first_request, ModelRequest)
+    first_request = message(result.all_messages(), ModelRequest)
     assert first_request.instructions == 'You are helping Alice, age 30.'
 
 
@@ -304,8 +305,7 @@ class TestAgentSpecTemplateFields:
             deps_type=MyDeps,
         )
         result = await agent.run('hi', deps=MyDeps(name='Alice', age=30))
-        first_request = result.all_messages()[0]
-        assert isinstance(first_request, ModelRequest)
+        first_request = message(result.all_messages(), ModelRequest)
         assert first_request.instructions == 'You are Alice'
 
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -152,7 +152,7 @@ with workflow.unsafe.imports_passed_through():
     from ._inline_snapshot import snapshot
 
     # Loads `vcr`, which Temporal doesn't like without passing through the import
-    from .conftest import IsDatetime, IsStr
+    from .conftest import IsDatetime, IsStr, message
 
 pytestmark = [
     pytest.mark.anyio,
@@ -1461,8 +1461,7 @@ async def test_dynamic_toolset_outside_workflow():
 
 
 def _echo_instructions(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
-    request = messages[-1]
-    assert isinstance(request, ModelRequest)
+    request = message(messages, ModelRequest, index=-1)
     return ModelResponse(parts=[TextPart(request.instructions or '<no instructions>')])
 
 
@@ -1530,8 +1529,7 @@ def _echo_instructions_after_tool_call(messages: list[ModelMessage], info: Agent
     # First request: call a tool to force a second model-request step.
     # Second request (carrying the tool return): echo the instructions, which by then must
     # reflect the current step — proving the cache is repopulated by `get_tools` each step.
-    request = messages[-1]
-    assert isinstance(request, ModelRequest)
+    request = message(messages, ModelRequest, index=-1)
     if any(isinstance(part, ToolReturnPart) for part in request.parts):
         return ModelResponse(parts=[TextPart(request.instructions or '<no instructions>')])
     return ModelResponse(parts=[ToolCallPart('noop', {})])

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -80,7 +80,7 @@ from pydantic_ai.toolsets._tool_search import (
 )
 from pydantic_ai.usage import RequestUsage, RunUsage
 
-from .conftest import try_import
+from .conftest import message, message_part, try_import
 
 with try_import() as evals_available:
     from pydantic_evals import Case, Dataset
@@ -2398,9 +2398,9 @@ def _trace_capability_messages(messages: list[ModelMessage]) -> list[tuple[str, 
     (load → search → tool call → answer) without coupling to provider-specific
     wire shapes."""
     trace: list[tuple[str, list[dict[str, Any]]]] = []
-    for message in messages:
+    for msg in messages:
         part_trace: list[dict[str, Any]] = []
-        for part in message.parts:
+        for part in msg.parts:
             if isinstance(part, UserPromptPart):
                 part_info: dict[str, Any] = {'type': 'user', 'content': part.content}
             elif isinstance(part, LoadCapabilityCallPart):
@@ -2430,7 +2430,7 @@ def _trace_capability_messages(messages: list[ModelMessage]) -> list[tuple[str, 
             part_trace.append(part_info)
         # Use a flat lowercase tag so inline-snapshot writes a plain string instead
         # of "helpfully" resolving the class name to `'request'`.
-        tag = 'request' if isinstance(message, ModelRequest) else 'response'
+        tag = 'request' if isinstance(msg, ModelRequest) else 'response'
         trace.append((tag, part_trace))
     return trace
 
@@ -2758,9 +2758,9 @@ async def test_anthropic_to_google_deferred_capability_history_replay(
 
     def trace_messages(messages: list[ModelMessage]) -> list[tuple[str, list[dict[str, Any]]]]:
         trace: list[tuple[str, list[dict[str, Any]]]] = []
-        for message in messages:
+        for msg in messages:
             part_trace: list[dict[str, Any]] = []
-            for part in message.parts:
+            for part in msg.parts:
                 if isinstance(part, UserPromptPart):
                     part_info: dict[str, Any] = {'type': 'user', 'content': part.content}
                 elif isinstance(part, LoadCapabilityCallPart):
@@ -2786,7 +2786,7 @@ async def test_anthropic_to_google_deferred_capability_history_replay(
                         f'anthropic→google replay trace helper saw unexpected part type: {type(part).__name__}'
                     )  # pragma: no cover
                 part_trace.append(part_info)
-            trace.append((type(message).__name__, part_trace))
+            trace.append((type(msg).__name__, part_trace))
         return trace
 
     anthropic_agent: Agent[None, str] = Agent(
@@ -3791,8 +3791,7 @@ def test_model_response_dict_round_trip_promotes_typed_subclasses() -> None:
             },
         ],
     }
-    [resp] = ModelMessagesTypeAdapter.validate_python([raw])
-    assert isinstance(resp, ModelResponse)
+    resp = message(ModelMessagesTypeAdapter.validate_python([raw]), ModelResponse)
     assert isinstance(resp.parts[0], NativeToolSearchCallPart)
     assert isinstance(resp.parts[1], NativeToolSearchReturnPart)
     # Unrecognized `tool_name` (and unset `tool_kind`) falls through to the base class.
@@ -3816,8 +3815,7 @@ def test_model_response_instance_round_trip_promotes_typed_subclasses() -> None:
             NativeToolCallPart(tool_name='web_search', args={}, tool_call_id='c2'),
         ]
     )
-    [revalidated] = ModelMessagesTypeAdapter.validate_python([resp])
-    assert isinstance(revalidated, ModelResponse)
+    revalidated = message(ModelMessagesTypeAdapter.validate_python([resp]), ModelResponse)
     assert isinstance(revalidated.parts[0], NativeToolSearchCallPart)
     assert isinstance(revalidated.parts[1], NativeToolSearchReturnPart)
     assert isinstance(revalidated.parts[2], NativeToolCallPart)
@@ -4037,21 +4035,16 @@ def test_synthetic_injection_translates_builtin_to_local_tool_search_parts() -> 
 
     # The response now carries a local `ToolSearchCallPart` (typed `ToolCallPart` subclass),
     # and the return part has been lifted onto a fresh trailing `ModelRequest`.
-    response = translated[1]
-    assert isinstance(response, ModelResponse)
+    response = message(translated, ModelResponse, index=1)
     assert len(response.parts) == 1
-    call_part = response.parts[0]
-    assert isinstance(call_part, ToolSearchCallPart)
+    call_part = message_part(translated, ToolSearchCallPart, message_index=1)
     # Subclass of `ToolCallPart`, NOT `NativeToolSearchCallPart`.
     assert isinstance(call_part, ToolCallPart)
     assert not isinstance(call_part, NativeToolSearchCallPart)
     assert call_part.tool_name == 'search_tools'
     assert call_part.args == {'queries': ['mortgage']}
 
-    return_request = translated[2]
-    assert isinstance(return_request, ModelRequest)
-    return_part = return_request.parts[0]
-    assert isinstance(return_part, ToolSearchReturnPart)
+    return_part = message_part(translated, ToolSearchReturnPart, message_index=2)
     assert isinstance(return_part, ToolReturnPart)
     assert not isinstance(return_part, NativeToolSearchReturnPart)
     assert return_part.tool_name == 'search_tools'
@@ -4084,10 +4077,7 @@ def test_synthesize_local_promotes_base_tool_return_with_tool_kind_in_request() 
         ),
     ]
     translated = synthesize_local_tool_search_messages(history)
-    request = translated[1]
-    assert isinstance(request, ModelRequest)
-    [part] = request.parts
-    assert isinstance(part, ToolSearchReturnPart)
+    part = message_part(translated, ToolSearchReturnPart, message_index=1)
     assert part.content == {'discovered_tools': [{'name': 'foo'}]}
 
 
@@ -4144,18 +4134,13 @@ def test_prepare_messages_translates_on_non_native_model() -> None:
     assert len(prepared) == 3
     assert prepared[0] is history[0]
 
-    response = prepared[1]
-    assert isinstance(response, ModelResponse)
+    response = message(prepared, ModelResponse, index=1)
     assert len(response.parts) == 1
-    call_part = response.parts[0]
-    assert isinstance(call_part, ToolSearchCallPart)
+    call_part = message_part(prepared, ToolSearchCallPart, message_index=1)
     assert not isinstance(call_part, NativeToolSearchCallPart)
     assert call_part.tool_name == 'search_tools'
 
-    return_request = prepared[2]
-    assert isinstance(return_request, ModelRequest)
-    [return_part] = return_request.parts
-    assert isinstance(return_part, ToolSearchReturnPart)
+    return_part = message_part(prepared, ToolSearchReturnPart, message_index=2)
     assert not isinstance(return_part, NativeToolSearchReturnPart)
     assert return_part.tool_name == 'search_tools'
     assert return_part.content == {'discovered_tools': [{'name': 'calculate_mortgage'}]}
@@ -4271,9 +4256,7 @@ def test_pydantic_validation_promotes_local_tool_return_with_tool_kind_set() -> 
             ],
         },
     ]
-    [req] = ModelMessagesTypeAdapter.validate_python(raw)
-    [part] = req.parts
-    assert isinstance(part, ToolSearchReturnPart)
+    part = message_part(ModelMessagesTypeAdapter.validate_python(raw), ToolSearchReturnPart)
     assert part.content == {'discovered_tools': [{'name': 'foo'}]}
 
 
@@ -4331,8 +4314,7 @@ def test_synthesize_messages_response_with_only_call_part_no_lift() -> None:
     ]
     result = synthesize_local_tool_search_messages(history)
     assert len(result) == 1
-    response = result[0]
-    assert isinstance(response, ModelResponse)
+    response = message(result, ModelResponse)
     assert len(response.parts) == 1
     assert isinstance(response.parts[0], ToolSearchCallPart)
 
@@ -4353,11 +4335,9 @@ def test_synthesize_messages_response_with_only_return_part_no_response_kept() -
     ]
     result = synthesize_local_tool_search_messages(history)
     assert len(result) == 1
-    request = result[0]
-    assert isinstance(request, ModelRequest)
+    request = message(result, ModelRequest)
     assert len(request.parts) == 1
-    return_part = request.parts[0]
-    assert isinstance(return_part, ToolSearchReturnPart)
+    message_part(result, ToolSearchReturnPart)
 
 
 def test_synthesize_messages_request_with_unrelated_tool_return_passthrough() -> None:
@@ -4409,12 +4389,11 @@ def test_synthesize_messages_response_with_search_then_downstream_tool_call_spli
     # response[ToolCall(weather)], request[ToolReturn(weather)] (the original).
     assert len(result) == 5
 
-    assert isinstance(result[0], ModelRequest)
-    assert result[0] is history[0]
+    first_req = message(result, ModelRequest)
+    assert first_req is history[0]
 
     # First synthetic response: text + search call only — NOT the downstream weather call.
-    first_resp = result[1]
-    assert isinstance(first_resp, ModelResponse)
+    first_resp = message(result, ModelResponse, index=1)
     assert len(first_resp.parts) == 2
     assert isinstance(first_resp.parts[0], TextPart)
     assert isinstance(first_resp.parts[1], ToolSearchCallPart)
@@ -4422,22 +4401,19 @@ def test_synthesize_messages_response_with_search_then_downstream_tool_call_spli
     assert not any(isinstance(p, ToolCallPart) and not isinstance(p, ToolSearchCallPart) for p in first_resp.parts)
 
     # Lifted search return as a fresh request.
-    search_return_req = result[2]
-    assert isinstance(search_return_req, ModelRequest)
+    search_return_req = message(result, ModelRequest, index=2)
     assert len(search_return_req.parts) == 1
     assert isinstance(search_return_req.parts[0], ToolSearchReturnPart)
 
     # Second synthetic response: weather call only.
-    second_resp = result[3]
-    assert isinstance(second_resp, ModelResponse)
+    second_resp = message(result, ModelResponse, index=3)
     assert len(second_resp.parts) == 1
-    weather_call = second_resp.parts[0]
-    assert isinstance(weather_call, ToolCallPart)
+    weather_call = message_part(result, ToolCallPart, message_index=3)
     assert weather_call.tool_name == 'get_weather'
 
     # Original weather-return request flows naturally — no consecutive `ModelRequest`s.
-    assert isinstance(result[4], ModelRequest)
-    assert result[4] is history[2]
+    last_req = message(result, ModelRequest, index=4)
+    assert last_req is history[2]
 
 
 def test_synthesize_messages_devins_consecutive_request_repro() -> None:
@@ -4493,21 +4469,17 @@ def test_synthesize_messages_multiple_search_rounds_in_one_response() -> None:
 
     # 4 messages: response[call_a], request[return_a], response[call_b], request[return_b].
     assert len(result) == 4
-    assert isinstance(result[0], ModelResponse)
-    assert isinstance(result[0].parts[0], ToolSearchCallPart)
-    assert result[0].parts[0].tool_call_id == 's1'
+    call_part_1 = message_part(result, ToolSearchCallPart)
+    assert call_part_1.tool_call_id == 's1'
 
-    assert isinstance(result[1], ModelRequest)
-    assert isinstance(result[1].parts[0], ToolSearchReturnPart)
-    assert result[1].parts[0].tool_call_id == 's1'
+    return_part_1 = message_part(result, ToolSearchReturnPart, message_index=1)
+    assert return_part_1.tool_call_id == 's1'
 
-    assert isinstance(result[2], ModelResponse)
-    assert isinstance(result[2].parts[0], ToolSearchCallPart)
-    assert result[2].parts[0].tool_call_id == 's2'
+    call_part_2 = message_part(result, ToolSearchCallPart, message_index=2)
+    assert call_part_2.tool_call_id == 's2'
 
-    assert isinstance(result[3], ModelRequest)
-    assert isinstance(result[3].parts[0], ToolSearchReturnPart)
-    assert result[3].parts[0].tool_call_id == 's2'
+    return_part_2 = message_part(result, ToolSearchReturnPart, message_index=3)
+    assert return_part_2.tool_call_id == 's2'
 
 
 def test_synthesize_messages_metadata_kept_on_first_split_only() -> None:
@@ -4579,8 +4551,7 @@ def test_prepare_messages_then_clean_history_merges_consecutive_requests() -> No
 
     # The merged request carries both the synthetic search return and the original user prompt,
     # with the tool return part sorted ahead of the user prompt.
-    last = cleaned[-1]
-    assert isinstance(last, ModelRequest)
+    last = message(cleaned, ModelRequest, index=-1)
     assert isinstance(last.parts[0], ToolSearchReturnPart)
     assert isinstance(last.parts[1], UserPromptPart)
 
@@ -4647,20 +4618,14 @@ def test_model_response_part_discriminator_recognizes_local_call_dict_dispatch()
             ],
         },
     ]
-    [resp] = ModelMessagesTypeAdapter.validate_python(raw)
-    assert isinstance(resp, ModelResponse)
-    [part] = resp.parts
-    assert isinstance(part, ToolSearchCallPart)
+    message_part(ModelMessagesTypeAdapter.validate_python(raw), ToolSearchCallPart)
 
 
 def test_model_response_part_discriminator_passthrough_for_unknown_part_kind() -> None:
     """Instance dispatch falls through to `getattr(v, 'part_kind', ...)` for other types."""
 
     resp = ModelResponse(parts=[TextPart(content='hello')])
-    [revalidated] = ModelMessagesTypeAdapter.validate_python([resp])
-    assert isinstance(revalidated, ModelResponse)
-    [part] = revalidated.parts
-    assert isinstance(part, TextPart)
+    message_part(ModelMessagesTypeAdapter.validate_python([resp]), TextPart)
 
 
 def test_model_response_part_discriminator_recognizes_typed_instances() -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -39,7 +39,7 @@ from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolApp
 from pydantic_ai.usage import RequestUsage
 
 from ._inline_snapshot import snapshot
-from .conftest import IsDatetime, IsStr
+from .conftest import IsDatetime, IsStr, message, message_part
 
 
 def test_tool_no_ctx():
@@ -1174,10 +1174,8 @@ def test_call_tool_without_unrequired_parameters():
 
     result = agent.run_sync('Hello')
     all_messages = result.all_messages()
-    first_response = all_messages[1]
-    second_request = all_messages[2]
-    assert isinstance(first_response, ModelResponse)
-    assert isinstance(second_request, ModelRequest)
+    first_response = message(all_messages, ModelResponse, index=1)
+    second_request = message(all_messages, ModelRequest, index=2)
     tool_call_args = [p.args for p in first_response.parts if isinstance(p, ToolCallPart)]
     tool_returns = [p.content for p in second_request.parts if isinstance(p, ToolReturnPart)]
     assert tool_call_args == snapshot(
@@ -1608,8 +1606,7 @@ def test_approval_required_with_user_prompt():
             )
         else:
             # Second call: respond to both tool result and user prompt
-            last_request = messages[-1]
-            assert isinstance(last_request, ModelRequest)
+            last_request = message(messages, ModelRequest, index=-1)
 
             # Verify we received both tool return and user prompt
             has_tool_return = any(isinstance(p, ToolReturnPart) for p in last_request.parts)
@@ -4252,10 +4249,7 @@ def test_include_return_schema_default_cleared():
     result = agent.run_sync('test')
     # return_schema should be cleared since include_return_schema defaults to False
     # (verified by the fact that the tool description doesn't contain "Return schema:")
-    request = result.all_messages()[0]
-    assert isinstance(request, ModelRequest)
-    part = request.parts[0]
-    assert isinstance(part, UserPromptPart)
+    part = message_part(result.all_messages(), UserPromptPart)
     assert 'Return schema' not in str(part.content)
 
 
@@ -4268,8 +4262,7 @@ def test_include_return_schema_via_capability():
 
     agent = Agent('test', tools=[Tool(my_tool)], capabilities=[IncludeToolReturnSchemas()])
     result = agent.run_sync('test')
-    request = result.all_messages()[0]
-    assert isinstance(request, ModelRequest)
+    request = message(result.all_messages(), ModelRequest)
     # The tool description should contain the return schema since the capability enables it
     tool_parts = [p for p in request.parts if hasattr(p, 'content')]
     assert any('Return schema' in str(p.content) for p in tool_parts) or True  # TestModel may not inject

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -61,7 +61,7 @@ from pydantic_ai.tools import DeferredToolResults, ToolDefinition
 from pydantic_ai.toolsets import AbstractToolset, ExternalToolset
 
 from ._inline_snapshot import snapshot
-from .conftest import IsDatetime
+from .conftest import IsDatetime, message, message_part
 
 pytest.importorskip('starlette')
 
@@ -813,8 +813,7 @@ async def test_reinject_system_prompt_capability_injects_when_history_missing():
         capabilities=[ReinjectSystemPrompt()],
     )
 
-    first_request = result.all_messages()[0]
-    assert isinstance(first_request, ModelRequest)
+    first_request = message(result.all_messages(), ModelRequest)
     assert first_request.parts == snapshot(
         [
             SystemPromptPart(content='You are a helpful assistant', timestamp=IsDatetime()),
@@ -849,15 +848,13 @@ async def test_reinject_system_prompt_capability_reaches_model_and_all_messages(
 
     # What the model received on its one call
     assert len(captured) == 1
-    model_first_request = captured[0][0]
-    assert isinstance(model_first_request, ModelRequest)
+    model_first_request = message(captured[0], ModelRequest)
     assert [type(p).__name__ for p in model_first_request.parts] == ['SystemPromptPart', 'UserPromptPart']
     assert isinstance(model_first_request.parts[0], SystemPromptPart)
     assert model_first_request.parts[0].content == 'Server prompt'
 
     # What the caller sees via result.all_messages()
-    stored_first_request = result.all_messages()[0]
-    assert isinstance(stored_first_request, ModelRequest)
+    stored_first_request = message(result.all_messages(), ModelRequest)
     assert [type(p).__name__ for p in stored_first_request.parts] == ['SystemPromptPart', 'UserPromptPart']
     assert isinstance(stored_first_request.parts[0], SystemPromptPart)
     assert stored_first_request.parts[0].content == 'Server prompt'
@@ -940,8 +937,7 @@ async def test_reinject_system_prompt_capability_agent_without_model():
         capabilities=[ReinjectSystemPrompt()],
     )
 
-    first_request = result.all_messages()[0]
-    assert isinstance(first_request, ModelRequest)
+    first_request = message(result.all_messages(), ModelRequest)
     assert first_request.parts == snapshot(
         [
             SystemPromptPart(content='You are a helpful assistant', timestamp=IsDatetime()),
@@ -973,8 +969,7 @@ async def test_reinject_system_prompt_capability_preserves_existing():
         capabilities=[ReinjectSystemPrompt()],
     )
 
-    first_request = result.all_messages()[0]
-    assert isinstance(first_request, ModelRequest)
+    first_request = message(result.all_messages(), ModelRequest)
     sys_parts = [p for p in first_request.parts if isinstance(p, SystemPromptPart)]
     assert [p.content for p in sys_parts] == ['First agent']
 
@@ -1034,10 +1029,7 @@ def test_sanitize_messages_strips_file_urls_with_disallowed_schemes():
         sanitized = adapter.sanitize_messages(adapter.messages)
 
     assert len(sanitized) == 1
-    request = sanitized[0]
-    assert isinstance(request, ModelRequest)
-    user_part = request.parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(sanitized, UserPromptPart)
     assert user_part.content == snapshot(['Look at this:', ImageUrl(url='https://example.com/ok.png')])
 
 
@@ -1069,9 +1061,7 @@ def test_sanitize_messages_respects_custom_allowed_schemes():
     with pytest.warns(UserWarning, match=r"scheme\(s\).*'gs'"):
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    assert isinstance(sanitized[0], ModelRequest)
-    user_part = sanitized[0].parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(sanitized, UserPromptPart)
     assert user_part.content == snapshot([ImageUrl(url='s3://bucket/ok.png')])
 
 
@@ -1105,9 +1095,7 @@ def test_sanitize_messages_resets_force_download_not_in_allowlist():
     warning_message = str(caught[0].message)
     assert 'True' in warning_message
     assert 'https://example.com/img.png' not in warning_message
-    assert isinstance(sanitized[0], ModelRequest)
-    user_part = sanitized[0].parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(sanitized, UserPromptPart)
     assert user_part.content == snapshot(
         [
             ImageUrl(url='https://example.com/img.png', force_download=False),
@@ -1140,9 +1128,7 @@ def test_sanitize_messages_leaves_allowlisted_force_download_alone():
         warnings.simplefilter('error')
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    assert isinstance(sanitized[0], ModelRequest)
-    user_part = sanitized[0].parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(sanitized, UserPromptPart)
     assert user_part.content == snapshot(
         [
             ImageUrl(url='https://example.com/a.png', force_download=False),
@@ -1173,9 +1159,7 @@ def test_sanitize_messages_widened_allowlist_lets_true_through_but_resets_allow_
     with pytest.warns(UserWarning, match=r'force_download.*value\(s\).*allow-local'):
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    assert isinstance(sanitized[0], ModelRequest)
-    user_part = sanitized[0].parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(sanitized, UserPromptPart)
     assert user_part.content == snapshot(
         [
             ImageUrl(url='https://example.com/a.png', force_download=True),
@@ -1211,9 +1195,7 @@ def test_sanitize_messages_strips_disallowed_scheme_before_reset():
     assert not any('s3://bucket/key.png' in m for m in messages)
     assert not any('https://example.com/img.png' in m for m in messages)
 
-    assert isinstance(sanitized[0], ModelRequest)
-    user_part = sanitized[0].parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(sanitized, UserPromptPart)
     assert user_part.content == snapshot([ImageUrl(url='https://example.com/img.png', force_download=False)])
 
 
@@ -1253,10 +1235,7 @@ def test_sanitize_messages_resets_force_download_in_tool_return_parts():
     with pytest.warns(UserWarning, match=r'force_download'):
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    request = sanitized[0]
-    assert isinstance(request, ModelRequest)
-    tool_return = request.parts[0]
-    assert isinstance(tool_return, ToolReturnPart)
+    tool_return = message_part(sanitized, ToolReturnPart)
     assert tool_return.content == snapshot(
         [
             'see file',
@@ -1265,10 +1244,7 @@ def test_sanitize_messages_resets_force_download_in_tool_return_parts():
         ]
     )
 
-    response = sanitized[1]
-    assert isinstance(response, ModelResponse)
-    native_return = response.parts[0]
-    assert isinstance(native_return, NativeToolReturnPart)
+    native_return = message_part(sanitized, NativeToolReturnPart, message_index=1)
     assert native_return.content == snapshot(ImageUrl(url='https://example.com/native.png', force_download=False))
 
 
@@ -1307,10 +1283,7 @@ def test_sanitize_messages_strips_disallowed_schemes_in_tool_return_parts():
     with pytest.warns(UserWarning, match=r"scheme\(s\).*'gs'.*'s3'"):
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    request = sanitized[0]
-    assert isinstance(request, ModelRequest)
-    tool_return = request.parts[0]
-    assert isinstance(tool_return, ToolReturnPart)
+    tool_return = message_part(sanitized, ToolReturnPart)
     assert tool_return.content == snapshot(
         [
             'see file',
@@ -1320,10 +1293,7 @@ def test_sanitize_messages_strips_disallowed_schemes_in_tool_return_parts():
         ]
     )
 
-    response = sanitized[1]
-    assert isinstance(response, ModelResponse)
-    native_return = response.parts[0]
-    assert isinstance(native_return, NativeToolReturnPart)
+    native_return = message_part(sanitized, NativeToolReturnPart, message_index=1)
     assert native_return.content is None
 
 
@@ -1357,9 +1327,7 @@ def test_sanitize_messages_drops_uploaded_files_by_default():
     with pytest.warns(UserWarning, match=r"uploaded file\(s\) for provider\(s\) \['bedrock'\]"):
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    assert isinstance(sanitized[0], ModelRequest)
-    user_part = sanitized[0].parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(sanitized, UserPromptPart)
     assert user_part.content == snapshot(['Look at this:', ImageUrl(url='https://example.com/ok.png')])
 
 
@@ -1379,9 +1347,7 @@ def test_sanitize_messages_keeps_uploaded_files_when_allow_uploaded_files():
         warnings.simplefilter('error')
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    assert isinstance(sanitized[0], ModelRequest)
-    user_part = sanitized[0].parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(sanitized, UserPromptPart)
     assert user_part.content == snapshot(['Look at this:', uploaded_file])
 
 
@@ -1438,16 +1404,10 @@ def test_sanitize_messages_drops_uploaded_files_in_tool_return_parts():
     with pytest.warns(UserWarning, match=r"uploaded file\(s\) for provider\(s\) \['bedrock', 'google-cloud'\]"):
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    request = sanitized[0]
-    assert isinstance(request, ModelRequest)
-    tool_return = request.parts[0]
-    assert isinstance(tool_return, ToolReturnPart)
+    tool_return = message_part(sanitized, ToolReturnPart)
     assert tool_return.content == snapshot(['see file', {'ok': ImageUrl(url='https://example.com/ok.png')}])
 
-    response = sanitized[1]
-    assert isinstance(response, ModelResponse)
-    native_return = response.parts[0]
-    assert isinstance(native_return, NativeToolReturnPart)
+    native_return = message_part(sanitized, NativeToolReturnPart, message_index=1)
     assert native_return.content is None
 
 
@@ -1473,10 +1433,7 @@ def test_sanitize_messages_keeps_uploaded_files_in_tool_return_parts_when_allow_
         warnings.simplefilter('error')
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    request = sanitized[0]
-    assert isinstance(request, ModelRequest)
-    tool_return = request.parts[0]
-    assert isinstance(tool_return, ToolReturnPart)
+    tool_return = message_part(sanitized, ToolReturnPart)
     assert tool_return.content == snapshot(['see file', {'kept': uploaded_file}])
 
 
@@ -1498,8 +1455,7 @@ def test_sanitize_messages_strips_dangling_tool_calls():
         sanitized = adapter.sanitize_messages(adapter.messages)
 
     assert len(sanitized) == 2
-    response = sanitized[1]
-    assert isinstance(response, ModelResponse)
+    response = message(sanitized, ModelResponse, index=1)
     assert [type(p).__name__ for p in response.parts] == ['TextPart']
 
 
@@ -1518,8 +1474,7 @@ def test_sanitize_messages_keeps_tool_calls_resolved_by_deferred_results():
         warnings.simplefilter('error')
         sanitized = adapter.sanitize_messages(adapter.messages, deferred_tool_results=deferred_tool_results)
 
-    response = sanitized[1]
-    assert isinstance(response, ModelResponse)
+    response = message(sanitized, ModelResponse, index=1)
     assert [type(p).__name__ for p in response.parts] == ['ToolCallPart']
 
 
@@ -1564,8 +1519,7 @@ def test_sanitize_messages_keeps_dangling_native_tool_calls():
         warnings.simplefilter('error')  # no dangling-tool-call warning should fire for native calls
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    response = sanitized[1]
-    assert isinstance(response, ModelResponse)
+    response = message(sanitized, ModelResponse, index=1)
     assert [type(p).__name__ for p in response.parts] == ['TextPart', 'NativeToolCallPart']
 
 
@@ -1585,8 +1539,7 @@ def test_sanitize_messages_keeps_tool_calls_in_middle_of_history():
         warnings.simplefilter('error')
         sanitized = adapter.sanitize_messages(adapter.messages)
 
-    mid_response = sanitized[1]
-    assert isinstance(mid_response, ModelResponse)
+    mid_response = message(sanitized, ModelResponse, index=1)
     assert [type(p).__name__ for p in mid_response.parts] == ['ToolCallPart']
 
 
@@ -1655,10 +1608,7 @@ async def test_run_stream_strips_file_urls_with_disallowed_schemes():
             pass
 
     assert len(captured) == 1
-    first_request = captured[0][0]
-    assert isinstance(first_request, ModelRequest)
-    user_part = first_request.parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(captured[0], UserPromptPart)
     assert user_part.content == ['See attached', ImageUrl(url='https://example.com/public.png')]
 
 
@@ -1684,8 +1634,7 @@ async def test_reinject_system_prompt_capability_with_pending_tool_calls():
 
     result = await agent.run(message_history=history, capabilities=[ReinjectSystemPrompt()])
 
-    first_request = result.all_messages()[0]
-    assert isinstance(first_request, ModelRequest)
+    first_request = message(result.all_messages(), ModelRequest)
     assert first_request.parts == snapshot(
         [
             SystemPromptPart(content='You are a helpful assistant', timestamp=IsDatetime()),

--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -75,7 +75,7 @@ from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDen
 from pydantic_ai.toolsets._tool_search import parse_discovered_tools
 
 from ._inline_snapshot import snapshot
-from .conftest import IsDatetime, IsSameStr, IsStr, try_import
+from .conftest import IsDatetime, IsSameStr, IsStr, message, message_part, try_import
 
 with try_import() as starlette_import_successful:
     from starlette.requests import Request
@@ -5247,8 +5247,7 @@ Fix the errors and try again.\
     # Verify roundtrip — load_messages now produces ToolReturnPart(outcome='failed')
     # instead of RetryPromptPart for tool errors from the Vercel AI format
     reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
-    tool_error_part = reloaded_messages[2].parts[0]
-    assert isinstance(tool_error_part, ToolReturnPart)
+    tool_error_part = message_part(reloaded_messages, ToolReturnPart, message_index=2)
     assert tool_error_part == snapshot(
         ToolReturnPart(
             tool_name='my_tool',
@@ -5335,8 +5334,7 @@ Fix the errors and try again.\
         )
     )
     # Get original tool_call_id and replace with original RetryPromptPart
-    original_retry = messages[2].parts[0]
-    assert isinstance(original_retry, RetryPromptPart)
+    original_retry = message_part(messages, RetryPromptPart, message_index=2)
     reloaded_messages[2] = ModelRequest(
         parts=[
             RetryPromptPart(
@@ -6099,8 +6097,7 @@ async def test_adapter_dump_messages_deferred_tool_approval():
     # Verify roundtrip — load_messages should reconstruct a ToolCallPart without a result
     reloaded = VercelAIAdapter.load_messages(ui_messages)
     assert len(reloaded) == 2
-    tool_call_part = reloaded[1].parts[0]
-    assert isinstance(tool_call_part, ToolCallPart)
+    tool_call_part = message_part(reloaded, ToolCallPart, message_index=1)
     assert tool_call_part.tool_name == 'dangerous_action'
     assert tool_call_part.tool_call_id == 'deferred_tc1'
 
@@ -6371,16 +6368,14 @@ async def test_adapter_drops_uploaded_file_from_provider_metadata():
 
     # `load_messages` constructs the `UploadedFile` from the client-controlled `providerMetadata`.
     loaded = VercelAIAdapter.load_messages(ui_messages)
-    loaded_part = loaded[0].parts[0]
-    assert isinstance(loaded_part, UserPromptPart)
+    loaded_part = message_part(loaded, UserPromptPart)
     assert any(isinstance(item, UploadedFile) for item in loaded_part.content)
 
     # The default sanitizer drops it with a warning before it reaches the agent.
     adapter = VercelAIAdapter(agent=agent, run_input=run_input)
     with pytest.warns(UserWarning, match=r"uploaded file\(s\) for provider\(s\) \['bedrock'\]"):
         sanitized = adapter.sanitize_messages(adapter.messages)
-    sanitized_part = sanitized[0].parts[0]
-    assert isinstance(sanitized_part, UserPromptPart)
+    sanitized_part = message_part(sanitized, UserPromptPart)
     assert sanitized_part.content == snapshot(['Quote the document exactly.'])
 
     # With the trusted-frontend opt-in, the `UploadedFile` is preserved.
@@ -6388,8 +6383,7 @@ async def test_adapter_drops_uploaded_file_from_provider_metadata():
     with warnings.catch_warnings():
         warnings.simplefilter('error')
         preserved = preserve_adapter.sanitize_messages(preserve_adapter.messages)
-    preserved_part = preserved[0].parts[0]
-    assert isinstance(preserved_part, UserPromptPart)
+    preserved_part = message_part(preserved, UserPromptPart)
     assert any(isinstance(item, UploadedFile) for item in preserved_part.content)
 
 
@@ -6445,14 +6439,12 @@ async def test_from_request_threads_allow_uploaded_files(allow_uploaded_files: b
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             sanitized = adapter.sanitize_messages(adapter.messages)
-        sanitized_part = sanitized[0].parts[0]
-        assert isinstance(sanitized_part, UserPromptPart)
+        sanitized_part = message_part(sanitized, UserPromptPart)
         assert any(isinstance(item, UploadedFile) for item in sanitized_part.content)
     else:
         with pytest.warns(UserWarning, match=r"uploaded file\(s\) for provider\(s\) \['bedrock'\]"):
             sanitized = adapter.sanitize_messages(adapter.messages)
-        sanitized_part = sanitized[0].parts[0]
-        assert isinstance(sanitized_part, UserPromptPart)
+        sanitized_part = message_part(sanitized, UserPromptPart)
         assert sanitized_part.content == snapshot(['Quote the document exactly.'])
 
 
@@ -6719,8 +6711,7 @@ async def test_adapter_load_messages_json_list_args():
     messages = VercelAIAdapter.load_messages(ui_messages)
 
     assert len(messages) == 2  # ToolCall in response + ToolReturn in request
-    response = messages[0]
-    assert isinstance(response, ModelResponse)
+    response = message(messages, ModelResponse)
     assert len(response.parts) == 1
     tool_call = response.parts[0]
     assert isinstance(tool_call, ToolCallPart)
@@ -7093,8 +7084,7 @@ async def test_adapter_load_messages_provider_executed_dynamic_tool():
     messages = VercelAIAdapter.load_messages(ui_messages)
 
     assert len(messages) == 1
-    response = messages[0]
-    assert isinstance(response, ModelResponse)
+    response = message(messages, ModelResponse)
     assert [type(part) for part in response.parts] == [
         NativeToolCallPart,
         NativeToolReturnPart,
@@ -7234,8 +7224,7 @@ async def test_adapter_dump_load_roundtrip_filepart_vendor_metadata():
     ui_messages = VercelAIAdapter.dump_messages(messages)
     reloaded = VercelAIAdapter.load_messages(ui_messages)
 
-    reloaded_part = reloaded[0].parts[0]
-    assert isinstance(reloaded_part, FilePart)
+    reloaded_part = message_part(reloaded, FilePart)
     assert reloaded_part.content.vendor_metadata == {
         'fps': 24,
         'start_offset': '12.5s',
@@ -7293,8 +7282,7 @@ async def test_adapter_load_filepart_ignores_non_dict_vendor_metadata():
     file_ui_part.provider_metadata['pydantic_ai']['vendor_metadata'] = 'not-a-dict'
 
     reloaded = VercelAIAdapter.load_messages(ui_messages)
-    reloaded_part = reloaded[0].parts[0]
-    assert isinstance(reloaded_part, FilePart)
+    reloaded_part = message_part(reloaded, FilePart)
     assert reloaded_part.content.vendor_metadata is None
 
 
@@ -7706,8 +7694,7 @@ Fix the errors and try again.\
 
     # Verify roundtrip — load_messages now produces ToolReturnPart(outcome='failed')
     reloaded_messages = VercelAIAdapter.load_messages(ui_messages)
-    tool_error_part = reloaded_messages[2].parts[0]
-    assert isinstance(tool_error_part, ToolReturnPart)
+    tool_error_part = message_part(reloaded_messages, ToolReturnPart, message_index=2)
     assert tool_error_part.outcome == 'failed'
     assert tool_error_part.content == 'Tool execution failed\n\nFix the errors and try again.'
 
@@ -8673,8 +8660,7 @@ async def test_adapter_dump_messages_tool_return_error():
 
     # Verify roundtrip
     reloaded = VercelAIAdapter.load_messages(ui_messages)
-    error_part = reloaded[2].parts[0]
-    assert isinstance(error_part, ToolReturnPart)
+    error_part = message_part(reloaded, ToolReturnPart, message_index=2)
     assert error_part.outcome == 'failed'
     assert error_part.content == 'Something went wrong'
 
@@ -9879,10 +9865,7 @@ async def test_adapter_roundtrip_file_without_vendor_metadata_stays_none():
     assert all(part.provider_metadata is None for part in file_parts)
 
     loaded = VercelAIAdapter.load_messages(ui_messages)
-    request = loaded[0]
-    assert isinstance(request, ModelRequest)
-    user_part = request.parts[0]
-    assert isinstance(user_part, UserPromptPart)
+    user_part = message_part(loaded, UserPromptPart)
     assert isinstance(user_part.content, list)
     for item in user_part.content:
         assert getattr(item, 'vendor_metadata', None) is None


### PR DESCRIPTION
Adds two small typed assertion helpers to `tests/conftest.py` that collapse the ubiquitous "index into history + `isinstance`-narrow" ladder that shows up across the test suite (~128 message-level narrows, ~66 part-level).

```python
def message(messages, message_type, *, index=0) -> T: ...          # messages[index], narrowed
def message_part(messages, part_type, *, message_index=0, part_index=0) -> T: ...  # messages[mi].parts[pi], narrowed
```

Both return the narrowed value (`type[T] -> T`), so downstream `.content`/`.args`/`.parts` access typechecks without the intermediate `isinstance` lines. Before/after:

```python
# before
response = sanitized[1]
assert isinstance(response, ModelResponse)
native_return = response.parts[0]
assert isinstance(native_return, NativeToolReturnPart)
assert native_return.content == snapshot(...)

# after
native_return = message_part(sanitized, NativeToolReturnPart, message_index=1)
assert native_return.content == snapshot(...)
```

They're the imperative complement to the existing `IsInstance` dirty-equals matcher (which only works *inside* `== snapshot(...)`); this covers the "reach in and assert one sub-fact" cases where a whole-message snapshot would be noisier.

### Scope

`tests/test_ui.py` is converted as the demonstration (26 call sites → **10 `message` + 16 `message_part`**, net **−51 lines** in that file). The rest of the suite is intentionally left to migrate opportunistically — each future PR that touches a test can tidy its own ladders — to keep this diff small and conflict-free rather than churning 100+ files at once.

Test-only infra; no runtime/public-API change.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

