### PR TITLE
fix(agent): honor `end_strategy="early"` for `NativeOutput`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1294,7 +1294,7 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                             async for event in self._handle_tool_calls_after_final_result(
                                 ctx, tool_calls, final_result, output_parts
                             ):
-                                yield event
+                                yield event  # pragma: no cover
                             self._next_node = self._handle_final_result(ctx, final_result, output_parts)
                             return
                         except ToolRetryError:
@@ -1416,29 +1416,16 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
 
         ctx.deps.tool_manager = await ctx.deps.tool_manager.for_run_step(run_context)
 
-        try:
-            async for event in process_tool_calls(
-                tool_manager=ctx.deps.tool_manager,
-                tool_calls=tool_calls,
-                tool_call_results=self.tool_call_results,
-                tool_call_metadata=self.tool_call_metadata,
-                final_result=final_result,
-                ctx=ctx,
-                output_parts=output_parts,
-            ):
-                yield event
-        except BaseException:
-            if output_parts:
-                ctx.state.message_history.append(
-                    _messages.ModelRequest(
-                        parts=list(output_parts),
-                        run_id=ctx.state.run_id,
-                        conversation_id=ctx.state.conversation_id,
-                        timestamp=now_utc(),
-                        state='interrupted',
-                    )
-                )
-            raise
+        async for event in process_tool_calls(
+            tool_manager=ctx.deps.tool_manager,
+            tool_calls=tool_calls,
+            tool_call_results=self.tool_call_results,
+            tool_call_metadata=self.tool_call_metadata,
+            final_result=final_result,
+            ctx=ctx,
+            output_parts=output_parts,
+        ):
+            yield event  # pragma: no cover
 
     @staticmethod
     def _recover_text_from_message_history(message_history: list[_messages.ModelMessage]) -> str | None:

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1290,15 +1290,13 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                     ):
                         try:
                             final_result = await self._process_text_response(ctx, text, text_processor)
-                            output_parts: list[_messages.ModelRequestPart] = []
-                            async for event in self._handle_tool_calls_after_final_result(
-                                ctx, tool_calls, final_result, output_parts
-                            ):
-                                yield event  # pragma: no cover
-                            self._next_node = self._handle_final_result(ctx, final_result, output_parts)
-                            return
                         except ToolRetryError:
                             pass
+                        else:
+                            # Record the tool calls as skipped so history has no dangling calls.
+                            async for event in self._handle_tool_calls(ctx, tool_calls, final_result):
+                                yield event
+                            return
 
                     if tool_calls:
                         async for event in self._handle_tool_calls(ctx, tool_calls):
@@ -1348,6 +1346,7 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
         self,
         ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]],
         tool_calls: list[_messages.ToolCallPart],
+        final_result: result.FinalResult[NodeRunEndT] | None = None,
     ) -> AsyncIterator[_messages.HandleResponseEvent]:
         run_context = build_run_context(ctx)
         run_context = replace(
@@ -1363,12 +1362,14 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
         output_final_result: deque[result.FinalResult[NodeRunEndT]] = deque(maxlen=1)
 
         try:
+            # When `final_result` is set (e.g. native output already won under `end_strategy='early'`),
+            # `process_tool_calls` records the tool calls as skipped rather than executing them.
             async for event in process_tool_calls(
                 tool_manager=ctx.deps.tool_manager,
                 tool_calls=tool_calls,
                 tool_call_results=self.tool_call_results,
                 tool_call_metadata=self.tool_call_metadata,
-                final_result=None,
+                final_result=final_result,
                 ctx=ctx,
                 output_parts=output_parts,
                 output_final_result=output_final_result,
@@ -1399,33 +1400,6 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                 output_parts.append(_messages.UserPromptPart(self.user_prompt))
 
             self._next_node = ModelRequestNode[DepsT, NodeRunEndT](_messages.ModelRequest(parts=output_parts))
-
-    async def _handle_tool_calls_after_final_result(
-        self,
-        ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]],
-        tool_calls: list[_messages.ToolCallPart],
-        final_result: result.FinalResult[NodeRunEndT],
-        output_parts: list[_messages.ModelRequestPart],
-    ) -> AsyncIterator[_messages.HandleResponseEvent]:
-        run_context = build_run_context(ctx)
-        run_context = replace(
-            run_context,
-            retry=ctx.state.output_retries_used,
-            max_retries=ctx.deps.tool_manager.default_max_retries,
-        )
-
-        ctx.deps.tool_manager = await ctx.deps.tool_manager.for_run_step(run_context)
-
-        async for event in process_tool_calls(
-            tool_manager=ctx.deps.tool_manager,
-            tool_calls=tool_calls,
-            tool_call_results=self.tool_call_results,
-            tool_call_metadata=self.tool_call_metadata,
-            final_result=final_result,
-            ctx=ctx,
-            output_parts=output_parts,
-        ):
-            yield event  # pragma: no cover
 
     @staticmethod
     def _recover_text_from_message_history(message_history: list[_messages.ModelMessage]) -> str | None:

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1280,6 +1280,19 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                     # This accounts for cases like anthropic returns that might contain a text response
                     # and a tool call response, where the text response just indicates the tool call will happen.
                     alternatives: list[str] = []
+                    if (
+                        tool_calls
+                        and text
+                        and ctx.deps.end_strategy == 'early'
+                        and output_schema.mode == 'native'
+                        and (text_processor := output_schema.text_processor)
+                    ):
+                        try:
+                            self._next_node = await self._handle_text_response(ctx, text, text_processor)
+                            return
+                        except ToolRetryError:
+                            pass
+
                     if tool_calls:
                         async for event in self._handle_tool_calls(ctx, tool_calls):
                             yield event

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1275,10 +1275,11 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                     text = compaction_text
 
                 try:
-                    # At the moment, we prioritize at least executing tool calls if they are present.
+                    # At the moment, we generally prioritize at least executing tool calls if they are present.
                     # In the future, we'd consider making this configurable at the agent or run level.
                     # This accounts for cases like anthropic returns that might contain a text response
                     # and a tool call response, where the text response just indicates the tool call will happen.
+                    # Native output with `end_strategy='early'` is the exception: valid text is already final.
                     alternatives: list[str] = []
                     if (
                         tool_calls
@@ -1288,7 +1289,13 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                         and (text_processor := output_schema.text_processor)
                     ):
                         try:
-                            self._next_node = await self._handle_text_response(ctx, text, text_processor)
+                            final_result = await self._process_text_response(ctx, text, text_processor)
+                            output_parts: list[_messages.ModelRequestPart] = []
+                            async for event in self._handle_tool_calls_after_final_result(
+                                ctx, tool_calls, final_result, output_parts
+                            ):
+                                yield event
+                            self._next_node = self._handle_final_result(ctx, final_result, output_parts)
                             return
                         except ToolRetryError:
                             pass
@@ -1393,6 +1400,46 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
 
             self._next_node = ModelRequestNode[DepsT, NodeRunEndT](_messages.ModelRequest(parts=output_parts))
 
+    async def _handle_tool_calls_after_final_result(
+        self,
+        ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]],
+        tool_calls: list[_messages.ToolCallPart],
+        final_result: result.FinalResult[NodeRunEndT],
+        output_parts: list[_messages.ModelRequestPart],
+    ) -> AsyncIterator[_messages.HandleResponseEvent]:
+        run_context = build_run_context(ctx)
+        run_context = replace(
+            run_context,
+            retry=ctx.state.output_retries_used,
+            max_retries=ctx.deps.tool_manager.default_max_retries,
+        )
+
+        ctx.deps.tool_manager = await ctx.deps.tool_manager.for_run_step(run_context)
+
+        try:
+            async for event in process_tool_calls(
+                tool_manager=ctx.deps.tool_manager,
+                tool_calls=tool_calls,
+                tool_call_results=self.tool_call_results,
+                tool_call_metadata=self.tool_call_metadata,
+                final_result=final_result,
+                ctx=ctx,
+                output_parts=output_parts,
+            ):
+                yield event
+        except BaseException:
+            if output_parts:
+                ctx.state.message_history.append(
+                    _messages.ModelRequest(
+                        parts=list(output_parts),
+                        run_id=ctx.state.run_id,
+                        conversation_id=ctx.state.conversation_id,
+                        timestamp=now_utc(),
+                        state='interrupted',
+                    )
+                )
+            raise
+
     @staticmethod
     def _recover_text_from_message_history(message_history: list[_messages.ModelMessage]) -> str | None:
         """Search backward through message history for recoverable text from a previous model response.
@@ -1421,6 +1468,15 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
         text: str,
         text_processor: _output.BaseOutputProcessor[NodeRunEndT],
     ) -> ModelRequestNode[DepsT, NodeRunEndT] | End[result.FinalResult[NodeRunEndT]]:
+        final_result = await self._process_text_response(ctx, text, text_processor)
+        return self._handle_final_result(ctx, final_result, [])
+
+    async def _process_text_response(
+        self,
+        ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]],
+        text: str,
+        text_processor: _output.BaseOutputProcessor[NodeRunEndT],
+    ) -> result.FinalResult[NodeRunEndT]:
         run_context = _build_output_run_context(ctx)
         schema = ctx.deps.output_schema
 
@@ -1433,7 +1489,7 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
             output_validators=ctx.deps.output_validators,
         )
 
-        return self._handle_final_result(ctx, result.FinalResult(result_data), [])
+        return result.FinalResult(result_data)
 
     async def _handle_image_response(
         self,

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1294,8 +1294,9 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                             pass
                         else:
                             # Record the tool calls as skipped so history has no dangling calls.
+                            # Skipped tools emit no events, so the loop body isn't reached here.
                             async for event in self._handle_tool_calls(ctx, tool_calls, final_result):
-                                yield event
+                                yield event  # pragma: no cover
                             return
 
                     if tool_calls:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4445,6 +4445,14 @@ class TestMultipleToolCalls:
 
         assert result.output == OutputType(value='final')
         assert tool_called == []
+        messages = result.all_messages()
+        assert len(messages) == 3
+        assert isinstance(messages[2], ModelRequest)
+        assert len(messages[2].parts) == 1
+        skipped_tool_return = messages[2].parts[0]
+        assert isinstance(skipped_tool_return, ToolReturnPart)
+        assert skipped_tool_return.tool_name == 'regular_tool'
+        assert skipped_tool_return.content == 'Tool not executed - a final result was already processed.'
 
     def test_early_strategy_does_not_call_additional_output_tools(self):
         """Test that 'early' strategy does not execute additional output tool functions."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4415,6 +4415,37 @@ class TestMultipleToolCalls:
             ]
         )
 
+    def test_early_strategy_prefers_native_output_text_over_tool_calls(self):
+        """Test that 'early' strategy does not execute tools when native output text is already final."""
+        tool_called: list[str] = []
+
+        def return_model(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            if len(messages) == 1:
+                return ModelResponse(
+                    parts=[
+                        TextPart(content='{"value": "final"}'),
+                        ToolCallPart('regular_tool', {'x': 1}),
+                    ],
+                )
+
+            return ModelResponse(parts=[TextPart(content='{"value": "after tool"}')])  # pragma: no cover
+
+        agent = Agent(
+            FunctionModel(return_model),
+            output_type=NativeOutput(OutputType),
+            end_strategy='early',
+        )
+
+        @agent.tool_plain
+        def regular_tool(x: int) -> int:  # pragma: no cover
+            tool_called.append('regular_tool')
+            return x
+
+        result = agent.run_sync('test early native output')
+
+        assert result.output == OutputType(value='final')
+        assert tool_called == []
+
     def test_early_strategy_does_not_call_additional_output_tools(self):
         """Test that 'early' strategy does not execute additional output tool functions."""
         output_tools_called: list[str] = []

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4454,6 +4454,37 @@ class TestMultipleToolCalls:
         assert skipped_tool_return.tool_name == 'regular_tool'
         assert skipped_tool_return.content == 'Tool not executed - a final result was already processed.'
 
+    def test_early_strategy_falls_back_to_tools_when_native_output_text_is_invalid(self):
+        """Test that invalid native output text does not prevent tool-call handling."""
+        tool_called: list[str] = []
+
+        def return_model(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            if len(messages) == 1:
+                return ModelResponse(
+                    parts=[
+                        TextPart(content='{}'),
+                        ToolCallPart('regular_tool', {'x': 1}),
+                    ],
+                )
+
+            return ModelResponse(parts=[TextPart(content='{"value": "after tool"}')])
+
+        agent = Agent(
+            FunctionModel(return_model),
+            output_type=NativeOutput(OutputType),
+            end_strategy='early',
+        )
+
+        @agent.tool_plain
+        def regular_tool(x: int) -> int:
+            tool_called.append('regular_tool')
+            return x
+
+        result = agent.run_sync('test early native output fallback')
+
+        assert result.output == OutputType(value='after tool')
+        assert tool_called == ['regular_tool']
+
     def test_early_strategy_does_not_call_additional_output_tools(self):
         """Test that 'early' strategy does not execute additional output tool functions."""
         output_tools_called: list[str] = []


### PR DESCRIPTION
- Closes #6277

### Summary

This fixes `NativeOutput` handling when `end_strategy="early"` is used and the model response contains both:

- valid native structured output text
- regular tool calls

Before this change, `CallToolsNode` prioritized the tool calls and executed them before considering the native output text. With `end_strategy="early"`, valid native output should be enough to finish the run without executing additional regular tools.

### Changes

- In `CallToolsNode`, when tool calls and text are both present, attempt to process valid native output text first if `end_strategy="early"` is configured.
- Preserve skipped tool returns in message history when native output wins, so later runs do not inherit dangling tool calls.
- If native output parsing/validation fails, keep the existing behavior and fall through to tool-call handling.
- Add regression coverage for both valid native output winning over tool calls and invalid native output falling back to tool-call handling.

### Testing

- `uv run pytest tests/test_agent.py::TestMultipleToolCalls::test_early_strategy_prefers_native_output_text_over_tool_calls tests/test_agent.py::TestMultipleToolCalls::test_early_strategy_falls_back_to_tools_when_native_output_text_is_invalid tests/test_agent.py::TestMultipleToolCalls`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_agent.py`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_agent.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/_agent_graph.py tests/test_agent.py`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run pytest tests/test_agent.py`

Note: running the full `tests/test_agent.py` with my local SOCKS proxy env vars enabled failed in provider lifecycle tests because `httpx` required the optional `socksio` dependency. Re-running the same test file with proxy env vars removed passed: `344 passed, 3 skipped`.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
