### PR TITLE
feat(FallbackModel): attribute failures to models and support `(exception, model)` `fallback_on`

### DIFF
--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -350,6 +350,8 @@ The `fallback_on` parameter accepts:
 
 Handler type is auto-detected by inspecting type hints on the first parameter. If the first parameter is hinted as [`ModelResponse`][pydantic_ai.messages.ModelResponse], it's a response handler. Otherwise (including untyped handlers and lambdas), it's an exception handler.
 
+Handlers may optionally accept the [`Model`][pydantic_ai.models.Model] that raised the exception (or produced the response) as a second positional argument, so you can make per-model fallback decisions — see [Per-Model Fallback Decisions](#per-model-fallback-decisions).
+
 #### Finish Reason Example
 
 A simple use case is checking the model's finish reason — for example, falling back if the response was truncated due to length limits:
@@ -459,6 +461,53 @@ fallback_model = FallbackModel(
     ],
 )
 ```
+
+#### Per-Model Fallback Decisions
+
+Any handler may accept the [`Model`][pydantic_ai.models.Model] that raised the exception (or produced the response) as a second positional argument. This lets a single handler behave differently depending on which model is being tried — for example, to avoid retrying an authentication failure on your primary model while still falling back for other errors:
+
+```python {title="fallback_on_per_model.py"}
+from pydantic_ai import Agent
+from pydantic_ai.exceptions import ModelAPIError
+from pydantic_ai.models import Model
+from pydantic_ai.models.fallback import FallbackModel
+
+
+def fall_back_unless_primary_auth_error(exc: Exception, model: Model) -> bool:
+    """Fall back on API errors, except for auth failures on the primary model."""
+    if not isinstance(exc, ModelAPIError):
+        return False
+    if model.model_name == 'gpt-5.2' and 'authentication' in str(exc).lower():
+        return False  # let the auth error propagate instead of masking it behind a fallback
+    return True
+
+
+fallback_model = FallbackModel(
+    'openai:gpt-5.2',
+    'anthropic:claude-sonnet-4-5',
+    fallback_on=fall_back_unless_primary_auth_error,
+)
+agent = Agent(fallback_model)
+```
+
+The second argument is optional and detected per handler, so existing single-argument handlers keep working unchanged.
+
+### Attributing Failures to Models
+
+When all models fail, the resulting [`FallbackExceptionGroup`][pydantic_ai.exceptions.FallbackExceptionGroup] wraps each model's exception in order of attempt, matching the order of the models passed to `FallbackModel`. Each sub-exception is annotated with a [PEP 678](https://peps.python.org/pep-0678/) note identifying the model that raised it, so tracebacks (and `exception.__notes__`) tell you exactly which model produced which error:
+
+```
+  | pydantic_ai.exceptions.FallbackExceptionGroup: All models from FallbackModel failed (2 sub-exceptions)
+  +-+---------------- 1 ----------------
+    | pydantic_ai.exceptions.ModelHTTPError: status_code: 401, model_name: gpt-5.2, body: ...
+    | Raised by fallback model 'gpt-5.2'.
+    +---------------- 2 ----------------
+    | pydantic_ai.exceptions.ModelHTTPError: status_code: 529, model_name: claude-sonnet-4-5, body: ...
+    | Raised by fallback model 'claude-sonnet-4-5'.
+    +------------------------------------
+```
+
+On the success path, the winning model is identified as usual by the `model_name` field of the returned [`ModelResponse`][pydantic_ai.messages.ModelResponse].
 
 ### Exception Handling in Middleware and Decorators
 

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -496,7 +496,7 @@ The second argument is optional and detected per handler, so existing single-arg
 
 When all models fail, the resulting [`FallbackExceptionGroup`][pydantic_ai.exceptions.FallbackExceptionGroup] wraps each model's exception in order of attempt, matching the order of the models passed to `FallbackModel`. Each sub-exception is annotated with a [PEP 678](https://peps.python.org/pep-0678/) note identifying the model that raised it, so tracebacks (and `exception.__notes__`) tell you exactly which model produced which error:
 
-```
+```text
   | pydantic_ai.exceptions.FallbackExceptionGroup: All models from FallbackModel failed (2 sub-exceptions)
   +-+---------------- 1 ----------------
     | pydantic_ai.exceptions.ModelHTTPError: status_code: 401, model_name: gpt-5.2, body: ...

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
@@ -159,3 +159,8 @@ Good defaults:
 - primary expensive/strong model, cheaper fallback for resilience
 - same prompt/output contract across both models
 - per-model settings only when the user actually needs them
+
+Control failover with `fallback_on` (exception types/handlers and/or response handlers). A handler may take
+an optional second `model` argument (`def check(exc: Exception, model: Model) -> bool`) to make per-model
+decisions. When every model fails, the raised `FallbackExceptionGroup` orders sub-exceptions by attempt and
+annotates each with the failing model's name (visible in tracebacks and `exception.__notes__`).

--- a/pydantic_ai_slim/pydantic_ai/models/fallback.py
+++ b/pydantic_ai_slim/pydantic_ai/models/fallback.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import inspect
 from collections.abc import AsyncGenerator, Awaitable, Callable, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass, field
@@ -24,11 +25,29 @@ if TYPE_CHECKING:
     from ..messages import ModelMessage
     from ..settings import ModelSettings
 
-ExceptionHandler = Callable[[Exception], Awaitable[bool]] | Callable[[Exception], bool]
-"""A sync or async callable that decides whether an exception should trigger fallback."""
+ExceptionHandler = (
+    Callable[[Exception], Awaitable[bool]]
+    | Callable[[Exception], bool]
+    | Callable[[Exception, 'Model'], Awaitable[bool]]
+    | Callable[[Exception, 'Model'], bool]
+)
+"""A sync or async callable that decides whether an exception should trigger fallback.
 
-ResponseHandler = Callable[[ModelResponse], Awaitable[bool]] | Callable[[ModelResponse], bool]
-"""A sync or async callable that decides whether a model response should trigger fallback."""
+The callable receives the raised exception, and may optionally accept the [`Model`][pydantic_ai.models.Model]
+that raised it as a second positional argument, to make per-model fallback decisions.
+"""
+
+ResponseHandler = (
+    Callable[[ModelResponse], Awaitable[bool]]
+    | Callable[[ModelResponse], bool]
+    | Callable[[ModelResponse, 'Model'], Awaitable[bool]]
+    | Callable[[ModelResponse, 'Model'], bool]
+)
+"""A sync or async callable that decides whether a model response should trigger fallback.
+
+The callable receives the model's [`ModelResponse`][pydantic_ai.messages.ModelResponse], and may optionally accept
+the [`Model`][pydantic_ai.models.Model] that produced it as a second positional argument.
+"""
 
 FallbackOn = (
     type[Exception]
@@ -65,6 +84,37 @@ def _is_exception_type(value: Any) -> TypeGuard[type[Exception]]:
     return isinstance(value, type) and issubclass(value, Exception)
 
 
+def _handler_accepts_model(handler: Callable[..., Any]) -> bool:
+    """Whether a `fallback_on` handler accepts the failing `Model` as a second positional argument.
+
+    Inspected once when the handler is registered so the signature isn't re-parsed on every request.
+    """
+    try:
+        sig = inspect.signature(handler)
+    except (TypeError, ValueError):  # pragma: no cover
+        return False
+    positional = 0
+    for param in sig.parameters.values():
+        if param.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD):
+            positional += 1
+        elif param.kind is inspect.Parameter.VAR_POSITIONAL:
+            return True
+    return positional >= 2
+
+
+@dataclass
+class _FallbackHandler:
+    """A parsed `fallback_on` handler with its call metadata cached at registration time."""
+
+    call: ExceptionHandler | ResponseHandler
+    is_async: bool
+    accepts_model: bool
+
+    @classmethod
+    def build(cls, handler: Callable[..., Any]) -> _FallbackHandler:
+        return cls(call=handler, is_async=is_async_callable(handler), accepts_model=_handler_accepts_model(handler))
+
+
 @dataclass(init=False)
 class FallbackModel(Model):
     """A model that uses one or more fallback models upon failure.
@@ -74,8 +124,8 @@ class FallbackModel(Model):
 
     models: list[Model]
 
-    _exception_handlers: list[ExceptionHandler] = field(repr=False)
-    _response_handlers: list[ResponseHandler] = field(repr=False)
+    _exception_handlers: list[_FallbackHandler] = field(repr=False)
+    _response_handlers: list[_FallbackHandler] = field(repr=False)
 
     @cached_property
     def _enter_lock(self) -> anyio.Lock:
@@ -105,6 +155,10 @@ class FallbackModel(Model):
                 Handler type is auto-detected by inspecting type hints on the first parameter.
                 If the first parameter is hinted as `ModelResponse`, it's a response handler.
                 Otherwise (including untyped handlers and lambdas), it's an exception handler.
+
+                Handlers may optionally accept the [`Model`][pydantic_ai.models.Model] that raised the
+                exception (or produced the response) as a second positional argument, to make per-model
+                fallback decisions: `def check(exc: Exception, model: Model) -> bool`.
         """
         super().__init__()
         self.models = [infer_model(default_model), *[infer_model(m) for m in fallback_models]]
@@ -120,10 +174,10 @@ class FallbackModel(Model):
         if isinstance(fallback_on, tuple):
             if fallback_on:
                 # Tuple of exception types (typing guarantees tuple contents are exception types)
-                self._exception_handlers.append(_exception_types_to_handler(fallback_on))  # type: ignore[arg-type]
+                self._add_exception_types(fallback_on)  # type: ignore[arg-type]
         elif _is_exception_type(fallback_on):
             # Single exception type
-            self._exception_handlers.append(_exception_types_to_handler((fallback_on,)))
+            self._add_exception_types((fallback_on,))
         elif callable(fallback_on):
             # Single callable - auto-detect by type hints
             self._add_handler(fallback_on)
@@ -131,7 +185,7 @@ class FallbackModel(Model):
             # Sequence of mixed handlers/types
             for item in fallback_on:
                 if _is_exception_type(item):
-                    self._exception_handlers.append(_exception_types_to_handler((item,)))
+                    self._add_exception_types((item,))
                 elif callable(item):
                     self._add_handler(item)
                 else:
@@ -147,19 +201,28 @@ class FallbackModel(Model):
                 'Use fallback_on=(ModelAPIError,) for default behavior.'
             )
 
+    def _add_exception_types(self, exceptions: tuple[type[Exception], ...]) -> None:
+        """Register a fallback handler that triggers on the given exception types."""
+        self._exception_handlers.append(_FallbackHandler.build(_exception_types_to_handler(exceptions)))
+
     def _add_handler(self, handler: Callable[..., Any]) -> None:
         """Add a handler, auto-detecting its type by inspecting type hints."""
         if _is_response_handler(handler):
-            self._response_handlers.append(handler)
+            self._response_handlers.append(_FallbackHandler.build(handler))
         else:
-            self._exception_handlers.append(handler)
+            self._exception_handlers.append(_FallbackHandler.build(handler))
 
-    async def _should_fallback(self, value: Exception | ModelResponse) -> bool:
-        """Check if any handler wants to trigger fallback."""
+    async def _should_fallback(self, value: Exception | ModelResponse, model: Model) -> bool:
+        """Check if any handler wants to trigger fallback to the next model.
+
+        `model` is the model that raised `value` (or produced it, for a response), and is passed to
+        handlers that accept it as a second positional argument.
+        """
         handlers = self._exception_handlers if isinstance(value, Exception) else self._response_handlers
         for handler in handlers:
-            # pyright can't narrow handler's param type from the isinstance check on value
-            result = await handler(value) if is_async_callable(handler) else handler(value)  # type: ignore[arg-type]
+            args = (value, model) if handler.accepts_model else (value,)
+            # pyright can't narrow the handler's parameter types from the isinstance check on value
+            result = await handler.call(*args) if handler.is_async else handler.call(*args)  # type: ignore[arg-type]
             if result:
                 return True
         return False
@@ -229,12 +292,13 @@ class FallbackModel(Model):
                 prepared_messages = model.prepare_messages(messages)
                 response = await model.request(prepared_messages, model_settings, model_request_parameters)
             except Exception as exc:
-                if await self._should_fallback(exc):
+                if await self._should_fallback(exc, model):
+                    _attribute_exception_to_model(exc, model)
                     exceptions.append(exc)
                     continue
                 raise exc
 
-            if await self._should_fallback(response):
+            if await self._should_fallback(response, model):
                 rejected_responses.append(response)
                 continue
 
@@ -263,7 +327,8 @@ class FallbackModel(Model):
                         model.request_stream(prepared_messages, model_settings, model_request_parameters, run_context)
                     )
                 except Exception as exc:
-                    if await self._should_fallback(exc):
+                    if await self._should_fallback(exc, model):
+                        _attribute_exception_to_model(exc, model)
                         exceptions.append(exc)
                         continue
                     raise exc  # pragma: no cover
@@ -314,8 +379,27 @@ def _exception_types_to_handler(exceptions: tuple[type[Exception], ...]) -> Exce
     return handler
 
 
+def _attribute_exception_to_model(exc: Exception, model: Model) -> None:
+    """Attach the failing model's name to `exc` as a [PEP 678](https://peps.python.org/pep-0678/) note.
+
+    Without this, the exceptions collected into a `FallbackExceptionGroup` carry no indication of which
+    model raised them. The note surfaces the model in tracebacks and in `exc.__notes__`, so callers can
+    tell attempts apart even when several models raise the same exception type.
+    """
+    note = f'Raised by fallback model {model.model_name!r}.'
+    # Write `__notes__` directly rather than via the `BaseException.add_note` API, which only exists on
+    # Python 3.11+; both the standard-library traceback formatter and the `exceptiongroup` backport read
+    # `__notes__`, so attribution renders consistently across supported Python versions.
+    exc.__notes__ = [*getattr(exc, '__notes__', []), note]  # type: ignore[attr-defined]  # 3.10 typeshed lacks `__notes__`
+
+
 def _raise_fallback_exception_group(exceptions: list[Exception], rejected_responses: list[ModelResponse]) -> NoReturn:
     """Raise a FallbackExceptionGroup combining exceptions and response rejections.
+
+    The sub-exceptions are ordered by attempt, matching the order of the models that raised them in
+    `FallbackModel.models`, and each is annotated with the failing model's name (see
+    `_attribute_exception_to_model`). If any responses were rejected by a response handler, a single
+    trailing `ResponseRejected` summarizes them.
 
     Args:
         exceptions: List of exceptions raised by models.

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -28,7 +28,7 @@ from pydantic_ai import (
 )
 from pydantic_ai.capabilities.instrumentation import Instrumentation
 from pydantic_ai.messages import InstructionPart, NativeToolCallPart, NativeToolReturnPart
-from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models import Model, ModelRequestParameters
 from pydantic_ai.models.fallback import FallbackModel, ResponseRejected
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings, InstrumentedModel
@@ -1806,3 +1806,167 @@ async def test_fallback_model_concurrent_entry():
     await task2
     assert provider1._own_http_client.is_closed  # pyright: ignore[reportPrivateUsage]
     assert provider2._own_http_client.is_closed  # pyright: ignore[reportPrivateUsage]
+
+
+# `(exception, model)` and `(response, model)` handlers + failure-to-model attribution
+
+
+def exception_notes(exc: BaseException) -> list[str]:
+    """The PEP 678 notes attached to an exception (typeshed only exposes `__notes__` on Python 3.11+)."""
+    return exc.__notes__  # type: ignore[attr-defined]
+
+
+def first_http_failure(_: list[ModelMessage], __: AgentInfo) -> ModelResponse:
+    raise ModelHTTPError(status_code=500, model_name='first', body=None)
+
+
+def second_http_failure(_: list[ModelMessage], __: AgentInfo) -> ModelResponse:
+    raise ModelHTTPError(status_code=503, model_name='second', body=None)
+
+
+async def test_two_arg_exception_handler_receives_failing_model() -> None:
+    """A 2-arg `fallback_on` handler is called with the exception and the model that raised it, per attempt."""
+    seen: list[tuple[str, int]] = []
+
+    def should_fallback(exc: Exception, model: Model) -> bool:
+        assert isinstance(exc, ModelHTTPError)
+        seen.append((model.model_name, exc.status_code))
+        return True
+
+    first_model = FunctionModel(first_http_failure)
+    second_model = FunctionModel(second_http_failure)
+    fallback = FallbackModel(first_model, second_model, fallback_on=should_fallback)
+    agent = Agent(model=fallback)
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await agent.run('hello')
+
+    # The handler saw each model paired with its own exception, in attempt order.
+    assert seen == [('function:first_http_failure:', 500), ('function:second_http_failure:', 503)]
+
+    # The grouped sub-exceptions are ordered by attempt and annotated with the failing model's name.
+    exceptions = exc_info.value.exceptions
+    assert [exception_notes(e) for e in exceptions] == snapshot(
+        [
+            ["Raised by fallback model 'function:first_http_failure:'."],
+            ["Raised by fallback model 'function:second_http_failure:'."],
+        ]
+    )
+
+
+async def test_two_arg_exception_handler_per_model_decision() -> None:
+    """A 2-arg handler can make different fallback decisions depending on which model raised."""
+
+    def only_fall_back_from_primary(exc: Exception, model: Model) -> bool:
+        # Fall back away from the primary model, but let the secondary's failure propagate as-is.
+        return model.model_name == 'function:first_http_failure:'
+
+    first_model = FunctionModel(first_http_failure)
+    second_model = FunctionModel(second_http_failure)
+    fallback = FallbackModel(first_model, second_model, fallback_on=only_fall_back_from_primary)
+    agent = Agent(model=fallback)
+
+    # Primary falls back to secondary; secondary's error is re-raised directly (not wrapped in a group).
+    with pytest.raises(ModelHTTPError) as exc_info:
+        await agent.run('hello')
+    assert exc_info.value.status_code == 503
+
+
+async def test_two_arg_async_exception_handler_receives_model() -> None:
+    """Async 2-arg exception handlers receive the failing model too."""
+    seen: list[str] = []
+
+    async def should_fallback(exc: Exception, model: Model) -> bool:
+        seen.append(model.model_name)
+        return isinstance(exc, ModelHTTPError)
+
+    fallback = FallbackModel(failure_model, success_model, fallback_on=should_fallback)
+    agent = Agent(model=fallback)
+
+    result = await agent.run('hello')
+    assert result.output == 'success'
+    assert seen == ['function:failure_response:']
+
+
+def test_var_args_exception_handler_receives_model() -> None:
+    """A `*args` handler is recognized as accepting the model and is called with both arguments."""
+    seen: list[int] = []
+
+    def should_fallback(*args: object) -> bool:
+        seen.append(len(args))
+        exc = args[0]
+        return isinstance(exc, ModelHTTPError)
+
+    fallback = FallbackModel(failure_model, success_model, fallback_on=should_fallback)
+    agent = Agent(model=fallback)
+
+    result = agent.run_sync('hello')
+    assert result.output == 'success'
+    assert seen == [2]  # called with (exception, model)
+
+
+async def test_two_arg_response_handler_receives_producing_model() -> None:
+    """A 2-arg response handler is called with the response and the model that produced it."""
+    seen: list[str] = []
+
+    def reject_primary(response: ModelResponse, model: Model, **_: object) -> bool:
+        # The trailing `**_` also exercises handler-arity detection past positional parameters.
+        seen.append(model.model_name)
+        part = response.parts[0] if response.parts else None
+        return isinstance(part, TextPart) and 'primary' in part.content
+
+    fallback = FallbackModel(primary_model, fallback_model_impl, fallback_on=reject_primary)
+    agent = Agent(model=fallback)
+
+    result = await agent.run('hello')
+    assert result.output == 'fallback response'
+    assert seen == ['function:primary_response:', 'function:fallback_response:']
+
+
+async def test_two_arg_exception_handler_streaming_attribution() -> None:
+    """Streaming fallback passes the failing model to 2-arg handlers and annotates grouped exceptions."""
+    seen: list[str] = []
+
+    def should_fallback(exc: Exception, model: Model) -> bool:
+        seen.append(model.model_name)
+        return True
+
+    fallback = FallbackModel(failure_model_stream, failure_model_stream, fallback_on=should_fallback)
+    agent = Agent(model=fallback)
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        async with agent.run_stream('hello') as result:
+            [c async for c in result.stream_response(debounce_by=None)]  # pragma: lax no cover
+
+    assert seen == ['function::failure_response_stream', 'function::failure_response_stream']
+    exceptions = exc_info.value.exceptions
+    assert [exception_notes(e) for e in exceptions] == snapshot(
+        [
+            ["Raised by fallback model 'function::failure_response_stream'."],
+            ["Raised by fallback model 'function::failure_response_stream'."],
+        ]
+    )
+
+
+def test_success_path_reports_serving_model() -> None:
+    """The successful `ModelResponse` identifies the underlying model that served it, not the `FallbackModel`."""
+    fallback = FallbackModel(failure_model, success_model)
+    agent = Agent(model=fallback)
+
+    result = agent.run_sync('hello')
+    response = result.all_messages()[-1]
+    assert isinstance(response, ModelResponse)
+    assert response.model_name == 'function:success_response:'
+    assert fallback.model_name == 'fallback:function:failure_response:,function:success_response:'
+
+
+async def test_success_path_reports_serving_model_streaming() -> None:
+    """Streaming responses also identify the underlying model that served the request."""
+    fallback = FallbackModel(failure_model_stream, success_model_stream)
+    agent = Agent(model=fallback)
+
+    async with agent.run_stream('hello') as result:
+        await result.get_output()
+        response = result.all_messages()[-1]
+    assert isinstance(response, ModelResponse)
+    assert response.model_name == 'function::success_response_stream'


### PR DESCRIPTION
## What

Makes `FallbackModel` failures attributable to the model that produced them, and lets `fallback_on` handlers make per-model decisions. Backward compatible — no API break.

Motivation: `FallbackModel`'s `fallback_on` callback and the final `FallbackExceptionGroup` don't tell you *which* model failed. VStorm's `pydantic-deep` (a large production consumer) had to build a ContextVar hop-counter to recover this; the [model-gated-prompts design](https://github.com/pydantic/pydantic-ai-notes/blob/main/features/model-gated-prompts/2026-07-06%20design%20-%20per-model%20prompts%20x%20cross-model%20histories.md) flags the same gap. Fixed at the source.

## How

1. **Attribution via PEP-678 notes**: each grouped sub-exception in `FallbackExceptionGroup` gets a `Raised by fallback model '<name>'.` note (written directly to `__notes__` for 3.10 cross-version cleanliness; visible in tracebacks and via the `exceptiongroup` backport), ordered to match `FallbackModel.models`.
2. **Optional second `Model` arg on `fallback_on`**: continues to accept the existing 1-arg callable / exception tuple unchanged; *additionally* accepts a 2-arg `(exception, model) -> bool`. Arity is inspected once at registration and cached; applied uniformly to exception and response handlers.
3. **Success-path attribution verified**: the serving model is already reported via `ModelResponse.model_name` when going through `FallbackModel` — locked with explicit non-streaming and streaming tests (no `RunContext` changes).

## Tests

2-arg `fallback_on` receives the correct model per attempt; 1-arg and tuple forms unchanged; exception-group note ordering; success-path `model_name` attribution on both request and streaming paths. 100% coverage on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
