### PR TITLE
Allow `to_cli()` to pass `model` for unset-model agents

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/_cli/__init__.py
@@ -11,7 +11,7 @@ from typing import Any
 import anyio
 from pydantic import ImportString, TypeAdapter, ValidationError
 
-from .. import __version__, usage as _usage
+from .. import __version__, models, usage as _usage
 from .._run_context import AgentDepsT
 from ..agent import AbstractAgent, Agent
 from ..exceptions import UserError
@@ -336,6 +336,7 @@ async def run_chat(
     config_dir: Path | None = None,
     deps: AgentDepsT = None,
     message_history: Sequence[ModelMessage] | None = None,
+    model: models.Model | models.KnownModelName | str | None = None,
     model_settings: ModelSettings | None = None,
     usage_limits: _usage.UsageLimits | None = None,
 ) -> int:
@@ -365,7 +366,16 @@ async def run_chat(
         else:
             try:
                 messages = await ask_agent(
-                    agent, text, stream, console, code_theme, deps, messages, model_settings, usage_limits
+                    agent,
+                    text,
+                    stream,
+                    console,
+                    code_theme,
+                    deps=deps,
+                    messages=messages,
+                    model=model,
+                    model_settings=model_settings,
+                    usage_limits=usage_limits,
                 )
             except anyio.get_cancelled_exc_class():  # pragma: no cover
                 console.print('[dim]Interrupted[/dim]')
@@ -384,6 +394,7 @@ async def ask_agent(
     code_theme: str,
     deps: AgentDepsT = None,
     messages: Sequence[ModelMessage] | None = None,
+    model: models.Model | models.KnownModelName | str | None = None,
     model_settings: ModelSettings | None = None,
     usage_limits: _usage.UsageLimits | None = None,
 ) -> list[ModelMessage]:
@@ -391,14 +402,26 @@ async def ask_agent(
 
     if not stream:
         with status:
-            result = await agent.run(prompt, message_history=messages, deps=deps)
+            result = await agent.run(
+                prompt,
+                message_history=messages,
+                deps=deps,
+                model=model,
+                model_settings=model_settings,
+                usage_limits=usage_limits,
+            )
         content = str(result.output)
         console.print(Markdown(content, code_theme=code_theme))
         return result.all_messages()
 
     with status, ExitStack() as stack:
         async with agent.iter(
-            prompt, message_history=messages, deps=deps, model_settings=model_settings, usage_limits=usage_limits
+            prompt,
+            message_history=messages,
+            deps=deps,
+            model=model,
+            model_settings=model_settings,
+            usage_limits=usage_limits,
         ) as agent_run:
             live = Live('', refresh_per_second=15, console=console, vertical_overflow='ellipsis')
             async for node in agent_run:

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1639,9 +1639,9 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         deps: AgentDepsT = None,
         prog_name: str = 'pydantic-ai',
         message_history: Sequence[_messages.ModelMessage] | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
         model_settings: ModelSettings | None = None,
         usage_limits: _usage.UsageLimits | None = None,
+        model: models.Model | models.KnownModelName | str | None = None,
     ) -> None:
         """Run the agent in a CLI chat interface.
 
@@ -1649,9 +1649,9 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             deps: The dependencies to pass to the agent.
             prog_name: The name of the program to use for the CLI. Defaults to 'pydantic-ai'.
             message_history: History of the conversation so far.
-            model: Optional model to use for the agent run.
             model_settings: Optional settings to use for this model's request.
             usage_limits: Optional limits on model request count or token usage.
+            model: Optional model to use for the agent run.
 
         Example:
         ```python {title="agent_to_cli.py" test="skip"}
@@ -1685,9 +1685,9 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         deps: AgentDepsT = None,
         prog_name: str = 'pydantic-ai',
         message_history: Sequence[_messages.ModelMessage] | None = None,
-        model: models.Model | models.KnownModelName | str | None = None,
         model_settings: ModelSettings | None = None,
         usage_limits: _usage.UsageLimits | None = None,
+        model: models.Model | models.KnownModelName | str | None = None,
     ) -> None:
         """Run the agent in a CLI chat interface with the non-async interface.
 
@@ -1695,9 +1695,9 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             deps: The dependencies to pass to the agent.
             prog_name: The name of the program to use for the CLI. Defaults to 'pydantic-ai'.
             message_history: History of the conversation so far.
-            model: Optional model to use for the agent run.
             model_settings: Optional settings to use for this model's request.
             usage_limits: Optional limits on model request count or token usage.
+            model: Optional model to use for the agent run.
 
         ```python {title="agent_to_cli_sync.py" test="skip"}
         from pydantic_ai import Agent

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -1639,6 +1639,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         deps: AgentDepsT = None,
         prog_name: str = 'pydantic-ai',
         message_history: Sequence[_messages.ModelMessage] | None = None,
+        model: models.Model | models.KnownModelName | str | None = None,
         model_settings: ModelSettings | None = None,
         usage_limits: _usage.UsageLimits | None = None,
     ) -> None:
@@ -1648,6 +1649,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             deps: The dependencies to pass to the agent.
             prog_name: The name of the program to use for the CLI. Defaults to 'pydantic-ai'.
             message_history: History of the conversation so far.
+            model: Optional model to use for the agent run.
             model_settings: Optional settings to use for this model's request.
             usage_limits: Optional limits on model request count or token usage.
 
@@ -1673,6 +1675,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             code_theme='monokai',
             prog_name=prog_name,
             message_history=message_history,
+            model=model,
             model_settings=model_settings,
             usage_limits=usage_limits,
         )
@@ -1682,6 +1685,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
         deps: AgentDepsT = None,
         prog_name: str = 'pydantic-ai',
         message_history: Sequence[_messages.ModelMessage] | None = None,
+        model: models.Model | models.KnownModelName | str | None = None,
         model_settings: ModelSettings | None = None,
         usage_limits: _usage.UsageLimits | None = None,
     ) -> None:
@@ -1691,6 +1695,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
             deps: The dependencies to pass to the agent.
             prog_name: The name of the program to use for the CLI. Defaults to 'pydantic-ai'.
             message_history: History of the conversation so far.
+            model: Optional model to use for the agent run.
             model_settings: Optional settings to use for this model's request.
             usage_limits: Optional limits on model request count or token usage.
 
@@ -1707,6 +1712,7 @@ class AbstractAgent(Generic[AgentDepsT, OutputDataT], ABC):
                 deps=deps,
                 prog_name=prog_name,
                 message_history=message_history,
+                model=model,
                 model_settings=model_settings,
                 usage_limits=usage_limits,
             )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4249,6 +4249,13 @@ def test_override_model_no_model():
     assert result.output == snapshot((0, 'a'))
 
 
+def test_run_without_model():
+    agent = Agent()
+
+    with pytest.raises(UserError, match=r'`model` must either be set on the agent or included when calling it\.'):
+        agent.run_sync('Hello')
+
+
 async def test_agent_name():
     my_agent = Agent('test')
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -810,6 +810,42 @@ async def test_agent_to_cli_async_with_model(mocker: MockerFixture, env: TestEnv
     )
 
 
+@pytest.mark.anyio
+async def test_ask_agent_non_stream_forwards_run_kwargs(mocker: MockerFixture):
+    from pydantic_ai._cli import ask_agent
+
+    result = mocker.Mock()
+    result.output = 'hello'
+    result.all_messages.return_value = []
+
+    agent = mocker.Mock()
+    agent.run = mocker.AsyncMock(return_value=result)
+
+    model_settings = ModelSettings(temperature=0)
+    usage_limits = UsageLimits(request_limit=5)
+
+    messages = await ask_agent(
+        agent,
+        'Hello',
+        stream=False,
+        console=Console(file=StringIO()),
+        code_theme='monokai',
+        model='test',
+        model_settings=model_settings,
+        usage_limits=usage_limits,
+    )
+
+    agent.run.assert_awaited_once_with(
+        'Hello',
+        message_history=None,
+        deps=None,
+        model='test',
+        model_settings=model_settings,
+        usage_limits=usage_limits,
+    )
+    assert messages == []
+
+
 def test_clai_web_with_html_source(mocker: MockerFixture, env: TestEnv):
     """Test web command with --html-source flag."""
     env.set('OPENAI_API_KEY', 'test')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -320,6 +320,7 @@ def test_agent_to_cli_sync(mocker: MockerFixture, env: TestEnv):
         prog_name='pydantic-ai',
         deps=None,
         message_history=None,
+        model=None,
         model_settings=None,
         usage_limits=None,
     )
@@ -338,6 +339,7 @@ async def test_agent_to_cli_async(mocker: MockerFixture, env: TestEnv):
         prog_name='pydantic-ai',
         deps=None,
         message_history=None,
+        model=None,
         model_settings=None,
         usage_limits=None,
     )
@@ -360,6 +362,7 @@ async def test_agent_to_cli_with_message_history(mocker: MockerFixture, env: Tes
         prog_name='pydantic-ai',
         deps=None,
         message_history=test_messages,
+        model=None,
         model_settings=None,
         usage_limits=None,
     )
@@ -381,6 +384,7 @@ def test_agent_to_cli_sync_with_message_history(mocker: MockerFixture, env: Test
         prog_name='pydantic-ai',
         deps=None,
         message_history=test_messages,
+        model=None,
         model_settings=None,
         usage_limits=None,
     )
@@ -735,8 +739,29 @@ def test_agent_to_cli_sync_with_args(mocker: MockerFixture, env: TestEnv):
         prog_name='pydantic-ai',
         deps=None,
         message_history=None,
+        model=None,
         model_settings=model_settings,
         usage_limits=usage_limits,
+    )
+
+
+def test_agent_to_cli_sync_with_model(mocker: MockerFixture, env: TestEnv):
+    env.set('OPENAI_API_KEY', 'test')
+    mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
+
+    cli_agent.to_cli_sync(model='test')
+
+    mock_run_chat.assert_awaited_once_with(
+        stream=True,
+        agent=IsInstance(Agent),
+        console=IsInstance(Console),
+        code_theme='monokai',
+        prog_name='pydantic-ai',
+        deps=None,
+        message_history=None,
+        model='test',
+        model_settings=None,
+        usage_limits=None,
     )
 
 
@@ -758,8 +783,30 @@ async def test_agent_to_cli_async_with_args(mocker: MockerFixture, env: TestEnv)
         prog_name='pydantic-ai',
         deps=None,
         message_history=None,
+        model=None,
         model_settings=model_settings,
         usage_limits=usage_limits,
+    )
+
+
+@pytest.mark.anyio
+async def test_agent_to_cli_async_with_model(mocker: MockerFixture, env: TestEnv):
+    env.set('OPENAI_API_KEY', 'test')
+    mock_run_chat = mocker.patch('pydantic_ai._cli.run_chat')
+
+    await cli_agent.to_cli(model='test')
+
+    mock_run_chat.assert_awaited_once_with(
+        stream=True,
+        agent=IsInstance(Agent),
+        console=IsInstance(Console),
+        code_theme='monokai',
+        prog_name='pydantic-ai',
+        deps=None,
+        message_history=None,
+        model='test',
+        model_settings=None,
+        usage_limits=None,
     )
 
 


### PR DESCRIPTION
Supersedes #6358 (rebased onto `main`). Original author: @godququ5-code — the commit retains their authorship.

The first action item of #6316 (dropping the `override(model=...)` guard) already landed in #6357, so this PR contains **only the second action item**: threading `model` through `to_cli()`.

### Summary

- Add a `model` argument to `to_cli()` and `to_cli_sync()` and pass it through the CLI chat loop to `agent.run()` / `agent.iter()`.
- Also forward `model_settings`/`usage_limits` on the non-stream `ask_agent` path, which were previously dropped.
- Add coverage for both sync/async `to_cli(model=...)` entry points, plus a `test_run_without_model` regression test.

### Note on provenance

This branch is a clean rebase of #6358 onto current `main`. #6358 was accidentally closed while rebasing (an errant push set its fork branch equal to `main`, which auto-closed it and revoked maintainer-edit access, so it could not be restored in place). This PR reproduces the author's work exactly, with the duplicate first-action-item changes dropped since they're already on `main`.

### Test plan

- `uv run pytest tests/test_cli.py tests/test_agent.py::test_override_model_no_model tests/test_agent.py::test_run_without_model -q`
- `uv run ruff format --check` + `uv run ruff check` on the changed files
- `uv run pyright` on `_cli/__init__.py` and `agent/abstract.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

