### PR TITLE
Fix `repr()` crash on message parts whose field `!=` returns a non-bool (#6415)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -559,6 +559,8 @@ def dataclasses_no_defaults_repr(self: Any) -> str:
         try:
             return bool(getattr(self, f.name) != f.default)
         except Exception:
+            # `repr()` must never raise, regardless of how a field value implements `__ne__`/`__bool__`
+            # (e.g. numpy/pandas return non-bool comparisons), so the broad catch here is intentional.
             return True
 
     kv_pairs = (f'{f.name}={getattr(self, f.name)!r}' for f in fields(self) if include_field(f))

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -21,7 +21,7 @@ from collections.abc import (
 from concurrent.futures import Executor
 from contextlib import asynccontextmanager, contextmanager, suppress
 from contextvars import ContextVar, copy_context
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import MISSING, dataclass, fields, is_dataclass
 from datetime import datetime, timezone
 from functools import partial
 from types import GenericAlias
@@ -539,10 +539,29 @@ def get_traceparent(x: AgentRun | AgentRunResult | GraphRun[Any, Any, Any]) -> s
 
 
 def dataclasses_no_defaults_repr(self: Any) -> str:
-    """Exclude fields with values equal to the field default."""
-    kv_pairs = (
-        f'{f.name}={getattr(self, f.name)!r}' for f in fields(self) if f.repr and getattr(self, f.name) != f.default
-    )
+    """Exclude fields with values equal to the field default.
+
+    A field is shown when its value differs from an explicit `default`. Fields that are
+    required or that only have a `default_factory` have no plain default to compare against
+    here, so they are always shown (the `default_factory` is deliberately not called: some
+    factories are impure, e.g. `uuid7()` or `now_utc()`, and `repr()` must stay observational).
+
+    The comparison is guarded because a value whose `__ne__`/`__bool__` does not return a plain
+    `bool` (e.g. a numpy array or pandas `Series`/`DataFrame`) would otherwise make `repr()`
+    raise `ValueError`, which breaks logging and traceback formatting of the message history.
+    """
+
+    def include_field(f: Any) -> bool:
+        if not f.repr:
+            return False
+        if f.default is MISSING:
+            return True
+        try:
+            return bool(getattr(self, f.name) != f.default)
+        except Exception:
+            return True
+
+    kv_pairs = (f'{f.name}={getattr(self, f.name)!r}' for f in fields(self) if include_field(f))
     return f'{self.__class__.__qualname__}({", ".join(kv_pairs)})'
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -937,7 +937,7 @@ class _AmbiguousBool:
 class _ArrayLike:
     """Mimics a numpy array: `!=` returns a value whose `bool()` raises, instead of a plain bool."""
 
-    def __ne__(self, other: object) -> _AmbiguousBool:
+    def __ne__(self, other: object) -> Any:
         return _AmbiguousBool()
 
     def __repr__(self) -> str:
@@ -958,11 +958,15 @@ class _HasDefaultField:
     __repr__ = dataclasses_no_defaults_repr
 
 
+def _empty_int_list() -> list[int]:
+    return []
+
+
 @dataclass(repr=False)
 class _HasMixedFields:
     required: int
     flag: bool = False
-    items: list[int] = field(default_factory=list)
+    items: list[int] = field(default_factory=_empty_int_list)
 
     __repr__ = dataclasses_no_defaults_repr
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ import sys
 import threading
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
 from importlib.metadata import distributions
 from typing import Any
 
@@ -21,6 +22,7 @@ from pydantic_ai._utils import (
     UNSET,
     PeekableAsyncStream,
     check_object_json_schema,
+    dataclasses_no_defaults_repr,
     group_by_temporal,
     is_async_callable,
     merge_json_schema_defs,
@@ -923,3 +925,64 @@ def test_strip_markdown_fences():
     # Nested JSON objects should still be fully captured
     assert strip_markdown_fences('```json\n{"nested": {"key": "value"}}\n```') == '{"nested": {"key": "value"}}'
     assert strip_markdown_fences('```json\n{"a": {"b": {"c": 1}}}\n```') == '{"a": {"b": {"c": 1}}}'
+
+
+class _AmbiguousBool:
+    """Mimics the result of a numpy array comparison: its truth value is ambiguous."""
+
+    def __bool__(self) -> bool:
+        raise ValueError('The truth value of an array with more than one element is ambiguous.')
+
+
+class _ArrayLike:
+    """Mimics a numpy array: `!=` returns a value whose `bool()` raises, instead of a plain bool."""
+
+    def __ne__(self, other: object) -> _AmbiguousBool:
+        return _AmbiguousBool()
+
+    def __repr__(self) -> str:
+        return 'ArrayLike()'
+
+
+@dataclass(repr=False)
+class _HasRequiredField:
+    content: Any
+
+    __repr__ = dataclasses_no_defaults_repr
+
+
+@dataclass(repr=False)
+class _HasDefaultField:
+    content: Any = None
+
+    __repr__ = dataclasses_no_defaults_repr
+
+
+@dataclass(repr=False)
+class _HasMixedFields:
+    required: int
+    flag: bool = False
+    items: list[int] = field(default_factory=list)
+
+    __repr__ = dataclasses_no_defaults_repr
+
+
+def test_dataclasses_no_defaults_repr_non_bool_ne():
+    """repr() must not raise when a field holds a value whose `!=` returns a non-bool (e.g. a numpy array).
+
+    Regression test for #6415: `repr()` of message parts crashed with `ValueError` when a field
+    such as `ToolReturnPart.content` held a numpy array. Covers both branches of the helper: a
+    required field (no default) and a field with an explicit default that holds such a value.
+    """
+    # Required field: value is always shown, and the ambiguous `!=` result must not be evaluated.
+    assert repr(_HasRequiredField(content=_ArrayLike())) == '_HasRequiredField(content=ArrayLike())'
+    # Explicit-default field holding the same value: the guarded comparison falls back to showing it.
+    assert repr(_HasDefaultField(content=_ArrayLike())) == '_HasDefaultField(content=ArrayLike())'
+
+
+def test_dataclasses_no_defaults_repr_omits_defaults():
+    """Fields equal to an explicit default are omitted; differing and factory-backed fields are shown."""
+    # `flag` equals its default and is omitted; `items` has only a `default_factory` so it is always shown.
+    assert repr(_HasMixedFields(required=1)) == '_HasMixedFields(required=1, items=[])'
+    # `flag` differs from its default and is shown.
+    assert repr(_HasMixedFields(required=1, flag=True)) == '_HasMixedFields(required=1, flag=True, items=[])'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -958,15 +958,25 @@ class _HasDefaultField:
     __repr__ = dataclasses_no_defaults_repr
 
 
-def _empty_int_list() -> list[int]:
-    return []
+class _CountingIntListFactory:
+    """A `default_factory` that records how many times it is called, to prove `repr()` never calls it."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> list[int]:
+        self.calls += 1
+        return []
+
+
+_items_factory = _CountingIntListFactory()
 
 
 @dataclass(repr=False)
 class _HasMixedFields:
     required: int
     flag: bool = False
-    items: list[int] = field(default_factory=_empty_int_list)
+    items: list[int] = field(default_factory=_items_factory)
 
     __repr__ = dataclasses_no_defaults_repr
 
@@ -977,6 +987,9 @@ def test_dataclasses_no_defaults_repr_non_bool_ne():
     Regression test for #6415: `repr()` of message parts crashed with `ValueError` when a field
     such as `ToolReturnPart.content` held a numpy array. Covers both branches of the helper: a
     required field (no default) and a field with an explicit default that holds such a value.
+
+    This is a plain unit test rather than a public-API/VCR test because it exercises the pure
+    `dataclasses_no_defaults_repr` helper in memory and makes no model or network requests.
     """
     # Required field: value is always shown, and the ambiguous `!=` result must not be evaluated.
     assert repr(_HasRequiredField(content=_ArrayLike())) == '_HasRequiredField(content=ArrayLike())'
@@ -985,8 +998,22 @@ def test_dataclasses_no_defaults_repr_non_bool_ne():
 
 
 def test_dataclasses_no_defaults_repr_omits_defaults():
-    """Fields equal to an explicit default are omitted; differing and factory-backed fields are shown."""
+    """Fields equal to an explicit default are omitted; differing and factory-backed fields are shown.
+
+    Also asserts `repr()` never calls the `default_factory`: some factories are impure (e.g. `uuid7()`,
+    `now_utc()`), so materializing them during `repr()` would consume randomness/time or mutate state.
+
+    This is a plain unit test rather than a public-API/VCR test because it exercises the pure
+    `dataclasses_no_defaults_repr` helper in memory and makes no model or network requests.
+    """
     # `flag` equals its default and is omitted; `items` has only a `default_factory` so it is always shown.
-    assert repr(_HasMixedFields(required=1)) == '_HasMixedFields(required=1, items=[])'
+    instance = _HasMixedFields(required=1)
+    _items_factory.calls = 0  # reset the count incurred while constructing the instance above
+    assert repr(instance) == '_HasMixedFields(required=1, items=[])'
+    assert _items_factory.calls == 0  # repr must not invoke the default_factory
+
     # `flag` differs from its default and is shown.
-    assert repr(_HasMixedFields(required=1, flag=True)) == '_HasMixedFields(required=1, flag=True, items=[])'
+    instance = _HasMixedFields(required=1, flag=True)
+    _items_factory.calls = 0
+    assert repr(instance) == '_HasMixedFields(required=1, flag=True, items=[])'
+    assert _items_factory.calls == 0


### PR DESCRIPTION
## Problem

`dataclasses_no_defaults_repr` in `_utils.py` is installed as `__repr__` on many public dataclasses (`ToolReturnPart`, `UserPromptPart`, `ModelRequest`, `ModelResponse`, ...). It decided whether to show each field with:

```python
getattr(self, f.name) != f.default
```

For a **required** field such as `ToolReturnPart.content`, `f.default` is the `dataclasses.MISSING` sentinel, so the expression became `value != MISSING`. When `value` is a numpy array (or a pandas `Series`/`DataFrame`, or any object whose `__ne__` returns a non-bool), this yields an elementwise result and the implicit `bool(...)` raises:

```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Since `repr()` is expected never to raise, this breaks `repr(part)`, `print(result.all_messages())`, logging, and any traceback that formats the message history — a common case in data/analysis agents whose tools return arrays.

```python
import numpy as np
from pydantic_ai.messages import ToolReturnPart, ModelRequest

part = ToolReturnPart(tool_name='get_array', content=np.array([1, 2, 3]))
repr(part)                        # ValueError before this PR
repr(ModelRequest(parts=[part]))  # ValueError before this PR
```

## Fix

Decide field inclusion without ever tripping over a non-bool comparison:

- Fields with **no plain default** (`f.default is MISSING`) — required fields and `default_factory`-only fields — are always shown, with no comparison performed. This is exactly the previous behavior, so repr output is unchanged. The `default_factory` is **deliberately not called**: several factories in this codebase are impure (`uuid7()`, `now_utc()`, `generate_tool_call_id()`), and `repr()` must stay observational.
- Fields with an explicit `default` are still compared, but the `!=` is guarded so a value whose `__ne__`/`__bool__` doesn't return a plain `bool` shows the field instead of raising.

## Tests

Added `test_dataclasses_no_defaults_repr_non_bool_ne` and `test_dataclasses_no_defaults_repr_omits_defaults` in `tests/test_utils.py`, using a numpy-mimicking stand-in (its `__ne__` returns an object whose `__bool__` raises), so no numpy/pandas test dependency is needed. The regression test was verified to **fail against the previous implementation** (crashes with `ValueError`) and pass with the fix, and the second test confirms default-collapsing and factory-backed-field behavior are preserved.

Closes #6415


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

