### PR TITLE
Fix `RetryPromptPart.content` round-trip when `ErrorDetails` entries omit `input`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -301,7 +301,9 @@ class ToolRetryError(Exception):
         for e in errors:
             loc = '.'.join(str(x) for x in e['loc']) if e['loc'] else '__root__'
             lines.append(loc)
-            lines.append(f'  {e["msg"]} [type={e["type"]}, input_value={e["input"]!r}]')
+            # `input` may be omitted, e.g. when the part was built with `errors(include_input=False)`.
+            input_value = f', input_value={e["input"]!r}' if 'input' in e else ''
+            lines.append(f'  {e["msg"]} [type={e["type"]}{input_value}]')
         return '\n'.join(lines)
 
 

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -19,7 +19,7 @@ import pydantic
 import pydantic_core
 from genai_prices import calc_price, types as genai_types
 from pydantic.dataclasses import dataclass as pydantic_dataclass
-from typing_extensions import TypeAliasType, TypedDict, TypeVar, assert_never
+from typing_extensions import NotRequired, TypeAliasType, TypedDict, TypeVar, assert_never
 
 from . import _otel_messages, _utils
 from ._instrumentation import serialize_any
@@ -1496,30 +1496,26 @@ class NativeToolReturnPart(BaseToolReturnPart):
 
 
 if TYPE_CHECKING:
-    _ErrorDetails: TypeAlias = pydantic_core.ErrorDetails
+    from pydantic_core import ErrorDetails
 else:
 
-    class _ErrorDetails(TypedDict, total=False):
-        """Runtime stand-in for [`ErrorDetails`][pydantic_core.ErrorDetails] with every key optional.
+    class ErrorDetails(TypedDict):
+        """[`pydantic_core.ErrorDetails`][pydantic_core.ErrorDetails] with an optional `input` key.
 
-        `ErrorDetails` marks `type`, `loc`, `msg`, and `input` as required, but nothing enforces that when a
-        [`RetryPromptPart`][pydantic_ai.messages.RetryPromptPart] is constructed, and `content` is commonly
-        built from dicts that omit some of them, e.g. `ValidationError.errors(include_input=False)` or
-        history processors that redact `input`. Validating and serializing against this all-optional shape
-        keeps such message histories round-trippable through
-        [`ModelMessagesTypeAdapter`][pydantic_ai.messages.ModelMessagesTypeAdapter], instead of failing on
-        load after serializing with a `PydanticSerializationUnexpectedValue` warning.
+        `input` is not always present, e.g. when [`RetryPromptPart.content`][pydantic_ai.messages.RetryPromptPart.content]
+        was built with `ValidationError.errors(include_input=False)`, so it must not be required for a
+        serialized message history to load back.
         """
 
         type: str
         loc: tuple[int | str, ...]
         msg: str
-        input: Any
-        ctx: dict[str, Any]
-        url: str
+        input: NotRequired[Any]
+        ctx: NotRequired[dict[str, Any]]
+        url: NotRequired[str]
 
 
-error_details_ta = pydantic.TypeAdapter(list[_ErrorDetails], config=pydantic.ConfigDict(defer_build=True))
+error_details_ta = pydantic.TypeAdapter(list[ErrorDetails], config=pydantic.ConfigDict(defer_build=True))
 
 
 @dataclass(repr=False)
@@ -1538,11 +1534,11 @@ class RetryPromptPart:
     * an output validator raised a [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] exception
     """
 
-    content: list[_ErrorDetails] | str
+    content: list[ErrorDetails] | str
     """Details of why and how the model should retry.
 
     If the retry was triggered by a [`ValidationError`][pydantic_core.ValidationError], this will be a list of
-    [`ErrorDetails`][pydantic_core.ErrorDetails]. Entries are allowed to omit keys (e.g. when built with
+    [`ErrorDetails`][pydantic_core.ErrorDetails]. Entries may omit the `input` key (e.g. when built with
     `ValidationError.errors(include_input=False)`) and still (de)serialize.
     """
 

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -19,7 +19,7 @@ import pydantic
 import pydantic_core
 from genai_prices import calc_price, types as genai_types
 from pydantic.dataclasses import dataclass as pydantic_dataclass
-from typing_extensions import TypeAliasType, TypeVar, assert_never
+from typing_extensions import TypeAliasType, TypedDict, TypeVar, assert_never
 
 from . import _otel_messages, _utils
 from ._instrumentation import serialize_any
@@ -1495,7 +1495,31 @@ class NativeToolReturnPart(BaseToolReturnPart):
         return _narrow_return(part, _NATIVE_RETURN_NARROWERS, tool_kind)
 
 
-error_details_ta = pydantic.TypeAdapter(list[pydantic_core.ErrorDetails], config=pydantic.ConfigDict(defer_build=True))
+if TYPE_CHECKING:
+    _ErrorDetails: TypeAlias = pydantic_core.ErrorDetails
+else:
+
+    class _ErrorDetails(TypedDict, total=False):
+        """Runtime stand-in for [`ErrorDetails`][pydantic_core.ErrorDetails] with every key optional.
+
+        `ErrorDetails` marks `type`, `loc`, `msg`, and `input` as required, but nothing enforces that when a
+        [`RetryPromptPart`][pydantic_ai.messages.RetryPromptPart] is constructed, and `content` is commonly
+        built from dicts that omit some of them, e.g. `ValidationError.errors(include_input=False)` or
+        history processors that redact `input`. Validating and serializing against this all-optional shape
+        keeps such message histories round-trippable through
+        [`ModelMessagesTypeAdapter`][pydantic_ai.messages.ModelMessagesTypeAdapter], instead of failing on
+        load after serializing with a `PydanticSerializationUnexpectedValue` warning.
+        """
+
+        type: str
+        loc: tuple[int | str, ...]
+        msg: str
+        input: Any
+        ctx: dict[str, Any]
+        url: str
+
+
+error_details_ta = pydantic.TypeAdapter(list[_ErrorDetails], config=pydantic.ConfigDict(defer_build=True))
 
 
 @dataclass(repr=False)
@@ -1514,11 +1538,12 @@ class RetryPromptPart:
     * an output validator raised a [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] exception
     """
 
-    content: list[pydantic_core.ErrorDetails] | str
+    content: list[_ErrorDetails] | str
     """Details of why and how the model should retry.
 
     If the retry was triggered by a [`ValidationError`][pydantic_core.ValidationError], this will be a list of
-    error details.
+    [`ErrorDetails`][pydantic_core.ErrorDetails]. Entries are allowed to omit keys (e.g. when built with
+    `ValidationError.errors(include_input=False)`) and still (de)serialize.
     """
 
     _: KW_ONLY

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any, cast, get_args, get_origin
 
 import pytest
 from pydantic import TypeAdapter
+from pydantic_core import ErrorDetails
 
 from pydantic_ai import (
     Agent,
@@ -734,6 +735,56 @@ def test_model_messages_type_adapter_back_compat_missing_conversation_id():
     ]
     deserialized = ModelMessagesTypeAdapter.validate_python(pre_pr_serialized)
     assert all(m.conversation_id is None for m in deserialized)
+
+
+@pytest.mark.parametrize(
+    'content',
+    [
+        pytest.param(
+            [{'type': 'missing', 'loc': ('x',), 'msg': 'Field required', 'input': {'y': 1}}],
+            id='no-ctx-url',
+        ),
+        pytest.param(
+            [{'type': 'missing', 'loc': ('x',), 'msg': 'Field required'}],
+            id='no-input',
+        ),
+        pytest.param(
+            [
+                {
+                    'type': 'greater_than',
+                    'loc': ('a', 'b'),
+                    'msg': 'Input should be greater than 0',
+                    'input': -1,
+                    'ctx': {'gt': 0},
+                    'url': 'https://errors.pydantic.dev/2/v/greater_than',
+                }
+            ],
+            id='full',
+        ),
+    ],
+)
+def test_retry_prompt_content_round_trips_with_partial_error_details(content: list[dict[str, Any]]):
+    """`RetryPromptPart.content` entries may omit `ErrorDetails` keys that construction never enforces,
+    e.g. when built with `ValidationError.errors(include_input=False)`; a serialized history containing
+    them must load back without warnings or errors (https://github.com/pydantic/pydantic-ai/issues/5987).
+
+    Unit test: this pins the (de)serialization contract of `ModelMessagesTypeAdapter`, which no model
+    request exercises.
+    """
+    messages: list[ModelMessage] = [
+        ModelRequest(
+            parts=[RetryPromptPart(content=cast('list[ErrorDetails]', content), tool_name='foo', tool_call_id='call_1')]
+        )
+    ]
+
+    with warnings.catch_warnings():
+        # A `PydanticSerializationUnexpectedValue` warning here means the serialization schema regressed.
+        warnings.simplefilter('error')
+        serialized = ModelMessagesTypeAdapter.dump_json(messages)
+
+    part = ModelMessagesTypeAdapter.validate_json(serialized)[0].parts[0]
+    assert isinstance(part, RetryPromptPart)
+    assert part.content == content
 
 
 def test_model_messages_type_adapter_preserves_user_text_prompt_metadata():

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -765,7 +765,7 @@ def test_model_messages_type_adapter_back_compat_missing_conversation_id():
     ],
 )
 def test_retry_prompt_content_round_trips_with_partial_error_details(content: list[dict[str, Any]]):
-    """`RetryPromptPart.content` entries may omit `ErrorDetails` keys that construction never enforces,
+    """`RetryPromptPart.content` entries may omit the `input` key, which construction never enforces,
     e.g. when built with `ValidationError.errors(include_input=False)`; a serialized history containing
     them must load back without warnings or errors (https://github.com/pydantic/pydantic-ai/issues/5987).
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any, cast, get_args, get_origin
 
 import pytest
 from pydantic import TypeAdapter
-from pydantic_core import ErrorDetails
+from pydantic_core import ErrorDetails, ValidationError
 
 from pydantic_ai import (
     Agent,
@@ -39,6 +39,7 @@ from pydantic_ai import (
     UserPromptPart,
     VideoUrl,
 )
+from pydantic_ai.exceptions import ToolRetryError
 from pydantic_ai.messages import (
     INVALID_JSON_KEY,
     MULTI_MODAL_CONTENT_TYPES,
@@ -781,10 +782,41 @@ def test_retry_prompt_content_round_trips_with_partial_error_details(content: li
         # A `PydanticSerializationUnexpectedValue` warning here means the serialization schema regressed.
         warnings.simplefilter('error')
         serialized = ModelMessagesTypeAdapter.dump_json(messages)
+        dumped = ModelMessagesTypeAdapter.dump_python(messages, mode='python')
 
-    part = ModelMessagesTypeAdapter.validate_json(serialized)[0].parts[0]
-    assert isinstance(part, RetryPromptPart)
-    assert part.content == content
+    for deserialized in (
+        ModelMessagesTypeAdapter.validate_json(serialized),
+        ModelMessagesTypeAdapter.validate_python(dumped),
+    ):
+        part = deserialized[0].parts[0]
+        assert isinstance(part, RetryPromptPart)
+        assert part.content == content
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            assert 'validation error' in part.model_response()
+
+
+def test_retry_prompt_content_rejects_non_error_details_dicts():
+    """Only the `input` key is optional: entries missing `type`/`loc`/`msg` are not valid `ErrorDetails`
+    and must keep failing loudly on load rather than validating to empty dicts."""
+    serialized = (
+        b'[{"parts":[{"content":[{"foo":"bar"}],"tool_name":"foo","tool_call_id":"call_1",'
+        b'"timestamp":"2026-01-01T00:00:00Z","part_kind":"retry-prompt"}],"kind":"request"}]'
+    )
+    with pytest.raises(ValidationError):
+        ModelMessagesTypeAdapter.validate_json(serialized)
+
+
+def test_tool_retry_error_formats_content_without_input():
+    """`ToolRetryError` renders `RetryPromptPart.content` entries that omit the optional `input` key."""
+    part = RetryPromptPart(
+        content=cast('list[ErrorDetails]', [{'type': 'missing', 'loc': ('x',), 'msg': 'Field required'}]),
+        tool_name='foo',
+    )
+    assert str(ToolRetryError(part)) == snapshot("""\
+1 validation error for 'foo'
+x
+  Field required [type=missing]""")
 
 
 def test_model_messages_type_adapter_preserves_user_text_prompt_metadata():


### PR DESCRIPTION
- Closes #5987

`RetryPromptPart.content` is typed `list[pydantic_core.ErrorDetails] | str`, and `ErrorDetails` requires the `input` key. Construction never validates (plain dataclass), and `ModelMessagesTypeAdapter.dump_json` serializes entries missing `input` with only a `UserWarning`, but `validate_json` then rejects the payload. Any history containing such a part (e.g. built with `ValidationError.errors(include_input=False)`, or with `input` redacted by a history processor) serializes fine and can never be loaded back, breaking `message_history=` reload and durable-exec replay.

Fix: validate and serialize `content` against a runtime `TypedDict` identical to `pydantic_core.ErrorDetails` except `input` is `NotRequired`. At type-check time the annotation stays `pydantic_core.ErrorDetails`, so the public static type, rendered API docs, and the `$defs.ErrorDetails` JSON schema name are unchanged; the schema only drops `input` from `required`. `type`/`loc`/`msg` stay required so non-`ErrorDetails` garbage still fails loudly on load instead of validating to empty dicts. `ToolRetryError._format_error_details` now renders entries without `input` instead of raising `KeyError` (reachable with a user-supplied `RetryPromptPart` via `DeferredToolResults`).

Deliberate trade-off: constructing partial entries still needs a `cast` because the static type keeps `input` required. Making it `NotRequired` statically would break existing typed user code that passes `part.content` to `list[pydantic_core.ErrorDetails]`-annotated functions (verified with pyright), so the loosening is runtime-only.

Framework-produced histories were never affected; both internal producers keep `input`. Tests cover the `include_input=False` shape, the framework shape, the full shape (JSON and python modes, `model_response()` warning-free), garbage rejection, and `ToolRetryError` formatting.

Supersedes #5990.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

