### PR TITLE
fix: use `get_running_loop` instead of deprecated `get_event_loop`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -806,15 +806,6 @@ def get_union_args(tp: Any) -> tuple[Any, ...]:
         return ()
 
 
-def get_event_loop() -> asyncio.AbstractEventLoop:
-    try:
-        return asyncio.get_running_loop()
-    except RuntimeError:  # pragma: lax no cover
-        event_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(event_loop)
-        return event_loop
-
-
 def is_str_dict(obj: Any) -> TypeGuard[dict[str, Any]]:
     """Check if obj is a dict, narrowing the type to `dict[str, Any]`."""
     return isinstance(obj, dict)

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -808,11 +808,11 @@ def get_union_args(tp: Any) -> tuple[Any, ...]:
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
-        event_loop = asyncio.get_event_loop()
+        return asyncio.get_running_loop()
     except RuntimeError:  # pragma: lax no cover
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
-    return event_loop
+        return event_loop
 
 
 def is_str_dict(obj: Any) -> TypeGuard[dict[str, Any]]:

--- a/pydantic_evals/pydantic_evals/_utils.py
+++ b/pydantic_evals/pydantic_evals/_utils.py
@@ -79,13 +79,19 @@ _P = ParamSpec('_P')
 _R = TypeVar('_R')
 
 
+_event_loop: asyncio.AbstractEventLoop | None = None
+
+
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
-        event_loop = asyncio.get_event_loop()
-    except RuntimeError:  # pragma: lax no cover
-        event_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(event_loop)
-    return event_loop
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    global _event_loop
+    if _event_loop is None or _event_loop.is_closed():
+        _event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_event_loop)
+    return _event_loop
 
 
 def run_until_complete(coro: Awaitable[T]) -> T:

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -50,11 +50,11 @@ except ImportError:  # pragma: no cover
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
-        event_loop = asyncio.get_event_loop()
+        return asyncio.get_running_loop()
     except RuntimeError:
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
-    return event_loop
+        return event_loop
 
 
 _T = TypeVar('_T')

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -48,13 +48,19 @@ except ImportError:  # pragma: no cover
         return None
 
 
+_event_loop: asyncio.AbstractEventLoop | None = None
+
+
 def get_event_loop() -> asyncio.AbstractEventLoop:
     try:
         return asyncio.get_running_loop()
     except RuntimeError:
-        event_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(event_loop)
-        return event_loop
+        pass
+    global _event_loop
+    if _event_loop is None or _event_loop.is_closed():
+        _event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_event_loop)
+    return _event_loop
 
 
 _T = TypeVar('_T')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -932,6 +932,9 @@ def test_run_sync_does_not_emit_event_loop_deprecation_warning():
 
     Uses `get_running_loop()` with a `new_event_loop()` fallback instead of
     the deprecated `get_event_loop()` / `get_event_loop_policy()` (issue #1196).
+
+    Not a VCR test: this pins internal event-loop / warning behavior that
+    request cassettes would not exercise or catch a regression in.
     """
 
     async def noop_tool(ctx: object) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,6 +30,7 @@ from pydantic_ai._utils import (
     using_thread_executor,
 )
 from pydantic_ai.models.test import TestModel
+from pydantic_graph._utils import get_event_loop, run_until_complete
 
 from ._inline_snapshot import snapshot
 from .models.mock_async_stream import MockAsyncStream
@@ -203,7 +204,7 @@ def test_run_until_complete_cleans_up_own_task_on_interrupt():
         finally:
             cleaned.append('cleaned')
 
-    loop = utils_module.get_event_loop()
+    loop = get_event_loop()
 
     # An unrelated task on the (caller-owned) loop that must survive: the reporter's `all_tasks()`
     # sledgehammer would cancel this, ours must not.
@@ -230,7 +231,7 @@ def test_run_until_complete_cleans_up_own_task_on_interrupt():
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(loop, 'run_until_complete', interrupt_once)
         with pytest.raises(KeyboardInterrupt):
-            utils_module.run_until_complete(coro())
+            run_until_complete(coro())
 
     assert cleaned == ['cleaned']  # our coroutine's cleanup ran
     assert not bystander_task.cancelled()  # the unrelated task was left alone

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import importlib
 import os
 import sys
 import threading
+import warnings
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
 from importlib.metadata import distributions
@@ -16,7 +17,7 @@ from typing import Any
 import pytest
 
 import pydantic_ai._utils as utils_module
-from pydantic_ai import UserError
+from pydantic_ai import Agent, UserError
 from pydantic_ai._utils import (
     UNSET,
     PeekableAsyncStream,
@@ -28,6 +29,7 @@ from pydantic_ai._utils import (
     strip_markdown_fences,
     using_thread_executor,
 )
+from pydantic_ai.models.test import TestModel
 
 from ._inline_snapshot import snapshot
 from .models.mock_async_stream import MockAsyncStream
@@ -923,3 +925,24 @@ def test_strip_markdown_fences():
     # Nested JSON objects should still be fully captured
     assert strip_markdown_fences('```json\n{"nested": {"key": "value"}}\n```') == '{"nested": {"key": "value"}}'
     assert strip_markdown_fences('```json\n{"a": {"b": {"c": 1}}}\n```') == '{"a": {"b": {"c": 1}}}'
+
+
+def test_run_sync_does_not_emit_event_loop_deprecation_warning():
+    """`agent.run_sync` must obtain the event loop without a DeprecationWarning.
+
+    Uses `get_running_loop()` with a `new_event_loop()` fallback instead of
+    the deprecated `get_event_loop()` / `get_event_loop_policy()` (issue #1196).
+    """
+
+    async def noop_tool(ctx: object) -> str:
+        return 'ok'
+
+    agent = Agent(TestModel(), tools=[noop_tool])
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter('always')
+        agent.run_sync('hello')
+
+    event_loop_warnings = [
+        w for w in recorded if issubclass(w.category, DeprecationWarning) and 'event loop' in str(w.message).lower()
+    ]
+    assert event_loop_warnings == []


### PR DESCRIPTION
Fix #1196

Replace asyncio.get_event_loop() (deprecated since 3.12, warns on 3.14+) with asyncio.get_running_loop() and a new_event_loop() fallback, removing the intermediate get_event_loop_policy() call that is also slated for removal in Python 3.16.

The previous approach (using get_event_loop_policy()) was rejected because that function is itself deprecated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

