### PR TITLE
Fix empty and thinking-only responses reusing earlier text as the run output

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -693,9 +693,9 @@ Once upon a time, in a hidden underwater cave, lived a curious axolotl named Pip
 
 ## Optional output (allowing `None`) {#optional-output}
 
-Some agents perform their work entirely through tool calls and don't need to produce a final output — for example, an agent that updates a record via a tool and then stops. Certain models (notably [Anthropic](models/anthropic.md)) will return an empty response in this case, which by default causes Pydantic AI to retry until the model produces content.
+Some agents perform their work entirely through tool calls and don't need to produce a final output — for example, an agent that updates a record via a tool and then stops. But with `str` in the `output_type` — including the default — the model is required to end its final turn with text. If it considers its work finished and has nothing left to say, it will return an empty response, or one containing only [thinking](thinking.md) content (as [Anthropic](models/anthropic.md) models notably do), and Pydantic AI will ask it to produce text anyway.
 
-To instead treat an empty response as a successful run, include `None` in the `output_type`:
+Include `None` in the `output_type` when finishing without a final message is a valid outcome for your agent, and you'd rather receive `None` than have the model say something for the sake of saying it:
 
 ```python {title="optional_output.py"}
 from pydantic_ai import Agent
@@ -717,8 +717,6 @@ print(result.output)
 When the model returns an empty response and `None` is an allowed output type, the agent will return `None` instead of retrying. [Output validator functions](#output-validator-functions) still run with `None` as the argument, so you can raise [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] to reject it if needed.
 
 `output_type=str | None` is the canonical case: it's handled as regular text output, and the **only** way the model signals `None` is by returning a response with no text output — either an empty response, or one containing only [thinking](thinking.md) content, which some reasoning models emit after completing their work through a tool call. There's no output tool or structured schema involved. This mirrors how plain `str` is already treated specially as free-form text output rather than a structured tool call.
-
-Note that text the model returned alongside a tool call is never reused as the run's output. Such text usually announces the tool call ("I'll look that up for you") rather than concluding the run, so treating it as the output would end the run on the wrong message. If the model produces no output of its own after the tool call, the agent asks it for one. Including `None` in the `output_type` is how you tell the agent that finishing without a final message is a valid outcome, rather than something to retry.
 
 `None` is also supported in the other output modes, with an extra structured commit path in addition to (or in place of) the empty-response fallback:
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -718,6 +718,8 @@ When the model returns an empty response and `None` is an allowed output type, t
 
 `output_type=str | None` is the canonical case: it's handled as regular text output, and the **only** way the model signals `None` is by returning a response with no text output — either an empty response, or one containing only [thinking](thinking.md) content, which some reasoning models emit after completing their work through a tool call. There's no output tool or structured schema involved. This mirrors how plain `str` is already treated specially as free-form text output rather than a structured tool call.
 
+Note that text the model returned alongside a tool call is never reused as the run's output. Such text usually announces the tool call ("I'll look that up for you") rather than concluding the run, so treating it as the output would end the run on the wrong message. If the model produces no output of its own after the tool call, the agent asks it for one. Including `None` in the `output_type` is how you tell the agent that finishing without a final message is a valid outcome, rather than something to retry.
+
 `None` is also supported in the other output modes, with an extra structured commit path in addition to (or in place of) the empty-response fallback:
 
 - **Bare unions including `None` that use tool mode** — e.g. `output_type=int | None`, `output_type=[int, float, None]`, or `output_type=[ToolOutput(Foo), None]`: a dedicated `final_result_NoneType` output tool is exposed alongside the other output tools, so the model can commit to `None` through a tool call. An empty or thinking-only model response is still also treated as `None`, as with `str | None`.

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1231,24 +1231,10 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                             )
                         return
 
-                    # Try to recover text from a previous model response.
-                    # This handles the case where the model returned text alongside tool calls
-                    # (so the text was discarded in favor of executing the tools) and subsequently
-                    # returned an empty or thinking-only response.
-                    if text_processor := output_schema.text_processor:
-                        text = self._recover_text_from_message_history(ctx.state.message_history)
-                        if text is not None:
-                            try:
-                                self._next_node = await self._handle_text_response(ctx, text, text_processor)
-                                return
-                            except ToolRetryError:  # pragma: no cover
-                                # If the recovered text was invalid, fall through.
-                                pass
-
-                    # For empty or thinking-only responses without recoverable text, fall through to
-                    # the normal retry prompt below. That prompt is built from the output schema and
-                    # available tools, so it tells the model which kinds of output are actually valid
-                    # (text, tool call, and/or image) rather than assuming text is always an option.
+                    # For empty or thinking-only responses, fall through to the normal retry prompt
+                    # below. That prompt is built from the output schema and available tools, so it
+                    # tells the model which kinds of output are actually valid (text, tool call,
+                    # and/or image) rather than assuming text is always an option.
 
                 text = ''
                 compaction_text = ''
@@ -1388,28 +1374,6 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                 output_parts.append(_messages.UserPromptPart(self.user_prompt))
 
             self._next_node = ModelRequestNode[DepsT, NodeRunEndT](_messages.ModelRequest(parts=output_parts))
-
-    @staticmethod
-    def _recover_text_from_message_history(message_history: list[_messages.ModelMessage]) -> str | None:
-        """Search backward through message history for recoverable text from a previous model response.
-
-        This handles cases where the model returned text alongside tool calls (so the text was
-        discarded in favor of executing the tools) and subsequently returned an empty or
-        thinking-only response. Returns the recovered text, or None if no text was found.
-        """
-        for message in reversed(message_history):
-            if isinstance(message, _messages.ModelResponse):
-                text = ''
-                for part in message.parts:
-                    if isinstance(part, _messages.TextPart):
-                        text += part.content
-                    elif isinstance(part, _messages.NativeToolCallPart):
-                        # Text parts before a built-in tool call are essentially thoughts,
-                        # not part of the final result output, so we reset the accumulated text.
-                        text = ''  # pragma: no cover
-                if text:
-                    return text
-        return None
 
     async def _handle_text_response(
         self,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3676,7 +3676,7 @@ def test_empty_response():
     )
 
 
-def test_empty_response_without_recovery():
+def test_empty_response_exceeds_max_retries():
     def llm(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
         return ModelResponse(parts=[])
 
@@ -7971,13 +7971,17 @@ def test_multi_agent_instructions_with_structured_output():
 
 
 def test_empty_final_response():
+    """An empty final response asks the model for text rather than reusing text sent alongside a tool call."""
+
     def llm(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
         if len(messages) == 1:
             return ModelResponse(parts=[TextPart('foo'), ToolCallPart('my_tool', {'x': 1})])
         elif len(messages) == 3:
             return ModelResponse(parts=[TextPart('bar'), ToolCallPart('my_tool', {'x': 2})])
-        else:
+        elif len(messages) == 5:
             return ModelResponse(parts=[])
+        else:
+            return ModelResponse(parts=[TextPart('baz')])
 
     agent = Agent(FunctionModel(llm))
 
@@ -7986,13 +7990,13 @@ def test_empty_final_response():
         return x * 2
 
     result = agent.run_sync('Hello')
-    assert result.output == 'bar'
+    assert result.output == 'baz'
 
     assert result.new_messages() == snapshot(
         [
             ModelRequest(
-                parts=[UserPromptPart(content='Hello', timestamp=IsNow(tz=timezone.utc))],
-                timestamp=IsNow(tz=timezone.utc),
+                parts=[UserPromptPart(content='Hello', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
@@ -8003,17 +8007,20 @@ def test_empty_final_response():
                 ],
                 usage=RequestUsage(input_tokens=51, output_tokens=5),
                 model_name='function:llm:',
-                timestamp=IsNow(tz=timezone.utc),
+                timestamp=IsDatetime(),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
                     ToolReturnPart(
-                        tool_name='my_tool', content=2, tool_call_id=IsStr(), timestamp=IsNow(tz=timezone.utc)
+                        tool_name='my_tool',
+                        content=2,
+                        tool_call_id=IsStr(),
+                        timestamp=IsDatetime(),
                     )
                 ],
-                timestamp=IsNow(tz=timezone.utc),
+                timestamp=IsDatetime(),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
@@ -8024,17 +8031,20 @@ def test_empty_final_response():
                 ],
                 usage=RequestUsage(input_tokens=52, output_tokens=10),
                 model_name='function:llm:',
-                timestamp=IsNow(tz=timezone.utc),
+                timestamp=IsDatetime(),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
             ModelRequest(
                 parts=[
                     ToolReturnPart(
-                        tool_name='my_tool', content=4, tool_call_id=IsStr(), timestamp=IsNow(tz=timezone.utc)
+                        tool_name='my_tool',
+                        content=4,
+                        tool_call_id=IsStr(),
+                        timestamp=IsDatetime(),
                     )
                 ],
-                timestamp=IsNow(tz=timezone.utc),
+                timestamp=IsDatetime(),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
@@ -8042,7 +8052,27 @@ def test_empty_final_response():
                 parts=[],
                 usage=RequestUsage(input_tokens=53, output_tokens=10),
                 model_name='function:llm:',
-                timestamp=IsNow(tz=timezone.utc),
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    RetryPromptPart(
+                        content='Please return text or call a tool.',
+                        tool_call_id=IsStr(),
+                        timestamp=IsDatetime(),
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='baz')],
+                usage=RequestUsage(input_tokens=69, output_tokens=11),
+                model_name='function:llm:',
+                timestamp=IsDatetime(),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
@@ -9588,8 +9618,12 @@ async def test_thinking_only_response_retry_with_tool_output():
     )
 
 
-async def test_thinking_only_response_backward_looking_recovery():
-    """Test that thinking-only response after a tool call recovers text from prior model response."""
+async def test_thinking_only_response_after_tool_call_retries():
+    """Text returned alongside a tool call is not reused as output when a later response is thinking-only.
+
+    Such text typically announces the tool call rather than concluding the run, so the model is
+    asked for a fresh text response instead.
+    """
     call_count = 0
 
     def model_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -9600,15 +9634,18 @@ async def test_thinking_only_response_backward_looking_recovery():
             # First call: return text alongside a tool call
             return ModelResponse(
                 parts=[
-                    TextPart(content="Here's my analysis."),
+                    TextPart(content="I'll save your progress."),
                     ToolCallPart(tool_name='save_progress', args='{"data": "test"}'),
                 ],
             )
-        else:
+        elif call_count == 2:
             # Second call (after tool return): return thinking-only
             return ModelResponse(
                 parts=[ThinkingPart(content='Nothing more to say.')],
             )
+        else:
+            # Third call (after the retry prompt): return the actual output
+            return ModelResponse(parts=[TextPart(content='Your progress is saved.')])
 
     agent = Agent(FunctionModel(model_function))
 
@@ -9618,26 +9655,25 @@ async def test_thinking_only_response_backward_looking_recovery():
 
     result = await agent.run('Hello')
 
-    assert result.output == "Here's my analysis."
+    assert result.output == 'Your progress is saved.'
     assert result.all_messages() == snapshot(
         [
             ModelRequest(
-                parts=[
-                    UserPromptPart(
-                        content='Hello',
-                        timestamp=IsDatetime(),
-                    )
-                ],
-                timestamp=IsNow(tz=timezone.utc),
+                parts=[UserPromptPart(content='Hello', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
             ModelResponse(
                 parts=[
-                    TextPart(content="Here's my analysis."),
-                    ToolCallPart(tool_name='save_progress', args='{"data": "test"}', tool_call_id=IsStr()),
+                    TextPart(content="I'll save your progress."),
+                    ToolCallPart(
+                        tool_name='save_progress',
+                        args='{"data": "test"}',
+                        tool_call_id=IsStr(),
+                    ),
                 ],
-                usage=RequestUsage(input_tokens=51, output_tokens=9),
+                usage=RequestUsage(input_tokens=51, output_tokens=10),
                 model_name='function:model_function:',
                 timestamp=IsDatetime(),
                 run_id=IsStr(),
@@ -9652,13 +9688,33 @@ async def test_thinking_only_response_backward_looking_recovery():
                         timestamp=IsDatetime(),
                     )
                 ],
-                timestamp=IsNow(tz=timezone.utc),
+                timestamp=IsDatetime(),
                 run_id=IsStr(),
                 conversation_id=IsStr(),
             ),
             ModelResponse(
                 parts=[ThinkingPart(content='Nothing more to say.')],
-                usage=RequestUsage(input_tokens=52, output_tokens=14),
+                usage=RequestUsage(input_tokens=52, output_tokens=15),
+                model_name='function:model_function:',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    RetryPromptPart(
+                        content='Please return text or call a tool.',
+                        tool_call_id=IsStr(),
+                        timestamp=IsDatetime(),
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='Your progress is saved.')],
+                usage=RequestUsage(input_tokens=68, output_tokens=20),
                 model_name='function:model_function:',
                 timestamp=IsDatetime(),
                 run_id=IsStr(),


### PR DESCRIPTION
<!-- No issue to close: this reverts a behavior we shipped, rather than fixing a filed bug. -->

Reverts the backward-looking text recovery added in #4558 (which closed #4557).

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

## Summary

When a model response was empty or contained only thinking, `CallToolsNode` searched backward through the message history for text from an earlier `ModelResponse` and used it as the run's final output. The intent was to avoid making the model repeat text it had already emitted alongside a tool call.

In practice that text is usually a *pre-announcement* of the tool calls it accompanied ("I'll look that up for you") rather than a conclusion, so recovering it ends the run with the wrong output. The scan was also unbounded: with nothing to stop it at a turn boundary, it could reach back across a `UserPromptPart` and resurrect a previous turn's answer as the current turn's output.

Empty and thinking-only responses now fall through to the retry prompt that already existed below, which asks the model for a fresh response. That prompt is built from the output schema and the available tools, so it names the kinds of output that are actually valid (`Please return text or call a tool.`).

This is a behavior change rather than an API change: no public signature moves, but a run that previously ended with recovered text will now spend one more model request to get a real answer. That is the intended trade. A spurious extra turn is recoverable; a confidently-wrong final output is not.

`#4557`'s original complaint — that the model is forced to restate itself — is accepted as the cost. Its concrete flow (text + tool call, tool returns, thinking-only) is precisely the pre-announcement shape that produced wrong output in the field.

### Unchanged

- Output types that allow `None` (`str | None`, `output_type=[int, None]`, …) still treat an empty or thinking-only response as a valid `None` result, per [the documented rule](https://ai.pydantic.dev/output/). That branch runs before the removed code and is untouched.
- `finish_reason == 'length'` still raises `UnexpectedModelBehavior`, and an empty response with `finish_reason == 'content_filter'` still raises `ContentFilterError`.

### Changes

- Removed the recovery block in `CallToolsNode` and the `_recover_text_from_message_history` static method it called.
- `test_thinking_only_response_backward_looking_recovery` → `test_thinking_only_response_after_tool_call_retries`, now a regression test for the pre-announcement case: the first response says `"I'll save your progress."` alongside the tool call, and the run must not end with that string.
- `test_empty_final_response` asserted the recovered `'bar'`; it now expects the retry prompt and a fresh response.
- `test_empty_response_without_recovery` → `test_empty_response_exceeds_max_retries`, since "without recovery" no longer names anything.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


- `docs/output.md`: the optional-output section now frames `str` (including the default `output_type`) as an obligation for the model to end its final turn with text, and `None` as the way to relax it. Thinking-only responses are named alongside empty ones as not producing output.

### Follow-up

#6404 tracks the fact that the retry prompt this change leans on goes out as a plain `role: user` message, so the model can't tell our validation feedback from something the human typed.
