### PR TITLE
Don't flag coverage-gate / `pragma: no cover` predictions in PR review

### DIFF
--- a/.github/workflows/shared/prompts/pydantic-ai-pr-review.md
+++ b/.github/workflows/shared/prompts/pydantic-ai-pr-review.md
@@ -174,6 +174,9 @@ bot reviewing another bot's PR. If the PR author is a bot, submit a
   it.
 - Don't post speculative "this might break" findings without a concrete
   trigger.
+- Don't flag coverage-gate or `# pragma: no cover` outcomes — the
+  `fail_under = 100` CI job reports uncovered lines (and wrongly-placed
+  pragmas) deterministically; predicting them is noise.
 - Don't comment on lines without an `NL:` prefix in the per-file diff.
 - Don't write to the workspace — every output is a safe-output call.
 - Don't exceed 30 inline comments — pick the top-severity 30 and put the

--- a/scripts/gather-pydantic-ai-review-context.sh
+++ b/scripts/gather-pydantic-ai-review-context.sh
@@ -435,6 +435,14 @@ the surrounding code before posting.
 
 - **Style / formatting** — ruff handles it.
 - **Type nits already covered by pyright** — `make typecheck` runs in CI.
+- **Coverage-gate / `# pragma: no cover` predictions** — coverage is
+  deterministic and CI reports it exactly: the `fail_under = 100` job names
+  every uncovered `file:line`, and a strict-no-cover audit flags a
+  `# pragma: no cover` sitting on a line that was actually covered. Don't
+  flag "this drops below 100%", "removing this pragma breaks coverage", or
+  "this pragma is wrong/unneeded" — CI catches all of these clearly. (A
+  missing test for genuinely *new* behavior or public API is still fair
+  game — that's about correctness, not the coverage number.)
 - **"Missing tests" for pure refactor** — if the PR moves or renames
   existing code and existing tests still exercise the behavior, no new
   test is needed. Only flag missing tests for new behavior or new public


### PR DESCRIPTION
The gh-aw PR reviewer was spending HIGH findings predicting deterministic coverage outcomes that CI already reports exactly: the `fail_under = 100` job names every uncovered `file:line`, and the strict-no-cover audit flags a `# pragma: no cover` on a line that was actually covered. This adds a false-positive-catalog bullet (the source of truth in the gather script) plus a matching recap line in the seed prompt, so the reviewer stops predicting coverage/pragma outcomes CI catches on its own.

Example of the noise this prevents: https://github.com/pydantic/pydantic-ai/pull/6304#discussion_r3554025940