### PR TITLE
fix: obtain event loop via policy to avoid `asyncio.get_event_loop()` deprecation (#1196)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -8,6 +8,7 @@ import re
 import sys
 import time
 import uuid
+import warnings
 from collections.abc import (
     AsyncGenerator,
     AsyncIterable,
@@ -807,11 +808,17 @@ def get_union_args(tp: Any) -> tuple[Any, ...]:
 
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
-    try:
-        event_loop = asyncio.get_event_loop()
-    except RuntimeError:  # pragma: lax no cover
-        event_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(event_loop)
+    # `asyncio.get_event_loop()` is deprecated (and warns or raises) when there is
+    # no running event loop, so obtain the loop via the event loop policy instead.
+    # The DeprecationWarning is suppressed to stay clean on Python 3.14+ where the
+    # policy method itself still emits it.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        try:
+            event_loop = asyncio.get_event_loop_policy().get_event_loop()
+        except RuntimeError:  # pragma: lax no cover
+            event_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(event_loop)
     return event_loop
 
 

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -49,11 +49,17 @@ except ImportError:  # pragma: no cover
 
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
-    try:
-        event_loop = asyncio.get_event_loop()
-    except RuntimeError:
-        event_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(event_loop)
+    # `asyncio.get_event_loop()` is deprecated (and warns or raises) when there is
+    # no running event loop, so obtain the loop via the event loop policy instead.
+    # The DeprecationWarning is suppressed to stay clean on Python 3.14+ where the
+    # policy method itself still emits it.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        try:
+            event_loop = asyncio.get_event_loop_policy().get_event_loop()
+        except RuntimeError:
+            event_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(event_loop)
     return event_loop
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import importlib
 import os
 import sys
 import threading
+import warnings
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
 from importlib.metadata import distributions
@@ -16,7 +17,7 @@ from typing import Any
 import pytest
 
 import pydantic_ai._utils as utils_module
-from pydantic_ai import UserError
+from pydantic_ai import Agent, UserError
 from pydantic_ai._utils import (
     UNSET,
     PeekableAsyncStream,
@@ -28,6 +29,7 @@ from pydantic_ai._utils import (
     strip_markdown_fences,
     using_thread_executor,
 )
+from pydantic_ai.models.test import TestModel
 
 from ._inline_snapshot import snapshot
 from .models.mock_async_stream import MockAsyncStream
@@ -923,3 +925,25 @@ def test_strip_markdown_fences():
     # Nested JSON objects should still be fully captured
     assert strip_markdown_fences('```json\n{"nested": {"key": "value"}}\n```') == '{"nested": {"key": "value"}}'
     assert strip_markdown_fences('```json\n{"a": {"b": {"c": 1}}}\n```') == '{"a": {"b": {"c": 1}}}'
+
+
+def test_run_sync_does_not_emit_event_loop_deprecation_warning():
+    """`agent.run_sync` must obtain the event loop without a DeprecationWarning.
+
+    `asyncio.get_event_loop()` is deprecated (and warns or raises) when there is
+    no running event loop, so the internal `get_event_loop` helper now uses the
+    event loop policy instead (issue #1196).
+    """
+
+    async def noop_tool(ctx: object) -> str:
+        return 'ok'
+
+    agent = Agent(TestModel(), tools=[noop_tool])
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter('always')
+        agent.run_sync('hello')
+
+    event_loop_warnings = [
+        w for w in recorded if issubclass(w.category, DeprecationWarning) and 'event loop' in str(w.message).lower()
+    ]
+    assert event_loop_warnings == []


### PR DESCRIPTION
## Summary

Fixes #1196. `Agent.run_sync(...)` (and other sync wrappers) emit a `DeprecationWarning: There is no current event loop` on Python 3.12/3.13 because the internal `get_event_loop()` helper calls the deprecated `asyncio.get_event_loop()`.

This replaces that call with `asyncio.get_event_loop_policy().get_event_loop()`, wrapped in a `DeprecationWarning` suppression so it also stays clean on Python 3.14+, where the policy method itself still emits the warning. Behavior is otherwise unchanged (it still falls back to creating and setting a new loop when none exists).

## Test plan

- Added `tests/test_utils.py::test_run_sync_does_not_emit_event_loop_deprecation_warning`, which runs `Agent(TestModel()).run_sync(...)` under `warnings.catch_warnings(record=True)` and asserts no asyncio "event loop" `DeprecationWarning` is emitted.
- `uv run pytest tests/test_utils.py::test_run_sync_does_not_emit_event_loop_deprecation_warning` passes locally.
- `uv run ruff check` / `ruff format` clean on the touched files.

This is a narrow fix scoped to the single reported defect (the two identical `get_event_loop()` helpers that back the sync run path).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

