### PR TITLE
docs: add TokenLab OpenAI-compatible example

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -343,6 +343,23 @@ agent = Agent(model)
 ...
 ```
 
+For example, TokenLab exposes an OpenAI-compatible `/v1` endpoint:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+model = OpenAIChatModel(
+    'claude-sonnet-5',
+    provider=OpenAIProvider(
+        base_url='https://api.tokenlab.sh/v1', api_key='your-tokenlab-api-key'
+    ),
+)
+agent = Agent(model)
+...
+```
+
 Various providers also have their own provider classes so that you don't need to specify the base URL yourself and you can use the standard `<PROVIDER>_API_KEY` environment variable to set the API key.
 When a provider has its own provider class, you can use the `Agent("<provider>:<model>")` shorthand, e.g. `Agent("deepseek:deepseek-chat")` or `Agent("moonshotai:kimi-k2-0711-preview")`, instead of building the `OpenAIChatModel` explicitly. Similarly, you can pass the provider name as a string to the `provider` argument on `OpenAIChatModel` instead of instantiating the provider class explicitly.
 


### PR DESCRIPTION
## Summary
- Document TokenLab as an OpenAI-compatible provider for Pydantic AI's OpenAIChatModel.
- Use TokenLab's OpenAI-compatible base URL: https://api.tokenlab.sh/v1
- No runtime behavior changes; documentation only.

## Verification
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

