### PR TITLE
fix: preserve deferred calls and output retries on sibling task exception

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -688,14 +688,16 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
             # consistent ordering.
             self.output_parts.extend([tool_parts_by_index[k] for k in sorted(tool_parts_by_index)])
             self.output_parts.extend([user_parts_by_index[k] for k in sorted(user_parts_by_index)])
-
-        self._populate_deferred_calls(
-            tool_calls,
-            deferred_calls_by_index=deferred_calls_by_index,
-            deferred_metadata_by_index=deferred_metadata_by_index,
-            deferred_calls=deferred_calls,
-            deferred_metadata=deferred_metadata,
-        )
+            # Deferred calls must also be preserved on exception — a sibling task
+            # that crashes with a non-CancelledError (e.g. RuntimeError) must not
+            # silently drop deferred calls already accumulated by completed tasks.
+            self._populate_deferred_calls(
+                tool_calls,
+                deferred_calls_by_index=deferred_calls_by_index,
+                deferred_metadata_by_index=deferred_metadata_by_index,
+                deferred_calls=deferred_calls,
+                deferred_metadata=deferred_metadata,
+            )
 
     def _populate_deferred_calls(
         self,
@@ -1083,12 +1085,14 @@ class _ExhaustiveProcessor(_ToolCallProcessor[DepsT, NodeRunEndT]):
                 for i in executable_indices:  # pragma: no branch
                     if i in function_user_parts:
                         self.output_parts.append(function_user_parts[i])
+                # Preserve deferred calls and output retries on exception — same
+                # sibling-crash safety as in `_call_tools`.
+                self._populate_deferred_calls(
+                    self.tool_calls,
+                    deferred_calls_by_index=deferred_by_index,
+                    deferred_metadata_by_index=deferred_meta_by_index,
+                    deferred_calls=self.deferred_calls,
+                    deferred_metadata=self.deferred_metadata,
+                )
+                self.ctx.state.output_retries_used += self.output_retries_increment
 
-        self._populate_deferred_calls(
-            self.tool_calls,
-            deferred_calls_by_index=deferred_by_index,
-            deferred_metadata_by_index=deferred_meta_by_index,
-            deferred_calls=self.deferred_calls,
-            deferred_metadata=self.deferred_metadata,
-        )
-        self.ctx.state.output_retries_used += self.output_retries_increment


### PR DESCRIPTION
Fixes a bug where deferred tool calls (CallDeferred / ApprovalRequired) and output validation retries were silently dropped when a sibling task in the same parallel segment raised an exception.

## Problem

In both _call_tools and _ExhaustiveProcessor._run_strategy, _populate_deferred_calls and output_retries_increment were placed after the try/finally block. When a sibling task crashed with a non-CancelledError, the finally block ran (capturing only output_parts) but the deferred calls and retry state were never committed:



## Fix

Moved both _populate_deferred_calls and output_retries_used increment into the finally block, where they survive both normal completion and exception propagation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

