### PR TITLE
Scope `MCPToolset` sessions to the entering context so concurrent callers don't share auth identity

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -27,7 +27,7 @@ Each `MCPToolset` instance is a [toolset](../toolsets.md) and can be registered 
 
 You can use [`async with agent`][pydantic_ai.agent.Agent.__aenter__] to open and close connections to all registered MCP toolsets (and in the case of stdio servers, start and stop the subprocesses) around the context where they'll be used in agent runs. You can also use `async with toolset` to manage the lifecycle of a specific toolset directly, for example if you'd like to share it across multiple agents. If you don't explicitly enter one of these context managers, the toolset will be opened and closed automatically as needed.
 
-Note that a shared `MCPToolset` instance connects to the server as a single identity; if your users have their own credentials for the MCP server, see [per-user authentication](#per-user-authentication).
+An MCP session is shared exactly as far as you share it: everything inside an explicit `async with agent:` / `async with toolset:` — including agent runs elsewhere while it's open — uses the one session it opened, while concurrent callers that each enter on their own (or don't enter at all) each get their own session. A session connects to the server as a single identity, so only share one across users who should be the same identity; see [per-user authentication](#per-user-authentication).
 
 ### Streamable HTTP
 
@@ -443,10 +443,9 @@ For HTTP transports, `MCPToolset` accepts an `auth` argument: a bearer token str
 
 In a multi-user or multi-tenant application, each user typically has their own credentials for the MCP server, such as a tenant-scoped bearer token.
 
-!!! warning "A shared `MCPToolset` instance is a single identity"
-    An `MCPToolset` instance maintains one MCP session that's shared by all concurrent agent runs using it: the connection is established (and authentication resolved) by whichever run needs it first, and only torn down once the last one finishes. Deriving credentials per-request from task-local state like a [`ContextVar`][contextvars.ContextVar] inside an `httpx.Auth` does not work on a shared instance: overlapping runs will silently send their requests with the credentials of whichever run opened the session.
+Because authentication is resolved (and the MCP session initialized) in the context that opens the connection, an MCP session is inherently a single identity. Concurrent agent runs that don't explicitly enter the agent or toolset each open their own session, so per-user credentials can't leak between them — but don't wrap runs on behalf of *different* users in a single `async with agent:` / `async with toolset:` block, as everything inside shares the one session (and identity) it opened.
 
-To make requests with the credentials of the user in question, each concurrent run needs its own `MCPToolset` instance so that it establishes its own authenticated session. The recommended way to do this is to build the toolset [dynamically](../toolsets.md#dynamically-building-a-toolset) using the [`@agent.toolset`][pydantic_ai.agent.Agent.toolset] decorator: the decorated function is passed the [run context][pydantic_ai.tools.RunContext] and can read the user's credentials from the run's [dependencies](../dependencies.md):
+The recommended way to authenticate as the user in question is to build the toolset [dynamically](../toolsets.md#dynamically-building-a-toolset) using the [`@agent.toolset`][pydantic_ai.agent.Agent.toolset] decorator: the decorated function is passed the [run context][pydantic_ai.tools.RunContext] and can read the user's credentials from the run's [dependencies](../dependencies.md):
 
 ```python {title="mcp_per_user_auth.py"}
 from dataclasses import dataclass
@@ -478,7 +477,7 @@ async def main():
 
 _(This example is complete, it can be run "as is" — you'll need to add `asyncio.run(main())` to run `main`)_
 
-Because the per-run toolset's session is established inside the run itself, credentials held in a `ContextVar` also resolve correctly with this pattern — but passing them through deps is more explicit and doesn't depend on task-local state.
+Because each run's session is established inside the run itself, credentials held in task-local state like a [`ContextVar`][contextvars.ContextVar] (e.g. inside an `httpx.Auth` on a shared `MCPToolset` instance) also resolve to the right user per run — but passing them through deps is more explicit and doesn't depend on task-local state.
 
 As an alternative to a dynamic toolset, you can construct a new `MCPToolset` yourself for each request and pass it to the [`toolsets` argument](../toolsets.md) of the agent run methods.
 

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -85,6 +85,7 @@ from ..toolsets._dynamic import (
     ToolsetFunc,
 )
 from ..toolsets._tool_search import parse_discovered_tools
+from ..toolsets.abstract import implicit_enter
 from ..toolsets.combined import CombinedToolset
 from ..toolsets.function import FunctionToolset
 from ..toolsets.prepared import PreparedToolset
@@ -1529,7 +1530,8 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             # Enter toolset AFTER context vars are propagated so that
             # toolset __aenter__/__aexit__ run inside the run span context
             # (set by the Instrumentation capability's wrap_run).
-            await stack.enter_async_context(toolset)
+            with implicit_enter():
+                await stack.enter_async_context(toolset)
 
             async def _finalize_result(r: AgentRunResult[Any]) -> None:
                 """Call after_run, store the result override, and clear any pending error."""

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -821,6 +821,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
     _sessions: list[_MCPSession]
     _shared_session: _MCPSession | None
     _session_var: ContextVar[_MCPSession | None]
+    _template_client_reserved: bool
     _user_message_handler: MessageHandlerT | None
 
     @functools.cached_property
@@ -1008,6 +1009,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         self._sessions = []
         self._shared_session = None
         self._session_var = ContextVar('_MCPToolset_session', default=None)
+        self._template_client_reserved = False
 
     @property
     def id(self) -> str | None:
@@ -1143,20 +1145,40 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 shared.ref_count += 1
                 self._session_var.set(shared)
                 return self
-            session = await self._open_session()
+            client = self._reserve_client()
+        # Connect outside the lock so concurrent entrants perform their handshakes in parallel —
+        # sessions are per-context, so there's no singleton invariant to protect while connecting.
+        try:
+            session = await self._open_session(client)
+        except BaseException:
+            if client is self.client:
+                async with self._enter_lock:
+                    self._template_client_reserved = False
+            raise
+        async with self._enter_lock:
+            if client is self.client:
+                self._template_client_reserved = False
             self._sessions.append(session)
             self._session_var.set(session)
             if not implicit and self._shared_session is None:
                 self._shared_session = session
         return self
 
-    async def _open_session(self) -> _MCPSession:
-        # Reuse the template client for the first session so `toolset.client` reflects the live
-        # session in the common single-session case; additional overlapping sessions get
-        # independent clones via `Client.new()`.
-        client = self.client
-        if any(session.client is client for session in self._sessions):
-            client = self.client.new()
+    def _reserve_client(self) -> FastMCPClient[Any]:
+        """Pick the client to back a new session; must be called while holding `_enter_lock`.
+
+        The template `self.client` backs the first session so `toolset.client` reflects the live
+        session in the common single-session case; overlapping sessions get independent clones via
+        `Client.new()`. The reservation flag keeps two concurrent entrants from both picking the
+        template before either has committed a session — they'd silently share the underlying
+        FastMCP session.
+        """
+        if self._template_client_reserved or any(session.client is self.client for session in self._sessions):
+            return self.client.new()
+        self._template_client_reserved = True
+        return self.client
+
+    async def _open_session(self, client: FastMCPClient[Any]) -> _MCPSession:
         # Build the exit stack inside an `async with` so any failure after
         # `enter_async_context(client)` cleans up the open session — the `_MCPSession` is only
         # constructed (and committed by the caller) once initialization fully succeeds.
@@ -1181,11 +1203,17 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             session = self._session_var.get()
             if session is None or session.closed or session.owner is not self:
                 # `__aexit__` may run in a different task/context than the matching `__aenter__`
-                # (e.g. when a framework moves cleanup to another task); fall back to the most
-                # recently opened session rather than requiring context affinity.
-                session = self._sessions[-1] if self._sessions else None
-            if session is None:
-                raise ValueError(f'`{self.__class__.__name__}.__aexit__` called more times than `__aenter__`')
+                # (e.g. when a framework moves cleanup to another task). With a single open session
+                # the intent is unambiguous; with several, picking one could close another caller's
+                # session out from under them, so refuse instead of guessing.
+                if not self._sessions:
+                    raise ValueError(f'`{self.__class__.__name__}.__aexit__` called more times than `__aenter__`')
+                if len(self._sessions) > 1:
+                    raise ValueError(
+                        f'`{self.__class__.__name__}.__aexit__` was called from a context that did not enter the '
+                        'toolset while multiple sessions are open; call `__aexit__` from the entering context instead.'
+                    )
+                session = self._sessions[0]
             session.ref_count -= 1
             if session.ref_count == 0:
                 session.closed = True

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -1110,7 +1110,8 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
 
     def _invalidate_tools_cache(self) -> None:
         # A `list_changed` notification arrives on one session, but the wrapped message handler
-        # can't tell which one it belongs to — invalidate across all open sessions.
+        # can't tell which one it belongs to — invalidate across all open sessions. Every session
+        # has the handler: `Client.new()` preserves custom message handlers on cloned clients.
         for session in self._sessions:
             session.cached_tools = None
 

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -6,8 +6,9 @@ import os
 import re
 import ssl
 from abc import ABC
-from collections.abc import Awaitable, Callable, Sequence
-from contextlib import AsyncExitStack
+from collections.abc import AsyncGenerator, Awaitable, Callable, Sequence
+from contextlib import AsyncExitStack, asynccontextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Protocol, TypeAlias, cast, overload
@@ -21,7 +22,7 @@ from typing_extensions import Self, assert_never
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 
 from .direct import model_request
-from .toolsets.abstract import AbstractToolset, ToolsetTool
+from .toolsets.abstract import AbstractToolset, ToolsetTool, implicit_enter, is_implicit_enter
 
 try:
     from mcp import types as mcp_types
@@ -667,6 +668,31 @@ keeps the conflict checks in sync with the actual default values, so changing a 
 silently break the conflict check."""
 
 
+@dataclass
+class _MCPSession:
+    """A single open MCP session owned by an `MCPToolset`.
+
+    An `MCPToolset` can hold multiple sessions at once — one per calling context that entered it —
+    so that concurrent callers don't silently share a connection (and therefore an identity: auth
+    is resolved, and the MCP session initialized, in the context that opens the connection).
+    Everything scoped to one connection lives here rather than on the toolset: the initialize-time
+    server metadata, and the tool/resource/prompt list caches (servers may expose different lists
+    per session, e.g. based on the session's credentials).
+    """
+
+    owner: MCPToolset[Any]
+    client: FastMCPClient[Any]
+    exit_stack: AsyncExitStack
+    server_info: mcp_types.Implementation
+    server_capabilities: ServerCapabilities
+    instructions: str | None
+    ref_count: int = 1
+    closed: bool = False
+    cached_tools: list[mcp_types.Tool] | None = None
+    cached_resources: list[Resource] | None = None
+    cached_prompts: list[Prompt] | None = None
+
+
 @dataclass(init=False, repr=False)
 class MCPToolset(AbstractToolset[AgentDepsT]):
     """A toolset for connecting to an MCP server.
@@ -792,14 +818,9 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
     """
 
     _id: str | None
-    _server_info: mcp_types.Implementation | None
-    _server_capabilities: ServerCapabilities | None
-    _instructions: str | None
-    _cached_tools: list[mcp_types.Tool] | None
-    _cached_resources: list[Resource] | None
-    _cached_prompts: list[Prompt] | None
-    _running_count: int
-    _exit_stack: AsyncExitStack | None
+    _sessions: list[_MCPSession]
+    _shared_session: _MCPSession | None
+    _session_var: ContextVar[_MCPSession | None]
     _user_message_handler: MessageHandlerT | None
 
     @functools.cached_property
@@ -984,14 +1005,9 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         self.sampling_model = sampling_model
         self.log_level = log_level
 
-        self._server_info = None
-        self._server_capabilities = None
-        self._instructions = None
-        self._cached_tools = None
-        self._cached_resources = None
-        self._cached_prompts = None
-        self._running_count = 0
-        self._exit_stack = None
+        self._sessions = []
+        self._shared_session = None
+        self._session_var = ContextVar('_MCPToolset_session', default=None)
 
     @property
     def id(self) -> str | None:
@@ -1011,15 +1027,49 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
     def tool_name_conflict_hint(self) -> str:
         return 'Wrap the toolset with `.prefixed("...")` to disambiguate tool names from multiple MCP servers.'
 
+    def _joinable_session(self) -> _MCPSession | None:
+        """The open session the current context would use: its own, or the explicitly-opened one.
+
+        The context's own session (recorded by `__aenter__` in `_session_var`) wins; a session the
+        user explicitly opened via `async with toolset:` / `async with agent:` is the fallback.
+        Sessions opened implicitly by *other* contexts are never returned: their ambient context
+        (and e.g. request-scoped credentials) may differ from the current caller's.
+        """
+        session = self._session_var.get()
+        if session is not None and not session.closed and session.owner is self:
+            return session
+        shared = self._shared_session
+        if shared is not None and not shared.closed:
+            return shared
+        return None
+
+    @property
+    def _current_session(self) -> _MCPSession | None:
+        """The session the current context would use, falling back to the oldest open session.
+
+        The fallback keeps initialize-time metadata (`server_info` etc.) readable from tasks other
+        than the one that entered the toolset, matching the pre-session-scoping behavior.
+        """
+        session = self._joinable_session()
+        if session is not None:
+            return session
+        return self._sessions[0] if self._sessions else None
+
+    @property
+    def _session(self) -> _MCPSession:
+        session = self._current_session
+        assert session is not None, f'`{self.__class__.__name__}` must be entered before use'
+        return session
+
     @property
     def server_info(self) -> mcp_types.Implementation:
         """The server-implementation info sent during initialization.
 
         Raises [`AttributeError`][AttributeError] when accessed before the toolset has been entered.
         """
-        if self._server_info is None:
+        if (session := self._current_session) is None:
             raise AttributeError(f'`{self.__class__.__name__}.server_info` is only available after initialization.')
-        return self._server_info
+        return session.server_info
 
     @property
     def capabilities(self) -> ServerCapabilities:
@@ -1027,9 +1077,9 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
 
         Raises [`AttributeError`][AttributeError] when accessed before the toolset has been entered.
         """
-        if self._server_capabilities is None:
+        if (session := self._current_session) is None:
             raise AttributeError(f'`{self.__class__.__name__}.capabilities` is only available after initialization.')
-        return self._server_capabilities
+        return session.server_capabilities
 
     @property
     def instructions(self) -> str | None:
@@ -1037,14 +1087,14 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
 
         Raises [`AttributeError`][AttributeError] when accessed before the toolset has been entered.
         """
-        if not self._initialized:
+        if (session := self._current_session) is None:
             raise AttributeError(f'`{self.__class__.__name__}.instructions` is only available after initialization.')
-        return self._instructions
+        return session.instructions
 
     @property
     def is_running(self) -> bool:
-        """Whether the toolset is currently entered (the FastMCP session is open)."""
-        return self._running_count > 0
+        """Whether the toolset is currently entered (at least one FastMCP session is open)."""
+        return len(self._sessions) > 0
 
     def set_sampling_model(self, model: models.Model) -> None:
         """Set the [`sampling_model`][pydantic_ai.mcp.MCPToolset.sampling_model] on an already-constructed toolset.
@@ -1056,68 +1106,121 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         self.sampling_model = model
         self.client.set_sampling_callback(_build_sampling_handler(model))  # pyright: ignore[reportUnknownMemberType]
 
-    @property
-    def _initialized(self) -> bool:
-        return self._server_info is not None
-
     def _invalidate_tools_cache(self) -> None:
-        self._cached_tools = None
+        # A `list_changed` notification arrives on one session, but the wrapped message handler
+        # can't tell which one it belongs to — invalidate across all open sessions.
+        for session in self._sessions:
+            session.cached_tools = None
 
     def _invalidate_resources_cache(self) -> None:
-        self._cached_resources = None
+        for session in self._sessions:
+            session.cached_resources = None
 
     def _invalidate_prompts_cache(self) -> None:
-        self._cached_prompts = None
+        for session in self._sessions:
+            session.cached_prompts = None
 
     async def __aenter__(self) -> Self:
+        """Enter the toolset, opening an MCP session scoped to the current context.
+
+        A session is shared exactly as far as the entering context is shared: re-entering from the
+        same context (or a task spawned after entering) joins the existing session, while entering
+        from an unrelated concurrent context opens a separate session. This keeps auth — which is
+        resolved in the context that opens the connection — from leaking between concurrent callers
+        (e.g. per-request credentials in a multi-tenant app).
+
+        A session opened by an *explicit* `async with toolset:` / `async with agent:` is also
+        joined by agent runs that enter the toolset implicitly, so entering around a batch of
+        concurrent runs is the way to share one connection between them.
+        """
+        implicit = is_implicit_enter()
         async with self._enter_lock:
-            if self._running_count == 0:
-                # Build the exit stack inside an `async with` so any failure after
-                # `enter_async_context(self.client)` cleans up the open session — only commit the
-                # stack and write `_server_info`/`_server_capabilities`/`_instructions` to `self`
-                # once initialization fully succeeds, so `_initialized` can't see stale data from a
-                # session that got torn down mid-setup.
-                async with AsyncExitStack() as exit_stack:
-                    await exit_stack.enter_async_context(self.client)
-                    init_result = self.client.initialize_result
-                    assert init_result is not None, 'FastMCP Client initialization returned no result'
-                    server_info = init_result.serverInfo
-                    server_capabilities = ServerCapabilities.from_mcp_sdk(init_result.capabilities)
-                    instructions = init_result.instructions
-                    if self.log_level is not None:
-                        await self.client.session.set_logging_level(self.log_level)
-                    self._exit_stack = exit_stack.pop_all()
-                    self._server_info = server_info
-                    self._server_capabilities = server_capabilities
-                    self._instructions = instructions
-            self._running_count += 1
+            session = self._session_var.get()
+            if session is not None and not session.closed and session.owner is self:
+                session.ref_count += 1
+                return self
+            if implicit and (shared := self._shared_session) is not None and not shared.closed:
+                shared.ref_count += 1
+                self._session_var.set(shared)
+                return self
+            session = await self._open_session()
+            self._sessions.append(session)
+            self._session_var.set(session)
+            if not implicit and self._shared_session is None:
+                self._shared_session = session
         return self
+
+    async def _open_session(self) -> _MCPSession:
+        # Reuse the template client for the first session so `toolset.client` reflects the live
+        # session in the common single-session case; additional overlapping sessions get
+        # independent clones via `Client.new()`.
+        client = self.client
+        if any(session.client is client for session in self._sessions):
+            client = self.client.new()
+        # Build the exit stack inside an `async with` so any failure after
+        # `enter_async_context(client)` cleans up the open session — the `_MCPSession` is only
+        # constructed (and committed by the caller) once initialization fully succeeds.
+        async with AsyncExitStack() as exit_stack:
+            await exit_stack.enter_async_context(client)
+            init_result = client.initialize_result
+            assert init_result is not None, 'FastMCP Client initialization returned no result'
+            if self.log_level is not None:
+                await client.session.set_logging_level(self.log_level)
+            return _MCPSession(
+                owner=self,
+                client=client,
+                exit_stack=exit_stack.pop_all(),
+                server_info=init_result.serverInfo,
+                server_capabilities=ServerCapabilities.from_mcp_sdk(init_result.capabilities),
+                instructions=init_result.instructions,
+            )
+        raise AssertionError('unreachable')  # pragma: no cover
 
     async def __aexit__(self, *args: Any) -> bool | None:
         async with self._enter_lock:
-            if self._running_count == 0:
+            session = self._session_var.get()
+            if session is None or session.closed or session.owner is not self:
+                # `__aexit__` may run in a different task/context than the matching `__aenter__`
+                # (e.g. when a framework moves cleanup to another task); fall back to the most
+                # recently opened session rather than requiring context affinity.
+                session = self._sessions[-1] if self._sessions else None
+            if session is None:
                 raise ValueError(f'`{self.__class__.__name__}.__aexit__` called more times than `__aenter__`')
-            self._running_count -= 1
-            if self._running_count == 0 and self._exit_stack is not None:
-                await self._exit_stack.aclose()
-                self._exit_stack = None
-                self._server_info = None
-                self._server_capabilities = None
-                self._instructions = None
-                self._cached_tools = None
-                self._cached_resources = None
-                self._cached_prompts = None
+            session.ref_count -= 1
+            if session.ref_count == 0:
+                session.closed = True
+                self._sessions.remove(session)
+                if self._shared_session is session:
+                    self._shared_session = None
+                await session.exit_stack.aclose()
         return None
+
+    @asynccontextmanager
+    async def _borrow_session(self) -> AsyncGenerator[_MCPSession]:
+        """Enter the toolset as an implicit entrant and yield the current context's session.
+
+        Used around every direct operation (`list_tools`, `direct_call_tool`, resource and prompt
+        methods) so a standalone call joins the context's or the explicitly-opened session when one
+        exists, and otherwise opens a short-lived private session — without registering it as
+        shared state that unrelated concurrent callers would join.
+        """
+        with implicit_enter():
+            await self.__aenter__()
+        try:
+            yield self._session
+        finally:
+            await self.__aexit__(None, None, None)
 
     async def get_instructions(self, ctx: RunContext[AgentDepsT]) -> messages.InstructionPart | None:
         """Return the server's instructions if `include_instructions` is enabled."""
         if not self.include_instructions:
             return None
-        if not self._initialized or self._instructions is None:
+        session = self._current_session
+        if session is None or session.instructions is None:
             return None
-        # Instructions are captured once during `__aenter__` and don't change across runs while
-        # the toolset stays entered — so they're static from the agent's perspective, not dynamic.
-        return messages.InstructionPart(content=self._instructions, dynamic=False)
+        # Instructions are captured once when the session is opened and don't change across runs
+        # while it stays open — so they're static from the agent's perspective, not dynamic.
+        return messages.InstructionPart(content=session.instructions, dynamic=False)
 
     async def list_tools(self) -> list[mcp_types.Tool]:
         """Retrieve the tools currently exposed by the server.
@@ -1126,12 +1229,12 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         are cached and invalidated by `notifications/tools/list_changed` or the toolset's last
         `__aexit__`.
         """
-        if self.cache_tools and self._cached_tools is not None:
-            return self._cached_tools
-        async with self:
-            tools = await self.client.list_tools()
+        if self.cache_tools and (session := self._joinable_session()) is not None and session.cached_tools is not None:
+            return session.cached_tools
+        async with self._borrow_session() as session:
+            tools = await session.client.list_tools()
             if self.cache_tools:
-                self._cached_tools = tools
+                session.cached_tools = tools
             return tools
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
@@ -1189,15 +1292,15 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             ModelRetry: If the tool errors and `tool_error_behavior='retry'` (the default).
             fastmcp.exceptions.ToolError: If the tool errors and `tool_error_behavior='error'`.
         """
-        async with self:
+        async with self._borrow_session() as session:
             try:
                 if use_task:
-                    tool_task: ToolTask = await self.client.call_tool(
+                    tool_task: ToolTask = await session.client.call_tool(
                         name=name, arguments=args, task=True, meta=metadata
                     )
                     result: CallToolResult = await tool_task.result()
                 else:
-                    result = await self.client.call_tool(name=name, arguments=args, meta=metadata)
+                    result = await session.client.call_tool(name=name, arguments=args, meta=metadata)
             except ToolError as e:
                 if self.tool_error_behavior == 'retry':
                     raise exceptions.ModelRetry(message=str(e)) from e
@@ -1263,18 +1366,22 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         Raises:
             MCPError: If the server returns an error.
         """
-        if self.cache_prompts and self._cached_prompts is not None:
-            return self._cached_prompts
-        async with self:
-            if not self.capabilities.prompts:
+        if (
+            self.cache_prompts
+            and (session := self._joinable_session()) is not None
+            and session.cached_prompts is not None
+        ):
+            return session.cached_prompts
+        async with self._borrow_session() as session:
+            if not session.server_capabilities.prompts:
                 return []
             try:
-                mcp_prompts = await self.client.list_prompts()
+                mcp_prompts = await session.client.list_prompts()
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
             prompts = [Prompt.from_mcp_sdk(p) for p in mcp_prompts]
             if self.cache_prompts:
-                self._cached_prompts = prompts
+                session.cached_prompts = prompts
             return prompts
 
     async def get_prompt(self, name: str, arguments: dict[str, str] | None = None) -> PromptResult:
@@ -1288,14 +1395,14 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             MCPError: If the server doesn't advertise the `prompts` capability, or if it returns
                 an error response.
         """
-        async with self:
-            if not self.capabilities.prompts:
+        async with self._borrow_session() as session:
+            if not session.server_capabilities.prompts:
                 raise MCPError(
                     message=f'Server does not advertise the `prompts` capability; cannot get prompt {name!r}.',
                     code=-32601,
                 )
             try:
-                result = await self.client.get_prompt(name, arguments)
+                result = await session.client.get_prompt(name, arguments)
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
             return PromptResult(
@@ -1318,18 +1425,22 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         Raises:
             MCPError: If the server returns an error.
         """
-        if self.cache_resources and self._cached_resources is not None:
-            return self._cached_resources
-        async with self:
-            if not self.capabilities.resources:
+        if (
+            self.cache_resources
+            and (session := self._joinable_session()) is not None
+            and session.cached_resources is not None
+        ):
+            return session.cached_resources
+        async with self._borrow_session() as session:
+            if not session.server_capabilities.resources:
                 return []
             try:
-                mcp_resources = await self.client.list_resources()
+                mcp_resources = await session.client.list_resources()
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
             resources = [Resource.from_mcp_sdk(r) for r in mcp_resources]
             if self.cache_resources:
-                self._cached_resources = resources
+                session.cached_resources = resources
             return resources
 
     async def list_resource_templates(self) -> list[ResourceTemplate]:
@@ -1340,11 +1451,11 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         Raises:
             MCPError: If the server returns an error.
         """
-        async with self:
-            if not self.capabilities.resources:
+        async with self._borrow_session() as session:
+            if not session.server_capabilities.resources:
                 return []
             try:
-                mcp_templates = await self.client.list_resource_templates()
+                mcp_templates = await session.client.list_resource_templates()
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
         return [ResourceTemplate.from_mcp_sdk(t) for t in mcp_templates]
@@ -1374,9 +1485,9 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             MCPError: If the server returns an error.
         """
         resource_uri = uri if isinstance(uri, str) else uri.uri
-        async with self:
+        async with self._borrow_session() as session:
             try:
-                contents = await self.client.read_resource(AnyUrl(resource_uri))
+                contents = await session.client.read_resource(AnyUrl(resource_uri))
             except mcp_exceptions.McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
 
@@ -1468,10 +1579,43 @@ def _build_transport(
     )
 
 
+class _NonClosingHTTPClient:
+    """Delegating proxy that shields a user-supplied `httpx.AsyncClient` from being closed.
+
+    The MCP SDK `async with`-closes whatever the transport's `httpx_client_factory` returns, on
+    every session teardown. A user-supplied `http_client` is shared by all of the toolset's
+    sessions and owned by the user, so it must survive: this proxy forwards everything to the real
+    client but turns lifecycle calls into no-ops. (`httpx.AsyncClient` doesn't require entering
+    before use, so skipping `__aenter__` on the real client is safe.)
+    """
+
+    def __init__(self, client: httpx.AsyncClient):
+        self._pai_client = client
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._pai_client, name)
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        return None
+
+
 def _make_httpx_client_factory(
     http_client: httpx.AsyncClient,
 ) -> Callable[..., httpx.AsyncClient]:
-    """Return an `httpx_client_factory` that always returns the user-supplied `http_client`."""
+    """Return an `httpx_client_factory` that always returns the user-supplied `http_client`.
+
+    The returned client is shielded from the per-session close the MCP SDK performs on
+    factory-created clients, since it's shared by all of the toolset's sessions and owned by the user.
+    """
+    # The proxy is duck-type compatible with the `httpx.AsyncClient` surface the transport uses;
+    # the cast satisfies the `McpHttpClientFactory` protocol's declared return type.
+    proxied = cast(httpx.AsyncClient, _NonClosingHTTPClient(http_client))
 
     def factory(
         headers: dict[str, str] | None = None,
@@ -1481,7 +1625,7 @@ def _make_httpx_client_factory(
         # which the mcp SDK's `McpHttpClientFactory` protocol doesn't declare.
         follow_redirects: bool = True,
     ) -> httpx.AsyncClient:
-        return http_client
+        return proxied
 
     return factory
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/_dynamic.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/_dynamic.py
@@ -8,7 +8,7 @@ from typing_extensions import Self
 
 from .._run_context import AgentDepsT, RunContext
 from ..messages import InstructionPart
-from .abstract import AbstractToolset, ToolsetTool
+from .abstract import AbstractToolset, ToolsetTool, implicit_enter
 
 ToolsetFunc: TypeAlias = Callable[
     [RunContext[AgentDepsT]],
@@ -106,7 +106,8 @@ class DynamicToolset(AbstractToolset[AgentDepsT]):
         self._toolset = None
         if toolset is None:
             return
-        await toolset.__aenter__()
+        with implicit_enter():
+            await toolset.__aenter__()
         self._toolset = toolset
 
     async def __aexit__(self, *args: Any) -> bool | None:

--- a/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Generator, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, Literal, Protocol
 
@@ -21,6 +23,36 @@ if TYPE_CHECKING:
     from .prepared import PreparedToolset
     from .renamed import RenamedToolset
     from .set_metadata import SetMetadataToolset
+
+
+_implicit_enter_var: ContextVar[bool] = ContextVar('_implicit_enter_var', default=False)
+
+
+@contextmanager
+def implicit_enter() -> Generator[None]:
+    """Mark toolset `__aenter__` calls in this block as implicit (framework-initiated).
+
+    The framework enters toolsets on the user's behalf around each agent run (and around individual
+    direct operations like an MCP tool call), as opposed to the user explicitly entering a toolset
+    via `async with toolset:` or `async with agent:`. Toolsets whose `__aenter__` allocates a
+    connection-like resource can use [`is_implicit_enter`][pydantic_ai.toolsets.abstract.is_implicit_enter]
+    to tell these apart: an implicit entrant may join a resource the user explicitly opened, but
+    should not implicitly share resources with other concurrent implicit entrants, whose ambient
+    context (and e.g. request-scoped credentials) may differ.
+    """
+    token = _implicit_enter_var.set(True)
+    try:
+        yield
+    finally:
+        _implicit_enter_var.reset(token)
+
+
+def is_implicit_enter() -> bool:
+    """Whether the current toolset `__aenter__` call is implicit (framework-initiated).
+
+    See [`implicit_enter`][pydantic_ai.toolsets.abstract.implicit_enter].
+    """
+    return _implicit_enter_var.get()
 
 
 class SchemaValidatorProt(Protocol):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1199,13 +1199,16 @@ class TestMCPSessionScoping:
         the user, so the factory shields it from lifecycle calls."""
         client = httpx.AsyncClient()
         factory = _make_httpx_client_factory(client)
-        proxied = factory()
-        async with proxied:
-            pass
-        await proxied.aclose()
-        assert client.is_closed is False
+        # Each session teardown `async with`-closes the factory result; the user's client must
+        # survive repeated teardowns (one per session).
+        for _ in range(2):
+            proxied = factory()
+            async with proxied:
+                pass
+            await proxied.aclose()
+            assert client.is_closed is False
         # Everything else delegates to the real client.
-        assert proxied.headers is client.headers
+        assert factory().headers is client.headers
         await client.aclose()
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -17,6 +17,7 @@ import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
+from unittest import mock
 from unittest.mock import AsyncMock
 
 import anyio
@@ -1147,6 +1148,41 @@ class TestMCPSessionScoping:
         assert toolset.is_running is True
         await toolset.__aexit__(None, None, None)
         assert toolset.is_running is False
+
+    async def test_contextless_exit_with_multiple_sessions_raises(self, fastmcp_server: FastMCP[None]):
+        """A contextless `__aexit__` is ambiguous when several sessions are open: closing an
+        arbitrary one could pull another caller's session out from under them, so it refuses."""
+        toolset = MCPToolset(fastmcp_server)
+        entered = asyncio.Semaphore(0)
+        release = asyncio.Event()
+
+        async def enter_and_hold() -> None:
+            async with toolset:
+                entered.release()
+                await release.wait()
+
+        holders = [asyncio.ensure_future(enter_and_hold()) for _ in range(2)]
+        await entered.acquire()
+        await entered.acquire()
+        try:
+            assert len(toolset._sessions) == 2  # pyright: ignore[reportPrivateUsage]
+            with pytest.raises(ValueError, match='did not enter the toolset while multiple sessions are open'):
+                await toolset.__aexit__(None, None, None)
+        finally:
+            release.set()
+            await asyncio.gather(*holders)
+        assert toolset.is_running is False
+
+    async def test_failed_connection_releases_template_client(self, fastmcp_server: FastMCP[None]):
+        """A failed connection releases the template client reservation so the next `__aenter__`
+        can back its session with `toolset.client` again."""
+        toolset = MCPToolset(fastmcp_server)
+        with mock.patch.object(Client, '__aenter__', side_effect=RuntimeError('connect failed')):
+            with pytest.raises(RuntimeError, match='connect failed'):
+                await toolset.__aenter__()
+        assert toolset.is_running is False
+        async with toolset:
+            assert toolset._session.client is toolset.client  # pyright: ignore[reportPrivateUsage]
 
     async def test_copied_toolset_does_not_join_original_session(self, fastmcp_server: FastMCP[None]):
         """A (shallow) copy shares the context variable but not session identity: entering the

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import copy
 import json
 import re
 from pathlib import Path
@@ -23,10 +24,12 @@ import httpx
 import pytest
 from inline_snapshot import snapshot
 
-from pydantic_ai import models
+from pydantic_ai import Agent, models
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._utils import BaseExceptionGroup
+from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.messages import ToolReturnPart
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
@@ -41,6 +44,7 @@ with try_import() as imports_successful:
     from fastmcp.exceptions import ToolError
     from fastmcp.prompts import Message
     from fastmcp.server import FastMCP
+    from fastmcp.server.dependencies import get_context
     from fastmcp.server.tasks import TaskConfig
     from mcp import types as mcp_types
     from mcp.shared.exceptions import McpError
@@ -67,6 +71,7 @@ with try_import() as imports_successful:
         ResourceTemplate,
         ServerCapabilities,
         _make_httpx_client_factory,  # pyright: ignore[reportPrivateUsage]
+        _NonClosingHTTPClient,  # pyright: ignore[reportPrivateUsage]
         load_mcp_toolsets,
     )
     from pydantic_ai.messages import TextContent
@@ -101,20 +106,26 @@ class TestMCPToolsetConstruction:
         toolset = MCPToolset('https://example.com/mcp', http_client=client)
         assert isinstance(toolset.client.transport, StreamableHttpTransport)
         assert toolset.client.transport.httpx_client_factory is not None
-        assert toolset.client.transport.httpx_client_factory() is client
+        proxied = toolset.client.transport.httpx_client_factory()
+        assert isinstance(proxied, _NonClosingHTTPClient)
+        assert proxied._pai_client is client  # pyright: ignore[reportPrivateUsage]
         # FastMCP's StreamableHttpTransport calls the factory with `follow_redirects`, which the
         # mcp SDK's `McpHttpClientFactory` protocol doesn't declare; the factory must accept it.
-        factory = _make_httpx_client_factory(client)
-        assert factory(follow_redirects=True) is client
+        proxied = _make_httpx_client_factory(client)(follow_redirects=True)
+        assert isinstance(proxied, _NonClosingHTTPClient)
+        assert proxied._pai_client is client  # pyright: ignore[reportPrivateUsage]
 
     def test_sse_url_with_http_client_uses_factory(self):
         client = httpx.AsyncClient()
         toolset = MCPToolset('https://example.com/sse', http_client=client)
         assert isinstance(toolset.client.transport, SSETransport)
         assert toolset.client.transport.httpx_client_factory is not None
-        assert toolset.client.transport.httpx_client_factory() is client
-        factory = _make_httpx_client_factory(client)
-        assert factory(follow_redirects=True) is client
+        proxied = toolset.client.transport.httpx_client_factory()
+        assert isinstance(proxied, _NonClosingHTTPClient)
+        assert proxied._pai_client is client  # pyright: ignore[reportPrivateUsage]
+        proxied = _make_httpx_client_factory(client)(follow_redirects=True)
+        assert isinstance(proxied, _NonClosingHTTPClient)
+        assert proxied._pai_client is client  # pyright: ignore[reportPrivateUsage]
 
     def test_http_kwargs_with_non_url_input_raises(self):
         """HTTP-only kwargs (headers/auth/verify/http_client) must error out when the connection
@@ -271,6 +282,19 @@ async def fastmcp_server() -> FastMCP[None]:
         """A tool that always raises an error — used to test error handling."""
         raise ValueError('boom')
 
+    # Strong references keep sessions alive so `is`-identity below can't be confused by
+    # a freed session's memory being reused for a later one.
+    seen_sessions: list[Any] = []
+
+    @server.tool()
+    async def session_marker() -> str:
+        """Return an identifier unique to the MCP session this call arrived on."""
+        session = get_context().session
+        if not any(seen is session for seen in seen_sessions):
+            seen_sessions.append(session)
+        index = next(i for i, seen in enumerate(seen_sessions) if seen is session)
+        return f'session-{index}'
+
     @server.tool()
     async def image_tool() -> ImageContent:
         """A tool that returns an image content block."""
@@ -404,7 +428,7 @@ class TestMCPToolsetIntegration:
         assert toolset.is_running is False
 
     async def test_aexit_called_before_aenter_raises(self, fastmcp_server: FastMCP[None]):
-        """Calling `__aexit__` before any `__aenter__` should raise — `_running_count` is 0."""
+        """Calling `__aexit__` before any `__aenter__` should raise — no session is open."""
         toolset = MCPToolset(fastmcp_server)
         with pytest.raises(ValueError, match='called more times than'):
             await toolset.__aexit__(None, None, None)
@@ -450,7 +474,7 @@ class TestMCPToolsetIntegration:
         toolset = MCPToolset(fastmcp_server, cache_tools=False)
         async with toolset:
             await toolset.get_tools(run_context)
-            assert toolset._cached_tools is None  # pyright: ignore[reportPrivateUsage]
+            assert toolset._session.cached_tools is None  # pyright: ignore[reportPrivateUsage]
 
     async def test_call_tool_returns_structured_content(self, fastmcp_server: FastMCP[None], run_context: RunContext):
         toolset = MCPToolset(fastmcp_server)
@@ -577,7 +601,7 @@ class TestMCPToolsetIntegration:
         toolset = MCPToolset(fastmcp_server, cache_resources=False)
         async with toolset:
             await toolset.list_resources()
-            assert toolset._cached_resources is None  # pyright: ignore[reportPrivateUsage]
+            assert toolset._session.cached_resources is None  # pyright: ignore[reportPrivateUsage]
 
     async def test_list_resource_templates(self, fastmcp_server: FastMCP[None]):
         toolset = MCPToolset(fastmcp_server)
@@ -613,7 +637,7 @@ class TestMCPToolsetIntegration:
         toolset = MCPToolset(fastmcp_server)
         async with toolset:
             # Force the capability off to exercise the early-return branches.
-            toolset._server_capabilities = ServerCapabilities()  # pyright: ignore[reportPrivateUsage]
+            toolset._session.server_capabilities = ServerCapabilities()  # pyright: ignore[reportPrivateUsage]
             assert await toolset.list_resources() == []
             assert await toolset.list_resource_templates() == []
 
@@ -697,7 +721,7 @@ class TestMCPToolsetIntegration:
         toolset = MCPToolset(fastmcp_server)
         async with toolset:
             first = await toolset.list_prompts()
-            assert toolset._cached_prompts is not None  # pyright: ignore[reportPrivateUsage]
+            assert toolset._session.cached_prompts is not None  # pyright: ignore[reportPrivateUsage]
             second = await toolset.list_prompts()
         assert first == second
 
@@ -705,27 +729,28 @@ class TestMCPToolsetIntegration:
         toolset = MCPToolset(fastmcp_server, cache_prompts=False)
         async with toolset:
             await toolset.list_prompts()
-            assert toolset._cached_prompts is None  # pyright: ignore[reportPrivateUsage]
+            assert toolset._session.cached_prompts is None  # pyright: ignore[reportPrivateUsage]
 
     async def test_prompts_cache_invalidation_on_notification(self, fastmcp_server: FastMCP[None]):
         from pydantic_ai.mcp import _build_message_handler  # type: ignore[attr-defined]
 
         toolset = MCPToolset(fastmcp_server)
         handler = _build_message_handler(toolset, user_handler=None)
-        toolset._cached_prompts = []  # pyright: ignore[reportPrivateUsage]
+        async with toolset:
+            toolset._session.cached_prompts = []  # pyright: ignore[reportPrivateUsage]
 
-        await handler(
-            mcp_types.ServerNotification(
-                root=mcp_types.PromptListChangedNotification(method='notifications/prompts/list_changed')
+            await handler(
+                mcp_types.ServerNotification(
+                    root=mcp_types.PromptListChangedNotification(method='notifications/prompts/list_changed')
+                )
             )
-        )
-        assert toolset._cached_prompts is None  # pyright: ignore[reportPrivateUsage]
+            assert toolset._session.cached_prompts is None  # pyright: ignore[reportPrivateUsage]
 
     async def test_prompts_without_capability(self, fastmcp_server: FastMCP[None]):
         """`list_prompts` returns `[]` and `get_prompt` raises `MCPError` when prompts capability is absent."""
         toolset = MCPToolset(fastmcp_server)
         async with toolset:
-            toolset._server_capabilities = ServerCapabilities()  # pyright: ignore[reportPrivateUsage]
+            toolset._session.server_capabilities = ServerCapabilities()  # pyright: ignore[reportPrivateUsage]
             assert await toolset.list_prompts() == []
             with pytest.raises(MCPError, match='does not advertise the `prompts` capability') as exc_info:
                 await toolset.get_prompt('does_not_matter')
@@ -881,50 +906,54 @@ class TestMCPToolsetIntegration:
 
         toolset = MCPToolset(fastmcp_server)
         handler = _build_message_handler(toolset, user_handler=None)
-        toolset._cached_tools = []  # pyright: ignore[reportPrivateUsage]
-        # `LoggingMessageNotification` is unrelated to any cache.
-        await handler(
-            mcp_types.ServerNotification(
-                root=mcp_types.LoggingMessageNotification(
-                    method='notifications/message',
-                    params=mcp_types.LoggingMessageNotificationParams(level='info', data='hi'),
+        async with toolset:
+            toolset._session.cached_tools = []  # pyright: ignore[reportPrivateUsage]
+            # `LoggingMessageNotification` is unrelated to any cache.
+            await handler(
+                mcp_types.ServerNotification(
+                    root=mcp_types.LoggingMessageNotification(
+                        method='notifications/message',
+                        params=mcp_types.LoggingMessageNotificationParams(level='info', data='hi'),
+                    )
                 )
             )
-        )
-        assert toolset._cached_tools == []  # pyright: ignore[reportPrivateUsage]
+            assert toolset._session.cached_tools == []  # pyright: ignore[reportPrivateUsage]
 
     async def test_message_handler_ignores_non_notification_messages(self, fastmcp_server: FastMCP[None]):
         from pydantic_ai.mcp import _build_message_handler  # type: ignore[attr-defined]
 
         toolset = MCPToolset(fastmcp_server)
         handler = _build_message_handler(toolset, user_handler=None)
-        toolset._cached_tools = []  # pyright: ignore[reportPrivateUsage]
-        # Exception messages are passed through but shouldn't crash or invalidate caches.
-        await handler(RuntimeError('transport error'))
-        assert toolset._cached_tools == []  # pyright: ignore[reportPrivateUsage]
+        async with toolset:
+            toolset._session.cached_tools = []  # pyright: ignore[reportPrivateUsage]
+            # Exception messages are passed through but shouldn't crash or invalidate caches.
+            await handler(RuntimeError('transport error'))
+            assert toolset._session.cached_tools == []  # pyright: ignore[reportPrivateUsage]
 
     async def test_message_handler_invalidates_caches(self, fastmcp_server: FastMCP[None], run_context: RunContext):
         from pydantic_ai.mcp import _build_message_handler  # type: ignore[attr-defined]
 
         toolset = MCPToolset(fastmcp_server)
         handler = _build_message_handler(toolset, user_handler=None)
-        toolset._cached_tools = []  # pyright: ignore[reportPrivateUsage]
-        toolset._cached_resources = []  # pyright: ignore[reportPrivateUsage]
+        async with toolset:
+            session = toolset._session  # pyright: ignore[reportPrivateUsage]
+            session.cached_tools = []
+            session.cached_resources = []
 
-        await handler(
-            mcp_types.ServerNotification(
-                root=mcp_types.ToolListChangedNotification(method='notifications/tools/list_changed')
+            await handler(
+                mcp_types.ServerNotification(
+                    root=mcp_types.ToolListChangedNotification(method='notifications/tools/list_changed')
+                )
             )
-        )
-        assert toolset._cached_tools is None  # pyright: ignore[reportPrivateUsage]
+            assert session.cached_tools is None
 
-        toolset._cached_tools = []  # pyright: ignore[reportPrivateUsage]
-        await handler(
-            mcp_types.ServerNotification(
-                root=mcp_types.ResourceListChangedNotification(method='notifications/resources/list_changed')
+            session.cached_tools = []
+            await handler(
+                mcp_types.ServerNotification(
+                    root=mcp_types.ResourceListChangedNotification(method='notifications/resources/list_changed')
+                )
             )
-        )
-        assert toolset._cached_resources is None  # pyright: ignore[reportPrivateUsage]
+            assert session.cached_resources is None
 
     async def test_message_handler_forwards_to_user_handler(self, fastmcp_server: FastMCP[None]):
         from pydantic_ai.mcp import _build_message_handler  # type: ignore[attr-defined]
@@ -993,6 +1022,155 @@ class TestMCPToolsetIntegration:
         async with toolset:
             with pytest.raises(ToolError):
                 await toolset.direct_call_tool('boom', {})
+
+
+def _session_marker_from(result: AgentRunResult[Any]) -> str:
+    """Extract the `session_marker` tool return from a run's message history."""
+    for message in result.all_messages():
+        for part in message.parts:
+            if isinstance(part, ToolReturnPart) and part.tool_name == 'session_marker':
+                return str(part.content)
+    raise AssertionError('session_marker tool was not called')  # pragma: no cover
+
+
+def _session_marker_model() -> TestModel:
+    return TestModel(call_tools=['session_marker'], custom_output_text='done')
+
+
+class TestMCPSessionScoping:
+    """Which callers share one MCP session: a session is shared exactly as far as you share it.
+
+    Auth is resolved (and the MCP session initialized) in the context that opens the connection,
+    so silently attaching a concurrent caller to another context's session sends its requests
+    under the wrong identity (issue #6411). These tests pin the session topology: concurrent
+    contexts get isolated sessions, while the sharing patterns established in #2818/#4514 —
+    an explicit `async with` around parallel runs, and a module-level toolset entered in a
+    lifespan task and used from sibling request-handler tasks — keep sharing one session.
+    """
+
+    async def test_concurrent_explicit_enters_are_isolated(self, fastmcp_server: FastMCP[None]):
+        """Two overlapping `async with toolset:` callers each get their own session (issue #6411)."""
+        toolset = MCPToolset(fastmcp_server)
+        first_entered = asyncio.Event()
+        second_done = asyncio.Event()
+
+        async def first() -> str:
+            async with toolset:
+                first_entered.set()
+                marker = await toolset.direct_call_tool('session_marker', {})
+                await second_done.wait()
+                return marker
+
+        async def second() -> str:
+            await first_entered.wait()
+            async with toolset:
+                assert len(toolset._sessions) == 2  # pyright: ignore[reportPrivateUsage]
+                try:
+                    return await toolset.direct_call_tool('session_marker', {})
+                finally:
+                    second_done.set()
+
+        first_marker, second_marker = await asyncio.gather(first(), second())
+        assert first_marker != second_marker
+        assert toolset.is_running is False
+
+    async def test_implicit_caller_joins_explicitly_opened_session(self, fastmcp_server: FastMCP[None]):
+        """A direct call from a sibling task joins the explicitly-opened session.
+
+        This is the module-level-singleton pattern: `async with toolset:` in a lifespan task,
+        requests handled in sibling tasks that don't inherit the lifespan task's context.
+        """
+        toolset = MCPToolset(fastmcp_server)
+        opened = asyncio.Event()
+        handler_done = asyncio.Event()
+
+        async def lifespan() -> str:
+            async with toolset:
+                opened.set()
+                marker = await toolset.direct_call_tool('session_marker', {})
+                await handler_done.wait()
+                return marker
+
+        async def handler() -> str:
+            await opened.wait()
+            try:
+                marker = await toolset.direct_call_tool('session_marker', {})
+                assert len(toolset._sessions) == 1  # pyright: ignore[reportPrivateUsage]
+                return marker
+            finally:
+                handler_done.set()
+
+        lifespan_marker, handler_marker = await asyncio.gather(lifespan(), handler())
+        assert lifespan_marker == handler_marker
+
+    async def test_explicit_enter_shares_session_across_parallel_runs(self, fastmcp_server: FastMCP[None]):
+        """`async with agent:` around parallel runs shares one session between them (#2818/#4514)."""
+        toolset = MCPToolset(fastmcp_server)
+        agent = Agent(_session_marker_model(), toolsets=[toolset])
+        async with agent:
+            results = await asyncio.gather(agent.run('call it'), agent.run('call it'))
+        markers = {_session_marker_from(result) for result in results}
+        assert len(markers) == 1
+
+    async def test_concurrent_implicit_runs_get_isolated_sessions(self, fastmcp_server: FastMCP[None]):
+        """Parallel runs that don't explicitly enter the agent/toolset each get their own session,
+        opened in their own context — so per-context state like request-scoped credentials can't
+        leak between them (issue #6411)."""
+        toolset = MCPToolset(fastmcp_server)
+        agent = Agent(_session_marker_model(), toolsets=[toolset])
+        results = await asyncio.gather(agent.run('call it'), agent.run('call it'))
+        markers = {_session_marker_from(result) for result in results}
+        assert len(markers) == 2
+        assert toolset.is_running is False
+
+    async def test_nested_enter_shares_session(self, fastmcp_server: FastMCP[None]):
+        """Re-entering from the same context joins the existing session, and the session stays
+        open until the outermost exit."""
+        toolset = MCPToolset(fastmcp_server)
+        async with toolset:
+            outer = await toolset.direct_call_tool('session_marker', {})
+            async with toolset:
+                inner = await toolset.direct_call_tool('session_marker', {})
+            after_inner_exit = await toolset.direct_call_tool('session_marker', {})
+        assert outer == inner == after_inner_exit
+        assert toolset.is_running is False
+
+    async def test_exit_from_task_without_context_falls_back(self, fastmcp_server: FastMCP[None]):
+        """`__aexit__` from a task that didn't inherit the entering context still closes the
+        session (frameworks sometimes move cleanup to a different task)."""
+        toolset = MCPToolset(fastmcp_server)
+
+        async def enter_only() -> None:
+            await toolset.__aenter__()
+
+        await asyncio.create_task(enter_only())
+        assert toolset.is_running is True
+        await toolset.__aexit__(None, None, None)
+        assert toolset.is_running is False
+
+    async def test_copied_toolset_does_not_join_original_session(self, fastmcp_server: FastMCP[None]):
+        """A (shallow) copy shares the context variable but not session identity: entering the
+        copy opens its own session instead of adopting the original's."""
+        toolset = MCPToolset(fastmcp_server)
+        async with toolset:
+            clone = copy.copy(toolset)
+            async with clone:
+                assert clone._session is not toolset._session  # pyright: ignore[reportPrivateUsage]
+
+    async def test_user_http_client_is_not_closed_by_session_teardown(self):
+        """The MCP SDK `async with`-closes the client its transport factory returns on every
+        session teardown; a user-supplied `http_client` is shared by all sessions and owned by
+        the user, so the factory shields it from lifecycle calls."""
+        client = httpx.AsyncClient()
+        factory = _make_httpx_client_factory(client)
+        proxied = factory()
+        async with proxied:
+            pass
+        await proxied.aclose()
+        assert client.is_closed is False
+        # Everything else delegates to the real client.
+        assert proxied.headers is client.headers
+        await client.aclose()
 
 
 class TestToolResultMapping:


### PR DESCRIPTION
- Closes #6411

## The problem

As reported in #6411, a shared MCP toolset silently coalesces *concurrent* callers onto one session: `MCPToolset.__aenter__` ref-counts on the instance, so whichever caller enters first opens the connection and everyone overlapping rides along. Since auth is resolved (and the MCP session initialized) in the context that opens the connection, a per-request `httpx.Auth` reading a `ContextVar` sends overlapping callers' requests under the **first caller's identity** — the reporter hit this propagating tenant-scoped bearer tokens. The same applies to concurrent `agent.run()`s on a shared instance, with no `async with` in user code at all.

#6425 documented the safe pattern (fresh `MCPToolset` per run via `@agent.toolset`), but the intuitive code remains a footgun: `async with server:` inside a request handler *reads* as "the connection is scoped to this block" while actually attaching to a session another task created. This PR makes the intuitive code correct.

## The new rule: a session is shared exactly as far as you share it

- **Re-entering from the same context** (nested `async with`, or a task spawned after entering) joins the existing session — unchanged.
- **An explicit `async with toolset:` / `async with agent:`** opens a session that is also joined by agent runs and direct calls that enter implicitly while it's open — so entering around a batch of concurrent runs is (still) how you share one connection between them.
- **Concurrent callers that each enter on their own** — parallel explicit `async with` blocks in sibling tasks, or parallel runs with no explicit enter — each get their **own session**, opened in their own context with their own credentials.

Explicit vs. implicit entering is distinguished by a small internal `ContextVar` flag (`toolsets/abstract.py: implicit_enter()`) set by the framework around the per-run toolset enter, `DynamicToolset`'s inner-toolset transitions, and `MCPToolset`'s own self-entry around direct operations.

## Scenario matrix

| Scenario | Before | After |
|---|---|---|
| #6411 repro: parallel tasks each `async with server:` + call, ContextVar auth | one session, **second caller authenticated as the first** | one session per caller, correct auth ✅ |
| Concurrent `agent.run()`s on a shared instance (implicit) | one session, first run's identity | one session per run, correct auth ✅ |
| `async with agent:` around `asyncio.gather(run, run)` | one session | one session (lease inherited by child tasks) — unchanged |
| Module-level singleton: `async with toolset:` in a FastAPI lifespan task, runs in sibling request-handler tasks | one session | one session (implicit entrants join the explicitly-opened session) — unchanged |
| Parallel tasks each doing their own `async with agent:` | one session | one session per task, shared within it |
| Sequential runs, no explicit enter | reconnect per run | reconnect per run — unchanged |
| `__aexit__` from a different task than `__aenter__` (e.g. LangGraph moving cleanup) | works via refcount | works via most-recently-opened fallback |

All rows verified live against a streamable HTTP FastMCP server that echoes the `Authorization` header it receives, and pinned by new tests.

## Relationship to #2818 / #4514

The first version of #4514 implemented per-context connections with a plain `ContextVar` and was rejected for two empirically-verified regressions: `gather(run × 5)` opened 5 subprocesses, and the lifespan/singleton pattern opened one connection *per request handler* (sibling tasks don't inherit a lifespan task's contextvars). The shipped #4514 kept instance-level sharing, which fixed the cancel-scope crash but is what made concurrent identity-coalescing silent.

This design keeps the load-bearing pattern from that decision — the lifespan case stays at one connection via the "implicit entrants join the explicitly-opened session" rule rather than contextvar inheritance — and deliberately flips only the rows where ambient identity can actually differ. The #4514-era regression tests (`test_parallel_agent_runs_share_one_connection`, `test_server_shared_across_sibling_tasks`) died with the old `MCPServer*` classes in #5337; they're restored here under the new semantics in `TestMCPSessionScoping`, alongside tests for the #6411 shape, implicit-run isolation, nested reentry, and the mismatched-task exit fallback. Session identity is asserted behaviorally via a `session_marker` tool on the in-process test server.

## Implementation notes

- Per-connection state moves off the toolset onto a private `_MCPSession` (initialize-time `server_info`/`capabilities`/`instructions`, and the tool/resource/prompt caches — servers may expose different lists per session, e.g. based on the session's credentials). `list_changed` notifications invalidate across all open sessions, since the shared message handler can't tell which session a notification belongs to.
- Additional concurrent sessions use `fastmcp.Client.new()` (FastMCP's documented API for "independent sessions for concurrent operations"). The first session reuses the template `self.client`, so `toolset.client` still reflects the live session in the common single-session case and nothing changes until sessions actually overlap.
- A user-supplied `http_client` is now wrapped in a non-closing proxy before being handed to the MCP SDK, which `async with`-closes whatever the transport factory returns on **every session teardown**. Without this, the first session to close would close the user's client under all others; it also fixes a latent pre-existing bug where fully exiting and re-entering a toolset with a custom `http_client` would hit a closed client.
- `__aexit__` from a context without the entering lease falls back to the most-recently-opened session (best effort, matching how loose the old refcount was about pairing).

## Implications and tradeoffs

- **Perf**: runs that previously coalesced by racing each other now each perform an MCP initialize handshake (and for stdio, each get their own subprocess) while they overlap. Sequential runs are unaffected (they already reconnected per run). The one-line opt-in to the old single-connection behavior is the explicit `async with agent:` / `async with toolset:` around the batch — which the docs already recommended for connection reuse. A future optimization could coalesce implicit entrants when the toolset's configuration is provably context-independent (static token, no `httpx.Auth`/custom `http_client`); deferred here to keep the semantics uniform and predictable.
- **Observability**: MCP transport spans previously all parented under whichever caller opened the shared session; they now nest under the run that owns the session, which is arguably more correct but visible in traces.
- **Durable exec**: Temporal/DBOS/Prefect wrappers enter the wrapped toolset per activity/step and are unaffected (sessions there were already per-call except under in-worker concurrency, where isolation is now guaranteed rather than racy).

Docs: the lifecycle paragraph and the [per-user authentication](https://ai.pydantic.dev/mcp/client/#per-user-authentication) section from #6425 are updated for the new semantics — the dynamic-toolset deps pattern remains the recommended explicit approach, and the warning about ContextVar-derived auth is replaced by the sharing rule.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md) — see the scenario matrix: the flipped rows are the identity-leaking behaviors reported as a bug; documented sharing patterns are preserved.
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

