### PR TITLE
Add nvidia model profile: Nemotron servings break on tool_choice='required'

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/nvidia.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/nvidia.py
@@ -1,0 +1,14 @@
+from __future__ import annotations as _annotations
+
+from . import ModelProfile
+from .openai import OpenAIModelProfile
+
+
+def nvidia_model_profile(model_name: str) -> ModelProfile | None:
+    """Get the model profile for an NVIDIA model."""
+    # Nemotron servings on OpenAI-compatible providers (e.g. Together, reached directly or
+    # via OpenRouter) answer `tool_choice: 'required'` with the tool-call JSON rendered as
+    # content text (a `[{"name": ..., "parameters": ...}]` array) that is never mapped back
+    # into `tool_calls`, so forced tool use fails output validation. The same servings
+    # tool-call correctly under `tool_choice: 'auto'`.
+    return OpenAIModelProfile(openai_supports_tool_choice_required=False)

--- a/pydantic_ai_slim/pydantic_ai/providers/nebius.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/nebius.py
@@ -15,6 +15,7 @@ from pydantic_ai.profiles.harmony import harmony_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+from pydantic_ai.profiles.nvidia import nvidia_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.providers import Provider
@@ -53,6 +54,7 @@ class NebiusProvider(Provider[AsyncOpenAI]):
             'openai': harmony_model_profile,  # used for gpt-oss models on Nebius
             'mistralai': mistral_model_profile,
             'moonshotai': moonshotai_model_profile,
+            'nvidia': nvidia_model_profile,
         }
 
         profile = None

--- a/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openrouter.py
@@ -20,6 +20,7 @@ from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+from pydantic_ai.profiles.nvidia import nvidia_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.providers import Provider
@@ -141,6 +142,7 @@ class OpenRouterProvider(Provider[AsyncOpenAI]):
             'deepseek': deepseek_model_profile,
             'meta-llama': meta_model_profile,
             'moonshotai': moonshotai_model_profile,
+            'nvidia': nvidia_model_profile,
         }
 
         profile = None

--- a/pydantic_ai_slim/pydantic_ai/providers/together.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/together.py
@@ -14,6 +14,7 @@ from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import google_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
+from pydantic_ai.profiles.nvidia import nvidia_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, OpenAIModelProfile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 from pydantic_ai.providers import Provider
@@ -50,6 +51,7 @@ class TogetherProvider(Provider[AsyncOpenAI]):
             'qwen': qwen_model_profile,
             'meta-llama': meta_model_profile,
             'mistralai': mistral_model_profile,
+            'nvidia': nvidia_model_profile,
         }
 
         profile = None

--- a/tests/providers/test_nebius.py
+++ b/tests/providers/test_nebius.py
@@ -12,6 +12,7 @@ from pydantic_ai.profiles.harmony import harmony_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+from pydantic_ai.profiles.nvidia import nvidia_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
@@ -75,6 +76,7 @@ def test_nebius_provider_model_profile(mocker: MockerFixture):
     harmony_mock = mocker.patch(f'{ns}.harmony_model_profile', wraps=harmony_model_profile)
     mistral_mock = mocker.patch(f'{ns}.mistral_model_profile', wraps=mistral_model_profile)
     moonshotai_mock = mocker.patch(f'{ns}.moonshotai_model_profile', wraps=moonshotai_model_profile)
+    nvidia_mock = mocker.patch(f'{ns}.nvidia_model_profile', wraps=nvidia_model_profile)
 
     # Test meta provider
     meta_profile = provider.model_profile('meta-llama/Llama-3.3-70B-Instruct')
@@ -117,6 +119,13 @@ def test_nebius_provider_model_profile(mocker: MockerFixture):
     moonshotai_mock.assert_called_with('kimi-k2-instruct')
     assert moonshotai_profile is not None
     assert moonshotai_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    # Test nvidia provider
+    nvidia_profile = provider.model_profile('nvidia/Nemotron-3-Ultra-550B-A55B')
+    nvidia_mock.assert_called_with('nemotron-3-ultra-550b-a55b')
+    assert nvidia_profile is not None
+    assert nvidia_profile.get('openai_supports_tool_choice_required', True) is False
+    assert nvidia_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     # Test unknown provider
     unknown_profile = provider.model_profile('unknown-provider/unknown-model')

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -16,6 +16,7 @@ from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.moonshotai import moonshotai_model_profile
+from pydantic_ai.profiles.nvidia import nvidia_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, openai_model_profile
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
@@ -108,6 +109,7 @@ def test_openrouter_provider_model_profile(mocker: MockerFixture):
     deepseek_model_profile_mock = mocker.patch(f'{ns}.deepseek_model_profile', wraps=deepseek_model_profile)
     meta_model_profile_mock = mocker.patch(f'{ns}.meta_model_profile', wraps=meta_model_profile)
     moonshotai_model_profile_mock = mocker.patch(f'{ns}.moonshotai_model_profile', wraps=moonshotai_model_profile)
+    nvidia_model_profile_mock = mocker.patch(f'{ns}.nvidia_model_profile', wraps=nvidia_model_profile)
 
     google_profile = provider.model_profile('google/gemini-2.5-pro-preview')
     google_model_profile_mock.assert_called_with('gemini-2.5-pro-preview')
@@ -182,6 +184,12 @@ def test_openrouter_provider_model_profile(mocker: MockerFixture):
     assert moonshotai_profile is not None
     assert moonshotai_profile.get('ignore_streamed_leading_whitespace', False) is True
     assert moonshotai_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+
+    nvidia_profile = provider.model_profile('nvidia/nemotron-3-ultra-550b-a55b')
+    nvidia_model_profile_mock.assert_called_with('nemotron-3-ultra-550b-a55b')
+    assert nvidia_profile is not None
+    assert nvidia_profile.get('openai_supports_tool_choice_required', True) is False
+    assert nvidia_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     unknown_profile = provider.model_profile('unknown/model')
     assert unknown_profile is not None

--- a/tests/providers/test_together.py
+++ b/tests/providers/test_together.py
@@ -10,6 +10,7 @@ from pydantic_ai.profiles.deepseek import deepseek_model_profile
 from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer, google_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
+from pydantic_ai.profiles.nvidia import nvidia_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 from pydantic_ai.profiles.qwen import qwen_model_profile
 
@@ -68,6 +69,7 @@ def test_together_provider_model_profile(mocker: MockerFixture):
     meta_model_profile_mock = mocker.patch(f'{ns}.meta_model_profile', wraps=meta_model_profile)
     qwen_model_profile_mock = mocker.patch(f'{ns}.qwen_model_profile', wraps=qwen_model_profile)
     mistral_model_profile_mock = mocker.patch(f'{ns}.mistral_model_profile', wraps=mistral_model_profile)
+    nvidia_model_profile_mock = mocker.patch(f'{ns}.nvidia_model_profile', wraps=nvidia_model_profile)
     google_model_profile_mock = mocker.patch(f'{ns}.google_model_profile', wraps=google_model_profile)
 
     deepseek_profile = provider.model_profile('deepseek-ai/DeepSeek-R1')
@@ -94,6 +96,12 @@ def test_together_provider_model_profile(mocker: MockerFixture):
     google_model_profile_mock.assert_called_with('gemma-3-27b-it')
     assert google_profile is not None
     assert google_profile.get('json_schema_transformer', None) == GoogleJsonSchemaTransformer
+
+    nvidia_profile = provider.model_profile('nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4')
+    nvidia_model_profile_mock.assert_called_with('nvidia-nemotron-3-ultra-550b-a55b-nvfp4')
+    assert nvidia_profile is not None
+    assert nvidia_profile.get('openai_supports_tool_choice_required', True) is False
+    assert nvidia_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
 
     unknown_profile = provider.model_profile('unknown/model')
     assert unknown_profile is not None


### PR DESCRIPTION
## Problem

`nvidia/*` models (Nemotron 3 family) have no model profile, so OpenAI-compatible requests default to sending `tool_choice: 'required'` whenever text output is not allowed (e.g. an agent with a required tool/structured output and `allow_text_output=False`).

At least Together's Nemotron 3 Ultra serving (reached directly or via OpenRouter, where Together is currently the default provider for `nvidia/nemotron-3-ultra-550b-a55b`) responds to `tool_choice: 'required'` by emitting the tool-call JSON **as content text** — a `[{"name": ..., "parameters": ...}]` array (note `parameters`, not `arguments`) that is never mapped back into `tool_calls`. Pydantic AI then fails output validation (`Input should be an object`) and aborts after the retry limit.

Minimal repro against OpenRouter (2/2 reproducible; drop `tool_choice` and it tool-calls correctly 5/5, including parallel calls and `$defs`-heavy schemas):

```json
{"model": "nvidia/nemotron-3-ultra-550b-a55b",
 "messages": [{"role": "user", "content": "What is the weather in Reykjavik? Use the tool."}],
 "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}],
 "tool_choice": "required"}
```

Response: `tool_calls: null`, `content: "[{\"name\": \"get_weather\", \"parameters\": {\"city\": \"Reykjavik\"}}]"`.

## Fix

Add `profiles/nvidia.py` with `nvidia_model_profile` returning `OpenAIModelProfile(openai_supports_tool_choice_required=False)` — the same treatment `qwen-3-coder` and the harmony profile already get for this class of provider-template quirk — and wire the `nvidia` prefix into the `OpenRouterProvider`, `TogetherProvider`, and `NebiusProvider` profile maps.

With the flag off, requests fall back to `tool_choice: 'auto'`, which the same servings handle correctly.

## Tests

Added `nvidia` cases to the three provider `model_profile` tests, mirroring the existing per-vendor cases.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

