### PR TITLE
Allow `override(model=...)` on an agent with no model set

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -2404,12 +2404,6 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         """
         model_: models.Model
         if some_model := self._override_model.get():
-            # we don't want `override()` to cover up errors from the model not being defined, hence this check
-            if model is None and self.model is None:
-                raise exceptions.UserError(
-                    '`model` must either be set on the agent or included when calling it. '
-                    '(Even when `override(model=...)` is customizing the model that will actually be called)'
-                )
             model_ = some_model.value
         elif model is not None:
             model_ = models.infer_model(model)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4242,11 +4242,11 @@ def test_set_model(env: TestEnv):
 
 
 def test_override_model_no_model():
-    agent = Agent()
+    agent = Agent(output_type=tuple[int, str])
 
-    with pytest.raises(UserError, match=r'`model` must either be set.+Even when `override\(model=...\)` is customiz'):
-        with agent.override(model='test'):
-            agent.run_sync('Hello')
+    with agent.override(model='test'):
+        result = agent.run_sync('Hello')
+    assert result.output == snapshot((0, 'a'))
 
 
 async def test_agent_name():


### PR DESCRIPTION
Closes #6316

## Problem

`override(model=...)` raised a `UserError` when the agent had no model set (neither on `Agent(...)` nor passed to the run method), even though the override itself supplies a perfectly usable model:

```py
agent = Agent()  # no model, by design
with agent.override(model=model):
    await agent.to_cli()  # UserError: `model` must either be set on the agent or included when calling it.
```

The guard existed to stop a test-time `override` from masking the fact that an agent was never given a model. But as discussed in the issue, `override` is documented as "particularly useful when testing", **not** "only to be used in testing". Deliberately defining a model-less agent and injecting the model exclusively via `override` is a legitimate pattern, and this guard forced an ugly sentinel workaround.

## Change

Drop the guard in `Agent._get_model`. When an override model is present it is simply used. The genuine "no model set anywhere" mistake is still caught by the existing non-override path, so forgetting a model entirely still raises `UserError` as before.

## Tests

`test_override_model_no_model` previously asserted the `UserError` was raised; it now asserts the override succeeds and produces output. The no-model-anywhere error path remains covered by `test_model_arg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

