### PR TITLE
fix(ag-ui): preserve `ToolReturnPart.outcome`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -93,9 +93,11 @@ try:
         parse_ag_ui_version,
         parse_builtin_tool_call_id,
         parse_encrypted_tool_kind,
+        parse_encrypted_tool_outcome,
         rehydrate_tool_return_content,
         thinking_encrypted_metadata,
         tool_kind_encrypted_value_kwargs,
+        tool_return_encrypted_value_kwargs,
         warn_tool_kind_not_persisted,
     )
 except ImportError as e:  # pragma: no cover
@@ -475,11 +477,17 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     # slot, so client-built ToolMessages usually carry no `encrypted_value`. Error
                     # results stay untyped — typed return parts imply success to their readers.
                     tool_kind = None
+                    outcome: Literal['success', 'failed', 'denied'] = 'success'
                     if tool_msg.error is None:
                         encrypted_tool_kind = (
                             parse_encrypted_tool_kind(tool_msg.encrypted_value) if use_encrypted_value else None
                         )
                         tool_kind = encrypted_tool_kind or tool_kinds.get(tool_call_id)
+                    else:
+                        encrypted_outcome = (
+                            parse_encrypted_tool_outcome(tool_msg.encrypted_value) if use_encrypted_value else None
+                        )
+                        outcome = encrypted_outcome or 'failed'
 
                     builtin_id = parse_builtin_tool_call_id(tool_call_id)
                     if builtin_id is not None:
@@ -491,6 +499,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 tool_call_id=original_id,
                                 provider_name=provider_name,
                                 tool_kind=tool_kind,
+                                outcome=outcome,
                             )
                         )
                     else:
@@ -503,6 +512,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 content=content,
                                 tool_call_id=tool_call_id,
                                 tool_kind=tool_kind,
+                                outcome=outcome,
                             )
                         )
 
@@ -658,12 +668,18 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
             elif isinstance(part, ToolReturnPart):
                 flush_user_content()
                 # Tool-return files ride inline in `ToolMessage.content` (see `dump_tool_return_content`).
+                outcome = None if part.outcome == 'success' else part.outcome
                 result.append(
                     ToolMessage(
                         id=_new_message_id(),
                         content=dump_tool_return_content(part.content),
                         tool_call_id=part.tool_call_id,
-                        **tool_kind_encrypted_value_kwargs(part.tool_kind, supported=use_encrypted_value),
+                        error=part.model_response_str() if outcome is not None else None,
+                        **tool_return_encrypted_value_kwargs(
+                            tool_kind=part.tool_kind if outcome is None else None,
+                            outcome=outcome,
+                            supported=use_encrypted_value,
+                        ),
                     )
                 )
             elif isinstance(part, RetryPromptPart):

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
@@ -6,7 +6,7 @@ import importlib.metadata
 import json
 import re
 import warnings
-from typing import Any, Final
+from typing import Any, Final, Literal
 
 from typing_extensions import Required, TypedDict
 
@@ -130,6 +130,14 @@ _ENCRYPTED_VALUE_NAMESPACE: Final = 'pydantic_ai'
 provider blob in the same slot is never mistaken for our data."""
 
 
+ToolOutcome = Literal['failed', 'denied']
+
+
+def _pydantic_ai_encrypted_value(data: dict[str, Any]) -> str | None:
+    """Pack Pydantic AI metadata into an AG-UI `encrypted_value` blob."""
+    return json.dumps({_ENCRYPTED_VALUE_NAMESPACE: data}) if data else None
+
+
 def tool_kind_encrypted_value(tool_kind: ToolPartKind | None) -> str | None:
     """Pack a part's `tool_kind` into an AG-UI `encrypted_value` blob, namespaced under `pydantic_ai`.
 
@@ -140,9 +148,7 @@ def tool_kind_encrypted_value(tool_kind: ToolPartKind | None) -> str | None:
     in: `parse_encrypted_tool_kind` returns it only when the key is present, and it degrades to a
     plain part if it doesn't validate.
     """
-    if tool_kind is None:
-        return None
-    return json.dumps({_ENCRYPTED_VALUE_NAMESPACE: {'tool_kind': tool_kind}})
+    return _pydantic_ai_encrypted_value({'tool_kind': tool_kind} if tool_kind is not None else {})
 
 
 class _EncryptedValueKwargs(TypedDict, total=False):
@@ -159,6 +165,24 @@ def tool_kind_encrypted_value_kwargs(tool_kind: ToolPartKind | None, *, supporte
     claim to carry, never written as a bare `null` a pre-0.1.11 client wouldn't expect.
     """
     value = tool_kind_encrypted_value(tool_kind) if supported else None
+    return {'encrypted_value': value} if value is not None else {}
+
+
+def tool_return_encrypted_value_kwargs(
+    *,
+    tool_kind: ToolPartKind | None,
+    outcome: ToolOutcome | None,
+    supported: bool,
+) -> _EncryptedValueKwargs:
+    """`ToolMessage` kwargs carrying successful `tool_kind` and/or non-success `outcome`."""
+    if not supported:
+        return {}
+    data: dict[str, Any] = {}
+    if tool_kind is not None:
+        data['tool_kind'] = tool_kind
+    if outcome is not None:
+        data['tool_outcome'] = outcome
+    value = _pydantic_ai_encrypted_value(data)
     return {'encrypted_value': value} if value is not None else {}
 
 
@@ -179,13 +203,7 @@ def warn_tool_kind_not_persisted(ag_ui_version: str) -> None:
     )
 
 
-def parse_encrypted_tool_kind(encrypted_value: str | None) -> ToolPartKind | None:
-    """Read a `tool_kind` claim from the `pydantic_ai` namespace of an AG-UI `encrypted_value` blob.
-
-    Client-supplied and untrusted: anything that isn't a JSON object carrying
-    `{'pydantic_ai': {'tool_kind': <known ToolPartKind>}}` reads as `None`, so a genuine provider
-    encrypted blob (no `pydantic_ai` key) or a forged claim degrades to a plain part.
-    """
+def _parse_encrypted_pydantic_ai_data(encrypted_value: str | None) -> dict[str, Any] | None:
     if not encrypted_value:
         return None
     try:
@@ -195,10 +213,32 @@ def parse_encrypted_tool_kind(encrypted_value: str | None) -> ToolPartKind | Non
     if not is_str_dict(data):
         return None
     namespaced = data.get(_ENCRYPTED_VALUE_NAMESPACE)
-    if not is_str_dict(namespaced):
+    return namespaced if is_str_dict(namespaced) else None
+
+
+def parse_encrypted_tool_kind(encrypted_value: str | None) -> ToolPartKind | None:
+    """Read a `tool_kind` claim from the `pydantic_ai` namespace of an AG-UI `encrypted_value` blob.
+
+    Client-supplied and untrusted: anything that isn't a JSON object carrying
+    `{'pydantic_ai': {'tool_kind': <known ToolPartKind>}}` reads as `None`, so a genuine provider
+    encrypted blob (no `pydantic_ai` key) or a forged claim degrades to a plain part.
+    """
+    namespaced = _parse_encrypted_pydantic_ai_data(encrypted_value)
+    if namespaced is None:
         return None
     tool_kind = namespaced.get('tool_kind')
     return parse_tool_kind(tool_kind) if isinstance(tool_kind, str) else None
+
+
+def parse_encrypted_tool_outcome(encrypted_value: str | None) -> ToolOutcome | None:
+    """Read a non-success tool outcome from the `pydantic_ai` namespace."""
+    namespaced = _parse_encrypted_pydantic_ai_data(encrypted_value)
+    if namespaced is None:
+        return None
+    outcome = namespaced.get('tool_outcome')
+    if outcome in ('failed', 'denied'):
+        return outcome
+    return None
 
 
 def parse_builtin_tool_call_id(tool_call_id: str) -> tuple[str, str] | None:

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1608,6 +1608,34 @@ def test_dump_load_roundtrip_tools() -> None:
     assert reloaded == original
 
 
+@pytest.mark.parametrize('outcome', ['failed', 'denied'])
+def test_dump_load_roundtrip_tool_return_outcome(outcome: Literal['failed', 'denied']) -> None:
+    """Non-success tool returns must not reload as successful results."""
+    original: list[ModelMessage] = [
+        ModelResponse(parts=[ToolCallPart(tool_name='my_tool', tool_call_id='call_abc', args='{"x": 1}')]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name='my_tool',
+                    tool_call_id='call_abc',
+                    content='not allowed' if outcome == 'denied' else 'tool failed',
+                    outcome=outcome,
+                )
+            ]
+        ),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original, ag_ui_version='0.1.13')
+    tool_msg = next(m for m in ag_ui_msgs if isinstance(m, ToolMessage))
+    assert tool_msg.error == ('not allowed' if outcome == 'denied' else 'tool failed')
+    assert json.loads(tool_msg.encrypted_value or '{}') == {'pydantic_ai': {'tool_outcome': outcome}}
+
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    _sync_timestamps(original, reloaded)
+
+    assert reloaded == original
+
+
 def test_dump_load_roundtrip_load_capability() -> None:
     """Typed `load_capability` parts keep their identity through dump/load on >= 0.1.11.
 
@@ -1781,6 +1809,7 @@ def test_load_tool_kind_error_result_stays_plain() -> None:
     )
 
     assert type(loaded[1].parts[0]) is ToolReturnPart
+    assert loaded[1].parts[0].outcome == 'failed'
     assert parse_loaded_capabilities(loaded) == set()
 
 
@@ -2242,6 +2271,7 @@ def test_dump_load_roundtrip_retry_prompt_with_tool() -> None:
     retry_part = message_part(reloaded, ToolReturnPart, message_index=2)
     assert retry_part.tool_name == 'my_tool'
     assert retry_part.tool_call_id == 'call_1'
+    assert retry_part.outcome == 'failed'
 
 
 def test_dump_load_roundtrip_retry_prompt_without_tool() -> None:


### PR DESCRIPTION
- Closes #5870

### Summary

This preserves non-success `ToolReturnPart.outcome` values when AG-UI messages are dumped and loaded again.

- `ToolReturnPart(outcome='failed' | 'denied')` now dumps to a `ToolMessage` with `error` set.
- `ToolMessage(error=...)` now loads as a non-success tool return instead of silently defaulting to `outcome='success'`.
- `denied` round-trips through the existing Pydantic AI `encrypted_value` namespace; older/client-built messages without that metadata still load conservatively as `failed`.

This keeps failed or denied tool results from being replayed as successful tool evidence after AG-UI history serialization.

### Validation

- `uv run --extra ag-ui pytest tests/test_ag_ui.py::test_dump_load_roundtrip_tool_return_outcome tests/test_ag_ui.py::test_load_tool_kind_error_result_stays_plain tests/test_ag_ui.py::test_dump_load_roundtrip_retry_prompt_with_tool`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --extra ag-ui pytest tests/test_ag_ui.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --extra ag-ui pyright pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`
- `uv run --extra ag-ui ruff check pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`
- `uv run --extra ag-ui ruff format --check pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py tests/test_ag_ui.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

