### PR TITLE
Assert nested multimodal payloads survive Temporal boundary

### DIFF
--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -4741,10 +4741,12 @@ async def test_nested_multimodal_tool_return_survives_temporal(client: Client):
     attachment = tool_return_content['attachment']
     assert isinstance(attachment, BinaryImage)
     assert attachment.media_type == 'image/png'
+    assert attachment.data == b'\x89PNG'
 
     source = tool_return_content['source']
     assert isinstance(source, DocumentUrl)
     assert source.media_type == 'application/pdf'
+    assert source.url == 'https://example.com/doc/12345'
 
 
 async def test_text_content_serialization_in_workflow(client: Client):


### PR DESCRIPTION
## Summary
- Follow-up to #6349. That test verified `BinaryImage` and `DocumentUrl` kept their **type** and **media_type** across the Temporal activity boundary, but never asserted the actual **payloads** — the image bytes and the document URL.
- Add `attachment.data == b'\x89PNG'` and `source.url == 'https://example.com/doc/12345'` so corruption of the primary content during the serialization round-trip would be caught.

This addresses the [reviewer finding on #6349](https://github.com/pydantic/pydantic-ai/pull/6349#issuecomment-4915846995) ("Nested BinaryImage data and DocumentUrl url are not asserted to survive serialization"), whose auto-fix couldn't be pushed to the original PR.

## Tests
- `uv run ruff format --check tests/test_temporal.py`
- `uv run ruff check tests/test_temporal.py`
- `uv run pyright tests/test_temporal.py`
- `pytest tests/test_temporal.py::test_nested_multimodal_tool_return_survives_temporal` (Python 3.13) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

