### PR TITLE
fix: don't replace empty tool_call_id with generated ID

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -3115,7 +3115,7 @@ class ToolCallPartDelta:
         return ToolCallPart(
             self.tool_name_delta,
             self.args_delta,
-            self.tool_call_id or _generate_tool_call_id(),
+            self.tool_call_id if self.tool_call_id is not None else _generate_tool_call_id(),
             provider_name=self.provider_name,
             provider_details=self.provider_details,
         )
@@ -3190,7 +3190,7 @@ class ToolCallPartDelta:
             return ToolCallPart(
                 delta.tool_name_delta,
                 delta.args_delta,
-                delta.tool_call_id or _generate_tool_call_id(),
+                delta.tool_call_id if delta.tool_call_id is not None else _generate_tool_call_id(),
                 provider_name=delta.provider_name,
                 provider_details=delta.provider_details,
             )


### PR DESCRIPTION
Fixes #6390

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

