### PR TITLE
Bypass `PR Guard` for authors with a repo collaborator role

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -61,6 +61,25 @@ jobs:
             exit 0
           fi
 
+          # Author repo-role bypass. The webhook's `author_association` is unreliable — it
+          # can report CONTRIBUTOR for a genuine org member/collaborator (observed on #6359:
+          # `dsfaccini`, a public org member with `maintain` role, came through as
+          # CONTRIBUTOR, so the bypass above missed and the PR was wrongly closed). Confirm
+          # the author's actual role on THIS repo via the API — the same `role_name` signal
+          # the trusted-actor bypass below uses for the sender — and skip for triage-or-higher.
+          # Fails open toward *checking* (an unreadable/unknown role continues the checks), so
+          # an external contributor can never gain a bypass this way.
+          AUTHOR_ROLE=$(gh api "repos/${REPO}/collaborators/${PR_AUTHOR}/permission" --jq '.role_name' 2>/dev/null || echo "unknown")
+          case "$AUTHOR_ROLE" in
+            triage | write | maintain | admin)
+              echo "Author ${PR_AUTHOR} has ${AUTHOR_ROLE} access to this repo; skipping checks."
+              exit 0
+              ;;
+            *)
+              echo "Author ${PR_AUTHOR} repo role: ${AUTHOR_ROLE}; continuing checks."
+              ;;
+          esac
+
           # Private-membership bypass. The `author_association` in the webhook only
           # reflects *public* org membership, so a private member of the org that
           # owns this repo is reported as CONTRIBUTOR and misses the bypass above.


### PR DESCRIPTION
Closes #6360

`PR Guard` auto-closed #6359 — a PR by `dsfaccini`, who has `maintain` role on the repo and is a public `pydantic` org member — because the webhook `pull_request.author_association` came through as `CONTRIBUTOR` (the REST API reports `MEMBER`). The maintainer bypass keys off that webhook value, so it missed, and the guard fell through to the issue-link checks and closed the PR.

The guard already resolves the **sender's** real repo role via `repos/{repo}/collaborators/{sender}/permission` for the trusted-actor bypass, but never does the same for the **author**. This adds that author-side check right after the existing maintainer bypass: if the author has `triage`/`write`/`maintain`/`admin` access, skip the checks. It keys off actual repo access rather than the flaky webhook association or the org-membership token, and fails open toward *checking* (an unreadable/unknown role continues the checks), so an external contributor can never gain a bypass this way.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

