### PR TITLE
fix: validate max_queued in ConcurrencyLimit and ConcurrencyLimiter

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/concurrency.py
+++ b/pydantic_ai_slim/pydantic_ai/concurrency.py
@@ -27,8 +27,8 @@ def _validate_max_running(max_running: int) -> None:
         raise UserError(f'max_running must be >= 1, got {max_running}. Use None for no concurrency limiting.')
 
 
-def _validate_max_queued(max_queued: int) -> None:
-    if max_queued < 0:
+def _validate_max_queued(max_queued: int | None) -> None:
+    if max_queued is not None and max_queued < 0:
         raise UserError(f'max_queued must be >= 0, got {max_queued}. Use None for unlimited queue.')
 
 
@@ -89,8 +89,7 @@ class ConcurrencyLimit:
 
     def __post_init__(self) -> None:
         _validate_max_running(self.max_running)
-        if self.max_queued is not None:
-            _validate_max_queued(self.max_queued)
+        _validate_max_queued(self.max_queued)
 
 
 class ConcurrencyLimiter(AbstractConcurrencyLimiter):
@@ -122,8 +121,7 @@ class ConcurrencyLimiter(AbstractConcurrencyLimiter):
             UserError: If `max_running` is less than 1.
         """
         _validate_max_running(max_running)
-        if max_queued is not None:
-            _validate_max_queued(max_queued)
+        _validate_max_queued(max_queued)
         self._limiter = anyio.CapacityLimiter(max_running)
         self._max_queued = max_queued
         self._name = name

--- a/pydantic_ai_slim/pydantic_ai/concurrency.py
+++ b/pydantic_ai_slim/pydantic_ai/concurrency.py
@@ -80,7 +80,7 @@ class ConcurrencyLimit:
 
     Args:
         max_running: Maximum number of concurrent operations allowed. Must be >= 1.
-        max_queued: Maximum number of operations waiting in the queue.
+        max_queued: Maximum number of operations waiting in the queue. Must be >= 0.
             If None, the queue is unlimited. If exceeded, raises `ConcurrencyLimitExceeded`.
     """
 
@@ -112,13 +112,13 @@ class ConcurrencyLimiter(AbstractConcurrencyLimiter):
 
         Args:
             max_running: Maximum number of concurrent operations. Must be >= 1.
-            max_queued: Maximum queue depth before raising ConcurrencyLimitExceeded.
+            max_queued: Maximum queue depth before raising ConcurrencyLimitExceeded. Must be >= 0.
             name: Optional name for this limiter, used for observability when sharing
                 a limiter across multiple models or agents.
             tracer: OpenTelemetry tracer for span creation.
 
         Raises:
-            UserError: If `max_running` is less than 1.
+            UserError: If `max_running` is less than 1, or `max_queued` is less than 0.
         """
         _validate_max_running(max_running)
         _validate_max_queued(max_queued)

--- a/pydantic_ai_slim/pydantic_ai/concurrency.py
+++ b/pydantic_ai_slim/pydantic_ai/concurrency.py
@@ -27,6 +27,11 @@ def _validate_max_running(max_running: int) -> None:
         raise UserError(f'max_running must be >= 1, got {max_running}. Use None for no concurrency limiting.')
 
 
+def _validate_max_queued(max_queued: int) -> None:
+    if max_queued < 0:
+        raise UserError(f'max_queued must be >= 0, got {max_queued}. Use None for unlimited queue.')
+
+
 class AbstractConcurrencyLimiter(ABC):
     """Abstract base class for concurrency limiters.
 
@@ -84,6 +89,8 @@ class ConcurrencyLimit:
 
     def __post_init__(self) -> None:
         _validate_max_running(self.max_running)
+        if self.max_queued is not None:
+            _validate_max_queued(self.max_queued)
 
 
 class ConcurrencyLimiter(AbstractConcurrencyLimiter):
@@ -115,6 +122,8 @@ class ConcurrencyLimiter(AbstractConcurrencyLimiter):
             UserError: If `max_running` is less than 1.
         """
         _validate_max_running(max_running)
+        if max_queued is not None:
+            _validate_max_queued(max_queued)
         self._limiter = anyio.CapacityLimiter(max_running)
         self._max_queued = max_queued
         self._name = name

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -609,6 +609,22 @@ class TestConcurrencyLimiterName:
         attrs = spans[0]['attributes']
         assert attrs['max_queued'] == 5
 
+    def test_concurrency_limit_rejects_negative_max_queued(self):
+        with pytest.raises(UserError, match='max_queued must be >= 0'):
+            ConcurrencyLimit(max_running=5, max_queued=-1)
+
+    def test_concurrency_limiter_rejects_negative_max_queued(self):
+        with pytest.raises(UserError, match='max_queued must be >= 0'):
+            ConcurrencyLimiter(max_running=5, max_queued=-1)
+
+    def test_concurrency_limit_accepts_none_max_queued(self):
+        limit = ConcurrencyLimit(max_running=5, max_queued=None)
+        assert limit.max_queued is None
+
+    def test_concurrency_limit_accepts_zero_max_queued(self):
+        limit = ConcurrencyLimit(max_running=5, max_queued=0)
+        assert limit.max_queued == 0
+
 
 class TestConcurrencyLimiterWithTracer:
     """Tests for ConcurrencyLimiter with custom tracer."""

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -15,6 +15,8 @@ from pydantic_ai.exceptions import UserError
 from pydantic_ai.models.test import TestModel
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from logfire.testing import CaptureLogfire
 
 logfire_installed = importlib.util.find_spec('logfire') is not None
@@ -609,17 +611,16 @@ class TestConcurrencyLimiterName:
         attrs = spans[0]['attributes']
         assert attrs['max_queued'] == 5
 
-    def test_concurrency_limit_rejects_negative_max_queued(self):
+    @pytest.mark.parametrize(
+        'factory',
+        [
+            lambda: ConcurrencyLimit(max_running=5, max_queued=-1),
+            lambda: ConcurrencyLimiter(max_running=5, max_queued=-1),
+        ],
+    )
+    def test_rejects_negative_max_queued(self, factory: Callable[[], object]):
         with pytest.raises(UserError, match='max_queued must be >= 0'):
-            ConcurrencyLimit(max_running=5, max_queued=-1)
-
-    def test_concurrency_limiter_rejects_negative_max_queued(self):
-        with pytest.raises(UserError, match='max_queued must be >= 0'):
-            ConcurrencyLimiter(max_running=5, max_queued=-1)
-
-    def test_concurrency_limit_accepts_none_max_queued(self):
-        limit = ConcurrencyLimit(max_running=5, max_queued=None)
-        assert limit.max_queued is None
+            factory()
 
     def test_concurrency_limit_accepts_zero_max_queued(self):
         limit = ConcurrencyLimit(max_running=5, max_queued=0)


### PR DESCRIPTION
Fixes #6372

Adds validation for max_queued (same pattern as max_running in #6282). Negative max_queued silently blocks all queueing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

