### PR TITLE
Bump bundled chat UI to `2.0.0` and target `sdk_version=7` in `Agent.to_web()`

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -94,6 +94,10 @@ agent = Agent('openai:gpt-5.2')
 app = agent.to_web(instructions='Always respond in a friendly tone.')
 ```
 
+## Tool Approval
+
+Tools that [require approval](deferred-tools.md#human-in-the-loop-tool-approval) are surfaced in the UI as approve/reject prompts: when the agent calls such a tool, the UI renders the pending call and lets you approve or deny it before the run continues. This works out of the box — no extra configuration is needed.
+
 ## Reserved Routes
 
 The web UI app uses the following routes which should not be overwritten:
@@ -115,7 +119,7 @@ For offline usage, download the html file once while you have internet access:
 from pydantic_ai.ui import DEFAULT_HTML_URL
 
 print(DEFAULT_HTML_URL)  # Use this URL to download the UI HTML file
-#> https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@1.2.0/dist/index.html
+#> https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@2.0.0/dist/index.html
 ```
 
 You can then download the file using the URL printed above:

--- a/docs/web.md
+++ b/docs/web.md
@@ -98,6 +98,9 @@ app = agent.to_web(instructions='Always respond in a friendly tone.')
 
 Tools that [require approval](deferred-tools.md#human-in-the-loop-tool-approval) are surfaced in the UI as approve/reject prompts: when the agent calls such a tool, the UI renders the pending call and lets you approve or deny it before the run continues. This works out of the box — no extra configuration is needed.
 
+!!! warning
+    The chat endpoint executes tool approvals relayed by the client, including for tools marked `requires_approval=True`. The server trusts the approval decision it receives, so a client with direct access to the endpoint can approve any pending call. As noted above, the web UI is meant for local development — this is fine when it's bound to localhost, but do not expose `to_web()` to untrusted clients without putting authentication in front of it.
+
 ## Reserved Routes
 
 The web UI app uses the following routes which should not be overwritten:

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
@@ -1,7 +1,7 @@
 """API routes for the web chat UI."""
 
 from collections.abc import Mapping, Sequence
-from typing import TypeVar
+from typing import Literal, TypeVar
 
 from pydantic import BaseModel
 from pydantic.alias_generators import to_camel
@@ -84,6 +84,7 @@ def create_api_app(
     deps: AgentDepsT = None,
     model_settings: ModelSettings | None = None,
     instructions: str | None = None,
+    sdk_version: Literal[5, 6] = 6,
 ) -> Starlette:
     """Create API app for the web chat UI.
 
@@ -98,6 +99,8 @@ def create_api_app(
         deps: Optional dependencies to use for all requests.
         model_settings: Optional settings to use for all model requests.
         instructions: Optional extra instructions to pass to each agent run.
+        sdk_version: Vercel AI SDK version to target on the chat endpoint. Defaults to `6` to enable
+            tool-approval streaming for the bundled UI.
 
     Returns:
         A Starlette application with the API endpoints.
@@ -153,7 +156,9 @@ def create_api_app(
 
     async def post_chat(request: Request) -> Response:
         """Handle chat requests via Vercel AI Adapter."""
-        adapter = await VercelAIAdapter[AgentDepsT, OutputDataT].from_request(request, agent=agent)
+        adapter = await VercelAIAdapter[AgentDepsT, OutputDataT].from_request(
+            request, agent=agent, sdk_version=sdk_version
+        )
         extra_data = ChatRequestExtra.model_validate(adapter.run_input.__pydantic_extra__)
 
         if error := validate_request_options(extra_data, model_ids, allowed_tool_ids):
@@ -165,6 +170,7 @@ def create_api_app(
         streaming_response = await VercelAIAdapter[AgentDepsT, OutputDataT].dispatch_request(
             request,
             agent=agent,
+            sdk_version=sdk_version,
             model=model_ref,
             capabilities=request_capabilities,
             deps=deps,

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
@@ -23,6 +23,11 @@ OutputDataT = TypeVar('OutputDataT')
 # Type alias for models parameter - accepts model names/instances or a dict mapping labels to models
 ModelsParam = Sequence[Model | KnownModelName | str] | Mapping[str, Model | KnownModelName | str] | None
 
+# The bundled chat UI (v7 of the Vercel AI SDK) consumes the `sdk_version=6` wire protocol, which is
+# what enables tool-approval streaming. `to_web()` controls both ends (server + bundled UI), so the
+# API path targets 6 to match the UI it ships. See `VercelAIAdapter.sdk_version`.
+BUNDLED_UI_SDK_VERSION: Literal[6] = 6
+
 
 class ModelInfo(BaseModel, alias_generator=to_camel, populate_by_name=True):
     """Defines an AI model with its associated built-in tools."""
@@ -84,7 +89,7 @@ def create_api_app(
     deps: AgentDepsT = None,
     model_settings: ModelSettings | None = None,
     instructions: str | None = None,
-    sdk_version: Literal[5, 6] = 6,
+    sdk_version: Literal[5, 6] = BUNDLED_UI_SDK_VERSION,
 ) -> Starlette:
     """Create API app for the web chat UI.
 

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/api.py
@@ -23,10 +23,12 @@ OutputDataT = TypeVar('OutputDataT')
 # Type alias for models parameter - accepts model names/instances or a dict mapping labels to models
 ModelsParam = Sequence[Model | KnownModelName | str] | Mapping[str, Model | KnownModelName | str] | None
 
-# The bundled chat UI (v7 of the Vercel AI SDK) consumes the `sdk_version=6` wire protocol, which is
-# what enables tool-approval streaming. `to_web()` controls both ends (server + bundled UI), so the
-# API path targets 6 to match the UI it ships. See `VercelAIAdapter.sdk_version`.
-BUNDLED_UI_SDK_VERSION: Literal[6] = 6
+# The bundled chat UI ships v7 of the Vercel AI SDK, so the API path targets `sdk_version=7` to match
+# it. v7's data-stream protocol equals v6's (same wire, including the tool-approval chunks that enable
+# tool-approval streaming), so 7 emits identically to 6 today; targeting 7 keeps the value aligned with
+# the UI's real SDK major and reserves it for future v7-only chunks. `to_web()` controls both ends
+# (server + bundled UI). See `VercelAIAdapter.sdk_version`.
+BUNDLED_UI_SDK_VERSION: Literal[7] = 7
 
 
 class ModelInfo(BaseModel, alias_generator=to_camel, populate_by_name=True):
@@ -89,7 +91,7 @@ def create_api_app(
     deps: AgentDepsT = None,
     model_settings: ModelSettings | None = None,
     instructions: str | None = None,
-    sdk_version: Literal[5, 6] = BUNDLED_UI_SDK_VERSION,
+    sdk_version: Literal[5, 6, 7] = BUNDLED_UI_SDK_VERSION,
 ) -> Starlette:
     """Create API app for the web chat UI.
 
@@ -104,8 +106,9 @@ def create_api_app(
         deps: Optional dependencies to use for all requests.
         model_settings: Optional settings to use for all model requests.
         instructions: Optional extra instructions to pass to each agent run.
-        sdk_version: Vercel AI SDK version to target on the chat endpoint. Defaults to `6` to enable
-            tool-approval streaming for the bundled UI.
+        sdk_version: Vercel AI SDK version to target on the chat endpoint: 5, 6, or 7. Defaults to
+            `7` to match the bundled v7 UI, which enables tool-approval streaming (7 emits the same
+            wire as 6, since v7's data-stream protocol equals v6's).
 
     Returns:
         A Starlette application with the API endpoints.

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -13,7 +13,7 @@ from pydantic_ai import Agent
 from pydantic_ai.native_tools import AbstractNativeTool
 from pydantic_ai.settings import ModelSettings
 
-from .api import ModelsParam, create_api_app
+from .api import BUNDLED_UI_SDK_VERSION, ModelsParam, create_api_app
 
 try:
     from starlette.applications import Starlette
@@ -28,11 +28,6 @@ except ImportError as _import_error:  # pragma: no cover
 
 CHAT_UI_VERSION = '2.0.0'
 DEFAULT_HTML_URL = f'https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@{CHAT_UI_VERSION}/dist/index.html'
-
-# The bundled chat UI (v7 of the Vercel AI SDK) consumes the `sdk_version=6` wire protocol, which is
-# what enables tool-approval streaming. `to_web()` controls both ends (server + bundled UI), so the
-# API path targets 6 to match the UI it ships. See `VercelAIAdapter.sdk_version`.
-BUNDLED_UI_SDK_VERSION: Literal[6] = 6
 
 AgentDepsT = TypeVar('AgentDepsT')
 OutputDataT = TypeVar('OutputDataT')

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -150,7 +150,7 @@ def create_web_app(
     model_settings: ModelSettings | None = None,
     instructions: str | None = None,
     html_source: str | Path | None = None,
-    sdk_version: Literal[5, 6] = BUNDLED_UI_SDK_VERSION,
+    sdk_version: Literal[5, 6, 7] = BUNDLED_UI_SDK_VERSION,
 ) -> Starlette:
     """Create a Starlette app that serves a web chat UI for the given agent.
 
@@ -175,9 +175,10 @@ def create_web_app(
             - A Path instance: Reads from the local file
             - A URL string (http:// or https://): Fetches from the URL
             - A file path string: Reads from the local file
-        sdk_version: Vercel AI SDK version to target on the chat endpoint. Defaults to `6`, which the
-            bundled UI needs for tool-approval streaming. Only lower it to `5` when pairing an
-            older UI via `html_source`.
+        sdk_version: Vercel AI SDK version to target on the chat endpoint: 5, 6, or 7. Defaults to
+            `7` to match the bundled v7 UI, which needs it for tool-approval streaming (7 emits the
+            same wire as 6, since v7's data-stream protocol equals v6's). Only lower it to `5` when
+            pairing an older UI via `html_source`.
 
     Returns:
         A configured Starlette application ready to be served

--- a/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_web/app.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TypeVar
+from typing import Literal, TypeVar
 
 import httpx
 
@@ -26,8 +26,13 @@ except ImportError as _import_error:  # pragma: no cover
         'you can use the `web` optional group — `pip install "pydantic-ai-slim[web]"`'
     ) from _import_error
 
-CHAT_UI_VERSION = '1.2.0'
+CHAT_UI_VERSION = '2.0.0'
 DEFAULT_HTML_URL = f'https://cdn.jsdelivr.net/npm/@pydantic/ai-chat-ui@{CHAT_UI_VERSION}/dist/index.html'
+
+# The bundled chat UI (v7 of the Vercel AI SDK) consumes the `sdk_version=6` wire protocol, which is
+# what enables tool-approval streaming. `to_web()` controls both ends (server + bundled UI), so the
+# API path targets 6 to match the UI it ships. See `VercelAIAdapter.sdk_version`.
+BUNDLED_UI_SDK_VERSION: Literal[6] = 6
 
 AgentDepsT = TypeVar('AgentDepsT')
 OutputDataT = TypeVar('OutputDataT')
@@ -150,6 +155,7 @@ def create_web_app(
     model_settings: ModelSettings | None = None,
     instructions: str | None = None,
     html_source: str | Path | None = None,
+    sdk_version: Literal[5, 6] = BUNDLED_UI_SDK_VERSION,
 ) -> Starlette:
     """Create a Starlette app that serves a web chat UI for the given agent.
 
@@ -174,6 +180,9 @@ def create_web_app(
             - A Path instance: Reads from the local file
             - A URL string (http:// or https://): Fetches from the URL
             - A file path string: Reads from the local file
+        sdk_version: Vercel AI SDK version to target on the chat endpoint. Defaults to `6`, which the
+            bundled UI needs for tool-approval streaming. Only lower it to `5` when pairing an
+            older UI via `html_source`.
 
     Returns:
         A configured Starlette application ready to be served
@@ -185,6 +194,7 @@ def create_web_app(
         deps=deps,
         model_settings=model_settings,
         instructions=instructions,
+        sdk_version=sdk_version,
     )
 
     routes = [Mount('/api', app=api_app)]

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -137,10 +137,13 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
     """UI adapter for the Vercel AI protocol."""
 
     _: KW_ONLY
-    sdk_version: Literal[5, 6] = 5
+    sdk_version: Literal[5, 6, 7] = 5
     """Vercel AI SDK version to target. Default is 5 for backwards compatibility.
 
     Setting `sdk_version=6` enables tool approval streaming for human-in-the-loop workflows.
+    `sdk_version=7` emits the same wire as 6 (v7's data-stream protocol equals v6's); it is
+    accepted so the value reflects the client's real SDK major and reserves it for future
+    v7-only chunks.
     """
     server_message_id: str | None = None
     """Optional server-generated message ID to include in the `StartChunk`."""
@@ -166,7 +169,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
         request: Request,
         *,
         agent: AbstractAgent[AgentDepsT, OutputDataT],
-        sdk_version: Literal[5, 6] = 5,
+        sdk_version: Literal[5, 6, 7] = 5,
         server_message_id: str | None = None,
         manage_system_prompt: Literal['server', 'client'] = 'server',
         allowed_file_url_schemes: frozenset[str] = frozenset({'http', 'https'}),
@@ -198,7 +201,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
         request: Request,
         *,
         agent: AbstractAgent[DispatchDepsT, DispatchOutputDataT],
-        sdk_version: Literal[5, 6] = 5,
+        sdk_version: Literal[5, 6, 7] = 5,
         server_message_id: str | None = None,
         message_history: Sequence[ModelMessage] | None = None,
         deferred_tool_results: DeferredToolResults | None = None,
@@ -639,7 +642,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
         cls,
         msg: ModelResponse,
         tool_results: dict[str, ToolReturnPart | RetryPromptPart],
-        sdk_version: Literal[5, 6] = 5,
+        sdk_version: Literal[5, 6, 7] = 5,
     ) -> list[UIMessagePart]:
         """Convert a ModelResponse into a UIMessage."""
         ui_parts: list[UIMessagePart] = []
@@ -799,7 +802,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
     def _dump_tool_call_part(
         part: ToolCallPart,
         tool_results: dict[str, ToolReturnPart | RetryPromptPart],
-        sdk_version: Literal[5, 6] = 5,
+        sdk_version: Literal[5, 6, 7] = 5,
     ) -> list[UIMessagePart]:
         """Convert a ToolCallPart (with optional result) into UIMessageParts."""
         tool_result = tool_results.get(part.tool_call_id)
@@ -900,7 +903,7 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
         *,
         generate_message_id: Callable[[ModelRequest | ModelResponse, Literal['system', 'user', 'assistant'], int], str]
         | None = None,
-        sdk_version: Literal[5, 6] = 5,
+        sdk_version: Literal[5, 6, 7] = 5,
     ) -> list[UIMessage]:
         """Transform Pydantic AI messages into Vercel AI messages.
 
@@ -916,8 +919,9 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                 message index (incremented per UIMessage appended), and should return a unique
                 string ID. If not provided, uses `provider_response_id` for responses,
                 run_id-based IDs for messages with run_id, or a deterministic UUID5 fallback.
-            sdk_version: Vercel AI SDK version to target. Defaults to 5 for backwards compatibility.
-                Set to 6 to emit tool approval parts for deferred tool calls.
+            sdk_version: Vercel AI SDK version to target: 5, 6, or 7. Defaults to 5 for backwards
+                compatibility. Set to 6 to emit tool approval parts for deferred tool calls; 7 emits
+                identically to 6 (v7's data-stream protocol equals v6's).
 
         Returns:
             A list of UIMessage objects in Vercel AI format

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_event_stream.py
@@ -85,8 +85,9 @@ class VercelAIEventStream(UIEventStream[RequestData, BaseChunk, AgentDepsT, Outp
     """UI event stream transformer for the Vercel AI protocol."""
 
     _: KW_ONLY
-    sdk_version: Literal[5, 6] = 5
-    """Vercel AI SDK version to target. Setting to 6 enables tool approval streaming."""
+    sdk_version: Literal[5, 6, 7] = 5
+    """Vercel AI SDK version to target. Setting to 6 enables tool approval streaming; 7 emits the
+    same wire as 6 (v7's data-stream protocol equals v6's)."""
     server_message_id: str | None = None
     """Optional server-generated message ID to include in the `StartChunk`."""
 

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -458,13 +458,14 @@ def _parse_sse_chunk_types(body: str) -> list[str]:
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize('sdk_version', [None, 5, 6])
-async def test_post_chat_streams_tool_approval(allow_model_requests: None, sdk_version: Literal[5, 6] | None):
-    """The bundled web path targets Vercel AI SDK v6, so a tool call that requires approval streams a
+@pytest.mark.parametrize('sdk_version', [None, 5, 6, 7])
+async def test_post_chat_streams_tool_approval(allow_model_requests: None, sdk_version: Literal[5, 6, 7] | None):
+    """The bundled web path targets Vercel AI SDK v7, so a tool call that requires approval streams a
     `tool-approval-request` chunk the v7 UI renders as approve/reject buttons.
 
-    `sdk_version=None` exercises the default (`create_web_app` bundles the v7 UI, so it targets 6);
-    explicit `6` matches, while `5` falls back to `tool-input-available` with no approval chunk.
+    `sdk_version=None` exercises the default (`create_web_app` bundles the v7 UI, so it targets 7);
+    explicit `6`/`7` match (7 emits the same wire as 6), while `5` falls back to `tool-input-available`
+    with no approval chunk.
 
     Not a VCR test: this asserts the server→client SSE stream shape, which has no provider API to
     record. `FunctionModel` deterministically drives the deferred tool call the wire format hinges on.
@@ -500,7 +501,7 @@ async def test_post_chat_streams_tool_approval(allow_model_requests: None, sdk_v
         assert 'tool-approval-request' not in chunk_types
         assert 'tool-input-available' in chunk_types
     else:
-        # v6 emits `tool-input-available` (carrying the tool args the UI renders in the prompt)
+        # v6/v7 emit `tool-input-available` (carrying the tool args the UI renders in the prompt)
         # before `tool-approval-request` (which only carries approval_id + tool_call_id), so the
         # v7 UI can show the pending call's input alongside the approve/reject buttons.
         assert 'tool-input-available' in chunk_types

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -500,7 +500,12 @@ async def test_post_chat_streams_tool_approval(allow_model_requests: None, sdk_v
         assert 'tool-approval-request' not in chunk_types
         assert 'tool-input-available' in chunk_types
     else:
+        # v6 emits `tool-input-available` (carrying the tool args the UI renders in the prompt)
+        # before `tool-approval-request` (which only carries approval_id + tool_call_id), so the
+        # v7 UI can show the pending call's input alongside the approve/reject buttons.
+        assert 'tool-input-available' in chunk_types
         assert 'tool-approval-request' in chunk_types
+        assert chunk_types.index('tool-input-available') < chunk_types.index('tool-approval-request')
 
 
 def test_chat_app_options_endpoint():

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from pydantic_ai import Agent, ModelSettings
+from pydantic_ai.messages import ModelMessage
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool, MCPServerTool
@@ -466,7 +467,9 @@ async def test_post_chat_streams_tool_approval(allow_model_requests: None, sdk_v
     explicit `6` matches, while `5` falls back to `tool-input-available` with no approval chunk.
     """
 
-    async def stream_function(messages: list[Any], agent_info: AgentInfo) -> AsyncIterator[DeltaToolCalls | str]:
+    async def stream_function(
+        _messages: list[ModelMessage], agent_info: AgentInfo
+    ) -> AsyncIterator[DeltaToolCalls | str]:
         yield {0: DeltaToolCall(name='delete_file', json_args='{"path": "test.txt"}', tool_call_id='delete_1')}
 
     agent = Agent(model=FunctionModel(stream_function=stream_function), output_type=[str, DeferredToolRequests])

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -3,21 +3,25 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, Any
+from typing import IO, Any, Literal
 from unittest.mock import AsyncMock
 
 import pytest
 
 from pydantic_ai import Agent, ModelSettings
+from pydantic_ai.models.function import AgentInfo, DeltaToolCall, DeltaToolCalls, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS, AbstractNativeTool, MCPServerTool
 from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.profiles.google import GoogleModelProfile
 from pydantic_ai.profiles.groq import GroqModelProfile
 from pydantic_ai.profiles.openai import OpenAIModelProfile
+from pydantic_ai.tools import DeferredToolRequests
 
 from ._inline_snapshot import snapshot
 from .conftest import try_import
@@ -441,6 +445,56 @@ async def test_post_chat_endpoint():
         )
 
         assert response.status_code == 200
+
+
+def _parse_sse_chunk_types(body: str) -> list[str]:
+    """Extract the ordered `type` of each `data:` chunk from a Vercel AI SSE stream body."""
+    types: list[str] = []
+    for line in body.splitlines():
+        if line.startswith('data: ') and (payload := line.removeprefix('data: ')) != '[DONE]':
+            types.append(json.loads(payload)['type'])
+    return types
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize('sdk_version', [None, 5, 6])
+async def test_post_chat_streams_tool_approval(allow_model_requests: None, sdk_version: Literal[5, 6] | None):
+    """The bundled web path targets Vercel AI SDK v6, so a tool call that requires approval streams a
+    `tool-approval-request` chunk the v7 UI renders as approve/reject buttons.
+
+    `sdk_version=None` exercises the default (`create_web_app` bundles the v7 UI, so it targets 6);
+    explicit `6` matches, while `5` falls back to `tool-input-available` with no approval chunk.
+    """
+
+    async def stream_function(messages: list[Any], agent_info: AgentInfo) -> AsyncIterator[DeltaToolCalls | str]:
+        yield {0: DeltaToolCall(name='delete_file', json_args='{"path": "test.txt"}', tool_call_id='delete_1')}
+
+    agent = Agent(model=FunctionModel(stream_function=stream_function), output_type=[str, DeferredToolRequests])
+
+    @agent.tool_plain(requires_approval=True)
+    def delete_file(path: str) -> str:
+        return f'Deleted {path}'  # pragma: no cover
+
+    app = create_web_app(agent) if sdk_version is None else create_web_app(agent, sdk_version=sdk_version)
+
+    with TestClient(app) as client:
+        response = client.post(
+            '/api/chat',
+            json={
+                'trigger': 'submit-message',
+                'id': 'test-id',
+                'messages': [{'id': 'msg-1', 'role': 'user', 'parts': [{'type': 'text', 'text': 'Delete test.txt'}]}],
+                'builtinTools': [],
+            },
+        )
+        assert response.status_code == 200
+        chunk_types = _parse_sse_chunk_types(response.text)
+
+    if sdk_version == 5:
+        assert 'tool-approval-request' not in chunk_types
+        assert 'tool-input-available' in chunk_types
+    else:
+        assert 'tool-approval-request' in chunk_types
 
 
 def test_chat_app_options_endpoint():

--- a/tests/test_ui_web.py
+++ b/tests/test_ui_web.py
@@ -465,6 +465,9 @@ async def test_post_chat_streams_tool_approval(allow_model_requests: None, sdk_v
 
     `sdk_version=None` exercises the default (`create_web_app` bundles the v7 UI, so it targets 6);
     explicit `6` matches, while `5` falls back to `tool-input-available` with no approval chunk.
+
+    Not a VCR test: this asserts the server→client SSE stream shape, which has no provider API to
+    record. `FunctionModel` deterministically drives the deferred tool call the wire format hinges on.
     """
 
     async def stream_function(


### PR DESCRIPTION
<!-- No maintainer-assigned issue: maintainer-driven bump. -->

Supersedes #4670 (closed — was blocked on `@pydantic/ai-chat-ui@2.0.0` being published; now live on npm + jsdelivr).

## What

Bumps the bundled chat UI served by [`Agent.to_web()`][pydantic_ai.agent.Agent.to_web] to `@pydantic/ai-chat-ui@2.0.0` (Vercel AI SDK **v7**, which ships the tool-approval / denied-tool UI), and wires `sdk_version` through the `_web` path so the bundled UI actually receives the wire protocol that enables tool approval.

- `CHAT_UI_VERSION` `1.2.0` → `2.0.0` (`ui/_web/app.py`).
- `sdk_version` threaded through `create_web_app` → `create_api_app` → `post_chat` (both `VercelAIAdapter.from_request` and `.dispatch_request`), defaulting to **7** for the bundled path (single-sourced as `BUNDLED_UI_SDK_VERSION` in `ui/_web/api.py`) to match the bundled v7 UI.
- `docs/web.md`: bumped the `DEFAULT_HTML_URL` example output, added a **Tool Approval** section, and a security note on the client-relayed-approval trust posture (see below).
- Integration test at the real `/api/chat` HTTP boundary proving a `requires_approval` tool streams `tool-approval-request` at `sdk_version=6`/`7`/default and falls back to `tool-input-available` at `5`.

`v7` wire == `v6` wire (the `x-vercel-ai-ui-message-stream: v1` header is unchanged; v7's chunk types are a superset). The adapter's `sdk_version` `Literal` is widened to `[5, 6, 7]` and `7` is accepted so the value reflects the client's real SDK major and reserves it for future v7-only chunks — it emits **identically to 6** today (every `sdk_version` comparison is range-based `>= 6` / `< 6`, never `== 6`). `clai web` calls `create_web_app` without `sdk_version`, so it inherits the new default automatically.

## ⚠️ Decision flagged for maintainer review (@DouweM): `sdk_version` default for `to_web()`

This PR takes **Option A** — the bundled path defaults to `sdk_version=7`, and `sdk_version` is an **internal** param on the private `create_web_app`/`create_api_app` only; it is **not** exposed on the public `Agent.to_web()`.

Rationale: `to_web()` controls both ends (server + bundled UI) and bumps the UI to v7 in lockstep, so a coordinated 5→7 wire default is coherent and not a meaningful back-compat break for the default path (the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md) explicitly allows adding new stream chunk types). Keeping `sdk_version` off the high-level `to_web()` signature avoids leaking a Vercel-wire detail into a UI-agnostic convenience method — the lower-level `VercelAIAdapter` remains the escape hatch for full wire control. This extends #4670's original hardcode-a-tool-approval-version intent (it hardcoded `6`; the bundled UI is now v7, so we target `7`, which is wire-identical to `6`).

**The one edge worth a maintainer opinion:** a user who overrides `html_source` with an **old v5 UI** would now receive v6 wire (7 emits the v6 wire). I initially assumed this degrades benignly, but that's **incorrect**: per the research recorded on #3772, the Vercel AI SDK *client* is strict — it rejects unknown chunk types/keys and **interrupts streaming** rather than skipping them. So for the narrow case of a custom **v5** `html_source` UI **and** a `requires_approval` tool (which emits the new `tool-approval-request` chunk), streaming would likely break. (Non-approval flows emit no new chunks, so v6/v7 wire == v5 wire there — unaffected.) If you'd rather protect that path, **Option B** is a one-line change: expose `sdk_version` as a public `to_web(sdk_version=...)` param defaulting to `5`, setting the bundled UI internally to `7`. Note Option B does **not** change the security posture below (the bundled path still defaults to the tool-approval wire).

## 🔒 Security posture (documented, flagged for conscious accept)

Defaulting `to_web()` to `sdk_version=7` activates the client-relayed **tool-approval** channel: the chat endpoint executes approvals it receives from the client, including for `requires_approval=True` tools. The underlying channel is pre-existing and maintainer-approved (#6169 / GHSA-jpr8, 2026-07-03) for `VercelAIAdapter(sdk_version=6)` — `7` emits the same wire; this PR turns it on by default for the bundled `to_web()` path. `to_web()` is documented as a local-dev convenience, so this is fine bound to localhost — but a publicly-exposed app could have its approval gate bypassed by a forged approval. Mitigation shipped here is a **docs security note** under the Tool Approval section warning not to expose `to_web()` to untrusted clients without auth. No code revert (the approval channel is inseparable from the feature). Flagging the default-flip for a conscious accept.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
