### PR TITLE
fix(deps): bump soupsieve to 2.8.4 to fix ReDoS (CVE-2026-49477)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -7128,11 +7128,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.1"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/23/adf3796d740536d63a6fbda113d07e60c734b6ed5d3058d1e47fc0495e47/soupsieve-2.8.1.tar.gz", hash = "sha256:4cf733bc50fa805f5df4b8ef4740fc0e0fa6218cf3006269afd3f9d6d80fd350", size = 117856, upload-time = "2025-12-18T13:50:34.655Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/f3/b67d6ea49ca9154453b6d70b34ea22f3996b9fa55da105a79d8732227adc/soupsieve-2.8.1-py3-none-any.whl", hash = "sha256:a11fe2a6f3d76ab3cf2de04eb339c1be5b506a8a47f2ceb6d139803177f85434", size = 36710, upload-time = "2025-12-18T13:50:33.267Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes Dependabot alert [#190](https://github.com/pydantic/pydantic-ai/security/dependabot/190) — a **High** severity ReDoS vulnerability in `soupsieve`.

`soupsieve <= 2.8.3` contains a CSS selector parser regex vulnerable to catastrophic backtracking (**GHSA-836r-79rf-4m37** / **CVE-2026-49477**). An attribute selector with an unterminated quoted value (e.g. `[a="xxxx...`) triggers exponential backtracking — a ~300-byte payload can hang the regex engine for over 3 seconds, allowing CPU exhaustion / denial of service.

The package is pulled in **transitively** via `beautifulsoup4`, so the fix is purely a lockfile bump.

## Change

- `uv.lock`: pin `soupsieve` `2.8.1` → `2.8.4` (the first patched release).

This is a minimal, surgical edit to the single `soupsieve` package entry (version + sdist/wheel URLs and hashes). `uv lock --check` passes, confirming the lockfile stays consistent.

| | |
|---|---|
| Advisory | GHSA-836r-79rf-4m37 / CVE-2026-49477 |
| Severity | High (CVSS 7.5) |
| Vulnerable | `<= 2.8.3` |
| Patched | `2.8.4` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

