### PR TITLE
Document the message round-trip fidelity contract

### DIFF
--- a/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
@@ -48,9 +48,10 @@ existing suite. The bug must be one you triggered and observed.
 - A **UI adapter** (Vercel AI, AG-UI) dropping a field documented as **not sent to the model**
   (application-only annotations such as `TextContent.metadata`), or any field explicitly
   documented as by-design lossy. The UI wire formats have no place to carry application-only
-  fields, so that loss is by design, not a state-loss bug. `ModelMessagesTypeAdapter` round-trips
-  every field faithfully, so a drop *there* is a real bug — don't skip it. See the "What
-  survives a round-trip" note in `docs/message-history.md`.
+  fields, so that loss is by design, not a state-loss bug. `ModelMessagesTypeAdapter` carries
+  every field — a field *dropped* there is a real bug, so don't skip it (JSON-mode normalization
+  of `Any`-typed values, such as a `tuple` in `TextContent.metadata` reloading as a `list`, is
+  not a drop). See the "What survives a round-trip" note in `docs/message-history.md`.
 - Behavior already tracked by an open issue or fixed by an open PR — **search both first**.
 
 ## Deduplication — mandatory BEFORE filing an issue

--- a/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
@@ -45,11 +45,12 @@ existing suite. The bug must be one you triggered and observed.
 ## What to Skip
 
 - Speculation without a failing reproduction.
-- Fields documented as **not sent to the model** (application-only annotations such as
-  `TextContent.metadata`), or any field explicitly documented as by-design lossy. Round-trip
-  fidelity is scoped to fields that affect what the model sees or how a resumed run behaves —
-  see the "What survives a round-trip" note in `docs/message-history.md`. A protocol adapter
-  dropping an application-only field it can't carry is by design, not a state-loss bug.
+- A **UI adapter** (Vercel AI, AG-UI) dropping a field documented as **not sent to the model**
+  (application-only annotations such as `TextContent.metadata`), or any field explicitly
+  documented as by-design lossy. The UI wire formats have no place to carry application-only
+  fields, so that loss is by design, not a state-loss bug. `ModelMessagesTypeAdapter` round-trips
+  every field faithfully, so a drop *there* is a real bug — don't skip it. See the "What
+  survives a round-trip" note in `docs/message-history.md`.
 - Behavior already tracked by an open issue or fixed by an open PR — **search both first**.
 
 ## Deduplication — mandatory BEFORE filing an issue

--- a/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md
@@ -45,7 +45,11 @@ existing suite. The bug must be one you triggered and observed.
 ## What to Skip
 
 - Speculation without a failing reproduction.
-- By-design lossy fields explicitly documented as such.
+- Fields documented as **not sent to the model** (application-only annotations such as
+  `TextContent.metadata`), or any field explicitly documented as by-design lossy. Round-trip
+  fidelity is scoped to fields that affect what the model sees or how a resumed run behaves —
+  see the "What survives a round-trip" note in `docs/message-history.md`. A protocol adapter
+  dropping an application-only field it can't carry is by design, not a state-loss bug.
 - Behavior already tracked by an open issue or fixed by an open PR — **search both first**.
 
 ## Deduplication — mandatory BEFORE filing an issue

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -312,12 +312,15 @@ result2 = agent.run_sync(  # (3)!
 _(This example is complete, it can be run "as is")_
 
 !!! note "What survives a round-trip"
-    Round-trip fidelity is scoped to state that affects what the model sees or how a resumed
-    run behaves. Fields documented as *not sent to the model* — application-only annotations
-    such as [`TextContent.metadata`][pydantic_ai.messages.TextContent.metadata] — are not
-    guaranteed to survive every boundary: `ModelMessagesTypeAdapter` preserves them, but a
-    protocol adapter such as one of the [UI adapters](ui/overview.md) may drop them when its
-    wire format has no place to carry them. That loss is by design, not a state-loss bug.
+    `ModelMessagesTypeAdapter` round-trips messages faithfully: every field survives a
+    `to_jsonable_python` → `validate_python` cycle unchanged, including application-only
+    annotations such as [`TextContent.metadata`][pydantic_ai.messages.TextContent.metadata]
+    that are *not sent to the model*. This is the boundary you use to persist and reload history.
+
+    The [UI adapters](ui/overview.md) are different: they convert messages to a foreign wire
+    protocol (Vercel AI, AG-UI) whose message shape has no place for application-only fields,
+    so those fields are dropped when crossing that boundary. That loss is by design, not a
+    state-loss bug.
 
 ### Loading untrusted history
 

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -311,6 +311,14 @@ result2 = agent.run_sync(  # (3)!
 
 _(This example is complete, it can be run "as is")_
 
+!!! note "What survives a round-trip"
+    Round-trip fidelity is scoped to state that affects what the model sees or how a resumed
+    run behaves. Fields documented as *not sent to the model* — application-only annotations
+    such as [`TextContent.metadata`][pydantic_ai.messages.TextContent.metadata] — are not
+    guaranteed to survive every boundary: `ModelMessagesTypeAdapter` preserves them, but a
+    protocol adapter such as one of the [UI adapters](ui/overview.md) may drop them when its
+    wire format has no place to carry them. That loss is by design, not a state-loss bug.
+
 ### Loading untrusted history
 
 The `message_history` parameter is trusted server-side state. If you load history that came from a browser request or another untrusted boundary, sanitize it before passing it to the agent.

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -312,15 +312,16 @@ result2 = agent.run_sync(  # (3)!
 _(This example is complete, it can be run "as is")_
 
 !!! note "What survives a round-trip"
-    `ModelMessagesTypeAdapter` round-trips messages faithfully: every field survives a
-    `to_jsonable_python` → `validate_python` cycle unchanged, including application-only
-    annotations such as [`TextContent.metadata`][pydantic_ai.messages.TextContent.metadata]
-    that are *not sent to the model*. This is the boundary you use to persist and reload history.
+    `ModelMessagesTypeAdapter` preserves every field, including application-only annotations such
+    as [`TextContent.metadata`][pydantic_ai.messages.TextContent.metadata] that are *not sent to
+    the model*. Because `metadata` is typed `Any`, a JSON round-trip normalizes values with no
+    JSON-native form — a `tuple` reloads as a `list`, a `datetime` as its ISO string — while a
+    `dump_python` → `validate_python` round-trip preserves them exactly. This is the boundary you
+    use to persist and reload history.
 
     The [UI adapters](ui/overview.md) are different: they convert messages to a foreign wire
-    protocol (Vercel AI, AG-UI) whose message shape has no place for application-only fields,
-    so those fields are dropped when crossing that boundary. That loss is by design, not a
-    state-loss bug.
+    protocol (Vercel AI, AG-UI) whose message shape has no place for application-only fields, so
+    those fields are dropped entirely. That loss is by design, not a state-loss bug.
 
 ### Loading untrusted history
 

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -505,8 +505,9 @@ class TextContent:
     metadata: Any = None
     """Additional data that can be accessed programmatically by the application but is not sent to the LLM.
 
-    As application-only data it is not guaranteed to survive serialization round-trips through
-    protocol adapters; see [Storing and loading messages](../message-history.md#storing-and-loading-messages-to-json).
+    `ModelMessagesTypeAdapter` preserves this field, but as application-only data it is not
+    guaranteed to survive a round-trip through the UI adapters; see
+    [Storing and loading messages](../message-history.md#storing-and-loading-messages-to-json).
     """
 
     kind: Literal['text-content'] = 'text-content'

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -503,7 +503,11 @@ class TextContent:
     _: KW_ONLY
 
     metadata: Any = None
-    """Additional data that can be accessed programmatically by the application but is not sent to the LLM."""
+    """Additional data that can be accessed programmatically by the application but is not sent to the LLM.
+
+    As application-only data it is not guaranteed to survive serialization round-trips through
+    protocol adapters; see [Storing and loading messages](../message-history.md#storing-and-loading-messages-to-json).
+    """
 
     kind: Literal['text-content'] = 'text-content'
     """Type identifier, this is available on all parts as a discriminator."""


### PR DESCRIPTION
Documents the message round-trip fidelity contract that was, until now, only implicit.

## Context

The automated round-trip sweep filed #5679 (fixed in #5680), flagging that `TextContent.metadata` is dropped when a Vercel / AG-UI adapter round-trips a user prompt. Both were closed as **by design**: `TextContent.metadata` is documented as *not sent to the LLM* (application-only data), and while `ModelMessagesTypeAdapter` round-trips it faithfully, the UI adapters' wire formats have no place to carry it — so a UI adapter dropping it is intentional, not a state-loss bug.

That contract wasn't written down anywhere, so the sweep — and human/agent reviewers — had nothing to point at. This makes it canonical, in one place, with the other surfaces referencing it rather than re-encoding it:

- **`docs/message-history.md`** — adds a `What survives a round-trip` note under "Storing and loading messages": `ModelMessagesTypeAdapter` round-trips every field faithfully, and the [UI adapters](https://ai.pydantic.dev/ui/overview/) (Vercel AI, AG-UI) are the lossy-by-design boundary for application-only fields.
- **`TextContent.metadata` docstring** — points at that note, so a reader landing on the field learns the property locally.
- **round-trip-sweep agent prompt** (`.github/workflows/shared/prompts/pydantic-ai-roundtrip-sweep.md`) — its "What to Skip" rule now references the contract instead of restating it: skip a UI adapter dropping an application-only field, but a `ModelMessagesTypeAdapter` drop is still a real bug.

No code behavior changes; docs + docstring + the agent prompt only.

Follow-up to the closed #5679 / #5680 — no open issue to close.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
