### PR TITLE
fix(onboarding): suggest `Agent('test')` when provider credentials are missing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ _(This example is complete, it can be run "as is", assuming you've [installed th
     #> success (no tool calls)
     ```
 
-    1. [`TestModel`](testing.md#unit-testing-with-testmodel) returns canned responses so you can exercise your agent, tools, and outputs without a key.
+    1. [`TestModel`][pydantic_ai.models.test.TestModel] returns canned responses so you can exercise your agent, tools, and outputs without a key.
 
     When you're ready to use a real model, see [Models and Providers](models/overview.md) to pick a provider and set its API key.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,22 @@ The first known use of "hello, world" was in a 1974 textbook about the C program
 
 _(This example is complete, it can be run "as is", assuming you've [installed the `pydantic_ai` package](install.md))_
 
+!!! tip "No API key yet?"
+    You don't need a provider API key to try Pydantic AI. Pass the built-in [`'test'` model](testing.md#unit-testing-with-testmodel), which runs entirely offline without calling an LLM:
+
+    ```python {title="hello_world_test.py"}
+    from pydantic_ai import Agent
+
+    agent = Agent('test')  # (1)!
+    result = agent.run_sync('Where does "hello world" come from?')
+    print(result.output)
+    #> success (no tool calls)
+    ```
+
+    1. [`TestModel`](testing.md#unit-testing-with-testmodel) returns canned responses so you can exercise your agent, tools, and outputs without a key.
+
+    When you're ready to use a real model, see [Models and Providers](models/overview.md) to pick a provider and set its API key.
+
 The exchange will be very short: Pydantic AI will send the instructions and the user prompt to the LLM, and the model will return a text response.
 
 Not very interesting yet, but we can easily add [tools](tools.md), [dynamic instructions](agent.md#instructions), [structured outputs](output.md), or composable [capabilities](capabilities.md) to build more powerful agents.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,11 +32,11 @@ result = agent.run_sync('Who let the dogs out?')
 
 ## API Key Configuration
 
-### `UserError: Set the [PROVIDER]_API_KEY environment variable or pass it via [Provider](api_key=...)`
+### [`UserError`][pydantic_ai.exceptions.UserError]: Set the `[PROVIDER]_API_KEY` environment variable or pass it via the provider's `api_key=...` argument
 
 If you're running into issues with setting the API key for your model, visit the [Models](models/overview.md) page to learn more about how to set an environment variable and/or pass in an `api_key` argument.
 
-To try Pydantic AI without an API key, use the built-in [`'test'` model](testing.md#unit-testing-with-testmodel): `Agent('test')`.
+To try Pydantic AI without an API key, use the built-in [`'test'` model](testing.md#unit-testing-with-testmodel): [`Agent('test')`][pydantic_ai.agent.Agent].
 
 ## Monitoring HTTPX Requests
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,9 +32,11 @@ result = agent.run_sync('Who let the dogs out?')
 
 ## API Key Configuration
 
-### `UserError: API key must be provided or set in the [MODEL]_API_KEY environment variable`
+### `UserError: Set the [PROVIDER]_API_KEY environment variable or pass it via [Provider](api_key=...)`
 
 If you're running into issues with setting the API key for your model, visit the [Models](models/overview.md) page to learn more about how to set an environment variable and/or pass in an `api_key` argument.
+
+To try Pydantic AI without an API key, use the built-in [`'test'` model](testing.md#unit-testing-with-testmodel): `Agent('test')`.
 
 ## Monitoring HTTPX Requests
 

--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -15,9 +15,25 @@ import anyio
 import httpx
 from typing_extensions import Self, TypeVar
 
+from ..exceptions import UserError
 from ..profiles import ModelProfile
 
 InterfaceClient = TypeVar('InterfaceClient', default=Any)
+
+_KEYLESS_HINT = (
+    "To try Pydantic AI without an API key, use the built-in test model: `Agent('test')`. "
+    'See https://ai.pydantic.dev/testing/'
+)
+
+
+def missing_api_key_error(message: str) -> UserError:
+    """Build a [`UserError`][pydantic_ai.exceptions.UserError] for missing provider credentials.
+
+    The provider-specific `message` (which environment variable to set or how to pass the key) is followed by a
+    hint pointing newcomers to the keyless [test model](https://ai.pydantic.dev/testing/), so a missing key never
+    dead-ends the getting-started experience.
+    """
+    return UserError(f'{message} {_KEYLESS_HINT}')
 
 
 class Provider(ABC, Generic[InterfaceClient]):

--- a/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/anthropic.py
@@ -8,11 +8,10 @@ from typing import TypeAlias, overload
 import httpx
 
 from pydantic_ai import ModelProfile
-from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles import merge_profile
 from pydantic_ai.profiles.anthropic import AnthropicModelProfile, anthropic_model_profile
-from pydantic_ai.providers import Provider
+from pydantic_ai.providers import Provider, missing_api_key_error
 from pydantic_ai.providers._bedrock_model_names import split_bedrock_model_id
 
 from .._json_schema import JsonSchema, JsonSchemaTransformer
@@ -103,7 +102,7 @@ class AnthropicProvider(Provider[AsyncAnthropicClient]):
         else:
             api_key = api_key or os.getenv('ANTHROPIC_API_KEY')
             if not api_key:
-                raise UserError(
+                raise missing_api_key_error(
                     'Set the `ANTHROPIC_API_KEY` environment variable or pass it via `AnthropicProvider(api_key=...)`'
                     ' to use the Anthropic provider.'
                 )

--- a/pydantic_ai_slim/pydantic_ai/providers/google.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/google.py
@@ -7,10 +7,9 @@ from typing import Literal, overload
 import httpx
 
 from pydantic_ai import ModelProfile
-from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import DEFAULT_HTTP_TIMEOUT, create_async_http_client, get_user_agent
 from pydantic_ai.profiles.google import google_model_profile
-from pydantic_ai.providers import Provider
+from pydantic_ai.providers import Provider, missing_api_key_error
 
 try:
     from google.genai.client import Client
@@ -130,7 +129,7 @@ class GoogleProvider(BaseGoogleProvider):
         # NOTE: We are keeping GEMINI_API_KEY for backwards compatibility.
         api_key = api_key or os.getenv('GOOGLE_API_KEY') or os.getenv('GEMINI_API_KEY')
         if api_key is None:
-            raise UserError(
+            raise missing_api_key_error(
                 'Set the `GOOGLE_API_KEY` environment variable or pass it via `GoogleProvider(api_key=...)`'
                 ' to use the Gemini API.'
             )

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -69,19 +69,19 @@ class OpenAIProvider(Provider[AsyncOpenAI]):
                 client to use. If provided, `base_url`, `api_key`, and `http_client` must be `None`.
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
         """
-        # When talking to OpenAI directly (no custom `base_url`), a missing key would otherwise surface as a raw
-        # `openai.OpenAIError`; raise our own `UserError` instead so the message is consistent with other providers
-        # and points newcomers to the keyless test model.
-        if api_key is None and 'OPENAI_API_KEY' not in os.environ and base_url is None and openai_client is None:
-            raise missing_api_key_error(
-                'Set the `OPENAI_API_KEY` environment variable or pass it via `OpenAIProvider(api_key=...)`'
-                ' to use the OpenAI provider.'
-            )
-
-        # This is a workaround for the OpenAI client requiring an API key, whilst locally served,
-        # openai compatible models do not always need an API key, but a placeholder (non-empty) key is required.
-        if api_key is None and 'OPENAI_API_KEY' not in os.environ and base_url is not None and openai_client is None:
-            api_key = 'api-key-not-set'
+        if api_key is None and 'OPENAI_API_KEY' not in os.environ and openai_client is None:
+            if base_url is None and 'OPENAI_BASE_URL' not in os.environ:
+                # When talking to OpenAI directly, a missing key would otherwise surface as a raw
+                # `openai.OpenAIError`; raise our own `UserError` instead so the message is consistent with
+                # other providers and points newcomers to the keyless test model.
+                raise missing_api_key_error(
+                    'Set the `OPENAI_API_KEY` environment variable or pass it via `OpenAIProvider(api_key=...)`'
+                    ' to use the OpenAI provider.'
+                )
+            else:
+                # This is a workaround for the OpenAI client requiring an API key, whilst locally served,
+                # openai compatible models do not always need an API key, but a placeholder (non-empty) key is required.
+                api_key = 'api-key-not-set'
 
         if openai_client is not None:
             assert base_url is None, 'Cannot provide both `openai_client` and `base_url`'

--- a/pydantic_ai_slim/pydantic_ai/providers/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/openai.py
@@ -8,7 +8,7 @@ import httpx
 from pydantic_ai import ModelProfile
 from pydantic_ai.models import create_async_http_client
 from pydantic_ai.profiles.openai import openai_model_profile
-from pydantic_ai.providers import Provider
+from pydantic_ai.providers import Provider, missing_api_key_error
 
 try:
     from openai import AsyncOpenAI
@@ -69,6 +69,15 @@ class OpenAIProvider(Provider[AsyncOpenAI]):
                 client to use. If provided, `base_url`, `api_key`, and `http_client` must be `None`.
             http_client: An existing `httpx.AsyncClient` to use for making HTTP requests.
         """
+        # When talking to OpenAI directly (no custom `base_url`), a missing key would otherwise surface as a raw
+        # `openai.OpenAIError`; raise our own `UserError` instead so the message is consistent with other providers
+        # and points newcomers to the keyless test model.
+        if api_key is None and 'OPENAI_API_KEY' not in os.environ and base_url is None and openai_client is None:
+            raise missing_api_key_error(
+                'Set the `OPENAI_API_KEY` environment variable or pass it via `OpenAIProvider(api_key=...)`'
+                ' to use the OpenAI provider.'
+            )
+
         # This is a workaround for the OpenAI client requiring an API key, whilst locally served,
         # openai compatible models do not always need an API key, but a placeholder (non-empty) key is required.
         if api_key is None and 'OPENAI_API_KEY' not in os.environ and base_url is not None and openai_client is None:

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -2,11 +2,12 @@ from __future__ import annotations as _annotations
 
 import pytest
 
-from ..conftest import try_import
+from ..conftest import TestEnv, try_import
 
 with try_import() as imports_successful:
     from anthropic import AsyncAnthropic, AsyncAnthropicBedrock
 
+    from pydantic_ai.exceptions import UserError
     from pydantic_ai.native_tools import SUPPORTED_NATIVE_TOOLS
     from pydantic_ai.native_tools._tool_search import ToolSearchTool
     from pydantic_ai.providers.anthropic import AnthropicProvider
@@ -21,6 +22,18 @@ def test_anthropic_provider():
     assert provider.base_url == 'https://api.anthropic.com'
     assert isinstance(provider.client, AsyncAnthropic)
     assert provider.client.api_key == 'api-key'
+
+
+def test_anthropic_provider_without_api_key_raises_error(env: TestEnv):
+    env.remove('ANTHROPIC_API_KEY')
+    with pytest.raises(
+        UserError,
+        match=(
+            r'Set the `ANTHROPIC_API_KEY` environment variable or pass it via `AnthropicProvider\(api_key=\.\.\.\)`'
+            r" to use the Anthropic provider\. To try Pydantic AI without an API key, use the built-in test model: `Agent\('test'\)`\."
+        ),
+    ):
+        AnthropicProvider()
 
 
 def test_anthropic_provider_pass_anthropic_client() -> None:

--- a/tests/providers/test_google.py
+++ b/tests/providers/test_google.py
@@ -7,6 +7,7 @@ from ..conftest import TestEnv, try_import
 with try_import() as imports_successful:
     from google.genai.types import HttpRetryOptions
 
+    from pydantic_ai.exceptions import UserError
     from pydantic_ai.providers.google import GoogleProvider
     from pydantic_ai.providers.google_cloud import GoogleCloudProvider
 
@@ -15,6 +16,19 @@ pytestmark = pytest.mark.skipif(not imports_successful(), reason='google-genai n
 # `retry_options` only changes behavior on transient 429/5xx responses, which a recorded cassette
 # can't reliably reproduce, so these unit tests assert the resolved HTTP config directly via the
 # SDK's `get_read_only_http_options()` accessor rather than running an agent against a cassette.
+
+
+def test_google_provider_without_api_key_raises_error(env: TestEnv):
+    env.remove('GOOGLE_API_KEY')
+    env.remove('GEMINI_API_KEY')
+    with pytest.raises(
+        UserError,
+        match=(
+            r'Set the `GOOGLE_API_KEY` environment variable or pass it via `GoogleProvider\(api_key=\.\.\.\)`'
+            r" to use the Gemini API\. To try Pydantic AI without an API key, use the built-in test model: `Agent\('test'\)`\."
+        ),
+    ):
+        GoogleProvider()
 
 
 def test_google_provider_retry_options(env: TestEnv):

--- a/tests/providers/test_google.py
+++ b/tests/providers/test_google.py
@@ -28,7 +28,7 @@ def test_google_provider_without_api_key_raises_error(env: TestEnv):
             r" to use the Gemini API\. To try Pydantic AI without an API key, use the built-in test model: `Agent\('test'\)`\."
         ),
     ):
-        GoogleProvider()
+        GoogleProvider()  # pyright: ignore[reportCallIssue]  # deliberately no api_key, to test the missing-key error
 
 
 def test_google_provider_retry_options(env: TestEnv):

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -47,6 +47,13 @@ def test_init_of_openai_with_base_url_and_without_api_key(env: TestEnv):
     assert provider.client.api_key == 'api-key-not-set'
 
 
+def test_init_of_openai_with_base_url_env_var_and_without_api_key(env: TestEnv):
+    env.remove('OPENAI_API_KEY')
+    env.set('OPENAI_BASE_URL', 'https://example.com/v1')
+    provider = OpenAIProvider()
+    assert provider.client.api_key == 'api-key-not-set'
+
+
 async def test_init_with_http_client():
     async with httpx.AsyncClient() as http_client:
         provider = OpenAIProvider(http_client=http_client, api_key='foobar')

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -4,8 +4,7 @@ import pytest
 from ..conftest import TestEnv, try_import
 
 with try_import() as imports_successful:
-    from openai import OpenAIError
-
+    from pydantic_ai.exceptions import UserError
     from pydantic_ai.providers.openai import OpenAIProvider
 
 pytestmark = [
@@ -33,8 +32,11 @@ def test_init_with_non_openai_model():
 def test_init_of_openai_without_api_key_raises_error(env: TestEnv):
     env.remove('OPENAI_API_KEY')
     with pytest.raises(
-        OpenAIError,
-        match=r'^Missing credentials\. Please pass an `api_key`, `workload_identity`, `admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable\.$',
+        UserError,
+        match=(
+            r'Set the `OPENAI_API_KEY` environment variable or pass it via `OpenAIProvider\(api_key=\.\.\.\)`'
+            r" to use the OpenAI provider\. To try Pydantic AI without an API key, use the built-in test model: `Agent\('test'\)`\."
+        ),
     ):
         OpenAIProvider()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,6 @@ from ._inline_snapshot import snapshot
 from .conftest import IsInstance, IsStr, TestEnv, try_import
 
 with try_import() as imports_successful:
-    from openai import OpenAIError
     from prompt_toolkit.input import create_pipe_input
     from prompt_toolkit.output import DummyOutput
     from prompt_toolkit.shortcuts import PromptSession
@@ -97,15 +96,18 @@ def test_agent_flag(
     assert mock_ask.call_args[0][0] is test_agent
 
 
-def test_agent_flag_no_model(env: TestEnv, create_test_module: Callable[..., None]):
+def test_agent_flag_no_model(capfd: CaptureFixture[str], env: TestEnv, create_test_module: Callable[..., None]):
     env.remove('OPENAI_API_KEY')
     env.remove('OPENAI_ADMIN_KEY')
     test_agent = Agent()
     create_test_module(custom_agent=test_agent)
 
-    msg = r'Missing credentials\. Please pass an `api_key`, `workload_identity`, `admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable\.'
-    with pytest.raises(OpenAIError, match=msg):
-        cli(['--agent', 'test_module:custom_agent', 'hello'])
+    # The missing key now surfaces as a `UserError`, which the CLI reports cleanly instead of
+    # letting the provider SDK's exception escape as a traceback.
+    assert cli(['--agent', 'test_module:custom_agent', 'hello']) == 1
+    output = capfd.readouterr().out
+    assert 'Error initializing' in output
+    assert 'Set the `OPENAI_API_KEY` environment variable' in output
 
 
 def test_agent_flag_set_model(


### PR DESCRIPTION
## Summary

A keyless newcomer following the getting-started hello world hits a dead end at `Agent()` construction, and the failure never points at the no-key path Pydantic AI uniquely has (`Agent('test')` / `TestModel`). Worse, for OpenAI — the default provider for the CLI and examples, so the *most common* first error — the message is a raw third-party `openai.OpenAIError` mentioning `workload_identity` and `OPENAI_ADMIN_KEY`, which reads as enterprise noise and isn't catchable as a `pydantic_ai` `UserError`.

Surfaced by the onboarding fresh-eyes audit (findings F1 and F3): [onboarding audit doc](https://github.com/pydantic/pydantic-ai-notes/blob/main/features/onboarding-dx/2026-07-08%20fresh-eyes%20audit%20-%20onboarding%2C%20agent-native%20docs%2C%20logfire%20funnel.md).

## Changes

- **OpenAI now raises our `UserError`** (F3). When talking to OpenAI directly (no custom `base_url`) with no key available, `OpenAIProvider` raised the raw `openai.OpenAIError`; it now raises a `pydantic_ai` `UserError` with the same "Set the `OPENAI_API_KEY` ... or pass it via `OpenAIProvider(api_key=...)`" wording the other providers use. The existing local/OpenAI-compatible placeholder-key behavior (which only applies when a `base_url` is set) is unchanged.
- **A shared hint on the missing-key error** (F1). New module-level `missing_api_key_error()` helper (in `providers/__init__.py`) appends a short hint to the provider-specific message:

  > To try Pydantic AI without an API key, use the built-in test model: `Agent('test')`. See https://ai.pydantic.dev/testing/

  Applied to OpenAI, Anthropic, and Google — the three providers a newcomer is most likely to reach for (and the CLI/examples default). The remaining ~27 providers raise an identical "Set the `X_API_KEY` ..." `UserError` and can be migrated to the helper in a follow-up; I kept this PR scoped to the reproduced cases rather than rewording ~27 messages and their snapshots at once.
- **Docs**: a short "No API key yet?" admonition on the getting-started page showing `Agent('test')`, linking to the testing guide and Models & Providers.
- **Docs**: refreshed the stale missing-key error string quoted on the troubleshooting page (audit F5) and added the `Agent('test')` pointer there too.
- **Tests**: `test_agent_flag_no_model` previously asserted that the raw `OpenAIError` escaped the CLI as a traceback; the CLI's existing `UserError` handler now catches the missing-key error and reports it cleanly (`Error initializing ...` + message, exit code 1), so the test asserts that friendlier behavior.
- **Tests**: regression tests that the OpenAI/Anthropic/Google missing-key path raises `UserError` ending in the hint; the OpenAI test previously asserted the raw `OpenAIError` and is updated.

## Judgment calls

- **One shared location vs. per-provider**: there is no single runtime choke point where every provider's client is constructed, so the hint text lives in one shared helper that each provider calls. Per the audit's guidance I wired up OpenAI + Anthropic + Google and noted the pattern for the rest above.
- The hint links to `https://ai.pydantic.dev/testing/` since that's where `TestModel` / `Agent('test')` is documented today. Deeper testing-guide improvements (e.g. surfacing `defer_model_check=True`) are called out separately in the audit and are out of scope here.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


