### PR TITLE
Fix `NativeToolReturnPart` request-history round trips

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_enqueue.py
+++ b/pydantic_ai_slim/pydantic_ai/_enqueue.py
@@ -16,6 +16,7 @@ from .messages import (
     ModelRequest,
     ModelRequestPart,
     ModelResponse,
+    NativeToolReturnPart,
     RetryPromptPart,
     SystemPromptPart,
     ToolReturnPart,
@@ -96,7 +97,15 @@ def _build_enqueue_messages(items: Sequence[EnqueueContent]) -> list[ModelMessag
             flush_request()
             messages.append(item)
         elif isinstance(
-            item, (SystemPromptPart, UserPromptPart, ToolReturnPart, RetryPromptPart, ToolSearchReturnPart)
+            item,
+            (
+                SystemPromptPart,
+                UserPromptPart,
+                ToolReturnPart,
+                NativeToolReturnPart,
+                RetryPromptPart,
+                ToolSearchReturnPart,
+            ),
         ):
             flush_content()
             parts.append(item)

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -2154,6 +2154,8 @@ ModelRequestPart = Annotated[
     | Annotated[ToolSearchReturnPart, pydantic.Tag('tool-search-return')]
     | Annotated[LoadCapabilityReturnPart, pydantic.Tag('capability-load-return')]
     | Annotated[ToolReturnPart, pydantic.Tag('tool-return')]
+    | Annotated[NativeToolSearchReturnPart, pydantic.Tag('builtin-tool-search-return')]
+    | Annotated[NativeToolReturnPart, pydantic.Tag('builtin-tool-return')]
     | Annotated[RetryPromptPart, pydantic.Tag('retry-prompt')],
     pydantic.Discriminator(_model_request_part_discriminator),
 ]

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -1059,6 +1059,8 @@ class BedrockConverseModel(Model[BaseClient]):
                                     ],
                                 }
                             )
+                    elif isinstance(part, NativeToolReturnPart):
+                        pass
                     else:
                         assert_never(part)
             elif isinstance(message, ModelResponse):

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -368,6 +368,8 @@ class CohereModel(Model[AsyncClientV2]):
                     tool_call_id=_guard_tool_call_id(t=part),
                     content=part.model_response_str(),
                 )
+            elif isinstance(part, NativeToolReturnPart):
+                pass
             elif isinstance(part, RetryPromptPart):
                 if part.tool_name is None:
                     yield UserChatMessageV2(role='user', content=part.model_response())  # pragma: no cover

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -396,7 +396,7 @@ def _estimate_usage(messages: Iterable[ModelMessage]) -> usage.RequestUsage:
             for part in message.parts:
                 if isinstance(part, SystemPromptPart | UserPromptPart):
                     request_tokens += _estimate_string_tokens(part.content)
-                elif isinstance(part, ToolReturnPart):
+                elif isinstance(part, ToolReturnPart | NativeToolReturnPart):
                     request_tokens += _estimate_string_tokens(part.model_response_str())
                 elif isinstance(part, RetryPromptPart):
                     request_tokens += _estimate_string_tokens(part.model_response())

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -1016,6 +1016,8 @@ class GoogleModel(Model[Client]):
                         message_parts.extend(await self._map_user_prompt(part))
                     elif isinstance(part, ToolReturnPart):
                         message_parts.extend(await self._map_tool_return(part))
+                    elif isinstance(part, NativeToolReturnPart):
+                        pass
                     elif isinstance(part, RetryPromptPart):
                         if part.tool_name is None:
                             message_parts.append({'text': part.model_response()})

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -473,6 +473,8 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                         'content': tool_text,
                     }
                 )
+            elif isinstance(part, NativeToolReturnPart):
+                pass
             elif isinstance(part, RetryPromptPart):
                 if part.tool_name is None:
                     yield ChatCompletionInputMessage.parse_obj_as_instance(  # type: ignore

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -557,6 +557,8 @@ class MistralModel(Model[Mistral]):
                     tool_call_id=part.tool_call_id,
                     content=tool_text,
                 )
+            elif isinstance(part, NativeToolReturnPart):
+                pass
             elif isinstance(part, RetryPromptPart):
                 if part.tool_name is None:
                     yield MistralUserMessage(content=part.model_response())  # pragma: no cover

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -1499,6 +1499,8 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     tool_call_id=_guard_tool_call_id(t=part),
                     content=tool_text,
                 )
+            elif isinstance(part, NativeToolReturnPart):
+                pass
             elif isinstance(part, RetryPromptPart):
                 if part.tool_name is None:
                     yield chat.ChatCompletionUserMessageParam(role='user', content=part.model_response())
@@ -2729,6 +2731,8 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                 output=part.model_response(),
                             )
                             openai_messages.append(item)
+                    elif isinstance(part, NativeToolReturnPart):
+                        pass
                     else:
                         assert_never(part)
             elif isinstance(message, ModelResponse):

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -365,6 +365,8 @@ class XaiModel(Model[AsyncClient]):
                     xai_messages.append(user_msg)
             elif isinstance(part, ToolReturnPart):
                 tool_results.append(part)
+            elif isinstance(part, NativeToolReturnPart):
+                pass
             elif isinstance(part, RetryPromptPart):
                 if part.tool_name is None:
                     xai_messages.append(user(part.model_response()))

--- a/pydantic_ai_slim/pydantic_ai/ui/_messages_builder.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_messages_builder.py
@@ -31,18 +31,18 @@ class MessagesBuilder:
     def add(self, part: ModelRequestPart | ModelResponsePart) -> None:
         """Add a new part, creating a new request or response message if necessary."""
         last_message = self.messages[-1] if self.messages else None
-        if isinstance(part, get_union_args(ModelRequestPart)):
-            part = cast(ModelRequestPart, part)
-            if isinstance(last_message, ModelRequest):
-                last_message.parts = [*last_message.parts, part]
-            else:
-                self.messages.append(ModelRequest(parts=[part]))
-        else:
+        if isinstance(part, get_union_args(ModelResponsePart)):
             part = cast(ModelResponsePart, part)
             if isinstance(last_message, ModelResponse):
                 last_message.parts = [*last_message.parts, part]
             else:
                 self.messages.append(ModelResponse(parts=[part]))
+        else:
+            part = cast(ModelRequestPart, part)
+            if isinstance(last_message, ModelRequest):
+                last_message.parts = [*last_message.parts, part]
+            else:
+                self.messages.append(ModelRequest(parts=[part]))
 
     def checkpoint(self) -> BuilderCheckpoint:
         """Snapshot the current builder state. Pair with [`last_modified`][pydantic_ai.ui.MessagesBuilder.last_modified]."""

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -666,6 +666,8 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                         **tool_kind_encrypted_value_kwargs(part.tool_kind, supported=use_encrypted_value),
                     )
                 )
+            elif isinstance(part, NativeToolReturnPart):
+                pass
             elif isinstance(part, RetryPromptPart):
                 if part.tool_name:
                     flush_user_content()

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -626,6 +626,8 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
             elif isinstance(part, ToolReturnPart):
                 # Tool returns are merged into the tool call in the assistant message
                 pass
+            elif isinstance(part, NativeToolReturnPart):
+                pass
             elif isinstance(part, RetryPromptPart):
                 if part.tool_name:
                     # Tool-related retries are handled when processing ToolCallPart in ModelResponse

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -43,6 +43,7 @@ from pydantic_ai.messages import (
     MULTI_MODAL_CONTENT_TYPES,
     LoadCapabilityCallPart,
     LoadCapabilityReturnPart,
+    NativeToolSearchReturnPart,
     ToolReturnContent,
     is_multi_modal_content,
     narrow_message_parts,
@@ -1919,6 +1920,33 @@ def test_stripped_tool_kind_part_survives_roundtrip():
     messages: list[ModelMessage] = [ModelRequest(parts=[ToolReturnPart.narrow_type(invalid)])]
     reloaded = ModelMessagesTypeAdapter.validate_python(ModelMessagesTypeAdapter.dump_python(messages))
     assert type(reloaded[0].parts[0]) is ToolReturnPart
+
+
+def test_model_request_native_tool_return_parts_survive_json_roundtrip():
+    """Native tool returns can appear in request history and must survive persistence reloads."""
+    search_return = NativeToolSearchReturnPart(
+        content={'discovered_tools': [{'name': 'search_docs'}]},
+        tool_call_id='search-1',
+        provider_name='anthropic',
+    )
+    native_return = NativeToolReturnPart(
+        tool_name='web_fetch',
+        content='result text',
+        tool_call_id='fetch-1',
+        provider_name='anthropic',
+    )
+    messages: list[ModelMessage] = [ModelRequest(parts=[search_return, native_return])]
+
+    reloaded = message(
+        ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(messages)), ModelRequest
+    )
+    reloaded_search_return = reloaded.parts[0]
+    reloaded_native_return = reloaded.parts[1]
+
+    assert type(reloaded_search_return) is NativeToolSearchReturnPart
+    assert reloaded_search_return.content == {'discovered_tools': [{'name': 'search_docs'}]}
+    assert type(reloaded_native_return) is NativeToolReturnPart
+    assert reloaded_native_return == native_return
 
 
 def test_narrow_message_parts_promotes_valid_claims_and_leaves_plain_parts():


### PR DESCRIPTION
- Closes #6286

### Summary

- include `NativeToolSearchReturnPart` and `NativeToolReturnPart` in the `ModelRequestPart` discriminated union
- add a regression test proving native tool returns in `ModelRequest` survive `ModelMessagesTypeAdapter.dump_json()` -> `validate_json()` round trips

### Testing

- `python -m py_compile pydantic_ai_slim\pydantic_ai\messages.py tests\test_messages.py`
- `git diff --check`
- `python -m pytest tests\test_messages.py::test_model_request_native_tool_return_parts_survive_json_roundtrip -q` (not run successfully locally: bundled Python does not have `pytest`, and this checkout does not have the project `uv` environment installed)

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

