### PR TITLE
Add Temporal coverage for nested multimodal tool returns

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -4686,6 +4686,65 @@ async def test_multimodal_content_serialization_in_workflow(client: Client):
         ]
 
 
+nested_multimodal_tool_return_agent = Agent(TestModel(), name='nested_multimodal_tool_return_agent')
+
+
+@nested_multimodal_tool_return_agent.tool
+def get_nested_multimodal_content(ctx: RunContext) -> dict[str, str | MultiModalContent]:
+    """Return multimodal content nested inside a mapping."""
+    return {
+        'caption': 'see attached',
+        'attachment': BinaryImage(data=b'\x89PNG', media_type='image/png'),
+        'source': DocumentUrl(url='https://example.com/doc/12345', media_type='application/pdf'),
+    }
+
+
+nested_multimodal_tool_return_temporal_agent = TemporalAgent(
+    nested_multimodal_tool_return_agent, activity_config=BASE_ACTIVITY_CONFIG
+)
+
+
+@workflow.defn
+class NestedMultiModalToolReturnWorkflow:
+    @workflow.run
+    async def run(self, prompt: str) -> list[ModelMessage]:
+        result = await nested_multimodal_tool_return_temporal_agent.run(prompt)
+        return result.all_messages()
+
+
+async def test_nested_multimodal_tool_return_survives_temporal(client: Client):
+    """Nested multimodal values in tool returns survive the Temporal activity boundary."""
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[NestedMultiModalToolReturnWorkflow],
+        plugins=[AgentPlugin(nested_multimodal_tool_return_temporal_agent)],
+    ):
+        messages = await client.execute_workflow(
+            NestedMultiModalToolReturnWorkflow.run,
+            args=['inspect attachment'],
+            id='test_nested_multimodal_tool_return',
+            task_queue=TASK_QUEUE,
+        )
+
+    tool_return = next(
+        part
+        for message in messages
+        for part in message.parts
+        if isinstance(part, ToolReturnPart) and part.tool_name == 'get_nested_multimodal_content'
+    )
+    assert isinstance(tool_return.content, dict)
+    assert tool_return.content['caption'] == 'see attached'
+
+    attachment = tool_return.content['attachment']
+    assert isinstance(attachment, BinaryImage)
+    assert attachment.media_type == 'image/png'
+
+    source = tool_return.content['source']
+    assert isinstance(source, DocumentUrl)
+    assert source.media_type == 'application/pdf'
+
+
 async def test_text_content_serialization_in_workflow(client: Client):
     """Test that TextContent is properly serialized in Temporal."""
     async with Worker(


### PR DESCRIPTION
Summary
- add a Temporal workflow test for dict-nested multimodal tool return content
- assert BinaryImage and DocumentUrl survive the activity boundary inside a mapping

Tests
- `python -m ruff format --check tests/test_temporal.py`
- `python -m ruff check tests/test_temporal.py`
- `python -m pytest tests/test_temporal.py::test_nested_multimodal_tool_return_survives_temporal -q`

Fixes #6059