### PR TITLE
Bump `genai-prices` to 0.0.70

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -840,9 +840,9 @@ def _map_usage(
     }
     # `completion_tokens_details` carries `reasoning_tokens`, which the genai-prices
     # extractors don't surface, so lift its integer fields into `details` here.
-    # `cached_tokens` (from `prompt_tokens_details`) is intentionally left to the
-    # genai-prices extractors invoked by `RequestUsage.extract`; see
-    # https://github.com/pydantic/genai-prices/issues/414.
+    # `cached_tokens` (from `prompt_tokens_details`) needs no handling here: the
+    # genai-prices extractors invoked by `RequestUsage.extract` map it to
+    # `cache_read_tokens` (genai-prices >= 0.0.70).
     completion_tokens_details: dict[str, Any] = usage_data.get('completion_tokens_details') or {}
     details.update({k: v for k, v in completion_tokens_details.items() if isinstance(v, int)})
 

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -838,11 +838,9 @@ def _map_usage(
         if k not in {'prompt_tokens', 'completion_tokens', 'total_tokens'}
         if isinstance(v, int)
     }
-    # `completion_tokens_details` carries `reasoning_tokens`, which the genai-prices
-    # extractors don't surface, so lift its integer fields into `details` here.
-    # `cached_tokens` (from `prompt_tokens_details`) needs no handling here: the
-    # genai-prices extractors invoked by `RequestUsage.extract` map it to
-    # `cache_read_tokens` (genai-prices >= 0.0.70).
+    # Lift only `completion_tokens_details` (reasoning_tokens) into `details`: genai-prices
+    # doesn't surface those, but it does map `prompt_tokens_details.cached_tokens` to
+    # first-class `cache_read_tokens`, so lifting that too would double-report it.
     completion_tokens_details: dict[str, Any] = usage_data.get('completion_tokens_details') or {}
     details.update({k: v for k, v in completion_tokens_details.items() if isinstance(v, int)})
 

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "exceptiongroup>=1.2.2; python_version < '3.11'",
     "opentelemetry-api>=1.28.0",
     "typing-inspection>=0.4.0",
-    "genai-prices>=0.0.69",
+    "genai-prices>=0.0.70",
 ]
 
 [tool.hatch.metadata.hooks.uv-dynamic-versioning.optional-dependencies]

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -5463,7 +5463,9 @@ async def test_tool_use_failed_error(allow_model_requests: None, groq_api_key: s
                         content='The first call failed due to missing and extra parameters, as expected. The second call succeeded and returned: "Something with name: test".'
                     ),
                 ],
-                usage=RequestUsage(input_tokens=336, output_tokens=96, details={'reasoning_tokens': 59}),
+                usage=RequestUsage(
+                    input_tokens=336, cache_read_tokens=256, output_tokens=96, details={'reasoning_tokens': 59}
+                ),
                 model_name='openai/gpt-oss-120b',
                 timestamp=IsDatetime(),
                 provider_name='groq',

--- a/uv.lock
+++ b/uv.lock
@@ -2048,15 +2048,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.69"
+version = "0.0.70"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/17/b9a96d31908f1415b38e3bcba7883691fa2e0e69e18d0d9d6e80bf24be88/genai_prices-0.0.69.tar.gz", hash = "sha256:80ca72c4b59b62ef986be3f04ea528bf4aaac4bc91e1c34f32f354c0c0b23d16", size = 81492, upload-time = "2026-07-02T09:40:21.964Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/7c/e8bdd653fb9b292a920b6568b3949176b8de98ad2f84fede2ce44bf318d9/genai_prices-0.0.70.tar.gz", hash = "sha256:62d495aa867bb360ea359866b01d89932365417ba3bd013e0ba7c1d884e09ef9", size = 81827, upload-time = "2026-07-07T18:11:03.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/05/6bb176d603210b61d2bf4585c7119dcf5491bbcae195e21254668c5ee07a/genai_prices-0.0.69-py3-none-any.whl", hash = "sha256:281821349e301e938e00ba9a9e8df5be23336e2f04218a4979f6c5f89db083bb", size = 83972, upload-time = "2026-07-02T09:40:20.844Z" },
+    { url = "https://files.pythonhosted.org/packages/34/09/02ec13cb9108862a514cf05ea10ff7f18e523698606ed2976e2cbfa484fa/genai_prices-0.0.70-py3-none-any.whl", hash = "sha256:c7cb9da4944860329450b086dad402f17237b7552165fd3b61b24e291d1ddb88", size = 84312, upload-time = "2026-07-07T18:11:02.373Z" },
 ]
 
 [[package]]
@@ -5591,7 +5591,7 @@ requires-dist = [
     { name = "exa-py", marker = "extra == 'exa'", specifier = ">=2.0.0" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2.2" },
     { name = "fastmcp-slim", extras = ["client"], marker = "extra == 'mcp'", specifier = ">=3.3.0" },
-    { name = "genai-prices", specifier = ">=0.0.69" },
+    { name = "genai-prices", specifier = ">=0.0.70" },
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.70.0" },
     { name = "griffelib", specifier = ">=2.0" },
     { name = "groq", marker = "extra == 'groq'", specifier = ">=0.25.0" },


### PR DESCRIPTION
- Part of #4818 (unblocks the bedrock and cohere migrations, #6328 and #6329)

Bumps the `genai-prices` floor to 0.0.70, which adds the Bedrock Converse cache token mappings (pydantic/genai-prices#454), the Cohere `tokens` api_flavor (pydantic/genai-prices#453), and the Groq `cached_tokens` mapping (pydantic/genai-prices#426).

The Groq mapping takes effect immediately for the already-migrated groq model: one recorded cassette carries `prompt_tokens_details.cached_tokens: 256`, which now correctly surfaces as first-class `cache_read_tokens` (that snapshot is updated here; it resolves the remaining half of #5981, whose pydantic-ai side landed in #5986).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

