### PR TITLE
Reduce Google streamed response overhead

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -1258,39 +1258,48 @@ class GeminiStreamedResponse(StreamedResponse):
                 raise
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
+        stream_provider_details = self.provider_details
         if self._provider_timestamp is not None:
-            self.provider_details = {'timestamp': self._provider_timestamp}
+            stream_provider_details = {'timestamp': self._provider_timestamp}
+            self.provider_details = stream_provider_details
+        provider_name = self._provider_name
+        provider_url = self._provider_url
+        parts_manager = self._parts_manager
+
         try:
             async for chunk in self._response:
-                self._usage = _metadata_as_usage(chunk, self._provider_name, self._provider_url, self._usage)
+                self._usage = _metadata_as_usage(chunk, provider_name, provider_url, self._usage)
 
                 if (
                     chunk.sdk_http_response
                     and chunk.sdk_http_response.headers
                     and (service_tier := chunk.sdk_http_response.headers.get('x-gemini-service-tier'))
                 ):
-                    self.provider_details = {**(self.provider_details or {}), 'service_tier': service_tier.lower()}
+                    if stream_provider_details is None:
+                        stream_provider_details = {}
+                        self.provider_details = stream_provider_details
+                    stream_provider_details['service_tier'] = service_tier.lower()
 
                 # Capture traffic_type before the candidates guard, since usage_metadata
                 # may be present on chunks without candidates.
                 if chunk.usage_metadata and chunk.usage_metadata.traffic_type:
-                    self.provider_details = {
-                        **(self.provider_details or {}),
-                        'traffic_type': chunk.usage_metadata.traffic_type.value,
-                    }
+                    if stream_provider_details is None:
+                        stream_provider_details = {}
+                        self.provider_details = stream_provider_details
+                    stream_provider_details['traffic_type'] = chunk.usage_metadata.traffic_type.value
 
                 if not chunk.candidates:
                     if chunk.prompt_feedback and chunk.prompt_feedback.block_reason:
                         self._has_content_filter = True
                         block_reason = chunk.prompt_feedback.block_reason
-                        self.provider_details = {
-                            **(self.provider_details or {}),
-                            'block_reason': block_reason.value,
-                        }
+                        if stream_provider_details is None:
+                            stream_provider_details = {}
+                            self.provider_details = stream_provider_details
+                        stream_provider_details['block_reason'] = block_reason.value
                         if chunk.prompt_feedback.block_reason_message:
-                            self.provider_details['block_reason_message'] = chunk.prompt_feedback.block_reason_message
+                            stream_provider_details['block_reason_message'] = chunk.prompt_feedback.block_reason_message
                         if chunk.prompt_feedback.safety_ratings:
-                            self.provider_details['safety_ratings'] = [
+                            stream_provider_details['safety_ratings'] = [
                                 r.model_dump(by_alias=True) for r in chunk.prompt_feedback.safety_ratings
                             ]
                         self.finish_reason = 'content_filter'
@@ -1305,13 +1314,13 @@ class GeminiStreamedResponse(StreamedResponse):
 
                 raw_finish_reason = candidate.finish_reason
                 if raw_finish_reason and not self._has_content_filter:
-                    self.provider_details = {
-                        **(self.provider_details or {}),
-                        'finish_reason': raw_finish_reason.value,
-                    }
+                    if stream_provider_details is None:
+                        stream_provider_details = {}
+                        self.provider_details = stream_provider_details
+                    stream_provider_details['finish_reason'] = raw_finish_reason.value
 
                     if candidate.safety_ratings:
-                        self.provider_details['safety_ratings'] = [
+                        stream_provider_details['safety_ratings'] = [
                             r.model_dump(by_alias=True) for r in candidate.safety_ratings
                         ]
 
@@ -1342,11 +1351,11 @@ class GeminiStreamedResponse(StreamedResponse):
                 # tool_call/tool_response parts *instead of* the metadata, never both.
                 if not self._has_tool_invocations:
                     web_fetch_call, web_fetch_return = _map_url_context_metadata(
-                        candidate.url_context_metadata, self.provider_name
+                        candidate.url_context_metadata, provider_name
                     )
                     if web_fetch_call and web_fetch_return:
-                        yield self._parts_manager.handle_part(vendor_part_id=uuid4(), part=web_fetch_call)
-                        yield self._parts_manager.handle_part(vendor_part_id=uuid4(), part=web_fetch_return)
+                        yield parts_manager.handle_part(vendor_part_id=uuid4(), part=web_fetch_call)
+                        yield parts_manager.handle_part(vendor_part_id=uuid4(), part=web_fetch_return)
 
                 if candidate.content is None or candidate.content.parts is None:
                     continue
@@ -1356,7 +1365,10 @@ class GeminiStreamedResponse(StreamedResponse):
                     continue  # pragma: no cover
 
                 if not self._has_tool_invocations:
-                    self._has_tool_invocations = _has_native_tool_invocations(parts)
+                    for response_part in parts:
+                        if response_part.tool_call or response_part.tool_response:
+                            self._has_tool_invocations = True
+                            break
 
                 for part in parts:
                     provider_details: dict[str, Any] | None = None
@@ -1372,28 +1384,28 @@ class GeminiStreamedResponse(StreamedResponse):
                         if len(part.text) == 0 and not provider_details:
                             continue
                         if part.thought:
-                            for event in self._parts_manager.handle_thinking_delta(
+                            for event in parts_manager.handle_thinking_delta(
                                 vendor_part_id=None,
                                 content=part.text,
-                                provider_name=self.provider_name if provider_details else None,
+                                provider_name=provider_name if provider_details else None,
                                 provider_details=provider_details,
                             ):
                                 yield event
                         else:
-                            for event in self._parts_manager.handle_text_delta(
+                            for event in parts_manager.handle_text_delta(
                                 vendor_part_id=None,
                                 content=part.text,
-                                provider_name=self.provider_name if provider_details else None,
+                                provider_name=provider_name if provider_details else None,
                                 provider_details=provider_details,
                             ):
                                 yield event
                     elif part.function_call:
-                        maybe_event = self._parts_manager.handle_tool_call_delta(
+                        maybe_event = parts_manager.handle_tool_call_delta(
                             vendor_part_id=uuid4(),
                             tool_name=part.function_call.name,
                             args=part.function_call.args,
                             tool_call_id=part.function_call.id,
-                            provider_name=self.provider_name if provider_details else None,
+                            provider_name=provider_name if provider_details else None,
                             provider_details=provider_details,
                         )
                         if maybe_event is not None:  # pragma: no branch
@@ -1408,39 +1420,39 @@ class GeminiStreamedResponse(StreamedResponse):
                         mime_type = part.inline_data.mime_type
                         assert data and mime_type, 'Inline data must have data and mime type'
                         content = BinaryContent(data=data, media_type=mime_type)
-                        yield self._parts_manager.handle_part(
+                        yield parts_manager.handle_part(
                             vendor_part_id=uuid4(),
                             part=FilePart(
                                 content=BinaryContent.narrow_type(content),
-                                provider_name=self.provider_name if provider_details else None,
+                                provider_name=provider_name if provider_details else None,
                                 provider_details=provider_details,
                             ),
                         )
                     elif part.tool_call:
-                        tool_call_part = _map_tool_call(part.tool_call, self.provider_name)
+                        tool_call_part = _map_tool_call(part.tool_call, provider_name)
                         tool_call_part.provider_details = provider_details
-                        yield self._parts_manager.handle_part(vendor_part_id=uuid4(), part=tool_call_part)
+                        yield parts_manager.handle_part(vendor_part_id=uuid4(), part=tool_call_part)
                     elif part.tool_response:
-                        tool_response_part = _map_tool_response(part.tool_response, self.provider_name)
+                        tool_response_part = _map_tool_response(part.tool_response, provider_name)
                         tool_response_part.provider_details = provider_details
                         if tool_response_part.tool_name == FileSearchTool.kind and tool_response_part.content is None:
                             # Reserve the part's slot but defer its `PartStartEvent` until it's filled below,
                             # so consumers see a single populated file_search result rather than an empty one
                             # followed by a filled duplicate.
                             self._pending_file_search_returns.append(tool_response_part)
-                            self._parts_manager.handle_part(
+                            parts_manager.handle_part(
                                 vendor_part_id=tool_response_part.tool_call_id, part=tool_response_part
                             )
                         else:
-                            yield self._parts_manager.handle_part(vendor_part_id=uuid4(), part=tool_response_part)
+                            yield parts_manager.handle_part(vendor_part_id=uuid4(), part=tool_response_part)
                     elif part.executable_code is not None:
                         part_obj = self._handle_executable_code_streaming(part.executable_code)
                         part_obj.provider_details = provider_details
-                        yield self._parts_manager.handle_part(vendor_part_id=uuid4(), part=part_obj)
+                        yield parts_manager.handle_part(vendor_part_id=uuid4(), part=part_obj)
                     elif part.code_execution_result is not None:
                         part = self._map_code_execution_result(part.code_execution_result)
                         part.provider_details = provider_details
-                        yield self._parts_manager.handle_part(vendor_part_id=uuid4(), part=part)
+                        yield parts_manager.handle_part(vendor_part_id=uuid4(), part=part)
                     else:
                         assert part.function_response is not None, f'Unexpected part: {part}'  # pragma: no cover
 
@@ -1452,7 +1464,7 @@ class GeminiStreamedResponse(StreamedResponse):
                         candidate.grounding_metadata
                     )
                     if file_search_part is not None:
-                        yield self._parts_manager.handle_part(vendor_part_id=uuid4(), part=file_search_part)
+                        yield parts_manager.handle_part(vendor_part_id=uuid4(), part=file_search_part)
                 elif self._pending_file_search_returns:
                     # Fill every reserved file_search return from the (aggregate) `grounding_metadata`,
                     # matching the non-streaming path, and emit each filled part's deferred `PartStartEvent`
@@ -1466,14 +1478,14 @@ class GeminiStreamedResponse(StreamedResponse):
                         if pending.content is None:
                             still_pending.append(pending)
                         else:
-                            yield self._parts_manager.handle_part(vendor_part_id=pending.tool_call_id, part=pending)
+                            yield parts_manager.handle_part(vendor_part_id=pending.tool_call_id, part=pending)
                     self._pending_file_search_returns = still_pending
 
             # Grounding never arrived (or carried no retrieved contexts) for these reserved returns: emit
             # their deferred `PartStartEvent`s with empty content, so streaming consumers still see every
             # part present in the final response.
             for pending in self._pending_file_search_returns:
-                yield self._parts_manager.handle_part(vendor_part_id=pending.tool_call_id, part=pending)
+                yield parts_manager.handle_part(vendor_part_id=pending.tool_call_id, part=pending)
             self._pending_file_search_returns = []
         except errors.APIError as e:
             if (status_code := e.code) >= 400:
@@ -1902,8 +1914,12 @@ def _metadata_as_usage(
     if existing_usage:
         details = {**existing_usage.details, **details}
 
+    usage_metadata_payload = {
+        'modelVersion': response.model_version,
+        'usageMetadata': metadata.model_dump(by_alias=True),
+    }
     new_usage = usage.RequestUsage.extract(
-        response.model_dump(include={'model_version', 'usage_metadata'}, by_alias=True),
+        usage_metadata_payload,
         provider=provider,
         provider_url=provider_url,
         provider_fallback='google',

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -1258,7 +1258,7 @@ class GeminiStreamedResponse(StreamedResponse):
                 raise
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
-        stream_provider_details = self.provider_details
+        stream_provider_details: dict[str, Any] | None = self.provider_details
         if self._provider_timestamp is not None:
             stream_provider_details = {'timestamp': self._provider_timestamp}
             self.provider_details = stream_provider_details

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -4339,6 +4339,40 @@ async def test_gemini_streamed_response_initializes_provider_details_from_prompt
     }
 
 
+async def test_gemini_streamed_response_adds_prompt_feedback_to_existing_provider_details():
+    chunk = GenerateContentResponse(
+        response_id='stream-blocked-with-traffic-type',
+        usage_metadata=GenerateContentResponseUsageMetadata(
+            prompt_token_count=0,
+            candidates_token_count=0,
+            traffic_type=TrafficType.ON_DEMAND_FLEX,
+        ),
+        prompt_feedback=GenerateContentResponsePromptFeedback(block_reason=BlockedReason.PROHIBITED_CONTENT),
+    )
+
+    async def response_iterator() -> AsyncIterator[GenerateContentResponse]:
+        yield chunk
+
+    streamed_response = GeminiStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='gemini-test',
+        _response=cast(Any, PeekableAsyncStream(response_iterator())),
+        _timestamp=IsDatetime(),
+        _provider_name='test-provider',
+        _provider_url='',
+    )
+
+    events = [event async for event in streamed_response._get_event_iterator()]  # pyright: ignore[reportPrivateUsage]
+
+    assert events == []
+    assert streamed_response.finish_reason == 'content_filter'
+    assert streamed_response.provider_response_id == 'stream-blocked-with-traffic-type'
+    assert streamed_response.provider_details == {
+        'traffic_type': 'ON_DEMAND_FLEX',
+        'block_reason': 'PROHIBITED_CONTENT',
+    }
+
+
 def _usage_chunk(
     *,
     candidates: int,

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -4262,6 +4262,7 @@ async def test_gemini_streamed_response_emits_text_events_for_non_empty_parts():
 
 
 async def test_gemini_streamed_response_initializes_provider_details_from_service_tier():
+    """Pin internal provider details that a VCR cassette would not expose reliably."""
     chunk = _generate_response_with_texts('stream-service-tier', ['hello'])
     chunk.sdk_http_response = HttpResponse(headers={'x-gemini-service-tier': 'FLEX'})
 
@@ -4284,6 +4285,7 @@ async def test_gemini_streamed_response_initializes_provider_details_from_servic
 
 
 async def test_gemini_streamed_response_initializes_provider_details_from_traffic_type():
+    """Pin internal provider details that a VCR cassette would not expose reliably."""
     chunk = _generate_response_with_texts('stream-traffic-type', ['hello'])
     usage_metadata = chunk.usage_metadata
     assert usage_metadata is not None
@@ -4308,6 +4310,7 @@ async def test_gemini_streamed_response_initializes_provider_details_from_traffi
 
 
 async def test_gemini_streamed_response_initializes_provider_details_from_prompt_feedback():
+    """Pin internal provider details that a VCR cassette would not expose reliably."""
     chunk = GenerateContentResponse(
         response_id='stream-blocked',
         prompt_feedback=GenerateContentResponsePromptFeedback(
@@ -4340,6 +4343,7 @@ async def test_gemini_streamed_response_initializes_provider_details_from_prompt
 
 
 async def test_gemini_streamed_response_adds_prompt_feedback_to_existing_provider_details():
+    """Pin internal provider details that a VCR cassette would not expose reliably."""
     chunk = GenerateContentResponse(
         response_id='stream-blocked-with-traffic-type',
         usage_metadata=GenerateContentResponseUsageMetadata(

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -105,6 +105,7 @@ with try_import() as imports_successful:
         ModalityTokenCount,
         Part,
         SafetyRating,
+        TrafficType,
         UploadToFileSearchStoreConfigDict,
     )
 
@@ -4258,6 +4259,82 @@ async def test_gemini_streamed_response_emits_text_events_for_non_empty_parts():
 
     events = [event async for event in streamed_response._get_event_iterator()]  # pyright: ignore[reportPrivateUsage]
     assert events == snapshot([PartStartEvent(index=0, part=TextPart(content='streamed text'))])
+
+
+async def test_gemini_streamed_response_initializes_provider_details_from_service_tier():
+    chunk = _generate_response_with_texts('stream-service-tier', ['hello'])
+    chunk.sdk_http_response = HttpResponse(headers={'x-gemini-service-tier': 'FLEX'})
+
+    async def response_iterator() -> AsyncIterator[GenerateContentResponse]:
+        yield chunk
+
+    streamed_response = GeminiStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='gemini-test',
+        _response=cast(Any, PeekableAsyncStream(response_iterator())),
+        _timestamp=IsDatetime(),
+        _provider_name='test-provider',
+        _provider_url='',
+    )
+
+    events = [event async for event in streamed_response._get_event_iterator()]  # pyright: ignore[reportPrivateUsage]
+
+    assert events == snapshot([PartStartEvent(index=0, part=TextPart(content='hello'))])
+    assert streamed_response.provider_details == {'service_tier': 'flex', 'finish_reason': 'STOP'}
+
+
+async def test_gemini_streamed_response_initializes_provider_details_from_traffic_type():
+    chunk = _generate_response_with_texts('stream-traffic-type', ['hello'])
+    chunk.usage_metadata.traffic_type = TrafficType.ON_DEMAND_FLEX
+
+    async def response_iterator() -> AsyncIterator[GenerateContentResponse]:
+        yield chunk
+
+    streamed_response = GeminiStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='gemini-test',
+        _response=cast(Any, PeekableAsyncStream(response_iterator())),
+        _timestamp=IsDatetime(),
+        _provider_name='test-provider',
+        _provider_url='',
+    )
+
+    events = [event async for event in streamed_response._get_event_iterator()]  # pyright: ignore[reportPrivateUsage]
+
+    assert events == snapshot([PartStartEvent(index=0, part=TextPart(content='hello'))])
+    assert streamed_response.provider_details == {'traffic_type': 'ON_DEMAND_FLEX', 'finish_reason': 'STOP'}
+
+
+async def test_gemini_streamed_response_initializes_provider_details_from_prompt_feedback():
+    chunk = GenerateContentResponse(
+        response_id='stream-blocked',
+        prompt_feedback=GenerateContentResponsePromptFeedback(
+            block_reason=BlockedReason.PROHIBITED_CONTENT,
+            block_reason_message='The prompt was blocked.',
+        ),
+    )
+
+    async def response_iterator() -> AsyncIterator[GenerateContentResponse]:
+        yield chunk
+
+    streamed_response = GeminiStreamedResponse(
+        model_request_parameters=ModelRequestParameters(),
+        _model_name='gemini-test',
+        _response=cast(Any, PeekableAsyncStream(response_iterator())),
+        _timestamp=IsDatetime(),
+        _provider_name='test-provider',
+        _provider_url='',
+    )
+
+    events = [event async for event in streamed_response._get_event_iterator()]  # pyright: ignore[reportPrivateUsage]
+
+    assert events == []
+    assert streamed_response.finish_reason == 'content_filter'
+    assert streamed_response.provider_response_id == 'stream-blocked'
+    assert streamed_response.provider_details == {
+        'block_reason': 'PROHIBITED_CONTENT',
+        'block_reason_message': 'The prompt was blocked.',
+    }
 
 
 def _usage_chunk(

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -4285,7 +4285,9 @@ async def test_gemini_streamed_response_initializes_provider_details_from_servic
 
 async def test_gemini_streamed_response_initializes_provider_details_from_traffic_type():
     chunk = _generate_response_with_texts('stream-traffic-type', ['hello'])
-    chunk.usage_metadata.traffic_type = TrafficType.ON_DEMAND_FLEX
+    usage_metadata = chunk.usage_metadata
+    assert usage_metadata is not None
+    usage_metadata.traffic_type = TrafficType.ON_DEMAND_FLEX
 
     async def response_iterator() -> AsyncIterator[GenerateContentResponse]:
         yield chunk


### PR DESCRIPTION
## Summary

This reduces overhead in Google streamed response handling by avoiding repeated per-chunk attribute lookups and dict copies in `GeminiStreamedResponse._get_event_iterator`, while preserving the existing stream control flow and `uuid4()` vendor part IDs.

It also narrows the usage extraction payload so `_metadata_as_usage` passes only the response model version and usage metadata into `RequestUsage.extract` instead of dumping the whole response object slice.

This closes #6396.

Supplementary autoresearch: [public dashboard](https://dashboard.weco.ai/share/Aj5ACG8Fya3OT_IYxHCkhWA8XEjQQcp3).

## Validation

I used a focused evaluator that checks text chunk merging, file-search deferred returns, empty grounding flush behavior, code execution parts, and provider metadata updates across later stream chunks (`provider_response_id`, `service_tier`, and `traffic_type`). The final patch uses the conservative implementation that passes this strengthened metadata gate.

Strengthened metric repeats:

- Upstream: `2127.071475 us`, `2136.656975 us`
- This branch: `2060.2042125 us`, `2049.346975 us`

Checks run:

- `uvx ruff check --fix pydantic_ai_slim/pydantic_ai/models/google.py`
- `git diff --check`
- `python -m pytest tests/models/google/test_native_tools.py -q` (`9 passed`)
- `python -m pytest tests/models/google/test_code_execution.py -q` (`2 passed, 1 skipped`)

Fixes #6396.
