### PR TITLE
fix: preserve keywords alongside an inlined `$ref` in `InlineDefsJsonSchemaTransformer`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_json_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_json_schema.py
@@ -89,6 +89,7 @@ class JsonSchemaTransformer(ABC):
             return schema
 
         nested_refs = 0
+        ref_siblings: JsonSchema = {}
         if self.prefer_inlined_defs:
             while ref := schema.get('$ref'):
                 key = re.sub(r'^#/\$defs/', '', ref)
@@ -99,6 +100,12 @@ class JsonSchemaTransformer(ABC):
                     break  # recursive ref can't be unpacked
                 self.refs_stack.append(key)
                 nested_refs += 1
+
+                # Keep any keywords that accompany the `$ref` (e.g. a field-level
+                # `description`); resolving the ref below replaces the whole node.
+                for k, v in schema.items():
+                    if k != '$ref':
+                        ref_siblings.setdefault(k, v)
 
                 def_schema = self.defs.get(key)
                 if def_schema is None:  # pragma: no cover
@@ -118,6 +125,12 @@ class JsonSchemaTransformer(ABC):
 
         # Apply the base transform
         schema = self.transform(schema)
+
+        # Re-apply the keywords that accompanied an inlined `$ref` (e.g. a field-level
+        # `description`) so they are preserved rather than dropped, matching JSON Schema
+        # 2020-12 sibling semantics and the non-inlining transformers.
+        if ref_siblings and isinstance(schema, dict):
+            schema = {**schema, **ref_siblings}
 
         if nested_refs > 0:
             self.refs_stack = self.refs_stack[:-nested_refs]

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -193,3 +193,34 @@ def test_allof_with_refs_is_inlined():
     assert 'allOf' in result
     assert result['allOf'][0] == {'type': 'object', 'properties': {'a': {'type': 'string'}}}
     assert result['allOf'][1] == {'type': 'object', 'properties': {'b': {'type': 'integer'}}}
+
+
+def test_inline_defs_preserves_ref_siblings():
+    """InlineDefsJsonSchemaTransformer should keep keys that sit alongside a `$ref`.
+
+    Pydantic emits a nested-model field as `{'$ref': ..., 'description': ...}` (JSON
+    Schema 2020-12 sibling semantics). Before the fix, inlining replaced the whole node
+    with the referenced definition, dropping the sibling `description`. This is a unit
+    test pinning the internal walk shape because the schema transformer is an internal
+    helper used by providers, and a VCR test wouldn't catch the dropped description since
+    cassette matchers aren't sensitive to the request body.
+    """
+
+    from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'inner': {'$ref': '#/$defs/Inner', 'description': 'the inner thing'},
+        },
+        '$defs': {
+            'Inner': {'type': 'object', 'properties': {'a': {'type': 'string'}}},
+        },
+    }
+
+    result = InlineDefsJsonSchemaTransformer(deepcopy(schema)).walk()
+
+    inner = result['properties']['inner']
+    assert inner['type'] == 'object'
+    assert inner['description'] == 'the inner thing'
+    assert '$defs' not in result


### PR DESCRIPTION
<!-- No linked issue: this is a narrow, self-contained bug fix (data loss) with an obvious correct behavior. Happy to open an issue first if you'd prefer. -->

### The bug

`InlineDefsJsonSchemaTransformer` silently drops the `description` (and any other keyword) that sits alongside a `$ref` when it inlines the definition.

Pydantic emits a nested-model field exactly as `{'$ref': ..., 'description': ...}` (JSON Schema 2020-12 sibling semantics):

```python
from pydantic import BaseModel, Field
from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer

class Inner(BaseModel):
    a: str

class Outer(BaseModel):
    inner: Inner = Field(description='the inner thing')

raw = Outer.model_json_schema()
# raw['properties']['inner'] == {'$ref': '#/$defs/Inner', 'description': 'the inner thing'}

walked = InlineDefsJsonSchemaTransformer(raw).walk()
# before this PR: walked['properties']['inner'] has NO 'description' — it was dropped
```

In `JsonSchemaTransformer._handle`, the inline loop resolves the ref with `schema = def_schema`, which replaces the whole node with the referenced definition and discards every key that accompanied the `$ref` — most importantly the field-level `description`.

So a referenced-model field loses its description on every model that uses the inline transformer (Meta/Llama, Amazon Nova/Titan, Qwen, and OpenRouter's legacy Google path). The non-inlining transformers don't have this problem — OpenAI rewrites the field to `{'description': ..., 'anyOf': [{'$ref': ...}]}` and Google keeps `{'$ref': ..., 'description': ...}` — so the inline path is the inconsistent outlier, and the model loses schema information the user deliberately provided.

### The fix

Capture the non-`$ref` keywords before inlining and re-apply them after the transform, so a field-level `description` is preserved and wins over the definition's own (matching what OpenAI/Google already do). The change is confined to the inline path: `ref_siblings` is only populated under `prefer_inlined_defs`, so the non-inlining transformers are untouched. Recursive `$ref` handling is unaffected because the recursive-ref break path never reassigns `schema`.

### Test

Added a unit test (`test_inline_defs_preserves_ref_siblings`) that pins the internal walk shape — as with the neighboring `test_allof_with_refs_is_inlined`, this is internal provider-agnostic transformer logic, and a VCR test wouldn't catch the dropped description since cassette matchers aren't sensitive to the request body. It fails before the change (`KeyError: 'description'`) and passes after.

Verified locally: `tests/test_json_schema.py`, `tests/test_tools.py`, and `tests/profiles` all pass (152 + 185); `pyright` and `ruff` are clean on the changed files.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- Disclosure: this change was drafted with AI assistance and will be reviewed line-by-line by me (the human author) before I check the AI box above. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

