### PR TITLE
fix(ci): exempt private org members from PR-guard auto-close

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -61,6 +61,19 @@ jobs:
             exit 0
           fi
 
+          # Private-membership bypass. The `author_association` in the webhook only
+          # reflects *public* org membership, so a private member of the org that
+          # owns this repo is reported as CONTRIBUTOR and misses the bypass above.
+          # Confirm real membership via the API, which sees private members when the
+          # token has `read:org` — the default `github.token` cannot, so this uses
+          # `ORG_READ_TOKEN` (an existing org-scoped secret). Fails open: if that
+          # token is unset or lacks the scope the API call errors and the existing
+          # policy applies unchanged, so no unlinked PR is ever wrongly kept open.
+          if [ -n "${ORG_READ_TOKEN:-}" ] && GH_TOKEN="$ORG_READ_TOKEN" gh api "orgs/${REPO%/*}/members/${PR_AUTHOR}" >/dev/null 2>&1; then
+            echo "Author ${PR_AUTHOR} is an org member (confirmed via API, incl. private membership); skipping checks."
+            exit 0
+          fi
+
           # Trusted-actor bypass. AUTHOR_ASSOCIATION above is the PR *author's*
           # relationship to the repo, so without this the guard re-closes a
           # contributor PR every time a maintainer acts on it: reopening it, or
@@ -373,6 +386,10 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+          # Read-only org-scoped token, used solely to confirm private org
+          # membership (see the private-membership bypass). Falls back to empty
+          # when unset, which the bypass handles by failing open.
+          ORG_READ_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           GITHUB_EVENT_SENDER_LOGIN: ${{ github.event.sender.login }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -20,6 +20,11 @@ rules:
       - ci.yml
       - docs-preview.yml
       - manually-deploy-docs.yml
+      # `pr-guard.yml` reads `GH_AW_GITHUB_TOKEN` as job-level env solely to
+      # confirm private org membership via `gh api orgs/.../members/{author}`;
+      # it's used as a `gh` credential, never interpolated into a run script,
+      # and the job checks out no fork code, so shell-injection exposure is nil.
+      - pr-guard.yml
       # gh-aw-generated agentic workflow lockfiles (see
       # .github/workflows/README-pydantic-ai-agents.md). gh-aw injects API /
       # GitHub secrets as job-level env by design; they are held by the AWF


### PR DESCRIPTION
## What

Exempt **private** members of the `pydantic` org from PR Guard's "no linked issue → auto-close" behavior.

## Why

PR Guard already bypasses maintainers via `author_association ∈ {MEMBER, OWNER, COLLABORATOR}`. But that field comes from the **webhook payload**, which only reflects *public* org membership — a **private** org member is reported as `CONTRIBUTOR`, misses the bypass, and gets auto-closed.

This happened on #6297 (reopened by a maintainer): the guard logged `PR #6297 by ddanielcruzz (CONTRIBUTOR)` and closed it, even though the REST API (with an org-read token) reports that user as `MEMBER`.

## How

After the existing `author_association` bypass, confirm real membership via `GET /orgs/{org}/members/{author}`, which sees private members when the token has `read:org`. The default `github.token` cannot, so this uses `ORG_READ_TOKEN` (wired to the existing `GH_AW_GITHUB_TOKEN` secret).

- **Least-privilege**: the org-read token is used *only* for the membership check; the destructive `gh pr close` / comment calls keep the default `github.token`.
- **Fails open**: if `ORG_READ_TOKEN` is unset or lacks `read:org`, the API call errors and the existing policy applies unchanged — no unlinked PR is ever wrongly kept open. Worst case equals current behavior.
- **Safe under `pull_request_target`**: the guard never checks out fork code, and fork PRs run the base copy of this workflow, so a fork cannot modify it to exfiltrate the token.

> Note: this relies on `GH_AW_GITHUB_TOKEN` having `read:org` scope. If it does, private members bypass immediately; if not, behavior is unchanged and the token can be granted the scope later. The first private-member PR after merge confirms it.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

