### PR TITLE
fix: read test files as UTF-8 in check_cassettes.py

### DIFF
--- a/scripts/check_cassettes.py
+++ b/scripts/check_cassettes.py
@@ -56,7 +56,7 @@ def _has_module_vcr_marker(tree: ast.Module) -> bool:
 def _collect_vcr_tests_from_file(path: Path) -> set[str]:
     """Parse a Python test file and return cassette names for VCR-marked tests."""
     try:
-        tree = ast.parse(path.read_text())
+        tree = ast.parse(path.read_text(encoding='utf-8'))
     except SyntaxError:
         return set()
 


### PR DESCRIPTION
## Summary
`scripts/check_cassettes.py` reads every test file with `Path.read_text()`, which uses the platform default encoding. On Windows that's cp1252, so the `check-cassettes` pre-commit hook crashes with a `UnicodeDecodeError` when a test file contains non-ASCII bytes:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 26625: character maps to <undefined>
```

Read the files as UTF-8 explicitly. This matches `PLW1514` (unspecified-encoding), which the project already enforces via ruff on its included packages — `scripts/` just isn't in ruff's `include` list, so the rule never flagged it here.

## Verify
- Before: `python scripts/check_cassettes.py` crashes on Windows with the traceback above.
- After: it completes cleanly — `1141 matched, 0 orphaned` / `All cassettes have matching tests!`

No behavior change on Linux/macOS, where the default codec was already UTF-8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

