### PR TITLE
fix: validate ToolOutput max_retries

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/output.py
+++ b/pydantic_ai_slim/pydantic_ai/output.py
@@ -139,12 +139,12 @@ class ToolOutput(Generic[OutputDataT]):
         strict: bool | None = None,
         sequential: bool = False,
     ):
+        if max_retries is not None and max_retries < 0:
+            raise exceptions.UserError(f'max_retries must be >= 0, got {max_retries}')
         self.output = type_
         self.name = name
         self.description = description
         self.max_retries = max_retries
-        if self.max_retries is not None and self.max_retries < 0:
-            raise exceptions.UserError(f'max_retries must be >= 0, got {self.max_retries}')
         self.strict = strict
         self.sequential = sequential
 

--- a/pydantic_ai_slim/pydantic_ai/output.py
+++ b/pydantic_ai_slim/pydantic_ai/output.py
@@ -143,6 +143,8 @@ class ToolOutput(Generic[OutputDataT]):
         self.name = name
         self.description = description
         self.max_retries = max_retries
+        if self.max_retries is not None and self.max_retries < 0:
+            raise exceptions.UserError(f'max_retries must be >= 0, got {self.max_retries}')
         self.strict = strict
         self.sequential = sequential
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4466,3 +4466,17 @@ def test_tool_rejects_negative_timeout():
 def test_tool_accepts_none_timeout():
     tool = Tool(lambda: None, timeout=None)
     assert tool.timeout is None
+
+
+# --- ToolOutput parameter validation -------------------------------------------
+
+
+def test_tooloutput_rejects_negative_max_retries():
+    with pytest.raises(UserError, match='max_retries must be >= 0'):
+        ToolOutput(int, max_retries=-1)
+
+
+@pytest.mark.parametrize('max_retries', [0, None])
+def test_tooloutput_accepts_valid_max_retries(max_retries: int | None):
+    out = ToolOutput(int, max_retries=max_retries)
+    assert out.max_retries == max_retries


### PR DESCRIPTION
Fixes #6376

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

