### PR TITLE
Filter unconfigured Anthropic native tool calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -592,14 +592,16 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         model_settings = cast(AnthropicModelSettings, model_settings or {})
         try:
             response = await self._messages_create(messages, False, model_settings, model_request_parameters)
-            return self._process_response(response, model_request_parameters)
+            return self._process_response(response, model_request_parameters, model_settings)
         except ValueError as e:
             if 'Streaming is required' in str(e):
                 # Anthropic SDK requires streaming for high max_tokens; fall back transparently
                 # https://github.com/anthropics/anthropic-sdk-python/blob/49d639a671cb0ac30c767e8e1e68fdd5925205d5/src/anthropic/_base_client.py#L726
                 stream = await self._messages_create(messages, True, model_settings, model_request_parameters)
                 async with stream:
-                    streamed_response = await self._process_streamed_response(stream, model_request_parameters)
+                    streamed_response = await self._process_streamed_response(
+                        stream, model_request_parameters, model_settings
+                    )
                     async for _ in streamed_response:
                         pass
                     return streamed_response.get()
@@ -635,11 +637,10 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             model_settings,
             model_request_parameters,
         )
-        response = await self._messages_create(
-            messages, True, cast(AnthropicModelSettings, model_settings or {}), model_request_parameters
-        )
+        model_settings = cast(AnthropicModelSettings, model_settings or {})
+        response = await self._messages_create(messages, True, model_settings, model_request_parameters)
         async with response:
-            yield await self._process_streamed_response(response, model_request_parameters)
+            yield await self._process_streamed_response(response, model_request_parameters, model_settings)
 
     def prepare_request(
         self, model_settings: ModelSettings | None, model_request_parameters: ModelRequestParameters
@@ -1025,19 +1026,35 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             )
 
     def _process_response(  # noqa: C901
-        self, response: BetaMessage, model_request_parameters: ModelRequestParameters
+        self,
+        response: BetaMessage,
+        model_request_parameters: ModelRequestParameters,
+        model_settings: AnthropicModelSettings,
     ) -> ModelResponse:
         """Process a non-streamed response, and prepare a message to return."""
         items: list[ModelResponsePart] = []
         builtin_tool_calls: dict[str, NativeToolCallPart] = {}
-        enabled_native_tool_kinds = self._get_enabled_native_tool_kinds(model_request_parameters)
+        enabled_server_tool_names = self._get_enabled_server_tool_names(model_request_parameters, model_settings)
+        server_tool_result_ids = {
+            item.tool_use_id
+            for item in response.content
+            if isinstance(
+                item,
+                BetaWebSearchToolResultBlock
+                | BetaWebFetchToolResultBlock
+                | BetaCodeExecutionToolResultBlock
+                | BetaBashCodeExecutionToolResultBlock
+                | BetaTextEditorCodeExecutionToolResultBlock
+                | BetaToolSearchToolResultBlock,
+            )
+        }
         for item in response.content:
             if isinstance(item, BetaTextBlock):
                 items.append(TextPart(content=item.text))
             elif isinstance(item, BetaServerToolUseBlock):
-                call_part = _map_server_tool_use_block(item, self.system)
-                if call_part.tool_name not in enabled_native_tool_kinds:
+                if item.name not in enabled_server_tool_names and item.id not in server_tool_result_ids:
                     continue
+                call_part = _map_server_tool_use_block(item, self.system)
                 builtin_tool_calls[call_part.tool_call_id] = call_part
                 items.append(call_part)
             elif isinstance(item, BetaWebSearchToolResultBlock):
@@ -1103,21 +1120,36 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             provider_details=provider_details,
         )
 
-    def _get_enabled_native_tool_kinds(self, model_request_parameters: ModelRequestParameters) -> frozenset[str]:
-        enabled_native_tool_kinds = {
-            tool.kind
-            for tool in model_request_parameters.native_tools
-            if not isinstance(tool, ToolSearchTool) or tool.strategy != 'custom'
-        }
-        # The 20260209 web tools run dynamic filters through an implicit code execution tool.
+    def _get_enabled_server_tool_names(
+        self, model_request_parameters: ModelRequestParameters, model_settings: AnthropicModelSettings
+    ) -> frozenset[str]:
+        """Wire names that may legitimately appear in a `server_tool_use` block for this request.
+
+        Derived from the same `_add_native_tools` call that builds the request payload, so the
+        filter can't drift from what is actually sent to the API.
+        """
+        native_tools, _, _ = self._add_native_tools([], model_request_parameters, model_settings)
+        # `BetaMCPToolsetParam` is the only union member without a `name`, and `_add_native_tools`
+        # never emits it into `tools` (MCP servers are returned separately).
+        enabled_server_tool_names = {tool['name'] for tool in native_tools if 'name' in tool}  # pragma: no branch
+        # The native memory tool is client-executed and surfaces as a regular `tool_use` block.
+        enabled_server_tool_names.discard('memory')
+
+        implicit_code_execution_names = {'code_execution', 'bash_code_execution', 'text_editor_code_execution'}
+        if 'code_execution' in enabled_server_tool_names:
+            enabled_server_tool_names.update(implicit_code_execution_names)
+        # The 20260209 web tools provision code execution for dynamic filtering server-side.
         if self.profile.get('anthropic_supports_dynamic_filtering', False) and any(
             isinstance(tool, WebSearchTool | WebFetchTool) for tool in model_request_parameters.native_tools
         ):
-            enabled_native_tool_kinds.add(CodeExecutionTool.kind)
-        return frozenset(enabled_native_tool_kinds)
+            enabled_server_tool_names.update(implicit_code_execution_names)
+        return frozenset(enabled_server_tool_names)
 
     async def _process_streamed_response(
-        self, response: AsyncStream[BetaRawMessageStreamEvent], model_request_parameters: ModelRequestParameters
+        self,
+        response: AsyncStream[BetaRawMessageStreamEvent],
+        model_request_parameters: ModelRequestParameters,
+        model_settings: AnthropicModelSettings,
     ) -> StreamedResponse:
         peekable_response: _utils.PeekableAsyncStream[
             BetaRawMessageStreamEvent, AsyncStream[BetaRawMessageStreamEvent]
@@ -1142,7 +1174,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             _response=peekable_response,
             _provider_name=self._provider.name,
             _provider_url=self._provider.base_url,
-            _enabled_native_tool_kinds=self._get_enabled_native_tool_kinds(model_request_parameters),
+            _enabled_server_tool_names=self._get_enabled_server_tool_names(model_request_parameters, model_settings),
         )
 
     def _get_code_execution_tool_version(
@@ -2391,7 +2423,7 @@ class AnthropicStreamedResponse(StreamedResponse):
     _response: _utils.PeekableAsyncStream[BetaRawMessageStreamEvent, AsyncStream[BetaRawMessageStreamEvent]]
     _provider_name: str
     _provider_url: str
-    _enabled_native_tool_kinds: frozenset[str] = field(default_factory=lambda: frozenset[str]())
+    _enabled_server_tool_names: frozenset[str]
     _timestamp: datetime = field(default_factory=_utils.now_utc)
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
@@ -2446,10 +2478,14 @@ class AnthropicStreamedResponse(StreamedResponse):
                         if maybe_event is not None:  # pragma: no branch
                             yield maybe_event
                     elif isinstance(current_block, BetaServerToolUseBlock):
-                        call_part = _map_server_tool_use_block(current_block, self.provider_name)
-                        if call_part.tool_name not in self._enabled_native_tool_kinds:
+                        if current_block.name not in self._enabled_server_tool_names:
+                            # Unlike non-streaming, this cannot pre-scan later result blocks, so a gap in the
+                            # enabled-name set would leave their return part orphaned. Result presence is only
+                            # advisory: newer web tools can omit paired blocks with `response_inclusion: "excluded"`,
+                            # which pydantic-ai does not currently send.
                             ignored_server_tool_use_indices.add(event.index)
                             continue
+                        call_part = _map_server_tool_use_block(current_block, self.provider_name)
                         builtin_tool_calls[call_part.tool_call_id] = call_part
                         # In streaming, the block's `input` is empty at start and arrives via
                         # subsequent `BetaInputJSONDelta` events. Emit with `args=None` so the

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -592,7 +592,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         model_settings = cast(AnthropicModelSettings, model_settings or {})
         try:
             response = await self._messages_create(messages, False, model_settings, model_request_parameters)
-            return self._process_response(response)
+            return self._process_response(response, model_request_parameters)
         except ValueError as e:
             if 'Streaming is required' in str(e):
                 # Anthropic SDK requires streaming for high max_tokens; fall back transparently
@@ -1024,15 +1024,20 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                 extra_body=model_settings.get('extra_body'),
             )
 
-    def _process_response(self, response: BetaMessage) -> ModelResponse:  # noqa: C901
+    def _process_response(  # noqa: C901
+        self, response: BetaMessage, model_request_parameters: ModelRequestParameters
+    ) -> ModelResponse:
         """Process a non-streamed response, and prepare a message to return."""
         items: list[ModelResponsePart] = []
         builtin_tool_calls: dict[str, NativeToolCallPart] = {}
+        enabled_native_tool_kinds = self._get_enabled_native_tool_kinds(model_request_parameters)
         for item in response.content:
             if isinstance(item, BetaTextBlock):
                 items.append(TextPart(content=item.text))
             elif isinstance(item, BetaServerToolUseBlock):
                 call_part = _map_server_tool_use_block(item, self.system)
+                if call_part.tool_name not in enabled_native_tool_kinds:
+                    continue
                 builtin_tool_calls[call_part.tool_call_id] = call_part
                 items.append(call_part)
             elif isinstance(item, BetaWebSearchToolResultBlock):
@@ -1098,6 +1103,19 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             provider_details=provider_details,
         )
 
+    def _get_enabled_native_tool_kinds(self, model_request_parameters: ModelRequestParameters) -> frozenset[str]:
+        enabled_native_tool_kinds = {
+            tool.kind
+            for tool in model_request_parameters.native_tools
+            if not isinstance(tool, ToolSearchTool) or tool.strategy != 'custom'
+        }
+        # The 20260209 web tools run dynamic filters through an implicit code execution tool.
+        if self.profile.get('anthropic_supports_dynamic_filtering', False) and any(
+            isinstance(tool, WebSearchTool | WebFetchTool) for tool in model_request_parameters.native_tools
+        ):
+            enabled_native_tool_kinds.add(CodeExecutionTool.kind)
+        return frozenset(enabled_native_tool_kinds)
+
     async def _process_streamed_response(
         self, response: AsyncStream[BetaRawMessageStreamEvent], model_request_parameters: ModelRequestParameters
     ) -> StreamedResponse:
@@ -1124,6 +1142,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
             _response=peekable_response,
             _provider_name=self._provider.name,
             _provider_url=self._provider.base_url,
+            _enabled_native_tool_kinds=self._get_enabled_native_tool_kinds(model_request_parameters),
         )
 
     def _get_code_execution_tool_version(
@@ -2372,11 +2391,13 @@ class AnthropicStreamedResponse(StreamedResponse):
     _response: _utils.PeekableAsyncStream[BetaRawMessageStreamEvent, AsyncStream[BetaRawMessageStreamEvent]]
     _provider_name: str
     _provider_url: str
+    _enabled_native_tool_kinds: frozenset[str] = field(default_factory=lambda: frozenset[str]())
     _timestamp: datetime = field(default_factory=_utils.now_utc)
 
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
         with _map_api_errors(self._model_name):
             current_block: BetaContentBlock | None = None
+            ignored_server_tool_use_indices: set[int] = set()
 
             builtin_tool_calls: dict[str, NativeToolCallPart] = {}
             async for event in self._response:
@@ -2426,6 +2447,9 @@ class AnthropicStreamedResponse(StreamedResponse):
                             yield maybe_event
                     elif isinstance(current_block, BetaServerToolUseBlock):
                         call_part = _map_server_tool_use_block(current_block, self.provider_name)
+                        if call_part.tool_name not in self._enabled_native_tool_kinds:
+                            ignored_server_tool_use_indices.add(event.index)
+                            continue
                         builtin_tool_calls[call_part.tool_call_id] = call_part
                         # In streaming, the block's `input` is empty at start and arrives via
                         # subsequent `BetaInputJSONDelta` events. Emit with `args=None` so the
@@ -2501,6 +2525,8 @@ class AnthropicStreamedResponse(StreamedResponse):
                         )
 
                 elif isinstance(event, BetaRawContentBlockDeltaEvent):
+                    if event.index in ignored_server_tool_use_indices:
+                        continue
                     if isinstance(event.delta, BetaTextDelta):
                         for event_ in self._parts_manager.handle_text_delta(
                             vendor_part_id=event.index, content=event.delta.text
@@ -2557,7 +2583,9 @@ class AnthropicStreamedResponse(StreamedResponse):
                         self.provider_details['container_id'] = event.delta.container.id
 
                 elif isinstance(event, BetaRawContentBlockStopEvent):  # pragma: no branch
-                    if isinstance(current_block, BetaMCPToolUseBlock):
+                    if event.index in ignored_server_tool_use_indices:
+                        ignored_server_tool_use_indices.remove(event.index)
+                    elif isinstance(current_block, BetaMCPToolUseBlock):
                         maybe_event = self._parts_manager.handle_tool_call_delta(
                             vendor_part_id=event.index,
                             args='}',

--- a/tests/models/anthropic/test_native_tool_filtering.py
+++ b/tests/models/anthropic/test_native_tool_filtering.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
 
-from pydantic_ai import Agent, ModelMessage, ModelRequest, NativeToolCallPart, UserPromptPart
+from pydantic_ai import Agent, ModelMessage, ModelRequest, NativeToolCallPart, NativeToolReturnPart, UserPromptPart
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.native_tools import AbstractNativeTool, CodeExecutionTool, WebFetchTool
+from pydantic_ai.native_tools._tool_search import ToolSearchTool
 
 from ...conftest import try_import
 from ..test_anthropic import MockAnthropic, completion_message, get_mock_chat_completion_kwargs
 
 with try_import() as imports_successful:
     from anthropic.types.beta import (
+        BetaCodeExecutionResultBlock,
+        BetaCodeExecutionToolResultBlock,
         BetaDirectCaller,
         BetaInputJSONDelta,
         BetaMessage,
@@ -39,19 +44,31 @@ pytestmark = [
 ]
 
 _TOOL_CALL_ID = 'srvtoolu_test'
+ServerToolName = Literal[
+    'advisor',
+    'web_search',
+    'web_fetch',
+    'code_execution',
+    'bash_code_execution',
+    'text_editor_code_execution',
+    'tool_search_tool_regex',
+    'tool_search_tool_bm25',
+]
 
 
-def _code_execution_call() -> BetaServerToolUseBlock:
+def _server_tool_call(name: ServerToolName, input: dict[str, object]) -> BetaServerToolUseBlock:
     return BetaServerToolUseBlock(
         id=_TOOL_CALL_ID,
-        name='code_execution',
-        input={'code': 'print(1)'},
+        name=name,
+        input=input,
         type='server_tool_use',
         caller=BetaDirectCaller(type='direct'),
     )
 
 
-def _code_execution_stream() -> list[BetaRawMessageStreamEvent]:
+def _server_tool_stream(
+    name: ServerToolName, input_delta: str = '{"code":"print(1)"}'
+) -> list[BetaRawMessageStreamEvent]:
     return [
         BetaRawMessageStartEvent(
             type='message_start',
@@ -70,7 +87,7 @@ def _code_execution_stream() -> list[BetaRawMessageStreamEvent]:
             index=0,
             content_block=BetaServerToolUseBlock(
                 id=_TOOL_CALL_ID,
-                name='code_execution',
+                name=name,
                 input={},
                 type='server_tool_use',
                 caller=BetaDirectCaller(type='direct'),
@@ -79,7 +96,7 @@ def _code_execution_stream() -> list[BetaRawMessageStreamEvent]:
         BetaRawContentBlockDeltaEvent(
             type='content_block_delta',
             index=0,
-            delta=BetaInputJSONDelta(type='input_json_delta', partial_json='{"code":"print(1)"}'),
+            delta=BetaInputJSONDelta(type='input_json_delta', partial_json=input_delta),
         ),
         BetaRawContentBlockStopEvent(type='content_block_stop', index=0),
         BetaRawMessageDeltaEvent(
@@ -93,24 +110,60 @@ def _code_execution_stream() -> list[BetaRawMessageStreamEvent]:
 
 @pytest.mark.parametrize('stream', [False, True])
 @pytest.mark.parametrize(
-    ('native_tools', 'expected_call'),
+    ('server_tool_name', 'input', 'input_delta', 'native_tools', 'expected_call'),
     [
-        pytest.param([], False, id='unconfigured'),
-        pytest.param([CodeExecutionTool()], True, id='configured'),
-        pytest.param([WebFetchTool()], True, id='implicitly-enabled-by-web-fetch'),
+        pytest.param('code_execution', {'code': 'print(1)'}, '{"code":"print(1)"}', [], False, id='unconfigured'),
+        pytest.param(
+            'code_execution',
+            {'code': 'print(1)'},
+            '{"code":"print(1)"}',
+            [CodeExecutionTool()],
+            True,
+            id='configured',
+        ),
+        pytest.param(
+            'code_execution',
+            {'code': 'print(1)'},
+            '{"code":"print(1)"}',
+            [WebFetchTool()],
+            True,
+            id='implicitly-enabled-by-web-fetch',
+        ),
+        pytest.param('advisor', {}, '{}', [], False, id='unsupported-advisor'),
+        pytest.param(
+            'bash_code_execution',
+            {'code': 'print(1)'},
+            '{"code":"print(1)"}',
+            [CodeExecutionTool()],
+            True,
+            id='code-execution-sub-tool',
+        ),
+        pytest.param(
+            'tool_search_tool_bm25',
+            {'query': 'weather'},
+            '{"query":"weather"}',
+            [ToolSearchTool(strategy='custom')],
+            False,
+            id='custom-tool-search',
+        ),
     ],
 )
 async def test_anthropic_filters_unconfigured_native_tool_calls(
     allow_model_requests: None,
     stream: bool,
+    server_tool_name: ServerToolName,
+    input: dict[str, object],
+    input_delta: str,
     native_tools: list[AbstractNativeTool],
     expected_call: bool,
 ):
     """Unit test because an unconfigured server-tool call cannot be requested reliably from the live API."""
     if stream:
-        mock_client = MockAnthropic.create_stream_mock(_code_execution_stream())
+        mock_client = MockAnthropic.create_stream_mock(_server_tool_stream(server_tool_name, input_delta))
     else:
-        response = completion_message([_code_execution_call()], BetaUsage(input_tokens=1, output_tokens=1))
+        response = completion_message(
+            [_server_tool_call(server_tool_name, input)], BetaUsage(input_tokens=1, output_tokens=1)
+        )
         mock_client = MockAnthropic.create_mock(response)
 
     model = AnthropicModel('claude-sonnet-4-6', provider=AnthropicProvider(anthropic_client=mock_client))
@@ -133,9 +186,34 @@ async def test_anthropic_filters_unconfigured_native_tool_calls(
         assert calls[0].args_as_dict() == {'code': 'print(1)'}
 
 
+async def test_anthropic_keeps_server_tool_call_with_matching_result(allow_model_requests: None):
+    """A matching result proves the server executed the call despite the request's declared tool set."""
+    result = BetaCodeExecutionToolResultBlock(
+        tool_use_id=_TOOL_CALL_ID,
+        type='code_execution_tool_result',
+        content=BetaCodeExecutionResultBlock(
+            content=[], return_code=0, stderr='', stdout='1\n', type='code_execution_result'
+        ),
+    )
+    response = completion_message(
+        [_server_tool_call('code_execution', {'code': 'print(1)'}), result],
+        BetaUsage(input_tokens=1, output_tokens=1),
+    )
+    mock_client = MockAnthropic.create_mock(response)
+    model = AnthropicModel('claude-sonnet-4-6', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    model_response = await model.request(
+        [ModelRequest(parts=[UserPromptPart(content='hello')])], None, ModelRequestParameters()
+    )
+
+    assert [type(part) for part in model_response.parts] == [NativeToolCallPart, NativeToolReturnPart]
+
+
 async def test_anthropic_agent_recovers_from_unconfigured_native_tool_call(allow_model_requests: None):
     """The regression test uses a mock because the initial hallucination is nondeterministic."""
-    first_response = completion_message([_code_execution_call()], BetaUsage(input_tokens=1, output_tokens=1))
+    first_response = completion_message(
+        [_server_tool_call('code_execution', {'code': 'print(1)'})], BetaUsage(input_tokens=1, output_tokens=1)
+    )
     second_response = completion_message(
         [BetaTextBlock(text='ok', type='text')], BetaUsage(input_tokens=2, output_tokens=1)
     )

--- a/tests/models/anthropic/test_native_tool_filtering.py
+++ b/tests/models/anthropic/test_native_tool_filtering.py
@@ -1,0 +1,160 @@
+"""Filtering for Anthropic server-tool calls that were not enabled by the request."""
+
+from __future__ import annotations
+
+import pytest
+
+from pydantic_ai import Agent, ModelMessage, ModelRequest, NativeToolCallPart, UserPromptPart
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.native_tools import AbstractNativeTool, CodeExecutionTool, WebFetchTool
+
+from ...conftest import try_import
+from ..test_anthropic import MockAnthropic, completion_message, get_mock_chat_completion_kwargs
+
+with try_import() as imports_successful:
+    from anthropic.types.beta import (
+        BetaDirectCaller,
+        BetaInputJSONDelta,
+        BetaMessage,
+        BetaMessageDeltaUsage,
+        BetaRawContentBlockDeltaEvent,
+        BetaRawContentBlockStartEvent,
+        BetaRawContentBlockStopEvent,
+        BetaRawMessageDeltaEvent,
+        BetaRawMessageStartEvent,
+        BetaRawMessageStopEvent,
+        BetaRawMessageStreamEvent,
+        BetaServerToolUseBlock,
+        BetaTextBlock,
+        BetaUsage,
+    )
+    from anthropic.types.beta.beta_raw_message_delta_event import Delta
+
+    from pydantic_ai.models.anthropic import AnthropicModel
+    from pydantic_ai.providers.anthropic import AnthropicProvider
+
+pytestmark = [
+    pytest.mark.skipif(not imports_successful(), reason='anthropic not installed'),
+    pytest.mark.anyio,
+]
+
+_TOOL_CALL_ID = 'srvtoolu_test'
+
+
+def _code_execution_call() -> BetaServerToolUseBlock:
+    return BetaServerToolUseBlock(
+        id=_TOOL_CALL_ID,
+        name='code_execution',
+        input={'code': 'print(1)'},
+        type='server_tool_use',
+        caller=BetaDirectCaller(type='direct'),
+    )
+
+
+def _code_execution_stream() -> list[BetaRawMessageStreamEvent]:
+    return [
+        BetaRawMessageStartEvent(
+            type='message_start',
+            message=BetaMessage(
+                id='msg_test',
+                content=[],
+                model='claude-sonnet-4-6',
+                role='assistant',
+                stop_reason=None,
+                type='message',
+                usage=BetaUsage(input_tokens=1, output_tokens=0),
+            ),
+        ),
+        BetaRawContentBlockStartEvent(
+            type='content_block_start',
+            index=0,
+            content_block=BetaServerToolUseBlock(
+                id=_TOOL_CALL_ID,
+                name='code_execution',
+                input={},
+                type='server_tool_use',
+                caller=BetaDirectCaller(type='direct'),
+            ),
+        ),
+        BetaRawContentBlockDeltaEvent(
+            type='content_block_delta',
+            index=0,
+            delta=BetaInputJSONDelta(type='input_json_delta', partial_json='{"code":"print(1)"}'),
+        ),
+        BetaRawContentBlockStopEvent(type='content_block_stop', index=0),
+        BetaRawMessageDeltaEvent(
+            type='message_delta',
+            delta=Delta(stop_reason='end_turn'),
+            usage=BetaMessageDeltaUsage(output_tokens=1),
+        ),
+        BetaRawMessageStopEvent(type='message_stop'),
+    ]
+
+
+@pytest.mark.parametrize('stream', [False, True])
+@pytest.mark.parametrize(
+    ('native_tools', 'expected_call'),
+    [
+        pytest.param([], False, id='unconfigured'),
+        pytest.param([CodeExecutionTool()], True, id='configured'),
+        pytest.param([WebFetchTool()], True, id='implicitly-enabled-by-web-fetch'),
+    ],
+)
+async def test_anthropic_filters_unconfigured_native_tool_calls(
+    allow_model_requests: None,
+    stream: bool,
+    native_tools: list[AbstractNativeTool],
+    expected_call: bool,
+):
+    """Unit test because an unconfigured server-tool call cannot be requested reliably from the live API."""
+    if stream:
+        mock_client = MockAnthropic.create_stream_mock(_code_execution_stream())
+    else:
+        response = completion_message([_code_execution_call()], BetaUsage(input_tokens=1, output_tokens=1))
+        mock_client = MockAnthropic.create_mock(response)
+
+    model = AnthropicModel('claude-sonnet-4-6', provider=AnthropicProvider(anthropic_client=mock_client))
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(content='hello')])]
+    request_parameters = ModelRequestParameters(native_tools=native_tools)
+
+    if stream:
+        async with model.request_stream(messages, None, request_parameters) as streamed_response:
+            async for _ in streamed_response:
+                pass
+            model_response = streamed_response.get()
+    else:
+        model_response = await model.request(messages, None, request_parameters)
+
+    calls = [part for part in model_response.parts if isinstance(part, NativeToolCallPart)]
+    assert bool(calls) is expected_call
+    if expected_call:
+        assert calls[0].tool_name == 'code_execution'
+        assert calls[0].tool_call_id == _TOOL_CALL_ID
+        assert calls[0].args_as_dict() == {'code': 'print(1)'}
+
+
+async def test_anthropic_agent_recovers_from_unconfigured_native_tool_call(allow_model_requests: None):
+    """The regression test uses a mock because the initial hallucination is nondeterministic."""
+    first_response = completion_message([_code_execution_call()], BetaUsage(input_tokens=1, output_tokens=1))
+    second_response = completion_message(
+        [BetaTextBlock(text='ok', type='text')], BetaUsage(input_tokens=2, output_tokens=1)
+    )
+    mock_client = MockAnthropic.create_mock([first_response, second_response])
+    model = AnthropicModel('claude-sonnet-4-6', provider=AnthropicProvider(anthropic_client=mock_client))
+
+    result = await Agent(model).run('hello')
+
+    assert result.output == 'ok'
+    assert not any(isinstance(part, NativeToolCallPart) for message in result.all_messages() for part in message.parts)
+    assert get_mock_chat_completion_kwargs(mock_client)[1]['messages'] == [
+        {'role': 'user', 'content': [{'text': 'hello', 'type': 'text'}]},
+        {
+            'role': 'user',
+            'content': [
+                {
+                    'text': 'Validation feedback:\nPlease return text.\n\nFix the errors and try again.',
+                    'type': 'text',
+                }
+            ],
+        },
+    ]

--- a/tests/models/test_anthropic.py
+++ b/tests/models/test_anthropic.py
@@ -206,6 +206,7 @@ async def test_anthropic_cancelled_read_error_is_suppressed():
         _response=_peekable_broken_stream(stream),
         _provider_name='anthropic',
         _provider_url='https://api.anthropic.com',
+        _enabled_server_tool_names=frozenset(),
     )
 
     await response.cancel()
@@ -223,6 +224,7 @@ async def test_anthropic_read_error_is_raised_when_not_cancelled():
         _response=_peekable_broken_stream(_BrokenClosableStream()),
         _provider_name='anthropic',
         _provider_url='https://api.anthropic.com',
+        _enabled_server_tool_names=frozenset(),
     )
 
     with pytest.raises(httpx.ReadError):


### PR DESCRIPTION
- Closes #6401

### Summary

Anthropic can occasionally return a `server_tool_use` block for a native tool that was not enabled by the effective request. Replaying that block during the normal validation retry produces invalid history because no matching server-tool result can exist, and Anthropic rejects the request with HTTP 400.

This change filters unconfigured server-tool calls while parsing the response, using the parameters of the request that produced it. The same rule applies to streamed and non-streamed responses. Configured calls remain untouched, including `code_execution` calls implicitly enabled by the 20260209 web tools, so the existing empty-response retry can recover normally.

### Tests

- Added streamed and non-streamed coverage for unconfigured, explicitly configured, and implicitly enabled native calls.
- Added an agent-level regression test proving the retry omits the hallucinated call and returns text.
- The regression tests live in a dedicated feature-focused module because neither the monolithic provider suite nor the narrower web-tools suite is an appropriate home; they are automatically collected by the repository-wide pytest run.
- `uv run ruff format --check`
- `uv run ruff check`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright`

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

