### PR TITLE
Add `AgentMessagePart` message type for inter-agent communication

### DIFF
--- a/docs/api/messages.md
+++ b/docs/api/messages.md
@@ -8,6 +8,7 @@ graph RL
     UserPromptPart(UserPromptPart) --- ModelRequestPart
     ToolReturnPart(ToolReturnPart) --- ModelRequestPart
     RetryPromptPart(RetryPromptPart) --- ModelRequestPart
+    AgentMessagePart(AgentMessagePart) --- ModelRequestPart
     TextPart(TextPart) --- ModelResponsePart
     ToolCallPart(ToolCallPart) --- ModelResponsePart
     ThinkingPart(ThinkingPart) --- ModelResponsePart

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -489,7 +489,7 @@ A `priority` controls when the enqueued content is delivered:
 `enqueue` is variadic — each positional argument is one item, and can be:
 
 - a piece of [`UserContent`][pydantic_ai.messages.UserContent] — a `str` or multi-modal content like an [`ImageUrl`][pydantic_ai.messages.ImageUrl]. Adjacent user content is gathered into a single [`UserPromptPart`][pydantic_ai.messages.UserPromptPart], so `enqueue('caption', image)` forms one user turn. To pass an existing list, spread it: `enqueue(*items)`;
-- a [`ModelRequestPart`][pydantic_ai.messages.ModelRequestPart], such as a [`SystemPromptPart`][pydantic_ai.messages.SystemPromptPart];
+- a [`ModelRequestPart`][pydantic_ai.messages.ModelRequestPart], such as a [`SystemPromptPart`][pydantic_ai.messages.SystemPromptPart] or an [`AgentMessagePart`][pydantic_ai.messages.AgentMessagePart];
 - a complete [`ModelRequest`][pydantic_ai.messages.ModelRequest] or [`ModelResponse`][pydantic_ai.messages.ModelResponse], to control request-level fields like `instructions`/`metadata` or to inject a synthetic prior turn.
 
 Adjacent part-style items (user content and [`ModelRequestPart`][pydantic_ai.messages.ModelRequestPart]s) are coalesced into one [`ModelRequest`][pydantic_ai.messages.ModelRequest]; complete messages stay separate. This lets a single call inject an interleaved exchange — for example a synthetic tool call (a [`ModelResponse`][pydantic_ai.messages.ModelResponse]) followed by its result (a [`ModelRequest`][pydantic_ai.messages.ModelRequest]). The content must end in a request, so the agent has something to respond to.

--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -46,6 +46,7 @@ from .exceptions import (
 )
 from .format_prompt import format_as_xml
 from .messages import (
+    AgentMessagePart,
     AgentStreamEvent,
     AudioFormat,
     AudioMediaType,
@@ -204,6 +205,7 @@ __all__ = (
     'UsageLimitExceeded',
     'UserError',
     # messages
+    'AgentMessagePart',
     'AgentStreamEvent',
     'AudioFormat',
     'AudioMediaType',

--- a/pydantic_ai_slim/pydantic_ai/_enqueue.py
+++ b/pydantic_ai_slim/pydantic_ai/_enqueue.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from .exceptions import UserError
 from .messages import (
+    AgentMessagePart,
     ModelMessage,
     ModelRequest,
     ModelRequestPart,
@@ -96,7 +97,8 @@ def _build_enqueue_messages(items: Sequence[EnqueueContent]) -> list[ModelMessag
             flush_request()
             messages.append(item)
         elif isinstance(
-            item, (SystemPromptPart, UserPromptPart, ToolReturnPart, RetryPromptPart, ToolSearchReturnPart)
+            item,
+            (SystemPromptPart, UserPromptPart, ToolReturnPart, RetryPromptPart, ToolSearchReturnPart, AgentMessagePart),
         ):
             flush_content()
             parts.append(item)

--- a/pydantic_ai_slim/pydantic_ai/messages.py
+++ b/pydantic_ai_slim/pydantic_ai/messages.py
@@ -1596,6 +1596,56 @@ class RetryPromptPart:
     __repr__ = _utils.dataclasses_no_defaults_repr
 
 
+@dataclass(repr=False)
+class AgentMessagePart:
+    """A message from another agent, injected into the current agent's conversation.
+
+    This part type represents inter-agent communication — including subagent results,
+    progress updates, error notifications, and other messages from agents. It is mapped
+    to a `role='user'` text message in all provider APIs (prefixed with the agent name
+    for context), but is distinguished from `UserPromptPart` in the internal message
+    history and skipped by UI adapters so it is not displayed as user input.
+
+    Use this part with [`RunContext.enqueue`][pydantic_ai.tools.RunContext.enqueue]
+    to inject agent messages into the conversation.
+    """
+
+    agent_name: str
+    """The name of the agent that sent this message."""
+
+    content: str
+    """The text content of the agent message."""
+
+    _: KW_ONLY
+
+    message_type: Literal['result', 'progress', 'error', 'notification'] = 'result'
+    """The type of agent message.
+
+    - `'result'`: A final result from a completed subagent.
+    - `'progress'`: A progress update from a running subagent.
+    - `'error'`: An error notification from a subagent.
+    - `'notification'`: A general notification from an agent.
+    """
+
+    timestamp: datetime = field(default_factory=_now_utc)
+    """The timestamp of the message."""
+
+    metadata: dict[str, Any] | None = None
+    """Additional metadata for the message."""
+
+    part_kind: Literal['agent-message'] = 'agent-message'
+    """Part type identifier, used as a discriminator."""
+
+    def otel_message_parts(self, settings: InstrumentationSettings) -> list[_otel_messages.MessagePart]:
+        return [
+            _otel_messages.TextPart(
+                type='text', **({'content': f'[Agent: {self.agent_name}] {self.content}'} if settings.include_content else {})
+            )
+        ]
+
+    __repr__ = _utils.dataclasses_no_defaults_repr
+
+
 # `ModelRequestPart` is defined further down (after the typed `ToolSearchReturnPart`
 # subclass) so it can include the local `search_tools` return as a discriminated-union
 # member. The forward reference inside `ModelRequest.parts` works because of
@@ -2170,7 +2220,8 @@ ModelRequestPart = Annotated[
     | Annotated[ToolSearchReturnPart, pydantic.Tag('tool-search-return')]
     | Annotated[LoadCapabilityReturnPart, pydantic.Tag('capability-load-return')]
     | Annotated[ToolReturnPart, pydantic.Tag('tool-return')]
-    | Annotated[RetryPromptPart, pydantic.Tag('retry-prompt')],
+    | Annotated[RetryPromptPart, pydantic.Tag('retry-prompt')]
+    | Annotated[AgentMessagePart, pydantic.Tag('agent-message')],
     pydantic.Discriminator(_model_request_part_discriminator),
 ]
 """A message part sent by Pydantic AI to a model."""

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -20,6 +20,7 @@ from .._utils import guard_tool_call_id as _guard_tool_call_id, is_str_dict
 from ..capabilities.abstract import AbstractCapability
 from ..exceptions import ModelAPIError, UserError
 from ..messages import (
+    AgentMessagePart,
     AudioUrl,
     BinaryContent,
     CachePoint,
@@ -1457,7 +1458,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                             is_error=False,
                         )
                         user_content_params.append(tool_result_block_param)
-                    elif isinstance(request_part, RetryPromptPart):  # pragma: no branch
+                    elif isinstance(request_part, RetryPromptPart):
                         if request_part.tool_name is None:
                             text = request_part.model_response()
                             retry_param = BetaTextBlockParam(type='text', text=text)
@@ -1469,6 +1470,10 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                                 is_error=True,
                             )
                         user_content_params.append(retry_param)
+                    elif isinstance(request_part, AgentMessagePart):
+                        user_content_params.append(
+                            BetaTextBlockParam(type='text', text=f"[Agent '{request_part.agent_name}']: {request_part.content}")
+                        )
                 if len(user_content_params) > 0:
                     anthropic_messages.append(BetaMessageParam(role='user', content=user_content_params))
             elif isinstance(m, ModelResponse):

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -27,6 +27,7 @@ except ImportError as _import_error:
     ) from _import_error
 
 from pydantic_ai import (
+    AgentMessagePart,
     AudioUrl,
     BinaryContent,
     CachePoint,
@@ -1147,6 +1148,11 @@ class BedrockConverseModel(Model[BaseClient]):
                             if supports_tool_result_status:
                                 error_result['status'] = 'error'
                             bedrock_messages.append({'role': 'user', 'content': [{'toolResult': error_result}]})
+                    elif isinstance(part, AgentMessagePart):
+                        flush_deferred_media()
+                        bedrock_messages.append(
+                            {'role': 'user', 'content': [{'text': f"[Agent '{part.agent_name}']: {part.content}"}]}
+                        )
                     else:
                         assert_never(part)
             elif isinstance(message, ModelResponse):

--- a/pydantic_ai_slim/pydantic_ai/models/cohere.py
+++ b/pydantic_ai_slim/pydantic_ai/models/cohere.py
@@ -12,6 +12,7 @@ from pydantic_ai.exceptions import ModelAPIError
 from .. import ModelHTTPError, usage
 from .._utils import generate_tool_call_id as _generate_tool_call_id, guard_tool_call_id as _guard_tool_call_id
 from ..messages import (
+    AgentMessagePart,
     CachePoint,
     CompactionPart,
     FilePart,
@@ -382,6 +383,8 @@ class CohereModel(Model[AsyncClientV2]):
                         tool_call_id=_guard_tool_call_id(t=part),
                         content=part.model_response(),
                     )
+            elif isinstance(part, AgentMessagePart):
+                yield UserChatMessageV2(role='user', content=f"[Agent '{part.agent_name}']: {part.content}")
             else:
                 assert_never(part)
 

--- a/pydantic_ai_slim/pydantic_ai/models/function.py
+++ b/pydantic_ai_slim/pydantic_ai/models/function.py
@@ -16,6 +16,7 @@ from .._instrumentation import get_instructions
 from .._run_context import RunContext
 from .._utils import PeekableAsyncStream
 from ..messages import (
+    AgentMessagePart,
     BinaryContent,
     CompactionPart,
     FilePart,
@@ -383,7 +384,7 @@ class FunctionStreamedResponse(StreamedResponse):
         return self._timestamp
 
 
-def _estimate_usage(messages: Iterable[ModelMessage]) -> usage.RequestUsage:
+def _estimate_usage(messages: Iterable[ModelMessage]) -> usage.RequestUsage:  # noqa: C901
     """Very rough guesstimate of the token usage associated with a series of messages.
 
     This is designed to be used solely to give plausible numbers for testing!
@@ -400,6 +401,8 @@ def _estimate_usage(messages: Iterable[ModelMessage]) -> usage.RequestUsage:
                     request_tokens += _estimate_string_tokens(part.model_response_str())
                 elif isinstance(part, RetryPromptPart):
                     request_tokens += _estimate_string_tokens(part.model_response())
+                elif isinstance(part, AgentMessagePart):
+                    request_tokens += _estimate_string_tokens(part.content)
                 else:
                     assert_never(part)
         elif isinstance(message, ModelResponse):

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -17,6 +17,7 @@ from .. import UnexpectedModelBehavior, _utils, usage
 from .._run_context import RunContext
 from ..exceptions import ModelAPIError, ModelHTTPError, UserError
 from ..messages import (
+    AgentMessagePart,
     BinaryContent,
     CachePoint,
     CompactionPart,
@@ -1029,6 +1030,8 @@ class GoogleModel(Model[Client]):
                                     }
                                 }
                             )
+                    elif isinstance(part, AgentMessagePart):
+                        message_parts.append({'text': f"[Agent '{part.agent_name}']: {part.content}"})
                     else:
                         assert_never(part)
 

--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -18,6 +18,7 @@ from .._thinking_part import split_content_into_text_and_thinking
 from .._utils import generate_tool_call_id, guard_tool_call_id as _guard_tool_call_id, number_to_datetime
 from ..exceptions import ModelAPIError, UserError
 from ..messages import (
+    AgentMessagePart,
     AudioUrl,
     BinaryContent,
     CachePoint,
@@ -624,7 +625,7 @@ class GroqModel(Model[AsyncGroq]):
                     tool_call_id=_guard_tool_call_id(t=part),
                     content=tool_text,
                 )
-            elif isinstance(part, RetryPromptPart):  # pragma: no branch
+            elif isinstance(part, RetryPromptPart):
                 if part.tool_name is None:
                     yield chat.ChatCompletionUserMessageParam(role='user', content=part.model_response())
                 else:
@@ -633,6 +634,10 @@ class GroqModel(Model[AsyncGroq]):
                         tool_call_id=_guard_tool_call_id(t=part),
                         content=part.model_response(),
                     )
+            elif isinstance(part, AgentMessagePart):
+                yield chat.ChatCompletionUserMessageParam(
+                    role='user', content=f"[Agent '{part.agent_name}']: {part.content}"
+                )
         if file_content:
             yield await self._map_user_prompt(UserPromptPart(content=file_content))
 

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -13,6 +13,7 @@ from .._run_context import RunContext
 from .._thinking_part import split_content_into_text_and_thinking
 from .._utils import guard_tool_call_id as _guard_tool_call_id
 from ..messages import (
+    AgentMessagePart,
     AudioUrl,
     BinaryContent,
     CachePoint,
@@ -486,6 +487,10 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                             'content': part.model_response(),
                         }
                     )
+            elif isinstance(part, AgentMessagePart):
+                yield ChatCompletionInputMessage.parse_obj_as_instance(  # type: ignore
+                    {'role': 'user', 'content': f"[Agent '{part.agent_name}']: {part.content}"}
+                )
             else:
                 assert_never(part)
         if file_content:

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -15,6 +15,7 @@ from .._run_context import RunContext
 from .._utils import generate_tool_call_id as _generate_tool_call_id, now_utc as _now_utc, number_to_datetime
 from ..exceptions import ModelAPIError
 from ..messages import (
+    AgentMessagePart,
     AudioUrl,
     BinaryContent,
     CachePoint,
@@ -565,6 +566,8 @@ class MistralModel(Model[Mistral]):
                         tool_call_id=part.tool_call_id,
                         content=part.model_response(),
                     )
+            elif isinstance(part, AgentMessagePart):
+                yield MistralUserMessage(content=f"[Agent '{part.agent_name}']: {part.content}")
             else:
                 assert_never(part)
         if file_content:

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -39,6 +39,7 @@ from .._utils import (
 from ..capabilities.abstract import AbstractCapability
 from ..exceptions import UserError
 from ..messages import (
+    AgentMessagePart,
     AudioUrl,
     BinaryContent,
     BinaryImage,
@@ -1529,6 +1530,10 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                         tool_call_id=_guard_tool_call_id(t=part),
                         content=part.model_response(),
                     )
+            elif isinstance(part, AgentMessagePart):
+                yield chat.ChatCompletionUserMessageParam(
+                    role='user', content=f"[Agent '{part.agent_name}']: {part.content}"
+                )
             else:
                 assert_never(part)
         if file_content:
@@ -2760,6 +2765,10 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                 output=part.model_response(),
                             )
                             openai_messages.append(item)
+                    elif isinstance(part, AgentMessagePart):
+                        openai_messages.append(
+                            Message(role='user', content=[{'type': 'input_text', 'text': f"[Agent '{part.agent_name}']: {part.content}"}])
+                        )
                     else:
                         assert_never(part)
             elif isinstance(message, ModelResponse):

--- a/pydantic_ai_slim/pydantic_ai/models/xai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/xai.py
@@ -16,6 +16,7 @@ from .._run_context import RunContext
 from ..capabilities.x_search import XSearch as XSearch  # re-export for backward compat
 from ..exceptions import ModelAPIError, UnexpectedModelBehavior, UserError
 from ..messages import (
+    AgentMessagePart,
     AudioUrl,
     BinaryContent,
     CachePoint,
@@ -375,6 +376,8 @@ class XaiModel(Model[AsyncClient]):
                     xai_messages.append(user(part.model_response()))
                 else:
                     tool_results.append(part)
+            elif isinstance(part, AgentMessagePart):
+                xai_messages.append(user(f"[Agent '{part.agent_name}']: {part.content}"))
             else:
                 assert_never(part)
 

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -20,6 +20,7 @@ from typing_extensions import assert_never
 from ... import ExternalToolset, ToolDefinition
 from ..._utils import is_str_dict
 from ...messages import (
+    AgentMessagePart,
     AudioUrl,
     BinaryContent,
     CachePoint,
@@ -679,6 +680,9 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     )
                 else:
                     user_content.append(TextInputContent(type='text', text=part.model_response()))
+            elif isinstance(part, AgentMessagePart):
+                # Agent messages are not displayed in the UI as user input
+                pass
             else:
                 assert_never(part)
 

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -16,6 +16,7 @@ from pydantic_ai._utils import is_str_dict as _is_str_dict
 
 from ... import _instructions
 from ...messages import (
+    AgentMessagePart,
     AudioUrl,
     BinaryContent,
     CachePoint,
@@ -632,6 +633,9 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                 else:
                     # Non-tool retries (e.g., output validation errors) become user text
                     user_ui_parts.append(TextUIPart(text=part.model_response(), state='done'))
+            elif isinstance(part, AgentMessagePart):
+                # Agent messages are not displayed in the UI as user input
+                pass
             else:
                 assert_never(part)
 

--- a/tests/test_agent_message_part.py
+++ b/tests/test_agent_message_part.py
@@ -1,0 +1,223 @@
+"""Tests for AgentMessagePart across all provider adapters and UI adapters."""
+
+from __future__ import annotations
+
+import pytest
+
+from pydantic_ai import AgentMessagePart, ModelRequest
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models.test import TestModel
+
+from .conftest import try_import
+
+with try_import() as openai_imports:
+    from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+with try_import() as anthropic_imports:
+    from pydantic_ai.models.anthropic import AnthropicModel
+    from pydantic_ai.providers.anthropic import AnthropicProvider
+
+with try_import() as google_imports:
+    from pydantic_ai.models.google import GoogleModel
+    from pydantic_ai.providers.google import GoogleProvider
+
+with try_import() as groq_imports:
+    from pydantic_ai.models.groq import GroqModel
+    from pydantic_ai.providers.groq import GroqProvider
+
+with try_import() as mistral_imports:
+    from pydantic_ai.models.mistral import MistralModel
+    from pydantic_ai.providers.mistral import MistralProvider
+
+with try_import() as cohere_imports:
+    from pydantic_ai.models.cohere import CohereModel
+    from pydantic_ai.providers.cohere import CohereProvider
+
+with try_import() as huggingface_imports:
+    from pydantic_ai.models.huggingface import HuggingFaceModel
+    from pydantic_ai.providers.huggingface import HuggingFaceProvider
+
+with try_import() as xai_imports:
+    from pydantic_ai.models.xai import XaiModel
+    from pydantic_ai.providers.xai import XaiProvider
+
+with try_import() as bedrock_imports:
+    from pydantic_ai.models.bedrock import BedrockConverseModel
+    from pydantic_ai.providers.bedrock import BedrockProvider
+
+
+def _imports_ok(check_fn):
+    return check_fn()
+
+AGENT_MSG = AgentMessagePart(agent_name='researcher', content='Analysis complete.')
+EXPECTED_PREFIX = "[Agent 'researcher']"
+EXPECTED_CONTENT = 'Analysis complete.'
+
+
+def _make_request() -> ModelRequest:
+    return ModelRequest(parts=[AGENT_MSG])
+
+
+# --- OpenAI Chat Completions ---
+
+
+@pytest.mark.skipif(not openai_imports(), reason='openai not installed')
+async def test_openai_chat_maps_agent_message_part():
+    model = OpenAIChatModel('gpt-4o', provider=OpenAIProvider(api_key='test'))
+    messages = await model._map_messages([_make_request()], ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
+    # Find the user message with agent content
+    user_msgs = [m for m in messages if m.get('role') == 'user']
+    assert len(user_msgs) >= 1
+    assert any(EXPECTED_PREFIX in str(m.get('content', '')) for m in user_msgs)
+    assert any(EXPECTED_CONTENT in str(m.get('content', '')) for m in user_msgs)
+
+
+# --- OpenAI Responses API ---
+
+
+@pytest.mark.skipif(not openai_imports(), reason='openai not installed')
+async def test_openai_responses_maps_agent_message_part():
+    model = OpenAIResponsesModel('gpt-4o', provider=OpenAIProvider(api_key='test'))
+    _, messages = await model._map_messages([_make_request()], {}, ModelRequestParameters())  # pyright: ignore[reportPrivateUsage,reportArgumentType]
+    # The agent message should appear as a user message with the agent-prefixed content
+    all_content = str(messages)
+    assert EXPECTED_PREFIX in all_content
+    assert EXPECTED_CONTENT in all_content
+
+
+# --- Anthropic ---
+
+
+@pytest.mark.skipif(not anthropic_imports(), reason='anthropic not installed')
+async def test_anthropic_maps_agent_message_part():
+    model = AnthropicModel('claude-3-5-sonnet-latest', provider=AnthropicProvider(api_key='test'))
+    system, messages = await model._map_message([_make_request()], ModelRequestParameters(), {})  # pyright: ignore[reportPrivateUsage]
+    # Agent message should be in a user message as a text block
+    all_content = str(messages)
+    assert EXPECTED_PREFIX in all_content
+    assert EXPECTED_CONTENT in all_content
+
+
+# --- Google ---
+
+
+@pytest.mark.skipif(not google_imports(), reason='google not installed')
+async def test_google_maps_agent_message_part():
+    model = GoogleModel('gemini-1.5-flash', provider=GoogleProvider(api_key='test'))
+    _, contents = await model._map_messages([_make_request()], ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
+    all_content = str(contents)
+    assert EXPECTED_PREFIX in all_content
+    assert EXPECTED_CONTENT in all_content
+
+
+# --- Bedrock ---
+
+
+@pytest.mark.skipif(not bedrock_imports(), reason='bedrock not installed')
+async def test_bedrock_maps_agent_message_part():
+    model = BedrockConverseModel('anthropic.claude-3-5-sonnet-20241022-v2:0', provider=BedrockProvider(region_name='us-east-1'))
+    _, messages = await model._map_messages([_make_request()], ModelRequestParameters(), None)  # pyright: ignore[reportPrivateUsage]
+    all_content = str(messages)
+    assert EXPECTED_PREFIX in all_content
+    assert EXPECTED_CONTENT in all_content
+
+
+# --- Groq ---
+
+
+@pytest.mark.skipif(not groq_imports(), reason='groq not installed')
+async def test_groq_maps_agent_message_part():
+    model = GroqModel('llama-3.3-70b-versatile', provider=GroqProvider(api_key='test'))
+    messages = await model._map_messages([_make_request()], ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
+    user_msgs = [m for m in messages if m.get('role') == 'user']
+    assert len(user_msgs) >= 1
+    assert any(EXPECTED_PREFIX in str(m.get('content', '')) for m in user_msgs)
+
+
+# --- Mistral ---
+
+
+@pytest.mark.skipif(not mistral_imports(), reason='mistral not installed')
+async def test_mistral_maps_agent_message_part():
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(api_key='test'))
+    messages = await model._map_messages([_make_request()], ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
+    all_content = str(messages)
+    assert EXPECTED_PREFIX in all_content
+    assert EXPECTED_CONTENT in all_content
+
+
+# --- Cohere ---
+
+
+@pytest.mark.skipif(not cohere_imports(), reason='cohere not installed')
+async def test_cohere_maps_agent_message_part():
+    model = CohereModel('command-r-plus', provider=CohereProvider(api_key='test'))
+    messages = model._map_messages([_make_request()], ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
+    all_content = str(messages)
+    assert EXPECTED_PREFIX in all_content
+    assert EXPECTED_CONTENT in all_content
+
+
+# --- HuggingFace ---
+
+
+@pytest.mark.skipif(not huggingface_imports(), reason='huggingface not installed')
+async def test_huggingface_maps_agent_message_part():
+    model = HuggingFaceModel('meta-llama/Llama-3.1-8B-Instruct', provider=HuggingFaceProvider(api_key='test'))
+    messages = await model._map_messages([_make_request()], ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
+    all_content = str(messages)
+    assert EXPECTED_PREFIX in all_content
+    assert EXPECTED_CONTENT in all_content
+
+
+# --- xAI ---
+
+
+@pytest.mark.skipif(not xai_imports(), reason='xai not installed')
+async def test_xai_maps_agent_message_part():
+    model = XaiModel('grok-2', provider=XaiProvider(api_key='test'))
+    messages = await model._map_messages([_make_request()], ModelRequestParameters())  # pyright: ignore[reportPrivateUsage]
+    all_content = str(messages)
+    # xAI uses protobuf format which escapes single quotes
+    assert 'researcher' in all_content
+    assert EXPECTED_CONTENT in all_content
+
+
+# --- TestModel ---
+
+
+async def test_test_model_handles_agent_message_part():
+    """TestModel should not crash when message history contains AgentMessagePart."""
+    model = TestModel()
+    # TestModel._process_request should handle the message without crashing
+    response = await model.request([_make_request()], None, ModelRequestParameters())  # pyright: ignore[reportArgumentType]
+    assert response is not None
+
+
+# --- Vercel AI UI adapter ---
+
+
+async def test_vercel_ai_adapter_skips_agent_message_part():
+    """Vercel AI adapter should skip AgentMessagePart (not crash, not display as user input)."""
+    from pydantic_ai.ui.vercel_ai import VercelAIAdapter
+
+    # _dump_request_message is a static method
+    system_parts, user_parts = VercelAIAdapter._dump_request_message(_make_request())  # pyright: ignore[reportPrivateUsage]
+    # AgentMessagePart should not appear in either system or user UI parts
+    assert len(system_parts) == 0
+    assert len(user_parts) == 0
+
+
+# --- AG-UI adapter ---
+
+
+async def test_ag_ui_adapter_skips_agent_message_part():
+    """AG-UI adapter should skip AgentMessagePart (not crash, not display as user input)."""
+    from pydantic_ai.ui.ag_ui import AGUIAdapter
+
+    # dump_messages is a classmethod
+    messages = AGUIAdapter.dump_messages([_make_request()])  # pyright: ignore[reportAttributeAccessIssue]
+    # AgentMessagePart should not appear in the dumped messages as user content
+    all_content = str(messages)
+    assert EXPECTED_CONTENT not in all_content or EXPECTED_PREFIX not in all_content

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -12,6 +12,7 @@ from pydantic import TypeAdapter
 
 from pydantic_ai import (
     Agent,
+    AgentMessagePart,
     AgentStreamEvent,
     AudioUrl,
     BinaryContent,
@@ -1992,3 +1993,35 @@ def test_narrow_message_parts_promotes_valid_claims_and_leaves_plain_parts():
     assert type(narrowed[0].parts[0]) is LoadCapabilityCallPart
     assert narrowed[0].parts[1] is messages[0].parts[1]
     assert type(narrowed[1].parts[0]) is LoadCapabilityReturnPart
+
+
+def test_agent_message_part_roundtrip():
+    """AgentMessagePart serializes and deserializes through ModelMessagesTypeAdapter."""
+    part = AgentMessagePart(agent_name='researcher', content='Task complete.')
+    request = ModelRequest(parts=[part])
+    serialized = ModelMessagesTypeAdapter.dump_json([request])
+    deserialized = ModelMessagesTypeAdapter.validate_json(serialized)
+    assert deserialized[0].parts[0].agent_name == 'researcher'
+    assert deserialized[0].parts[0].content == 'Task complete.'
+    assert deserialized[0].parts[0].part_kind == 'agent-message'
+    assert deserialized[0].parts[0].message_type == 'result'
+
+
+def test_agent_message_part_otel():
+    """AgentMessagePart produces correct OTel message parts."""
+    settings = InstrumentationSettings()
+    part = AgentMessagePart(agent_name='helper', content='Done!')
+    otel_parts = part.otel_message_parts(settings)
+    assert len(otel_parts) == 1
+    assert otel_parts[0]['type'] == 'text'
+
+
+def test_enqueue_agent_message_part():
+    """AgentMessagePart is treated as a part-style item in _build_enqueue_messages."""
+    from pydantic_ai._enqueue import _build_enqueue_messages
+
+    part = AgentMessagePart(agent_name='worker', content='Result here')
+    messages = _build_enqueue_messages([part])
+    assert len(messages) == 1
+    assert isinstance(messages[0], ModelRequest)
+    assert messages[0].parts[0] is part


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

- Closes #

## Summary

This PR introduces `AgentMessagePart`, a new `ModelRequestPart` type for inter-agent communication. It represents messages from other agents (subagent results, progress updates, error notifications) injected into the current agent''s conversation via `RunContext.enqueue`.

### Design

- `AgentMessagePart` is a `ModelRequestPart` with `part_kind=''agent-message''`, carrying `agent_name`, `content`, `message_type` (`''result''` | `''progress''` | `''error''` | `''notification''`), `timestamp`, and optional `metadata`.
- All provider adapters map it to a `role=''user''` text message formatted as `[Agent ''{agent_name}'']: {content}`, consistent with how non-tool `RetryPromptPart` is handled.
- UI adapters (Vercel AI, AG-UI) skip `AgentMessagePart` so it is not displayed as user input.
- `_estimate_usage` in `function.py` counts `AgentMessagePart.content` tokens toward request tokens.
- `AgentMessagePart` is exported from `pydantic_ai` top-level and added to the `ModelRequestPart` union.

### Files changed (19 files, +388/-23)

- `messages.py` — `AgentMessagePart` class definition + union type
- `__init__.py` — export
- `_enqueue.py` — isinstance check for enqueue coalescing
- `models/function.py` — `_estimate_usage` token counting
- 9 provider adapters (`openai.py` x2, `anthropic.py`, `google.py`, `bedrock.py`, `groq.py`, `mistral.py`, `cohere.py`, `huggingface.py`, `xai.py`)
- 2 UI adapters (`vercel_ai/_adapter.py`, `ag_ui/_adapter.py`)
- `docs/api/messages.md` — mermaid graph
- `docs/message-history.md` — enqueue docs
- `tests/test_messages.py` — roundtrip, OTel, enqueue tests
- `tests/test_agent_message_part.py` — cross-provider adapter tests

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** — `AgentMessagePart` is purely additive to the `ModelRequestPart` union.
- [x] **PR title** is fit for the release changelog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

