### PR TITLE
ci: harden at-claude fork job against untrusted-checkout TOCTOU

### DIFF
--- a/.github/workflows/at-claude.yml
+++ b/.github/workflows/at-claude.yml
@@ -35,6 +35,7 @@ jobs:
       is_fork: ${{ steps.pr-info.outputs.is_fork }}
       pr_head_repo: ${{ steps.pr-info.outputs.pr_head_repo }}
       pr_head_sha: ${{ steps.pr-info.outputs.pr_head_sha }}
+      pr_base_sha: ${{ steps.pr-info.outputs.pr_base_sha }}
     steps:
       - name: Get PR info
         if: github.event.issue.pull_request || github.event.pull_request
@@ -44,6 +45,7 @@ jobs:
           PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${PR_NUMBER})
           echo "pr_head_repo=$(echo "$PR_DATA" | jq -r '.head.repo.full_name')" >> $GITHUB_OUTPUT
           echo "pr_head_sha=$(echo "$PR_DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
+          echo "pr_base_sha=$(echo "$PR_DATA" | jq -r '.base.sha')" >> $GITHUB_OUTPUT
           echo "is_fork=$(echo "$PR_DATA" | jq -r '.head.repo.fork')" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,8 +93,11 @@ jobs:
     if: needs.get-pr-info.outputs.is_fork == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Least privilege: on forks Claude may only read code and comment (see the
+    # restricted --allowedTools below — no push / pr create), so this job runs
+    # with read-only `contents`. It never gets write access to repository code.
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -107,15 +112,22 @@ jobs:
           persist-credentials: false
 
       - name: Check for modified config files
+        # Compare the exact immutable SHAs captured in get-pr-info (and checked
+        # out above) rather than the live PR head. Using `gh pr diff` would read
+        # whatever the PR points at now, so a force-push after get-pr-info could
+        # slip a modified CLAUDE.md/AGENTS.md past this guard while different
+        # code is what actually runs (TOCTOU). Pinning to BASE_SHA...HEAD_SHA
+        # ties the check to the code Claude will see.
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number || github.event.issue.number }}
-          CHANGED=$(gh pr diff "$PR_NUMBER" --name-only --repo ${{ github.repository }})
+          CHANGED=$(gh api --paginate "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}" --jq '.files[].filename')
           if echo "$CHANGED" | grep -qiE '(^|/)AGENTS\.md$|(^|/)CLAUDE\.md$|(^|/)\.claude/'; then
             echo "::error::PR modifies agent config files (AGENTS.md, CLAUDE.md, or .claude/). Skipping for security."
             exit 1
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ needs.get-pr-info.outputs.pr_base_sha }}
+          HEAD_SHA: ${{ needs.get-pr-info.outputs.pr_head_sha }}
 
       - name: Install bubblewrap
         run: sudo apt-get install -y bubblewrap

--- a/.github/workflows/at-claude.yml
+++ b/.github/workflows/at-claude.yml
@@ -118,9 +118,15 @@ jobs:
         # slip a modified CLAUDE.md/AGENTS.md past this guard while different
         # code is what actually runs (TOCTOU). Pinning to BASE_SHA...HEAD_SHA
         # ties the check to the code Claude will see.
+        #
+        # Use the diff media type, not the compare JSON: the JSON `.files` array
+        # is capped at 300 entries (and `--paginate` only pages commits, not
+        # files), so a >300-file PR could hide an agent-config edit. The diff
+        # emits a `diff --git a/<old> b/<new>` header for every changed file,
+        # including renames, so matching those lines cannot miss a path.
         run: |
-          CHANGED=$(gh api --paginate "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}" --jq '.files[].filename')
-          if echo "$CHANGED" | grep -qiE '(^|/)AGENTS\.md$|(^|/)CLAUDE\.md$|(^|/)\.claude/'; then
+          CHANGED=$(gh api "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}" -H 'Accept: application/vnd.github.v3.diff' | grep '^diff --git ')
+          if echo "$CHANGED" | grep -qiE '/(AGENTS\.md|CLAUDE\.md)( |$)|/\.claude/'; then
             echo "::error::PR modifies agent config files (AGENTS.md, CLAUDE.md, or .claude/). Skipping for security."
             exit 1
           fi


### PR DESCRIPTION
## Summary

Addresses the two open [code-scanning alerts](https://github.com/pydantic/pydantic-ai/security/code-scanning) on `.github/workflows/at-claude.yml`, both on the `at-claude-fork` job:

- **#21** `actions/untrusted-checkout-toctou/high` — Untrusted Checkout TOCTOU
- **#22** `actions/untrusted-checkout/high` — Checkout of untrusted code in a privileged context

### Threat

`at-claude-fork` checks out untrusted fork-PR code and runs `claude-code-action` with a write-scoped token and `ANTHROPIC_API_KEY`. A `CLAUDE.md`/`AGENTS.md`/`.claude/` guard exists to stop a fork PR from injecting agent instructions — but it read the **live** PR diff via `gh pr diff`, while the checkout uses the immutable `pr_head_sha` captured earlier in `get-pr-info`. A force-push between those two points makes the guard evaluate a *different* commit than the one Claude actually runs (**TOCTOU**), bypassing it.

### Changes

- **Fix the TOCTOU (#21):** the guard now diffs the exact immutable `BASE_SHA...HEAD_SHA` (the same SHA that is checked out) via the compare API, so the check covers precisely the code Claude will see. SHAs are passed through `env` rather than inlined into the run block. Adds a `pr_base_sha` output to `get-pr-info`. *(Verified the compare API resolves fork head SHAs against the base repo for open PRs.)*
- **Least privilege (#22 blast radius):** the fork job drops to `contents: read`. Its restricted `--allowedTools` only read code and post comments (no `git push` / `gh pr create`), so it never needs write access to repository code.

### Note on alert #22

Reducing permissions shrinks the blast radius but does not fully clear #22 — the alert is inherent to running an agent over fork code with secrets present, and the usual `pull_request` → `workflow_run` split doesn't fit an interactive agent that must both read the untrusted code and comment in one flow. The residual risk is held down by the existing compensating controls (author-association gate, the now-hardened config guard, restricted tools, and bubblewrap sandboxing). Fully resolving #22 is likely a **dismiss-with-justification** decision rather than a code change — happy to do that separately if you agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

