### PR TITLE
fix(gateway): preserve HTTPX event hooks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/gateway.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/gateway.py
@@ -12,6 +12,8 @@ import httpx
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
 
+_GATEWAY_REQUEST_HOOK = '_pydantic_ai_gateway_request_hook'
+
 if TYPE_CHECKING:
     from botocore.client import BaseClient
     from google.genai import Client as GoogleClient
@@ -167,11 +169,11 @@ def gateway_provider(
 
     own_http_client = http_client is None
     http_client = http_client or create_async_http_client()
-    http_client.event_hooks = {'request': [_request_hook(api_key)]}
+    _add_request_hook(http_client, _request_hook(api_key))
 
     def _http_client_factory() -> httpx.AsyncClient:
         client = create_async_http_client()
-        client.event_hooks = {'request': [_request_hook(api_key)]}
+        _add_request_hook(client, _request_hook(api_key))
         return client
 
     def _with_http_client(provider: Provider[Any]) -> Provider[Any]:
@@ -227,7 +229,21 @@ def _request_hook(api_key: str) -> Callable[[httpx.Request], Awaitable[httpx.Req
 
         return request
 
+    setattr(_hook, _GATEWAY_REQUEST_HOOK, True)
     return _hook
+
+
+def _add_request_hook(
+    http_client: httpx.AsyncClient, hook: Callable[[httpx.Request], Awaitable[httpx.Request]]
+) -> None:
+    """Add a request hook without replacing caller-provided HTTPX hooks."""
+    request_hooks = [
+        existing_hook
+        for existing_hook in http_client.event_hooks.setdefault('request', [])
+        if not getattr(existing_hook, _GATEWAY_REQUEST_HOOK, False)
+    ]
+    request_hooks.append(hook)
+    http_client.event_hooks['request'] = request_hooks
 
 
 def _merge_url_path(base_url: str, path: str) -> str:

--- a/tests/providers/test_gateway.py
+++ b/tests/providers/test_gateway.py
@@ -72,6 +72,52 @@ async def test_init_with_http_client():
         assert provider.client._client == http_client  # type: ignore
 
 
+async def test_init_with_http_client_preserves_existing_event_hooks():
+    async def existing_request_hook(request: httpx.Request) -> None:
+        request.headers['X-Existing-Request-Hook'] = 'kept'
+
+    async def existing_response_hook(response: httpx.Response) -> None:
+        response.headers['X-Existing-Response-Hook'] = 'kept'
+
+    async with httpx.AsyncClient(
+        event_hooks={'request': [existing_request_hook], 'response': [existing_response_hook]}
+    ) as http_client:
+        provider = gateway_provider('openai', http_client=http_client, api_key='foobar', base_url=GATEWAY_BASE_URL)
+        assert provider.client._client == http_client  # type: ignore
+        assert existing_request_hook in http_client.event_hooks['request']
+        assert existing_response_hook in http_client.event_hooks['response']
+
+        request = httpx.Request('GET', provider.base_url)
+        for hook in http_client.event_hooks['request']:
+            await hook(request)
+
+        assert request.headers['X-Existing-Request-Hook'] == 'kept'
+        assert request.headers['Authorization'] == 'Bearer foobar'
+
+
+async def test_init_with_http_client_replaces_existing_gateway_hook():
+    async def existing_request_hook(request: httpx.Request) -> None:
+        request.headers['X-Existing-Request-Hook'] = 'kept'
+
+    async with httpx.AsyncClient(event_hooks={'request': [existing_request_hook]}) as http_client:
+        first_provider = gateway_provider('openai', http_client=http_client, api_key='first', base_url=GATEWAY_BASE_URL)
+        second_provider = gateway_provider(
+            'openai', http_client=http_client, api_key='second', base_url=GATEWAY_BASE_URL
+        )
+
+        assert first_provider.client._client == http_client  # type: ignore
+        assert second_provider.client._client == http_client  # type: ignore
+        assert http_client.event_hooks['request'][0] == existing_request_hook
+        assert len(http_client.event_hooks['request']) == 2
+
+        request = httpx.Request('GET', second_provider.base_url)
+        for hook in http_client.event_hooks['request']:
+            await hook(request)
+
+        assert request.headers['X-Existing-Request-Hook'] == 'kept'
+        assert request.headers['Authorization'] == 'Bearer second'
+
+
 @pytest.fixture
 def gateway_api_key():
     return os.getenv('PYDANTIC_AI_GATEWAY_API_KEY', 'test-api-key')


### PR DESCRIPTION
Fixes #6326

Fixes a Gateway provider edge case where passing a pre-configured `httpx.AsyncClient` could silently drop the caller's existing event hooks.

## What Problem This Solves

`gateway_provider(..., http_client=client)` currently replaces the client's full `event_hooks` mapping with the Gateway request hook.

That means a caller-provided client loses any existing `request` hooks and all `response` hooks. These hooks are commonly used for tracing, metrics, request capture, auditing, custom diagnostics, or auth-adjacent behavior. The request can still succeed, so the failure mode is easy to miss: surrounding HTTP client behavior disappears after constructing the Gateway provider.

A minimal local reproduction before this change showed:

```text
before_request_hooks= ['existing_request_hook']
before_response_hooks= ['existing_response_hook']
after_request_hooks= ['_hook']
after_response_hooks= []
request_hook_preserved= False
response_hook_preserved= False
```

## Change

The Gateway provider now adds its request hook without replacing caller-provided HTTPX hooks.

For repeated `gateway_provider(..., http_client=same_client, ...)` calls, the Gateway-owned hook is replaced rather than duplicated. This keeps user hooks intact while ensuring the latest Gateway provider configuration owns the Gateway authorization hook.

Bedrock remains unchanged because that Gateway path does not use HTTPX.

## Evidence

Focused local validation:

```text
uv run --extra groq --extra bedrock pytest tests/providers/test_gateway.py::test_init_with_http_client tests/providers/test_gateway.py::test_init_with_http_client_preserves_existing_event_hooks tests/providers/test_gateway.py::test_init_with_http_client_replaces_existing_gateway_hook -q -rs

3 passed
```

Broader non-live Gateway subset:

```text
uv run --extra groq --extra bedrock pytest tests/providers/test_gateway.py -k "init_with_http_client or init_with_base_url or gateway_provider_unknown or routing_group" -q -rs

10 passed, 21 deselected
```

Static checks:

```text
uv run ruff format --check pydantic_ai_slim/pydantic_ai/providers/gateway.py tests/providers/test_gateway.py
uv run ruff check pydantic_ai_slim/pydantic_ai/providers/gateway.py tests/providers/test_gateway.py
PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/providers/gateway.py tests/providers/test_gateway.py

2 files already formatted
All checks passed!
0 errors, 0 warnings, 0 informations
```

## Possible call chain / impact

```text
user-created httpx.AsyncClient(event_hooks=...)
  -> gateway_provider(..., http_client=client)
  -> Gateway adds auth/trace request hook
  -> existing caller hooks should remain available
```

This affects the shared HTTPX Gateway setup used by OpenAI, Groq, Anthropic, and Google Cloud providers. It does not affect Bedrock, which returns before HTTPX client setup.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

