### PR TITLE
docs: clarify on-demand hooks and tool disclosure

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -49,10 +49,10 @@ The following capabilities are deferred and can be loaded using the `load_capabi
 - refunds: Use for refund eligibility, refund status, or processing a refund.
 ```
 
-The model does not receive the refund instructions, and `refund_status` is not callable yet. Depending on the active model, Pydantic AI may also send provider/tool-search plumbing to preserve the hidden state; that plumbing does not expose the refund tool until the capability is loaded. The exchange unfolds across model requests within a single `agent.run_sync` call:
+The model does not receive the refund instructions or the `refund_status` tool definition yet, so it has no reason to call the tool. Depending on the active model, Pydantic AI may also send provider/tool-search plumbing to preserve the hidden state; that plumbing does not expose the refund tool definition until the capability is loaded. The exchange unfolds across model requests within a single `agent.run_sync` call:
 
 1. **Request 1.** The model sees the catalog above and the user's prompt. It calls the `load_capability` tool with `id='refunds'`.
-2. **Load.** Pydantic AI returns the capability's instructions — *"Always confirm the order ID before issuing a refund."* — as the tool result, and registers `refund_status` for the next request.
+2. **Load.** Pydantic AI returns the capability's instructions — *"Always confirm the order ID before issuing a refund."* — as the tool result and exposes the `refund_status` definition on the next request.
 3. **Request 2.** The model now sees those instructions in history and `refund_status` in its tool list. It calls `refund_status(order_id='ABC-123')` and answers the user from the result.
 
 Already-loaded capabilities stay loaded for the rest of the run — the model never needs to re-open one.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -101,7 +101,7 @@ agent = Agent('openai-responses:gpt-5.4', capabilities=[request_logging_hooks])
 
 Pydantic AI skips hooks owned by a deferred `Hooks` instance until its capability is loaded.
 
-Use on-demand hooks for optional behavior that only applies after the capability is loaded. For human-in-the-loop tool approval, use the [approval mechanisms](deferred-tools.md#human-in-the-loop-tool-approval) designed for that purpose.
+Use on-demand hooks for optional behavior that only applies after the capability is loaded. For human-in-the-loop tool approval, pass [`requires_approval=True`](deferred-tools.md#human-in-the-loop-tool-approval) when registering a tool, raise [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] for conditional approval, or wrap a toolset with [`ApprovalRequiredToolset`][pydantic_ai.toolsets.ApprovalRequiredToolset].
 
 ## Hook types
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -74,40 +74,34 @@ Both sync and async hook functions are accepted. Sync functions are automaticall
 
 ### On-demand hooks
 
-[`Hooks`][pydantic_ai.capabilities.Hooks] is a capability, so it can be loaded on demand just like any other capability:
+[`Hooks`][pydantic_ai.capabilities.Hooks] is a capability, so it can be loaded on demand just like any other capability. This is useful for optional, user-requested behavior such as verbose request logging:
 
 ```python {title="deferred_hooks_capability.py"}
-from pydantic_ai import Agent, RunContext, ToolDefinition
-from pydantic_ai.capabilities import Hooks, ValidatedToolArgs
-from pydantic_ai.messages import ToolCallPart
+from pydantic_ai import Agent, ModelRequestContext, RunContext
+from pydantic_ai.capabilities import Hooks
 
-approval_hooks = Hooks(
-    id='approval-hooks',
-    description='Use when a workflow needs approval before destructive actions.',
+request_logging_hooks = Hooks(
+    id='request-logging',
+    description='Use when the user asks for verbose request diagnostics.',
     defer_loading=True,
 )
 
 
-@approval_hooks.on.before_tool_execute
-async def require_approval(
+@request_logging_hooks.on.before_model_request
+async def log_request(
     ctx: RunContext[None],
-    *,
-    call: ToolCallPart,
-    tool_def: ToolDefinition,
-    args: ValidatedToolArgs,
-) -> ValidatedToolArgs:
-    # Runs only after the model loads `approval-hooks`.
-    return args
+    request_context: ModelRequestContext,
+) -> ModelRequestContext:
+    print(f'Model request at step {ctx.run_step}: {len(request_context.messages)} messages')
+    return request_context
 
 
-agent = Agent('openai-responses:gpt-5.4', capabilities=[approval_hooks])
+agent = Agent('openai-responses:gpt-5.4', capabilities=[request_logging_hooks])
 ```
 
-You do not need to guard hooks owned by a deferred `Hooks` instance with `ctx.capability_loaded`; Pydantic AI skips those hooks until the model calls the `load_capability` tool for that capability. Once the hook runs, `ctx.capability_loaded` is true for that hook's owning capability. To check a different capability, inspect `ctx.loaded_capability_ids` or `ctx.available_capability_ids`.
+Pydantic AI skips hooks owned by a deferred `Hooks` instance until its capability is loaded.
 
-If a hook must enforce a rule before a workflow is loaded, keep that hook in an always-available capability and inspect `ctx.loaded_capability_ids`; an on-demand hook cannot run before the model loads its own capability.
-
-The run-scoped hooks — `before_run` and `wrap_run` — are bound at the start of the run, so a capability the model loads mid-run won't get them for that run; they only fire when the capability is already loaded at the start (for example after resuming from message history). The capability's per-step hooks (node, model-request, tool, output) fire from the next step onwards once it has loaded, and `after_run` fires at the end of the run if it was loaded at any point during it.
+Use on-demand hooks for optional behavior that only applies after the capability is loaded. For human-in-the-loop tool approval, use the [approval mechanisms](deferred-tools.md#human-in-the-loop-tool-approval) designed for that purpose.
 
 ## Hook types
 


### PR DESCRIPTION
- Closes #6469

Replaces the misleading on-demand approval hook with optional request logging and points human-in-the-loop approval use cases to the dedicated approval APIs.

Clarifies the two relevant on-demand loading behaviors:

- Pydantic AI skips hooks owned by a deferred `Hooks` capability until that capability is loaded.
- Before loading, the model is not shown deferred tool definitions, so it has no reason to call those tools.

### Validation

- `uv run pytest 'tests/test_examples.py::test_docs_examples[docs/hooks.md:79:deferred_hooks_capability.py]' -q`
- `uv run pytest tests/test_capabilities.py::test_deferred_hooks_do_not_fire_until_capability_is_loaded -q`
- `make docs`
- pre-commit

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
