### PR TITLE
Fix `has_values()` returning `True` for all-zero usage `details`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -111,7 +111,9 @@ class UsageBase:
 
     def has_values(self) -> bool:
         """Whether any values are set and non-zero."""
-        return any(dataclasses.asdict(self).values())
+        values = dataclasses.asdict(self)
+        details = values.pop('details')
+        return any(values.values()) or any(details.values())
 
 
 @dataclass(repr=False, kw_only=True)

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -111,9 +111,9 @@ class UsageBase:
 
     def has_values(self) -> bool:
         """Whether any values are set and non-zero."""
-        values = dataclasses.asdict(self)
-        details = values.pop('details')
-        return any(values.values()) or any(details.values())
+        return any(self.details.values()) or any(
+            getattr(self, f.name) for f in fields(self) if f.name != 'details'
+        )
 
 
 @dataclass(repr=False, kw_only=True)

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -111,9 +111,7 @@ class UsageBase:
 
     def has_values(self) -> bool:
         """Whether any values are set and non-zero."""
-        return any(self.details.values()) or any(
-            getattr(self, f.name) for f in fields(self) if f.name != 'details'
-        )
+        return any(self.details.values()) or any(getattr(self, f.name) for f in fields(self) if f.name != 'details')
 
 
 @dataclass(repr=False, kw_only=True)

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -185,6 +185,21 @@ def test_usage_so_far() -> None:
         )
 
 
+def test_usage_has_values_ignores_zero_details() -> None:
+    """`has_values()` must treat an all-zero `details` dict as no values, per its docstring.
+
+    A non-empty `details` dict is truthy, so the previous `any(asdict(...).values())` returned True
+    even when every count was zero. This pins the pure-method behavior directly; no model is involved,
+    so there is no VCR test to write.
+    """
+    assert RunUsage().has_values() is False
+    assert RunUsage(details={'reasoning_tokens': 0}).has_values() is False
+    assert RunUsage(input_tokens=1).has_values() is True
+    assert RunUsage(details={'reasoning_tokens': 3}).has_values() is True
+    # RequestUsage shares the same UsageBase implementation.
+    assert RequestUsage(details={'x': 0}).has_values() is False
+
+
 async def test_multi_agent_usage_no_incr():
     delegate_agent = Agent(TestModel(), output_type=int)
 


### PR DESCRIPTION
Closes #6465

`UsageBase.has_values()` (documented "any values are set and non-zero") returned `True` for a non-empty `details` dict even when every count was zero, because `any(dataclasses.asdict(self).values())` treats the `details` dict by truthiness rather than by its values. The scalar token fields are already filtered by non-zero-ness; this checks `details` by its values too.

```python
RunUsage(details={'reasoning_tokens': 0}).has_values()  # was True, now False
```

It gates the usage fallback in `models/function.py` (`if not response.usage.has_values(): ...`).

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

