### PR TITLE
fix: handle boolean JSON Schema nodes in function signature walker

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/function_signature.py
+++ b/pydantic_ai_slim/pydantic_ai/function_signature.py
@@ -479,13 +479,30 @@ def _path_to_typename(tool_name: str, path: str) -> str:
     return ''.join(_to_pascal_case(p) for p in parts)
 
 
+def _normalize_schema_node(node: dict[str, Any] | bool) -> dict[str, Any]:
+    """Normalize a JSON Schema node to a dict.
+
+    Per the JSON Schema spec, `True` and `False` are valid schemas anywhere a schema may
+    appear (most commonly as `additionalProperties`, but also as a property value or an
+    `allOf`/`anyOf`/`oneOf`/`items`/`$defs` member). `True` permits any value and `False`
+    permits none; neither maps to a precise Python type here, so both collapse to an empty
+    schema, which the walker renders as `Any` — the practical fallback for the model.
+    Non-bool nodes are returned unchanged.
+
+    Called at every point where a nested node may be a raw schema, so no walker has to
+    special-case the boolean form.
+    """
+    return {} if isinstance(node, bool) else node
+
+
 def _process_schema_defs(
     defs: dict[str, dict[str, Any]],
     referenced_types: dict[str, TypeSignature],
     tool_name: str,
 ) -> None:
     """Process $defs from a JSON schema, adding TypeSignatures for object-type definitions."""
-    for def_name, def_schema in defs.items():
+    for def_name, def_schema_raw in defs.items():
+        def_schema = _normalize_schema_node(def_schema_raw)
         if def_schema.get('type') == 'object' and 'properties' in def_schema:
             if def_name not in referenced_types:
                 _build_and_register_type(def_name, def_schema, defs, referenced_types, tool_name, def_name)
@@ -504,7 +521,8 @@ def _build_params_from_schema(
     required_params: dict[str, FunctionParam] = {}
     optional_params: dict[str, FunctionParam] = {}
 
-    for prop_name, prop_schema in properties.items():
+    for prop_name, prop_schema_raw in properties.items():
+        prop_schema = _normalize_schema_node(prop_schema_raw)
         type_expr = _schema_to_type_expr(prop_schema, defs, referenced_types, tool_name, prop_name)
 
         if 'default' in prop_schema:
@@ -529,27 +547,29 @@ def _schema_allows_null(schema: dict[str, Any]) -> bool:
     if isinstance(schema_type, list) and 'null' in schema_type:
         return True
     if 'anyOf' in schema:
-        return any(s.get('type') == 'null' for s in schema['anyOf'])
+        return any(_normalize_schema_node(s).get('type') == 'null' for s in schema['anyOf'])
     if 'oneOf' in schema:
-        return any(s.get('type') == 'null' for s in schema['oneOf'])
+        return any(_normalize_schema_node(s).get('type') == 'null' for s in schema['oneOf'])
     return False
 
 
 def _schema_to_type_expr(
-    schema: dict[str, Any],
+    schema: dict[str, Any] | bool,
     defs: dict[str, dict[str, Any]],
     referenced_types: dict[str, TypeSignature],
     tool_name: str,
     path: str,
 ) -> TypeExpr:
     """Convert a JSON schema to a TypeExpr."""
+    schema = _normalize_schema_node(schema)
+
     # Handle $ref
     if '$ref' in schema:
         ref = schema['$ref']
         ref_name = ref.split('/')[-1]
         # Ensure referenced def generates TypeSignature if needed
         if ref_name in defs and ref_name not in referenced_types:
-            ref_schema = defs[ref_name]
+            ref_schema = _normalize_schema_node(defs[ref_name])
             if ref_schema.get('type') == 'object' and 'properties' in ref_schema:
                 _build_and_register_type(ref_name, ref_schema, defs, referenced_types, tool_name, path)
         # Return the TypeSignature object if available, otherwise the name
@@ -677,7 +697,8 @@ def _handle_union_schema(
     type_exprs: list[TypeExpr] = []
     has_null = False
 
-    for s in schemas:
+    for s_raw in schemas:
+        s = _normalize_schema_node(s_raw)
         if s.get('type') == 'null':
             has_null = True
         else:
@@ -737,7 +758,8 @@ def _build_type_signature(
 
     fields: dict[str, TypeFieldSignature] = {}
 
-    for prop_name, prop_schema in properties.items():
+    for prop_name, prop_schema_raw in properties.items():
+        prop_schema = _normalize_schema_node(prop_schema_raw)
         prop_path = f'{path}.{prop_name}' if path else prop_name
         type_expr = _schema_to_type_expr(prop_schema, defs, referenced_types, tool_name, prop_path)
         is_required = prop_name in required

--- a/pydantic_ai_slim/pydantic_ai/function_signature.py
+++ b/pydantic_ai_slim/pydantic_ai/function_signature.py
@@ -484,9 +484,10 @@ def _normalize_schema_node(node: dict[str, Any] | bool) -> dict[str, Any]:
 
     Per the JSON Schema spec, `True` and `False` are valid schemas anywhere a schema may
     appear (most commonly as `additionalProperties`, but also as a property value or an
-    `allOf`/`anyOf`/`oneOf`/`items`/`$defs` member). `True` permits any value and `False`
-    permits none; neither maps to a precise Python type here, so both collapse to an empty
-    schema, which the walker renders as `Any` — the practical fallback for the model.
+    `allOf`/`anyOf`/`oneOf`/`items`/`$defs` member). `True` (equivalent to `{}`) permits any
+    value; `False` permits none and is *not* equivalent to `{}`. Neither the "anything" nor
+    the "nothing" case maps to a precise Python type here, so we deliberately collapse both to
+    an empty schema, which the walker renders as `Any` — the practical fallback for the model.
     Non-bool nodes are returned unchanged.
 
     Called at every point where a nested node may be a raw schema, so no walker has to
@@ -687,7 +688,7 @@ def _type_list_to_expr(
 
 
 def _handle_union_schema(
-    schemas: list[dict[str, Any]],
+    schemas: list[dict[str, Any] | bool],
     defs: dict[str, dict[str, Any]],
     referenced_types: dict[str, TypeSignature],
     tool_name: str,

--- a/tests/test_function_signature.py
+++ b/tests/test_function_signature.py
@@ -1432,3 +1432,106 @@ def test_render_empty_type_signature():
     # Empty with description renders docstring but no pass
     ts_with_desc = TypeSignature(name='Marker', description='A marker type')
     assert ts_with_desc.render_definition() == 'class Marker(TypedDict):\n    """A marker type"""'
+
+
+# Boolean JSON Schema nodes (`True`/`False` are valid schemas per spec, and surface from
+# e.g. MCP tool schemas). Each test below exercises a distinct walker entry point that would
+# otherwise index into a bool. See `_normalize_schema_node`.
+
+
+def test_boolean_property_schema_renders_as_any():
+    """A property whose schema is the bare boolean `True` renders as `Any` instead of crashing."""
+    sig = FunctionSignature.from_schema(
+        name='passthrough',
+        parameters_schema={
+            'type': 'object',
+            'properties': {'anything': True},
+            'required': ['anything'],
+        },
+    )
+    assert str(sig.params['anything'].type) == 'Any'
+
+
+def test_boolean_array_items_render_as_list_any():
+    """`items: True` (any element allowed) recurses with a bool and renders as `list[Any]`."""
+    sig = FunctionSignature.from_schema(
+        name='collect',
+        parameters_schema={
+            'type': 'object',
+            'properties': {'arr': {'type': 'array', 'items': True}},
+            'required': ['arr'],
+        },
+    )
+    assert str(sig.params['arr'].type) == 'list[Any]'
+
+
+def test_boolean_allof_member_renders_as_any():
+    """A single-member `allOf: [True]` recurses into `_schema_to_type_expr` with a bool."""
+    sig = FunctionSignature.from_schema(
+        name='allof_tool',
+        parameters_schema={
+            'type': 'object',
+            'properties': {'value': {'allOf': [True]}},
+            'required': ['value'],
+        },
+    )
+    assert str(sig.params['value'].type) == 'Any'
+
+
+def test_boolean_anyof_member_renders():
+    """A bool member inside `anyOf` is inspected (`.get('type')`) before recursion and must not crash."""
+    sig = FunctionSignature.from_schema(
+        name='anyof_tool',
+        parameters_schema={
+            'type': 'object',
+            'properties': {'value': {'anyOf': [True, {'type': 'null'}]}},
+            'required': ['value'],
+        },
+    )
+    assert str(sig.params['value'].type) == 'Any | None'
+
+
+def test_boolean_nested_object_property_renders_as_any():
+    """A bare-boolean property inside a NESTED object hits the `_build_type_signature` walker."""
+    sig = FunctionSignature.from_schema(
+        name='outer',
+        parameters_schema={
+            'type': 'object',
+            'properties': {'nested': {'type': 'object', 'properties': {'x': True}}},
+            'required': ['nested'],
+        },
+    )
+    nested = next(t for t in sig.referenced_types if 'x' in t.fields)
+    assert str(nested.fields['x'].type) == 'Any'
+
+
+def test_boolean_def_schema_does_not_crash():
+    """A bare-boolean `$defs` entry (referenced via `$ref`) must not crash `_process_schema_defs`."""
+    sig = FunctionSignature.from_schema(
+        name='defs_tool',
+        parameters_schema={
+            'type': 'object',
+            'properties': {'value': {'$ref': '#/$defs/Anything'}},
+            'required': ['value'],
+            '$defs': {'Anything': True},
+        },
+    )
+    assert 'value' in sig.params
+
+
+def test_boolean_additional_properties_render_as_dict_any():
+    """`additionalProperties: True`/`False` on an object render as `dict[str, Any]`.
+
+    Unlike the cases above these never crashed (the object branch reads the value directly),
+    but the assertion documents the rendered shape and guards against regressions.
+    """
+    for value in (True, False):
+        sig = FunctionSignature.from_schema(
+            name='cfg',
+            parameters_schema={
+                'type': 'object',
+                'properties': {'meta': {'type': 'object', 'additionalProperties': value}},
+                'required': ['meta'],
+            },
+        )
+        assert str(sig.params['meta'].type) == 'dict[str, Any]'


### PR DESCRIPTION
## Summary

`True` and `False` are valid JSON Schema nodes anywhere a schema may appear — most commonly as `additionalProperties`, but also as a property value or an `allOf`/`anyOf`/`oneOf`/`items`/`$defs` member. The signature walker in `function_signature.py` assumes every node is a `dict` and does `'$ref' in schema` / `prop_schema.get(...)`, which raises `TypeError` / `AttributeError` when it hits a bool.

This is the same bug shape as #4771 / #4989 (fixed in `_json_schema.py`), now in the second walker.

### Why it matters (real, reproducible path)

The `function_signature` walker is consumed by **code mode** ([`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness) `CodeMode`), which renders tools as callable Python signatures. Any code-mode user whose tools carry a boolean schema node — realistically a third-party **MCP server** the user doesn't control — gets a hard crash on every run:

```
TypeError: argument of type 'bool' is not a container or iterable
  File "pydantic_ai/function_signature.py", line 547, in _schema_to_type_expr
    if '$ref' in schema:
```

Verified end-to-end against `CodeMode()` + a tool registered via `Tool.from_schema` (the same pass-through path MCP uses).

## Changes

Add a single `_normalize_schema_node(node) -> dict` helper that collapses a bool node to `{}` (rendered downstream as `Any` — the practical fallback, since neither "anything" nor "nothing" maps to a precise Python type here). It is applied at **every** walker entry point where a raw node can arrive, so no future walker has to special-case the boolean form:

- `_build_params_from_schema` — top-level property values
- `_build_type_signature` — nested-object property values
- `_schema_to_type_expr` — the central recursion boundary (covers `allOf`/`items` recursion and `$ref` targets)
- `_handle_union_schema` — `anyOf`/`oneOf` members (inspected via `.get('type')` before recursion)
- `_schema_allows_null` — `anyOf`/`oneOf` members
- `_process_schema_defs` — `$defs` entries

## Tests

Seven regression tests, one per entry point, each asserting the concrete rendered type (e.g. `Any`, `list[Any]`, `Any | None`): bare property value, array `items`, `allOf` member, `anyOf` member, **nested-object property**, `$defs` entry, plus a behaviour guard for `additionalProperties: True/False → dict[str, Any]`. Six of them fail on `main` without the fix (the `additionalProperties` one already worked and is a behaviour guard).

## Relationship to #5346

This supersedes #5346, which addresses the same underlying bug but (a) attributes it to `additionalProperties: true` — a case that actually renders fine, so two of its four tests pass without the fix — and (b) patches only two of the walker entry points, leaving nested-object boolean properties (`_build_type_signature`) still crashing. This PR takes #5346's own suggested `_normalize_schema_node` approach and applies it everywhere. Thanks to @P0rth0s for the original report and diagnosis.

## Verified locally

- `ruff format --check`, `ruff check`, `pyright` — all clean
- `pytest tests/test_function_signature.py tests/test_toolsets.py` — 159 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

