### PR TITLE
docs: add DaoXE OpenAI-compatible gateway example

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -446,6 +446,31 @@ agent = Agent(model)
 ...
 ```
 
+### DaoXE
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway with an OpenAI-compatible Chat Completions endpoint. It also exposes OpenAI Responses and Anthropic Messages for other clients; with Pydantic AI you typically use the OpenAI-compatible Chat Completions path below.
+
+Create an API key in the [DaoXE dashboard](https://daoxe.com), then use an exact model ID from your DaoXE account catalog (`GET /v1/models` or your account UI). Prefer live account IDs over hard-coded public lists. DaoXE is not available in mainland China.
+
+```python {test="skip" lint="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+model = OpenAIChatModel(
+    'YOUR_DAOXE_MODEL_ID',  # exact ID from your DaoXE account
+    provider=OpenAIProvider(
+        base_url='https://daoxe.com/v1',
+        api_key='your-daoxe-api-key',
+    ),
+)
+agent = Agent(model)
+result = agent.run_sync('What is the capital of France?')
+print(result.output)
+```
+
+You can also set `OPENAI_BASE_URL=https://daoxe.com/v1` and `OPENAI_API_KEY` and use `OpenAIChatModel` without constructing `OpenAIProvider` explicitly. See [OpenAI-compatible Models](#openai-compatible-models).
+
 ### Alibaba Cloud Model Studio (DashScope)
 
 To use Qwen models via [Alibaba Cloud Model Studio (DashScope)](https://www.alibabacloud.com/en/product/modelstudio), you can set the `ALIBABA_API_KEY` (or `DASHSCOPE_API_KEY`) environment variable and use [`AlibabaProvider`][pydantic_ai.providers.alibaba.AlibabaProvider] by name:

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -22,6 +22,7 @@ In addition, many providers are compatible with the OpenAI API, and can be used 
 - [Alibaba Cloud Model Studio (DashScope)](openai.md#alibaba-cloud-model-studio-dashscope)
 - [Azure AI Foundry](openai.md#azure-ai-foundry)
 - [DeepSeek](openai.md#deepseek)
+- [DaoXE](openai.md#daoxe)
 - [Fireworks AI](openai.md#fireworks-ai)
 - [GitHub Models](openai.md#github-models)
 - [Heroku](openai.md#heroku-ai)


### PR DESCRIPTION
## Summary
- Document [DaoXE](https://daoxe.com) under OpenAI-compatible providers in `docs/models/openai.md`.
- Example uses `OpenAIChatModel` + `OpenAIProvider(base_url='https://daoxe.com/v1')` with an account-scoped model ID placeholder.
- Link from `docs/models/overview.md` OpenAI-compatible list.

DaoXE is a multi-model multi-protocol API gateway. This docs-only change covers the OpenAI Chat Completions path Pydantic AI already supports; no new provider class or static model table.

I am a DaoXE maintainer. Examples: https://github.com/seven7763/DaoXE-AI

## Checklist
- [x] Docs only
- [x] No hardcoded public model price list
- [x] Follows existing OpenAI-compatible docs patterns

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

