### PR TITLE
fix: repr() of message parts with non-bool __ne__ values (#6415)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -21,7 +21,7 @@ from collections.abc import (
 from concurrent.futures import Executor
 from contextlib import asynccontextmanager, contextmanager, suppress
 from contextvars import ContextVar, copy_context
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import MISSING, dataclass, fields, is_dataclass
 from datetime import datetime, timezone
 from functools import partial
 from types import GenericAlias
@@ -540,9 +540,25 @@ def get_traceparent(x: AgentRun | AgentRunResult | GraphRun[Any, Any, Any]) -> s
 
 def dataclasses_no_defaults_repr(self: Any) -> str:
     """Exclude fields with values equal to the field default."""
-    kv_pairs = (
-        f'{f.name}={getattr(self, f.name)!r}' for f in fields(self) if f.repr and getattr(self, f.name) != f.default
-    )
+    kv_pairs: list[str] = []
+    for f in fields(self):
+        if not f.repr:
+            continue
+        val = getattr(self, f.name)
+        if f.default is not MISSING:
+            try:
+                show = bool(val != f.default)
+            except Exception:
+                show = True
+        elif f.default_factory is not MISSING:
+            try:
+                show = bool(val != f.default_factory())
+            except Exception:
+                show = True
+        else:
+            show = True
+        if show:
+            kv_pairs.append(f'{f.name}={val!r}')
     return f'{self.__class__.__qualname__}({", ".join(kv_pairs)})'
 
 

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -551,10 +551,7 @@ def dataclasses_no_defaults_repr(self: Any) -> str:
             except Exception:
                 show = True
         elif f.default_factory is not MISSING:
-            try:
-                show = bool(val != f.default_factory())
-            except Exception:
-                show = True
+            show = True
         else:
             show = True
         if show:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1795,12 +1795,15 @@ def test_repr_handles_non_bool_ne_value():
     """repr() must not raise when a required field holds a value whose __ne__ returns a non-bool.
 
     This tests the `dataclasses_no_defaults_repr` helper in `_utils.py`, not a VCR
-    test because it pins internal event-loop acquisition behavior with no model I/O.
+    test because it uses only in-memory values and performs no model I/O.
     """
 
     class NonBoolLike:
         def __ne__(self, other: object) -> 'NonBoolLike':
             return NonBoolLike()
+
+        def __bool__(self) -> bool:
+            raise TypeError('cannot convert NonBoolLike to bool')
 
     part = ToolReturnPart(
         tool_name='get_array',

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1791,6 +1791,25 @@ class TestInstructionParts:
         assert repr(dynamic_part) == "InstructionPart(content='world', dynamic=True)"
 
 
+def test_repr_handles_non_bool_ne_value():
+    """repr() must not raise when a required field holds a value whose __ne__ returns a non-bool.
+
+    This tests the `dataclasses_no_defaults_repr` helper in `_utils.py`, not a VCR
+    test because it pins internal event-loop acquisition behavior with no model I/O.
+    """
+
+    class NonBoolLike:
+        def __ne__(self, other: object) -> 'NonBoolLike':
+            return NonBoolLike()
+
+    part = ToolReturnPart(
+        tool_name='get_array',
+        content=NonBoolLike(),
+    )
+    r = repr(part)
+    assert 'NonBoolLike' in r
+
+
 def test_retry_prompt_strips_input_from_top_level_errors():
     """Top-level validation errors should not include `input` in model_response() since it duplicates the entire generated output."""
     part = RetryPromptPart(


### PR DESCRIPTION
This is the same fix as #6416 but addresses the feedback that caused it to be closed:

1. Removed `f.default_factory()` call — always include factory-backed fields in repr (calling the factory for comparison could trigger arbitrary side effects).
2. Strengthened the test — `NonBoolLike.__bool__` now raises `TypeError` to properly simulate the numpy array case.

Closes #6415

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

