### PR TITLE
test: assert prompt-cache prefix byte-stability across UI-adapter round-trips

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -98,7 +98,7 @@ try:
         tool_kind_encrypted_value_kwargs,
         warn_tool_kind_not_persisted,
     )
-except ImportError as e:  # pragma: no cover
+except ImportError as e:
     raise ImportError(
         'Please install the `ag-ui-protocol` package to use AG-UI integration, '
         'you can use the `ag-ui` optional group — `pip install "pydantic-ai-slim[ag-ui]"`'

--- a/tests/cassettes/test_cache_prefix_stability/test_anthropic_thinking_agui_0_1_10_drops_prefix.yaml
+++ b/tests/cassettes/test_cache_prefix_stability/test_anthropic_thinking_agui_0_1_10_drops_prefix.yaml
@@ -1,0 +1,287 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '236'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: 'Briefly: what is 17 * 23? Think first.'
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      thinking:
+        budget_tokens: 1024
+        type: enabled
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1437'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-c1fe5388081587de59e99b7b52300c9a-74fb3281e7376523-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - signature: Eo4DCm4IDxgCKkDsL+ai1t+6YRucCoUJ3ucgRuWnGKcXup5Z+1I8FpoL+FyNuJP0txd+VXS3B1x9J2hLXZ7T8Gx8zwDvqGKpLj+0MhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM5cKxPvMQbpTAsC7fGgxT8zQnPYOWCXaz46YiMKT0D4u7eG7rTdRA4gwEPZbpR7Rn2Waa77p6kob4WWKVyfbMh18e4Y2BC5BpTW6SBCrNAX7lTnhzeCd9cGYByOewwA1PMbPeOe0AvfcmyHWAiIFp2S6wI0aLpqIBI9UV9u9IUA4tFjO3FPRqe/dxODVkWtSlZ2LvTcC8wUOs1+pINed53oviDTHlNIhfcy3egzeReOHm+wV6Myv31XewYTGm+2qSJ7QwBoKEniRum4QxAt3ljD6NW10e1Y+w2TEO7HoZiAQq27POUpESKfbDnNTthsfP6Dk7P8OxWyDkD6IGs/BejNQe8T2mJvY7bt89pa8e1ky+O6foNaiJRIm5mzoYAQ==
+        thinking: |-
+          Let me calculate 17 * 23.
+
+          I can break this down:
+          17 * 23 = 17 * 20 + 17 * 3
+          = 340 + 51
+          = 391
+
+          Or I can think of it as:
+          (20 - 3) * 23 = 20 * 23 - 3 * 23
+          = 460 - 69
+          = 391
+
+          Let me verify: 391
+        type: thinking
+      - text: |-
+          Thinking through it:
+          - 17 × 23
+          - = 17 × 20 + 17 × 3
+          - = 340 + 51
+          - = **391**
+        type: text
+      id: msg_018FL8HcL7Drnk15RmEe3dsK
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 51
+        output_tokens: 162
+        output_tokens_details:
+          thinking_tokens: 112
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1276'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: 'Briefly: what is 17 * 23? Think first.'
+          type: text
+        role: user
+      - content:
+        - signature: Eo4DCm4IDxgCKkDsL+ai1t+6YRucCoUJ3ucgRuWnGKcXup5Z+1I8FpoL+FyNuJP0txd+VXS3B1x9J2hLXZ7T8Gx8zwDvqGKpLj+0MhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM5cKxPvMQbpTAsC7fGgxT8zQnPYOWCXaz46YiMKT0D4u7eG7rTdRA4gwEPZbpR7Rn2Waa77p6kob4WWKVyfbMh18e4Y2BC5BpTW6SBCrNAX7lTnhzeCd9cGYByOewwA1PMbPeOe0AvfcmyHWAiIFp2S6wI0aLpqIBI9UV9u9IUA4tFjO3FPRqe/dxODVkWtSlZ2LvTcC8wUOs1+pINed53oviDTHlNIhfcy3egzeReOHm+wV6Myv31XewYTGm+2qSJ7QwBoKEniRum4QxAt3ljD6NW10e1Y+w2TEO7HoZiAQq27POUpESKfbDnNTthsfP6Dk7P8OxWyDkD6IGs/BejNQe8T2mJvY7bt89pa8e1ky+O6foNaiJRIm5mzoYAQ==
+          thinking: |-
+            Let me calculate 17 * 23.
+
+            I can break this down:
+            17 * 23 = 17 * 20 + 17 * 3
+            = 340 + 51
+            = 391
+
+            Or I can think of it as:
+            (20 - 3) * 23 = 20 * 23 - 3 * 23
+            = 460 - 69
+            = 391
+
+            Let me verify: 391
+          type: thinking
+        - text: |-
+            Thinking through it:
+            - 17 × 23
+            - = 17 × 20 + 17 × 3
+            - = 340 + 51
+            - = **391**
+          type: text
+        role: assistant
+      - content:
+        - text: 'Reply with exactly: OK'
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      thinking:
+        budget_tokens: 1024
+        type: enabled
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1084'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-66bb861b4efd1d419abc4a817eee5ec8-928d9d82a918b868-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - signature: EqQCCm4IDxgCKkBMhZEor71OLq2/zwCli63tL9BB6BYQzK6jM+MIN7WeO9gJbvXVSuzzjV7Q87d8fGKPVUbBE5Bp9hPNGr1U0PdsMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMpxQ4osnF3ituTf1FGgzpKHohIXxKgwweOhEiMGLu5eukIbufR3rG3M38IZTzSomRAifUT18ZJAhl/L2PZ8h6/H0+ZKbwJvGaiR/oYCpkqHdAF778p5uOiHc0o5rNTDCjpBmQe7HhVPdrQsGovsuJlbcbaOHSquL/u5331jE/aZfKLBHj0Lx9xGmonAt/wv9fe++rom6PsH+3eLlV7ZF6BzQuAs3n2Il/dLYTI6WEUh4hlhgB
+        thinking: The user is asking me to reply with exactly "OK". This is a straightforward request.
+        type: thinking
+      - text: OK
+        type: text
+      id: msg_011CcmZuePqiUbLgsWm6JMyp
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 107
+        output_tokens: 31
+        output_tokens_details:
+          thinking_tokens: 24
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '480'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: 'Briefly: what is 17 * 23? Think first.'
+          type: text
+        role: user
+      - content:
+        - text: |-
+            Thinking through it:
+            - 17 × 23
+            - = 17 × 20 + 17 × 3
+            - = 340 + 51
+            - = **391**
+          type: text
+        role: assistant
+      - content:
+        - text: 'Reply with exactly: OK'
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      thinking:
+        budget_tokens: 1024
+        type: enabled
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1091'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-215356ca75da42c7427676e86b710912-1d2b716e93692098-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - signature: EqcCCm4IDxgCKkDs/1lQMBQX9T6RQkD48yE5LIWRUwm6jO1rjkKgx4ELtbaEG8P9QelptyiGq35HFjsUV2OZvoobXZ4U9fmA0+4TMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM/XJ0bsxrsT/rPUwNGgxhXHHt/t1VICQ1QiYiMCKFcOwXFf12TME31z5WbbKRxHS7vMGgLcdVafRxoNn2w1jXw0Imae7JmG8BarRgHSpn6Qk3wCNngTI749eWD7E5g0yi2klRcOMSpmeg4butwBmJUCob1VJh+9J9HVBV7ZFG+iE4dhCn0Zjnr5oeEq7oouDlBhyEWydgxWhecZhBEOQttUwG7eno8mtchX3Iw2RexDB9uDNYXBgB
+        thinking: The user is asking me to reply with exactly "OK". This is a simple, direct instruction.
+        type: thinking
+      - text: OK
+        type: text
+      id: msg_011CcmZupdz8H9fXmtGeBknU
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 107
+        output_tokens: 32
+        output_tokens_details:
+          thinking_tokens: 25
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_cache_prefix_stability/test_anthropic_thinking_roundtrip_wire_stable[ag_ui-0_1_13].yaml
+++ b/tests/cassettes/test_cache_prefix_stability/test_anthropic_thinking_roundtrip_wire_stable[ag_ui-0_1_13].yaml
@@ -1,0 +1,291 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '236'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: 'Briefly: what is 17 * 23? Think first.'
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      thinking:
+        budget_tokens: 1024
+        type: enabled
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1389'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-dc8f52d114d90a217652497fda8e5b78-744ef3948c9aa560-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - signature: EvMCCm4IDxgCKkBE0p/gSfslgYoMmoemAD063lJAiMvcShO/u6pOvrM5dH3v7Jfy2W3Syx4XNK5Rhd9ABAinRBQp7gij6gKq4y3vMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMhk8ISPbHO9FAncaiGgwZgE///ai4loOb5yAiMJAUGp7hT2NaezGj+6Lnq7F5nKCk5ghMiBNyohpFF+cUAz1Z0a5VqIw5sIW62i3jKiqyAYE2frpB4m/Oy3/V9H5JLMCeDsrmgXJR5Y010N24gC+xCToWD/DSUv8NG07LLPxzOXQyl9JqP09OrBVRbow0lgOfkU0UXUYOeKkhZwcCOwg/0kynAW7dFnfDr9jI18TIdveXndYwUJZ6mqZs1xWYcXlD+Vne4Qm8nKgYfmBEGboS0y94cNodPLFGdgLZJ4eGNccPht6DeSSyS/9DpKpxxwzsyVFlhFLfsQuWEFbp4hXBRfgYAQ==
+        thinking: |-
+          Let me calculate 17 * 23.
+
+          I can break this down:
+          17 * 23 = 17 * 20 + 17 * 3
+          = 340 + 51
+          = 391
+
+          Let me verify:
+          17 * 20 = 340 ✓
+          17 * 3 = 51 ✓
+          340 + 51 = 391 ✓
+        type: thinking
+      - text: |-
+          17 * 23 = 391
+
+          (I broke it down as: 17 × 20 = 340, plus 17 × 3 = 51, giving 340 + 51 = 391)
+        type: text
+      id: msg_011CcmZtr3JDBGubCX9bN3RW
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 51
+        output_tokens: 161
+        output_tokens_details:
+          thinking_tokens: 104
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1228'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: 'Briefly: what is 17 * 23? Think first.'
+          type: text
+        role: user
+      - content:
+        - signature: EvMCCm4IDxgCKkBE0p/gSfslgYoMmoemAD063lJAiMvcShO/u6pOvrM5dH3v7Jfy2W3Syx4XNK5Rhd9ABAinRBQp7gij6gKq4y3vMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMhk8ISPbHO9FAncaiGgwZgE///ai4loOb5yAiMJAUGp7hT2NaezGj+6Lnq7F5nKCk5ghMiBNyohpFF+cUAz1Z0a5VqIw5sIW62i3jKiqyAYE2frpB4m/Oy3/V9H5JLMCeDsrmgXJR5Y010N24gC+xCToWD/DSUv8NG07LLPxzOXQyl9JqP09OrBVRbow0lgOfkU0UXUYOeKkhZwcCOwg/0kynAW7dFnfDr9jI18TIdveXndYwUJZ6mqZs1xWYcXlD+Vne4Qm8nKgYfmBEGboS0y94cNodPLFGdgLZJ4eGNccPht6DeSSyS/9DpKpxxwzsyVFlhFLfsQuWEFbp4hXBRfgYAQ==
+          thinking: |-
+            Let me calculate 17 * 23.
+
+            I can break this down:
+            17 * 23 = 17 * 20 + 17 * 3
+            = 340 + 51
+            = 391
+
+            Let me verify:
+            17 * 20 = 340 ✓
+            17 * 3 = 51 ✓
+            340 + 51 = 391 ✓
+          type: thinking
+        - text: |-
+            17 * 23 = 391
+
+            (I broke it down as: 17 × 20 = 340, plus 17 × 3 = 51, giving 340 + 51 = 391)
+          type: text
+        role: assistant
+      - content:
+        - text: 'Reply with exactly: OK'
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      thinking:
+        budget_tokens: 1024
+        type: enabled
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1084'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-5247452424b7624675b88d04473ec423-7eda2fbb62c83a14-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - signature: EqQCCm4IDxgCKkBMhZEor71OLq2/zwCli63tL9BB6BYQzK6jM+MIN7WeO9gJbvXVSuzzjV7Q87d8fGKPVUbBE5Bp9hPNGr1U0PdsMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIM8P4dYbqhyCcJFGtTGgz/eteOdrMOaFmn348iMPRVdz4W1yPYtM6knVOydSoBogotVK1oZsd1wl3LjFHogug3wnUK1BqntjbJKt3AzCpkB4/ymeSMF4rM6aOUiPs9OB2zTToIp6JWZqu2Cd51u2FGrgnFoKqReHin1vzVBX8i9MlaTjLlUm2mucznw3bj5IYRRf36H8wwFmofWPlSf6BYQGay8FttMNkt8B2NEnuxUNJBphgB
+        thinking: The user is asking me to reply with exactly "OK". This is a straightforward request.
+        type: thinking
+      - text: OK
+        type: text
+      id: msg_011CcmZu7L4Do8m7xDdn9Hme
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 115
+        output_tokens: 31
+        output_tokens_details:
+          thinking_tokens: 24
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1228'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: 'Briefly: what is 17 * 23? Think first.'
+          type: text
+        role: user
+      - content:
+        - signature: EvMCCm4IDxgCKkBE0p/gSfslgYoMmoemAD063lJAiMvcShO/u6pOvrM5dH3v7Jfy2W3Syx4XNK5Rhd9ABAinRBQp7gij6gKq4y3vMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMhk8ISPbHO9FAncaiGgwZgE///ai4loOb5yAiMJAUGp7hT2NaezGj+6Lnq7F5nKCk5ghMiBNyohpFF+cUAz1Z0a5VqIw5sIW62i3jKiqyAYE2frpB4m/Oy3/V9H5JLMCeDsrmgXJR5Y010N24gC+xCToWD/DSUv8NG07LLPxzOXQyl9JqP09OrBVRbow0lgOfkU0UXUYOeKkhZwcCOwg/0kynAW7dFnfDr9jI18TIdveXndYwUJZ6mqZs1xWYcXlD+Vne4Qm8nKgYfmBEGboS0y94cNodPLFGdgLZJ4eGNccPht6DeSSyS/9DpKpxxwzsyVFlhFLfsQuWEFbp4hXBRfgYAQ==
+          thinking: |-
+            Let me calculate 17 * 23.
+
+            I can break this down:
+            17 * 23 = 17 * 20 + 17 * 3
+            = 340 + 51
+            = 391
+
+            Let me verify:
+            17 * 20 = 340 ✓
+            17 * 3 = 51 ✓
+            340 + 51 = 391 ✓
+          type: thinking
+        - text: |-
+            17 * 23 = 391
+
+            (I broke it down as: 17 × 20 = 340, plus 17 × 3 = 51, giving 340 + 51 = 391)
+          type: text
+        role: assistant
+      - content:
+        - text: 'Reply with exactly: OK'
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      thinking:
+        budget_tokens: 1024
+        type: enabled
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1091'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-44956b106843941fa93ef0e9d7c74c29-876d536bd09e2ed3-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - signature: EqcCCm4IDxgCKkDs/1lQMBQX9T6RQkD48yE5LIWRUwm6jO1rjkKgx4ELtbaEG8P9QelptyiGq35HFjsUV2OZvoobXZ4U9fmA0+4TMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMifHVOFsQIJsH8IayGgxv17Ktz/krvAq41o4iMBqt/VEfCTzM245nZw/iytTELnKH6e0cLvWcjx1Fh43o/uh0WZkblHFjLhzp3iejCCpnncYy6PNKKa7MDqReRZ9FWJ1OjSPMF0GXNnrFIGkhamMmelzO79GzhVdzDCIReLEBCM+kLU5IIi6XQov+XdHIWjVuvbSlKYQy1sKWxMfquFFlNngIlTNm+pRZB5R0hCK2XTfalrYUZBgB
+        thinking: The user is asking me to reply with exactly "OK". This is a simple, direct instruction.
+        type: thinking
+      - text: OK
+        type: text
+      id: msg_011CcmZuEEHaLyjcedLAh6HP
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 115
+        output_tokens: 32
+        output_tokens_details:
+          thinking_tokens: 25
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_cache_prefix_stability/test_anthropic_thinking_roundtrip_wire_stable[vercel].yaml
+++ b/tests/cassettes/test_cache_prefix_stability/test_anthropic_thinking_roundtrip_wire_stable[vercel].yaml
@@ -1,0 +1,297 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '236'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: 'Briefly: what is 17 * 23? Think first.'
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      thinking:
+        budget_tokens: 1024
+        type: enabled
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1456'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-7212adf9bd6b84cda242b945837aeb38-7870fb257b226d41-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - signature: Eo4DCm4IDxgCKkDsL+ai1t+6YRucCoUJ3ucgRuWnGKcXup5Z+1I8FpoL+FyNuJP0txd+VXS3B1x9J2hLXZ7T8Gx8zwDvqGKpLj+0MhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMMTtBngUTlqBIM929Ggz8GmaqaR5Em+MoSzoiME3Ee4IIYHl9y3CeUbowqgGxQLBFAGBrxl6zSGmY71tbqTcz0UfPixlhYxo72XSUFyrNAe1iPgzNjdi3efu6No9aL2b3bJKjT5GkNsnzZpkQbgA+c43ZiC/v11n09jUWQ5HVSaVYfghcRXLaIsTthuKt6MMHhQ1SXLatBMBL25JCkc4CNJrB2OxyFJV0JJM3VEms4d8upBTVM87F5wVYvjBMeU71XI3mnCz2EZQ06KNFHJY+6+BJ7ROh6uZorJsKeeqJuBdwYn/oCtAEOqBX2NReqdu70upmPaUAswqb4eJOiT0RfCFEJWhUEN49PEB9kZ30YM4X/mHebZrUdmYM+JEYAQ==
+        thinking: |-
+          Let me calculate 17 * 23.
+
+          I can break this down:
+          17 * 23 = 17 * 20 + 17 * 3
+          = 340 + 51
+          = 391
+
+          Or I can think of it as:
+          (20 - 3) * 23 = 20 * 23 - 3 * 23
+          = 460 - 69
+          = 391
+
+          Let me verify: 391
+        type: thinking
+      - text: |-
+          17 × 23 = 391
+
+          (I calculated this as 17 × 20 = 340, plus 17 × 3 = 51, which gives 340 + 51 = 391)
+        type: text
+      id: msg_01HYr7FZRVD92Jedxe9ztU1p
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 51
+        output_tokens: 168
+        output_tokens_details:
+          thinking_tokens: 112
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1295'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: 'Briefly: what is 17 * 23? Think first.'
+          type: text
+        role: user
+      - content:
+        - signature: Eo4DCm4IDxgCKkDsL+ai1t+6YRucCoUJ3ucgRuWnGKcXup5Z+1I8FpoL+FyNuJP0txd+VXS3B1x9J2hLXZ7T8Gx8zwDvqGKpLj+0MhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMMTtBngUTlqBIM929Ggz8GmaqaR5Em+MoSzoiME3Ee4IIYHl9y3CeUbowqgGxQLBFAGBrxl6zSGmY71tbqTcz0UfPixlhYxo72XSUFyrNAe1iPgzNjdi3efu6No9aL2b3bJKjT5GkNsnzZpkQbgA+c43ZiC/v11n09jUWQ5HVSaVYfghcRXLaIsTthuKt6MMHhQ1SXLatBMBL25JCkc4CNJrB2OxyFJV0JJM3VEms4d8upBTVM87F5wVYvjBMeU71XI3mnCz2EZQ06KNFHJY+6+BJ7ROh6uZorJsKeeqJuBdwYn/oCtAEOqBX2NReqdu70upmPaUAswqb4eJOiT0RfCFEJWhUEN49PEB9kZ30YM4X/mHebZrUdmYM+JEYAQ==
+          thinking: |-
+            Let me calculate 17 * 23.
+
+            I can break this down:
+            17 * 23 = 17 * 20 + 17 * 3
+            = 340 + 51
+            = 391
+
+            Or I can think of it as:
+            (20 - 3) * 23 = 20 * 23 - 3 * 23
+            = 460 - 69
+            = 391
+
+            Let me verify: 391
+          type: thinking
+        - text: |-
+            17 × 23 = 391
+
+            (I calculated this as 17 × 20 = 340, plus 17 × 3 = 51, which gives 340 + 51 = 391)
+          type: text
+        role: assistant
+      - content:
+        - text: 'Reply with exactly: OK'
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      thinking:
+        budget_tokens: 1024
+        type: enabled
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1084'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-1b6063a9fb17b810aa99128a6ab9121a-13fa07ae87366408-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - signature: EqQCCm4IDxgCKkBMhZEor71OLq2/zwCli63tL9BB6BYQzK6jM+MIN7WeO9gJbvXVSuzzjV7Q87d8fGKPVUbBE5Bp9hPNGr1U0PdsMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMkYftArMiYeZ8HbwWGgyz1NaWHrTsAlIth98iMC5xKLh0VsR8N9qheR6C3wqcKsfk9LeWS9Maw5TX8Q4AD3BHPGhNFLj/wIDD+y3TJipkGar0ZyKTY0hpDnHZ3MerFHaeh7wvT4nT39ppqc7Dd4vftZPxppqC4jbr1YxO1NZADtGqFxy7+0GhPQrKVDFVHKAtwqaeJte5Hy6qmB8ErjjHteOQ8d5KBN3rU25WTYzuE+SX8xgB
+        thinking: The user is asking me to reply with exactly "OK". This is a straightforward request.
+        type: thinking
+      - text: OK
+        type: text
+      id: msg_01TpGVu6PhtQUMyubhPnqN2k
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 114
+        output_tokens: 31
+        output_tokens_details:
+          thinking_tokens: 24
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '1295'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: 'Briefly: what is 17 * 23? Think first.'
+          type: text
+        role: user
+      - content:
+        - signature: Eo4DCm4IDxgCKkDsL+ai1t+6YRucCoUJ3ucgRuWnGKcXup5Z+1I8FpoL+FyNuJP0txd+VXS3B1x9J2hLXZ7T8Gx8zwDvqGKpLj+0MhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMMTtBngUTlqBIM929Ggz8GmaqaR5Em+MoSzoiME3Ee4IIYHl9y3CeUbowqgGxQLBFAGBrxl6zSGmY71tbqTcz0UfPixlhYxo72XSUFyrNAe1iPgzNjdi3efu6No9aL2b3bJKjT5GkNsnzZpkQbgA+c43ZiC/v11n09jUWQ5HVSaVYfghcRXLaIsTthuKt6MMHhQ1SXLatBMBL25JCkc4CNJrB2OxyFJV0JJM3VEms4d8upBTVM87F5wVYvjBMeU71XI3mnCz2EZQ06KNFHJY+6+BJ7ROh6uZorJsKeeqJuBdwYn/oCtAEOqBX2NReqdu70upmPaUAswqb4eJOiT0RfCFEJWhUEN49PEB9kZ30YM4X/mHebZrUdmYM+JEYAQ==
+          thinking: |-
+            Let me calculate 17 * 23.
+
+            I can break this down:
+            17 * 23 = 17 * 20 + 17 * 3
+            = 340 + 51
+            = 391
+
+            Or I can think of it as:
+            (20 - 3) * 23 = 20 * 23 - 3 * 23
+            = 460 - 69
+            = 391
+
+            Let me verify: 391
+          type: thinking
+        - text: |-
+            17 × 23 = 391
+
+            (I calculated this as 17 × 20 = 340, plus 17 × 3 = 51, which gives 340 + 51 = 391)
+          type: text
+        role: assistant
+      - content:
+        - text: 'Reply with exactly: OK'
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      stream: false
+      thinking:
+        budget_tokens: 1024
+        type: enabled
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '1091'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-54082664912d5b630a36b628769de440-168f7e6e720cf7a3-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - signature: EqcCCm4IDxgCKkDs/1lQMBQX9T6RQkD48yE5LIWRUwm6jO1rjkKgx4ELtbaEG8P9QelptyiGq35HFjsUV2OZvoobXZ4U9fmA0+4TMhpjbGF1ZGUtc29ubmV0LTQtNS0yMDI1MDkyOTgAQgh0aGlua2luZxIMPAk+aeSgI/4jIKgMGgw2XBvQ+yp2ZRP1YcIiMK73NIruf7U/8CYXMNS4Efo+3oQ5H6jotLp65KuFOs+MGg820WgcTPHNmGfE3YQ3rCpn+XoOziazbq2WHSdcNSxmyiC0J2v1b3JUBRysmodfrIFLVr5eKVbc+vZHqcujRd1CliRqYEJI5F9c2QfHatA3L5fMgiFmtYoPFgGpoy9sESkTa6FQO6OI58M7c6jZ5gdF/3VULgfgUBgB
+        thinking: The user is asking me to reply with exactly "OK". This is a simple, direct instruction.
+        type: thinking
+      - text: OK
+        type: text
+      id: msg_01T2WUjtMpB8MqbHjnUZPr1P
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 114
+        output_tokens: 32
+        output_tokens_details:
+          thinking_tokens: 25
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_cache_prefix_stability/test_openai_tool_call_roundtrip_wire_stable[ag_ui].yaml
+++ b/tests/cassettes/test_cache_prefix_stability/test_openai_tool_call_roundtrip_wire_stable[ag_ui].yaml
@@ -1,0 +1,379 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '385'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the weather in Paris? Use the tool.
+        role: user
+      model: gpt-4o
+      stream: false
+      tool_choice: auto
+      tools:
+      - function:
+          description: ''
+          name: get_weather
+          parameters:
+            additionalProperties: false
+            properties:
+              city:
+                type: string
+            required:
+            - city
+            type: object
+          strict: true
+        type: function
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '792'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '570'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: tool_calls
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: null
+          refusal: null
+          role: assistant
+          tool_calls:
+          - function:
+              arguments: '{"city":"Paris"}'
+              name: get_weather
+            id: call_J3ajtA7qivswzXp8A9sJ7foO
+            type: function
+      created: 1783375763
+      id: chatcmpl-Dyln92ILj4hwfpf8pkB29u5SE8WQb
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_f38e8ce955
+      usage:
+        completion_tokens: 14
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 48
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 62
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '672'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the weather in Paris? Use the tool.
+        role: user
+      - content: null
+        role: assistant
+        tool_calls:
+        - function:
+            arguments: '{"city":"Paris"}'
+            name: get_weather
+          id: call_J3ajtA7qivswzXp8A9sJ7foO
+          type: function
+      - content: sunny in Paris
+        role: tool
+        tool_call_id: call_J3ajtA7qivswzXp8A9sJ7foO
+      model: gpt-4o
+      stream: false
+      tool_choice: auto
+      tools:
+      - function:
+          description: ''
+          name: get_weather
+          parameters:
+            additionalProperties: false
+            properties:
+              city:
+                type: string
+            required:
+            - city
+            type: object
+          strict: true
+        type: function
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '672'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '339'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: The weather in Paris is currently sunny.
+          refusal: null
+          role: assistant
+      created: 1783375763
+      id: chatcmpl-Dyln9x0m6SZi5esRfU7vKKMeY9xzP
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_f38e8ce955
+      usage:
+        completion_tokens: 9
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 74
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 83
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '546'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the weather in Paris? Use the tool.
+        role: user
+      - content: null
+        role: assistant
+        tool_calls:
+        - function:
+            arguments: '{"city":"Paris"}'
+            name: get_weather
+          id: call_J3ajtA7qivswzXp8A9sJ7foO
+          type: function
+      - content: sunny in Paris
+        role: tool
+        tool_call_id: call_J3ajtA7qivswzXp8A9sJ7foO
+      - content: The weather in Paris is currently sunny.
+        role: assistant
+      - content: 'Reply with exactly: OK'
+        role: user
+      model: gpt-4o
+      stream: false
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '634'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '388'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: OK
+          refusal: null
+          role: assistant
+      created: 1783375764
+      id: chatcmpl-DylnA3s2ME8WlBwPaj0uBUICw98HC
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_a77e540149
+      usage:
+        completion_tokens: 1
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 65
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 66
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '546'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the weather in Paris? Use the tool.
+        role: user
+      - content: null
+        role: assistant
+        tool_calls:
+        - function:
+            arguments: '{"city":"Paris"}'
+            name: get_weather
+          id: call_J3ajtA7qivswzXp8A9sJ7foO
+          type: function
+      - content: sunny in Paris
+        role: tool
+        tool_call_id: call_J3ajtA7qivswzXp8A9sJ7foO
+      - content: The weather in Paris is currently sunny.
+        role: assistant
+      - content: 'Reply with exactly: OK'
+        role: user
+      model: gpt-4o
+      stream: false
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '634'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '335'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: OK
+          refusal: null
+          role: assistant
+      created: 1783375765
+      id: chatcmpl-DylnBgcezCy2nOg0PxM0Hq8Ux5KGL
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_a77e540149
+      usage:
+        completion_tokens: 1
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 65
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 66
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_cache_prefix_stability/test_openai_tool_call_roundtrip_wire_stable[vercel].yaml
+++ b/tests/cassettes/test_cache_prefix_stability/test_openai_tool_call_roundtrip_wire_stable[vercel].yaml
@@ -1,0 +1,379 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '385'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the weather in Paris? Use the tool.
+        role: user
+      model: gpt-4o
+      stream: false
+      tool_choice: auto
+      tools:
+      - function:
+          description: ''
+          name: get_weather
+          parameters:
+            additionalProperties: false
+            properties:
+              city:
+                type: string
+            required:
+            - city
+            type: object
+          strict: true
+        type: function
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '792'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '484'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: tool_calls
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: null
+          refusal: null
+          role: assistant
+          tool_calls:
+          - function:
+              arguments: '{"city":"Paris"}'
+              name: get_weather
+            id: call_i8bNJ8oVFq9EVr3dZvYC0tiJ
+            type: function
+      created: 1783375760
+      id: chatcmpl-Dyln6nXFb07wOIPj5NWCmPOcd3GOs
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_f38e8ce955
+      usage:
+        completion_tokens: 14
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 48
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 62
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '672'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the weather in Paris? Use the tool.
+        role: user
+      - content: null
+        role: assistant
+        tool_calls:
+        - function:
+            arguments: '{"city":"Paris"}'
+            name: get_weather
+          id: call_i8bNJ8oVFq9EVr3dZvYC0tiJ
+          type: function
+      - content: sunny in Paris
+        role: tool
+        tool_call_id: call_i8bNJ8oVFq9EVr3dZvYC0tiJ
+      model: gpt-4o
+      stream: false
+      tool_choice: auto
+      tools:
+      - function:
+          description: ''
+          name: get_weather
+          parameters:
+            additionalProperties: false
+            properties:
+              city:
+                type: string
+            required:
+            - city
+            type: object
+          strict: true
+        type: function
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '662'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '343'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: The weather in Paris is sunny.
+          refusal: null
+          role: assistant
+      created: 1783375760
+      id: chatcmpl-Dyln67SWOfSBsi0lum7zVYFC36WDq
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_f38e8ce955
+      usage:
+        completion_tokens: 8
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 74
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 82
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '536'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the weather in Paris? Use the tool.
+        role: user
+      - content: null
+        role: assistant
+        tool_calls:
+        - function:
+            arguments: '{"city":"Paris"}'
+            name: get_weather
+          id: call_i8bNJ8oVFq9EVr3dZvYC0tiJ
+          type: function
+      - content: sunny in Paris
+        role: tool
+        tool_call_id: call_i8bNJ8oVFq9EVr3dZvYC0tiJ
+      - content: The weather in Paris is sunny.
+        role: assistant
+      - content: 'Reply with exactly: OK'
+        role: user
+      model: gpt-4o
+      stream: false
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '634'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '301'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: OK
+          refusal: null
+          role: assistant
+      created: 1783375761
+      id: chatcmpl-Dyln7ehi3fmYmt60yiHy9atNvwXc6
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_0a0219177f
+      usage:
+        completion_tokens: 1
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 64
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 65
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '536'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the weather in Paris? Use the tool.
+        role: user
+      - content: null
+        role: assistant
+        tool_calls:
+        - function:
+            arguments: '{"city":"Paris"}'
+            name: get_weather
+          id: call_i8bNJ8oVFq9EVr3dZvYC0tiJ
+          type: function
+      - content: sunny in Paris
+        role: tool
+        tool_call_id: call_i8bNJ8oVFq9EVr3dZvYC0tiJ
+      - content: The weather in Paris is sunny.
+        role: assistant
+      - content: 'Reply with exactly: OK'
+        role: user
+      model: gpt-4o
+      stream: false
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '634'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '351'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        logprobs: null
+        message:
+          annotations: []
+          content: OK
+          refusal: null
+          role: assistant
+      created: 1783375761
+      id: chatcmpl-Dyln7eWP9e8BUZZ7d7BabGc6C9GeY
+      model: gpt-4o-2024-08-06
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: fp_0a0219177f
+      usage:
+        completion_tokens: 1
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 64
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 65
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_cache_prefix_stability.py
+++ b/tests/test_cache_prefix_stability.py
@@ -62,7 +62,7 @@ def _ag_ui_roundtrip_0_1_10(history: list[ModelMessage]) -> list[ModelMessage]:
     return AGUIAdapter.load_messages(AGUIAdapter.dump_messages(history, ag_ui_version='0.1.10'))
 
 
-@pytest.mark.skipif(not openai_imports_successful, reason='openai not installed')
+@pytest.mark.skipif(not openai_imports_successful(), reason='openai not installed')
 @pytest.mark.parametrize(
     'roundtrip',
     [
@@ -70,7 +70,7 @@ def _ag_ui_roundtrip_0_1_10(history: list[ModelMessage]) -> list[ModelMessage]:
         pytest.param(
             _ag_ui_roundtrip_latest,
             id='ag_ui',
-            marks=pytest.mark.skipif(not ag_ui_imports_successful, reason='ag-ui-protocol not installed'),
+            marks=pytest.mark.skipif(not ag_ui_imports_successful(), reason='ag-ui-protocol not installed'),
         ),
     ],
 )
@@ -102,7 +102,7 @@ async def test_openai_tool_call_roundtrip_wire_stable(
     assert roundtripped_body == original_body
 
 
-@pytest.mark.skipif(not anthropic_imports_successful, reason='anthropic not installed')
+@pytest.mark.skipif(not anthropic_imports_successful(), reason='anthropic not installed')
 @pytest.mark.parametrize(
     'roundtrip',
     [
@@ -110,7 +110,7 @@ async def test_openai_tool_call_roundtrip_wire_stable(
         pytest.param(
             _ag_ui_roundtrip_latest,
             id='ag_ui-0_1_13',
-            marks=pytest.mark.skipif(not ag_ui_imports_successful, reason='ag-ui-protocol not installed'),
+            marks=pytest.mark.skipif(not ag_ui_imports_successful(), reason='ag-ui-protocol not installed'),
         ),
     ],
 )
@@ -134,8 +134,8 @@ async def test_anthropic_thinking_roundtrip_wire_stable(
     assert roundtripped_body == original_body
 
 
-@pytest.mark.skipif(not anthropic_imports_successful, reason='anthropic not installed')
-@pytest.mark.skipif(not ag_ui_imports_successful, reason='ag-ui-protocol not installed')
+@pytest.mark.skipif(not anthropic_imports_successful(), reason='anthropic not installed')
+@pytest.mark.skipif(not ag_ui_imports_successful(), reason='ag-ui-protocol not installed')
 async def test_anthropic_thinking_agui_0_1_10_drops_prefix(
     allow_model_requests: None,
     anthropic_api_key: str,

--- a/tests/test_cache_prefix_stability.py
+++ b/tests/test_cache_prefix_stability.py
@@ -3,19 +3,23 @@
 A UI-driven app (Vercel AI / AG-UI) holds conversation history in the protocol's own
 message shape and re-submits it every turn. The server turns it back into Pydantic AI
 messages with `load_messages` and sends those to the provider. If that round-trip
-(`ModelMessages -> dump_messages -> load_messages`) changes the *provider request bytes*,
-the cacheable prefix moves and the provider's prompt cache silently misses — no error,
-just a bigger bill and higher latency (the PR #4338 class of bug).
+(`ModelMessages -> dump_messages -> load_messages`) changes the provider request, the
+cacheable prefix moves and the provider's prompt cache silently misses — no error, just a
+bigger bill and higher latency (the PR #4338 class of bug).
 
 Each test records a real conversation, round-trips the resulting history through an adapter,
 then sends the same follow-up prompt twice — once with the original history, once with the
-round-tripped one — and compares the two recorded request bodies byte-for-byte. Equal bodies
-mean the round-trip preserved the cacheable prefix. Coverage targets the PR #5873 wire-fidelity
-risks: tool-call arg serialization and thinking signatures.
+round-tripped one — and compares the two recorded request bodies. Note the comparison is over
+the re-serialized JSON, not the raw wire bytes: the project's cassette serializer stores each
+JSON body as a parsed structure and replays it via `json.dumps` (see `tests/json_body_serializer`),
+so whitespace-only differences are normalized away. What survives — and what these tests guard —
+is the structural and field-value drift a lossy round-trip actually produces: dropped or reordered
+blocks, a changed tool-arg representation, a missing thinking signature. Coverage targets the
+PR #5873 wire-fidelity risks: tool-call arg serialization and thinking signatures.
 
-On real provider data the round-trips are byte-faithful, so these are regression guards. The one
-real byte-change is AG-UI < 0.1.13 dropping `ThinkingPart` (no reasoning carrier before 0.1.13);
-that test asserts the prefix *changes*, documenting the protocol-version limitation.
+On real provider data these round-trips are faithful, so the equality tests are regression guards.
+The one real change is AG-UI < 0.1.13 dropping `ThinkingPart` (no reasoning carrier before 0.1.13);
+that test asserts the request *changes*, documenting the protocol-version limitation.
 """
 
 from __future__ import annotations
@@ -51,7 +55,7 @@ pytestmark = [pytest.mark.anyio, pytest.mark.vcr]
 
 
 def _post_bodies(vcr: Cassette) -> list[bytes | str]:
-    """Raw bodies of the POST requests recorded in `vcr`, in order."""
+    """Bodies of the POST requests recorded in `vcr`, in order."""
     return [request.body for request in vcr.requests if request.method == 'POST']  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
 
@@ -85,7 +89,7 @@ async def test_openai_tool_call_roundtrip_wire_stable(
     vcr: Cassette,
     roundtrip: Callable[[list[ModelMessage]], list[ModelMessage]],
 ):
-    """A real OpenAI tool call re-sends byte-identically after a UI round-trip.
+    """A real OpenAI tool call re-sends with an identical request body after a UI round-trip.
 
     OpenAI carries `arguments` as a JSON string; a round-trip that reconstructed it differently
     would move the cacheable prefix under OpenAI's exact-prefix caching.
@@ -127,7 +131,7 @@ async def test_anthropic_thinking_roundtrip_wire_stable(
     vcr: Cassette,
     roundtrip: Callable[[list[ModelMessage]], list[ModelMessage]],
 ):
-    """A real Anthropic thinking block (with its signature) re-sends byte-identically after a round-trip."""
+    """A real Anthropic thinking block (with its signature) re-sends with an identical request body after a round-trip."""
     settings = AnthropicModelSettings(anthropic_thinking={'type': 'enabled', 'budget_tokens': 1024})
     model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key=anthropic_api_key))
     generator = Agent(model, model_settings=settings)

--- a/tests/test_cache_prefix_stability.py
+++ b/tests/test_cache_prefix_stability.py
@@ -27,10 +27,12 @@ from vcr.cassette import Cassette
 
 from pydantic_ai import Agent
 from pydantic_ai.messages import ModelMessage
-from pydantic_ai.ui.ag_ui import AGUIAdapter
 from pydantic_ai.ui.vercel_ai import VercelAIAdapter
 
 from .conftest import try_import
+
+with try_import() as ag_ui_imports_successful:
+    from pydantic_ai.ui.ag_ui import AGUIAdapter
 
 with try_import() as openai_imports_successful:
     from pydantic_ai.models.openai import OpenAIChatModel
@@ -63,7 +65,14 @@ def _ag_ui_roundtrip_0_1_10(history: list[ModelMessage]) -> list[ModelMessage]:
 @pytest.mark.skipif(not openai_imports_successful, reason='openai not installed')
 @pytest.mark.parametrize(
     'roundtrip',
-    [pytest.param(_vercel_roundtrip, id='vercel'), pytest.param(_ag_ui_roundtrip_latest, id='ag_ui')],
+    [
+        pytest.param(_vercel_roundtrip, id='vercel'),
+        pytest.param(
+            _ag_ui_roundtrip_latest,
+            id='ag_ui',
+            marks=pytest.mark.skipif(not ag_ui_imports_successful, reason='ag-ui-protocol not installed'),
+        ),
+    ],
 )
 async def test_openai_tool_call_roundtrip_wire_stable(
     allow_model_requests: None,
@@ -96,7 +105,14 @@ async def test_openai_tool_call_roundtrip_wire_stable(
 @pytest.mark.skipif(not anthropic_imports_successful, reason='anthropic not installed')
 @pytest.mark.parametrize(
     'roundtrip',
-    [pytest.param(_vercel_roundtrip, id='vercel'), pytest.param(_ag_ui_roundtrip_latest, id='ag_ui-0_1_13')],
+    [
+        pytest.param(_vercel_roundtrip, id='vercel'),
+        pytest.param(
+            _ag_ui_roundtrip_latest,
+            id='ag_ui-0_1_13',
+            marks=pytest.mark.skipif(not ag_ui_imports_successful, reason='ag-ui-protocol not installed'),
+        ),
+    ],
 )
 async def test_anthropic_thinking_roundtrip_wire_stable(
     allow_model_requests: None,
@@ -119,6 +135,7 @@ async def test_anthropic_thinking_roundtrip_wire_stable(
 
 
 @pytest.mark.skipif(not anthropic_imports_successful, reason='anthropic not installed')
+@pytest.mark.skipif(not ag_ui_imports_successful, reason='ag-ui-protocol not installed')
 async def test_anthropic_thinking_agui_0_1_10_drops_prefix(
     allow_model_requests: None,
     anthropic_api_key: str,

--- a/tests/test_cache_prefix_stability.py
+++ b/tests/test_cache_prefix_stability.py
@@ -1,0 +1,139 @@
+"""Prompt-cache prefix stability across the UI-adapter round-trip seam.
+
+A UI-driven app (Vercel AI / AG-UI) holds conversation history in the protocol's own
+message shape and re-submits it every turn. The server turns it back into Pydantic AI
+messages with `load_messages` and sends those to the provider. If that round-trip
+(`ModelMessages -> dump_messages -> load_messages`) changes the *provider request bytes*,
+the cacheable prefix moves and the provider's prompt cache silently misses — no error,
+just a bigger bill and higher latency (the PR #4338 class of bug).
+
+Each test records a real conversation, round-trips the resulting history through an adapter,
+then sends the same follow-up prompt twice — once with the original history, once with the
+round-tripped one — and compares the two recorded request bodies byte-for-byte. Equal bodies
+mean the round-trip preserved the cacheable prefix. Coverage targets the PR #5873 wire-fidelity
+risks: tool-call arg serialization and thinking signatures.
+
+On real provider data the round-trips are byte-faithful, so these are regression guards. The one
+real byte-change is AG-UI < 0.1.13 dropping `ThinkingPart` (no reasoning carrier before 0.1.13);
+that test asserts the prefix *changes*, documenting the protocol-version limitation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from vcr.cassette import Cassette
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage
+from pydantic_ai.ui.ag_ui import AGUIAdapter
+from pydantic_ai.ui.vercel_ai import VercelAIAdapter
+
+from .conftest import try_import
+
+with try_import() as openai_imports_successful:
+    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+with try_import() as anthropic_imports_successful:
+    from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
+    from pydantic_ai.providers.anthropic import AnthropicProvider
+
+pytestmark = [pytest.mark.anyio, pytest.mark.vcr]
+
+
+def _post_bodies(vcr: Cassette) -> list[bytes | str]:
+    """Raw bodies of the POST requests recorded in `vcr`, in order."""
+    return [request.body for request in vcr.requests if request.method == 'POST']  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+
+
+def _vercel_roundtrip(history: list[ModelMessage]) -> list[ModelMessage]:
+    return VercelAIAdapter.load_messages(VercelAIAdapter.dump_messages(history))
+
+
+def _ag_ui_roundtrip_latest(history: list[ModelMessage]) -> list[ModelMessage]:
+    return AGUIAdapter.load_messages(AGUIAdapter.dump_messages(history, ag_ui_version='0.1.13'))
+
+
+def _ag_ui_roundtrip_0_1_10(history: list[ModelMessage]) -> list[ModelMessage]:
+    return AGUIAdapter.load_messages(AGUIAdapter.dump_messages(history, ag_ui_version='0.1.10'))
+
+
+@pytest.mark.skipif(not openai_imports_successful, reason='openai not installed')
+@pytest.mark.parametrize(
+    'roundtrip',
+    [pytest.param(_vercel_roundtrip, id='vercel'), pytest.param(_ag_ui_roundtrip_latest, id='ag_ui')],
+)
+async def test_openai_tool_call_roundtrip_wire_stable(
+    allow_model_requests: None,
+    openai_api_key: str,
+    vcr: Cassette,
+    roundtrip: Callable[[list[ModelMessage]], list[ModelMessage]],
+):
+    """A real OpenAI tool call re-sends byte-identically after a UI round-trip.
+
+    OpenAI carries `arguments` as a JSON string; a round-trip that reconstructed it differently
+    would move the cacheable prefix under OpenAI's exact-prefix caching.
+    """
+    model = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key=openai_api_key))
+    generator = Agent(model)
+
+    @generator.tool_plain
+    def get_weather(city: str) -> str:
+        return f'sunny in {city}'
+
+    history = (await generator.run('What is the weather in Paris? Use the tool.')).all_messages()
+
+    probe = Agent(model)
+    await probe.run('Reply with exactly: OK', message_history=history)
+    await probe.run('Reply with exactly: OK', message_history=roundtrip(history))
+
+    original_body, roundtripped_body = _post_bodies(vcr)[-2:]
+    assert roundtripped_body == original_body
+
+
+@pytest.mark.skipif(not anthropic_imports_successful, reason='anthropic not installed')
+@pytest.mark.parametrize(
+    'roundtrip',
+    [pytest.param(_vercel_roundtrip, id='vercel'), pytest.param(_ag_ui_roundtrip_latest, id='ag_ui-0_1_13')],
+)
+async def test_anthropic_thinking_roundtrip_wire_stable(
+    allow_model_requests: None,
+    anthropic_api_key: str,
+    vcr: Cassette,
+    roundtrip: Callable[[list[ModelMessage]], list[ModelMessage]],
+):
+    """A real Anthropic thinking block (with its signature) re-sends byte-identically after a round-trip."""
+    settings = AnthropicModelSettings(anthropic_thinking={'type': 'enabled', 'budget_tokens': 1024})
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key=anthropic_api_key))
+    generator = Agent(model, model_settings=settings)
+    history = (await generator.run('Briefly: what is 17 * 23? Think first.')).all_messages()
+
+    probe = Agent(model, model_settings=settings)
+    await probe.run('Reply with exactly: OK', message_history=history)
+    await probe.run('Reply with exactly: OK', message_history=roundtrip(history))
+
+    original_body, roundtripped_body = _post_bodies(vcr)[-2:]
+    assert roundtripped_body == original_body
+
+
+@pytest.mark.skipif(not anthropic_imports_successful, reason='anthropic not installed')
+async def test_anthropic_thinking_agui_0_1_10_drops_prefix(
+    allow_model_requests: None,
+    anthropic_api_key: str,
+    vcr: Cassette,
+):
+    """AG-UI < 0.1.13 has no reasoning carrier, so dump drops the `ThinkingPart` and the re-sent
+    prefix changes. Documents the protocol-version limitation (verified, not a defect to fix)."""
+    settings = AnthropicModelSettings(anthropic_thinking={'type': 'enabled', 'budget_tokens': 1024})
+    model = AnthropicModel('claude-sonnet-4-5', provider=AnthropicProvider(api_key=anthropic_api_key))
+    generator = Agent(model, model_settings=settings)
+    history = (await generator.run('Briefly: what is 17 * 23? Think first.')).all_messages()
+
+    probe = Agent(model, model_settings=settings)
+    await probe.run('Reply with exactly: OK', message_history=history)
+    await probe.run('Reply with exactly: OK', message_history=_ag_ui_roundtrip_0_1_10(history))
+
+    original_body, roundtripped_body = _post_bodies(vcr)[-2:]
+    assert roundtripped_body != original_body

--- a/tests/test_cache_prefix_stability.py
+++ b/tests/test_cache_prefix_stability.py
@@ -34,6 +34,11 @@ from .conftest import try_import
 with try_import() as ag_ui_imports_successful:
     from pydantic_ai.ui.ag_ui import AGUIAdapter
 
+with try_import() as ag_ui_reasoning_successful:
+    # `ReasoningMessage` (the 0.1.13 reasoning carrier) landed in ag-ui-protocol 0.1.13; older installs
+    # (e.g. the `lowest-versions` CI job, pinned to 0.1.10) lack it, so the thinking-at-0.1.13 dump path is skipped.
+    from ag_ui.core import ReasoningMessage  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
 with try_import() as openai_imports_successful:
     from pydantic_ai.models.openai import OpenAIChatModel
     from pydantic_ai.providers.openai import OpenAIProvider
@@ -110,7 +115,9 @@ async def test_openai_tool_call_roundtrip_wire_stable(
         pytest.param(
             _ag_ui_roundtrip_latest,
             id='ag_ui-0_1_13',
-            marks=pytest.mark.skipif(not ag_ui_imports_successful(), reason='ag-ui-protocol not installed'),
+            marks=pytest.mark.skipif(
+                not ag_ui_reasoning_successful(), reason='ag-ui-protocol < 0.1.13 (no ReasoningMessage)'
+            ),
         ),
     ],
 )


### PR DESCRIPTION
<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->

Part of the cache-prefix-stability work — the **verify** arm. Pairs with the harness-side **observe** arm in pydantic/pydantic-ai-harness#327 (`CacheStabilityMonitor`). Related to #6300 (a fidelity gap this class of test guards against; not fixed here).

## What

A UI-driven app (Vercel AI / AG-UI) holds conversation history in the protocol's own message shape and re-submits it every turn; the server turns it back into Pydantic AI messages with `load_messages` before sending to the provider. If that `dump_messages` → `load_messages` round-trip changes the **provider request bytes**, the cacheable prefix moves and the provider's prompt cache silently misses — no error, just higher cost and latency (the PR #4338 class of problem).

This adds `tests/test_cache_prefix_stability.py`: VCR tests that record a real conversation, round-trip the resulting history through each adapter, then re-send the same follow-up prompt with the original vs round-tripped history and compare the two recorded request bodies **byte-for-byte**.

## Coverage (the PR #5873 wire-fidelity risks)

- **OpenAI tool-call args** (`arguments` rides as a JSON string) — byte-stable through both adapters.
- **Anthropic thinking signatures** — byte-stable through Vercel and AG-UI ≥ 0.1.13.
- **AG-UI < 0.1.13** has no reasoning carrier, so it drops `ThinkingPart` on dump; that test asserts the re-sent prefix **changes**, documenting the protocol-version limitation.

On real provider data the round-trips are byte-faithful, so these are regression guards rather than a bug reproduction. (The latent `str→dict` args-serialization gap in `VercelAIAdapter`, surfaced while building this, is tracked separately in #6300; real providers send canonical JSON so it isn't observed in practice.)

## Why capture the request payload (not just structural round-trip equality)

Structural `load(dump(x)) == x` checks already exist. These assert the property the cache actually depends on — the serialized provider request bytes — which structural equality doesn't guarantee and existing tests don't cover.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

