### PR TITLE
Fix `sanitize_messages` tail handling when a trailing client message is dropped

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/_adapter.py
@@ -374,10 +374,9 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         reset_force_download_values: set[ForceDownloadMode] = set()
         dropped_uploaded_file_providers: set[str] = set()
         dangling_tool_call_names: list[str] = []
-        last_index = len(messages) - 1
 
         sanitized: list[ModelMessage] = []
-        for index, message in enumerate(messages):
+        for message in messages:
             if isinstance(message, ModelRequest):
                 new_request_parts, request_stripped_system_prompt = self._sanitize_request_parts(
                     message.parts,
@@ -394,18 +393,18 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             elif isinstance(message, ModelResponse):
                 new_response_parts = self._sanitize_response_parts(
                     message.parts,
-                    resolved_tool_call_ids=resolved_tool_call_ids,
-                    dangling_names=dangling_tool_call_names if index == last_index else None,
                     disallowed_schemes=disallowed_url_schemes,
                     reset_force_download_values=reset_force_download_values,
                     dropped_uploaded_file_providers=dropped_uploaded_file_providers,
                 )
                 if new_response_parts:
                     sanitized.append(replace(message, parts=new_response_parts))
-                # Otherwise drop the final response entirely so we don't leave an empty
+                # Otherwise drop the response entirely so we don't leave an empty
                 # `ModelResponse(parts=[])` in history.
             else:
                 assert_never(message)
+
+        self._strip_dangling_tail_tool_calls(sanitized, resolved_tool_call_ids, dangling_tool_call_names)
 
         if stripped_system_prompt:
             warnings.warn(
@@ -613,12 +612,40 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
             return True, sanitized_sequence
         return True, content
 
+    def _strip_dangling_tail_tool_calls(
+        self,
+        sanitized: list[ModelMessage],
+        resolved_tool_call_ids: set[str],
+        dangling_names: list[str],
+    ) -> None:
+        """Strip unresolved (dangling) tool calls from the surviving tail of already-sanitized history.
+
+        The tail is only known once empty messages have been dropped: a trailing `ModelRequest` that
+        sanitized to empty (e.g. a client-supplied system prompt) is gone, which can re-expose an
+        earlier [`ModelResponse`][pydantic_ai.messages.ModelResponse] whose tool calls a promptless
+        run would dispatch directly. Anchoring on the pre-drop last index would miss that re-exposed
+        response. Walks back over trailing responses so several dropped messages can't hide a dangling
+        call, keeping calls in `resolved_tool_call_ids` so a same-request human-in-the-loop resume
+        still works. Mutates `sanitized` and appends stripped tool names to `dangling_names` in place.
+        """
+        while sanitized and isinstance(tail := sanitized[-1], ModelResponse):
+            kept_parts: list[ModelResponsePart] = []
+            for part in tail.parts:
+                if isinstance(part, BaseToolCallPart) and part.tool_call_id not in resolved_tool_call_ids:
+                    dangling_names.append(part.tool_name)
+                else:
+                    kept_parts.append(part)
+            if len(kept_parts) == len(tail.parts):
+                break
+            if kept_parts:
+                sanitized[-1] = replace(tail, parts=kept_parts)
+                break
+            sanitized.pop()
+
     def _sanitize_response_parts(
         self,
         parts: Sequence[ModelResponsePart],
         *,
-        resolved_tool_call_ids: set[str],
-        dangling_names: list[str] | None,
         disallowed_schemes: set[str],
         reset_force_download_values: set[ForceDownloadMode],
         dropped_uploaded_file_providers: set[str],
@@ -628,18 +655,12 @@ class UIAdapter(ABC, Generic[RunInputT, MessageT, EventT, AgentDepsT, OutputData
         Drops non-allowlisted schemes and resets non-allowlisted `force_download` values on `FileUrl`s
         nested in tool return parts, and drops `UploadedFile`s nested in tool return parts unless
         [`preserve_file_data`][pydantic_ai.ui.UIAdapter.preserve_file_data] is set.
-        When `dangling_names` is not `None` (i.e. this is the trailing response), also drops tool
-        calls that aren't resolved by `deferred_tool_results`, appending their names to it.
+
+        Unresolved (dangling) tool calls are stripped separately, from the surviving tail of the
+        sanitized history, since the tail is only known once empty messages have been dropped.
         """
         new_parts: list[ModelResponsePart] = []
         for part in parts:
-            if (
-                dangling_names is not None
-                and isinstance(part, BaseToolCallPart)
-                and part.tool_call_id not in resolved_tool_call_ids
-            ):
-                dangling_names.append(part.tool_name)
-                continue
             if isinstance(part, BaseToolReturnPart) and part.tool_kind is None:
                 # Skip narrower subclasses (`tool_kind` set): their `content` is a typed
                 # `TypedDict` with required fields, and stripping a `FileUrl`-bearing key

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1581,6 +1581,23 @@ def test_sanitize_messages_drops_response_left_empty_after_stripping():
     assert isinstance(sanitized[0], ModelRequest)
 
 
+def test_sanitize_messages_drops_empty_response():
+    """A `ModelResponse` that arrives with no parts is dropped, not kept as `parts=[]`."""
+    adapter = _make_dummy_adapter(
+        [
+            ModelRequest(parts=[UserPromptPart(content='Run it')]),
+            ModelResponse(parts=[]),
+        ]
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        sanitized = adapter.sanitize_messages(adapter.messages)
+
+    assert len(sanitized) == 1
+    assert isinstance(sanitized[0], ModelRequest)
+
+
 def test_sanitize_messages_strips_dangling_native_tool_calls():
     """Builtin tool calls are also model-emitted, so a dangling `NativeToolCallPart` at
     the end of client-supplied history is treated the same as a `ToolCallPart`.

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1626,6 +1626,57 @@ def test_sanitize_messages_keeps_tool_calls_in_middle_of_history():
     assert [type(p).__name__ for p in mid_response.parts] == ['ToolCallPart']
 
 
+def test_sanitize_messages_strips_dangling_call_exposed_by_dropped_tail():
+    """A dangling tool call re-exposed as the surviving tail by a dropped trailing message is stripped.
+
+    The trailing client `ModelRequest` is only a `SystemPromptPart`, which sanitizes away under the
+    default `manage_system_prompt='server'`. Dropping it makes the preceding `ModelResponse` the real
+    surviving tail, so its unresolved tool call must be stripped even though it wasn't the last message
+    before sanitization.
+    """
+    adapter = _make_dummy_adapter(
+        [
+            ModelRequest(parts=[UserPromptPart(content='Run it')]),
+            ModelResponse(
+                parts=[
+                    TextPart(content='Working on it'),
+                    ToolCallPart(tool_name='refresh_cache', args={'key': 1}, tool_call_id='call-1'),
+                ]
+            ),
+            ModelRequest(parts=[SystemPromptPart(content='Client system prompt')]),
+        ]
+    )
+
+    # Two warnings fire here (system-prompt strip + dangling call); assert on the dangling one.
+    with pytest.warns(UserWarning) as record:
+        sanitized = adapter.sanitize_messages(adapter.messages)
+    assert any('unresolved tool call' in str(w.message) and 'refresh_cache' in str(w.message) for w in record)
+
+    assert len(sanitized) == 2
+    response = sanitized[-1]
+    assert isinstance(response, ModelResponse)
+    assert [type(p).__name__ for p in response.parts] == ['TextPart']
+
+
+def test_sanitize_messages_keeps_resolved_call_in_tail_exposed_by_dropped_message():
+    """The dropped-tail counterpart: a *resolved* call in the re-exposed tail is preserved for HITL resumption."""
+    adapter = _make_dummy_adapter(
+        [
+            ModelRequest(parts=[UserPromptPart(content='Run it')]),
+            ModelResponse(parts=[ToolCallPart(tool_name='refresh_cache', args={'key': 1}, tool_call_id='call-1')]),
+            ModelRequest(parts=[SystemPromptPart(content='Client system prompt')]),
+        ]
+    )
+    deferred_tool_results = DeferredToolResults(approvals={'call-1': True})
+
+    with pytest.warns(UserWarning, match=r'system prompt'):
+        sanitized = adapter.sanitize_messages(adapter.messages, deferred_tool_results=deferred_tool_results)
+
+    response = sanitized[-1]
+    assert isinstance(response, ModelResponse)
+    assert [type(p).__name__ for p in response.parts] == ['ToolCallPart']
+
+
 async def test_run_stream_strips_dangling_tool_calls_from_client_history():
     """End-to-end: a client-submitted history ending in an unresolved tool call has
     that tool call stripped before the agent sees the history, so the agent never

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1582,7 +1582,11 @@ def test_sanitize_messages_drops_response_left_empty_after_stripping():
 
 
 def test_sanitize_messages_drops_empty_response():
-    """A `ModelResponse` that arrives with no parts is dropped, not kept as `parts=[]`."""
+    """A `ModelResponse` that arrives with no parts is dropped, not kept as `parts=[]`.
+
+    Not a VCR test: `sanitize_messages` runs locally before any request is sent, so a
+    recorded cassette can't exercise or protect this behavior.
+    """
     adapter = _make_dummy_adapter(
         [
             ModelRequest(parts=[UserPromptPart(content='Run it')]),


### PR DESCRIPTION
`UIAdapter.sanitize_messages` decides which `ModelResponse` is the tail of the history — and only strips unresolved (non-deferred) tool calls from that tail, since a promptless run would dispatch a trailing response's tool calls directly.

The tail was anchored on `last_index = len(messages) - 1`, computed from the **pre-sanitization** list. When the message at that index sanitizes to empty and is dropped — e.g. a client `SystemPromptPart` under the default `manage_system_prompt='server'` — the preceding `ModelResponse` becomes the real surviving tail, but it was already processed with `dangling_names=None`, so its unresolved tool calls were never stripped.

This moves the dangling-tool-call strip to a post-pass over the already-sanitized list (`_strip_dangling_tail_tool_calls`). It walks back over trailing responses, so a run of dropped messages can't hide a dangling call, and keeps calls resolved via `deferred_tool_results` so human-in-the-loop resumption still works.

**Invariant restored:** dangling tool calls are stripped from whichever `ModelResponse` is actually last *after* sanitization, not from the pre-drop last index.

### Tests

- `test_sanitize_messages_strips_dangling_call_exposed_by_dropped_tail` — a trailing client system prompt sanitizes away, re-exposing a preceding `ModelResponse` whose unresolved `ToolCallPart` must be stripped from the surviving tail (fails before this change).
- `test_sanitize_messages_keeps_resolved_call_in_tail_exposed_by_dropped_message` — the counterpart: a call resolved via `deferred_tool_results` in the re-exposed tail is preserved.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

