### PR TITLE
docs(models): show how to inspect model capabilities via `model.profile`

### DIFF
--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -86,8 +86,7 @@ print(WebSearchTool in profile['supported_native_tools'])
 #> True
 ```
 
-`model.profile` is always the fully *resolved* profile: every documented capability field is populated (merged from [`DEFAULT_PROFILE`][pydantic_ai.profiles.DEFAULT_PROFILE]), so direct key access like `profile['supports_tools']` is safe. If you build a partial profile yourself, use `profile.get('supports_tools', <default>)` to tolerate missing keys.
-
+`model.profile` is usually the fully *resolved* profile: keys from [`DEFAULT_PROFILE`][pydantic_ai.profiles.DEFAULT_PROFILE] are merged with the provider's defaults, so direct key access like `profile['supports_tools']` works. If you supply `profile=` as a callable (or otherwise have a partial profile dict), use `profile.get('supports_tools', DEFAULT_PROFILE['supports_tools'])` (after importing `DEFAULT_PROFILE`) to tolerate missing keys.
 Any [`Model`][pydantic_ai.models.Model] instance exposes its resolved profile the same way, so the same check works whether the model was selected automatically from a `<provider>:<model>` name or instantiated directly. Don't confuse this with [Capabilities](../capabilities.md), which are reusable bundles of tools, hooks, and settings you add to an agent — the profile describes what the underlying model itself supports.
 
 ## HTTP Client Lifecycle

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -67,12 +67,13 @@ When you instantiate an [`Agent`][pydantic_ai.Agent] with just a name formatted 
 Pydantic AI will automatically select the appropriate model class, provider, and profile.
 If you want to use a different provider or profile, you can instantiate a model class directly and pass in `provider` and/or `profile` arguments.
 
-### Inspecting model capabilities
+### Inspecting a model's profile
 
-A model's [`ModelProfile`][pydantic_ai.profiles.ModelProfile] also describes what the model can do. It is a `TypedDict`, so you read capability flags with normal dictionary access via `model.profile`. This is useful when you want to branch on a capability rather than discover a limitation at request time — for example checking whether a model supports tool calling or native JSON-schema output before relying on it:
+A model's [`ModelProfile`][pydantic_ai.profiles.ModelProfile] also describes what the model can do. It is a `TypedDict`, so you read capability flags with normal dictionary access via `model.profile` — for example [`supports_tools`][pydantic_ai.profiles.ModelProfile.supports_tools], [`supports_json_schema_output`][pydantic_ai.profiles.ModelProfile.supports_json_schema_output], and [`supported_native_tools`][pydantic_ai.profiles.ModelProfile.supported_native_tools]. This is useful when you want to branch on a capability rather than discover a limitation at request time — for example checking whether a model supports tool calling, native JSON-schema output, or a specific native tool before relying on it:
 
 ```python
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.native_tools import WebSearchTool
 
 model = TestModel()
 profile = model.profile
@@ -81,9 +82,13 @@ print(profile['supports_tools'])
 #> True
 print(profile['supports_json_schema_output'])
 #> False
+print(WebSearchTool in profile['supported_native_tools'])
+#> True
 ```
 
-Any [`Model`][pydantic_ai.models.Model] instance exposes its resolved profile the same way, so the same check works whether the model was selected automatically from a `<provider>:<model>` name or instantiated directly. See [`ModelProfile`][pydantic_ai.profiles.ModelProfile] for the full set of capability fields (including `supported_native_tools`).
+`model.profile` is always the fully *resolved* profile: every documented capability field is populated (merged from [`DEFAULT_PROFILE`][pydantic_ai.profiles.DEFAULT_PROFILE]), so direct key access like `profile['supports_tools']` is safe. If you build a partial profile yourself, use `profile.get('supports_tools', <default>)` to tolerate missing keys.
+
+Any [`Model`][pydantic_ai.models.Model] instance exposes its resolved profile the same way, so the same check works whether the model was selected automatically from a `<provider>:<model>` name or instantiated directly. Don't confuse this with [Capabilities](../capabilities.md), which are reusable bundles of tools, hooks, and settings you add to an agent — the profile describes what the underlying model itself supports.
 
 ## HTTP Client Lifecycle
 

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -67,6 +67,24 @@ When you instantiate an [`Agent`][pydantic_ai.Agent] with just a name formatted 
 Pydantic AI will automatically select the appropriate model class, provider, and profile.
 If you want to use a different provider or profile, you can instantiate a model class directly and pass in `provider` and/or `profile` arguments.
 
+### Inspecting model capabilities
+
+A model's [`ModelProfile`][pydantic_ai.profiles.ModelProfile] also describes what the model can do. It is a `TypedDict`, so you read capability flags with normal dictionary access via `model.profile`. This is useful when you want to branch on a capability rather than discover a limitation at request time — for example checking whether a model supports tool calling or native JSON-schema output before relying on it:
+
+```python
+from pydantic_ai.models.test import TestModel
+
+model = TestModel()
+profile = model.profile
+
+print(profile['supports_tools'])
+#> True
+print(profile['supports_json_schema_output'])
+#> False
+```
+
+Any [`Model`][pydantic_ai.models.Model] instance exposes its resolved profile the same way, so the same check works whether the model was selected automatically from a `<provider>:<model>` name or instantiated directly. See [`ModelProfile`][pydantic_ai.profiles.ModelProfile] for the full set of capability fields (including `supported_native_tools`).
+
 ## HTTP Client Lifecycle
 
 When a [`Provider`][pydantic_ai.providers.Provider] creates its own HTTP client (i.e. you don't pass a custom `http_client`), it owns that client's lifecycle. Using the [`Agent`][pydantic_ai.Agent] as an async context manager ensures the HTTP client is closed cleanly on exit:


### PR DESCRIPTION
## Summary

Small docs-only addition: a short **"Inspecting model capabilities"** subsection in `docs/models/overview.md` showing how to read a model's capability flags at runtime via `model.profile`.

## Why

The `ModelProfile` capability flags (`supports_tools`, `supports_json_schema_output`, `supported_native_tools`, …) are currently only surfaced in the auto-generated API reference. There's no narrative example showing how to actually read them, and it's easy to miss that they exist at all.

This came out of my own confusion: I went looking for a "does this model support tool calling?" check and initially assumed one didn't exist — when in fact `model.profile` already provides exactly that. Documenting it should save the next person the same detour. The subsection also flags the one non-obvious bit: `ModelProfile` is a `TypedDict`, so it's `profile['supports_tools']` (dict key), not attribute access.

## Verification

- The code example passes the repo's `pytest-examples` output check (`#> True` / `#> False`) against pydantic-ai `2.8.0`.
- Cross-reference targets (`ModelProfile`, `Model`, `Agent`) confirmed importable.
- Docs-only; no code changes.

Entirely happy to trim, reword, or relocate this if you'd prefer it elsewhere (or to drop it if you feel the API reference is sufficient) — just let me know what fits the docs' style best.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

