### PR TITLE
cohere: migrate usage extraction to `RequestUsage.extract()`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -10,7 +10,11 @@ from typing_extensions import assert_never
 from pydantic_ai.exceptions import ModelAPIError
 
 from .. import ModelHTTPError, usage
-from .._utils import generate_tool_call_id as _generate_tool_call_id, guard_tool_call_id as _guard_tool_call_id
+from .._utils import (
+    generate_tool_call_id as _generate_tool_call_id,
+    guard_tool_call_id as _guard_tool_call_id,
+    is_str_dict as _is_str_dict,
+)
 from ..messages import (
     CachePoint,
     CompactionPart,
@@ -264,12 +268,13 @@ class CohereModel(Model[AsyncClientV2]):
         provider_details = {'finish_reason': raw_finish_reason}
         finish_reason = _FINISH_REASON_MAP.get(raw_finish_reason)
 
+        provider_url = self.base_url
         return ModelResponse(
             parts=parts,
-            usage=_map_usage(response),
+            usage=_map_usage(response, self._provider.name, provider_url, self._model_name),
             model_name=self._model_name,
             provider_name=self._provider.name,
-            provider_url=self.base_url,
+            provider_url=provider_url,
             finish_reason=finish_reason,
             provider_details=provider_details,
         )
@@ -386,7 +391,7 @@ class CohereModel(Model[AsyncClientV2]):
                 assert_never(part)
 
 
-def _map_usage(response: V2ChatResponse) -> usage.RequestUsage:
+def _map_usage(response: V2ChatResponse, provider: str, provider_url: str, model: str) -> usage.RequestUsage:
     u = response.usage
     if u is None:
         return usage.RequestUsage()
@@ -402,12 +407,20 @@ def _map_usage(response: V2ChatResponse) -> usage.RequestUsage:
             if u.billed_units.classifications:  # pragma: no cover
                 details['classifications'] = int(u.billed_units.classifications)
 
-        request_tokens = int(u.tokens.input_tokens) if u.tokens and u.tokens.input_tokens else 0
-        response_tokens = int(u.tokens.output_tokens) if u.tokens and u.tokens.output_tokens else 0
-        cache_read_tokens = int(u.cached_tokens) if u.cached_tokens else 0
-        return usage.RequestUsage(
-            input_tokens=request_tokens,
-            output_tokens=response_tokens,
-            cache_read_tokens=cache_read_tokens,
-            details=details,
+        usage_data: dict[str, object] = u.model_dump(exclude_none=True)
+        # Cohere SDK usage counts are typed as floats, while genai-prices extracts integer token fields.
+        if _is_str_dict(tokens := usage_data.get('tokens')):
+            for key in ('input_tokens', 'output_tokens'):
+                if isinstance(value := tokens.get(key), int | float):
+                    tokens[key] = int(value)
+        if isinstance(cached_tokens := usage_data.get('cached_tokens'), int | float):
+            usage_data['cached_tokens'] = int(cached_tokens)
+
+        return usage.RequestUsage.extract(
+            dict(model=model, usage=usage_data),
+            provider=provider,
+            provider_url=provider_url,
+            provider_fallback='cohere',
+            api_flavor='tokens',
+            details=details or None,
         )

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -231,6 +231,45 @@ async def test_request_usage_without_tokens(allow_model_requests: None):
     )
 
 
+async def test_request_usage_with_cached_tokens_mock(allow_model_requests: None):
+    """Top-level `usage.cached_tokens` surfaces as first-class `cache_read_tokens` via the genai-prices tokens flavor.
+
+    Unit-style mock rather than VCR: the SDK types these counts as floats, and this pins the
+    float-to-int normalization plus nonzero token extraction, so a silently-broken extraction
+    path (which yields all-zero tokens with details preserved) cannot pass. The VCR variant
+    `test_request_usage_with_cached_tokens` covers the recorded-API path.
+    """
+    c = completion_message(
+        AssistantMessageResponse(
+            content=[TextAssistantMessageResponseContentItem(text='world')],
+            role='assistant',
+        ),
+        usage=cohere.Usage(
+            billed_units=cohere.UsageBilledUnits(input_tokens=13, output_tokens=8),
+            tokens=cohere.UsageTokens(input_tokens=542, output_tokens=8),
+            cached_tokens=37,
+        ),
+    )
+    mock_client = MockAsyncClientV2.create_mock(c)
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    result = await agent.run('Hello')
+    assert result.output == 'world'
+    assert result.usage == snapshot(
+        RunUsage(
+            requests=1,
+            input_tokens=542,
+            cache_read_tokens=37,
+            output_tokens=8,
+            details={
+                'input_tokens': 13,
+                'output_tokens': 8,
+            },
+        )
+    )
+
+
 async def test_request_structured_response(allow_model_requests: None):
     c = completion_message(
         AssistantMessageResponse(

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -232,6 +232,33 @@ async def test_request_usage_without_tokens(allow_model_requests: None):
     )
 
 
+async def test_request_usage_with_partial_tokens(allow_model_requests: None):
+    """The mock pins optional token fields, which a VCR response cannot reliably trigger."""
+    c = completion_message(
+        AssistantMessageResponse(
+            content=[TextAssistantMessageResponseContentItem(text='world')],
+            role='assistant',
+        ),
+        usage=cohere.Usage(
+            tokens=cohere.UsageTokens(input_tokens=4),
+            billed_units=cohere.UsageBilledUnits(input_tokens=3),
+        ),
+    )
+    mock_client = MockAsyncClientV2.create_mock(c)
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    result = await agent.run('Hello')
+    assert result.output == 'world'
+    assert result.usage == snapshot(
+        RunUsage(
+            requests=1,
+            input_tokens=4,
+            details={'input_tokens': 3},
+        )
+    )
+
+
 async def test_request_usage_with_cached_tokens_mock(allow_model_requests: None):
     """Top-level `usage.cached_tokens` surfaces as first-class `cache_read_tokens` via the genai-prices tokens flavor.
 

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -204,6 +204,33 @@ async def test_request_simple_usage(allow_model_requests: None):
     )
 
 
+async def test_request_usage_without_tokens(allow_model_requests: None):
+    c = completion_message(
+        AssistantMessageResponse(
+            content=[TextAssistantMessageResponseContentItem(text='world')],
+            role='assistant',
+        ),
+        usage=cohere.Usage(
+            billed_units=cohere.UsageBilledUnits(input_tokens=4, output_tokens=2),
+        ),
+    )
+    mock_client = MockAsyncClientV2.create_mock(c)
+    m = CohereModel('command-r7b-12-2024', provider=CohereProvider(cohere_client=mock_client))
+    agent = Agent(m)
+
+    result = await agent.run('Hello')
+    assert result.output == 'world'
+    assert result.usage == snapshot(
+        RunUsage(
+            requests=1,
+            details={
+                'input_tokens': 4,
+                'output_tokens': 2,
+            },
+        )
+    )
+
+
 async def test_request_structured_response(allow_model_requests: None):
     c = completion_message(
         AssistantMessageResponse(

--- a/tests/models/test_cohere.py
+++ b/tests/models/test_cohere.py
@@ -205,6 +205,7 @@ async def test_request_simple_usage(allow_model_requests: None):
 
 
 async def test_request_usage_without_tokens(allow_model_requests: None):
+    """The mock pins billed-unit mapping when Cohere omits `tokens`, a response shape VCR cannot reliably trigger."""
     c = completion_message(
         AssistantMessageResponse(
             content=[TextAssistantMessageResponseContentItem(text='world')],


### PR DESCRIPTION
- Part of #4818 (Cohere item; the issue stays open for the remaining models)

Migrates Cohere usage mapping to `RequestUsage.extract()` via genai-prices using the new opt-in `api_flavor='tokens'` (pydantic/genai-prices#453), so reported usage is unchanged: raw `usage.tokens` counts stay top-level and billed units stay in `details` exactly as before. Cohere types token counts as floats, which the genai-prices engine skips, so they are normalized to ints before extraction.

Existing snapshots pass unchanged; new tests cover the billed-units-only response shape and pin nonzero `cache_read_tokens` extraction through the tokens flavor so a silently-broken extraction path cannot pass.

Requires genai-prices 0.0.70. The minimum version is already on `main` via #6330, so this PR now contains only the Cohere migration and regression tests.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
