### PR TITLE
Guard against id-less `MCPToolset` on the `DBOSAgent` wrapper path

### DIFF
--- a/docs/durable_execution/dbos.md
+++ b/docs/durable_execution/dbos.md
@@ -113,6 +113,8 @@ When using DBOS with Pydantic AI agents, there are a few important consideration
 
 Each agent instance must have a unique `name` so DBOS can correctly resume workflows after a failure or restart.
 
+Each [`MCPToolset`][pydantic_ai.mcp.MCPToolset] must have a unique [`id`][pydantic_ai.toolsets.AbstractToolset.id], as DBOS derives its step names and per-run tool-defs cache key from it. This field is normally optional, but is required when using DBOS. It should not be changed once the durable agent has been deployed to production, as this would break active workflows.
+
 Tools and event stream handlers are not automatically wrapped by DBOS. You can decide how to integrate them:
 
 * Decorate with `@DBOS.step` if the function involves non-determinism or I/O.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -121,6 +121,11 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
                 pass
             else:
                 if isinstance(toolset, MCPToolset):
+                    if toolset.id is None:
+                        raise UserError(
+                            'MCP toolsets need to have a unique `id` in order to be used with DBOS. '
+                            "The ID will be used to identify the MCP server's steps within the workflow."
+                        )
                     return DBOSMCPToolset(
                         wrapped=toolset,
                         step_name_prefix=dbosagent_name,

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -809,6 +809,20 @@ async def test_toolset_without_id():
     DBOSAgent(Agent(model=model, name='test_agent', toolsets=[FunctionToolset()]))
 
 
+async def test_mcp_toolset_without_id():
+    # Unlike `FunctionToolset`, an `MCPToolset` is wrapped in a `DBOSMCPToolset` whose step names and per-run
+    # tool-defs cache key both derive from the toolset's `id`; without one, two id-less MCP toolsets would
+    # collide on both. Require an `id` up front, like Temporal does for all leaf toolsets.
+    with pytest.raises(
+        UserError,
+        match=re.escape(
+            'MCP toolsets need to have a unique `id` in order to be used with DBOS. '
+            "The ID will be used to identify the MCP server's steps within the workflow."
+        ),
+    ):
+        DBOSAgent(Agent(model=model, name='test_agent', toolsets=[MCPToolset('https://example.com/mcp')]))
+
+
 async def test_dbos_agent():
     assert isinstance(complex_dbos_agent.model, DBOSModel)
     assert complex_dbos_agent.model.wrapped == complex_agent.model


### PR DESCRIPTION
- Closes #5885

## Problem

On the `DBOSAgent` **wrapper** path, an id-less [`MCPToolset`][pydantic_ai.mcp.MCPToolset] has `wrapped.id is None`, which makes two of them collide on:

1. **The per-run tool-defs cache key** — `DBOSMCPToolsetBase.get_tools` keys the cache by `self.id or ''` (introduced in #5883), so a second id-less toolset silently returns the **first's** tool definitions and never lists its own.
2. **DBOS step names** — `DBOSMCPToolsetBase.__init__` derives its step-name prefix as `{agent}__mcp_server` (empty `id_suffix`), so two id-less toolsets register identically-named `@DBOS.step`s (`.get_tools`/`.get_instructions`/`.call_tool`), which DBOS can't distinguish in the workflow journal — breaking recovery.

Both stem from the same root cause named in the issue: unlike Temporal, DBOS doesn't require ids on MCP leaf toolsets. Temporal's `temporalize_toolset` raises `UserError` for any leaf with `id is None`; the DBOS wrapper's `dbosify_toolset` had no such guard. Thanks to @DouweM for [documenting the sibling step-name symptom](https://github.com/pydantic/pydantic-ai/issues/5885#issuecomment-4921054731).

## Fix

Mirror Temporal: raise `UserError` in the `dbosify_toolset` closure (`durable_exec/dbos/_agent.py`) for an id-less `MCPToolset`. **One guard closes both symptoms** — an id-less MCP toolset can no longer reach `DBOSMCPToolset.__init__`, so neither the cache key nor the step name can collide. `_mcp.py` is intentionally untouched (the guard sits upstream of it).

**Scope is deliberately narrow:**
- **DBOS wraps only `MCPToolset` at construction**, so the guard covers only that type — not all leaf toolsets the way Temporal does. `FunctionToolset` runs inline (an id-less one stays allowed, by design), and runtime `mcp`/`dynamic` toolsets are already rejected by `_reject_unsupported_runtime_toolsets`.
- **Not Prefect.** #6334 lumps Prefect in, but Prefect names tasks by tool name (`Call MCP Tool: {name}`) with no id-keyed cache — the mechanism here is DBOS-specific.
- **#4977 (`DBOSDurability` capability) is unmerged**, and already handles this at bind time on that path. The scope here is the `DBOSAgent` wrapper path on `main`.

## ⚠️ Design decision for a sanity pass

The guard raises for **any** id-less `MCPToolset` (Temporal-consistent), **not only** when 2+ id-less toolsets would actually collide.

The trade-off: a **single** id-less MCP toolset currently works (it gets the generic name, no collision). Raising for it is a minor **backward-compatibility change** — those users now need to add an `id=` (e.g. `MCPToolset(url, id='...')`).

I went with matching Temporal for engine consistency and because the fix is trivial for users, but this single-toolset back-compat point is your call — happy to switch to collision-only if you'd prefer to preserve it.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md). _Intentional minor back-compat change: a single id-less `MCPToolset` now raises, matching Temporal (which requires an `id` on leaf toolsets). Pending @DouweM's decision on the raise-for-any-id-less vs. only-on-collision fork flagged above._
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

