### PR TITLE
feat: ephemeral per-request context parts for capabilities and hooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -149,6 +149,26 @@ Model request hooks fire around each LLM call. [`ModelRequestContext`][pydantic_
 
 To skip the model call entirely, raise [`SkipModelRequest(response)`][pydantic_ai.exceptions.SkipModelRequest] from `before_model_request` or `model_request` (wrap).
 
+#### Ephemeral per-request context
+
+Edits to `request_context.messages` from `before_model_request` are **persisted**: they become part of the run's message history and are visible in [`result.all_messages()`][pydantic_ai.run.AgentRunResult.all_messages]. That's the right channel for durable changes (history processing, injecting a message that should stick).
+
+For per-request notices that the model should *see but that should not persist* — a token-budget line, a staleness warning, a "you are being evaluated" note — use [`request_context.add_ephemeral_part(content)`][pydantic_ai.models.ModelRequestContext.add_ephemeral_part] instead:
+
+```python {test="skip" lint="skip"}
+@hooks.on.before_model_request
+async def budget_notice(ctx, request_context):
+    request_context.add_ephemeral_part(f'<system-reminder>Token budget: {remaining()} left.</system-reminder>')
+    return request_context
+```
+
+Ephemeral parts are appended to the tail of the outgoing request (after the latest user message), so the model reads them as context sitting next to the conversation rather than as standing instructions. They reach the provider for that one request only: they are never written to the message history, so `result.all_messages()` stays byte-identical and the prompt-cache prefix is never invalidated (a [`CachePoint`][pydantic_ai.messages.CachePoint] is placed in front of the ephemeral tail, so the stable conversation prefix stays cacheable and only the small notice is re-read each turn). Multiple contributors render in composition order.
+
+Frame the content with your own delimiter (e.g. a `<system-reminder>` tag) so the model reads it as an out-of-band notice rather than user speech. Because the parts do not persist, an unchanged condition re-emits its notice every request — that's intended: the signal is "still true now", not "told you once".
+
+!!! note "Two ephemeral channels"
+    Both [instructions](agent.md#instructions) and ephemeral parts are rebuilt per request and never stored in history, but they land in different places: instructions are **standing guidance** delivered as system-level instructions, while ephemeral parts are **contextual notices** delivered next to the latest message. Reach for instructions when the content is stable guidance about *how to behave*; reach for ephemeral parts when it's a transient fact about *the current state of the world*. Never hand-append synthetic notices to `request_context.messages` (or `message_history`) to fake this — that persists them into user-owned history and busts the cache prefix.
+
 ### Tool validation hooks
 
 | `hooks.on.` | Constructor kwarg | `AbstractCapability` method |

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
@@ -102,7 +102,14 @@ Use hooks when the user wants observability, auditing, or light interception wit
 
 From `before_model_request`, edits to `request_context.messages` are persisted into history. For notices the model should see but that must NOT persist (budget lines, staleness warnings, "you are being evaluated" notes), call `request_context.add_ephemeral_part(content)` instead.
 
-```python {test="skip" lint="skip"}
+```python
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities.hooks import Hooks
+from pydantic_ai.models import ModelRequestContext
+
+hooks = Hooks()
+
+
 @hooks.on.before_model_request
 async def staleness(ctx: RunContext, request_context: ModelRequestContext) -> ModelRequestContext:
     request_context.add_ephemeral_part('<system-reminder>src/foo.py changed on disk; re-read it.</system-reminder>')

--- a/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
+++ b/pydantic_ai_slim/pydantic_ai/.agents/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
@@ -98,6 +98,19 @@ Important hook families:
 
 Use hooks when the user wants observability, auditing, or light interception without adding a new abstraction.
 
+## Show the Model Per-Request Context Without Persisting It
+
+From `before_model_request`, edits to `request_context.messages` are persisted into history. For notices the model should see but that must NOT persist (budget lines, staleness warnings, "you are being evaluated" notes), call `request_context.add_ephemeral_part(content)` instead.
+
+```python {test="skip" lint="skip"}
+@hooks.on.before_model_request
+async def staleness(ctx: RunContext, request_context: ModelRequestContext) -> ModelRequestContext:
+    request_context.add_ephemeral_part('<system-reminder>src/foo.py changed on disk; re-read it.</system-reminder>')
+    return request_context
+```
+
+Ephemeral parts are appended after the latest user message (behind a `CachePoint`), reach the provider for that one request, and never enter `result.all_messages()`, so history stays byte-identical and the prompt-cache prefix stays warm. This is the blessed alternative to hand-rolling `wrap_model_request` + tail-append + `CachePoint`. Two ephemeral channels: instructions (`get_instructions`) for standing guidance delivered as system instructions; ephemeral parts for contextual notices delivered next to the conversation. Never fake this by appending synthetic parts to `message_history`.
+
 ## Build a Custom Capability
 
 Subclass `AbstractCapability` when the user wants reusable behavior that combines tools, hooks, instructions, or model settings into one package.

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1026,6 +1026,13 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
         else:
             messages = prepared
 
+        # Render any `before_model_request`-contributed ephemeral parts onto the outgoing messages *after* the
+        # durable history was written back to state above, so they reach the provider (and count against the
+        # token budget below) for this request only and never enter `ctx.state.message_history`. Empty is the
+        # common case and skips all work.
+        if request_context.ephemeral_parts:
+            messages = _append_ephemeral_parts(messages, request_context.ephemeral_parts)
+
         ctx.state.last_max_tokens = model_settings.get('max_tokens') if model_settings else None
         ctx.state.last_model_request_parameters = model_request_parameters
         usage = ctx.state.usage
@@ -1829,3 +1836,27 @@ def _clean_message_history(messages: list[_messages.ModelMessage]) -> list[_mess
             else:
                 clean_messages.append(message)
     return clean_messages
+
+
+# TTL for the `CachePoint` placed in front of the ephemeral tail. Cache-supporting providers then cache the
+# stable conversation prefix and re-read only the small ephemeral block; non-supporting providers drop the
+# `CachePoint`. `'5m'` matches the shortest-lived Anthropic/Bedrock option, minimizing cache-write cost.
+_EPHEMERAL_CACHE_TTL: Literal['5m', '1h'] = '5m'
+
+
+def _append_ephemeral_parts(
+    messages: list[_messages.ModelMessage],
+    ephemeral_parts: Sequence[_messages.UserContent],
+) -> list[_messages.ModelMessage]:
+    """Render per-request `ephemeral_parts` onto a non-persisted copy of the outgoing messages.
+
+    The parts are appended, in contribution order and behind a `CachePoint`, as a fresh `UserPromptPart` on the
+    trailing `ModelRequest`. This returns a new list wrapping a replaced-in-copy final request, so the caller's
+    persisted history (which shares the original `ModelRequest` object) is never mutated: the parts reach the
+    provider for this request only and the cached prefix stays byte-identical across turns.
+    """
+    last = messages[-1]
+    # `_prepare_request` guarantees the outgoing history ends with a `ModelRequest`.
+    assert isinstance(last, _messages.ModelRequest), 'ephemeral parts require a trailing `ModelRequest`'
+    tail = _messages.UserPromptPart(content=[_messages.CachePoint(ttl=_EPHEMERAL_CACHE_TTL), *ephemeral_parts])
+    return [*messages[:-1], replace(last, parts=[*last.parts, tail])]

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -950,6 +950,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             messages=ctx.state.message_history[:],
             model_settings=model_settings,
             model_request_parameters=model_request_parameters,
+            _accepts_ephemeral_parts=True,
         )
         messages_before_processing = len(request_context.messages)
         self.last_request_context = request_context

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -51,6 +51,7 @@ from ..messages import (
     ThinkingPart,
     ToolCallPart,
     UploadedFile,
+    UserContent,
     UserPromptPart,
     VideoUrl,
 )
@@ -189,6 +190,44 @@ class ModelRequestContext:
     messages: list[ModelMessage]
     model_settings: ModelSettings | None
     model_request_parameters: ModelRequestParameters
+
+    ephemeral_parts: list[UserContent] = field(default_factory=list[UserContent])
+    """Per-request context appended to the tail of the outgoing request but never written to history.
+
+    Contribute to this list from
+    [`before_model_request`][pydantic_ai.capabilities.AbstractCapability.before_model_request] (usually via
+    [`add_ephemeral_part`][pydantic_ai.models.ModelRequestContext.add_ephemeral_part]) to show the model
+    per-request notices -- budget lines, staleness warnings, harness-state notes -- that should sit *next to
+    the conversation* (as context) rather than as standing instructions.
+
+    Unlike edits to [`messages`][pydantic_ai.models.ModelRequestContext.messages] (which are persisted to the
+    run's message history), these parts reach the provider for this one request only: they are rendered onto a
+    non-persisted copy of the outgoing messages, so `result.all_messages()` and the durable history stay
+    byte-identical and the cached prefix is never invalidated. Contributions are rendered in order, behind a
+    [`CachePoint`][pydantic_ai.messages.CachePoint] so the stable conversation prefix stays cacheable and only
+    the ephemeral tail falls outside the cached region.
+    """
+
+    def add_ephemeral_part(self, content: str | UserContent) -> None:
+        """Append per-request context that reaches the model without being persisted to history.
+
+        This is the blessed seam for "ephemeral" content -- see
+        [`ephemeral_parts`][pydantic_ai.models.ModelRequestContext.ephemeral_parts] for the full contract.
+        Call it from
+        [`before_model_request`][pydantic_ai.capabilities.AbstractCapability.before_model_request]:
+
+        ```python {test="skip"}
+        async def before_model_request(self, ctx, request_context):
+            request_context.add_ephemeral_part(f'<system-reminder>Token budget: {self.remaining} left.</system-reminder>')
+            return request_context
+        ```
+
+        Args:
+            content: Text (or any [`UserContent`][pydantic_ai.messages.UserContent], e.g. an image) to append
+                after the latest user message for this request only. Frame text with your own delimiter (e.g. a
+                `<system-reminder>` tag) so the model reads it as context rather than user speech.
+        """
+        self.ephemeral_parts.append(content)
 
 
 class Model(ABC, Generic[InterfaceClient]):

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -208,6 +208,15 @@ class ModelRequestContext:
     the ephemeral tail falls outside the cached region.
     """
 
+    _accepts_ephemeral_parts: bool = field(default=False, repr=False)
+    """Whether `add_ephemeral_part` may be called on this context.
+
+    Only the `before_model_request` context renders `ephemeral_parts` (they're appended to the outgoing
+    request before it's sent). The `wrap_model_request`, `after_model_request`, and `on_model_request_error`
+    contexts run once the outgoing messages are finalized, so parts added there would be silently dropped --
+    `add_ephemeral_part` raises instead of failing quietly.
+    """
+
     def add_ephemeral_part(self, content: str | UserContent) -> None:
         """Append per-request context that reaches the model without being persisted to history.
 
@@ -227,6 +236,12 @@ class ModelRequestContext:
                 after the latest user message for this request only. Frame text with your own delimiter (e.g. a
                 `<system-reminder>` tag) so the model reads it as context rather than user speech.
         """
+        if not self._accepts_ephemeral_parts:
+            raise UserError(
+                '`add_ephemeral_part` can only be called from `before_model_request`; '
+                'other model-request hooks run after the outgoing messages are finalized, '
+                'so parts added there would be silently dropped.'
+            )
         self.ephemeral_parts.append(content)
 
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -21407,7 +21407,10 @@ async def test_add_ephemeral_part_rejected_outside_before_model_request() -> Non
             request_context.add_ephemeral_part('too late')
             return await handler(request_context)
 
-    agent = Agent(FunctionModel(lambda m, i: make_text_response('done')), capabilities=[_LateContributor()])
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        return make_text_response('done')  # pragma: no cover - guard raises before the model is called
+
+    agent = Agent(FunctionModel(model_fn), capabilities=[_LateContributor()])
     with pytest.raises(UserError, match='can only be called from `before_model_request`'):
         await agent.run('hi')
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -21236,6 +21236,14 @@ def _last_request(messages: list[ModelMessage]) -> ModelRequest:
     return next(m for m in reversed(messages) if isinstance(m, ModelRequest))
 
 
+# These are `FunctionModel` unit tests rather than VCR cassette tests on purpose: they pin the *internal
+# outgoing-request payload shape* (where the `CachePoint` sits, the ephemeral tail's structure, and the
+# byte-stability of the cacheable prefix) by capturing the exact `list[ModelMessage]` the model was handed.
+# A cassette records the serialized wire request but not this pre-serialization structure or the
+# history-vs-outgoing split, so it could not reliably catch a regression that moves the `CachePoint` or
+# leaks an ephemeral part into persisted history.
+
+
 async def test_ephemeral_part_reaches_provider_but_not_history() -> None:
     """An ephemeral part is appended (behind a `CachePoint`) to the outgoing request, but never persisted."""
     seen: list[list[ModelMessage]] = []
@@ -21342,6 +21350,66 @@ async def test_no_ephemeral_parts_leaves_request_untouched() -> None:
 
     sent = _last_request(seen[0])
     assert sent.parts == snapshot([UserPromptPart(content='hi', timestamp=IsDatetime())])
+
+
+async def test_ephemeral_part_keeps_cacheable_region_stable_across_requests() -> None:
+    """Across two consecutive requests sharing the same history, the messages *before* the ephemeral
+    `CachePoint` are byte-identical -- so the cacheable prefix is stable and only the ephemeral tail is
+    re-read each turn (per the `AGENTS.md` prompt-cache-stability rule). This is a `FunctionModel` unit
+    test rather than a VCR test because it asserts the byte-identity of the pre-`CachePoint` region across
+    two outgoing requests, which a cassette (one recorded request) cannot pin.
+    """
+    seen: list[list[ModelMessage]] = []
+
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        seen.append(messages)
+        return make_text_response('done')
+
+    agent = Agent(FunctionModel(model_fn), capabilities=[_EphemeralNotice(note='ctx')])
+    result = await agent.run('hi')
+    # Second request continues the conversation so the shared prefix grows the same way each turn.
+    await agent.run('again', message_history=result.all_messages())
+
+    def strip_ephemeral_tail(last: ModelRequest) -> ModelRequest:
+        # Drop the trailing ephemeral `UserPromptPart` (the one carrying the `CachePoint` + contributed
+        # content) so what remains is exactly the region a cache-supporting provider keeps stable.
+        assert last.parts and isinstance(last.parts[-1], UserPromptPart)
+        content = last.parts[-1].content
+        assert isinstance(content, list) and content and isinstance(content[0], CachePoint)
+        return replace(last, parts=last.parts[:-1])
+
+    # The cacheable region of request 1 (its 'hi' `ModelRequest` minus the ephemeral tail) must reappear
+    # byte-identical as the corresponding leading messages of request 2 -- the ephemeral tail never enters
+    # history, so a per-request injection that moved with history length would break this equality.
+    first = seen[0]
+    second = seen[1]
+    assert isinstance(first[-1], ModelRequest)
+    cacheable_first = [*first[:-1], strip_ephemeral_tail(first[-1])]
+    assert second[: len(cacheable_first)] == cacheable_first
+
+
+async def test_add_ephemeral_part_rejected_outside_before_model_request() -> None:
+    """`add_ephemeral_part` raises when called from a hook that runs after the outgoing messages are
+    finalized (`wrap_model_request`/`after_model_request`/`on_model_request_error`), where parts would
+    otherwise be silently dropped. `FunctionModel` unit test: it exercises the pre-request guard, which a
+    cassette cannot cover.
+    """
+
+    @dataclass
+    class _LateContributor(AbstractCapability[Any]):
+        async def wrap_model_request(
+            self,
+            ctx: RunContext[Any],
+            *,
+            request_context: ModelRequestContext,
+            handler: Callable[[ModelRequestContext], Awaitable[ModelResponse]],
+        ) -> ModelResponse:
+            request_context.add_ephemeral_part('too late')
+            return await handler(request_context)
+
+    agent = Agent(FunctionModel(lambda m, i: make_text_response('done')), capabilities=[_LateContributor()])
+    with pytest.raises(UserError, match='can only be called from `before_model_request`'):
+        await agent.run('hi')
 
 
 # endregion

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -21388,31 +21388,22 @@ async def test_ephemeral_part_keeps_cacheable_region_stable_across_requests() ->
     assert second[: len(cacheable_first)] == cacheable_first
 
 
-async def test_add_ephemeral_part_rejected_outside_before_model_request() -> None:
-    """`add_ephemeral_part` raises when called from a hook that runs after the outgoing messages are
-    finalized (`wrap_model_request`/`after_model_request`/`on_model_request_error`), where parts would
-    otherwise be silently dropped. `FunctionModel` unit test: it exercises the pre-request guard, which a
-    cassette cannot cover.
+def test_add_ephemeral_part_rejected_outside_before_model_request() -> None:
+    """`add_ephemeral_part` raises on a context that doesn't accept ephemeral parts -- i.e. the ones the
+    framework hands to `wrap_model_request`/`after_model_request`/`on_model_request_error`, which run after
+    the outgoing messages are finalized so added parts would be silently dropped. Only the
+    `before_model_request` context sets `_accepts_ephemeral_parts=True`. Direct unit test of the guard (not
+    a VCR test): it pins the pre-request guard, which a cassette cannot observe.
     """
-
-    @dataclass
-    class _LateContributor(AbstractCapability[Any]):
-        async def wrap_model_request(
-            self,
-            ctx: RunContext[Any],
-            *,
-            request_context: ModelRequestContext,
-            handler: Callable[[ModelRequestContext], Awaitable[ModelResponse]],
-        ) -> ModelResponse:
-            request_context.add_ephemeral_part('too late')
-            return await handler(request_context)
-
-    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
-        return make_text_response('done')  # pragma: no cover - guard raises before the model is called
-
-    agent = Agent(FunctionModel(model_fn), capabilities=[_LateContributor()])
+    # Default `_accepts_ephemeral_parts=False`, mirroring every context except `before_model_request`.
+    request_context = ModelRequestContext(
+        model=FunctionModel(lambda m, i: make_text_response('unused')),  # pragma: no cover
+        messages=[],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(),
+    )
     with pytest.raises(UserError, match='can only be called from `before_model_request`'):
-        await agent.run('hi')
+        request_context.add_ephemeral_part('too late')
 
 
 # endregion

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -21397,7 +21397,7 @@ def test_add_ephemeral_part_rejected_outside_before_model_request() -> None:
     """
     # Default `_accepts_ephemeral_parts=False`, mirroring every context except `before_model_request`.
     request_context = ModelRequestContext(
-        model=FunctionModel(lambda m, i: make_text_response('unused')),  # pragma: no cover
+        model=FunctionModel(lambda m, i: make_text_response('unused')),
         messages=[],
         model_settings=None,
         model_request_parameters=ModelRequestParameters(),

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -66,6 +66,7 @@ from pydantic_ai.exceptions import (
 from pydantic_ai.messages import (
     AgentStreamEvent,
     BinaryImage,
+    CachePoint,
     FilePart,
     ImageUrl,
     LoadCapabilityCallPart,
@@ -21210,6 +21211,137 @@ def test_dynamic_capability_rejects_wrapper_fields() -> None:
 
     with pytest.raises(UserError, match='not supported on `DynamicCapability`'):
         DynamicCapability(capability_func=factory, defer_loading=True)
+
+
+# endregion
+
+
+# region ephemeral parts
+
+
+@dataclass
+class _EphemeralNotice(AbstractCapability[Any]):
+    """Test capability that contributes one ephemeral part per request via `before_model_request`."""
+
+    note: str = 'hello'
+
+    async def before_model_request(
+        self, ctx: RunContext[Any], request_context: ModelRequestContext
+    ) -> ModelRequestContext:
+        request_context.add_ephemeral_part(self.note)
+        return request_context
+
+
+def _last_request(messages: list[ModelMessage]) -> ModelRequest:
+    return next(m for m in reversed(messages) if isinstance(m, ModelRequest))
+
+
+async def test_ephemeral_part_reaches_provider_but_not_history() -> None:
+    """An ephemeral part is appended (behind a `CachePoint`) to the outgoing request, but never persisted."""
+    seen: list[list[ModelMessage]] = []
+
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        seen.append(messages)
+        return make_text_response('done')
+
+    agent = Agent(FunctionModel(model_fn), capabilities=[_EphemeralNotice(note='<reminder>stale</reminder>')])
+    result = await agent.run('hi')
+
+    # (a) The content reached the provider: the last request the model saw ends with an ephemeral
+    # `UserPromptPart` carrying a `CachePoint` in front of the contributed text.
+    sent = _last_request(seen[0])
+    assert sent.parts[-1] == UserPromptPart(
+        content=[CachePoint(ttl='5m'), '<reminder>stale</reminder>'], timestamp=IsDatetime()
+    )
+
+    # (b) Stored history is byte-unchanged: no ephemeral part, no `CachePoint`, just the user's own prompt.
+    stored = _last_request(result.all_messages())
+    assert stored.parts == snapshot([UserPromptPart(content='hi', timestamp=IsDatetime())])
+    assert not any(
+        isinstance(part, UserPromptPart) and not isinstance(part.content, str) and CachePoint() in part.content
+        for message in result.all_messages()
+        for part in message.parts
+    )
+
+
+async def test_ephemeral_parts_multi_contributor_ordering() -> None:
+    """Parts from multiple capabilities render in contribution (composition) order."""
+    seen: list[list[ModelMessage]] = []
+
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        seen.append(messages)
+        return make_text_response('done')
+
+    agent = Agent(
+        FunctionModel(model_fn),
+        capabilities=[_EphemeralNotice(note='first'), _EphemeralNotice(note='second')],
+    )
+    await agent.run('hi')
+
+    sent = _last_request(seen[0])
+    assert sent.parts[-1] == UserPromptPart(content=[CachePoint(ttl='5m'), 'first', 'second'], timestamp=IsDatetime())
+
+
+async def test_ephemeral_part_via_hooks_and_non_str_content() -> None:
+    """The `Hooks.on.before_model_request` seam works and `add_ephemeral_part` accepts any `UserContent`."""
+    seen: list[list[ModelMessage]] = []
+    image = ImageUrl(url='https://example.com/x.png')
+
+    hooks = Hooks()
+
+    @hooks.on.before_model_request
+    async def add(ctx: RunContext, request_context: ModelRequestContext) -> ModelRequestContext:
+        request_context.add_ephemeral_part('label:')
+        request_context.add_ephemeral_part(image)
+        return request_context
+
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        seen.append(messages)
+        return make_text_response('done')
+
+    result = await Agent(FunctionModel(model_fn), capabilities=[hooks]).run('hi')
+
+    sent = _last_request(seen[0])
+    assert sent.parts[-1] == UserPromptPart(content=[CachePoint(ttl='5m'), 'label:', image], timestamp=IsDatetime())
+    # Still not persisted.
+    assert _last_request(result.all_messages()).parts == snapshot(
+        [UserPromptPart(content='hi', timestamp=IsDatetime())]
+    )
+
+
+async def test_ephemeral_part_streaming() -> None:
+    """Ephemeral parts also reach the provider on the `run_stream` path and stay out of history."""
+    seen: list[list[ModelMessage]] = []
+
+    async def stream_fn(messages: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+        seen.append(messages)
+        yield 'streamed'
+
+    agent = Agent(FunctionModel(stream_function=stream_fn), capabilities=[_EphemeralNotice(note='ctx')])
+    async with agent.run_stream('hi') as stream:
+        output = await stream.get_output()
+        messages = stream.all_messages()
+
+    assert output == 'streamed'
+    sent = _last_request(seen[0])
+    assert sent.parts[-1] == UserPromptPart(content=[CachePoint(ttl='5m'), 'ctx'], timestamp=IsDatetime())
+    assert _last_request(messages).parts == snapshot([UserPromptPart(content='hi', timestamp=IsDatetime())])
+
+
+async def test_no_ephemeral_parts_leaves_request_untouched() -> None:
+    """With no contributions, the outgoing request is unchanged: no extra part, no `CachePoint`, zero overhead."""
+    seen: list[list[ModelMessage]] = []
+
+    def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        seen.append(messages)
+        return make_text_response('done')
+
+    # A capability that hooks the request but contributes nothing.
+    agent = Agent(FunctionModel(model_fn), capabilities=[_RecordingCapability(label='noop')])
+    await agent.run('hi')
+
+    sent = _last_request(seen[0])
+    assert sent.parts == snapshot([UserPromptPart(content='hi', timestamp=IsDatetime())])
 
 
 # endregion


### PR DESCRIPTION
## What

A blessed seam for capabilities and hooks to contribute **ephemeral, per-request context** the model sees but that is never persisted into history — budget lines, staleness notices, harness-state notes, cross-model labels. Core blesses only one ephemeral channel today (instructions); system-reminder-style content that should sit *adjacent to the conversation* has no supported seam, so harness capabilities (`Planning`, `StalenessTracker`) each hand-roll it via `wrap_model_request` + tail-append + `CachePoint`, and getting it wrong either persists synthetic parts into user-owned history or busts the cache prefix.

## How

Investigation (code truth): in `_agent_graph._prepare_request`, `before_model_request` edits to `messages` are written **back** to `ctx.state.message_history` — i.e. they persist. Only the later post-clean outgoing list is non-persisted, which is why capabilities hand-roll the notice channel.

The seam:
- `ModelRequestContext.ephemeral_parts: list[UserContent]` + `add_ephemeral_part(content: str | UserContent)`, called from `before_model_request`.
- Core renders the parts **once**, in the shared `_prepare_request`, after the durable history is written back and messages are cleaned — appending one trailing `UserPromptPart` (preceded by a `CachePoint`) to a non-persisted copy of the outgoing messages. Single render site covering both `run` and `run_stream`; short-circuits when empty.

## Deliberate scope

- Contribution via `before_model_request` (natural request-shaping hook with full `RunContext`); migrating the harness capabilities onto it is a scoped follow-up.
- Auto-inserts a `CachePoint` (ttl `5m`) before the ephemeral tail so the stable prefix stays cacheable (mirrors `Planning`); `CachePoint` is safely dropped by non-caching providers.
- Core imposes no semantic delimiter — callers frame their own (`<system-reminder>` etc.), avoiding double-wrapping the harness's existing tags.

## Tests

5 new cases: content reaches the provider behind a `CachePoint` while `all_messages()` stays byte-identical; deterministic multi-contributor ordering; the `Hooks` seam + non-`str` `UserContent`; `run_stream`; empty = untouched request. Docs: a "two ephemeral channels" section in `docs/hooks.md`. 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
