### PR TITLE
fix: `repr()` of message parts with non-bool `__ne__` values (#6415)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -21,7 +21,7 @@ from collections.abc import (
 from concurrent.futures import Executor
 from contextlib import asynccontextmanager, contextmanager, suppress
 from contextvars import ContextVar, copy_context
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import MISSING, dataclass, fields, is_dataclass
 from datetime import datetime, timezone
 from functools import partial
 from types import GenericAlias
@@ -540,9 +540,25 @@ def get_traceparent(x: AgentRun | AgentRunResult | GraphRun[Any, Any, Any]) -> s
 
 def dataclasses_no_defaults_repr(self: Any) -> str:
     """Exclude fields with values equal to the field default."""
-    kv_pairs = (
-        f'{f.name}={getattr(self, f.name)!r}' for f in fields(self) if f.repr and getattr(self, f.name) != f.default
-    )
+    kv_pairs: list[str] = []
+    for f in fields(self):
+        if not f.repr:
+            continue
+        val = getattr(self, f.name)
+        if f.default is not MISSING:
+            try:
+                show = bool(val != f.default)
+            except Exception:
+                show = True
+        elif f.default_factory is not MISSING:
+            try:
+                show = bool(val != f.default_factory())
+            except Exception:
+                show = True
+        else:
+            show = True
+        if show:
+            kv_pairs.append(f'{f.name}={val!r}')
     return f'{self.__class__.__qualname__}({", ".join(kv_pairs)})'
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1791,6 +1791,25 @@ class TestInstructionParts:
         assert repr(dynamic_part) == "InstructionPart(content='world', dynamic=True)"
 
 
+def test_repr_handles_non_bool_ne_value():
+    """repr() must not raise when a required field holds a value whose __ne__ returns a non-bool.
+
+    This tests the `dataclasses_no_defaults_repr` helper in `_utils.py`, not a VCR
+    test because it pins internal event-loop acquisition behavior with no model I/O.
+    """
+
+    class NonBoolLike:
+        def __ne__(self, other: object) -> 'NonBoolLike':
+            return NonBoolLike()
+
+    part = ToolReturnPart(
+        tool_name='get_array',
+        content=NonBoolLike(),
+    )
+    r = repr(part)
+    assert 'NonBoolLike' in r
+
+
 def test_retry_prompt_strips_input_from_top_level_errors():
     """Top-level validation errors should not include `input` in model_response() since it duplicates the entire generated output."""
     part = RetryPromptPart(


### PR DESCRIPTION
`dataclasses_no_defaults_repr` is installed as `__repr__` on public dataclasses like `ToolReturnPart`, `UserPromptPart`, `ModelRequest`, etc. It decides whether to show each field by comparing the field value against its default using `!=`. When a required field (such as `ToolReturnPart.content`) holds a value whose `__ne__` returns a non-bool — e.g. a numpy array — the implicit `bool(...)` raises:

```
ValueError: The truth value of an array with more than one element is ambiguous.
```

This breaks `repr(part)`, `print(result.all_messages())`, and any log line or traceback that formats message history.

**Fix:** wrap the `!=` comparison in a `try/except`, and skip the comparison entirely for required fields (which can never equal the `MISSING` sentinel).

Closes #6415

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

