### PR TITLE
fix(azure): disable encrypted reasoning content for Azure OpenAI

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -76,8 +76,16 @@ class AzureProvider(Provider[AsyncOpenAI]):
             # OpenAI models are unprefixed.
             base = openai_model_profile(model_name)
 
-        # Azure Chat Completions API doesn't support document input.
-        return merge_profile(base, OpenAIModelProfile(openai_chat_supports_document_input=False))
+        # Azure Chat Completions API doesn't support document input, and Azure OpenAI rejects the
+        # `include=['reasoning.encrypted_content']` request option that reasoning models otherwise send
+        # (see https://github.com/pydantic/pydantic-ai/issues/2915).
+        return merge_profile(
+            base,
+            OpenAIModelProfile(
+                openai_chat_supports_document_input=False,
+                openai_supports_encrypted_reasoning_content=False,
+            ),
+        )
 
     @overload
     def __init__(self, *, openai_client: AsyncAzureOpenAI) -> None: ...

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -926,7 +926,6 @@ def test_azure_openai_gpt_5():
             'supported_native_tools': frozenset(
                 {CodeExecutionTool, FileSearchTool, ImageGenerationTool, MCPServerTool, ToolSearchTool, WebSearchTool}
             ),
-            'openai_supports_encrypted_reasoning_content': True,
             'openai_supports_reasoning': True,
             'openai_supports_reasoning_effort_none': True,
             'openai_supports_phase': True,

--- a/tests/providers/test_azure.py
+++ b/tests/providers/test_azure.py
@@ -150,6 +150,9 @@ def test_azure_provider_model_profile(mocker: MockerFixture):
     openai_model_profile_mock.assert_called_with('o4-mini')
     assert openai_profile is not None
     assert openai_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    # Azure OpenAI rejects `include=['reasoning.encrypted_content']`, so even reasoning models
+    # must not send it. See https://github.com/pydantic/pydantic-ai/issues/2915.
+    assert openai_profile.get('openai_supports_encrypted_reasoning_content', None) is False
 
     unknown_profile = provider.model_profile('unknown-model')
     openai_model_profile_mock.assert_called_with('unknown-model')


### PR DESCRIPTION
## Summary

Disables the `include=['reasoning.encrypted_content']` request option for Azure OpenAI, which the provider rejects.

## Motivation

Closes #2915.

Running a reasoning model (e.g. `gpt-5`) through Azure OpenAI with `OpenAIResponsesModel` fails with:

```
ModelHTTPError: status_code: 400, body: {'message': 'Encrypted content is not supported with this model.', 'type': 'invalid_request_error', 'param': 'include', 'code': None}
```

### Root cause

`AzureProvider.model_profile` derives OpenAI model profiles from `openai_model_profile`, which sets `openai_supports_encrypted_reasoning_content=True` for reasoning models (gpt-5, o-series). The Responses model then always requests encrypted reasoning content via `include`, and Azure OpenAI rejects it with a 400.

The reporter confirmed the failure occurs on **both** the legacy `AsyncAzureOpenAI` client and the new v1 GA API (`.../openai/v1`), and that non-reasoning models (gpt-4.1) work fine — so this is Azure-wide for reasoning models, not client-specific.

### Fix

Override `openai_supports_encrypted_reasoning_content=False` in `AzureProvider.model_profile`, alongside the existing `openai_chat_supports_document_input=False` Azure override. This matches the per-model workaround @DouweM suggested in the issue thread.

### Scope / intended resolution

The reproductions in #2915 use `OpenAIProvider` with an Azure client (or `.../openai/v1` base URL). The intended resolution is to use **`AzureProvider`**, which with this change disables encrypted reasoning content out of the box (no manual profile override needed). `OpenAIProvider.model_profile` is a `@staticmethod` that only receives `model_name` and can't inspect the base URL to detect Azure, so covering the raw `OpenAIProvider`+Azure path would require a larger design change and can be a follow-up if preferred.

## Tests

- Extended `test_azure_provider_model_profile` to assert `openai_supports_encrypted_reasoning_content is False` for a reasoning model (`o4-mini`), where the base OpenAI profile sets it to `True`.

## Verification

- `uv run pytest tests/providers/test_azure.py` — 12 passed
- `uv run ruff check` / `ruff format --check` — clean
- `uv run mypy pydantic_ai_slim/pydantic_ai/providers/azure.py` — no issues

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


