### PR TITLE
ci: allow pydanty bot to trigger PR category classification

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -142,6 +142,7 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_API_KEY || secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
           allowed_non_write_users: "*"
+          allowed_bots: "pydanty"
           claude_args: |
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*)"
             --json-schema '{"type":"object","properties":{"category":{"type":"string"}},"required":["category"]}'


### PR DESCRIPTION
## Problem

The **Category Classify** job in `.github/workflows/bots.yml` runs `anthropics/claude-code-action` on the `pull_request` event, so the triggering actor is the PR author. When the **pydanty** dogfooding bot opens a PR, the action aborts:

```
Action failed with error: Workflow initiated by non-human actor: pydanty (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

The classify step already sets `allowed_non_write_users: "*"` but has no `allowed_bots`, so **every** bot-authored PR fails classification (not just one). Example failing run: https://github.com/pydantic/pydantic-ai/actions/runs/29015489408/job/86109328187

## Fix

Add `allowed_bots: "pydanty"` to the classify step's `with:` block. Scoped to the known dogfooding bot rather than `"*"` to keep the allowlist tight.

## Notes

- Purely a CI/workflow fix — no library code changes, so no tests are affected.
- Surfaced while triaging #6392 / #6394 (the pydanty bot's PR failed this check). Independent of that bug fix, hence a separate PR.
- The other `claude-code-action` usage (the Review job) triggers on the `auto-review` label and its actor is the labeler, so it's not affected today; only add `allowed_bots` there if a bot ever applies that label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

