### PR TITLE
bedrock: migrate usage extraction to `RequestUsage.extract()`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -88,7 +88,6 @@ if TYPE_CHECKING:
         ContentBlockUnionTypeDef,
         ConverseRequestTypeDef,
         ConverseResponseTypeDef,
-        ConverseStreamMetadataEventTypeDef,
         ConverseStreamOutputTypeDef,
         ConverseStreamResponseTypeDef,
         ConverseTokensRequestTypeDef,
@@ -105,6 +104,7 @@ if TYPE_CHECKING:
         S3LocationTypeDef,
         ServiceTierTypeDef,
         SystemContentBlockTypeDef,
+        TokenUsageTypeDef,
         ToolChoiceTypeDef,
         ToolConfigurationTypeDef,
         ToolResultBlockOutputTypeDef,
@@ -129,6 +129,9 @@ def _map_api_errors(model_name: str) -> Generator[None]:
 _SUPPORTED_IMAGE_FORMATS = ('jpeg', 'png', 'gif', 'webp')
 _SUPPORTED_VIDEO_FORMATS = ('mkv', 'mov', 'mp4', 'webm', 'flv', 'mpeg', 'mpg', 'wmv', 'three_gp')
 _SUPPORTED_DOCUMENT_FORMATS = ('pdf', 'txt', 'csv', 'doc', 'docx', 'xls', 'xlsx', 'html', 'md')
+_BEDROCK_USAGE_FIELDS = frozenset(
+    {'inputTokens', 'outputTokens', 'totalTokens', 'cacheReadInputTokens', 'cacheWriteInputTokens'}
+)
 
 
 def _make_image_block(format: str, source: DocumentSourceTypeDef) -> ContentBlockUnionTypeDef:
@@ -761,15 +764,11 @@ class BedrockConverseModel(Model[BaseClient]):
                             )
                         )
 
-        input_tokens = response['usage']['inputTokens']
-        output_tokens = response['usage']['outputTokens']
-        cache_read_tokens = response['usage'].get('cacheReadInputTokens', 0)
-        cache_write_tokens = response['usage'].get('cacheWriteInputTokens', 0)
-        u = usage.RequestUsage(
-            input_tokens=input_tokens + cache_write_tokens + cache_read_tokens,
-            output_tokens=output_tokens,
-            cache_read_tokens=cache_read_tokens,
-            cache_write_tokens=cache_write_tokens,
+        u = _map_usage(
+            response['usage'],
+            self._provider.name,
+            self.base_url,
+            remove_bedrock_geo_prefix(self.model_name),
         )
         response_id = response.get('ResponseMetadata', {}).get('RequestId', None)
         raw_finish_reason = response['stopReason']
@@ -1547,7 +1546,12 @@ class BedrockStreamedResponse(StreamedResponse):
                         self.finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
                     case {'metadata': metadata}:
                         if 'usage' in metadata:  # pragma: no branch
-                            self._usage += self._map_usage(metadata)
+                            self._usage += _map_usage(
+                                metadata['usage'],
+                                self._provider_name,
+                                self._provider_url,
+                                remove_bedrock_geo_prefix(self._model_name),
+                            )
                     case {'contentBlockStart': content_block_start}:
                         index = content_block_start['contentBlockIndex']
                         start = content_block_start['start']
@@ -1666,17 +1670,18 @@ class BedrockStreamedResponse(StreamedResponse):
     def timestamp(self) -> datetime:
         return self._timestamp
 
-    def _map_usage(self, metadata: ConverseStreamMetadataEventTypeDef) -> usage.RequestUsage:
-        input_tokens = metadata['usage']['inputTokens']
-        output_tokens = metadata['usage']['outputTokens']
-        cache_read_tokens = metadata['usage'].get('cacheReadInputTokens', 0)
-        cache_write_tokens = metadata['usage'].get('cacheWriteInputTokens', 0)
-        return usage.RequestUsage(
-            input_tokens=input_tokens + cache_write_tokens + cache_read_tokens,
-            output_tokens=output_tokens,
-            cache_read_tokens=cache_read_tokens,
-            cache_write_tokens=cache_write_tokens,
-        )
+
+def _map_usage(usage_data: TokenUsageTypeDef, provider: str, provider_url: str, model: str) -> usage.RequestUsage:
+    details: dict[str, int] = {
+        k: v for k, v in usage_data.items() if k not in _BEDROCK_USAGE_FIELDS if isinstance(v, int)
+    }
+    return usage.RequestUsage.extract(
+        dict(model=model, usage=dict(usage_data)),
+        provider=provider,
+        provider_url=provider_url,
+        provider_fallback='bedrock',
+        details=details or None,
+    )
 
 
 class _AsyncIteratorWrapper(Generic[T]):

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -764,12 +764,7 @@ class BedrockConverseModel(Model[BaseClient]):
                             )
                         )
 
-        u = _map_usage(
-            response['usage'],
-            self._provider.name,
-            self.base_url,
-            remove_bedrock_geo_prefix(self.model_name),
-        )
+        u = _map_usage(response['usage'], self._provider.name, self.base_url, self.model_name)
         response_id = response.get('ResponseMetadata', {}).get('RequestId', None)
         raw_finish_reason = response['stopReason']
         provider_details = {'finish_reason': raw_finish_reason}
@@ -1547,10 +1542,7 @@ class BedrockStreamedResponse(StreamedResponse):
                     case {'metadata': metadata}:
                         if 'usage' in metadata:  # pragma: no branch
                             self._usage += _map_usage(
-                                metadata['usage'],
-                                self._provider_name,
-                                self._provider_url,
-                                remove_bedrock_geo_prefix(self._model_name),
+                                metadata['usage'], self._provider_name, self._provider_url, self._model_name
                             )
                     case {'contentBlockStart': content_block_start}:
                         index = content_block_start['contentBlockIndex']
@@ -1676,7 +1668,7 @@ def _map_usage(usage_data: TokenUsageTypeDef, provider: str, provider_url: str, 
         k: v for k, v in usage_data.items() if k not in _BEDROCK_USAGE_FIELDS if isinstance(v, int)
     }
     return usage.RequestUsage.extract(
-        dict(model=model, usage=dict(usage_data)),
+        dict(model=remove_bedrock_geo_prefix(model), usage=usage_data),
         provider=provider,
         provider_url=provider_url,
         provider_fallback='bedrock',

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 import json
 import os
+from collections.abc import Iterator
 from datetime import date, datetime, timezone
 from itertools import count
 from types import SimpleNamespace
@@ -879,46 +880,31 @@ async def test_bedrock_stream_usage_with_cached_tokens(
     allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
 ):
     """Mocked because synthetic stream metadata is needed to isolate the internal usage mapping."""
-
-    class BedrockStream:
-        def __init__(self, events: list[Any]):
-            self._events = iter(events)
-
-        def __iter__(self) -> BedrockStream:
-            return self
-
-        def __next__(self) -> Any:
-            return next(self._events)
-
-        def close(self) -> None:
-            pass
-
     model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
     agent = Agent(model=model)
 
+    def _stream() -> Iterator[dict[str, Any]]:
+        yield {'messageStart': {'role': 'assistant'}}
+        yield {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'hello'}}}
+        yield {'contentBlockStop': {'contentBlockIndex': 0}}
+        yield {'messageStop': {'stopReason': 'end_turn'}}
+        yield {
+            'metadata': {
+                'usage': {
+                    'inputTokens': 13,
+                    'outputTokens': 5,
+                    'totalTokens': 1529,
+                    'cacheReadInputTokens': 1504,
+                    'cacheWriteInputTokens': 7,
+                    'cacheDetails': [],
+                    'futureBillableTokens': 11,
+                }
+            }
+        }
+
     mock_converse_stream = mocker.patch.object(model.client, 'converse_stream')
     mock_converse_stream.return_value = {
-        'stream': BedrockStream(
-            [
-                {'messageStart': {'role': 'assistant'}},
-                {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'hello'}}},
-                {'contentBlockStop': {'contentBlockIndex': 0}},
-                {'messageStop': {'stopReason': 'end_turn'}},
-                {
-                    'metadata': {
-                        'usage': {
-                            'inputTokens': 13,
-                            'outputTokens': 5,
-                            'totalTokens': 1529,
-                            'cacheReadInputTokens': 1504,
-                            'cacheWriteInputTokens': 7,
-                            'cacheDetails': [],
-                            'futureBillableTokens': 11,
-                        }
-                    }
-                },
-            ]
-        ),
+        'stream': _stream(),
         'ResponseMetadata': {'RequestId': 'stub'},
     }
 

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -840,6 +840,7 @@ async def test_bedrock_unified_service_tier_auto_omits(
 async def test_bedrock_usage_with_cached_tokens(
     allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
 ):
+    """Mocked because synthetic fields are needed to isolate the internal usage mapping."""
     model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
     agent = Agent(model=model)
 
@@ -877,6 +878,8 @@ async def test_bedrock_usage_with_cached_tokens(
 async def test_bedrock_stream_usage_with_cached_tokens(
     allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
 ):
+    """Mocked because synthetic stream metadata is needed to isolate the internal usage mapping."""
+
     class BedrockStream:
         def __init__(self, events: list[Any]):
             self._events = iter(events)
@@ -910,6 +913,7 @@ async def test_bedrock_stream_usage_with_cached_tokens(
                             'cacheReadInputTokens': 1504,
                             'cacheWriteInputTokens': 7,
                             'cacheDetails': [],
+                            'futureBillableTokens': 11,
                         }
                     }
                 },
@@ -922,7 +926,14 @@ async def test_bedrock_stream_usage_with_cached_tokens(
         assert await result.get_output() == 'hello'
 
     assert result.usage == snapshot(
-        RunUsage(input_tokens=1524, cache_write_tokens=7, cache_read_tokens=1504, output_tokens=5, requests=1)
+        RunUsage(
+            input_tokens=1524,
+            cache_write_tokens=7,
+            cache_read_tokens=1504,
+            output_tokens=5,
+            requests=1,
+            details={'futureBillableTokens': 11},
+        )
     )
 
 

--- a/tests/models/test_bedrock.py
+++ b/tests/models/test_bedrock.py
@@ -837,6 +837,95 @@ async def test_bedrock_unified_service_tier_auto_omits(
     assert 'serviceTier' not in kwargs
 
 
+async def test_bedrock_usage_with_cached_tokens(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+):
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+    agent = Agent(model=model)
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': 'hello'}]}},
+        'stopReason': 'end_turn',
+        'usage': {
+            'inputTokens': 13,
+            'outputTokens': 5,
+            'totalTokens': 1529,
+            'cacheReadInputTokens': 1504,
+            'cacheWriteInputTokens': 7,
+            'cacheDetails': [],
+            'futureBillableTokens': 11,
+        },
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    result = await agent.run('hello')
+
+    assert result.output == 'hello'
+    assert result.usage == snapshot(
+        RunUsage(
+            input_tokens=1524,
+            cache_write_tokens=7,
+            cache_read_tokens=1504,
+            output_tokens=5,
+            requests=1,
+            details={'futureBillableTokens': 11},
+        )
+    )
+
+
+async def test_bedrock_stream_usage_with_cached_tokens(
+    allow_model_requests: None, bedrock_provider: BedrockProvider, mocker: MockerFixture
+):
+    class BedrockStream:
+        def __init__(self, events: list[Any]):
+            self._events = iter(events)
+
+        def __iter__(self) -> BedrockStream:
+            return self
+
+        def __next__(self) -> Any:
+            return next(self._events)
+
+        def close(self) -> None:
+            pass
+
+    model = BedrockConverseModel('us.anthropic.claude-sonnet-4-5-20250929-v1:0', provider=bedrock_provider)
+    agent = Agent(model=model)
+
+    mock_converse_stream = mocker.patch.object(model.client, 'converse_stream')
+    mock_converse_stream.return_value = {
+        'stream': BedrockStream(
+            [
+                {'messageStart': {'role': 'assistant'}},
+                {'contentBlockDelta': {'contentBlockIndex': 0, 'delta': {'text': 'hello'}}},
+                {'contentBlockStop': {'contentBlockIndex': 0}},
+                {'messageStop': {'stopReason': 'end_turn'}},
+                {
+                    'metadata': {
+                        'usage': {
+                            'inputTokens': 13,
+                            'outputTokens': 5,
+                            'totalTokens': 1529,
+                            'cacheReadInputTokens': 1504,
+                            'cacheWriteInputTokens': 7,
+                            'cacheDetails': [],
+                        }
+                    }
+                },
+            ]
+        ),
+        'ResponseMetadata': {'RequestId': 'stub'},
+    }
+
+    async with agent.run_stream('hello') as result:
+        assert await result.get_output() == 'hello'
+
+    assert result.usage == snapshot(
+        RunUsage(input_tokens=1524, cache_write_tokens=7, cache_read_tokens=1504, output_tokens=5, requests=1)
+    )
+
+
 async def test_bedrock_model_service_tier(allow_model_requests: None, bedrock_provider: BedrockProvider):
     model = BedrockConverseModel('us.amazon.nova-micro-v1:0', provider=bedrock_provider)
     model_settings = BedrockModelSettings(bedrock_service_tier={'type': 'flex'})


### PR DESCRIPTION
- Part of #4818 (bedrock item; the issue stays open for the remaining models)

Migrates Bedrock Converse usage mapping to `RequestUsage.extract()` via genai-prices, replacing the manual field mapping in both the sync and streaming paths (`count_tokens` is a different API shape and intentionally untouched).

Semantics are unchanged: AWS documents Converse `inputTokens` as excluding cache tokens, and the genai-prices aws extractor (0.0.70, pydantic/genai-prices#454) performs the same cache-inclusive add-back the manual code did, so all existing tests pass with zero snapshot changes. New mocked tests cover cache read/write extraction in both paths, including skipping the non-integer `cacheDetails` breakdown.

Requires genai-prices 0.0.70 (on 0.0.69 the aws default extractor dropped cache tokens entirely); main already pins `>=0.0.70` since #6330, so this is a pure migration with no dependency changes.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
