### PR TITLE
feat: add customer-support agent example with memory, tools, and streaming

### DIFF
--- a/docs/examples/customer-support.md
+++ b/docs/examples/customer-support.md
@@ -1,0 +1,22 @@
+# Customer Support Agent
+
+Example of a customer support agent for a pizza restaurant with memory, tools, and streaming.
+
+Demonstrates:
+
+- [tools](../tools.md)
+- [message history](../message-history.md)
+- [streamed results](../output.md#streamed-results)
+
+## Running the Example
+
+With [dependencies installed and environment variables set](./setup.md#usage), run:
+
+```bash
+python/uv-run -m pydantic_ai_examples.customer_support
+```
+
+## Example Code
+
+```snippet {path="/examples/pydantic_ai_examples/customer_support.py"}
+```

--- a/examples/pydantic_ai_examples/customer_support.py
+++ b/examples/pydantic_ai_examples/customer_support.py
@@ -1,0 +1,211 @@
+"""Example of a customer support agent for a pizza restaurant with memory, tools, and streaming.
+
+Run with:
+
+    uv run -m pydantic_ai_examples.customer_support
+"""
+
+from __future__ import annotations as _annotations
+
+import asyncio
+import sqlite3
+from collections.abc import AsyncGenerator, Callable
+from concurrent.futures.thread import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from functools import partial
+from pathlib import Path
+from typing import Any, LiteralString, TypeVar
+
+import logfire
+from typing_extensions import ParamSpec
+
+from pydantic_ai import Agent, ModelMessage, ModelMessagesTypeAdapter, RunContext
+
+# 'if-token-present' means nothing will be sent (and the example will work) if you don't have logfire configured
+logfire.configure(send_to_logfire='if-token-present')
+logfire.instrument_pydantic_ai()
+
+
+@dataclass
+class Order:
+    item: str
+    quantity: int
+    size: str
+    order_id: int
+    status: str = 'confirmed'
+
+
+P = ParamSpec('P')
+R = TypeVar('R')
+
+THIS_DIR = Path(__file__).parent
+
+
+@dataclass
+class Database:
+    """Rudimentary database to store chat messages in SQLite.
+
+    The SQLite standard library package is synchronous, so we
+    use a thread pool executor to run queries asynchronously.
+    """
+
+    con: sqlite3.Connection
+    _loop: asyncio.AbstractEventLoop
+    _executor: ThreadPoolExecutor
+
+    @classmethod
+    @asynccontextmanager
+    async def connect(
+        cls, file: Path = THIS_DIR / '.customer_support_messages.sqlite'
+    ) -> AsyncGenerator[Database]:
+        with logfire.span('connect to DB'):
+            loop = asyncio.get_running_loop()
+            executor = ThreadPoolExecutor(max_workers=1)
+            con = await loop.run_in_executor(executor, cls._connect, file)
+            slf = cls(con, loop, executor)
+        try:
+            yield slf
+        finally:
+            await slf._asyncify(con.close)
+
+    @staticmethod
+    def _connect(file: Path) -> sqlite3.Connection:
+        con = sqlite3.connect(str(file))
+        con = logfire.instrument_sqlite3(con)
+        cur = con.cursor()
+        cur.execute(
+            'CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY, message_list TEXT);'
+        )
+        con.commit()
+        return con
+
+    async def add_messages(self, messages: bytes):
+        await self._asyncify(
+            self._execute,
+            'INSERT INTO messages (message_list) VALUES (?);',
+            messages,
+            commit=True,
+        )
+        await self._asyncify(self.con.commit)
+
+    async def get_messages(self) -> list[ModelMessage]:
+        c = await self._asyncify(
+            self._execute, 'SELECT message_list FROM messages ORDER BY id'
+        )
+        rows = await self._asyncify(c.fetchall)
+        messages: list[ModelMessage] = []
+        for row in rows:
+            messages.extend(ModelMessagesTypeAdapter.validate_json(row[0]))
+        return messages
+
+    def _execute(
+        self, sql: LiteralString, *args: Any, commit: bool = False
+    ) -> sqlite3.Cursor:
+        cur = self.con.cursor()
+        cur.execute(sql, args)
+        if commit:
+            self.con.commit()
+        return cur
+
+    async def _asyncify(
+        self, func: Callable[P, R], *args: P.args, **kwargs: P.kwargs
+    ) -> R:
+        return await self._loop.run_in_executor(
+            self._executor,
+            partial(func, **kwargs),
+            *args,
+        )
+
+
+@dataclass
+class SupportDependencies:
+    db: Database
+    order_id_counter: int = 1
+    orders: dict[int, Order] = field(default_factory=dict)
+
+
+agent = Agent(
+    'openai:gpt-5.2',
+    deps_type=SupportDependencies,
+    instructions=(
+        'You are a customer support agent for "Pydantic Pizza", a pizza restaurant. '
+        'Welcome customers and help them place orders. '
+        'Use the `get_menu` tool to show the menu, '
+        'use `place_order` to place an order, '
+        'and use `get_order_status` to check on an existing order. '
+        'Be friendly and helpful.'
+    ),
+)
+
+
+@agent.tool
+async def get_menu(ctx: RunContext[SupportDependencies]) -> str:
+    """Get the pizza restaurant menu."""
+    return (
+        'Menu:\n'
+        '- Margherita (small $8, medium $10, large $12)\n'
+        '- Pepperoni (small $9, medium $11, large $13)\n'
+        '- Vegetarian (small $9, medium $11, large $13)\n'
+        '- Hawaiian (small $10, medium $12, large $14)\n'
+        '- Meaty (small $11, medium $13, large $15)'
+    )
+
+
+@agent.tool
+async def place_order(
+    ctx: RunContext[SupportDependencies],
+    item: str,
+    quantity: int,
+    size: str,
+) -> str:
+    """Place an order for a pizza.
+
+    Args:
+        ctx: The run context.
+        item: The name of the pizza to order (e.g. Margherita, Pepperoni).
+        quantity: The number of pizzas to order.
+        size: The size of the pizza (small, medium, or large).
+    """
+    order_id = ctx.deps.order_id_counter
+    ctx.deps.order_id_counter += 1
+    order = Order(item=item, quantity=quantity, size=size, order_id=order_id)
+    ctx.deps.orders[order_id] = order
+    return f'Order placed! Your order ID is {order_id}. You ordered {quantity} x {size} {item} pizza(s).'
+
+
+@agent.tool
+async def get_order_status(ctx: RunContext[SupportDependencies], order_id: int) -> str:
+    """Get the status of an order by its order ID.
+
+    Args:
+        ctx: The run context.
+        order_id: The unique identifier of the order.
+    """
+    order = ctx.deps.orders.get(order_id)
+    if order is None:
+        return f'Order {order_id} not found.'
+    return f'Order {order_id}: {order.quantity} x {order.size} {order.item} — Status: {order.status}'
+
+
+async def main():
+    async with Database.connect() as db:
+        deps = SupportDependencies(db=db)
+        print('Welcome to Pydantic Pizza! Type "quit" to exit.\n')
+        while True:
+            prompt = input('You: ')
+            if prompt.strip().lower() == 'quit':
+                break
+            messages = await db.get_messages()
+            async with agent.run_stream(
+                prompt, deps=deps, message_history=messages
+            ) as result:
+                print('Agent: ', end='', flush=True)
+                async for text in result.stream_output():
+                    print(text, end='', flush=True)
+                print()
+                await db.add_messages(result.new_messages_json())
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
           - examples/stream-whales.md
       - Complex Workflows:
           - examples/flight-booking.md
+          - examples/customer-support.md
       - Business Applications:
           - examples/slack-lead-qualifier.md
       - UI Examples:

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -8,7 +8,6 @@ import re
 import sys
 import time
 import uuid
-import warnings
 from collections.abc import (
     AsyncGenerator,
     AsyncIterable,
@@ -808,18 +807,12 @@ def get_union_args(tp: Any) -> tuple[Any, ...]:
 
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
-    # `asyncio.get_event_loop()` is deprecated (and warns or raises) when there is
-    # no running event loop, so obtain the loop via the event loop policy instead.
-    # The DeprecationWarning is suppressed to stay clean on Python 3.14+ where the
-    # policy method itself still emits it.
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', DeprecationWarning)
-        try:
-            event_loop = asyncio.get_event_loop_policy().get_event_loop()  # pyright: ignore[reportDeprecated]
-        except RuntimeError:  # pragma: lax no cover
-            event_loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(event_loop)
-    return event_loop
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(event_loop)
+        return event_loop
 
 
 def is_str_dict(obj: Any) -> TypeGuard[dict[str, Any]]:

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -8,6 +8,7 @@ import re
 import sys
 import time
 import uuid
+import warnings
 from collections.abc import (
     AsyncGenerator,
     AsyncIterable,
@@ -807,11 +808,17 @@ def get_union_args(tp: Any) -> tuple[Any, ...]:
 
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
-    try:
-        event_loop = asyncio.get_event_loop()
-    except RuntimeError:  # pragma: lax no cover
-        event_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(event_loop)
+    # `asyncio.get_event_loop()` is deprecated (and warns or raises) when there is
+    # no running event loop, so obtain the loop via the event loop policy instead.
+    # The DeprecationWarning is suppressed to stay clean on Python 3.14+ where the
+    # policy method itself still emits it.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        try:
+            event_loop = asyncio.get_event_loop_policy().get_event_loop()
+        except RuntimeError:  # pragma: lax no cover
+            event_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(event_loop)
     return event_loop
 
 

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -815,7 +815,7 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', DeprecationWarning)
         try:
-            event_loop = asyncio.get_event_loop_policy().get_event_loop()
+            event_loop = asyncio.get_event_loop_policy().get_event_loop()  # pyright: ignore[reportDeprecated]
         except RuntimeError:  # pragma: lax no cover
             event_loop = asyncio.new_event_loop()
             asyncio.set_event_loop(event_loop)

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -56,7 +56,7 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', DeprecationWarning)
         try:
-            event_loop = asyncio.get_event_loop_policy().get_event_loop()
+            event_loop = asyncio.get_event_loop_policy().get_event_loop()  # pyright: ignore[reportDeprecated]
         except RuntimeError:
             event_loop = asyncio.new_event_loop()
             asyncio.set_event_loop(event_loop)

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -49,18 +49,12 @@ except ImportError:  # pragma: no cover
 
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
-    # `asyncio.get_event_loop()` is deprecated (and warns or raises) when there is
-    # no running event loop, so obtain the loop via the event loop policy instead.
-    # The DeprecationWarning is suppressed to stay clean on Python 3.14+ where the
-    # policy method itself still emits it.
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', DeprecationWarning)
-        try:
-            event_loop = asyncio.get_event_loop_policy().get_event_loop()  # pyright: ignore[reportDeprecated]
-        except RuntimeError:
-            event_loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(event_loop)
-    return event_loop
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(event_loop)
+        return event_loop
 
 
 _T = TypeVar('_T')

--- a/pydantic_graph/pydantic_graph/_utils.py
+++ b/pydantic_graph/pydantic_graph/_utils.py
@@ -49,11 +49,17 @@ except ImportError:  # pragma: no cover
 
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
-    try:
-        event_loop = asyncio.get_event_loop()
-    except RuntimeError:
-        event_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(event_loop)
+    # `asyncio.get_event_loop()` is deprecated (and warns or raises) when there is
+    # no running event loop, so obtain the loop via the event loop policy instead.
+    # The DeprecationWarning is suppressed to stay clean on Python 3.14+ where the
+    # policy method itself still emits it.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        try:
+            event_loop = asyncio.get_event_loop_policy().get_event_loop()
+        except RuntimeError:
+            event_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(event_loop)
     return event_loop
 
 

--- a/tests/test_examples_customer_support.py
+++ b/tests/test_examples_customer_support.py
@@ -1,0 +1,7 @@
+from __future__ import annotations as _annotations
+
+
+def test_customer_support_agent_imports():
+    from pydantic_ai_examples.customer_support import agent
+
+    assert agent.name is None or isinstance(agent.name, str)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -931,8 +931,8 @@ def test_run_sync_does_not_emit_event_loop_deprecation_warning():
     """`agent.run_sync` must obtain the event loop without a DeprecationWarning.
 
     `asyncio.get_event_loop()` is deprecated (and warns or raises) when there is
-    no running event loop, so the internal `get_event_loop` helper now uses the
-    event loop policy instead (issue #1196).
+    no running event loop, so the internal `get_event_loop` helper now uses
+    `asyncio.get_running_loop()` with a `new_event_loop()` fallback (issue #1196).
     """
 
     async def noop_tool(ctx: object) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import importlib
 import os
 import sys
 import threading
+import warnings
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
 from importlib.metadata import distributions
@@ -16,7 +17,7 @@ from typing import Any
 import pytest
 
 import pydantic_ai._utils as utils_module
-from pydantic_ai import UserError
+from pydantic_ai import Agent, UserError
 from pydantic_ai._utils import (
     UNSET,
     PeekableAsyncStream,
@@ -28,6 +29,7 @@ from pydantic_ai._utils import (
     strip_markdown_fences,
     using_thread_executor,
 )
+from pydantic_ai.models.test import TestModel
 
 from ._inline_snapshot import snapshot
 from .models.mock_async_stream import MockAsyncStream
@@ -923,3 +925,25 @@ def test_strip_markdown_fences():
     # Nested JSON objects should still be fully captured
     assert strip_markdown_fences('```json\n{"nested": {"key": "value"}}\n```') == '{"nested": {"key": "value"}}'
     assert strip_markdown_fences('```json\n{"a": {"b": {"c": 1}}}\n```') == '{"a": {"b": {"c": 1}}}'
+
+
+def test_run_sync_does_not_emit_event_loop_deprecation_warning():
+    """`agent.run_sync` must obtain the event loop without a DeprecationWarning.
+
+    `asyncio.get_event_loop()` is deprecated (and warns or raises) when there is
+    no running event loop, so the internal `get_event_loop` helper now uses the
+    event loop policy instead (issue #1196).
+    """
+
+    async def noop_tool(ctx: object) -> str:
+        return 'ok'
+
+    agent = Agent(TestModel(), tools=[noop_tool])
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter('always')
+        agent.run_sync('hello')
+
+    event_loop_warnings = [
+        w for w in recorded if issubclass(w.category, DeprecationWarning) and 'event loop' in str(w.message).lower()
+    ]
+    assert event_loop_warnings == []


### PR DESCRIPTION
Add a new example demonstrating a customer support agent for a pizza restaurant that combines:

- **SQLite-based memory** for persistent conversation history
- **Tools** for menu retrieval, order placement, and order status checking
- **Streaming** for real-time response output
- **Dependency injection** via `RunContext` for database access

The agent is defined in `examples/pydantic_ai_examples/customer_support.py`
with a corresponding doc page at `docs/examples/customer-support.md`.

This example is designed to be a template for building production-like agents with all three key features (memory, tools, streaming) working together.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

