### PR TITLE
ci: harden agentic-workflow sweeps and add an adversarial validity gate

### DIFF
--- a/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
@@ -154,9 +154,15 @@ INSTRUCTIONS = (
     'pyright. Prefer `uv run pytest <test_file>` over a bare `pytest` call; '
     'uv handles the virtual env automatically.\n\n'
     '## GitHub issue search\n\n'
-    '`gh issue list --search` returns HTTP 403 via the AWF firewall proxy. '
-    'Use the MCP tools instead: '
-    '`mcp__github__search_issues(query="repo:pydantic/pydantic-ai <keywords>")`.'
+    'The GitHub toolset runs in gh-proxy mode: there are NO `mcp__github__*` '
+    'tools, and the /search/issues endpoint (`gh issue list --search`, '
+    '`gh search issues`) returns HTTP 403 via the AWF firewall proxy. The '
+    'issue-list endpoint IS allowed, including its server-side `?labels=` '
+    'filter. When the sweep files under a dedicated label, prefer a narrow label '
+    "query (`gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=<label>&per_page=100' "
+    "--jq '.[] | select(.pull_request == null) | {number, title}'`); if it has no "
+    'dedicated label or the filter is inconclusive, widen to a full `--paginate` '
+    'open-issue scan.'
 )
 
 # The real task spec rides in `instructions=`; the user message is a trigger.

--- a/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
+++ b/.github/scripts/pydantic_ai_gh_aw_shim/cli.py
@@ -161,8 +161,10 @@ INSTRUCTIONS = (
     'filter. When the sweep files under a dedicated label, prefer a narrow label '
     "query (`gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=<label>&per_page=100' "
     "--jq '.[] | select(.pull_request == null) | {number, title}'`); if it has no "
-    'dedicated label or the filter is inconclusive, widen to a full `--paginate` '
-    'open-issue scan.'
+    'dedicated label or the filter is inconclusive, widen to a full open-issue scan '
+    "(`gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' "
+    "--jq '.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name]}'`). "
+    '`select(.pull_request == null)` drops PRs, which the issues endpoint also returns.'
 )
 
 # The real task spec rides in `instructions=`; the user message is a trigger.

--- a/.github/workflows/pydantic-ai-bug-hunter.lock.yml
+++ b/.github/workflows/pydantic-ai-bug-hunter.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6a21aac9714bc66c7e94d3cca6f5e9966efd1c9701f9ba4a3147f6a985866053","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3d73d2d0a31a4cabb59bd6ee86aa1dc3db92ed28bc51d06f77cf5a0179b6f066","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_READ_EXTERNAL_VARIABLES","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -26,6 +26,7 @@
 #
 # Resolved workflow manifest:
 #   Imports:
+#     - shared/adversarial-review.md
 #     - shared/checkout.md
 #     - shared/engine-minimax.md
 #     - shared/network-vendor-domains.md
@@ -210,20 +211,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_f62af35c26c2bad6_EOF'
+          cat << 'GH_AW_PROMPT_89ed31f464a4bcf5_EOF'
           <system>
-          GH_AW_PROMPT_f62af35c26c2bad6_EOF
+          GH_AW_PROMPT_89ed31f464a4bcf5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f62af35c26c2bad6_EOF'
+          cat << 'GH_AW_PROMPT_89ed31f464a4bcf5_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_f62af35c26c2bad6_EOF
+          GH_AW_PROMPT_89ed31f464a4bcf5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_f62af35c26c2bad6_EOF'
+          cat << 'GH_AW_PROMPT_89ed31f464a4bcf5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -255,21 +256,22 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_f62af35c26c2bad6_EOF
+          GH_AW_PROMPT_89ed31f464a4bcf5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f62af35c26c2bad6_EOF'
+          cat << 'GH_AW_PROMPT_89ed31f464a4bcf5_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/network-vendor-domains.md}}
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
           {{#runtime-import .github/workflows/shared/tool-hints.md}}
           {{#runtime-import .github/workflows/shared/repo-context.md}}
           {{#runtime-import .github/workflows/shared/rigor.md}}
+          {{#runtime-import .github/workflows/shared/adversarial-review.md}}
           {{#runtime-import .github/workflows/shared/checkout.md}}
           {{#runtime-import .github/workflows/shared/engine-minimax.md}}
           {{#runtime-import .github/workflows/shared/pre-steps.md}}
           {{#runtime-import .github/workflows/shared/pre-agent-steps.md}}
           {{#runtime-import .github/workflows/pydantic-ai-bug-hunter.md}}
-          GH_AW_PROMPT_f62af35c26c2bad6_EOF
+          GH_AW_PROMPT_89ed31f464a4bcf5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -489,9 +491,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_283f1d1209eb3307_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_acc43018adf1f5da_EOF'
           {"create_issue":{"close_older_issues":false,"close_older_key":"[bug-hunter]","expires":168,"footer":false,"max":1,"title_prefix":"[bug-hunter] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_283f1d1209eb3307_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_acc43018adf1f5da_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -695,7 +697,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_55b6b8f0cd570486_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_140e9091c41e7ce6_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -725,7 +727,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_55b6b8f0cd570486_EOF
+          GH_AW_MCP_CONFIG_140e9091c41e7ce6_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/pydantic-ai-bug-hunter.md
+++ b/.github/workflows/pydantic-ai-bug-hunter.md
@@ -31,6 +31,7 @@ imports:
   - shared/tool-hints.md
   - shared/repo-context.md
   - shared/rigor.md
+  - shared/adversarial-review.md
   - shared/checkout.md
   - shared/engine-minimax.md
   - shared/pre-steps.md

--- a/.github/workflows/pydantic-ai-docs-drift.lock.yml
+++ b/.github/workflows/pydantic-ai-docs-drift.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8e0720db9ff8fada79a26bf880647b3f5321130e51da296b80d97c951c2a568f","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"573f1758123c4b7b1858938f0f275afb31c5e1060a8d969d37ee1c1c3af8ce8e","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_READ_EXTERNAL_VARIABLES","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -210,20 +210,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_4569f0510f978d30_EOF'
+          cat << 'GH_AW_PROMPT_8b95318cdd0ff5c9_EOF'
           <system>
-          GH_AW_PROMPT_4569f0510f978d30_EOF
+          GH_AW_PROMPT_8b95318cdd0ff5c9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4569f0510f978d30_EOF'
+          cat << 'GH_AW_PROMPT_8b95318cdd0ff5c9_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_4569f0510f978d30_EOF
+          GH_AW_PROMPT_8b95318cdd0ff5c9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_4569f0510f978d30_EOF'
+          cat << 'GH_AW_PROMPT_8b95318cdd0ff5c9_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -255,9 +255,9 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_4569f0510f978d30_EOF
+          GH_AW_PROMPT_8b95318cdd0ff5c9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4569f0510f978d30_EOF'
+          cat << 'GH_AW_PROMPT_8b95318cdd0ff5c9_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/network-vendor-domains.md}}
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
@@ -269,7 +269,7 @@ jobs:
           {{#runtime-import .github/workflows/shared/pre-steps.md}}
           {{#runtime-import .github/workflows/shared/pre-agent-steps.md}}
           {{#runtime-import .github/workflows/pydantic-ai-docs-drift.md}}
-          GH_AW_PROMPT_4569f0510f978d30_EOF
+          GH_AW_PROMPT_8b95318cdd0ff5c9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -489,15 +489,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_fbfec098d796edcd_EOF'
-          {"create_issue":{"close_older_issues":false,"close_older_key":"[docs-drift]","expires":168,"footer":false,"max":1,"title_prefix":"[docs-drift] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_fbfec098d796edcd_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f580912ff387fade_EOF'
+          {"create_issue":{"close_older_issues":false,"close_older_key":"[docs-drift]","expires":168,"footer":false,"labels":["docs-drift"],"max":1,"title_prefix":"[docs-drift] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_f580912ff387fade_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[docs-drift] \"."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[docs-drift] \". Labels [\"docs-drift\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -695,7 +695,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_b7a09c1cf92fde68_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_859751c9ed2b7315_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -725,7 +725,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_b7a09c1cf92fde68_EOF
+          GH_AW_MCP_CONFIG_859751c9ed2b7315_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1503,7 +1503,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.google.com,*.googleapis.com,*.gvt1.com,*.pythonhosted.org,ai-sdk.dev,ai.azure.com,ai.google.dev,ai.pydantic.dev,amazonaws.com,anaconda.org,anthropic.com,api-docs.deepseek.com,api.anthropic.com,api.cerebras.ai,api.cohere.com,api.deepseek.com,api.fireworks.ai,api.github.com,api.groq.com,api.minimax.io,api.mistral.ai,api.openai.com,api.perplexity.ai,api.sambanova.ai,api.snapcraft.io,api.studio.nebius.com,api.together.xyz,api.x.ai,archive.ubuntu.com,aws.amazon.com,azure.archive.ubuntu.com,binstar.org,bootstrap.pypa.io,boto3.amazonaws.com,cdn.playwright.dev,cerebras.ai,cloud.cerebras.ai,cloud.sambanova.ai,codeload.github.com,cohere.com,conda.anaconda.org,conda.binstar.org,console.anthropic.com,console.groq.com,console.mistral.ai,console.x.ai,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dashboard.cohere.com,dashscope-intl.aliyuncs.com,dashscope.aliyuncs.com,deepseek.com,developers.openai.com,docs.ag-ui.com,docs.anthropic.com,docs.aws.amazon.com,docs.github.com,docs.perplexity.ai,docs.sambanova.ai,docs.x.ai,endpoints.ai.cloud.ovh.net,files.pythonhosted.org,fireworks.ai,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,groq.com,hf.co,host.docker.internal,huggingface.co,inference-docs.cerebras.ai,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,logfire-api.pydantic.dev,logfire-api.pydantic.info,logfire-eu.pydantic.dev,logfire-eu.pydantic.info,logfire-us.pydantic.dev,logfire-us.pydantic.info,mistral.ai,models.github.ai,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,ollama.com,openrouter.ai,ovh.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pip.pypa.io,platform.claude.com,platform.moonshot.ai,platform.openai.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pydantic.dev,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.npmjs.org,repo.anaconda.com,repo.continuum.io,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,studio.nebius.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,vercel.com,www.alibabacloud.com,www.googleapis.com,www.together.ai,x.ai"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[docs-drift]\",\"expires\":168,\"footer\":false,\"max\":1,\"title_prefix\":\"[docs-drift] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[docs-drift]\",\"expires\":168,\"footer\":false,\"labels\":[\"docs-drift\"],\"max\":1,\"title_prefix\":\"[docs-drift] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pydantic-ai-docs-drift.md
+++ b/.github/workflows/pydantic-ai-docs-drift.md
@@ -21,6 +21,7 @@ safe-outputs:
   create-issue:
     max: 1
     title-prefix: "[docs-drift] "
+    labels: [docs-drift]
     close-older-key: "[docs-drift]"
     close-older-issues: false
     expires: 7d

--- a/.github/workflows/pydantic-ai-provider-mapping-sweep.lock.yml
+++ b/.github/workflows/pydantic-ai-provider-mapping-sweep.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ed19369d11818d7c004f0562b1398f2f5b0aac08a604f7c309197ebf4dcf7020","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c370af35001ca7e23de70e6b1a8b8cad6d8f644396c583cddc88b2232b45f468","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_READ_EXTERNAL_VARIABLES","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -26,6 +26,7 @@
 #
 # Resolved workflow manifest:
 #   Imports:
+#     - shared/adversarial-review.md
 #     - shared/checkout.md
 #     - shared/engine-minimax.md
 #     - shared/network-vendor-domains.md
@@ -210,20 +211,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_7e5708ecb3d4b1f9_EOF'
+          cat << 'GH_AW_PROMPT_b36a2bee685f4cac_EOF'
           <system>
-          GH_AW_PROMPT_7e5708ecb3d4b1f9_EOF
+          GH_AW_PROMPT_b36a2bee685f4cac_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7e5708ecb3d4b1f9_EOF'
+          cat << 'GH_AW_PROMPT_b36a2bee685f4cac_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_7e5708ecb3d4b1f9_EOF
+          GH_AW_PROMPT_b36a2bee685f4cac_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_7e5708ecb3d4b1f9_EOF'
+          cat << 'GH_AW_PROMPT_b36a2bee685f4cac_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -255,21 +256,22 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_7e5708ecb3d4b1f9_EOF
+          GH_AW_PROMPT_b36a2bee685f4cac_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_7e5708ecb3d4b1f9_EOF'
+          cat << 'GH_AW_PROMPT_b36a2bee685f4cac_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/network-vendor-domains.md}}
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
           {{#runtime-import .github/workflows/shared/tool-hints.md}}
           {{#runtime-import .github/workflows/shared/repo-context.md}}
           {{#runtime-import .github/workflows/shared/rigor.md}}
+          {{#runtime-import .github/workflows/shared/adversarial-review.md}}
           {{#runtime-import .github/workflows/shared/checkout.md}}
           {{#runtime-import .github/workflows/shared/engine-minimax.md}}
           {{#runtime-import .github/workflows/shared/pre-steps.md}}
           {{#runtime-import .github/workflows/shared/pre-agent-steps.md}}
           {{#runtime-import .github/workflows/pydantic-ai-provider-mapping-sweep.md}}
-          GH_AW_PROMPT_7e5708ecb3d4b1f9_EOF
+          GH_AW_PROMPT_b36a2bee685f4cac_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -489,15 +491,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_25aa92721676e6cd_EOF'
-          {"create_issue":{"close_older_issues":false,"close_older_key":"[provider-mapping-sweep]","expires":168,"footer":false,"max":1,"title_prefix":"[provider-mapping-sweep] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_25aa92721676e6cd_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7837240dec0dc448_EOF'
+          {"create_issue":{"close_older_issues":false,"close_older_key":"[provider-mapping-sweep]","expires":168,"footer":false,"labels":["provider-mapping-sweep"],"max":1,"title_prefix":"[provider-mapping-sweep] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_7837240dec0dc448_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[provider-mapping-sweep] \"."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[provider-mapping-sweep] \". Labels [\"provider-mapping-sweep\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -695,7 +697,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_fe1145f75999c708_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_a21f44a27a1f4464_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -725,7 +727,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_fe1145f75999c708_EOF
+          GH_AW_MCP_CONFIG_a21f44a27a1f4464_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1503,7 +1505,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.google.com,*.googleapis.com,*.gvt1.com,*.pythonhosted.org,ai-sdk.dev,ai.azure.com,ai.google.dev,ai.pydantic.dev,amazonaws.com,anaconda.org,anthropic.com,api-docs.deepseek.com,api.anthropic.com,api.cerebras.ai,api.cohere.com,api.deepseek.com,api.fireworks.ai,api.github.com,api.groq.com,api.minimax.io,api.mistral.ai,api.openai.com,api.perplexity.ai,api.sambanova.ai,api.snapcraft.io,api.studio.nebius.com,api.together.xyz,api.x.ai,archive.ubuntu.com,aws.amazon.com,azure.archive.ubuntu.com,binstar.org,bootstrap.pypa.io,boto3.amazonaws.com,cdn.playwright.dev,cerebras.ai,cloud.cerebras.ai,cloud.sambanova.ai,codeload.github.com,cohere.com,conda.anaconda.org,conda.binstar.org,console.anthropic.com,console.groq.com,console.mistral.ai,console.x.ai,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dashboard.cohere.com,dashscope-intl.aliyuncs.com,dashscope.aliyuncs.com,deepseek.com,developers.openai.com,docs.ag-ui.com,docs.anthropic.com,docs.aws.amazon.com,docs.github.com,docs.perplexity.ai,docs.sambanova.ai,docs.x.ai,endpoints.ai.cloud.ovh.net,files.pythonhosted.org,fireworks.ai,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,groq.com,hf.co,host.docker.internal,huggingface.co,inference-docs.cerebras.ai,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,logfire-api.pydantic.dev,logfire-api.pydantic.info,logfire-eu.pydantic.dev,logfire-eu.pydantic.info,logfire-us.pydantic.dev,logfire-us.pydantic.info,mistral.ai,models.github.ai,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,ollama.com,openrouter.ai,ovh.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pip.pypa.io,platform.claude.com,platform.moonshot.ai,platform.openai.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pydantic.dev,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.npmjs.org,repo.anaconda.com,repo.continuum.io,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,studio.nebius.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,vercel.com,www.alibabacloud.com,www.googleapis.com,www.together.ai,x.ai"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[provider-mapping-sweep]\",\"expires\":168,\"footer\":false,\"max\":1,\"title_prefix\":\"[provider-mapping-sweep] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[provider-mapping-sweep]\",\"expires\":168,\"footer\":false,\"labels\":[\"provider-mapping-sweep\"],\"max\":1,\"title_prefix\":\"[provider-mapping-sweep] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pydantic-ai-provider-mapping-sweep.md
+++ b/.github/workflows/pydantic-ai-provider-mapping-sweep.md
@@ -21,6 +21,7 @@ safe-outputs:
   create-issue:
     max: 1
     title-prefix: "[provider-mapping-sweep] "
+    labels: [provider-mapping-sweep]
     close-older-key: "[provider-mapping-sweep]"
     close-older-issues: false
     expires: 7d
@@ -31,6 +32,7 @@ imports:
   - shared/tool-hints.md
   - shared/repo-context.md
   - shared/rigor.md
+  - shared/adversarial-review.md
   - shared/checkout.md
   - shared/engine-minimax.md
   - shared/pre-steps.md

--- a/.github/workflows/pydantic-ai-provider-parity-explore.lock.yml
+++ b/.github/workflows/pydantic-ai-provider-parity-explore.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"08328b19561619ce2217c46de610f7eaf50a3b0d0f7e0f822d3215982f9415ab","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"86c7b8ca77222bf6f7f2bfb2caff6c06794f37777ac5bf45a9b150f68453141c","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_READ_EXTERNAL_VARIABLES","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -26,6 +26,7 @@
 #
 # Resolved workflow manifest:
 #   Imports:
+#     - shared/adversarial-review.md
 #     - shared/checkout.md
 #     - shared/engine-minimax.md
 #     - shared/network-vendor-domains.md
@@ -210,20 +211,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_867597ee2e5a85a4_EOF'
+          cat << 'GH_AW_PROMPT_4990dac713a63988_EOF'
           <system>
-          GH_AW_PROMPT_867597ee2e5a85a4_EOF
+          GH_AW_PROMPT_4990dac713a63988_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_867597ee2e5a85a4_EOF'
+          cat << 'GH_AW_PROMPT_4990dac713a63988_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_867597ee2e5a85a4_EOF
+          GH_AW_PROMPT_4990dac713a63988_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_867597ee2e5a85a4_EOF'
+          cat << 'GH_AW_PROMPT_4990dac713a63988_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -255,21 +256,22 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_867597ee2e5a85a4_EOF
+          GH_AW_PROMPT_4990dac713a63988_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_867597ee2e5a85a4_EOF'
+          cat << 'GH_AW_PROMPT_4990dac713a63988_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/network-vendor-domains.md}}
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
           {{#runtime-import .github/workflows/shared/tool-hints.md}}
           {{#runtime-import .github/workflows/shared/repo-context.md}}
           {{#runtime-import .github/workflows/shared/rigor.md}}
+          {{#runtime-import .github/workflows/shared/adversarial-review.md}}
           {{#runtime-import .github/workflows/shared/checkout.md}}
           {{#runtime-import .github/workflows/shared/engine-minimax.md}}
           {{#runtime-import .github/workflows/shared/pre-steps.md}}
           {{#runtime-import .github/workflows/shared/pre-agent-steps.md}}
           {{#runtime-import .github/workflows/pydantic-ai-provider-parity-explore.md}}
-          GH_AW_PROMPT_867597ee2e5a85a4_EOF
+          GH_AW_PROMPT_4990dac713a63988_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -489,15 +491,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_74c7fa64f1d55a0b_EOF'
-          {"create_issue":{"close_older_issues":false,"close_older_key":"[provider-parity-explore]","expires":168,"footer":false,"max":1,"title_prefix":"[provider-parity-explore] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_74c7fa64f1d55a0b_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_fd1556357666d584_EOF'
+          {"create_issue":{"close_older_issues":false,"close_older_key":"[provider-parity-explore]","expires":168,"footer":false,"labels":["provider-parity-explore"],"max":1,"title_prefix":"[provider-parity-explore] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_fd1556357666d584_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[provider-parity-explore] \"."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[provider-parity-explore] \". Labels [\"provider-parity-explore\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -695,7 +697,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_dd054e50d77cea53_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b943e73eef775243_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -725,7 +727,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_dd054e50d77cea53_EOF
+          GH_AW_MCP_CONFIG_b943e73eef775243_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1503,7 +1505,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.google.com,*.googleapis.com,*.gvt1.com,*.pythonhosted.org,ai-sdk.dev,ai.azure.com,ai.google.dev,ai.pydantic.dev,amazonaws.com,anaconda.org,anthropic.com,api-docs.deepseek.com,api.anthropic.com,api.cerebras.ai,api.cohere.com,api.deepseek.com,api.fireworks.ai,api.github.com,api.groq.com,api.minimax.io,api.mistral.ai,api.openai.com,api.perplexity.ai,api.sambanova.ai,api.snapcraft.io,api.studio.nebius.com,api.together.xyz,api.x.ai,archive.ubuntu.com,aws.amazon.com,azure.archive.ubuntu.com,binstar.org,bootstrap.pypa.io,boto3.amazonaws.com,cdn.playwright.dev,cerebras.ai,cloud.cerebras.ai,cloud.sambanova.ai,codeload.github.com,cohere.com,conda.anaconda.org,conda.binstar.org,console.anthropic.com,console.groq.com,console.mistral.ai,console.x.ai,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dashboard.cohere.com,dashscope-intl.aliyuncs.com,dashscope.aliyuncs.com,deepseek.com,developers.openai.com,docs.ag-ui.com,docs.anthropic.com,docs.aws.amazon.com,docs.github.com,docs.perplexity.ai,docs.sambanova.ai,docs.x.ai,endpoints.ai.cloud.ovh.net,files.pythonhosted.org,fireworks.ai,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,groq.com,hf.co,host.docker.internal,huggingface.co,inference-docs.cerebras.ai,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,logfire-api.pydantic.dev,logfire-api.pydantic.info,logfire-eu.pydantic.dev,logfire-eu.pydantic.info,logfire-us.pydantic.dev,logfire-us.pydantic.info,mistral.ai,models.github.ai,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,ollama.com,openrouter.ai,ovh.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pip.pypa.io,platform.claude.com,platform.moonshot.ai,platform.openai.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pydantic.dev,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.npmjs.org,repo.anaconda.com,repo.continuum.io,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,studio.nebius.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,vercel.com,www.alibabacloud.com,www.googleapis.com,www.together.ai,x.ai"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[provider-parity-explore]\",\"expires\":168,\"footer\":false,\"max\":1,\"title_prefix\":\"[provider-parity-explore] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[provider-parity-explore]\",\"expires\":168,\"footer\":false,\"labels\":[\"provider-parity-explore\"],\"max\":1,\"title_prefix\":\"[provider-parity-explore] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pydantic-ai-provider-parity-explore.md
+++ b/.github/workflows/pydantic-ai-provider-parity-explore.md
@@ -21,6 +21,7 @@ safe-outputs:
   create-issue:
     max: 1
     title-prefix: "[provider-parity-explore] "
+    labels: [provider-parity-explore]
     close-older-key: "[provider-parity-explore]"
     close-older-issues: false
     expires: 7d
@@ -31,6 +32,7 @@ imports:
   - shared/tool-hints.md
   - shared/repo-context.md
   - shared/rigor.md
+  - shared/adversarial-review.md
   - shared/checkout.md
   - shared/engine-minimax.md
   - shared/pre-steps.md

--- a/.github/workflows/pydantic-ai-regression-detector.lock.yml
+++ b/.github/workflows/pydantic-ai-regression-detector.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2e6cd4b68a8809cb540df8fd69b6770506ed194330dbb97b1fb3b444b865b29f","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fac0fdc3d00026f5ba2fb4ab0bfa9b91b6a718d476db84df5e19ebf7c752a3c8","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_READ_EXTERNAL_VARIABLES","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -26,6 +26,7 @@
 #
 # Resolved workflow manifest:
 #   Imports:
+#     - shared/adversarial-review.md
 #     - shared/checkout.md
 #     - shared/engine-minimax.md
 #     - shared/network-vendor-domains.md
@@ -210,20 +211,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_626da77593941e33_EOF'
+          cat << 'GH_AW_PROMPT_722b1892de765fc1_EOF'
           <system>
-          GH_AW_PROMPT_626da77593941e33_EOF
+          GH_AW_PROMPT_722b1892de765fc1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_626da77593941e33_EOF'
+          cat << 'GH_AW_PROMPT_722b1892de765fc1_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_626da77593941e33_EOF
+          GH_AW_PROMPT_722b1892de765fc1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_626da77593941e33_EOF'
+          cat << 'GH_AW_PROMPT_722b1892de765fc1_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -255,21 +256,22 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_626da77593941e33_EOF
+          GH_AW_PROMPT_722b1892de765fc1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_626da77593941e33_EOF'
+          cat << 'GH_AW_PROMPT_722b1892de765fc1_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/network-vendor-domains.md}}
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
           {{#runtime-import .github/workflows/shared/tool-hints.md}}
           {{#runtime-import .github/workflows/shared/repo-context.md}}
           {{#runtime-import .github/workflows/shared/rigor.md}}
+          {{#runtime-import .github/workflows/shared/adversarial-review.md}}
           {{#runtime-import .github/workflows/shared/checkout.md}}
           {{#runtime-import .github/workflows/shared/engine-minimax.md}}
           {{#runtime-import .github/workflows/shared/pre-steps.md}}
           {{#runtime-import .github/workflows/shared/pre-agent-steps.md}}
           {{#runtime-import .github/workflows/pydantic-ai-regression-detector.md}}
-          GH_AW_PROMPT_626da77593941e33_EOF
+          GH_AW_PROMPT_722b1892de765fc1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -489,15 +491,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e631c0a1ffc6beb3_EOF'
-          {"create_issue":{"close_older_issues":false,"close_older_key":"[regression-detector]","expires":168,"footer":false,"max":1,"title_prefix":"[regression-detector] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e631c0a1ffc6beb3_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_342fde39caf96c7b_EOF'
+          {"create_issue":{"close_older_issues":false,"close_older_key":"[regression-detector]","expires":168,"footer":false,"labels":["regression"],"max":1,"title_prefix":"[regression-detector] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_342fde39caf96c7b_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[regression-detector] \"."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[regression-detector] \". Labels [\"regression\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -695,7 +697,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_138cd0577d397ddd_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_89fb0d790ba4f321_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -725,7 +727,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_138cd0577d397ddd_EOF
+          GH_AW_MCP_CONFIG_89fb0d790ba4f321_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1503,7 +1505,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.google.com,*.googleapis.com,*.gvt1.com,*.pythonhosted.org,ai-sdk.dev,ai.azure.com,ai.google.dev,ai.pydantic.dev,amazonaws.com,anaconda.org,anthropic.com,api-docs.deepseek.com,api.anthropic.com,api.cerebras.ai,api.cohere.com,api.deepseek.com,api.fireworks.ai,api.github.com,api.groq.com,api.minimax.io,api.mistral.ai,api.openai.com,api.perplexity.ai,api.sambanova.ai,api.snapcraft.io,api.studio.nebius.com,api.together.xyz,api.x.ai,archive.ubuntu.com,aws.amazon.com,azure.archive.ubuntu.com,binstar.org,bootstrap.pypa.io,boto3.amazonaws.com,cdn.playwright.dev,cerebras.ai,cloud.cerebras.ai,cloud.sambanova.ai,codeload.github.com,cohere.com,conda.anaconda.org,conda.binstar.org,console.anthropic.com,console.groq.com,console.mistral.ai,console.x.ai,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dashboard.cohere.com,dashscope-intl.aliyuncs.com,dashscope.aliyuncs.com,deepseek.com,developers.openai.com,docs.ag-ui.com,docs.anthropic.com,docs.aws.amazon.com,docs.github.com,docs.perplexity.ai,docs.sambanova.ai,docs.x.ai,endpoints.ai.cloud.ovh.net,files.pythonhosted.org,fireworks.ai,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,groq.com,hf.co,host.docker.internal,huggingface.co,inference-docs.cerebras.ai,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,logfire-api.pydantic.dev,logfire-api.pydantic.info,logfire-eu.pydantic.dev,logfire-eu.pydantic.info,logfire-us.pydantic.dev,logfire-us.pydantic.info,mistral.ai,models.github.ai,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,ollama.com,openrouter.ai,ovh.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pip.pypa.io,platform.claude.com,platform.moonshot.ai,platform.openai.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pydantic.dev,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.npmjs.org,repo.anaconda.com,repo.continuum.io,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,studio.nebius.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,vercel.com,www.alibabacloud.com,www.googleapis.com,www.together.ai,x.ai"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[regression-detector]\",\"expires\":168,\"footer\":false,\"max\":1,\"title_prefix\":\"[regression-detector] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[regression-detector]\",\"expires\":168,\"footer\":false,\"labels\":[\"regression\"],\"max\":1,\"title_prefix\":\"[regression-detector] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pydantic-ai-regression-detector.md
+++ b/.github/workflows/pydantic-ai-regression-detector.md
@@ -21,6 +21,7 @@ safe-outputs:
   create-issue:
     max: 1
     title-prefix: "[regression-detector] "
+    labels: [regression]
     close-older-key: "[regression-detector]"
     close-older-issues: false
     expires: 7d
@@ -31,6 +32,7 @@ imports:
   - shared/tool-hints.md
   - shared/repo-context.md
   - shared/rigor.md
+  - shared/adversarial-review.md
   - shared/checkout.md
   - shared/engine-minimax.md
   - shared/pre-steps.md

--- a/.github/workflows/pydantic-ai-roundtrip-sweep.lock.yml
+++ b/.github/workflows/pydantic-ai-roundtrip-sweep.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8efbdd972baaea6f35576752770d63badfe538198ea4d2ff45945e8b2b38c98a","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b5d453dbe21bce4f24db8ad9683c632e0b92c03dcd05ca03d19b5802105ce49c","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_READ_EXTERNAL_VARIABLES","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -26,6 +26,7 @@
 #
 # Resolved workflow manifest:
 #   Imports:
+#     - shared/adversarial-review.md
 #     - shared/checkout.md
 #     - shared/engine-minimax.md
 #     - shared/network-vendor-domains.md
@@ -210,20 +211,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b70163c48d17fd92_EOF'
+          cat << 'GH_AW_PROMPT_ff3c288cefed0568_EOF'
           <system>
-          GH_AW_PROMPT_b70163c48d17fd92_EOF
+          GH_AW_PROMPT_ff3c288cefed0568_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b70163c48d17fd92_EOF'
+          cat << 'GH_AW_PROMPT_ff3c288cefed0568_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_b70163c48d17fd92_EOF
+          GH_AW_PROMPT_ff3c288cefed0568_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_b70163c48d17fd92_EOF'
+          cat << 'GH_AW_PROMPT_ff3c288cefed0568_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -255,21 +256,22 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_b70163c48d17fd92_EOF
+          GH_AW_PROMPT_ff3c288cefed0568_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b70163c48d17fd92_EOF'
+          cat << 'GH_AW_PROMPT_ff3c288cefed0568_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/network-vendor-domains.md}}
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
           {{#runtime-import .github/workflows/shared/tool-hints.md}}
           {{#runtime-import .github/workflows/shared/repo-context.md}}
           {{#runtime-import .github/workflows/shared/rigor.md}}
+          {{#runtime-import .github/workflows/shared/adversarial-review.md}}
           {{#runtime-import .github/workflows/shared/checkout.md}}
           {{#runtime-import .github/workflows/shared/engine-minimax.md}}
           {{#runtime-import .github/workflows/shared/pre-steps.md}}
           {{#runtime-import .github/workflows/shared/pre-agent-steps.md}}
           {{#runtime-import .github/workflows/pydantic-ai-roundtrip-sweep.md}}
-          GH_AW_PROMPT_b70163c48d17fd92_EOF
+          GH_AW_PROMPT_ff3c288cefed0568_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -489,15 +491,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_ffdbc014405dadfb_EOF'
-          {"create_issue":{"close_older_issues":false,"close_older_key":"[roundtrip-sweep]","expires":168,"footer":false,"max":1,"title_prefix":"[roundtrip-sweep] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_ffdbc014405dadfb_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_edd3f35a54a6316b_EOF'
+          {"create_issue":{"close_older_issues":false,"close_older_key":"[roundtrip-sweep]","expires":168,"footer":false,"labels":["roundtrip-sweep"],"max":1,"title_prefix":"[roundtrip-sweep] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_edd3f35a54a6316b_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[roundtrip-sweep] \"."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[roundtrip-sweep] \". Labels [\"roundtrip-sweep\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -695,7 +697,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_b2866682a18f812a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_cd83a9054395dafc_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -725,7 +727,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_b2866682a18f812a_EOF
+          GH_AW_MCP_CONFIG_cd83a9054395dafc_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1503,7 +1505,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.google.com,*.googleapis.com,*.gvt1.com,*.pythonhosted.org,ai-sdk.dev,ai.azure.com,ai.google.dev,ai.pydantic.dev,amazonaws.com,anaconda.org,anthropic.com,api-docs.deepseek.com,api.anthropic.com,api.cerebras.ai,api.cohere.com,api.deepseek.com,api.fireworks.ai,api.github.com,api.groq.com,api.minimax.io,api.mistral.ai,api.openai.com,api.perplexity.ai,api.sambanova.ai,api.snapcraft.io,api.studio.nebius.com,api.together.xyz,api.x.ai,archive.ubuntu.com,aws.amazon.com,azure.archive.ubuntu.com,binstar.org,bootstrap.pypa.io,boto3.amazonaws.com,cdn.playwright.dev,cerebras.ai,cloud.cerebras.ai,cloud.sambanova.ai,codeload.github.com,cohere.com,conda.anaconda.org,conda.binstar.org,console.anthropic.com,console.groq.com,console.mistral.ai,console.x.ai,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dashboard.cohere.com,dashscope-intl.aliyuncs.com,dashscope.aliyuncs.com,deepseek.com,developers.openai.com,docs.ag-ui.com,docs.anthropic.com,docs.aws.amazon.com,docs.github.com,docs.perplexity.ai,docs.sambanova.ai,docs.x.ai,endpoints.ai.cloud.ovh.net,files.pythonhosted.org,fireworks.ai,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,groq.com,hf.co,host.docker.internal,huggingface.co,inference-docs.cerebras.ai,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,logfire-api.pydantic.dev,logfire-api.pydantic.info,logfire-eu.pydantic.dev,logfire-eu.pydantic.info,logfire-us.pydantic.dev,logfire-us.pydantic.info,mistral.ai,models.github.ai,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,ollama.com,openrouter.ai,ovh.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pip.pypa.io,platform.claude.com,platform.moonshot.ai,platform.openai.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pydantic.dev,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.npmjs.org,repo.anaconda.com,repo.continuum.io,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,studio.nebius.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,vercel.com,www.alibabacloud.com,www.googleapis.com,www.together.ai,x.ai"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[roundtrip-sweep]\",\"expires\":168,\"footer\":false,\"max\":1,\"title_prefix\":\"[roundtrip-sweep] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[roundtrip-sweep]\",\"expires\":168,\"footer\":false,\"labels\":[\"roundtrip-sweep\"],\"max\":1,\"title_prefix\":\"[roundtrip-sweep] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pydantic-ai-roundtrip-sweep.md
+++ b/.github/workflows/pydantic-ai-roundtrip-sweep.md
@@ -25,6 +25,7 @@ safe-outputs:
   create-issue:
     max: 1
     title-prefix: "[roundtrip-sweep] "
+    labels: [roundtrip-sweep]
     close-older-key: "[roundtrip-sweep]"
     close-older-issues: false
     expires: 7d
@@ -35,6 +36,7 @@ imports:
   - shared/tool-hints.md
   - shared/repo-context.md
   - shared/rigor.md
+  - shared/adversarial-review.md
   - shared/checkout.md
   - shared/engine-minimax.md
   - shared/pre-steps.md

--- a/.github/workflows/pydantic-ai-stale-issues-finder.lock.yml
+++ b/.github/workflows/pydantic-ai-stale-issues-finder.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c364947905f64447ba8999835e0fd5b5ef2427fc7cbb9c3e29a577c1163342d2","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e89cd1d71a33dc24977d3aecd72e1f59733d7e156fad3ec0edae9f14e6c837b5","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_PROMPT_TOKEN","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -206,20 +206,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_cb2545c31c25af9f_EOF'
+          cat << 'GH_AW_PROMPT_8ea8139514ad56cc_EOF'
           <system>
-          GH_AW_PROMPT_cb2545c31c25af9f_EOF
+          GH_AW_PROMPT_8ea8139514ad56cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_cb2545c31c25af9f_EOF'
+          cat << 'GH_AW_PROMPT_8ea8139514ad56cc_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_cb2545c31c25af9f_EOF
+          GH_AW_PROMPT_8ea8139514ad56cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_cb2545c31c25af9f_EOF'
+          cat << 'GH_AW_PROMPT_8ea8139514ad56cc_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -251,9 +251,9 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_cb2545c31c25af9f_EOF
+          GH_AW_PROMPT_8ea8139514ad56cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_cb2545c31c25af9f_EOF'
+          cat << 'GH_AW_PROMPT_8ea8139514ad56cc_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/network-vendor-domains.md}}
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
@@ -261,7 +261,7 @@ jobs:
           {{#runtime-import .github/workflows/shared/repo-context.md}}
           {{#runtime-import .github/workflows/shared/rigor.md}}
           {{#runtime-import .github/workflows/pydantic-ai-stale-issues-finder.md}}
-          GH_AW_PROMPT_cb2545c31c25af9f_EOF
+          GH_AW_PROMPT_8ea8139514ad56cc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -487,15 +487,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_bc75001224f50475_EOF'
-          {"create_issue":{"close_older_issues":false,"close_older_key":"[stale-finder]","expires":168,"footer":false,"max":1,"title_prefix":"[stale-finder] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_bc75001224f50475_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_fc720fe3e1286f3d_EOF'
+          {"create_issue":{"close_older_issues":false,"close_older_key":"[stale-finder]","expires":168,"footer":false,"labels":["stale-issues"],"max":1,"title_prefix":"[stale-finder] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_fc720fe3e1286f3d_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[stale-finder] \"."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[stale-finder] \". Labels [\"stale-issues\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -693,7 +693,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8bf59343e7547c99_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_f9b8e16d91947cce_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -723,7 +723,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_8bf59343e7547c99_EOF
+          GH_AW_MCP_CONFIG_f9b8e16d91947cce_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1501,7 +1501,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.google.com,*.googleapis.com,*.gvt1.com,*.pythonhosted.org,ai-sdk.dev,ai.azure.com,ai.google.dev,ai.pydantic.dev,amazonaws.com,anaconda.org,anthropic.com,api-docs.deepseek.com,api.anthropic.com,api.cerebras.ai,api.cohere.com,api.deepseek.com,api.fireworks.ai,api.github.com,api.groq.com,api.minimax.io,api.mistral.ai,api.openai.com,api.perplexity.ai,api.sambanova.ai,api.snapcraft.io,api.studio.nebius.com,api.together.xyz,api.x.ai,archive.ubuntu.com,aws.amazon.com,azure.archive.ubuntu.com,binstar.org,bootstrap.pypa.io,boto3.amazonaws.com,cdn.playwright.dev,cerebras.ai,cloud.cerebras.ai,cloud.sambanova.ai,codeload.github.com,cohere.com,conda.anaconda.org,conda.binstar.org,console.anthropic.com,console.groq.com,console.mistral.ai,console.x.ai,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dashboard.cohere.com,dashscope-intl.aliyuncs.com,dashscope.aliyuncs.com,deepseek.com,developers.openai.com,docs.ag-ui.com,docs.anthropic.com,docs.aws.amazon.com,docs.github.com,docs.perplexity.ai,docs.sambanova.ai,docs.x.ai,endpoints.ai.cloud.ovh.net,files.pythonhosted.org,fireworks.ai,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,groq.com,hf.co,host.docker.internal,huggingface.co,inference-docs.cerebras.ai,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,logfire-api.pydantic.dev,logfire-api.pydantic.info,logfire-eu.pydantic.dev,logfire-eu.pydantic.info,logfire-us.pydantic.dev,logfire-us.pydantic.info,mistral.ai,models.github.ai,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,ollama.com,openrouter.ai,ovh.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pip.pypa.io,platform.claude.com,platform.moonshot.ai,platform.openai.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pydantic.dev,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.npmjs.org,repo.anaconda.com,repo.continuum.io,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,studio.nebius.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,vercel.com,www.alibabacloud.com,www.googleapis.com,www.together.ai,x.ai"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[stale-finder]\",\"expires\":168,\"footer\":false,\"max\":1,\"title_prefix\":\"[stale-finder] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[stale-finder]\",\"expires\":168,\"footer\":false,\"labels\":[\"stale-issues\"],\"max\":1,\"title_prefix\":\"[stale-finder] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pydantic-ai-stale-issues-finder.md
+++ b/.github/workflows/pydantic-ai-stale-issues-finder.md
@@ -63,6 +63,7 @@ safe-outputs:
   create-issue:
     max: 1
     title-prefix: "[stale-finder] "
+    labels: [stale-issues]
     close-older-key: "[stale-finder]"
     close-older-issues: false
     expires: 7d

--- a/.github/workflows/pydantic-ai-streaming-resilience-sweep.lock.yml
+++ b/.github/workflows/pydantic-ai-streaming-resilience-sweep.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3c32da83b559aee23abaf3d3ccbec6cfe1f782564c822f327859628e57008553","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"51a4657cc514e8339cbb727ae4b134d4795d80d8c59ce682464455be0147c874","compiler_version":"v0.74.8","strict":true,"agent_id":"claude","agent_model":"${{ vars.GH_AW_MODEL }}"}
 # gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","LOGFIRE_READ_EXTERNAL_VARIABLES","LOGFIRE_TOKEN","LOGFIRE_URL","MINIMAX_API_KEY"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"08807647e7069bb48b6ef5acd8ec9567f424441b","version":"v8.1.0"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -26,6 +26,7 @@
 #
 # Resolved workflow manifest:
 #   Imports:
+#     - shared/adversarial-review.md
 #     - shared/checkout.md
 #     - shared/engine-minimax.md
 #     - shared/network-vendor-domains.md
@@ -68,8 +69,8 @@
 name: "Pydantic AI Streaming Resilience Sweep"
 on:
   schedule:
-  - cron: "54 23 * * 4"
-    # Friendly format: weekly on thursday (scattered)
+  - cron: "54 23 * * 6"
+    # Friendly format: weekly on saturday (scattered)
   workflow_dispatch:
     inputs:
       aw_context:
@@ -210,20 +211,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_720a68012dc7d86b_EOF'
+          cat << 'GH_AW_PROMPT_8b60ebbfae751076_EOF'
           <system>
-          GH_AW_PROMPT_720a68012dc7d86b_EOF
+          GH_AW_PROMPT_8b60ebbfae751076_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_720a68012dc7d86b_EOF'
+          cat << 'GH_AW_PROMPT_8b60ebbfae751076_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_720a68012dc7d86b_EOF
+          GH_AW_PROMPT_8b60ebbfae751076_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_720a68012dc7d86b_EOF'
+          cat << 'GH_AW_PROMPT_8b60ebbfae751076_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -255,21 +256,22 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_720a68012dc7d86b_EOF
+          GH_AW_PROMPT_8b60ebbfae751076_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_720a68012dc7d86b_EOF'
+          cat << 'GH_AW_PROMPT_8b60ebbfae751076_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/network-vendor-domains.md}}
           {{#runtime-import .github/workflows/shared/otel-logfire.md}}
           {{#runtime-import .github/workflows/shared/tool-hints.md}}
           {{#runtime-import .github/workflows/shared/repo-context.md}}
           {{#runtime-import .github/workflows/shared/rigor.md}}
+          {{#runtime-import .github/workflows/shared/adversarial-review.md}}
           {{#runtime-import .github/workflows/shared/checkout.md}}
           {{#runtime-import .github/workflows/shared/engine-minimax.md}}
           {{#runtime-import .github/workflows/shared/pre-steps.md}}
           {{#runtime-import .github/workflows/shared/pre-agent-steps.md}}
           {{#runtime-import .github/workflows/pydantic-ai-streaming-resilience-sweep.md}}
-          GH_AW_PROMPT_720a68012dc7d86b_EOF
+          GH_AW_PROMPT_8b60ebbfae751076_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -489,15 +491,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0deba97490f24b74_EOF'
-          {"create_issue":{"close_older_issues":false,"close_older_key":"[streaming-resilience-sweep]","expires":168,"footer":false,"max":1,"title_prefix":"[streaming-resilience-sweep] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0deba97490f24b74_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a3d73051c630abcf_EOF'
+          {"create_issue":{"close_older_issues":false,"close_older_key":"[streaming-resilience-sweep]","expires":168,"footer":false,"labels":["streaming"],"max":1,"title_prefix":"[streaming-resilience-sweep] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_a3d73051c630abcf_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[streaming-resilience-sweep] \"."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[streaming-resilience-sweep] \". Labels [\"streaming\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -695,7 +697,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v '"${DOCKER_SOCK_PATH}"':/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DOCKER_HOST=unix:///var/run/docker.sock -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e GITHUB_AW_OTEL_TRACE_ID -e GITHUB_AW_OTEL_PARENT_SPAN_ID -e OTEL_EXPORTER_OTLP_HEADERS -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.9'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e62d9725f0074bc3_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_1555840ddfc48f93_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -725,7 +727,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_e62d9725f0074bc3_EOF
+          GH_AW_MCP_CONFIG_1555840ddfc48f93_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1503,7 +1505,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.google.com,*.googleapis.com,*.gvt1.com,*.pythonhosted.org,ai-sdk.dev,ai.azure.com,ai.google.dev,ai.pydantic.dev,amazonaws.com,anaconda.org,anthropic.com,api-docs.deepseek.com,api.anthropic.com,api.cerebras.ai,api.cohere.com,api.deepseek.com,api.fireworks.ai,api.github.com,api.groq.com,api.minimax.io,api.mistral.ai,api.openai.com,api.perplexity.ai,api.sambanova.ai,api.snapcraft.io,api.studio.nebius.com,api.together.xyz,api.x.ai,archive.ubuntu.com,aws.amazon.com,azure.archive.ubuntu.com,binstar.org,bootstrap.pypa.io,boto3.amazonaws.com,cdn.playwright.dev,cerebras.ai,cloud.cerebras.ai,cloud.sambanova.ai,codeload.github.com,cohere.com,conda.anaconda.org,conda.binstar.org,console.anthropic.com,console.groq.com,console.mistral.ai,console.x.ai,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dashboard.cohere.com,dashscope-intl.aliyuncs.com,dashscope.aliyuncs.com,deepseek.com,developers.openai.com,docs.ag-ui.com,docs.anthropic.com,docs.aws.amazon.com,docs.github.com,docs.perplexity.ai,docs.sambanova.ai,docs.x.ai,endpoints.ai.cloud.ovh.net,files.pythonhosted.org,fireworks.ai,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,groq.com,hf.co,host.docker.internal,huggingface.co,inference-docs.cerebras.ai,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,learn.microsoft.com,lfs.github.com,logfire-api.pydantic.dev,logfire-api.pydantic.info,logfire-eu.pydantic.dev,logfire-eu.pydantic.info,logfire-us.pydantic.dev,logfire-us.pydantic.info,mistral.ai,models.github.ai,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,ollama.com,openrouter.ai,ovh.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,pip.pypa.io,platform.claude.com,platform.moonshot.ai,platform.openai.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pydantic.dev,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.npmjs.org,repo.anaconda.com,repo.continuum.io,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,studio.nebius.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,vercel.com,www.alibabacloud.com,www.googleapis.com,www.together.ai,x.ai"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[streaming-resilience-sweep]\",\"expires\":168,\"footer\":false,\"max\":1,\"title_prefix\":\"[streaming-resilience-sweep] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":false,\"close_older_key\":\"[streaming-resilience-sweep]\",\"expires\":168,\"footer\":false,\"labels\":[\"streaming\"],\"max\":1,\"title_prefix\":\"[streaming-resilience-sweep] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pydantic-ai-streaming-resilience-sweep.md
+++ b/.github/workflows/pydantic-ai-streaming-resilience-sweep.md
@@ -2,7 +2,7 @@
 emoji: "🌊"
 name: "Pydantic AI Streaming Resilience Sweep"
 description: "Audit the streaming state machine for ordering/lifecycle bugs and file a reproducible report. Runs on the Pydantic AI gh-aw shim; the prompt is iterable from a Logfire managed variable."
-on: weekly on thursday
+on: weekly on saturday
 permissions:
   contents: read
   issues: read
@@ -21,6 +21,7 @@ safe-outputs:
   create-issue:
     max: 1
     title-prefix: "[streaming-resilience-sweep] "
+    labels: [streaming]
     close-older-key: "[streaming-resilience-sweep]"
     close-older-issues: false
     expires: 7d
@@ -31,6 +32,7 @@ imports:
   - shared/tool-hints.md
   - shared/repo-context.md
   - shared/rigor.md
+  - shared/adversarial-review.md
   - shared/checkout.md
   - shared/engine-minimax.md
   - shared/pre-steps.md

--- a/.github/workflows/shared/adversarial-review.md
+++ b/.github/workflows/shared/adversarial-review.md
@@ -1,0 +1,56 @@
+---
+# Shared adversarial validity gate for bug/behavior-filing gh-aw sweeps.
+# gh-aw imports this file; the markdown below (after the closing ---) is
+# appended to the agent's task prompt at runtime via {{#runtime-import}}.
+#
+# Encodes the concrete failure modes that made past sweep issues get closed as
+# not-a-bug / by-design / duplicate. Every create-issue must clear this gate.
+---
+
+## Adversarial validity gate — mandatory before `create_issue`
+
+Put the finding through this validity gate before filing, reviewing it as a
+skeptical maintainer would — treat **"this is NOT a bug"** as the default and
+file **only** if it survives every check below; otherwise call
+`mcp__safeoutputs__noop`. Most runs should noop — a false or by-design report
+costs more maintainer time than a missed one.
+
+Record the results as an **`## Adversarial review`** section in the issue body.
+An issue that omits it is incomplete — noop instead.
+
+1. **Reproduced on current `main`, for real.** You must have *executed* code this
+   run — a source-level snippet via `uv run python -c …`, a tiny script, or a
+   single `uv run pytest -k …` — and **observed** the failure. Paste the exact
+   command and its actual output. A claim you only reasoned about (e.g. "this
+   *would* fail") is not a bug and is the most common reason past reports were
+   rejected as a false premise.
+
+2. **Existing tests don't already bless the behavior.** Grep the suite for the
+   symbol / code path and **read** the nearest tests. If a passing test already
+   asserts the current behavior — or your proposed fix would change or break any
+   existing test — the behavior is intentional → noop. (Past reports proposed
+   one-line "fixes" that broke a dozen adapter/serialization tests asserting the
+   opposite on purpose.)
+
+3. **Ruled out "by design."** Check for: a nearby comment/docstring explaining
+   the choice, the provider profile, a maintainer decision in a linked issue/PR,
+   and whether other providers/adapters deliberately do the same thing.
+   Programmatic-only fields (`metadata`, `conversation_id`) excluded from wire /
+   UI protocols, and request-only parts absent from a *response* union (or vice
+   versa), are intentional — not bugs.
+
+4. **No cross-provider false equivalence** *(provider-specific findings only)*.
+   If the finding concerns a provider's request/response payload or SDK shape,
+   verify the real type for **that** provider from its own types or docs — never
+   infer a bug by analogy to a different provider. For provider-agnostic findings
+   (core serialization/round-trip, streaming lifecycle, message plumbing), this
+   check does not apply — skip it.
+
+5. **Not already tracked.** Re-confirm the dedup above — label-filtered where
+   this sweep has a dedicated label, otherwise the full open-issue scan —
+   returned nothing covering this exact finding.
+
+If any *applicable* check fails or is genuinely inconclusive,
+`mcp__safeoutputs__noop`. A check that doesn't apply (e.g. the provider check for
+a core finding) is not a failure — skip it. One issue that clears every
+applicable check beats five that don't.

--- a/.github/workflows/shared/adversarial-review.md
+++ b/.github/workflows/shared/adversarial-review.md
@@ -27,10 +27,13 @@ An issue that omits it is incomplete — noop instead.
 
 2. **Existing tests don't already bless the behavior.** Grep the suite for the
    symbol / code path and **read** the nearest tests. If a passing test already
-   asserts the current behavior — or your proposed fix would change or break any
-   existing test — the behavior is intentional → noop. (Past reports proposed
-   one-line "fixes" that broke a dozen adapter/serialization tests asserting the
-   opposite on purpose.)
+   asserts the current behavior, the behavior is intentional → noop. (Past
+   reports proposed one-line "fixes" that broke a dozen adapter/serialization
+   tests asserting the opposite on purpose.) A fix that would merely require
+   *updating* tests is not, by itself, proof of intent — real fixes often update
+   a stale test — but it raises the bar: read every test the fix would touch and
+   noop if any of them asserts the current behavior deliberately (an explicit
+   comment/docstring, or the same expectation repeated across several tests).
 
 3. **Ruled out "by design."** Check for: a nearby comment/docstring explaining
    the choice, the provider profile, a maintainer decision in a linked issue/PR,

--- a/.github/workflows/shared/prompts/pydantic-ai-bug-hunter.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-bug-hunter.md
@@ -67,14 +67,18 @@ weak or speculative issue is worse than filing nothing.
 ### Deduplication — mandatory BEFORE filing an issue
 
 Search for existing issues that might overlap
-your run's scope. Use the MCP GitHub tools (not the `gh` CLI, which is blocked
-by the firewall proxy):
+your run's scope. List open issues through the proxied `gh` CLI and filter
+locally — the `/search/issues` endpoint is blocked by the firewall proxy and
+there are no `mcp__github__*` tools:
 
 ```
-mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open "[bug-hunter]" OR "[provider-mapping-sweep]" OR "[streaming-resilience-sweep]" OR "[roundtrip-sweep]"
+gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name]}'
 ```
 
-Also search for keywords related to whatever subsystem you're investigating.
+Scan the titles for the sweep prefixes (`[bug-hunter]`,
+`[provider-mapping-sweep]`, `[streaming-resilience-sweep]`, `[roundtrip-sweep]`)
+and for keywords related to whatever subsystem you're investigating.
 If a matching issue already covers the same root cause, call
 `mcp__safeoutputs__noop` immediately — do NOT file a duplicate, even to
 "independently confirm" the bug. Confirming is not value-add.
@@ -115,3 +119,9 @@ Call `mcp__safeoutputs__noop` if any of these are true:
 >
 > ## Evidence
 > - [Commands/output captured, file references with `path:line`]
+>
+> ## Adversarial review
+> - **Reproduced on `main`:** [exact command + real captured output]
+> - **Existing tests checked:** [tests read; none assert the current behavior, and the fix doesn't break them]
+> - **Ruled out by-design:** [nearby comment / profile / maintainer decision / same in other providers]
+> - **SDK verified for this provider:** [the real type/shape, not inferred by analogy to another provider]

--- a/.github/workflows/shared/prompts/pydantic-ai-bug-hunter.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-bug-hunter.md
@@ -125,3 +125,4 @@ Call `mcp__safeoutputs__noop` if any of these are true:
 > - **Existing tests checked:** [tests read; none assert the current behavior, and the fix doesn't break them]
 > - **Ruled out by-design:** [nearby comment / profile / maintainer decision / same in other providers]
 > - **SDK verified for this provider:** [the real type/shape, not inferred by analogy to another provider]
+> - **Not a duplicate:** [open-issue scan returned nothing covering this]

--- a/.github/workflows/shared/prompts/pydantic-ai-docs-drift.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-docs-drift.md
@@ -62,11 +62,22 @@ the window, and check whether an open issue/PR already tracks it.
 
 ### Deduplication — mandatory before filing
 
-Before filing, search for existing issues covering the same drift:
+Before filing, first check this sweep's own prior findings with a tight,
+server-side label filter — the `/search/issues` endpoint is blocked by the
+firewall proxy and there are no `mcp__github__*` tools, but the `?labels=`
+filter on the issue-list endpoint is allowed:
 
 ```bash
-mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open "[docs-drift]"
-mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open <keywords from your finding>
+gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=docs-drift&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title}'
+```
+
+Only if that is inconclusive, widen to a full open-issue scan and grep locally
+for keywords from your finding:
+
+```bash
+gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name]}'
 ```
 
 If a matching issue exists, call `mcp__safeoutputs__noop`. Do NOT file duplicates.

--- a/.github/workflows/shared/prompts/pydantic-ai-provider-mapping-sweep.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-provider-mapping-sweep.md
@@ -62,12 +62,22 @@ be triggered by code you wrote and observed to fail.
 
 ## Deduplication — mandatory BEFORE filing an issue
 
-Search for existing issues using the MCP
-GitHub tools (not `gh` CLI — it's blocked by the firewall proxy):
+First check this sweep's own prior findings with a tight, server-side label
+filter — the `/search/issues` endpoint is blocked by the firewall proxy and
+there are no `mcp__github__*` tools, but the `?labels=` filter on the
+issue-list endpoint is allowed:
 
 ```
-mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open "[provider-mapping-sweep]" OR "[bug-hunter]"
-mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open <chosen-provider>
+gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=provider-mapping-sweep&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title}'
+```
+
+Only if that is inconclusive, widen to a full open-issue scan and grep locally
+for your chosen provider name (and the `[bug-hunter]` prefix):
+
+```
+gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name]}'
 ```
 
 If a matching issue covers the same mapping bug, call `mcp__safeoutputs__noop`.
@@ -109,3 +119,9 @@ the impact is cosmetic. One well-evidenced issue beats several weak ones.
 >
 > ## Evidence
 > - [SDK type / docs reference showing the correct shape; `path:line` refs]
+>
+> ## Adversarial review
+> - **Reproduced on `main`:** [exact command + real captured output]
+> - **Existing tests checked:** [tests read; none assert the current behavior, and the fix doesn't break them]
+> - **Ruled out by-design:** [nearby comment / profile / maintainer decision / same in other providers]
+> - **SDK verified for this provider:** [the real type/shape, not inferred by analogy to another provider]

--- a/.github/workflows/shared/prompts/pydantic-ai-provider-mapping-sweep.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-provider-mapping-sweep.md
@@ -73,7 +73,8 @@ gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=provider-mapping-swe
 ```
 
 Only if that is inconclusive, widen to a full open-issue scan and grep locally
-for your chosen provider name (and the `[bug-hunter]` prefix):
+for your chosen provider name (and the `[provider-mapping-sweep]` and
+`[bug-hunter]` prefixes — the latter also files provider bugs):
 
 ```
 gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' \
@@ -125,3 +126,4 @@ the impact is cosmetic. One well-evidenced issue beats several weak ones.
 > - **Existing tests checked:** [tests read; none assert the current behavior, and the fix doesn't break them]
 > - **Ruled out by-design:** [nearby comment / profile / maintainer decision / same in other providers]
 > - **SDK verified for this provider:** [the real type/shape, not inferred by analogy to another provider]
+> - **Not a duplicate:** [label-filtered dedup returned nothing]

--- a/.github/workflows/shared/prompts/pydantic-ai-provider-parity-explore.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-provider-parity-explore.md
@@ -107,3 +107,4 @@ run.
 > - **Existing tests checked:** [tests read; none assert this behavior is intentional]
 > - **Ruled out by-design:** [nearby comment / profile / maintainer decision checked]
 > - **SDK verified for this provider:** [the real type/shape, not inferred by analogy to another provider]
+> - **Not a duplicate:** [label-filtered dedup returned nothing]

--- a/.github/workflows/shared/prompts/pydantic-ai-provider-parity-explore.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-provider-parity-explore.md
@@ -53,12 +53,22 @@ Distinguish **silent drops** (input accepted, quietly ignored — a bug) from
 
 ## Deduplication — mandatory BEFORE filing an issue
 
-Search for existing issues using the MCP
-GitHub tools (not `gh` CLI — it's blocked by the firewall proxy):
+First check this sweep's own prior findings with a tight, server-side label
+filter — the `/search/issues` endpoint is blocked by the firewall proxy and
+there are no `mcp__github__*` tools, but the `?labels=` filter on the
+issue-list endpoint is allowed:
 
 ```
-mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open "[provider-parity-explore]" OR "parity"
-mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open <capability you're auditing>
+gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=provider-parity-explore&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title}'
+```
+
+Only if that is inconclusive, widen to a full open-issue scan and grep locally
+for "parity" and the capability you're auditing:
+
+```
+gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name]}'
 ```
 
 If a matching issue exists, call `mcp__safeoutputs__noop` immediately.
@@ -91,3 +101,9 @@ run.
 >
 > ## Evidence
 > - [SDK/docs references; `path:line`; a short snippet showing the silent drop]
+>
+> ## Adversarial review
+> - **Reproduced on `main`:** [exact command + real output demonstrating the gap]
+> - **Existing tests checked:** [tests read; none assert this behavior is intentional]
+> - **Ruled out by-design:** [nearby comment / profile / maintainer decision checked]
+> - **SDK verified for this provider:** [the real type/shape, not inferred by analogy to another provider]

--- a/.github/workflows/shared/prompts/pydantic-ai-regression-detector.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-regression-detector.md
@@ -108,3 +108,4 @@ test that passes on `OLD` and fails on `NEW`, with both outputs captured.
 > - **Reproduced on OLD and NEW:** [commands + real outputs for both versions]
 > - **Change was NOT intentional:** [found the commit/PR that changed it and confirmed it wasn't a deliberate behavior change — the #1 reason regression reports get rejected]
 > - **Existing tests checked:** [NEW-version tests read; none assert the new behavior as intended]
+> - **Not a duplicate:** [label-filtered dedup returned nothing]

--- a/.github/workflows/shared/prompts/pydantic-ai-regression-detector.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-regression-detector.md
@@ -52,11 +52,23 @@ only "looks risky" in the diff is not a finding.
 
 ## Deduplication — mandatory BEFORE filing an issue
 
-Search for existing issues using the MCP
-GitHub tools (not `gh` CLI — it's blocked by the firewall proxy):
+First narrow to regression-labelled issues with a tight, server-side filter —
+the `/search/issues` endpoint is blocked by the firewall proxy and there are no
+`mcp__github__*` tools, but the `?labels=` filter on the issue-list endpoint is
+allowed. This covers both prior `[regression-detector]` findings and human-filed
+regression reports:
 
 ```
-mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open "[regression-detector]" OR "regression"
+gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=regression&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title}'
+```
+
+Only if that is inconclusive, widen to a full open-issue scan and grep locally
+for "regression" and the affected symbol:
+
+```
+gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name]}'
 ```
 
 If a matching issue exists, call `mcp__safeoutputs__noop` immediately.
@@ -91,3 +103,8 @@ test that passes on `OLD` and fails on `NEW`, with both outputs captured.
 >
 > ## Evidence
 > - [Captured outputs for both versions; `path:line` of the change]
+>
+> ## Adversarial review
+> - **Reproduced on OLD and NEW:** [commands + real outputs for both versions]
+> - **Change was NOT intentional:** [found the commit/PR that changed it and confirmed it wasn't a deliberate behavior change — the #1 reason regression reports get rejected]
+> - **Existing tests checked:** [NEW-version tests read; none assert the new behavior as intended]

--- a/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
@@ -51,21 +51,33 @@ existing suite. The bug must be one you triggered and observed.
 ## Deduplication — mandatory BEFORE filing an issue
 
 The gap may already be tracked by an open **issue** or already fixed by an
-open **PR** — check both. Use the MCP GitHub tools (not `gh` CLI — it's
-blocked by the firewall proxy).
+open **PR** — check both. List them through the proxied `gh` CLI and filter
+locally — the `/search/issues` endpoint is blocked by the firewall proxy and
+there are no `mcp__github__*` tools.
 
-**(a) Existing issues** — by sweep signature and by the specific
-boundary/function you investigated:
-
-```
-mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open "[roundtrip-sweep]" OR "round-trip" OR "serialize"
-```
-
-**(b) Existing PRs** — a fix may already be open (and even approved). Search
-open PRs touching the failing symbol or file:
+**(a) Existing issues** — first check this sweep's own prior findings with a
+tight, server-side label filter (`?labels=` on the issue-list endpoint is
+allowed even though `/search/issues` is not):
 
 ```
-mcp__github__search_pull_requests repo:pydantic/pydantic-ai is:pr is:open <failing symbol / file path>
+gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=roundtrip-sweep&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title}'
+```
+
+Only if that is inconclusive, widen to a full open-issue scan and grep locally
+for "round-trip", "serialize", and the boundary/function you investigated:
+
+```
+gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name]}'
+```
+
+**(b) Existing PRs** — a fix may already be open (and even approved). List
+open PRs and scan for one touching the failing symbol or file:
+
+```
+gh api --paginate 'repos/pydantic/pydantic-ai/pulls?state=open&per_page=100' \
+  --jq '.[] | {number, title}'
 ```
 
 If a matching open issue or PR exists, call `mcp__safeoutputs__noop`
@@ -106,3 +118,9 @@ concrete, minimal, failing round-trip reproduction with observed output.
 >
 > ## Evidence
 > - [Captured output / diff; `path:line` references]
+>
+> ## Adversarial review
+> - **Reproduced on `main`:** [exact command + real captured output]
+> - **Existing tests checked:** [adapter/serialization tests read; none assert this loss is intentional, and the fix doesn't break them]
+> - **Ruled out by-design:** [programmatic-only field / request-vs-response union placement / maintainer decision checked]
+> - **Not a duplicate:** [label-filtered dedup returned nothing]

--- a/.github/workflows/shared/prompts/pydantic-ai-stale-issues-finder.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-stale-issues-finder.md
@@ -115,8 +115,12 @@ issue, or if it looks only partially fixed, skip it.
    After all subagents complete:
    - Aggregate all subagent JSON responses
    - Build shortlist = all `CANDIDATE` + `NEEDS_COMMENT_CHECK`
-   - For shortlist only, query comments/timeline as needed using MCP GitHub
-     tools to confirm or reject closure confidence
+   - For shortlist only, fetch comments live to confirm or reject closure
+     confidence — comments are NOT in the prefetched corpus. Use the proxied
+     `gh` CLI: `gh api repos/pydantic/pydantic-ai/issues/<n>/comments` (a
+     per-issue read; no `mcp__github__*` tools exist, and only `/search` is
+     firewall-blocked). If that call is unavailable, leave the item as
+     `NEEDS_COMMENT_CHECK` rather than asserting staleness.
    - If comment evidence weakens confidence, downgrade to `SKIP`
 
 4. **Build final close-candidate set**
@@ -193,10 +197,12 @@ candidates is far more valuable than a long report full of maybes.
 
 ### Deduplication — mandatory BEFORE filing
 
-Search for existing stale-finder reports that might overlap this run:
+Search the prefetched local corpus for existing stale-finder reports that might
+overlap this run — grep the on-disk issue list for the `[stale-finder]` title
+prefix (no live GitHub call needed):
 
 ```
-mcp__github__search_issues: repo:pydantic/pydantic-ai is:issue is:open "[stale-finder]"
+grep -F '[stale-finder]' /tmp/gh-aw/agent/open-issues.tsv
 ```
 
 Do not skip this run just because a previous report exists. You are reviewing
@@ -210,11 +216,15 @@ the full corpus every run. If no candidates qualify this run, call
 - Read files in large ranges (500+ lines per call). Do NOT read 30–80 lines at
   a time.
 - Use the native `Grep` and `Glob` tools for codebase search.
-- The `gh` CLI is blocked by the AWF firewall proxy — use MCP GitHub tools
-  (`mcp__github__search_issues`, `mcp__github__get_issue`, etc.) for all GitHub
-  API calls from within the agent.
-- First pass triage is local-only from disk. Use MCP GitHub tools only for
-  second-pass validation of shortlisted candidates.
+- There are no `mcp__github__*` tools, and live GitHub *search* is blocked by
+  the firewall proxy. Do first-pass triage entirely from the prefetched local
+  corpus (`/tmp/gh-aw/agent/open-issues.tsv` and `issues/all/{number}.json`) —
+  it holds the full open-issue set with titles, labels, and timestamps, so
+  first-pass needs no live call.
+- The corpus does NOT include comments. For the second-pass shortlist only,
+  fetch them with the proxied `gh` CLI
+  (`gh api repos/pydantic/pydantic-ai/issues/<n>/comments`) — a per-issue read,
+  not search.
 
 ---
 

--- a/.github/workflows/shared/prompts/pydantic-ai-streaming-resilience-sweep.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-streaming-resilience-sweep.md
@@ -111,3 +111,4 @@ minimal, failing streaming reproduction and captured event trace.
 > - **Reproduced on `main`:** [exact command + real captured trace — confirm the asymmetry/failure actually exists, not a false premise]
 > - **Existing tests checked:** [streaming tests read; none assert the current behavior, and the fix doesn't break them]
 > - **Ruled out by-design:** [sibling streaming methods behave the same / nearby comment / maintainer decision checked]
+> - **Not a duplicate:** [label-filtered dedup returned nothing]

--- a/.github/workflows/shared/prompts/pydantic-ai-streaming-resilience-sweep.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-streaming-resilience-sweep.md
@@ -55,11 +55,23 @@ assertion leakage on early exit. Do not run and report the existing suite.
 
 ## Deduplication — mandatory BEFORE filing an issue
 
-Search for existing issues using the MCP
-GitHub tools (not `gh` CLI — it's blocked by the firewall proxy):
+First narrow to streaming-labelled issues with a tight, server-side filter — the
+`/search/issues` endpoint is blocked by the firewall proxy and there are no
+`mcp__github__*` tools, but the `?labels=` filter on the issue-list endpoint is
+allowed. This covers both prior `[streaming-resilience-sweep]` findings and
+human-filed streaming issues:
 
 ```
-mcp__github__search_issues repo:pydantic/pydantic-ai is:issue is:open "[streaming-resilience-sweep]" OR "streaming" OR "stream_output" OR "stream_text"
+gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=streaming&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title}'
+```
+
+Only if that is inconclusive, widen to a full open-issue scan and grep locally
+for "stream_output" / "stream_text":
+
+```
+gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name]}'
 ```
 
 If a matching issue exists, call `mcp__safeoutputs__noop` immediately.
@@ -94,3 +106,8 @@ minimal, failing streaming reproduction and captured event trace.
 >
 > ## Evidence
 > - [Captured event trace / output; `path:line` references]
+>
+> ## Adversarial review
+> - **Reproduced on `main`:** [exact command + real captured trace — confirm the asymmetry/failure actually exists, not a false premise]
+> - **Existing tests checked:** [streaming tests read; none assert the current behavior, and the fix doesn't break them]
+> - **Ruled out by-design:** [sibling streaming methods behave the same / nearby comment / maintainer decision checked]

--- a/.github/workflows/shared/rigor.md
+++ b/.github/workflows/shared/rigor.md
@@ -15,3 +15,11 @@
   or speculative issue or review.
 - If you need to hedge with "might", "could", or "possibly", it is not
   ready.
+
+## Adversarial self-review
+
+- Before emitting any issue, discussion, or review, switch sides: assume your
+  finding is WRONG and try your hardest to refute it. Emit it only if it
+  survives your own strongest counter-argument.
+- A false or by-design report costs maintainers more than a missed one.
+  Precision beats recall — when in doubt, `mcp__safeoutputs__noop`.

--- a/.github/workflows/shared/tool-hints.md
+++ b/.github/workflows/shared/tool-hints.md
@@ -22,6 +22,26 @@ dependencies are **not** pre-installed; run `make install` once before using
 `pytest`, `ruff`, or `pyright`. Prefer `uv run pytest <test_file>` over a bare
 `pytest` call.
 
-**GitHub issue search** — `gh issue list --search` returns HTTP 403 via the AWF
-firewall proxy. Use MCP tools instead:
-`mcp__github__search_issues(query="repo:pydantic/pydantic-ai <keywords>")`
+**GitHub issue search** — this workflow runs the GitHub toolset in `gh-proxy`
+mode, so there are **no `mcp__github__*` tools**, and the `/search/issues`
+endpoint (`gh issue list --search`, `gh search issues`) returns HTTP 403 via the
+AWF firewall proxy. The issue-**list** endpoint **is** allowed through the
+proxied `gh` CLI, including its server-side `?labels=` filter. When this sweep
+files under a dedicated label, prefer a narrow label query over listing
+everything:
+
+```
+gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=<label>&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title}'
+```
+
+If this sweep has no dedicated label, or the label filter is inconclusive, widen
+to a full open-issue scan:
+
+```
+gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' \
+  --jq '.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name]}'
+```
+
+`select(.pull_request == null)` drops PRs, which the issues endpoint also
+returns.

--- a/.github/workflows/shared/tool-hints.md
+++ b/.github/workflows/shared/tool-hints.md
@@ -30,7 +30,7 @@ proxied `gh` CLI, including its server-side `?labels=` filter. When this sweep
 files under a dedicated label, prefer a narrow label query over listing
 everything:
 
-```
+```bash
 gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=<label>&per_page=100' \
   --jq '.[] | select(.pull_request == null) | {number, title}'
 ```
@@ -38,7 +38,7 @@ gh api 'repos/pydantic/pydantic-ai/issues?state=open&labels=<label>&per_page=100
 If this sweep has no dedicated label, or the label filter is inconclusive, widen
 to a full open-issue scan:
 
-```
+```bash
 gh api --paginate 'repos/pydantic/pydantic-ai/issues?state=open&per_page=100' \
   --jq '.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name]}'
 ```


### PR DESCRIPTION
Addresses the recent sweep failures (#6298 and others) and the pattern of sweeps filing invalid issues.

- De-collide `streaming-resilience-sweep` (Thursday -> Saturday) so it stops running into `bug-hunter` and exhausting the shared MiniMax token quota.
- Fix GitHub issue-search guidance for `gh-proxy` mode: `mcp__github__*` tools do not exist and `/search/issues` is firewall-blocked (403), so route dedup through the allowed `gh api` issue-list endpoint with a server-side `?labels=` filter (broad list only as fallback). Applied in `shared/tool-hints.md`, the mirrored shim `INSTRUCTIONS`, and the committed prompt defaults.
- Add a dedicated `labels:` to each labelling sweep's `create-issue` config so findings are reliably self-labelled, enabling the label-first dedup above. (`bug-hunter` keeps no dedicated label on purpose — the repo's generic `bug` label wouldn't discriminate its own reports — so it dedups via the full open-issue scan.)
- Add `shared/adversarial-review.md`, a mandatory validity gate imported by the six bug/behaviour sweeps, plus a universal skeptic clause in `shared/rigor.md`. The gate encodes the concrete reasons past issues were closed as not-a-bug / by-design / duplicate: reproduce on `main` for real, check that no existing test blesses the behaviour, rule out by-design, avoid cross-provider false equivalence, and confirm no duplicate. Each bug sweep now requires a recorded `## Adversarial review` section before filing.
- Route `stale-issues-finder` dedup to its prefetched local corpus.

Note: the `.lock.yml` files are regenerated and committed (canonical gh-aw toolchain) so the frontmatter changes (schedule, `labels:`, the new import directive) take effect. The prompt (`shared/prompts/*`) and shim (`cli.py`) changes are runtime-resolved and need no recompile.

<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) don't need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://ai.pydantic.dev/harness/overview/#what-goes-where -->

- Closes #<issue>

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


