### PR TITLE
Fix `RenamedToolset` silently dropping a tool on a name collision

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/toolsets/renamed.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/renamed.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, replace
 from typing import Any
 
 from .._run_context import AgentDepsT, RunContext
+from ..exceptions import UserError
 from .abstract import ToolsetTool
 from .wrapper import WrapperToolset
 
@@ -23,6 +24,12 @@ class RenamedToolset(WrapperToolset[AgentDepsT]):
         tools: dict[str, ToolsetTool[AgentDepsT]] = {}
         for original_name, tool in original_tools.items():
             new_name = original_to_new_name_map.get(original_name, None)
+            final_name = new_name or original_name
+            if final_name in tools:
+                if final_name != original_name:
+                    raise UserError(f'Renaming tool {original_name!r} to {final_name!r} conflicts with existing tool.')
+                else:
+                    raise UserError(f'Tool name conflicts with previously renamed tool: {final_name!r}.')
             if new_name:
                 tools[new_name] = replace(
                     tool,

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1494,6 +1494,32 @@ async def test_wrapper_toolsets_delegate_instructions():
     assert await prepared_toolset.get_instructions(ctx) == base_instructions
 
 
+async def test_renamed_toolset_name_collision():
+    """Renaming a tool onto a name another tool already occupies must raise, not silently drop one.
+
+    This is the same conflict `FunctionToolset.get_tools` already raises on; `RenamedToolset` was the
+    lone wrapper that overwrote silently. It's a config-time guard with no model involved, so there is
+    no VCR test to write here.
+    """
+
+    def a(x: int) -> int:  # pragma: no cover
+        return x
+
+    def b(x: int) -> int:  # pragma: no cover
+        return x
+
+    toolset = FunctionToolset(tools=[Tool(a), Tool(b)])
+    ctx = build_run_context(None)
+
+    # Renaming `a` to `b` collides with the existing `b`.
+    with pytest.raises(UserError, match=re.escape("Tool name conflicts with previously renamed tool: 'b'.")):
+        await toolset.renamed({'b': 'a'}).get_tools(ctx)
+
+    # A genuine swap is not a collision and must preserve both tools.
+    swapped = await toolset.renamed({'b': 'a', 'a': 'b'}).get_tools(ctx)
+    assert sorted(swapped.keys()) == ['a', 'b']
+
+
 async def test_combined_toolset_instructions():
     """Test that CombinedToolset aggregates instructions from all contained toolsets."""
     instructions1 = 'Instructions from toolset 1.'

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1511,9 +1511,13 @@ async def test_renamed_toolset_name_collision():
     toolset = FunctionToolset(tools=[Tool(a), Tool(b)])
     ctx = build_run_context(None)
 
-    # Renaming `a` to `b` collides with the existing `b`.
+    # Renaming `a` to `b`: the unchanged `b` then lands on the taken name.
     with pytest.raises(UserError, match=re.escape("Tool name conflicts with previously renamed tool: 'b'.")):
         await toolset.renamed({'b': 'a'}).get_tools(ctx)
+
+    # Renaming `b` to `a`: the renamed tool lands on the existing `a`.
+    with pytest.raises(UserError, match=re.escape("Renaming tool 'b' to 'a' conflicts with existing tool.")):
+        await toolset.renamed({'a': 'b'}).get_tools(ctx)
 
     # A genuine swap is not a collision and must preserve both tools.
     swapped = await toolset.renamed({'b': 'a', 'a': 'b'}).get_tools(ctx)


### PR DESCRIPTION
Closes #6461

`RenamedToolset.get_tools` writes its output dict unconditionally, so renaming a tool onto a name another tool already occupies silently overwrites one of them — the model loses access to a tool with no error, and which one survives depends on iteration order.

Every sibling wrapper already raises `UserError` on this exact conflict — `FunctionToolset`, `CombinedToolset`, and `PreparedToolset` — so `RenamedToolset` was the lone outlier that swallowed it. This adds the same guard and reuses `FunctionToolset`'s two existing error messages.

Before/after: a toolset with tools `a` and `b` wrapped with `.renamed({'b': 'a'})` returned just `{'b'}` (tool `a` silently gone); it now raises `UserError`. A genuine swap `.renamed({'b': 'a', 'a': 'b'})` is unaffected and still returns both tools.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

