### PR TITLE
fix(cli): make command name consistent between entry point, `--help`, and docs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -136,6 +136,15 @@ def cli_exit(prog_name: str = 'clai'):  # pragma: no cover
     sys.exit(cli(prog_name=prog_name))
 
 
+def pai_cli_exit():  # pragma: no cover
+    """Run the CLI under its legacy `pai` command name and exit.
+
+    `pai` was the original name of the CLI (now `clai`) and is kept as an alias; this ensures `pai --help`
+    reports `pai` rather than `clai` as the program name.
+    """
+    cli_exit('pai')
+
+
 def cli(args_list: Sequence[str] | None = None, *, prog_name: str = 'clai', default_model: str = 'openai:gpt-5') -> int:
     """Run the CLI and return the exit code for the process."""
     # we don't want to autocomplete or list models that don't include the provider,

--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -131,12 +131,12 @@ The current date and time is {datetime.now()} {tzname}.
 The user is running {sys.platform}."""
 
 
-def cli_exit(prog_name: str = 'clai'):  # pragma: no cover
+def cli_exit(prog_name: str = 'clai'):
     """Run the CLI and exit."""
     sys.exit(cli(prog_name=prog_name))
 
 
-def pai_cli_exit():  # pragma: no cover
+def pai_cli_exit():
     """Run the CLI under its legacy `pai` command name and exit.
 
     `pai` was the original name of the CLI (now `clai`) and is kept as an alias; this ensures `pai --help`

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -129,7 +129,7 @@ spec = ["pyyaml>=6.0.2", "pydantic-handlebars>=0.1.0"]
 allow-direct-references = true
 
 [project.scripts]
-pai = "pydantic_ai._cli:cli_exit" # TODO remove this when clai has been out for a while
+pai = "pydantic_ai._cli:pai_cli_exit" # TODO remove this when clai has been out for a while
 
 [tool.hatch.build.targets.wheel]
 packages = ["pydantic_ai"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ Documentation = "https://ai.pydantic.dev"
 Changelog = "https://github.com/pydantic/pydantic-ai/releases"
 
 [project.scripts]
-pai = "pydantic_ai._cli:cli_exit" # TODO remove this when clai has been out for a while
+pai = "pydantic_ai._cli:pai_cli_exit" # TODO remove this when clai has been out for a while
 
 [tool.uv.sources]
 pydantic-ai = { workspace = true }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ with try_import() as imports_successful:
     from prompt_toolkit.output import DummyOutput
     from prompt_toolkit.shortcuts import PromptSession
 
-    from pydantic_ai._cli import cli, cli_agent, handle_slash_command
+    from pydantic_ai._cli import cli, cli_agent, handle_slash_command, pai_cli_exit
     from pydantic_ai._cli.web import run_web_command
     from pydantic_ai.models.openai import OpenAIChatModel
 
@@ -46,6 +46,20 @@ def reset_sniffio_cvar() -> Iterator[None]:
 def test_cli_version(capfd: CaptureFixture[str]):
     assert cli(['--version']) == 0
     assert capfd.readouterr().out.startswith('clai - Pydantic AI CLI')
+
+
+def test_cli_pai_prog_name(capfd: CaptureFixture[str]):
+    # The legacy `pai` command should report itself as `pai`, not `clai`.
+    assert cli(['--version'], prog_name='pai') == 0
+    assert capfd.readouterr().out.startswith('pai - Pydantic AI CLI')
+
+
+def test_pai_cli_exit_uses_pai_prog_name(mocker: MockerFixture):
+    # The `pai` entry point passes its own program name through to argparse.
+    mock_cli = mocker.patch('pydantic_ai._cli.cli', return_value=0)
+    with pytest.raises(SystemExit):
+        pai_cli_exit()
+    mock_cli.assert_called_once_with(prog_name='pai')
 
 
 def test_invalid_model(capfd: CaptureFixture[str]):


### PR DESCRIPTION
## Summary

A newcomer following the [CLI docs](https://ai.pydantic.dev/cli/) learns the command is `clai`, but the `pai` command shipped by `pydantic-ai`/`pydantic-ai-slim` prints `usage: clai ...` for `pai --help`. This fixes that self-inconsistency: the `pai` command now reports itself as `pai`.

Surfaced by the onboarding fresh-eyes audit (finding F4): [onboarding audit doc](https://github.com/pydantic/pydantic-ai-notes/blob/main/features/onboarding-dx/2026-07-08%20fresh-eyes%20audit%20-%20onboarding%2C%20agent-native%20docs%2C%20logfire%20funnel.md).

## The rename story (for the record)

- #1031 added the CLI as **`pai`**.
- #1504 **switched the CLI to `clai`** (the standalone [`clai`](https://pypi.org/project/clai/) package owns the `clai` command; docs use `clai` throughout). `pai` was kept in `pydantic-ai`/`pydantic-ai-slim` as a legacy alias, with `# TODO remove this when clai has been out for a while`.

So the intended name is unambiguously **`clai`**. The `pai` entry point mapped directly to `cli_exit`, whose `prog_name` defaults to `'clai'`, so `pai --help` reported the wrong program name.

## Change

- Route the `pai` entry point through a small `pai_cli_exit` wrapper that passes `prog_name='pai'`, in `pydantic_ai/_cli/__init__.py` and the `[project.scripts]` of both `pyproject.toml` and `pydantic_ai_slim/pyproject.toml`.
- Regression tests: `pai` reports `pai` in its output, and the entry point passes `prog_name='pai'`.

Docs already use `clai` consistently, so no doc changes were needed for the command name.

## Judgment call / note for review

I deliberately kept this surgical and did **not** add a `clai` console script to `pydantic-ai-slim`. The standalone `clai` package depends on `pydantic-ai` → `pydantic-ai-slim`, so a `clai` script in slim would collide with the standalone package's `clai` script on every `pip install clai`. The current architecture (standalone `clai` package owns `clai`; slim keeps `pai` as a legacy alias) is deliberate.

One remaining wrinkle worth your call: `docs/install.md` says `pip install pydantic-ai` includes "the CLI", but that install exposes only `pai` (the documented `clai` requires `uvx clai` / `pip install clai`). If you'd prefer `pip install pydantic-ai` to expose `clai` too, that's a packaging decision (and would need the duplicate-script question resolved) — happy to follow up separately.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

