### PR TITLE
fix: skip empty ModelResponse in Groq and HuggingFace message history

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -527,7 +527,7 @@ class GroqModel(Model[AsyncGroq]):
                 )
         return tools, search_settings
 
-    async def _map_messages(
+    async def _map_messages(  # noqa: C901
         self, messages: list[ModelMessage], model_request_parameters: ModelRequestParameters
     ) -> list[chat.ChatCompletionMessageParam]:
         """Just maps a `pydantic_ai.Message` to a `groq.types.ChatCompletionMessageParam`."""
@@ -558,6 +558,12 @@ class GroqModel(Model[AsyncGroq]):
                         pass
                     else:
                         assert_never(item)
+                if not texts and not tool_calls:
+                    # An assistant message must carry content or tool calls; a bare
+                    # `{'role': 'assistant'}` is rejected by the Chat Completions API. Skip an empty
+                    # `ModelResponse` (e.g. one the agent graph recorded before retrying) rather than
+                    # send it, matching the OpenAI, Anthropic, Mistral, and Cohere adapters.
+                    continue
                 message_param = chat.ChatCompletionAssistantMessageParam(role='assistant')
                 if texts:
                     # Note: model responses from this model should only have one text item, so the following

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -377,7 +377,7 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
         tools = [HuggingFaceModel._map_tool_definition(r) for r in tool_defs.values()]
         return tools, tool_choice
 
-    async def _map_messages(
+    async def _map_messages(  # noqa: C901
         self, messages: list[ModelMessage], model_request_parameters: ModelRequestParameters
     ) -> list[ChatCompletionInputMessage | ChatCompletionOutputMessage]:
         """Just maps a `pydantic_ai.Message` to a `huggingface_hub.ChatCompletionInputMessage`."""
@@ -408,6 +408,12 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                         pass
                     else:
                         assert_never(item)
+                if not texts and not tool_calls:
+                    # An assistant message must carry content or tool calls; a bare
+                    # `{'role': 'assistant'}` is rejected by the Chat Completions API. Skip an empty
+                    # `ModelResponse` (e.g. one the agent graph recorded before retrying) rather than
+                    # send it, matching the OpenAI, Anthropic, Mistral, and Cohere adapters.
+                    continue
                 message_param = ChatCompletionInputMessage(role='assistant')
                 if texts:
                     # Note: model responses from this model should only have one text item, so the following

--- a/tests/models/test_groq.py
+++ b/tests/models/test_groq.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import cached_property
 from typing import Any, Literal, cast
@@ -94,6 +94,7 @@ class MockGroq:
     completions: MockChatCompletion | Sequence[MockChatCompletion] | None = None
     stream: Sequence[MockChatCompletionChunk] | Sequence[Sequence[MockChatCompletionChunk]] | None = None
     index: int = 0
+    chat_completion_kwargs: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
     base_url: str = 'https://api.groq.com'
 
     @cached_property
@@ -113,8 +114,9 @@ class MockGroq:
         return cast(AsyncGroq, cls(stream=stream))
 
     async def chat_completions_create(
-        self, *_args: Any, stream: bool = False, **_kwargs: Any
+        self, *_args: Any, stream: bool = False, **kwargs: Any
     ) -> chat.ChatCompletion | MockAsyncStream[MockChatCompletionChunk]:
+        self.chat_completion_kwargs.append(kwargs)
         if stream:
             assert self.stream is not None, 'you can only used `stream=True` if `stream` is provided'
             if isinstance(self.stream[0], Sequence):
@@ -135,6 +137,13 @@ class MockGroq:
         return response
 
 
+def get_mock_chat_completion_kwargs(async_groq: AsyncGroq) -> list[dict[str, Any]]:
+    if isinstance(async_groq, MockGroq):
+        return async_groq.chat_completion_kwargs
+    else:  # pragma: no cover
+        raise RuntimeError('Not a MockGroq instance')
+
+
 def completion_message(message: ChatCompletionMessage, *, usage: CompletionUsage | None = None) -> chat.ChatCompletion:
     return chat.ChatCompletion(
         id='123',
@@ -144,6 +153,29 @@ def completion_message(message: ChatCompletionMessage, *, usage: CompletionUsage
         object='chat.completion',
         usage=usage,
     )
+
+
+async def test_empty_response_skipped_in_history(allow_model_requests: None):
+    """An empty `ModelResponse(parts=[])` from a previous turn must not be sent back as a bare
+    assistant message (no content, no tool calls), which the Chat Completions API rejects with a
+    400. The agent graph retries the empty response by emitting a `RetryPromptPart`, relying on the
+    model adapter to omit the empty response from the payload.
+    """
+    responses = [
+        completion_message(ChatCompletionMessage(content=None, role='assistant')),
+        completion_message(ChatCompletionMessage(content='hello back', role='assistant')),
+    ]
+    mock_client = MockGroq.create_mock(responses)
+    m = GroqModel('llama-3.3-70b-versatile', provider=GroqProvider(groq_client=mock_client))
+    agent = Agent(m)
+
+    result = await agent.run('hello')
+    assert result.output == 'hello back'
+
+    # The empty response is omitted from the retry payload (no bare assistant message that 400s);
+    # a retry prompt is appended instead so the model can self-correct.
+    second_call_messages = get_mock_chat_completion_kwargs(mock_client)[1]['messages']
+    assert not any(message['role'] == 'assistant' for message in second_call_messages)
 
 
 async def test_request_simple_success(allow_model_requests: None):

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -948,6 +948,28 @@ async def test_retry_prompt_without_tool_name(allow_model_requests: None):
     }
 
 
+async def test_empty_response_skipped_in_history(allow_model_requests: None):
+    """An empty `ModelResponse(parts=[])` from a previous turn must not be sent back as a bare
+    assistant message (no content, no tool calls), which the Chat Completions API rejects with a
+    400. The agent graph retries the empty response by emitting a `RetryPromptPart`, relying on the
+    model adapter to omit the empty response from the payload.
+    """
+    responses = [
+        completion_message(ChatCompletionOutputMessage(content=None, role='assistant')),
+        completion_message(ChatCompletionOutputMessage(content='hello back', role='assistant')),
+    ]
+    mock_client = MockHuggingFace.create_mock(responses)
+    model = HuggingFaceModel('hf-model', provider=HuggingFaceProvider(hf_client=mock_client, api_key='x'))
+    agent = Agent(model)
+
+    result = await agent.run('hello')
+    assert result.output == 'hello back'
+
+    # The empty response is omitted from the retry payload (no bare assistant message that 400s).
+    sent_messages = get_mock_chat_completion_kwargs(mock_client)[1]['messages']
+    assert not any(asdict(m).get('role') == 'assistant' for m in sent_messages)
+
+
 async def test_thinking_part_in_history(allow_model_requests: None):
     c = completion_message(ChatCompletionOutputMessage(content='response', role='assistant'))
     mock_client = MockHuggingFace.create_mock(c)


### PR DESCRIPTION
Fixes #6364

## Problem

`GroqModel._map_messages` and `HuggingFaceModel._map_messages` append an assistant message for every `ModelResponse`, even an empty one with no content and no tool calls. A bare `{'role': 'assistant'}` is rejected by the Chat Completions API with a 400.

This breaks the empty-response retry flow. When a model returns an empty response, the agent graph records `ModelResponse(parts=[])` and retries by appending a `RetryPromptPart`, relying on the model adapter to omit the empty response from the next request. On the retry, `_map_messages` turns the empty response into the invalid assistant message and the request 400s, so the self-correction crashes instead of recovering.

This is the same bug (and the same fix) as the already-merged sweep for the other Chat Completions adapters: #6138 (OpenAI) and #6302 (Mistral + Cohere, "mirroring the OpenAI and Anthropic adapters"). Groq and HuggingFace have their own `_map_messages` and were missed by that sweep, so they still lack the guard.

## Fix

Skip an assistant message that has neither content nor tool calls, matching the OpenAI (`_into_message_param` returns `None`), Anthropic, Mistral, and Cohere adapters.

```python
if not texts and not tool_calls:
    continue
```

(`# noqa: C901` is added to each `_map_messages` because the one extra branch pushes the existing function one over the complexity limit; this matches the `# noqa: C901` convention used across the codebase for these mapping functions.)

## Tests

Adds `test_empty_response_skipped_in_history` to `test_groq.py` and `test_huggingface.py`, mirroring the existing OpenAI test: an empty response is followed by a valid one, and the retry request payload must contain no assistant message. The Groq test needed request-kwargs recording on `MockGroq` (a few lines), which `MockHuggingFace` and `MockOpenAI` already have.

## Verification

Clean container (`uv sync --frozen --all-extras --all-packages`):

- Both new tests fail on `main` (the empty response is sent as `{'role': 'assistant'}`) and pass with the fix.
- The offline (`-m "not vcr"`) suites for both files stay green (26 passed).
- `ruff check` and `ruff format --check` on the changed files pass.

## Notes

- No public API change and no breaking change; only an empty, API-invalid message is dropped from the request payload.
- This change was prepared with AI assistance and reviewed and verified as described above. Happy to move it to an issue first if you'd prefer that route for the two remaining adapters.
