### PR TITLE
fix(agent): skip tool calls when NativeOutput is ready with end_strategy=early

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1290,6 +1290,17 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                     # and a tool call response, where the text response just indicates the tool call will happen.
                     alternatives: list[str] = []
                     if tool_calls:
+                        if (
+                            text
+                            and output_schema.mode == 'native'
+                            and ctx.deps.end_strategy == 'early'
+                            and (text_processor := output_schema.text_processor)
+                        ):
+                            try:
+                                self._next_node = await self._handle_text_response(ctx, text, text_processor)
+                                return
+                            except ToolRetryError:
+                                pass
                         async for event in self._handle_tool_calls(ctx, tool_calls):
                             yield event
                         return

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4427,6 +4427,58 @@ class TestMultipleToolCalls:
             ]
         )
 
+    def test_early_strategy_prefers_native_output_over_function_tools(self):
+        """NativeOutput + early should skip function tools when native output is already valid."""
+        tool_called: list[str] = []
+
+        class Answer(BaseModel):
+            answer: str
+
+        request_count = 0
+
+        def return_model(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            nonlocal request_count
+            request_count += 1
+            if request_count == 1:
+                return ModelResponse(
+                    parts=[
+                        TextPart(
+                            content=json.dumps(
+                                {'result': {'kind': 'Answer', 'data': {'answer': 'done'}}},
+                            ),
+                        ),
+                        ToolCallPart(
+                            tool_name='search',
+                            args={'q': 'x'},
+                            tool_call_id='call_1',
+                        ),
+                    ],
+                )
+            return ModelResponse(
+                parts=[
+                    TextPart(
+                        content=json.dumps(
+                            {'result': {'kind': 'Answer', 'data': {'answer': 'done'}}},
+                        ),
+                    ),
+                ],
+            )
+
+        agent = Agent(
+            FunctionModel(return_model),
+            output_type=NativeOutput(Answer),
+            end_strategy='early',
+        )
+
+        @agent.tool_plain
+        def search(q: str) -> str:  # pragma: no cover
+            tool_called.append(q)
+            return 'results'
+
+        result = agent.run_sync('test native early strategy')
+        assert result.output == Answer(answer='done')
+        assert tool_called == []
+
     def test_early_strategy_does_not_call_additional_output_tools(self):
         """Test that 'early' strategy does not execute additional output tool functions."""
         output_tools_called: list[str] = []


### PR DESCRIPTION
Fixes #6277

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

