### PR TITLE
Resolve capability `for_run` once per run and preserve resolved native tools under `override(native_tools=...)`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1245,26 +1245,25 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             extra_capabilities.append(resolved.capability)
         extra_capabilities.extend(wrap_capability_funcs(capabilities))
 
+        # The capability layers resolved for this run: the base, then the extras. The
+        # Instrumentation capability is prepended (outermost) so its spans wrap everything,
+        # but only if the user hasn't already added one themselves.
+        run_layers: list[AbstractCapability[AgentDepsT]] = [base_capability, *extra_capabilities]
+        if instrumentation_cap is not None and not has_capability_type(run_layers, InstrumentationCap):
+            run_layers.insert(0, instrumentation_cap)
+
         # Per-run capability: resolve `for_run` exactly once per capability (it's documented as
         # called once per run and may have per-run side effects), keeping the resolved extras
-        # separate so `override(native_tools=...)` below can see native tools that only
+        # addressable so `override(native_tools=...)` below can see native tools that only
         # materialize at resolution time, e.g. from a capability function's returned capability.
         # `CombinedCapability` auto-flattens its input, so composing from the resolved pieces
         # yields the same structure as resolving a pre-composed tree.
-        resolved_base, *resolved_extras = await _utils.gather(
-            base_capability.for_run(initial_ctx), *(cap.for_run(initial_ctx) for cap in extra_capabilities)
-        )
-        if resolved_extras:
-            run_capability = CombinedCapability([resolved_base, *resolved_extras])
+        resolved_layers = await _utils.gather(*(cap.for_run(initial_ctx) for cap in run_layers))
+        resolved_extras = resolved_layers[len(resolved_layers) - len(extra_capabilities) :]
+        if len(resolved_layers) > 1:
+            run_capability = CombinedCapability(resolved_layers)
         else:
-            run_capability = resolved_base
-
-        # Prepend Instrumentation capability (outermost) so its spans wrap everything,
-        # but only if the user hasn't already added one themselves.
-        if instrumentation_cap is not None and not has_capability_type(
-            [base_capability, *extra_capabilities], InstrumentationCap
-        ):
-            run_capability = CombinedCapability([await instrumentation_cap.for_run(initial_ctx), run_capability])
+            run_capability = resolved_layers[0]
 
         # Re-extract get_*() from the resolved capability if anything is contributed per-run
         capabilities_dict = _build_run_capabilities(run_capability)

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1252,13 +1252,21 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         if instrumentation_cap is not None and not has_capability_type(run_layers, InstrumentationCap):
             run_layers.insert(0, instrumentation_cap)
 
-        # Per-run capability: resolve `for_run` exactly once per capability (it's documented as
-        # called once per run and may have per-run side effects), keeping the resolved extras
-        # addressable so `override(native_tools=...)` below can see native tools that only
-        # materialize at resolution time, e.g. from a capability function's returned capability.
-        # `CombinedCapability` auto-flattens its input, so composing from the resolved pieces
-        # yields the same structure as resolving a pre-composed tree.
+        # Per-run capability: resolve `for_run` on the layers directly instead of composing a
+        # `CombinedCapability` first and resolving that (which would gather over the same
+        # children): `override(native_tools=...)` below needs the *resolved* extras — their
+        # native tools may only materialize in `for_run`, e.g. from a capability function's
+        # returned capability — and the composed tree can't give them back. `CombinedCapability`
+        # re-flattens and re-sorts its children both at construction and on the `replace()`
+        # inside its `for_run`, erasing which resolved children formed which layer. Nor can the
+        # extras be re-resolved afterwards to peek at them: `for_run` is documented as called
+        # once per run and may have per-run side effects (e.g. the durable-exec integrations
+        # rely on this for deterministic replay). Composing from the resolved pieces below
+        # yields the same structure as resolving a pre-composed tree, since the same
+        # flatten-and-sort runs on the same resolved children either way.
         resolved_layers = await _utils.gather(*(cap.for_run(initial_ctx) for cap in run_layers))
+        # The extras are the tail of `run_layers` (instrumentation, if added, is at the front).
+        # Slicing from the front avoids the `[-0:]` full-list pitfall when there are no extras.
         resolved_extras = resolved_layers[len(resolved_layers) - len(extra_capabilities) :]
         if len(resolved_layers) > 1:
             run_capability = CombinedCapability(resolved_layers)

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1244,20 +1244,29 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         if resolved is not None and resolved.capability is not None:
             extra_capabilities.append(resolved.capability)
         extra_capabilities.extend(wrap_capability_funcs(capabilities))
-        if extra_capabilities:
-            effective_capability = CombinedCapability([base_capability, *extra_capabilities])
+
+        # Per-run capability: resolve `for_run` exactly once per capability (it's documented as
+        # called once per run and may have per-run side effects), keeping the resolved extras
+        # separate so `override(native_tools=...)` below can see native tools that only
+        # materialize at resolution time, e.g. from a capability function's returned capability.
+        # `CombinedCapability` auto-flattens its input, so composing from the resolved pieces
+        # yields the same structure as resolving a pre-composed tree.
+        resolved_base, *resolved_extras = await _utils.gather(
+            base_capability.for_run(initial_ctx), *(cap.for_run(initial_ctx) for cap in extra_capabilities)
+        )
+        if resolved_extras:
+            run_capability = CombinedCapability([resolved_base, *resolved_extras])
         else:
-            effective_capability = base_capability
+            run_capability = resolved_base
 
         # Prepend Instrumentation capability (outermost) so its spans wrap everything,
-        # but only if the user hasn't already added one themselves. `CombinedCapability`
-        # auto-flattens its input so a nested `effective_capability` is splatted into
-        # the new outer container — leaves participate as siblings in the ordering pass.
-        if instrumentation_cap is not None and not has_capability_type([effective_capability], InstrumentationCap):
-            effective_capability = CombinedCapability([instrumentation_cap, effective_capability])
+        # but only if the user hasn't already added one themselves.
+        if instrumentation_cap is not None and not has_capability_type(
+            [base_capability, *extra_capabilities], InstrumentationCap
+        ):
+            run_capability = CombinedCapability([await instrumentation_cap.for_run(initial_ctx), run_capability])
 
-        # Per-run capability: re-extract get_*() if for_run returns a different instance
-        run_capability = await effective_capability.for_run(initial_ctx)
+        # Re-extract get_*() from the resolved capability if anything is contributed per-run
         capabilities_dict = _build_run_capabilities(run_capability)
         # Inject the loader only if a deferred capability is present AND `for_run` didn't already
         # return one, mirroring the `has_capability_type` guard used for instrumentation above.
@@ -1270,10 +1279,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             capabilities_dict = _build_run_capabilities(run_capability)
         cap_toolsets: list[AgentToolset[AgentDepsT]] | None
 
-        if run_capability is not effective_capability:
+        if run_capability is not base_capability or override_cap is not None:
             source_cap = run_capability
-        elif override_cap is not None or extra_capabilities:
-            source_cap = effective_capability
         else:
             source_cap = None
 
@@ -1291,10 +1298,11 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
 
         # `override(native_tools=...)` replaces the agent's *baseline* native tools while still
         # preserving any additional per-run capability-contributed native tools (e.g. from
-        # `capabilities=[NativeTool(...)]`) on top.
+        # `capabilities=[NativeTool(...)]`) on top. Read those from the *resolved* capabilities,
+        # as they may only materialize in `for_run`, e.g. from a capability function.
         if some_native_tools := self._override_native_tools.get():
             extra_native_tools: list[AgentNativeTool[AgentDepsT]] = []
-            for cap in extra_capabilities:
+            for cap in resolved_extras:
                 extra_native_tools.extend(cap.get_native_tools())
             cap_native_tools = [*some_native_tools.value, *extra_native_tools]
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -10711,6 +10711,9 @@ def test_agent_override_native_tools_preserves_runtime_additive_tools():
 def test_agent_override_native_tools_preserves_dynamic_capability_tools():
     """Native tools that only materialize in `for_run` (here from a capability function) are
     preserved under `override(native_tools=...)`, which replaces only the agent's baseline tools.
+
+    Unit test rather than VCR: it pins the `native_tools` request parameters ahead of the
+    `TestModel` pre-request guard, which no cassette would reliably catch.
     """
     model = TestModel()
     agent = Agent(model=model, capabilities=[NativeTool(WebSearchTool())])

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -10708,15 +10708,20 @@ def test_agent_override_native_tools_preserves_runtime_additive_tools():
     )
 
 
-def test_agent_override_native_tools_preserves_dynamic_capability_tools():
+@pytest.mark.parametrize('instrument', [False, True])
+def test_agent_override_native_tools_preserves_dynamic_capability_tools(instrument: bool):
     """Native tools that only materialize in `for_run` (here from a capability function) are
     preserved under `override(native_tools=...)`, which replaces only the agent's baseline tools.
+
+    With `instrument=True`, the Instrumentation capability joins the resolved layers as part of
+    the baseline, and must not be attributed to the preserved per-run layer.
 
     Unit test rather than VCR: it pins the `native_tools` request parameters ahead of the
     `TestModel` pre-request guard, which no cassette would reliably catch.
     """
     model = TestModel()
     agent = Agent(model=model, capabilities=[NativeTool(WebSearchTool())])
+    agent.instrument = instrument
 
     def dynamic_cap(ctx: RunContext) -> AbstractCapability:
         return NativeTool(MCPServerTool(id='example', url='https://mcp.example.com/mcp'))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -10708,6 +10708,52 @@ def test_agent_override_native_tools_preserves_runtime_additive_tools():
     )
 
 
+def test_agent_override_native_tools_preserves_dynamic_capability_tools():
+    """Native tools that only materialize in `for_run` (here from a capability function) are
+    preserved under `override(native_tools=...)`, which replaces only the agent's baseline tools.
+    """
+    model = TestModel()
+    agent = Agent(model=model, capabilities=[NativeTool(WebSearchTool())])
+
+    def dynamic_cap(ctx: RunContext) -> AbstractCapability:
+        return NativeTool(MCPServerTool(id='example', url='https://mcp.example.com/mcp'))
+
+    with (
+        agent.override(native_tools=[CodeExecutionTool()]),
+        pytest.raises(UserError, match='TestModel does not support built-in tools'),
+    ):
+        agent.run_sync('Hello', capabilities=[dynamic_cap])
+
+    assert model.last_model_request_parameters is not None
+    assert model.last_model_request_parameters.native_tools == snapshot(
+        [CodeExecutionTool(), MCPServerTool(id='example', url='https://mcp.example.com/mcp')]
+    )
+
+
+async def test_agent_capability_for_run_called_once_per_run():
+    """`AbstractCapability.for_run` is documented as called once per run and may have per-run
+    side effects, so agent-level and run-level capabilities must each be resolved exactly once —
+    including when `for_run` returns a fresh instance for per-run state isolation.
+
+    Unit test rather than VCR: resolution counts are internal and wouldn't show up in any
+    request payload a cassette could pin.
+    """
+    for_run_calls: dict[str, int] = {}
+
+    class CountingCapability(AbstractCapability):
+        def __init__(self, name: str):
+            self.name = name
+
+        async def for_run(self, ctx: RunContext) -> AbstractCapability:
+            for_run_calls[self.name] = for_run_calls.get(self.name, 0) + 1
+            return CountingCapability(self.name)
+
+    agent = Agent(TestModel(), capabilities=[CountingCapability('agent')])
+    await agent.run('Hello', capabilities=[CountingCapability('run')])
+
+    assert for_run_calls == {'agent': 1, 'run': 1}
+
+
 async def test_run_with_unapproved_tool_call_in_history():
     def should_not_call_model(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
         raise ValueError('The agent should not call the model.')  # pragma: no cover


### PR DESCRIPTION
- Closes #6331

Native tools that only materialize when a capability is resolved for the run — e.g. from a capability function passed as `capabilities=[fn]` — were silently dropped from the model request when `override(native_tools=...)` was active: the override merge read the per-run capabilities' native tools *before* `for_run` resolution.

Fix by resolving the base and per-run capability layers explicitly — each `for_run` called exactly once, per its documented once-per-run contract — and composing the run capability from the already-resolved pieces, so the override merge can read the per-run layer's native tools post-resolution. `CombinedCapability` auto-flattens and re-sorts its input on construction (and again on the `replace()` inside its `for_run`), so composing from resolved pieces yields the same final structure as resolving a pre-composed tree; the `Instrumentation` capability is now resolved explicitly as part of the same flow.

A similar restructure was attempted in #6242 and reverted after `test_complex_agent_run_in_workflow` regressed — that attempt left the `Instrumentation` capability unresolved, which this version doesn't. The full Temporal, DBOS, and Prefect suites pass locally on Python 3.13.

Includes regression tests for the override case and for the once-per-run resolution contract (including `for_run` implementations that return a fresh instance).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

