### PR TITLE
fix: make nested `capture_run_messages` capture correctly (#1568)

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1353,6 +1353,8 @@ assert any(
 !!! note
     If you call [`run`][pydantic_ai.agent.AbstractAgent.run], [`run_sync`][pydantic_ai.agent.AbstractAgent.run_sync], or [`run_stream`][pydantic_ai.agent.AbstractAgent.run_stream] more than once within a single `capture_run_messages` context, `messages` will represent the messages exchanged during the first call only.
 
+    `capture_run_messages` contexts can be nested: each context captures the runs for which it is the innermost active context. A run started inside a nested context is captured by that nested context, not by any enclosing one. This means you can wrap a nested agent run (for example inside a tool that calls another agent) in its own `capture_run_messages` to inspect that inner run's messages independently.
+
 ## Agent Specs
 
 Agents can also be defined declaratively in YAML or JSON using [agent specs](agent-spec.md). This separates agent configuration from application code:

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1614,27 +1614,24 @@ def capture_run_messages() -> Generator[list[_messages.ModelMessage]]:
         If you call `run`, `run_sync`, or `run_stream` more than once within a single `capture_run_messages` context,
         `messages` will represent the messages exchanged during the first call only.
 
+        Contexts can be nested: each `capture_run_messages` context captures the runs for which it is the
+        innermost active context. A run started inside a nested context is captured by that nested context,
+        not by any enclosing one, so wrapping a nested agent run (e.g. inside a tool) in its own
+        `capture_run_messages` lets you inspect that inner run's messages independently.
+
     If a run is interrupted by an exception or cancellation while streaming a response or executing
     tool calls, the partial [`ModelResponse`][pydantic_ai.messages.ModelResponse] or
     [`ModelRequest`][pydantic_ai.messages.ModelRequest] is still captured here with
     `state='interrupted'`, so consumers can detect and inspect partial state.
     """
-    token = None
     messages: list[_messages.ModelMessage] = []
-
-    # Try to reuse existing message context if available
-    try:
-        messages = _messages_ctx_var.get().messages
-    except LookupError:
-        # No existing context, create a new one
-        token = _messages_ctx_var.set(_RunMessages(messages))
-
+    # Always push a fresh context so nested `capture_run_messages` contexts each capture their own runs,
+    # rather than sharing (and overwriting) the enclosing context's messages.
+    token = _messages_ctx_var.set(_RunMessages(messages))
     try:
         yield messages
     finally:
-        # Clean up context if we created it
-        if token is not None:
-            _messages_ctx_var.reset(token)
+        _messages_ctx_var.reset(token)
 
 
 def get_captured_run_messages() -> _RunMessages:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -6835,27 +6835,37 @@ def test_heterogeneous_responses_non_streaming() -> None:
 
 
 def test_nested_capture_run_messages() -> None:
-    agent = Agent('test')
+    """Each `capture_run_messages` context captures the runs for which it is the innermost active context.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/1568.
+    """
+    agent1 = Agent('test')
+    agent2 = Agent(TestModel(custom_output_text='inner result'))
 
     with capture_run_messages() as messages1:
         assert messages1 == []
-        with capture_run_messages() as messages2:
-            assert messages2 == []
-            assert messages1 is messages2
-            result = agent.run_sync('Hello')
-            assert result.output == 'success (no tool calls)'
+        res1 = agent1.run_sync('Hi Bro')
+        assert res1.output == 'success (no tool calls)'
 
+        with capture_run_messages() as messages2:
+            # A nested context starts empty and captures only its own run.
+            assert messages2 == []
+            assert messages1 is not messages2
+            res2 = agent2.run_sync('Hello')
+            assert res2.output == 'inner result'
+
+    # The outer context still holds only the run(s) it captured before nesting.
     assert messages1 == snapshot(
         [
             ModelRequest(
-                parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))],
+                parts=[UserPromptPart(content='Hi Bro', timestamp=IsNow(tz=timezone.utc))],
                 timestamp=IsNow(tz=timezone.utc),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
             ModelResponse(
                 parts=[TextPart(content='success (no tool calls)')],
-                usage=RequestUsage(input_tokens=51, output_tokens=4),
+                usage=RequestUsage(input_tokens=52, output_tokens=4),
                 model_name='test',
                 timestamp=IsNow(tz=timezone.utc),
                 provider_name='test',
@@ -6864,7 +6874,84 @@ def test_nested_capture_run_messages() -> None:
             ),
         ]
     )
-    assert messages1 == messages2
+    # The inner context holds only the nested run.
+    assert messages2 == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))],
+                timestamp=IsNow(tz=timezone.utc),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='inner result')],
+                usage=RequestUsage(input_tokens=51, output_tokens=2),
+                model_name='test',
+                timestamp=IsNow(tz=timezone.utc),
+                provider_name='test',
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+        ]
+    )
+    assert messages1 != messages2
+
+
+def test_nested_capture_run_messages_in_tool() -> None:
+    """A nested agent run wrapped in its own `capture_run_messages` (e.g. inside a tool) is captured
+    independently of the outer run, even when the inner run raises.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/1568.
+    """
+
+    def raise_unexpected(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        raise UnexpectedModelBehavior('boom')
+
+    agent_outer = Agent('test')
+    agent_inner = Agent(FunctionModel(raise_unexpected))
+
+    captured_inner: list[ModelMessage] | None = None
+
+    @agent_outer.tool_plain
+    async def call_inner(x: str) -> str:
+        nonlocal captured_inner
+        with capture_run_messages() as inner_messages:
+            captured_inner = inner_messages
+            result = await agent_inner.run(x)
+            return result.output
+
+    with capture_run_messages() as outer_messages:
+        with pytest.raises(UnexpectedModelBehavior):
+            agent_outer.run_sync('foobar')
+
+    # The inner context captured the inner run's request even though it raised...
+    assert captured_inner is not None
+    assert any(isinstance(m, ModelRequest) for m in captured_inner)
+    # ...and it is a distinct list from the outer capture.
+    assert captured_inner is not outer_messages
+    # The outer context captured the outer run up to the tool call that triggered the failing inner run.
+    assert any(
+        isinstance(m, ModelResponse) and any(isinstance(p, ToolCallPart) for p in m.parts) for m in outer_messages
+    )
+
+
+def test_sequential_capture_run_messages() -> None:
+    """Sequential (non-nested) `capture_run_messages` contexts each capture their own run."""
+    agent = Agent('test')
+
+    with capture_run_messages() as messages1:
+        agent.run_sync('First')
+
+    with capture_run_messages() as messages2:
+        agent.run_sync('Second')
+
+    assert messages1 is not messages2
+    first_prompt = messages1[0]
+    second_prompt = messages2[0]
+    assert isinstance(first_prompt, ModelRequest)
+    assert isinstance(second_prompt, ModelRequest)
+    assert first_prompt.parts[0] == snapshot(UserPromptPart(content='First', timestamp=IsNow(tz=timezone.utc)))
+    assert second_prompt.parts[0] == snapshot(UserPromptPart(content='Second', timestamp=IsNow(tz=timezone.utc)))
 
 
 def test_double_capture_run_messages() -> None:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -6918,7 +6918,7 @@ def test_nested_capture_run_messages_in_tool() -> None:
         with capture_run_messages() as inner_messages:
             captured_inner = inner_messages
             result = await agent_inner.run(x)
-            return result.output
+            return result.output  # pragma: no cover
 
     with capture_run_messages() as outer_messages:
         with pytest.raises(UnexpectedModelBehavior):


### PR DESCRIPTION
- Closes #1568

### What

`capture_run_messages()` previously reused the enclosing context's message list when nested, so an inner `capture_run_messages()` did not start empty and the inner run's messages were never captured separately (the exact scenario in #1568).

Each `capture_run_messages` context now captures the runs for which it is the **innermost active context**:

- A run started inside a nested context is captured by that nested context, not by any enclosing one.
- The existing single-context behavior is unchanged: within one context, only the first run's messages are captured, and partial/interrupted state is still recorded.

This is the semantics the issue asks for and it makes the practical case work: wrapping a nested agent run (e.g. a tool that calls another agent, which may raise) in its own `capture_run_messages` lets you inspect that inner run's messages independently, even on the exception path.

### Why

Sub-agent orchestration always runs nested, so this blocked recovering partial history from inner runs. It's pain point (e.6) in the VStorm `pydantic-deep` ecosystem survey — their sub-agent retry machinery has to drive `Agent.iter()` by hand to work around it: [survey doc](https://github.com/pydantic/pydantic-ai-notes/blob/main/features/harness-comparison/2026-07-07%20vstorm%20pydantic-deep%20ecosystem%20-%20survey%20+%20overlap%20analysis.md).

### How

Always push a fresh `_RunMessages` frame onto the contextvar instead of reusing an existing one; the innermost frame is the one runs write into. Docstring + docs note updated to describe nesting. The pre-existing `test_nested_capture_run_messages` (which asserted the old shared-list behavior) is rewritten to the new semantics, plus regression tests for nested-in-tool-with-exception and sequential captures.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

