### PR TITLE
fix: preserve ToolReturnPart metadata and timestamp in AG-UI round-trip

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -8,6 +8,7 @@ import warnings
 from base64 import b64decode
 from collections.abc import Sequence
 from dataclasses import KW_ONLY, dataclass
+from datetime import datetime
 from functools import cached_property
 from typing import (
     TYPE_CHECKING,
@@ -93,6 +94,7 @@ try:
         parse_ag_ui_version,
         parse_builtin_tool_call_id,
         parse_encrypted_tool_kind,
+        parse_encrypted_tool_return_data,
         rehydrate_tool_return_content,
         thinking_encrypted_metadata,
         tool_kind_encrypted_value_kwargs,
@@ -475,11 +477,24 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     # slot, so client-built ToolMessages usually carry no `encrypted_value`. Error
                     # results stay untyped — typed return parts imply success to their readers.
                     tool_kind = None
+                    metadata = None
+                    timestamp = None
                     if tool_msg.error is None:
-                        encrypted_tool_kind = (
-                            parse_encrypted_tool_kind(tool_msg.encrypted_value) if use_encrypted_value else None
-                        )
+                        if use_encrypted_value:
+                            encrypted_tool_kind, metadata, timestamp = parse_encrypted_tool_return_data(
+                                tool_msg.encrypted_value
+                            )
+                        else:
+                            encrypted_tool_kind = None
                         tool_kind = encrypted_tool_kind or tool_kinds.get(tool_call_id)
+
+                    kwargs: dict[str, Any] = {}
+                    if tool_kind is not None:
+                        kwargs['tool_kind'] = tool_kind
+                    if metadata is not None:
+                        kwargs['metadata'] = metadata
+                    if timestamp is not None:
+                        kwargs['timestamp'] = timestamp
 
                     builtin_id = parse_builtin_tool_call_id(tool_call_id)
                     if builtin_id is not None:
@@ -490,7 +505,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 content=content,
                                 tool_call_id=original_id,
                                 provider_name=provider_name,
-                                tool_kind=tool_kind,
+                                **kwargs,
                             )
                         )
                     else:
@@ -502,7 +517,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 tool_name=tool_name,
                                 content=content,
                                 tool_call_id=tool_call_id,
-                                tool_kind=tool_kind,
+                                **kwargs,
                             )
                         )
 
@@ -663,7 +678,12 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                         id=_new_message_id(),
                         content=dump_tool_return_content(part.content),
                         tool_call_id=part.tool_call_id,
-                        **tool_kind_encrypted_value_kwargs(part.tool_kind, supported=use_encrypted_value),
+                        **tool_kind_encrypted_value_kwargs(
+                            part.tool_kind,
+                            part.metadata,
+                            part.timestamp,
+                            supported=use_encrypted_value,
+                        ),
                     )
                 )
             elif isinstance(part, RetryPromptPart):
@@ -771,7 +791,12 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                             id=_new_message_id(),
                             content=dump_tool_return_content(builtin_return.content),
                             tool_call_id=prefixed_id,
-                            **tool_kind_encrypted_value_kwargs(builtin_return.tool_kind, supported=use_encrypted_value),
+                            **tool_kind_encrypted_value_kwargs(
+                                builtin_return.tool_kind,
+                                builtin_return.metadata,
+                                builtin_return.timestamp,
+                                supported=use_encrypted_value,
+                            ),
                         )
                     )
             elif isinstance(part, NativeToolReturnPart):

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
@@ -6,6 +6,7 @@ import importlib.metadata
 import json
 import re
 import warnings
+from datetime import datetime
 from typing import Any, Final
 
 from typing_extensions import Required, TypedDict
@@ -130,19 +131,30 @@ _ENCRYPTED_VALUE_NAMESPACE: Final = 'pydantic_ai'
 provider blob in the same slot is never mistaken for our data."""
 
 
-def tool_kind_encrypted_value(tool_kind: ToolPartKind | None) -> str | None:
-    """Pack a part's `tool_kind` into an AG-UI `encrypted_value` blob, namespaced under `pydantic_ai`.
+def tool_kind_encrypted_value(
+    tool_kind: ToolPartKind | None,
+    metadata: Any | None = None,
+    timestamp: datetime | None = None,
+) -> str | None:
+    """Pack a part's `tool_kind`, `metadata`, and `timestamp` into an AG-UI `encrypted_value` blob, namespaced under `pydantic_ai`.
 
     AG-UI has no generic per-tool metadata field, so we carry the `tool_kind` discriminator in
     `encrypted_value` — the protocol's opaque, client-echoed state-continuity slot. Our payload is
     nested under a `pydantic_ai` key so a genuine provider blob in the same slot (e.g. Google's
     encrypted thinking on a tool call) is never read as our data. The claim is untrusted coming back
-    in: `parse_encrypted_tool_kind` returns it only when the key is present, and it degrades to a
+    in: `parse_encrypted_tool_return_data` returns it only when the key is present, and it degrades to a
     plain part if it doesn't validate.
     """
-    if tool_kind is None:
+    if tool_kind is None and metadata is None and timestamp is None:
         return None
-    return json.dumps({_ENCRYPTED_VALUE_NAMESPACE: {'tool_kind': tool_kind}})
+    payload: dict[str, Any] = {}
+    if tool_kind is not None:
+        payload['tool_kind'] = tool_kind
+    if metadata is not None:
+        payload['metadata'] = metadata
+    if timestamp is not None:
+        payload['timestamp'] = timestamp.isoformat()
+    return json.dumps({_ENCRYPTED_VALUE_NAMESPACE: payload})
 
 
 class _EncryptedValueKwargs(TypedDict, total=False):
@@ -151,14 +163,20 @@ class _EncryptedValueKwargs(TypedDict, total=False):
     encrypted_value: str
 
 
-def tool_kind_encrypted_value_kwargs(tool_kind: ToolPartKind | None, *, supported: bool) -> _EncryptedValueKwargs:
-    """`ToolCall`/`ToolMessage` kwargs carrying `tool_kind` as an `encrypted_value`, or empty to omit it.
+def tool_kind_encrypted_value_kwargs(
+    tool_kind: ToolPartKind | None,
+    metadata: Any | None = None,
+    timestamp: datetime | None = None,
+    *,
+    supported: bool,
+) -> _EncryptedValueKwargs:
+    """`ToolCall`/`ToolMessage` kwargs carrying `tool_kind`, `metadata`, and `timestamp` as an `encrypted_value`, or empty to omit it.
 
     Empty when the target version predates the `encrypted_value` field (`supported=False`) or the part
     has no `tool_kind`, so — like the streaming carrier — the field is only ever set when there's a
     claim to carry, never written as a bare `null` a pre-0.1.11 client wouldn't expect.
     """
-    value = tool_kind_encrypted_value(tool_kind) if supported else None
+    value = tool_kind_encrypted_value(tool_kind, metadata, timestamp) if supported else None
     return {'encrypted_value': value} if value is not None else {}
 
 
@@ -179,6 +197,40 @@ def warn_tool_kind_not_persisted(ag_ui_version: str) -> None:
     )
 
 
+def parse_encrypted_tool_return_data(encrypted_value: str | None) -> tuple[ToolPartKind | None, Any | None, datetime | None]:
+    """Read `tool_kind`, `metadata`, and `timestamp` claims from the `pydantic_ai` namespace of an AG-UI `encrypted_value` blob.
+
+    Client-supplied and untrusted: anything that isn't a valid JSON object or lacks the `pydantic_ai` key
+    degrades to `(None, None, None)`.
+    """
+    if not encrypted_value:
+        return None, None, None
+    try:
+        data = json.loads(encrypted_value)
+    except json.JSONDecodeError:
+        return None, None, None
+    if not is_str_dict(data):
+        return None, None, None
+    namespaced = data.get(_ENCRYPTED_VALUE_NAMESPACE)
+    if not is_str_dict(namespaced):
+        return None, None, None
+
+    tool_kind_raw = namespaced.get('tool_kind')
+    tool_kind = parse_tool_kind(tool_kind_raw) if isinstance(tool_kind_raw, str) else None
+
+    metadata = namespaced.get('metadata')
+
+    timestamp_raw = namespaced.get('timestamp')
+    timestamp: datetime | None = None
+    if isinstance(timestamp_raw, str):
+        try:
+            timestamp = datetime.fromisoformat(timestamp_raw)
+        except ValueError:
+            pass
+
+    return tool_kind, metadata, timestamp
+
+
 def parse_encrypted_tool_kind(encrypted_value: str | None) -> ToolPartKind | None:
     """Read a `tool_kind` claim from the `pydantic_ai` namespace of an AG-UI `encrypted_value` blob.
 
@@ -186,19 +238,8 @@ def parse_encrypted_tool_kind(encrypted_value: str | None) -> ToolPartKind | Non
     `{'pydantic_ai': {'tool_kind': <known ToolPartKind>}}` reads as `None`, so a genuine provider
     encrypted blob (no `pydantic_ai` key) or a forged claim degrades to a plain part.
     """
-    if not encrypted_value:
-        return None
-    try:
-        data = json.loads(encrypted_value)
-    except json.JSONDecodeError:
-        return None
-    if not is_str_dict(data):
-        return None
-    namespaced = data.get(_ENCRYPTED_VALUE_NAMESPACE)
-    if not is_str_dict(namespaced):
-        return None
-    tool_kind = namespaced.get('tool_kind')
-    return parse_tool_kind(tool_kind) if isinstance(tool_kind, str) else None
+    tool_kind, _, _ = parse_encrypted_tool_return_data(encrypted_value)
+    return tool_kind
 
 
 def parse_builtin_tool_call_id(tool_call_id: str) -> tuple[str, str] | None:

--- a/tests/test_ag_ui_tool_return_metadata_loss.py
+++ b/tests/test_ag_ui_tool_return_metadata_loss.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timezone
+
+from pydantic_ai import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.messages import NativeToolCallPart, NativeToolReturnPart
+from pydantic_ai.ui.ag_ui import AGUIAdapter
+
+ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+def test_tool_return_part_metadata_dropped_on_agui_roundtrip() -> None:
+    original = [
+        ModelResponse(
+            parts=[
+                TextPart(content='hello'),
+                ToolCallPart(tool_name='foo', args={'q': 'x'}, tool_call_id='tc-1'),
+            ],
+            timestamp=ts,
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='foo',
+                    content={'result': 'ok'},
+                    tool_call_id='tc-1',
+                    metadata={'app_state': {'k': 'v'}, 'attempt': 2},
+                    timestamp=ts,
+                )
+            ],
+        ),
+    ]
+
+    reloaded = AGUIAdapter.load_messages(AGUIAdapter.dump_messages(original))
+    tr = reloaded[1].parts[0]
+    assert tr.metadata == original[1].parts[0].metadata, (
+        f'metadata lost: reloaded={tr.metadata!r} != original={original[1].parts[0].metadata!r}'
+    )
+    assert tr.timestamp == original[1].parts[0].timestamp, (
+        f'timestamp lost: reloaded={tr.timestamp!r} != original={original[1].parts[0].timestamp!r}'
+    )
+
+
+def test_native_tool_return_part_metadata_dropped_on_agui_roundtrip() -> None:
+    original = [
+        ModelRequest(parts=[]),
+        ModelResponse(
+            parts=[
+                TextPart(content='hello'),
+                NativeToolCallPart(
+                    tool_name='web_search', args={'q': 'x'},
+                    tool_call_id='nc-1', provider_name='openai',
+                ),
+                NativeToolReturnPart(
+                    tool_name='web_search', content={'result': 'ok'},
+                    tool_call_id='nc-1', provider_name='openai',
+                    metadata={'caller': 'agent-1', 'attempt': 2},
+                    timestamp=ts,
+                ),
+            ],
+            timestamp=ts,
+        ),
+    ]
+
+    reloaded = AGUIAdapter.load_messages(AGUIAdapter.dump_messages(original))
+    ntr = next(p for p in reloaded[0].parts if isinstance(p, NativeToolReturnPart))
+    orig_ntr = next(p for p in original[1].parts if isinstance(p, NativeToolReturnPart))
+    assert ntr.metadata == orig_ntr.metadata, (
+        f'metadata lost: reloaded={ntr.metadata!r} != original={orig_ntr.metadata!r}'
+    )
+    assert ntr.timestamp == orig_ntr.timestamp, (
+        f'timestamp lost: reloaded={ntr.timestamp!r} != original={orig_ntr.timestamp!r}'
+    )


### PR DESCRIPTION
Fixes #6271

This ensures that `ToolReturnPart.metadata` and `timestamp` are preserved during `AGUIAdapter.dump_messages` -> `load_messages` by serializing them into the `encrypted_value` blob, addressing the issue where application-controlled state was lost. Added a unit test from the issue description to prevent regressions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

