### PR TITLE
docs: add DashScope vision recipe and two-step structured output

### DIFF
--- a/docs/examples/dashscope-vision.md
+++ b/docs/examples/dashscope-vision.md
@@ -1,0 +1,38 @@
+# DashScope Vision
+
+Image understanding with Alibaba Cloud Model Studio (DashScope) using a Qwen VL model, then structured output with a text model.
+
+Demonstrates:
+
+- [`alibaba:`](../models/openai.md#alibaba-cloud-model-studio-dashscope) provider prefix (recommended over generic `openai:` + `OPENAI_BASE_URL`)
+- [Image input](../input.md#image-input) with [`BinaryContent`][pydantic_ai.BinaryContent]
+- A **two-step** pattern: vision model for pixels, text model for [`output_type`](../output.md#structured-output)
+- Optional split between a **vision** model (`qwen-vl-plus`) and a **text** model (`qwen-plus`)
+
+## Running the Example
+
+With [dependencies installed](./setup.md#usage), set an API key and run:
+
+```bash
+export DASHSCOPE_API_KEY='your-key'   # or ALIBABA_API_KEY
+uv run -m pydantic_ai_examples.dashscope_vision
+```
+
+China region endpoint (optional — this example reads `ALIBABA_BASE_URL`; in your own code pass `base_url` to [`AlibabaProvider`][pydantic_ai.providers.alibaba.AlibabaProvider] as shown in [DashScope docs](../models/openai.md#alibaba-cloud-model-studio-dashscope)):
+
+```bash
+export ALIBABA_BASE_URL='https://dashscope.aliyuncs.com/compatible-mode/v1'
+uv run -m pydantic_ai_examples.dashscope_vision
+```
+
+Override models:
+
+```bash
+PYDANTIC_AI_VISION_MODEL=alibaba:qwen-vl-max \
+PYDANTIC_AI_TEXT_MODEL=alibaba:qwen-max \
+uv run -m pydantic_ai_examples.dashscope_vision
+```
+
+## Example Code
+
+```snippet {path="/examples/pydantic_ai_examples/dashscope_vision.py"}```

--- a/docs/input.md
+++ b/docs/input.md
@@ -143,7 +143,7 @@ Support for file URLs varies depending on type and provider:
 
 | Model | Send URL directly | Download and send bytes | Unsupported |
 |-------|-------------------|-------------------------|-------------|
-| [`OpenAIChatModel`][pydantic_ai.models.openai.OpenAIChatModel] | `ImageUrl` | `AudioUrl`, `DocumentUrl` | `VideoUrl`. `DocumentUrl` [not supported with `AzureProvider`](models/openai.md#using-azure-with-the-responses-api) |
+| [`OpenAIChatModel`][pydantic_ai.models.openai.OpenAIChatModel] | `ImageUrl` | `AudioUrl`, `DocumentUrl` | `VideoUrl`. [`DocumentUrl`][pydantic_ai.DocumentUrl] [not supported with `AzureProvider`](models/openai.md#using-azure-with-the-responses-api). PDF, [`DocumentUrl`][pydantic_ai.DocumentUrl], and non-`text/plain` [`BinaryContent`][pydantic_ai.BinaryContent] [not supported with `AlibabaProvider`](models/openai.md#alibaba-cloud-model-studio-dashscope) |
 | [`OpenAIResponsesModel`][pydantic_ai.models.openai.OpenAIResponsesModel] | `ImageUrl`, `AudioUrl`, `DocumentUrl` | — | `VideoUrl` |
 | [`AnthropicModel`][pydantic_ai.models.anthropic.AnthropicModel] | `ImageUrl`, `DocumentUrl` (PDF) | `DocumentUrl` (`text/plain`) | `AudioUrl`, `VideoUrl` |
 | [`GoogleModel`][pydantic_ai.models.google.GoogleModel] (Google Cloud) | All URL types | — | — |

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -472,6 +472,60 @@ agent = Agent(model)
 ...
 ```
 
+#### Choosing an integration path
+
+DashScope exposes an [OpenAI-compatible Chat Completions API](https://www.alibabacloud.com/help/en/model-studio/compatibility-of-openai-with-dashscope). Pydantic AI supports two ways to connect:
+
+| Approach | Example | API key env var | Qwen [`ModelProfile`][pydantic_ai.profiles.ModelProfile] |
+|----------|---------|-----------------|----------------------------------------------------------|
+| **Recommended** — [`AlibabaProvider`][pydantic_ai.providers.alibaba.AlibabaProvider] | `Agent('alibaba:qwen-max')` | `ALIBABA_API_KEY` or `DASHSCOPE_API_KEY` | Applied automatically (JSON schema tweaks, streaming whitespace, etc.) |
+| Generic OpenAI-compatible | `OPENAI_BASE_URL` + `Agent('openai:qwen-max')` | `OPENAI_API_KEY` | **Not** applied — uses the default OpenAI profile |
+
+Use the `alibaba:` prefix (or pass [`AlibabaProvider`][pydantic_ai.providers.alibaba.AlibabaProvider] explicitly) for Qwen models. The generic `openai:` + `OPENAI_BASE_URL` path can work for simple text prompts, but does not automatically apply Qwen-specific [`ModelProfile`][pydantic_ai.profiles.ModelProfile] settings — you can pass an explicit `profile=` to [`OpenAIChatModel`][pydantic_ai.models.openai.OpenAIChatModel] on that route if needed. With `alibaba:` or [`AlibabaProvider`][pydantic_ai.providers.alibaba.AlibabaProvider], [`AlibabaProvider.model_profile`][pydantic_ai.providers.alibaba.AlibabaProvider.model_profile] is applied by default.
+
+!!! note "PDF and document file input is not supported"
+    The DashScope compatible-mode Chat Completions API does not accept document content parts (`type='file'`). PDF [`DocumentUrl`][pydantic_ai.messages.DocumentUrl] and non-`text/plain` document [`BinaryContent`][pydantic_ai.messages.BinaryContent] (for example `application/pdf`) are not supported with [`AlibabaProvider`][pydantic_ai.providers.alibaba.AlibabaProvider]. Plain `text/plain` [`BinaryContent`][pydantic_ai.messages.BinaryContent] is sent as inline text and can work. Image input with vision models such as `qwen-vl-plus` is supported — see [Vision understanding with structured output](#vision-understanding-with-structured-output) below.
+
+#### Vision understanding with structured output
+
+Use a **vision** model (for example `qwen-vl-plus` or `qwen-vl-max`) when the agent must *understand* image content. Text-only models such as `qwen-max` cannot see pixels.
+
+Send images with [`BinaryContent`][pydantic_ai.messages.BinaryContent] (or [`ImageUrl`][pydantic_ai.messages.ImageUrl]) to the vision model. For validated structured fields, use a **second** text-model agent with [`output_type`](../output.md#structured-output) — Qwen VL models return reliable plain-text descriptions from image prompts, while `output_type` on text models such as `qwen-plus` maps cleanly to JSON schema.
+
+```py {title="dashscope_vision_structured.py" test="skip" lint="skip"}
+import httpx
+from pydantic import BaseModel, Field
+
+from pydantic_ai import Agent, BinaryContent
+
+
+class ImageCaption(BaseModel):
+    """Structured description of an uploaded image."""
+
+    description: str
+    tags: list[str] = Field(min_length=1, max_length=5)
+
+
+# Requires DASHSCOPE_API_KEY or ALIBABA_API_KEY in the environment.
+vision_agent = Agent('alibaba:qwen-vl-plus')
+caption_agent = Agent('alibaba:qwen-plus', output_type=ImageCaption)
+
+image_bytes = httpx.get('https://iili.io/3Hs4FMg.png').content
+vision = vision_agent.run_sync(
+    [
+        'Describe this image in a few sentences.',
+        BinaryContent(data=image_bytes, media_type='image/png'),
+    ]
+)
+caption = caption_agent.run_sync(
+    f'Describe this image and suggest short tags based on: {vision.output}'
+)
+print(caption.output)
+#> description='...' tags=['logo', 'pydantic', ...]
+```
+
+For a runnable version of this pattern (including social copy generation), see the [DashScope vision example](../examples/dashscope-vision.md).
+
 ### Ollama
 
 See [Ollama](ollama.md) for dedicated Ollama documentation, including structured output and Ollama Cloud limitations.

--- a/examples/pydantic_ai_examples/dashscope_vision.py
+++ b/examples/pydantic_ai_examples/dashscope_vision.py
@@ -1,0 +1,129 @@
+"""DashScope (Alibaba Cloud) vision + structured output example.
+
+Demonstrates image understanding with a Qwen VL model via the recommended
+`alibaba:` provider prefix, then structured output and copy generation with a
+text model such as `qwen-plus`.
+
+Qwen VL models reliably return plain text for image prompts. For validated
+structured fields, run a second agent with `output_type` on a text model.
+
+Run with:
+
+    export DASHSCOPE_API_KEY='your-key'   # or ALIBABA_API_KEY
+    uv run -m pydantic_ai_examples.dashscope_vision
+
+For the China region endpoint, set `ALIBABA_BASE_URL` (read by this example only;
+see docs/models/openai.md to configure AlibabaProvider explicitly in your own app):
+
+    export ALIBABA_BASE_URL='https://dashscope.aliyuncs.com/compatible-mode/v1'
+    uv run -m pydantic_ai_examples.dashscope_vision
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, TypeVar
+
+import httpx
+from pydantic import BaseModel, Field
+
+from pydantic_ai import Agent, AgentRunResult, BinaryContent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.alibaba import AlibabaProvider
+
+# Public sample image (Pydantic logo) — same URL used in docs/input.md
+SAMPLE_IMAGE_URL = 'https://iili.io/3Hs4FMg.png'
+SAMPLE_IMAGE_MEDIA_TYPE = 'image/png'
+
+DEFAULT_VISION_MODEL = 'alibaba:qwen-vl-plus'
+DEFAULT_TEXT_MODEL = 'alibaba:qwen-plus'
+
+VISION_PROMPT = 'Describe this image in a few sentences.'
+CAPTION_PROMPT_PREFIX = 'Describe this image and suggest concise tags based on: '
+COPY_PROMPT_PREFIX = (
+    'Write one short social-media sentence based on this image description: '
+)
+
+
+class ImageCaption(BaseModel):
+    description: str
+    tags: list[str] = Field(min_length=1, max_length=5)
+
+
+OutputT = TypeVar('OutputT')
+
+
+def _api_key() -> str | None:
+    """Same precedence as [`AlibabaProvider`][pydantic_ai.providers.alibaba.AlibabaProvider]."""
+    return os.getenv('ALIBABA_API_KEY') or os.getenv('DASHSCOPE_API_KEY')
+
+
+def _print_step(title: str, result: AgentRunResult[OutputT]) -> None:
+    print(f'\n--- {title} ---')
+    print(result.output)
+    print(f'usage: {result.usage}')
+
+
+def _agent(
+    model: str, *, output_type: type[ImageCaption] | None = None
+) -> Agent[Any, Any]:
+    """Build an Agent, optionally with a custom DashScope base URL for this example."""
+    prefix, _, name = model.partition(':')
+    if prefix != 'alibaba':
+        raise ValueError(f'Expected alibaba:<model>, got {model!r}')
+
+    base_url = os.getenv('ALIBABA_BASE_URL')
+    if base_url:
+        api_key = _api_key()
+        assert api_key is not None  # validated in main() before any agent runs
+        openai_model = OpenAIChatModel(
+            name,
+            provider=AlibabaProvider(api_key=api_key, base_url=base_url),
+        )
+        if output_type is None:
+            return Agent(openai_model)
+        return Agent(openai_model, output_type=output_type)
+
+    if output_type is None:
+        return Agent(model)
+    return Agent(model, output_type=output_type)
+
+
+def main() -> None:
+    if not _api_key():
+        raise SystemExit(
+            'Set ALIBABA_API_KEY or DASHSCOPE_API_KEY to run this example.'
+        )
+
+    vision_model = os.getenv('PYDANTIC_AI_VISION_MODEL', DEFAULT_VISION_MODEL)
+    text_model = os.getenv('PYDANTIC_AI_TEXT_MODEL', DEFAULT_TEXT_MODEL)
+
+    print(f'Vision model: {vision_model}')
+    print(f'Text model:   {text_model}')
+    if base := os.getenv('ALIBABA_BASE_URL'):
+        print(f'Base URL:     {base}')
+
+    image_bytes = httpx.get(
+        SAMPLE_IMAGE_URL, follow_redirects=True, timeout=10.0
+    ).content
+
+    vision_agent = _agent(vision_model)
+    vision = vision_agent.run_sync(
+        [
+            VISION_PROMPT,
+            BinaryContent(data=image_bytes, media_type=SAMPLE_IMAGE_MEDIA_TYPE),
+        ]
+    )
+    _print_step('Vision description (plain text)', vision)
+
+    caption_agent = _agent(text_model, output_type=ImageCaption)
+    caption = caption_agent.run_sync(f'{CAPTION_PROMPT_PREFIX}{vision.output}')
+    _print_step('Image caption (structured, text model)', caption)
+
+    copy_agent = _agent(text_model)
+    blurb = copy_agent.run_sync(f'{COPY_PROMPT_PREFIX}{caption.output.description}')
+    _print_step('Generated copy (text model)', blurb)
+
+
+if __name__ == '__main__':
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Setup: examples/setup.md
       - Getting Started:
           - examples/pydantic-model.md
+          - examples/dashscope-vision.md
           - examples/weather-agent.md
       - Conversational Agents:
           - examples/chat-app.md


### PR DESCRIPTION
Fixes #6273

## Summary

- Document `alibaba:` vs `openai:` + `OPENAI_BASE_URL` integration paths for DashScope (Qwen `ModelProfile` is only applied via `AlibabaProvider`)
- Narrow document input limits for `AlibabaProvider`: PDF, `DocumentUrl`, and non-`text/plain` `BinaryContent` are not supported; plain `text/plain` `BinaryContent` is sent as inline text (related to #5724 / PR #5727)
- Add runnable example `pydantic_ai_examples.dashscope_vision` and docs page: `qwen-vl-plus` for image understanding, `qwen-plus` for validated `output_type` and copy generation (two-step pattern)
- Link the example from Getting Started in `mkdocs.yml`

## Test plan

- [x] `uv sync --no-default-groups --package pydantic-ai-slim --extra openai`
- [x] `uv pip install -e examples --no-deps`
- [x] `export DASHSCOPE_API_KEY=...` and `export ALIBABA_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1`
- [x] `uv run --no-sync -m pydantic_ai_examples.dashscope_vision` → exit 0

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

