### PR TITLE
Fix repr() crash on message parts holding numpy arrays

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -540,9 +540,19 @@ def get_traceparent(x: AgentRun | AgentRunResult | GraphRun[Any, Any, Any]) -> s
 
 def dataclasses_no_defaults_repr(self: Any) -> str:
     """Exclude fields with values equal to the field default."""
-    kv_pairs = (
-        f'{f.name}={getattr(self, f.name)!r}' for f in fields(self) if f.repr and getattr(self, f.name) != f.default
-    )
+
+    def _show(f: Any) -> bool:
+        if not f.repr:
+            return False
+        try:
+            return bool(getattr(self, f.name) != f.default)
+        except Exception:
+            # A value whose `!=` doesn't return a plain bool (e.g. a numpy array, whose elementwise
+            # comparison has an ambiguous truth value) would otherwise make `repr()` raise. Fall back
+            # to showing the field so `repr()` never crashes.
+            return True
+
+    kv_pairs = (f'{f.name}={getattr(self, f.name)!r}' for f in fields(self) if _show(f))
     return f'{self.__class__.__qualname__}({", ".join(kv_pairs)})'
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ import sys
 import threading
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from importlib.metadata import distributions
 from typing import Any
 
@@ -21,6 +22,7 @@ from pydantic_ai._utils import (
     UNSET,
     PeekableAsyncStream,
     check_object_json_schema,
+    dataclasses_no_defaults_repr,
     group_by_temporal,
     is_async_callable,
     merge_json_schema_defs,
@@ -28,6 +30,7 @@ from pydantic_ai._utils import (
     strip_markdown_fences,
     using_thread_executor,
 )
+from pydantic_ai.messages import ToolReturnPart
 
 from ._inline_snapshot import snapshot
 from .models.mock_async_stream import MockAsyncStream
@@ -923,3 +926,43 @@ def test_strip_markdown_fences():
     # Nested JSON objects should still be fully captured
     assert strip_markdown_fences('```json\n{"nested": {"key": "value"}}\n```') == '{"nested": {"key": "value"}}'
     assert strip_markdown_fences('```json\n{"a": {"b": {"c": 1}}}\n```') == '{"a": {"b": {"c": 1}}}'
+
+
+def test_dataclasses_no_defaults_repr_non_bool_ne():
+    """`repr()` must not raise when a field holds a value whose `!=` doesn't return a plain bool.
+
+    Numpy arrays / pandas Series are the real-world triggers (their `!=` is elementwise and the
+    resulting truth value is ambiguous); a pure-Python stand-in reproduces the same crash without
+    the dependency. `dataclasses_no_defaults_repr` is `__repr__` on many public message dataclasses
+    (e.g. `ToolReturnPart`), so any such value used to make `repr()`/`print(result.all_messages())`
+    raise instead of returning a string.
+    """
+
+    class ArrayLike:
+        """A value whose `!=` returns a non-bool with an ambiguous (raising) truth value."""
+
+        def __ne__(self, other: object) -> Any:
+            class _Ambiguous:
+                def __bool__(self) -> bool:
+                    raise ValueError('The truth value of an array with more than one element is ambiguous.')
+
+            return _Ambiguous()
+
+        def __repr__(self) -> str:
+            return 'ArrayLike()'
+
+    # Required field (`content`) — previously compared against the `MISSING` sentinel and crashed.
+    part = ToolReturnPart(tool_name='t', content=ArrayLike())
+    part_repr = repr(part)
+    assert isinstance(part_repr, str)
+    assert 'content=ArrayLike()' in part_repr
+
+    # Field with a default — exercises the comparison fallback so a non-bool `!=` can't blow up.
+    @dataclass
+    class HasDefault:
+        value: Any = None
+        __repr__ = dataclasses_no_defaults_repr
+
+    obj_repr = repr(HasDefault(value=ArrayLike()))
+    assert isinstance(obj_repr, str)
+    assert 'value=ArrayLike()' in obj_repr


### PR DESCRIPTION
- Closes #6415

`dataclasses_no_defaults_repr` is installed as `__repr__` on many public message dataclasses (`ToolReturnPart`, `ModelRequest`, `ModelResponse`, `RequestUsage`, `FinalResult`, ...). To hide fields left at their default it evaluated `value != f.default` and used the result as a bool. When a field holds a value whose `!=` does not return a plain bool, such as a numpy array or a pandas `Series`/`DataFrame` whose comparison is elementwise and has an ambiguous truth value, the implicit `bool()` raised `ValueError: The truth value of an array with more than one element is ambiguous`.

**Who hits this:** anyone whose tool returns a numpy array or a pandas object, which is common in data and analysis agents. The resulting `ToolReturnPart.content` is that array, so `repr(part)`, `print(result.all_messages())`, `repr(result.new_messages())`, log lines, and any traceback formatting that touches the part all crash. Since `repr()` is expected never to raise, an unrelated error can turn into a confusing secondary crash while its traceback is being formatted.

**The fix:** guard the per-field comparison so a non-bool `!=` result can no longer make `repr()` raise, falling back to showing the field. Behaviour is otherwise unchanged: fields equal to their default are still hidden, and existing reprs are byte-for-byte identical. In particular this deliberately does not start honouring `default_factory`, which would silently drop `usage=RequestUsage()` from `ModelResponse` reprs.

### Before / after

```python
import numpy as np
from pydantic_ai.messages import ToolReturnPart

part = ToolReturnPart(tool_name='get_array', content=np.array([1, 2, 3]))
repr(part)
# before: ValueError: The truth value of an array with more than one element is ambiguous.
# after:  "ToolReturnPart(tool_name='get_array', content=array([1, 2, 3]), tool_call_id=..., timestamp=...)"
```

A regression test is added in `tests/test_utils.py`. It uses a pure-Python stand-in whose `__ne__` returns an object with an exploding `__bool__`, so numpy is not needed as a test dependency. It fails on the current code with the `ValueError` and passes with the fix.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

