### PR TITLE
fix: count tool calls in usage even when ModelRetry is raised

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -745,6 +745,7 @@ class ToolManager(Generic[AgentDepsT]):
 
         name = validated.call.tool_name
 
+        usage.tool_calls += 1
         try:
             tool_result = await self.toolset.call_tool(
                 name,
@@ -758,8 +759,6 @@ class ToolManager(Generic[AgentDepsT]):
             self._check_max_retries(name, validated.tool.max_retries, e)
             self.failed_tools.add(name)
             raise self._wrap_error_as_retry(name, validated.call, e) from e
-
-        usage.tool_calls += 1
 
         return tool_result
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -3962,7 +3962,7 @@ async def test_tool_raises_call_deferred():
         assert await result.validate_response_output(responses[0]) == snapshot(
             DeferredToolRequests(calls=[ToolCallPart(tool_name='my_tool', args={'x': 0}, tool_call_id=IsStr())])
         )
-        assert result.usage == snapshot(RunUsage(requests=1, input_tokens=51, output_tokens=0))
+        assert result.usage == snapshot(RunUsage(requests=1, input_tokens=51, output_tokens=0, tool_calls=1))
         assert result.timestamp == IsNow(tz=timezone.utc)
         assert result.is_complete
 

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -827,7 +827,12 @@ async def test_output_tool_allowed_at_limit() -> None:
 
 
 async def test_failed_tool_calls_not_counted() -> None:
-    """Test that failed tool calls (raising ModelRetry) are not counted in usage or against limits."""
+    """Test that tool calls that raise ModelRetry are still counted in usage.
+
+    Even though a tool call raises ModelRetry and is retried, the call was made
+    and should be counted against usage limits. This test verifies the counter
+    is incremented before the try/except guard.
+    """
     test_agent = Agent(TestModel())
 
     call_count = 0
@@ -840,9 +845,9 @@ async def test_failed_tool_calls_not_counted() -> None:
             raise ModelRetry('Temporary failure, please retry')
         return f'{x}-success'
 
-    result = await test_agent.run('test', usage_limits=UsageLimits(tool_calls_limit=1))
+    result = await test_agent.run('test', usage_limits=UsageLimits(tool_calls_limit=2))
     assert call_count == 2
-    assert result.usage == snapshot(RunUsage(requests=3, input_tokens=176, output_tokens=29, tool_calls=1))
+    assert result.usage == snapshot(RunUsage(requests=3, input_tokens=176, output_tokens=29, tool_calls=2))
     assert result.all_messages() == snapshot(
         [
             ModelRequest(

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -257,7 +257,7 @@ async def test_multi_agent_usage_no_incr():
     async def delegate_to_other_agent2(ctx: RunContext, sentence: str) -> int:
         delegate_result = await delegate_agent.run(sentence, usage=ctx.usage)
         delegate_usage = delegate_result.usage
-        assert delegate_usage == snapshot(RunUsage(requests=2, input_tokens=102, output_tokens=9))
+        assert delegate_usage == snapshot(RunUsage(requests=2, input_tokens=102, output_tokens=9, tool_calls=1))
         return delegate_result.output
 
     result2 = await controller_agent2.run('foobar')


### PR DESCRIPTION
Fixes #6388

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

