### PR TITLE
Support azure-responses:[model-id] shorthand

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -534,6 +534,17 @@ agent = Agent(model)
 
 Azure AI Foundry also supports the OpenAI Responses API through [`OpenAIResponsesModel`][pydantic_ai.models.openai.OpenAIResponsesModel]. This is particularly recommended when working with document inputs ([`DocumentUrl`][pydantic_ai.DocumentUrl] and [`BinaryContent`][pydantic_ai.BinaryContent]), as Azure's Chat Completions API does not support these input types.
 
+Use the `azure-responses:` prefix to select the Responses API by name (the `azure:` prefix uses the Chat Completions API):
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('azure-responses:gpt-5.2')
+...
+```
+
+Or initialise the model and provider directly:
+
 ??? example "Document processing with Azure using Responses API"
     ```python
     from pydantic_ai import Agent, BinaryContent

--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -543,6 +543,9 @@ agent = Agent('azure-responses:gpt-5.2')
 ...
 ```
 
+!!! note
+    Azure's Responses API doesn't yet support every feature of OpenAI's Responses API — for example, the web search built-in tool is unavailable, and there are limits around image editing and file uploads. See [Microsoft's Responses API docs](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/responses) for the current list. This applies whether you use the `azure-responses:` shorthand or construct `OpenAIResponsesModel` with `AzureProvider` directly.
+
 Or initialise the model and provider directly:
 
 ??? example "Document processing with Azure using Responses API"

--- a/pydantic_ai_slim/pydantic_ai/models/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/models/__init__.py
@@ -1056,7 +1056,7 @@ def infer_model(  # noqa: C901
         from .zai import ZaiModel
 
         return ZaiModel(model_name, provider=provider)
-    elif model_kind in ('openai', 'openai-responses'):
+    elif model_kind in ('openai', 'openai-responses', 'azure-responses'):
         from .openai import OpenAIResponsesModel
 
         return OpenAIResponsesModel(model_name, provider=provider)

--- a/pydantic_ai_slim/pydantic_ai/providers/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/__init__.py
@@ -135,7 +135,7 @@ def infer_provider_class(provider: str) -> type[Provider[Any]]:  # noqa: C901
         from .vercel import VercelProvider
 
         return VercelProvider
-    elif provider == 'azure':
+    elif provider in ('azure', 'azure-responses'):
         from .azure import AzureProvider
 
         return AzureProvider

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -130,6 +130,18 @@ TEST_CASES = [
         OpenAIChatModel,
     ),
     pytest.param(
+        {
+            'AZURE_OPENAI_API_KEY': 'azure-openai-api-key',
+            'AZURE_OPENAI_ENDPOINT': 'azure-openai-endpoint',
+            'OPENAI_API_VERSION': '2024-12-01-preview',
+        },
+        'azure-responses:gpt-3.5-turbo',
+        'gpt-3.5-turbo',
+        'azure',
+        'openai',
+        OpenAIResponsesModel,
+    ),
+    pytest.param(
         {'GEMINI_API_KEY': 'gemini-api-key'},
         'google:gemini-1.5-flash',
         'gemini-1.5-flash',

--- a/tests/providers/test_provider_names.py
+++ b/tests/providers/test_provider_names.py
@@ -46,6 +46,7 @@ with try_import() as imports_successful:
         ('vercel', VercelProvider, 'VERCEL_AI_GATEWAY_API_KEY'),
         ('openai', OpenAIProvider, 'OPENAI_API_KEY'),
         ('azure', AzureProvider, 'AZURE_OPENAI'),
+        ('azure-responses', AzureProvider, 'AZURE_OPENAI'),
         ('google', GoogleProvider, 'GOOGLE_API_KEY'),
         ('google-cloud', GoogleCloudProvider, 'Your default credentials were not found'),
         ('groq', GroqProvider, 'GROQ_API_KEY'),


### PR DESCRIPTION
### Description

Adds an `azure-responses:[model-id]` shorthand so an Azure model using the OpenAI Responses API can be selected by name, e.g.:

```python
from pydantic_ai import Agent

agent = Agent('azure-responses:gpt-5.5')
```

This mirrors the existing `openai-responses:` shorthand and resolves to an [`OpenAIResponsesModel`][pydantic_ai.models.openai.OpenAIResponsesModel] backed by [`AzureProvider`][pydantic_ai.providers.azure.AzureProvider], without requiring users to manually instantiate the model and provider.

The bare `azure:` prefix is unchanged — it continues to use the Chat Completions API (`OpenAIChatModel`). Only the explicit `-responses` suffix opts into the Responses API.

### Changes

- `providers/__init__.py`: `infer_provider_class` maps `azure-responses` to `AzureProvider`.
- `models/__init__.py`: `infer_model` routes `azure-responses` to `OpenAIResponsesModel`.
- Docs: documented the shorthand in the "Using Azure with the Responses API" section.
- Tests: added `azure-responses` cases to `test_infer_model` and the provider-inference parametrization.

Note: like `azure:` and `openai-responses:`, the prefix is intentionally **not** added to `KnownModelName` — Azure uses arbitrary deployment names rather than an enumerated model list.

Fixes #6335


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

