### PR TITLE
fix(ag-ui): preserve ToolReturnPart.outcome on dump/load round-trip

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -474,12 +474,17 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     # Fall back to the paired call's claim: `ToolCallResultEvent` has no metadata
                     # slot, so client-built ToolMessages usually carry no `encrypted_value`. Error
                     # results stay untyped — typed return parts imply success to their readers.
+                    # A non-`None` `error` (the AG-UI carrier for a failed/denied return) signals a
+                    # non-success outcome; AG-UI has no failed/denied distinction, so it maps to 'failed'.
                     tool_kind = None
+                    outcome: Literal['success', 'failed', 'denied'] = 'success'
                     if tool_msg.error is None:
                         encrypted_tool_kind = (
                             parse_encrypted_tool_kind(tool_msg.encrypted_value) if use_encrypted_value else None
                         )
                         tool_kind = encrypted_tool_kind or tool_kinds.get(tool_call_id)
+                    else:
+                        outcome = 'failed'
 
                     builtin_id = parse_builtin_tool_call_id(tool_call_id)
                     if builtin_id is not None:
@@ -491,6 +496,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 tool_call_id=original_id,
                                 provider_name=provider_name,
                                 tool_kind=tool_kind,
+                                outcome=outcome,
                             )
                         )
                     else:
@@ -503,6 +509,7 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                                 content=content,
                                 tool_call_id=tool_call_id,
                                 tool_kind=tool_kind,
+                                outcome=outcome,
                             )
                         )
 
@@ -658,11 +665,14 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
             elif isinstance(part, ToolReturnPart):
                 flush_user_content()
                 # Tool-return files ride inline in `ToolMessage.content` (see `dump_tool_return_content`).
+                # `outcome` has no AG-UI-native carrier, so failed/denied returns are signaled through the
+                # spec's `ToolMessage.error` field (a non-`None` error implies a non-success outcome on reload).
                 result.append(
                     ToolMessage(
                         id=_new_message_id(),
                         content=dump_tool_return_content(part.content),
                         tool_call_id=part.tool_call_id,
+                        error=part.model_response_str() if part.outcome != 'success' else None,
                         **tool_kind_encrypted_value_kwargs(part.tool_kind, supported=use_encrypted_value),
                     )
                 )
@@ -830,7 +840,9 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
         - `tool_kind` is lost when `ag_ui_version < '0.1.11'` (before its `encrypted_value` carrier
           existed), so typed tool parts reload as their base classes.
         - `tool_kind` is not restored on error/denied tool returns (a typed return implies
-          success to its readers), so those reload as plain `ToolReturnPart`.
+          success to its readers), so those reload as plain `ToolReturnPart`. The `outcome`
+          discriminator (`failed`/`denied`) is preserved via `ToolMessage.error` (both map to
+          `'failed'` on reload, since AG-UI has no denied/failed distinction).
         - `RetryPromptPart` becomes `ToolReturnPart` (or `UserPromptPart`) on reload.
         - `CachePoint` and `UploadedFile` content items are dropped (unless `preserve_file_data=True`).
         - `FileUrl.force_download` is dropped when `ag_ui_version < '0.1.15'` (before typed

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1608,6 +1608,45 @@ def test_dump_load_roundtrip_tools() -> None:
     assert reloaded == original
 
 
+@pytest.mark.parametrize('outcome', ['failed', 'denied'])
+def test_dump_load_roundtrip_tool_return_outcome(outcome: Literal['success', 'failed', 'denied']) -> None:
+    """`ToolReturnPart.outcome` survives a dump/load round-trip via `ToolMessage.error`.
+
+    AG-UI has no failed/denied distinction, so both encode through the spec's `error` field and
+    reload as `'failed'` (matching the Vercel adapter's symmetric mapping).
+    """
+    original: list[ModelMessage] = [
+        ModelResponse(parts=[ToolCallPart(tool_name='my_tool', tool_call_id='call_abc', args='{}')]),
+        ModelRequest(parts=[ToolReturnPart(tool_name='my_tool', tool_call_id='call_abc', content='boom', outcome=outcome)]),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+    tool_msg = ag_ui_msgs[1]
+    assert isinstance(tool_msg, ToolMessage)
+    assert tool_msg.error is not None
+
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    return_part = message_part(reloaded, ToolReturnPart, message_index=1)
+    assert return_part.outcome == 'failed'
+
+
+def test_dump_load_roundtrip_tool_return_success_has_no_error() -> None:
+    """A successful `ToolReturnPart` dumps with `ToolMessage.error=None` so it reloads as success."""
+    original: list[ModelMessage] = [
+        ModelResponse(parts=[ToolCallPart(tool_name='my_tool', tool_call_id='call_abc', args='{}')]),
+        ModelRequest(parts=[ToolReturnPart(tool_name='my_tool', tool_call_id='call_abc', content='ok')]),
+    ]
+
+    ag_ui_msgs = AGUIAdapter.dump_messages(original)
+    tool_msg = ag_ui_msgs[1]
+    assert isinstance(tool_msg, ToolMessage)
+    assert tool_msg.error is None
+
+    reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
+    return_part = message_part(reloaded, ToolReturnPart, message_index=1)
+    assert return_part.outcome == 'success'
+
+
 def test_dump_load_roundtrip_load_capability() -> None:
     """Typed `load_capability` parts keep their identity through dump/load on >= 0.1.11.
 


### PR DESCRIPTION
## Summary

Fixes #5870 — the AG-UI adapter silently dropped `ToolReturnPart.outcome` on a `dump_messages` → `load_messages` round-trip.

- **Dump** (`AGUIAdapter._dump_request_parts`): a `ToolReturnPart` with `outcome='failed'`/`'denied'` now emits `ToolMessage.error` (the AG-UI spec's documented carrier for tool error state) instead of `error=None`.
- **Load** (`AGUIAdapter.load_messages`): a `ToolMessage` with a non-`None` `error` now builds `ToolReturnPart(outcome='failed')` instead of hard-defaulting to `'success'`. (`NativeToolReturnPart` gets the same treatment.)

This mirrors the Vercel AI adapter, which already round-trips `outcome` correctly via `ToolOutputErrorPart`/`ToolOutputDeniedPart`. AG-UI has no failed/denied distinction in its `error` field, so both map to `'failed'` on reload — the docstring caveat is updated to reflect the preserved discriminator.

## Test plan

- Added `test_dump_load_roundtrip_tool_return_outcome` (parametrized over `failed`/`denied`) and `test_dump_load_roundtrip_tool_return_success_has_no_error` to `tests/test_ag_ui.py`.
- `pytest tests/test_ag_ui.py` → 180 passed (includes the new tests).
- `ruff check` on both touched files → all checks passed.

No `Signed-off-by` trailer: this repo does not enforce a DCO check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

