### PR TITLE
fix: pass reasoning text content in ResponseReasoningTextDeltaEvent handler

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2002,9 +2002,14 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                         signature = None
                         provider_details = {}
                 elif signature or provider_details:
+                    # When there are no summaries but there is raw CoT content
+                    # (e.g. from gpt-oss models, vLLM, or litellm bridge), use
+                    # the raw content text as the ThinkingPart content so it is
+                    # visible to consumers, not just stored in provider_details.
+                    raw_content_text = ' '.join(raw_content) if raw_content else ''
                     items.append(
                         ThinkingPart(
-                            content='',
+                            content=raw_content_text,
                             id=item.id,
                             signature=signature,
                             provider_name=self.system,
@@ -3699,9 +3704,12 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                         yield event
 
                 elif isinstance(chunk, responses.ResponseReasoningTextDeltaEvent):
-                    # Handle raw CoT from gpt-oss models using callback pattern
+                    # Handle raw CoT from gpt-oss models and OpenAI-compatible providers
+                    # (e.g. vLLM, LM Studio, litellm bridge) that use `reasoning_text` events
+                    # instead of `reasoning_summary_text` events.
                     for event in self._parts_manager.handle_thinking_delta(
                         vendor_part_id=chunk.item_id,
+                        content=chunk.delta,
                         id=chunk.item_id,
                         provider_name=self.provider_name,
                         provider_details=_make_raw_content_updater(chunk.delta, chunk.content_index),

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -9957,7 +9957,7 @@ async def test_openai_responses_raw_cot_only(allow_model_requests: None):
             ModelResponse(
                 parts=[
                     ThinkingPart(
-                        content='',
+                        content='Let me think about this... The answer is 4.',
                         id='rs_123',
                         provider_name='openai',
                         provider_details={'raw_content': ['Let me think about this...', 'The answer is 4.']},
@@ -10148,7 +10148,7 @@ async def test_openai_responses_raw_cot_stream_openrouter(allow_model_requests: 
             ModelResponse(
                 parts=[
                     ThinkingPart(
-                        content='',
+                        content='The user asks: "What is 2+2?" They expect a straightforward answer: 4. Just answer 4.',
                         id='rs_tmp_2kbe7x16sax',
                         provider_name='openrouter',
                         provider_details={
@@ -10294,7 +10294,7 @@ async def test_openai_responses_raw_cot_sent_in_multiturn(allow_model_requests: 
             ModelResponse(
                 parts=[
                     ThinkingPart(
-                        content='',
+                        content='Raw CoT step 1 Raw CoT step 2',
                         id='rs_123',
                         provider_name='openai',
                         provider_details={'raw_content': ['Raw CoT step 1', 'Raw CoT step 2']},
@@ -10331,7 +10331,7 @@ async def test_openai_responses_raw_cot_sent_in_multiturn(allow_model_requests: 
             ModelResponse(
                 parts=[
                     ThinkingPart(
-                        content='',
+                        content='Raw CoT step 1 Raw CoT step 2',
                         id='rs_123',
                         provider_name='openai',
                         provider_details={'raw_content': ['Raw CoT step 1', 'Raw CoT step 2']},
@@ -10400,7 +10400,7 @@ async def test_openai_responses_raw_cot_sent_in_multiturn(allow_model_requests: 
             ModelResponse(
                 parts=[
                     ThinkingPart(
-                        content='',
+                        content='Raw CoT step 1 Raw CoT step 2',
                         id='rs_123',
                         provider_name='openai',
                         provider_details={'raw_content': ['Raw CoT step 1', 'Raw CoT step 2']},


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #6305

## Summary

The `ResponseReasoningTextDeltaEvent` handler in `OpenAIResponsesModel` was dropping reasoning content from providers that use `reasoning_text` events (gpt-oss, vLLM, LM Studio, litellm bridge) instead of the official `reasoning_summary_text` events.

**Two fixes:**

1. **Streaming path** (~line 3704): Added `content=chunk.delta` to the `handle_thinking_delta()` call in the `ResponseReasoningTextDeltaEvent` handler. Previously, the delta text was only sent to `provider_details` via `_make_raw_content_updater`, but never passed as `content=` — so `ThinkingPart.content` stayed empty. The `ResponseReasoningSummaryTextDeltaEvent` handler already had this correctly.

2. **Non-streaming path** (~line 2004): When `item.summary` is empty but `item.content` has `reasoning_text` entries (raw CoT), `ThinkingPart(content='')` was created. Now uses `' '.join(raw_content)` so the reasoning text is visible in `ThinkingPart.content`, not just buried in `provider_details['raw_content']`.

## Context

- The `ResponseReasoningTextDeltaEvent` handler was added in response to #3191 (support for LM Studio with gpt-oss), but the handler was incomplete — missing the `content=` parameter.
- The official OpenAI Responses API only emits `response.reasoning_summary_text.delta`, so this event was originally unsupported. Third-party implementations (vLLM, LM Studio, litellm bridge) use `response.reasoning_text.delta` for raw chain-of-thought.
- Existing tests (`test_openai_responses_raw_cot_only`, `test_openai_responses_raw_cot_stream_openrouter`, `test_openai_responses_raw_cot_sent_in_multiturn`) were asserting `content=''` — this was the bug, not the expected behavior. Snapshots updated to reflect correct reasoning text.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

