### PR TITLE
Fix Mistral streamed structured output rejecting integer-valued JSON numbers

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -817,9 +817,9 @@ class MistralStreamedResponse(StreamedResponse):
                 if not isinstance(json_dict[param], list):
                     return False
                 for item in json_dict[param]:
-                    if not isinstance(item, VALID_JSON_TYPE_MAPPING[param_items_type]):
+                    if not _matches_json_type(item, param_items_type):
                         return False
-            elif param_type and not isinstance(json_dict[param], VALID_JSON_TYPE_MAPPING[param_type]):
+            elif param_type and not _matches_json_type(json_dict[param], param_type):
                 return False
 
             if isinstance(json_dict[param], dict) and 'properties' in param_schema:
@@ -828,6 +828,23 @@ class MistralStreamedResponse(StreamedResponse):
                     return False
 
         return True
+
+
+def _matches_json_type(value: Any, json_type: str) -> bool:
+    """Check whether a Python value parsed from JSON matches a JSON Schema type.
+
+    JSON has a single `number` type, and `pydantic_core.from_json` (like `json.loads`) parses a
+    fraction-less number such as `20` to a Python `int`, so a `number` field must accept both `int`
+    and `float`. Python's `bool` is a subclass of `int`, so it is excluded from the numeric types to
+    avoid accepting a JSON boolean for an `integer` or `number` field.
+    """
+    if json_type == 'number':
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    elif json_type == 'integer':
+        return isinstance(value, int) and not isinstance(value, bool)
+    elif json_type == 'boolean':
+        return isinstance(value, bool)
+    return isinstance(value, VALID_JSON_TYPE_MAPPING[json_type])
 
 
 VALID_JSON_TYPE_MAPPING: dict[str, Any] = {

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -75,6 +75,7 @@ with try_import() as imports_successful:
     from pydantic_ai.models.openai import OpenAIResponsesModel, OpenAIResponsesModelSettings
     from pydantic_ai.providers.mistral import MistralProvider
     from pydantic_ai.providers.openai import OpenAIProvider
+    from pydantic_ai.tools import ToolDefinition
 
     MockChatCompletion = MistralChatCompletionResponse | Exception
     MockCompletionEvent = MistralCompletionEvent | Exception
@@ -2136,11 +2137,79 @@ def test_generate_user_output_format_multiple(mistral_api_key: str):
             },
             True,
         ),
+        (
+            'Number accepts JSON int (fraction-less number is parsed as Python int)',
+            {'required': ['value'], 'properties': {'value': {'type': 'number'}}},
+            {'value': 20},
+            True,
+        ),
+        (
+            'Number accepts float',
+            {'required': ['value'], 'properties': {'value': {'type': 'number'}}},
+            {'value': 20.5},
+            True,
+        ),
+        (
+            'Integer rejects bool',
+            {'required': ['age'], 'properties': {'age': {'type': 'integer'}}},
+            {'age': True},
+            False,
+        ),
+        (
+            'Number rejects bool',
+            {'required': ['value'], 'properties': {'value': {'type': 'number'}}},
+            {'value': True},
+            False,
+        ),
+        (
+            'Nested number accepts int',
+            {
+                'required': ['user'],
+                'properties': {
+                    'user': {
+                        'type': 'object',
+                        'required': ['score'],
+                        'properties': {'score': {'type': 'number'}},
+                    }
+                },
+            },
+            {'user': {'score': 20}},
+            True,
+        ),
+        (
+            'Array of number accepts ints',
+            {'required': ['values'], 'properties': {'values': {'type': 'array', 'items': {'type': 'number'}}}},
+            {'values': [1, 2.5, 3]},
+            True,
+        ),
+        (
+            'Array of integer rejects bool item',
+            {'required': ['counts'], 'properties': {'counts': {'type': 'array', 'items': {'type': 'integer'}}}},
+            {'counts': [1, True, 3]},
+            False,
+        ),
     ],
 )
 def test_validate_required_json_schema(desc: str, schema: dict[str, Any], data: dict[str, Any], expected: bool) -> None:
     result = MistralStreamedResponse._validate_required_json_schema(data, schema)  # pyright: ignore[reportPrivateUsage]
     assert result == expected, f'{desc} — expected {expected}, got {result}'
+
+
+def test_try_get_output_tool_from_text_number_accepts_int() -> None:
+    tool = ToolDefinition(
+        name='final_result',
+        parameters_json_schema={
+            'type': 'object',
+            'required': ['value'],
+            'properties': {'value': {'type': 'number'}},
+        },
+    )
+    part = MistralStreamedResponse._try_get_output_tool_from_text(  # pyright: ignore[reportPrivateUsage]
+        '{"value": 20}', {'final_result': tool}
+    )
+    assert isinstance(part, ToolCallPart)
+    assert part.tool_name == 'final_result'
+    assert part.args_as_dict() == {'value': 20}
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Problem

When using streamed structured output with the Mistral model, a schema-valid response could be silently dropped.

`MistralStreamedResponse._try_get_output_tool_from_text` parses the accumulated stream text with `pydantic_core.from_json` and then gates the result through `MistralStreamedResponse._validate_required_json_schema`. That validator checks each required field with `isinstance(value, VALID_JSON_TYPE_MAPPING[type])`, where `number` maps to `float`.

JSON has a single `number` type, and `pydantic_core.from_json` (like `json.loads`) parses a fraction-less number such as `20` to a Python `int`:

```python
import pydantic_core
pydantic_core.from_json('{"value": 20}')['value']  # 20, a Python int
isinstance(20, float)                               # False  -> schema-valid `number` rejected
```

Because `isinstance(20, float)` is `False`, a schema-valid `number` value was rejected, `_validate_required_json_schema` returned `False`, `_try_get_output_tool_from_text` returned `None`, and the structured-output `ToolCallPart` was never emitted. This diverges from the non-streaming path and from pydantic itself, which coerces `int` to `float` for `float` fields. Nested `number` fields and arrays of `number` items were affected the same way.

There is also a secondary correctness issue in the same check: Python's `bool` is a subclass of `int`, so `isinstance(True, int)` is `True`, meaning a JSON boolean was wrongly accepted for an `integer` field.

## Fix

Add a small module-private helper `_matches_json_type(value, json_type)` and use it in both the array-items branch and the scalar branch of `_validate_required_json_schema`:

- `number` accepts `int` or `float`
- `integer` accepts `int`
- `boolean` accepts `bool`
- `bool` is excluded from the numeric types (since it subclasses `int`), so a JSON boolean is no longer accepted for an `integer`/`number` field
- all other types keep the existing `VALID_JSON_TYPE_MAPPING` behavior

This is a behavior-tightening bug fix: a JSON boolean is no longer accepted for a required `integer`/`number` field. That is strictly more correct per JSON Schema, and it only means a malformed payload now withholds the streamed `ToolCallPart` instead of emitting one that pydantic would reject downstream anyway. No public API changes.

## Testing

- Extended the existing parametrized `test_validate_required_json_schema` with cases covering: `number` accepts an int, `number` accepts a float, `integer` rejects a bool, `number` rejects a bool, a nested `number` accepts an int, an array of `number` accepts ints, and an array of `integer` rejects a bool item. The 6 pre-existing cases still pass unchanged.
- Added `test_try_get_output_tool_from_text_number_accepts_int`, which builds a `ToolDefinition` with a required `number` field, calls `_try_get_output_tool_from_text('{"value": 20}', ...)`, and asserts it returns a `ToolCallPart` with `args_as_dict() == {'value': 20}` rather than `None` — proving the user-visible symptom is fixed.

Before the fix these new tests fail (6 failing), after the fix the whole module passes:

```
uv run pytest tests/models/test_mistral.py -q
64 passed
```

`ruff format`, `ruff check`, and `pyright` are clean on both changed files.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Fixes #6477

