### PR TITLE
Process `StopRun` outputs through the output pipeline

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1306,7 +1306,7 @@ print(result.output)
 #> stopped early
 ```
 
-The `output` is run through the agent's [output validators](output.md#output-validator-functions) (the same ones a model-produced output would run through) and becomes the run's final output, with no further model request. It is used as-is after the validators run, so pass a value of the correct [output type](output.md). Any tool results produced so far in the current step are preserved in the [message history](message-history.md). If a validator rejects the value — including by raising [`ModelRetry`][pydantic_ai.exceptions.ModelRetry], which for a model-produced output would normally trigger a retry — the error propagates to you rather than silently continuing the run, since there is no further model request to retry against.
+The `output` is treated as the semantic final-output value, validated/coerced against the agent's [output type](output.md), and run through output hooks, output functions, and [output validators](output.md#output-validator-functions) before becoming the run's final output, with no further model request. For example, use `StopRun(1)` with `output_type=int`; you do not need to pass the internal structured-output wrapper shape a model provider might use. Any tool results produced so far in the current step are preserved in the [message history](message-history.md). If validation or a hook/validator rejects the value — including by raising [`ModelRetry`][pydantic_ai.exceptions.ModelRetry], which for a model-produced output would normally trigger a retry — the error propagates to you rather than silently continuing the run, since there is no further model request to retry against.
 
 #### Model request hooks
 

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1363,6 +1363,8 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
             output_data = await _output.run_stop_run_output(
                 e.output,
                 run_context=run_context,
+                capability=ctx.deps.root_capability,
+                schema=ctx.deps.output_schema,
                 output_validators=ctx.deps.output_validators,
             )
             self._next_node = self._handle_final_result(

--- a/pydantic_ai_slim/pydantic_ai/_output.py
+++ b/pydantic_ai_slim/pydantic_ai/_output.py
@@ -70,6 +70,7 @@ Usage `OutputValidatorFunc[AgentDepsT, T]`.
 
 DEFAULT_OUTPUT_TOOL_NAME = 'final_result'
 DEFAULT_OUTPUT_TOOL_DESCRIPTION = 'The final response which ends this conversation'
+_STR_TYPE_ADAPTER = TypeAdapter(str)
 
 
 def _build_output_handlers(
@@ -307,20 +308,208 @@ async def run_stop_run_output(
     output: Any,
     *,
     run_context: RunContext[AgentDepsT],
+    capability: AbstractCapability[AgentDepsT],
+    schema: OutputSchema[Any],
     output_validators: Sequence[OutputValidator[AgentDepsT, Any]] = (),
 ) -> Any:
-    """Validate an already-constructed output value from `StopRun` and run output validators.
+    """Validate a semantic output value from `StopRun` and run the normal output pipeline.
 
-    Unlike the text/structured/image output paths there is nothing to parse: the value is
-    already the agent's output type, so it is passed through the same output validators
-    (`@agent.output_validator`) that a model-produced output would run through, then returned.
+    Unlike model-produced output, `StopRun` receives the semantic value the caller wants to
+    use as final output, not the provider-facing transport shape. For example, use `StopRun(1)`
+    for `output_type=int`, not `StopRun({'response': 1})`.
 
-    An output validator raising `ModelRetry` propagates as an error rather than triggering a
-    model retry: the run is being stopped, so there is no further model request to retry against.
+    The value is still validated/coerced against the agent's output type, passed through output
+    validate/process hooks, output functions, and output validators. Validation errors and
+    `ModelRetry` propagate rather than triggering a model retry: the run is being stopped, so
+    there is no further model request to retry against.
     """
-    for validator in output_validators:
-        output = await validator.validate(output, run_context)
+    if output is None and schema.allows_none:
+        return await run_none_process_hooks(
+            capability=capability,
+            run_context=run_context,
+            schema=schema,
+            wrap_validation_errors=False,
+            output_validators=output_validators,
+        )
+
+    if isinstance(output, _messages.BinaryImage) and schema.allows_image:
+        return await run_image_process_hooks(
+            output,
+            capability=capability,
+            run_context=run_context,
+            schema=schema,
+            wrap_validation_errors=False,
+            output_validators=output_validators,
+        )
+
+    processor, mode = _stop_run_output_processor(output, schema=schema, run_context=run_context)
+    return await _run_semantic_output_with_hooks(
+        processor,
+        output=output,
+        run_context=run_context,
+        capability=capability,
+        schema=schema,
+        mode=mode,
+        output_validators=output_validators,
+    )
+
+
+def _stop_run_output_processor(
+    output: Any,
+    *,
+    schema: OutputSchema[Any],
+    run_context: RunContext[AgentDepsT],
+) -> tuple[BaseOutputProcessor[Any], OutputMode | None]:
+    if schema.text_processor is not None and schema.mode != 'tool':
+        return schema.text_processor, None
+
+    if schema.text_processor is not None:
+        try:
+            _validate_semantic_stop_run_output(schema.text_processor, output, run_context=run_context)
+        except (TypeError, ValueError, ValidationError):
+            pass
+        else:
+            return schema.text_processor, None
+
+    if schema.toolset is not None:
+        return _select_stop_run_output_tool_processor(output, schema=schema, run_context=run_context), 'tool'
+
+    if schema.text_processor is not None:
+        return schema.text_processor, None
+
+    raise ValueError('`StopRun` output does not match the agent output type.')
+
+
+def _select_stop_run_output_tool_processor(
+    output: Any,
+    *,
+    schema: OutputSchema[Any],
+    run_context: RunContext[AgentDepsT],
+) -> BaseOutputProcessor[Any]:
+    assert schema.toolset is not None
+    matches: list[tuple[str, BaseOutputProcessor[Any]]] = []
+    first_error: Exception | None = None
+    for tool_name, processor in schema.toolset.processors.items():
+        try:
+            _validate_semantic_stop_run_output(processor, output, run_context=run_context)
+        except (TypeError, ValueError, ValidationError) as e:
+            if first_error is None:
+                first_error = e
+        else:
+            matches.append((tool_name, processor))
+
+    if len(matches) == 1:
+        return matches[0][1]
+    if len(matches) > 1:
+        tool_names = ', '.join(repr(tool_name) for tool_name, _ in matches)
+        raise ValueError(f'`StopRun` output matches multiple output tools: {tool_names}.')
+    if first_error is not None:
+        raise first_error
+    raise ValueError('`StopRun` output does not match any output tool.')
+
+
+async def _run_semantic_output_with_hooks(
+    processor: BaseOutputProcessor[Any],
+    *,
+    output: Any,
+    run_context: RunContext[AgentDepsT],
+    capability: AbstractCapability[AgentDepsT],
+    schema: OutputSchema[Any],
+    mode: OutputMode | None,
+    output_validators: Sequence[OutputValidator[AgentDepsT, Any]],
+) -> Any:
+    output_context = processor.get_output_context(schema, mode=mode)
+    state: Any = None
+
+    async def do_validate(output: Any) -> Any:
+        nonlocal state
+        semantic, state = _validate_semantic_stop_run_output(processor, output, run_context=run_context)
+        return semantic
+
+    async def do_process(output: Any) -> Any:
+        result = await processor.hook_execute(
+            output,
+            state,
+            run_context=run_context,
+            wrap_validation_errors=False,
+        )
+        for validator in output_validators:
+            result = await validator.validate(result, run_context)
+        return result
+
+    if isinstance(processor, BaseObjectOutputProcessor):
+        validated = await run_output_validate_hooks(
+            capability,
+            run_context=run_context,
+            output_context=output_context,
+            output=output,
+            do_validate=do_validate,
+            wrap_validation_errors=False,
+        )
+    else:
+        validated, state = _validate_semantic_stop_run_output(processor, output, run_context=run_context)
+
+    return await run_output_process_hooks(
+        capability,
+        run_context=run_context,
+        output_context=output_context,
+        output=validated,
+        do_process=do_process,
+        wrap_validation_errors=False,
+    )
+
+
+def _validate_semantic_stop_run_output(
+    processor: BaseOutputProcessor[Any],
+    output: Any,
+    *,
+    run_context: RunContext[AgentDepsT],
+) -> tuple[Any, Any]:
+    if isinstance(processor, ObjectOutputProcessor):
+        return processor.hook_validate(
+            _raw_output_from_semantic_value(processor, output),
+            run_context=run_context,
+        )
+    if isinstance(processor, UnionOutputProcessor):
+        return _validate_union_semantic_stop_run_output(processor, output, run_context=run_context)
+    if isinstance(processor, TextOutputProcessor):
+        return _STR_TYPE_ADAPTER.validate_python(output), None
+    return output, None
+
+
+def _raw_output_from_semantic_value(processor: ObjectOutputProcessor[Any], output: Any) -> Any:
+    if (key := processor.hook_unwrap_key) is not None:
+        return {key: output}
     return output
+
+
+def _validate_union_semantic_stop_run_output(
+    processor: UnionOutputProcessor[Any],
+    output: Any,
+    *,
+    run_context: RunContext[AgentDepsT],
+) -> tuple[Any, str]:
+    matches: list[_UnionValidatedOutput] = []
+    first_error: Exception | None = None
+
+    for kind, inner in processor._processors.items():  # pyright: ignore[reportPrivateUsage]
+        try:
+            semantic, _ = _validate_semantic_stop_run_output(inner, output, run_context=run_context)
+        except (TypeError, ValueError, ValidationError) as e:
+            if first_error is None:
+                first_error = e
+        else:
+            matches.append(_UnionValidatedOutput(kind=kind, data=semantic))
+
+    if len(matches) == 1:
+        match = matches[0]
+        return match.data, match.kind
+    if len(matches) > 1:
+        kinds = ', '.join(repr(match.kind) for match in matches)
+        raise ValueError(f'`StopRun` output matches multiple output types: {kinds}.')
+    if first_error is not None:
+        raise first_error
+    raise ValueError('`StopRun` output does not match any output type.')
 
 
 async def run_output_with_hooks(

--- a/pydantic_ai_slim/pydantic_ai/exceptions.py
+++ b/pydantic_ai_slim/pydantic_ai/exceptions.py
@@ -85,17 +85,14 @@ class StopRun(Exception):
     `after_tool_execute`), or a node hook (`wrap_node_run`, `after_node_run`, `on_node_run_error`).
     It is *not* handled when raised from `before_node_run` — raise it from `wrap_node_run` instead.
 
-    The provided `output` is run through the agent's output validators (the same ones a
-    model-produced output would run through) and becomes the run's final output without another
-    model request. Any tool call results produced so far in the current step are preserved in the
-    message history.
-
-    Note: `output` is used as-is after the validators run; it is not re-validated or coerced against
-    the agent's output type, so it is your responsibility to pass a value of the correct type.
+    The provided `output` is treated as the semantic final-output value, validated/coerced against
+    the agent's output type, and run through output hooks, output functions, and output validators
+    before becoming the run's final output without another model request. Any tool call results
+    produced so far in the current step are preserved in the message history.
     """
 
     output: Any
-    """The value to use as the run's final output, after the output validators run."""
+    """The semantic value to validate and use as the run's final output."""
 
     def __init__(self, output: Any):
         self.output = output

--- a/pydantic_ai_slim/pydantic_ai/run.py
+++ b/pydantic_ai_slim/pydantic_ai/run.py
@@ -322,6 +322,8 @@ class AgentRun(Generic[AgentDepsT, OutputDataT]):
             output_data = await _output.run_stop_run_output(
                 e.output,
                 run_context=run_context,
+                capability=self.ctx.deps.root_capability,
+                schema=self.ctx.deps.output_schema,
                 output_validators=self.ctx.deps.output_validators,
             )
             end = End(FinalResult(output_data))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, Union
 
 import pytest
 from dirty_equals import IsJson
-from pydantic import BaseModel, TypeAdapter, field_validator
+from pydantic import BaseModel, TypeAdapter, ValidationError, field_validator
 from pydantic_core import ErrorDetails, to_json
 from typing_extensions import Self
 
@@ -12375,6 +12375,86 @@ async def test_stop_run_structured_output():
     assert result.output == Result(answer=42)
 
 
+async def test_stop_run_coerces_structured_output():
+    """A plain semantic value passed to `StopRun` is coerced against `output_type`.
+
+    Uses `FunctionModel` (not VCR): it pins the local StopRun output pipeline rather than
+    provider-specific structured-output behavior.
+    """
+
+    class Result(BaseModel):
+        answer: int
+
+    def call_stop(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ToolCallPart('stop', {})])
+
+    agent = Agent(FunctionModel(call_stop), output_type=Result)
+
+    @agent.tool_plain
+    def stop() -> None:
+        raise StopRun({'answer': '42'})
+
+    result = await agent.run('go')
+    assert result.output == Result(answer=42)
+
+
+async def test_stop_run_coerces_primitive_output():
+    """Primitive output types do not require Pydantic AI's internal transport wrapper."""
+
+    def call_stop(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ToolCallPart('stop', {})])
+
+    agent = Agent(FunctionModel(call_stop), output_type=int)
+
+    @agent.tool_plain
+    def stop() -> None:
+        raise StopRun('42')
+
+    result = await agent.run('go')
+    assert result.output == 42
+
+
+async def test_stop_run_runs_output_function():
+    """Output functions run on a `StopRun` semantic value before the final result is committed."""
+
+    class Result(BaseModel):
+        answer: int
+
+    def build_result(answer: int) -> Result:
+        return Result(answer=answer + 1)
+
+    def call_stop(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ToolCallPart('stop', {})])
+
+    agent = Agent(FunctionModel(call_stop), output_type=build_result)
+
+    @agent.tool_plain
+    def stop() -> None:
+        raise StopRun('41')
+
+    result = await agent.run('go')
+    assert result.output == Result(answer=42)
+
+
+async def test_stop_run_coerces_tool_output():
+    """Pure `ToolOutput` schemas validate a `StopRun` semantic value without a tool call wrapper."""
+
+    class Result(BaseModel):
+        answer: int
+
+    def call_stop(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ToolCallPart('stop', {})])
+
+    agent = Agent(FunctionModel(call_stop), output_type=ToolOutput(Result))
+
+    @agent.tool_plain
+    def stop() -> None:
+        raise StopRun({'answer': '42'})
+
+    result = await agent.run('go')
+    assert result.output == Result(answer=42)
+
+
 async def test_stop_run_runs_output_validators():
     """Output validators run on a `StopRun` output, transforming it just like a model-produced output.
 
@@ -12399,6 +12479,33 @@ async def test_stop_run_runs_output_validators():
     assert result.output == 'HELLO'
 
 
+async def test_stop_run_runs_output_process_hooks():
+    """Output process hooks wrap the `StopRun` output pipeline."""
+
+    @dataclass
+    class ProcessHookCapability(AbstractCapability[Any]):
+        async def after_output_process(
+            self,
+            ctx: RunContext[Any],
+            *,
+            output_context: Any,
+            output: Any,
+        ) -> Any:
+            return f'{output} processed'
+
+    def call_stop(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ToolCallPart('stop', {})])
+
+    agent = Agent(FunctionModel(call_stop), output_type=str, capabilities=[ProcessHookCapability()])
+
+    @agent.tool_plain
+    def stop() -> None:
+        raise StopRun('hello')
+
+    result = await agent.run('go')
+    assert result.output == 'hello processed'
+
+
 async def test_stop_run_validation_error_propagates():
     """An output validator rejecting a `StopRun` output propagates the error instead of continuing.
 
@@ -12420,6 +12527,25 @@ async def test_stop_run_validation_error_propagates():
         raise StopRun('hello')
 
     with pytest.raises(ValueError, match='rejected'):
+        await agent.run('go')
+
+
+async def test_stop_run_output_type_validation_error_propagates():
+    """Schema validation failures from `StopRun` propagate instead of retrying the model."""
+
+    class Result(BaseModel):
+        answer: int
+
+    def call_stop(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[ToolCallPart('stop', {})])
+
+    agent = Agent(FunctionModel(call_stop), output_type=Result)
+
+    @agent.tool_plain
+    def stop() -> None:
+        raise StopRun({'answer': 'not an int'})
+
+    with pytest.raises(ValidationError):
         await agent.run('go')
 
 


### PR DESCRIPTION
- Closes #6243

### Summary

Stacked on #6257 (`commit-final-output`). This makes `StopRun(output)` treat `output` as the semantic final-output value and run it through the normal output pipeline: output type validation/coercion, output validate/process hooks, output functions, and output validators.

This keeps Code Mode and similar capabilities from needing app-level magic output envelopes while still preserving the tool-return history behavior from #6257.

### Tests

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_agent.py -k stop_run`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pyright pydantic_ai_slim/pydantic_ai/_output.py pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/run.py tests/test_agent.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check pydantic_ai_slim/pydantic_ai/_output.py pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/run.py tests/test_agent.py docs/capabilities.md pydantic_ai_slim/pydantic_ai/exceptions.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check pydantic_ai_slim/pydantic_ai/_output.py pydantic_ai_slim/pydantic_ai/_agent_graph.py pydantic_ai_slim/pydantic_ai/run.py tests/test_agent.py pydantic_ai_slim/pydantic_ai/exceptions.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

