### PR TITLE
fix(openai): drop post-done Responses function-call args delta

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3379,6 +3379,10 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
             # `TextPart.provider_details` on `output_text.done`.
             _phase_by_item: dict[str, Literal['commentary', 'final_answer']] = {}
             mcp_list_tools_return_ids: set[str] = set()
+            # Track function-call items whose arguments have been signaled `done`, so a
+            # stray post-done arguments delta from a non-conforming endpoint doesn't corrupt
+            # the accumulated tool-call `args` (see #5757).
+            _done_function_call_item_ids: set[str] = set()
 
             if self._provider_timestamp is not None:  # pragma: no branch
                 self.provider_details = {'timestamp': self._provider_timestamp}
@@ -3427,6 +3431,11 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                     self._usage += self._map_usage(chunk.response)
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDeltaEvent):
+                    # Drop a stray arguments delta that arrives after the item's arguments were
+                    # signaled `done`; applying it would append to and corrupt the final
+                    # tool-call `args` (see #5757).
+                    if chunk.item_id in _done_function_call_item_ids:
+                        continue
                     maybe_event = self._parts_manager.handle_tool_call_delta(
                         vendor_part_id=chunk.item_id,
                         args=chunk.delta,
@@ -3435,7 +3444,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                         yield maybe_event
 
                 elif isinstance(chunk, responses.ResponseFunctionCallArgumentsDoneEvent):
-                    pass  # there's nothing we need to do here
+                    _done_function_call_item_ids.add(chunk.item_id)
 
                 elif isinstance(chunk, responses.ResponseIncompleteEvent):  # pragma: no cover
                     self._usage += self._map_usage(chunk.response)

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -12308,3 +12308,81 @@ def test_openai_responses_phase_profile_flag():
     assert openai_model_profile('gpt-5.2').get('openai_supports_phase', False) is False
     assert openai_model_profile('gpt-5').get('openai_supports_phase', False) is False
     assert openai_model_profile('gpt-4o').get('openai_supports_phase', False) is False
+
+
+async def test_openai_responses_stream_ignores_post_done_function_call_args_delta(allow_model_requests: None):
+    """A stray function-call arguments delta arriving after the item's arguments are `done`
+    must not corrupt the accumulated tool-call `args` (see #5757)."""
+    from openai.types.responses import ResponseFunctionToolCall
+
+    base_response = resp.Response(
+        id='resp_001',
+        model='gpt-4o',
+        object='response',
+        created_at=1704067200,
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice='auto',
+        tools=[],
+    )
+
+    stream: list[resp.ResponseStreamEvent] = [
+        resp.ResponseCreatedEvent(response=base_response, type='response.created', sequence_number=0),
+        resp.ResponseInProgressEvent(response=base_response, type='response.in_progress', sequence_number=1),
+        resp.ResponseOutputItemAddedEvent(
+            item=ResponseFunctionToolCall(
+                id='fc_001',
+                call_id='call_001',
+                name='my_tool',
+                arguments='',
+                type='function_call',
+            ),
+            output_index=0,
+            type='response.output_item.added',
+            sequence_number=2,
+        ),
+        resp.ResponseFunctionCallArgumentsDeltaEvent(
+            item_id='fc_001',
+            output_index=0,
+            delta='{"x": 1}',
+            type='response.function_call_arguments.delta',
+            sequence_number=3,
+        ),
+        resp.ResponseFunctionCallArgumentsDoneEvent(
+            item_id='fc_001',
+            output_index=0,
+            arguments='{"x": 1}',
+            name='my_tool',
+            type='response.function_call_arguments.done',
+            sequence_number=4,
+        ),
+        # Stray post-done delta from a non-conforming endpoint: must be ignored.
+        resp.ResponseFunctionCallArgumentsDeltaEvent(
+            item_id='fc_001',
+            output_index=0,
+            delta='}',
+            type='response.function_call_arguments.delta',
+            sequence_number=5,
+        ),
+        resp.ResponseCompletedEvent(
+            response=base_response.model_copy(update={'status': 'completed'}),
+            type='response.completed',
+            sequence_number=6,
+        ),
+    ]
+
+    mock_client = MockOpenAIResponses.create_mock_stream(stream)
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(openai_client=mock_client))
+
+    from pydantic_ai.direct import model_request_stream
+    from pydantic_ai.messages import ModelRequest
+
+    async with model_request_stream(model, [ModelRequest.user_text_prompt('')]) as stream_response:
+        async for _ in stream_response:
+            pass
+        response = stream_response.get()
+
+    tool_calls = [part for part in response.parts if part.part_kind == 'tool-call']
+    assert len(tool_calls) == 1
+    # Without the guard the stray '}' would append, yielding the invalid '{"x": 1}}'.
+    assert tool_calls[0].args == '{"x": 1}'


### PR DESCRIPTION
## Summary

- Drops a stray `response.function_call_arguments.delta` that a non-conforming OpenAI Responses endpoint emits *after* the item's arguments were signaled `done`.
- Prevents the final `ModelResponse` tool-call `args` from being corrupted (e.g. invalid JSON), which broke downstream tool-arg parsing/execution.

## Motivation

Closes #5757 (model-layer follow-up to #4733 / #5027).

#5027 fixed the AG-UI **event-protocol** violation in the generic stream wrapper (`StreamedResponse.iterator_with_part_end`): it suppresses a `PartDeltaEvent` emitted after `PartEndEvent`. But by the time that wrapper sees the event, `ModelResponsePartsManager.handle_tool_call_delta` has **already applied** the stray delta to the underlying part. So:

- the emitted `PartEndEvent` keeps a clean part reference (the stream looks fine), but
- the final `StreamedResponse.get()` / `ModelResponse` carries the **corrupted** `args`.

In the reported scenario the stray delta was `'}'`, turning a valid `'{...}'` into invalid JSON `'{...}}'`.

As the issue notes, this can't be fixed generically — the fix must live where an explicit "done" signal exists, which is the provider model layer.

## Fix

Guard at the source in `OpenAIResponsesStreamedResponse._get_event_iterator`:
- Track function-call `item_id`s seen in `ResponseFunctionCallArgumentsDoneEvent` in a `set[str]`.
- Skip any later `ResponseFunctionCallArgumentsDeltaEvent` whose `item_id` is already done.

Non-breaking: a spec-compliant Responses stream never sends a post-done delta, so conforming endpoints are unaffected. Provider-specific by nature (the explicit done signal is Responses-specific).

## Tests

- Added `test_openai_responses_stream_ignores_post_done_function_call_args_delta`: a synthetic Responses event sequence with a post-done `'}'` delta, fed through the model's stream via the `direct` API.
  - Fails without the guard (final args become `'{"x": 1}}'`).
  - Passes with it (final args stay `'{"x": 1}'`).

## Verification

- `python -m pytest tests/models/test_openai_responses.py` — **138 passed**
- `make lint` (ruff format + check) — clean
- `make typecheck` — no new errors on the two touched files (the 109 pre-existing errors are all in `ui/ag_ui` + `test_ag_ui.py` and are present on unmodified `main`).
- Diff is focused: +88/-1 across 2 files, one commit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

