### PR TITLE
fix: validate Tool max_retries and timeout parameters

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -435,6 +435,16 @@ ToolAgentDepsT = TypeVar('ToolAgentDepsT', default=object, contravariant=True)
 """Type variable for agent dependencies for a tool."""
 
 
+def _validate_max_retries(max_retries: int | None) -> None:
+    if max_retries is not None and max_retries < 0:
+        raise UserError(f'max_retries must be >= 0, got {max_retries}')
+
+
+def _validate_timeout(timeout: float | None) -> None:
+    if timeout is not None and timeout <= 0:
+        raise UserError(f'timeout must be > 0, got {timeout}')
+
+
 @dataclass(init=False)
 class Tool(Generic[ToolAgentDepsT]):
     """A tool function for an agent."""
@@ -575,10 +585,8 @@ class Tool(Generic[ToolAgentDepsT]):
         self.requires_approval = requires_approval
         self.metadata = metadata
         self.timeout = timeout
-        if self.max_retries is not None and self.max_retries < 0:
-            raise UserError(f'max_retries must be >= 0, got {self.max_retries}')
-        if self.timeout is not None and self.timeout <= 0:
-            raise UserError(f'timeout must be > 0, got {self.timeout}')
+        _validate_max_retries(max_retries)
+        _validate_timeout(timeout)
         self.defer_loading = defer_loading
         self.include_return_schema = include_return_schema
 

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -563,6 +563,8 @@ class Tool(Generic[ToolAgentDepsT]):
                 If `None`, defaults to `False` unless the [`IncludeToolReturnSchemas`][pydantic_ai.capabilities.IncludeToolReturnSchemas] capability is used.
             function_schema: The function schema to use for the tool. If not provided, it will be generated.
         """
+        _validate_max_retries(max_retries)
+        _validate_timeout(timeout)
         self.function = function
         self.name = name or function.__name__
         self.function_schema = function_schema or _function_schema.function_schema(
@@ -585,8 +587,6 @@ class Tool(Generic[ToolAgentDepsT]):
         self.requires_approval = requires_approval
         self.metadata = metadata
         self.timeout = timeout
-        _validate_max_retries(max_retries)
-        _validate_timeout(timeout)
         self.defer_loading = defer_loading
         self.include_return_schema = include_return_schema
 

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -13,7 +13,7 @@ from typing_extensions import ParamSpec, Self, TypeVar
 
 from . import _function_schema, _utils
 from ._run_context import AgentDepsT, RunContext
-from .exceptions import ModelRetry
+from .exceptions import ModelRetry, UserError
 from .function_signature import FunctionSignature
 from .messages import RetryPromptPart, ToolCallPart, ToolPartKind, ToolReturn
 from .native_tools import AbstractNativeTool
@@ -575,6 +575,10 @@ class Tool(Generic[ToolAgentDepsT]):
         self.requires_approval = requires_approval
         self.metadata = metadata
         self.timeout = timeout
+        if self.max_retries is not None and self.max_retries < 0:
+            raise UserError(f'max_retries must be >= 0, got {self.max_retries}')
+        if self.timeout is not None and self.timeout <= 0:
+            raise UserError(f'timeout must be > 0, got {self.timeout}')
         self.defer_loading = defer_loading
         self.include_return_schema = include_return_schema
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4433,3 +4433,36 @@ def test_include_return_schema_on_toolset_tool():
 
 
 # endregion
+
+
+# --- Tool parameter validation -------------------------------------------------
+
+
+def test_tool_rejects_negative_max_retries():
+    with pytest.raises(UserError, match='max_retries must be >= 0'):
+        Tool(lambda: None, max_retries=-1)
+
+
+def test_tool_accepts_zero_max_retries():
+    tool = Tool(lambda: None, max_retries=0)
+    assert tool.max_retries == 0
+
+
+def test_tool_accepts_none_max_retries():
+    tool = Tool(lambda: None, max_retries=None)
+    assert tool.max_retries is None
+
+
+def test_tool_rejects_non_positive_timeout():
+    with pytest.raises(UserError, match='timeout must be > 0'):
+        Tool(lambda: None, timeout=0)
+
+
+def test_tool_rejects_negative_timeout():
+    with pytest.raises(UserError, match='timeout must be > 0'):
+        Tool(lambda: None, timeout=-1)
+
+
+def test_tool_accepts_none_timeout():
+    tool = Tool(lambda: None, timeout=None)
+    assert tool.timeout is None


### PR DESCRIPTION
Fixes #6374

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

