### PR TITLE
feat(instrumentation): classify tool-call argument validation failures on spans

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -424,6 +424,11 @@ class InstrumentationNames:
     tool_deferral_name_attr: ClassVar[str] = 'pydantic_ai.tool.deferral.name'
     tool_deferral_metadata_attr: ClassVar[str] = 'pydantic_ai.tool.deferral.metadata'
 
+    # Tool-call argument validation-failure span event ("near-miss" telemetry)
+    tool_validation_failure_event_name: ClassVar[str] = 'pydantic_ai.tool.validation_failure'
+    tool_validation_failure_kind_attr: ClassVar[str] = 'pydantic_ai.tool.validation_failure.kind'
+    tool_validation_failure_unknown_keys_attr: ClassVar[str] = 'pydantic_ai.tool.validation_failure.unknown_keys'
+
     @classmethod
     def for_version(cls, version: int) -> Self:
         """Create instrumentation configuration for a specific version.

--- a/pydantic_ai_slim/pydantic_ai/_tool_validation.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_validation.py
@@ -1,0 +1,99 @@
+"""Classification of tool-call argument validation failures ("near-miss" telemetry).
+
+When a model emits a tool call whose arguments fail Pydantic validation, the shape of
+the failure is a useful signal: modern models increasingly emit payloads that are
+correct except for invented extra keys (see Armin Ronacher, "Better Models: Worse
+Tools", https://lucumr.pocoo.org/2026/7/4/better-models-worse-tools/). Today that is an
+undifferentiated validation error, so the phenomenon can't be measured.
+
+[`classify_tool_args_validation_failure`][pydantic_ai._tool_validation.classify_tool_args_validation_failure]
+is a small pure function that buckets a Pydantic `ValidationError` into a coarse `kind`.
+It is deliberately dependency-free and side-effect-free so the eventual argument-repair
+layer (which would drop unknown keys, coerce types, etc. before retrying) can reuse the
+exact same classification it is instrumented against.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from pydantic import ValidationError
+
+ToolArgsValidationFailureKind = Literal[
+    'not_json',
+    'unknown_keys_only',
+    'type_mismatch_only',
+    'missing_required',
+    'mixed',
+]
+"""Coarse classification of why a tool call's arguments failed validation.
+
+- `not_json`: the raw arguments string could not be parsed as JSON at all.
+- `unknown_keys_only`: every error is an unexpected/extra key (the Ronacher class).
+- `type_mismatch_only`: every error is a type/coercion error (no missing or extra keys).
+- `missing_required`: every error is a missing required field.
+- `mixed`: any other combination of the above.
+"""
+
+# Maximum number of unknown key names to record for an `unknown_keys_only` failure.
+# Bounded to keep the telemetry payload small; the fingerprint is the presence and
+# identity of the first few invented keys, not an exhaustive list.
+_MAX_UNKNOWN_KEYS = 5
+
+
+@dataclass(frozen=True)
+class ToolArgsValidationFailure:
+    """The classified shape of a tool-call argument validation failure."""
+
+    kind: ToolArgsValidationFailureKind
+    """The coarse failure category."""
+
+    unknown_keys: tuple[str, ...] = field(default=())
+    """The names of the unexpected keys, for a `unknown_keys_only` failure (bounded, deduplicated,
+    in first-seen order). Empty for every other `kind`."""
+
+
+def classify_tool_args_validation_failure(error: ValidationError) -> ToolArgsValidationFailure:
+    """Classify a Pydantic `ValidationError` raised while validating tool-call arguments.
+
+    Pure and side-effect-free: it only reads `error.errors()`. Shared by the instrumentation
+    layer (which records the result on the tool-call span) and, in the future, by an
+    argument-repair layer that would act on the same classification.
+    """
+    errors = error.errors(include_url=False, include_context=False)
+
+    unknown_keys: list[str] = []
+    saw_unknown = False
+    saw_missing = False
+    saw_type_mismatch = False
+
+    for err in errors:
+        err_type = err['type']
+        if err_type == 'json_invalid':
+            # The whole arguments string was unparsable; no field-level errors are meaningful.
+            return ToolArgsValidationFailure(kind='not_json')
+        elif err_type == 'extra_forbidden':
+            saw_unknown = True
+            loc = err['loc']
+            if loc:  # pragma: no branch - `extra_forbidden` always carries the offending key
+                key = str(loc[-1])
+                if key not in unknown_keys:
+                    unknown_keys.append(key)
+        elif err_type == 'missing':
+            saw_missing = True
+        else:
+            # Everything else (int_parsing, string_type, bool_parsing, list_type, ...) is a
+            # type/coercion mismatch.
+            saw_type_mismatch = True
+
+    if saw_unknown and not saw_missing and not saw_type_mismatch:
+        return ToolArgsValidationFailure(
+            kind='unknown_keys_only',
+            unknown_keys=tuple(unknown_keys[:_MAX_UNKNOWN_KEYS]),
+        )
+    if saw_missing and not saw_unknown and not saw_type_mismatch:
+        return ToolArgsValidationFailure(kind='missing_required')
+    if saw_type_mismatch and not saw_unknown and not saw_missing:
+        return ToolArgsValidationFailure(kind='type_mismatch_only')
+    return ToolArgsValidationFailure(kind='mixed')

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING, Any
 
 from opentelemetry.baggage import set_baggage as _otel_set_baggage
 from opentelemetry.context import attach as _otel_attach, detach as _otel_detach
-from opentelemetry.trace import StatusCode
+from opentelemetry.trace import StatusCode, get_current_span
+from pydantic import ValidationError
 from pydantic_core import to_json
 
 from pydantic_ai._instrumentation import (
@@ -21,14 +22,16 @@ from pydantic_ai._instrumentation import (
     serialize_any,
     time_to_first_chunk_ctx,
 )
+from pydantic_ai._tool_validation import classify_tool_args_validation_failure
 from pydantic_ai._utils import UNSET, Unset
-from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ToolRetryError
+from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry, ToolRetryError
 from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart, tool_return_ta
 from pydantic_ai.tools import ToolDefinition
 
 from .abstract import (
     AbstractCapability,
     CapabilityOrdering,
+    RawToolArgs,
     ValidatedToolArgs,
     WrapModelRequestHandler,
     WrapOutputProcessHandler,
@@ -407,6 +410,58 @@ class Instrumentation(AbstractCapability[Any]):
             serialize_result=lambda value: tool_return_ta.dump_json(value).decode(),
             handle_tool_control_flow=True,
         )
+
+    # ------------------------------------------------------------------
+    # on_tool_validate_error — near-miss telemetry (observe-only)
+    # ------------------------------------------------------------------
+
+    async def on_tool_validate_error(
+        self,
+        ctx: RunContext[AgentDepsT],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: RawToolArgs,
+        error: ValidationError | ModelRetry,
+    ) -> ValidatedToolArgs:
+        """Classify a tool-call argument validation failure and record it on the current span.
+
+        Fires when a model emits a tool call whose arguments fail Pydantic validation.
+        We classify the failure shape (unknown keys / type mismatch / missing / mixed /
+        unparsable JSON) and emit a span event so the "near-miss" rate — in particular the
+        Ronacher-class `unknown_keys_only` failures — can be measured per model and schema.
+
+        This is observe-only: the original `error` is always re-raised unchanged, so the
+        retry flow is exactly as it would be without instrumentation. `ModelRetry` (custom
+        validator rejection) carries no schema-level error shape, so it is not classified.
+
+        Validation runs before the tool-execution span is opened, so there is no per-call
+        tool span to attach to; the event lands on the enclosing agent-run span (the current
+        span when validation runs).
+        """
+        if isinstance(error, ValidationError):
+            self._record_validation_failure(call, error)
+        raise error
+
+    def _record_validation_failure(self, call: ToolCallPart, error: ValidationError) -> None:
+        """Emit the near-miss classification for `error` as an event on the current span."""
+        span = get_current_span()
+        if not span.is_recording():
+            return
+
+        names = self._instrumentation_names
+        failure = classify_tool_args_validation_failure(error)
+        attributes: dict[str, Any] = {
+            names.tool_validation_failure_kind_attr: failure.kind,
+            'gen_ai.tool.name': call.tool_name,
+        }
+        if call.tool_call_id:
+            attributes['gen_ai.tool.call.id'] = call.tool_call_id
+        # The unknown key names are model-emitted content, so gate them behind `include_content`;
+        # the `kind` alone already identifies the Ronacher class without exposing content.
+        if failure.unknown_keys and self.settings.include_content:
+            attributes[names.tool_validation_failure_unknown_keys_attr] = list(failure.unknown_keys)
+        span.add_event(names.tool_validation_failure_event_name, attributes=attributes)
 
     # ------------------------------------------------------------------
     # wrap_output_process — output tool execution span (tool-mode only)

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -444,24 +444,24 @@ class Instrumentation(AbstractCapability[Any]):
         raise error
 
     def _record_validation_failure(self, call: ToolCallPart, error: ValidationError) -> None:
-        """Emit the near-miss classification for `error` as an event on the current span."""
-        span = get_current_span()
-        if not span.is_recording():
-            return
+        """Emit the near-miss classification for `error` as an event on the current span.
 
+        Emitted on `get_current_span()` — the enclosing agent-run span, since validation runs
+        before any per-call tool span exists. If the span isn't recording (e.g. a no-op tracer),
+        `add_event` is a harmless no-op.
+        """
         names = self._instrumentation_names
         failure = classify_tool_args_validation_failure(error)
         attributes: dict[str, Any] = {
             names.tool_validation_failure_kind_attr: failure.kind,
             'gen_ai.tool.name': call.tool_name,
+            'gen_ai.tool.call.id': call.tool_call_id,
         }
-        if call.tool_call_id:
-            attributes['gen_ai.tool.call.id'] = call.tool_call_id
         # The unknown key names are model-emitted content, so gate them behind `include_content`;
         # the `kind` alone already identifies the Ronacher class without exposing content.
         if failure.unknown_keys and self.settings.include_content:
             attributes[names.tool_validation_failure_unknown_keys_attr] = list(failure.unknown_keys)
-        span.add_event(names.tool_validation_failure_event_name, attributes=attributes)
+        get_current_span().add_event(names.tool_validation_failure_event_name, attributes=attributes)
 
     # ------------------------------------------------------------------
     # wrap_output_process — output tool execution span (tool-mode only)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3798,3 +3798,62 @@ def test_tool_call_validation_failure_event_excludes_unknown_keys_without_conten
     assert event['name'] == 'pydantic_ai.tool.validation_failure'
     assert event['attributes']['pydantic_ai.tool.validation_failure.kind'] == 'unknown_keys_only'
     assert 'pydantic_ai.tool.validation_failure.unknown_keys' not in event['attributes']
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+def test_tool_call_validation_failure_event_type_mismatch(capfire: CaptureLogfire) -> None:
+    """A type-coercion failure is classified as `type_mismatch_only` with no unknown keys recorded."""
+
+    calls = 0
+
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return ModelResponse(parts=[ToolCallPart('my_tool', {'a': 'not-an-int'})])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(FunctionModel(model_function), capabilities=[Instrumentation(settings=InstrumentationSettings())])
+
+    @agent.tool_plain
+    def my_tool(a: int) -> str:
+        return f'ok {a}'
+
+    agent.run_sync('go')
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    agent_run_span = next(s for s in spans if s['name'] == 'invoke_agent agent')
+    [event] = agent_run_span['events']
+    assert event['name'] == 'pydantic_ai.tool.validation_failure'
+    assert event['attributes']['pydantic_ai.tool.validation_failure.kind'] == 'type_mismatch_only'
+    assert 'pydantic_ai.tool.validation_failure.unknown_keys' not in event['attributes']
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+def test_tool_call_model_retry_is_not_recorded_as_validation_failure(capfire: CaptureLogfire) -> None:
+    """A `ModelRetry` from a custom validator carries no schema-level shape and is not classified,
+    so no near-miss event is emitted (only schema `ValidationError`s are)."""
+
+    calls = 0
+
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return ModelResponse(parts=[ToolCallPart('my_tool', {'a': 1})])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(FunctionModel(model_function), capabilities=[Instrumentation(settings=InstrumentationSettings())])
+
+    def reject(ctx: RunContext[Any], a: int) -> None:
+        raise ModelRetry('please try again')
+
+    @agent.tool_plain(args_validator=reject)
+    def my_tool(a: int) -> str:  # pragma: no cover - body never runs; validator rejects first
+        return f'ok {a}'
+
+    agent.run_sync('go')
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    agent_run_span = next(s for s in spans if s['name'] == 'invoke_agent agent')
+    assert not agent_run_span.get('events')

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3720,3 +3720,81 @@ def test_output_function_call_deferred_recorded_as_error(
     # not the deferral-attribute path that `wrap_tool_execute` uses.
     assert span_attrs.get('logfire.level_num', 0) >= 17  # error level
     assert 'pydantic_ai.tool.deferral.name' not in span_attrs
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+def test_tool_call_validation_failure_near_miss_event(capfire: CaptureLogfire) -> None:
+    """A tool call with invented extra keys records a near-miss classification event on the run span.
+
+    Validation runs before any per-call tool span is opened (see `Instrumentation.on_tool_validate_error`),
+    so the event lands on the enclosing `invoke_agent` span, and no `execute_tool` span is created for the
+    failed call."""
+
+    calls = 0
+
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            # Byte-correct payload plus two invented trailing keys (the Ronacher class).
+            return ModelResponse(parts=[ToolCallPart('my_tool', {'a': 1, 'requireUnique': True, 'oldText2': 'x'})])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(FunctionModel(model_function), capabilities=[Instrumentation(settings=InstrumentationSettings())])
+
+    @agent.tool_plain
+    def my_tool(a: int) -> str:
+        return f'ok {a}'
+
+    agent.run_sync('go')
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    agent_run_span = next(s for s in spans if s['name'] == 'invoke_agent agent')
+    assert agent_run_span['events'] == snapshot(
+        [
+            {
+                'name': 'pydantic_ai.tool.validation_failure',
+                'timestamp': IsInt(),
+                'attributes': {
+                    'pydantic_ai.tool.validation_failure.kind': 'unknown_keys_only',
+                    'gen_ai.tool.name': 'my_tool',
+                    'gen_ai.tool.call.id': IsStr(),
+                    'pydantic_ai.tool.validation_failure.unknown_keys': ('requireUnique', 'oldText2'),
+                },
+            }
+        ]
+    )
+    # No per-call tool span exists for a call that failed validation.
+    assert not any(s['name'] == 'execute_tool my_tool' for s in spans)
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+def test_tool_call_validation_failure_event_excludes_unknown_keys_without_content(
+    capfire: CaptureLogfire,
+) -> None:
+    """The failure `kind` is always recorded, but the invented key names are gated behind `include_content`."""
+
+    calls = 0
+
+    def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return ModelResponse(parts=[ToolCallPart('my_tool', {'a': 1, 'bogus': 2})])
+        return ModelResponse(parts=[TextPart('done')])
+
+    settings = InstrumentationSettings(include_content=False)
+    agent = Agent(FunctionModel(model_function), capabilities=[Instrumentation(settings=settings)])
+
+    @agent.tool_plain
+    def my_tool(a: int) -> str:
+        return f'ok {a}'
+
+    agent.run_sync('go')
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    agent_run_span = next(s for s in spans if s['name'] == 'invoke_agent agent')
+    [event] = agent_run_span['events']
+    assert event['name'] == 'pydantic_ai.tool.validation_failure'
+    assert event['attributes']['pydantic_ai.tool.validation_failure.kind'] == 'unknown_keys_only'
+    assert 'pydantic_ai.tool.validation_failure.unknown_keys' not in event['attributes']

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -1,0 +1,110 @@
+"""Unit tests for the tool-call argument validation-failure classifier.
+
+These are unit tests rather than VCR/public-API tests: the classifier is a small pure
+function whose branches (unknown keys / type mismatch / missing / mixed / unparsable JSON)
+can't be reliably or exhaustively provoked through a real provider, and its output is
+definitory internal behavior that the instrumentation layer (and a future argument-repair
+layer) depends on, so it's worth pinning directly against drift.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
+
+from pydantic_ai._tool_validation import (
+    ToolArgsValidationFailure,
+    classify_tool_args_validation_failure,
+)
+
+
+class _Args(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    a: int
+    b: str
+
+
+_args_ta = TypeAdapter(_Args)
+_nested_ta = TypeAdapter(dict[str, _Args])
+
+
+def _error_from_python(value: object) -> ValidationError:
+    try:
+        _args_ta.validate_python(value)
+    except ValidationError as e:
+        return e
+    raise AssertionError('expected validation to fail')  # pragma: no cover
+
+
+def _error_from_json(value: str) -> ValidationError:
+    try:
+        _args_ta.validate_json(value)
+    except ValidationError as e:
+        return e
+    raise AssertionError('expected validation to fail')  # pragma: no cover
+
+
+def _error_from_nested(value: object) -> ValidationError:
+    try:
+        _nested_ta.validate_python(value)
+    except ValidationError as e:
+        return e
+    raise AssertionError('expected validation to fail')  # pragma: no cover
+
+
+def test_unknown_keys_only():
+    error = _error_from_python({'a': 1, 'b': 'x', 'bogus': 2, 'other': 3})
+    assert classify_tool_args_validation_failure(error) == ToolArgsValidationFailure(
+        kind='unknown_keys_only', unknown_keys=('bogus', 'other')
+    )
+
+
+def test_unknown_keys_are_bounded():
+    # Nine distinct extra keys; only the first five are recorded, in first-seen order.
+    payload = {'a': 1, 'b': 'x', **{f'k{i}': i for i in range(9)}}
+    error = _error_from_python(payload)
+    failure = classify_tool_args_validation_failure(error)
+    assert failure.kind == 'unknown_keys_only'
+    assert failure.unknown_keys == ('k0', 'k1', 'k2', 'k3', 'k4')
+
+
+def test_nested_unknown_key_uses_leaf_name():
+    error = _error_from_nested({'entry': {'a': 1, 'b': 'x', 'bogus': 2}})
+    assert classify_tool_args_validation_failure(error) == ToolArgsValidationFailure(
+        kind='unknown_keys_only', unknown_keys=('bogus',)
+    )
+
+
+def test_repeated_leaf_key_across_nested_objects_is_deduplicated():
+    # Two sibling objects each carry an extra key with the same leaf name; it's recorded once.
+    error = _error_from_nested({'e1': {'a': 1, 'b': 'x', 'bogus': 2}, 'e2': {'a': 1, 'b': 'x', 'bogus': 3}})
+    assert classify_tool_args_validation_failure(error) == ToolArgsValidationFailure(
+        kind='unknown_keys_only', unknown_keys=('bogus',)
+    )
+
+
+def test_type_mismatch_only():
+    error = _error_from_python({'a': 'not-an-int', 'b': 'x'})
+    assert classify_tool_args_validation_failure(error) == ToolArgsValidationFailure(kind='type_mismatch_only')
+
+
+def test_missing_required():
+    error = _error_from_python({'a': 1})
+    assert classify_tool_args_validation_failure(error) == ToolArgsValidationFailure(kind='missing_required')
+
+
+def test_mixed_missing_and_unknown():
+    error = _error_from_python({'bogus': 2})
+    assert classify_tool_args_validation_failure(error) == ToolArgsValidationFailure(kind='mixed')
+
+
+def test_mixed_type_and_unknown():
+    error = _error_from_python({'a': 'not-an-int', 'b': 'x', 'bogus': 2})
+    assert classify_tool_args_validation_failure(error) == ToolArgsValidationFailure(kind='mixed')
+
+
+@pytest.mark.parametrize('raw', ['{not valid json', '', 'null-ish {'])
+def test_not_json(raw: str):
+    error = _error_from_json(raw)
+    assert classify_tool_args_validation_failure(error) == ToolArgsValidationFailure(kind='not_json')


### PR DESCRIPTION
## What

When a tool call's arguments fail Pydantic validation, classify the failure and record it as a span event, so the "invented extra keys" phenomenon becomes measurable per model/schema. **Observe-only**: the validation error is always re-raised unchanged, so the retry flow is byte-identical to before. No new public API.

Motivation: Armin Ronacher's [Better Models: Worse Tools](https://lucumr.pocoo.org/2026/7/4/better-models-worse-tools/) — newer models emit tool calls whose payload is correct but carry invented extra keys; today that's an undifferentiated validation failure, and nobody can measure it. See the [slop-tolerant tool calls](https://github.com/pydantic/pydantic-ai-notes/blob/main/features/tool-error-handling/2026-07-07%20slop-tolerant%20tool%20calls%20-%20better%20models%20worse%20tools.md) note (work item 1).

## How

- `_tool_validation.py` (new, module-private): pure `classify_tool_args_validation_failure(ValidationError)` returning `kind ∈ {unknown_keys_only, type_mismatch_only, missing_required, mixed, not_json}` plus bounded/deduped unknown-key names. Docstring notes it's shared with the future repair layer.
- The `Instrumentation` capability implements the `on_tool_validate_error` hook — classifies, emits a `pydantic_ai.tool.validation_failure` span event (attached to the enclosing run span, since validation runs before any per-call tool span opens — so multiple failures in one run don't collide), then re-raises. Unknown key names are gated behind `include_content`; `kind` is always recorded.

## Deliberate scope

Observe-only; the argument-repair layer that would consume this classifier is a separate future PR.

## Tests

Classifier unit tests over representative `ValidationError`s (extra keys only, type errors, missing, mixed, unparsable JSON) + instrumentation tests asserting the event lands on the span when a tool is called with junk extra keys. 100% coverage on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
