### PR TITLE
deps: bump transformers floor to 5.3.0 to close CVE-2026-4372

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ constraint-dependencies = [
     "python-multipart>=0.0.31",
     "pyjwt>=2.13.0",
     "torch>=2.12.1",
+    "transformers>=5.3.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,7 @@ constraints = [
     { name = "ray", specifier = ">=2.55.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "torch", specifier = ">=2.12.1" },
+    { name = "transformers", specifier = ">=5.3.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "vcrpy", specifier = ">=8.2.1" },
     { name = "xgrammar", specifier = ">=0.1.32" },
@@ -7548,10 +7549,9 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.0.0"
+version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
@@ -7560,11 +7560,11 @@ dependencies = [
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
-    { name = "typer-slim" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/79/845941711811789c85fb7e2599cea425a14a07eda40f50896b9d3fda7492/transformers-5.0.0.tar.gz", hash = "sha256:5f5634efed6cf76ad068cc5834c7adbc32db78bbd6211fb70df2325a9c37dec8", size = 8424830, upload-time = "2026-01-26T10:46:46.813Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/1a/70e830d53ecc96ce69cfa8de38f163712d2b43ac52fbd743f39f56025c31/transformers-5.3.0.tar.gz", hash = "sha256:009555b364029da9e2946d41f1c5de9f15e6b1df46b189b7293f33a161b9c557", size = 8830831, upload-time = "2026-03-04T17:41:46.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/f3/ac976fa8e305c9e49772527e09fbdc27cc6831b8a2f6b6063406626be5dd/transformers-5.0.0-py3-none-any.whl", hash = "sha256:587086f249ce64c817213cf36afdb318d087f790723e9b3d4500b97832afd52d", size = 10142091, upload-time = "2026-01-26T10:46:43.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/88/ae8320064e32679a5429a2c9ebbc05c2bf32cefb6e076f9b07f6d685a9b4/transformers-5.3.0-py3-none-any.whl", hash = "sha256:50ac8c89c3c7033444fb3f9f53138096b997ebb70d4b5e50a2e810bf12d3d29a", size = 10661827, upload-time = "2026-03-04T17:41:42.722Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
@
## Summary

Closes Dependabot alert [#188](https://github.com/pydantic/pydantic-ai/security/dependabot/188) — **GHSA-29pf-2h5f-8g72 / CVE-2026-4372**, a critical RCE in HuggingFace `transformers` `< 5.3.0`.

A malicious `config.json` can set `_attn_implementation_internal` to an attacker-controlled Hub repo ID; loading such a model via the standard `from_pretrained()` API then downloads and executes arbitrary Python code with the victim's privileges, **bypassing `trust_remote_code`**. First patched release is `5.3.0`.

## Change

`transformers` is a purely transitive dependency (via `sentence-transformers`), so this lifts the security floor in `constraint-dependencies` — the same pattern used for the other security-driven floors (e.g. `torch`, `urllib3`, `cryptography`). `uv lock` then pulls the resolution up from `5.0.0` to `5.3.0`.

```
Updated transformers v5.0.0 -> v5.3.0
```

Only `pyproject.toml` (one constraint line) and `uv.lock` (the `transformers` entry) change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

