### PR TITLE
Add `include_model_request_parameters` instrumentation setting to omit the `model_request_parameters` span attribute

### DIFF
--- a/docs/logfire.md
+++ b/docs/logfire.md
@@ -390,6 +390,24 @@ Agent.instrument_all(instrumentation_settings)
 
 This setting is particularly useful in production environments where compliance requirements or data sensitivity concerns make it necessary to limit what content is sent to your observability platform.
 
+### Excluding model request parameters
+
+By default, each model request span carries a `model_request_parameters` attribute that serializes the full [`ModelRequestParameters`][pydantic_ai.models.ModelRequestParameters], including the output configuration and every tool definition. Tools that carry large output schemas (some MCP toolsets, for example) can make this attribute big enough to strain span export and inflate memory use. Set `include_model_request_parameters=False` to omit it entirely:
+
+```python {title="excluding_model_request_parameters.py"}
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Instrumentation
+from pydantic_ai.models.instrumented import InstrumentationSettings
+
+instrumentation_settings = InstrumentationSettings(include_model_request_parameters=False)
+
+agent = Agent('openai:gpt-5.2', capabilities=[Instrumentation(settings=instrumentation_settings)])
+# or to instrument all agents:
+Agent.instrument_all(instrumentation_settings)
+```
+
+The `gen_ai.tool.definitions` attribute (tool name, description, and parameters) is emitted regardless of this setting, so observability platforms that read the available tools from it are unaffected.
+
 ### Adding Custom Metadata
 
 Use the agent's `metadata` parameter to attach additional data to the agent's span.

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from pydantic_ai.messages import ModelMessage, ModelResponse
     from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
     from pydantic_ai.models.instrumented import InstrumentationSettings
+    from pydantic_ai.settings import ModelSettings
 
 DEFAULT_INSTRUMENTATION_VERSION = 5
 """Default instrumentation version for `InstrumentationSettings`."""
@@ -154,6 +155,16 @@ def model_request_parameters_attributes(
     return {'model_request_parameters': safe_to_json(serialize_any(model_request_parameters)).decode()}
 
 
+def model_settings_attributes(model_settings: ModelSettings | None) -> dict[str, AttributeValue]:
+    """Map the OTel-spec model settings (`max_tokens`, `temperature`, ...) to `gen_ai.request.*` attributes."""
+    attributes: dict[str, AttributeValue] = {}
+    if model_settings:
+        for key in MODEL_SETTING_ATTRIBUTES:
+            if isinstance(value := model_settings.get(key), float | int):
+                attributes[f'gen_ai.request.{key}'] = value
+    return attributes
+
+
 def annotate_tool_call_otel_metadata(response: ModelResponse, parameters: ModelRequestParameters) -> None:
     """Copy OTel-relevant metadata from tool definitions onto matching tool call parts.
 
@@ -241,24 +252,19 @@ def open_model_request_span(
     attributes: dict[str, AttributeValue] = {
         'gen_ai.operation.name': operation,
         **model_attributes(model),
-        **model_request_parameters_attributes(prepared_parameters),
         **get_agent_run_baggage_attributes(),
-        'logfire.json_schema': to_json(
-            {
-                'type': 'object',
-                'properties': {'model_request_parameters': {'type': 'object'}},
-            }
-        ).decode(),
     }
+    json_schema_properties: dict[str, Any] = {}
+    if settings.include_model_request_parameters:
+        attributes.update(model_request_parameters_attributes(prepared_parameters))
+        json_schema_properties['model_request_parameters'] = {'type': 'object'}
+    attributes['logfire.json_schema'] = to_json({'type': 'object', 'properties': json_schema_properties}).decode()
 
     tool_definitions = build_tool_definitions(prepared_parameters)
     if tool_definitions:
         attributes['gen_ai.tool.definitions'] = safe_to_json(tool_definitions).decode()
 
-    if prepared_settings:
-        for key in MODEL_SETTING_ATTRIBUTES:
-            if isinstance(value := prepared_settings.get(key), float | int):
-                attributes[f'gen_ai.request.{key}'] = value
+    attributes.update(model_settings_attributes(prepared_settings))
 
     record_metrics: Callable[[], None] | None = None
     try:

--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -254,7 +254,7 @@ def open_model_request_span(
         **model_attributes(model),
         **get_agent_run_baggage_attributes(),
     }
-    json_schema_properties: dict[str, Any] = {}
+    json_schema_properties: dict[str, dict[str, str]] = {}
     if settings.include_model_request_parameters:
         attributes.update(model_request_parameters_attributes(prepared_parameters))
         json_schema_properties['model_request_parameters'] = {'type': 'object'}

--- a/pydantic_ai_slim/pydantic_ai/models/fallback.py
+++ b/pydantic_ai_slim/pydantic_ai/models/fallback.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, NoReturn, TypeGuard
 
 import anyio
 from opentelemetry.trace import get_current_span
+from opentelemetry.util.types import AttributeValue
 from typing_extensions import assert_never
 
 from pydantic_ai._instrumentation import model_attributes, model_request_parameters_attributes
@@ -297,12 +298,13 @@ class FallbackModel(Model):
             if span.is_recording():
                 attributes = getattr(span, 'attributes', {})
                 if attributes.get('gen_ai.request.model') == self.model_name:  # pragma: no branch
-                    span.set_attributes(
-                        {
-                            **model_attributes(model),
-                            **model_request_parameters_attributes(model_request_parameters),
-                        }
-                    )
+                    span_attributes: dict[str, AttributeValue] = {**model_attributes(model)}
+                    # Only refresh `model_request_parameters` if it was emitted at span open; its absence
+                    # means `InstrumentationSettings.include_model_request_parameters` is off, and re-adding
+                    # it here would leak the attribute the setting is meant to suppress.
+                    if 'model_request_parameters' in attributes:
+                        span_attributes.update(model_request_parameters_attributes(model_request_parameters))
+                    span.set_attributes(span_attributes)
 
 
 def _exception_types_to_handler(exceptions: tuple[type[Exception], ...]) -> ExceptionHandler:

--- a/pydantic_ai_slim/pydantic_ai/models/instrumented.py
+++ b/pydantic_ai_slim/pydantic_ai/models/instrumented.py
@@ -66,6 +66,7 @@ class InstrumentationSettings:
     tracer: Tracer = field(repr=False)
     include_binary_content: bool = True
     include_content: bool = True
+    include_model_request_parameters: bool = True
     version: Literal[2, 3, 4, 5] = DEFAULT_INSTRUMENTATION_VERSION
     use_aggregated_usage_attribute_names: bool = True
 
@@ -76,6 +77,7 @@ class InstrumentationSettings:
         meter_provider: MeterProvider | None = None,
         include_binary_content: bool = True,
         include_content: bool = True,
+        include_model_request_parameters: bool = True,
         version: Literal[2, 3, 4, 5] = DEFAULT_INSTRUMENTATION_VERSION,
         use_aggregated_usage_attribute_names: bool = True,
     ):
@@ -91,6 +93,13 @@ class InstrumentationSettings:
             include_binary_content: Whether to include binary content in the instrumentation events.
             include_content: Whether to include prompts, completions, and tool call arguments and responses
                 in the instrumentation events.
+            include_model_request_parameters: Whether to emit the `model_request_parameters` span attribute on
+                model request spans. This serializes the full `ModelRequestParameters` (output configuration
+                and every tool definition, including fields that are not sent to the model such as tool
+                `metadata` and, when not requested, `return_schema`). Defaults to `True`. Set to `False` to
+                omit it entirely, which is useful when large tool output schemas make the attribute big enough
+                to strain span export. The OpenTelemetry `gen_ai.tool.definitions` attribute (tool name,
+                description, and parameters) is always emitted regardless of this setting.
             version: Version of the data format. This is unrelated to the Pydantic AI package version.
                 Defaults to version 5. Versions 2, 3, and 4 are deprecated compatibility formats
                 and emit a `PydanticAIDeprecationWarning` when used.
@@ -122,6 +131,7 @@ class InstrumentationSettings:
         self.meter = meter_provider.get_meter(scope_name, __version__)
         self.include_binary_content = include_binary_content
         self.include_content = include_content
+        self.include_model_request_parameters = include_model_request_parameters
 
         if version not in (2, 3, 4, 5):
             raise ValueError('Instrumentation version must be one of 2, 3, 4, or 5.')
@@ -217,7 +227,11 @@ class InstrumentationSettings:
                         'gen_ai.input.messages': {'type': 'array'},
                         'gen_ai.output.messages': {'type': 'array'},
                         **({'gen_ai.system_instructions': {'type': 'array'}} if system_instructions_attributes else {}),
-                        'model_request_parameters': {'type': 'object'},
+                        **(
+                            {'model_request_parameters': {'type': 'object'}}
+                            if self.include_model_request_parameters
+                            else {}
+                        ),
                     },
                 }
             ).decode(),

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -261,6 +261,27 @@ def test_first_failed_instrumented(capfire: CaptureLogfire) -> None:
 
 
 @pytest.mark.skipif(not logfire_imports_successful(), reason='logfire not installed')
+def test_first_failed_instrumented_excludes_request_parameters(capfire: CaptureLogfire) -> None:
+    """A fallback to a later model must not re-add `model_request_parameters` when the setting is off.
+
+    `FallbackModel` refreshes the span attributes for the model it actually used; it keys off whether
+    the attribute was emitted at span open, so `include_model_request_parameters=False` stays honored
+    even after a fallback overwrites the model attributes.
+    """
+    fallback_model = FallbackModel(failure_model, success_model)
+    agent = Agent(
+        model=fallback_model,
+        capabilities=[Instrumentation(settings=InstrumentationSettings(include_model_request_parameters=False))],
+    )
+    result = agent.run_sync('hello')
+    assert result.output == snapshot('success')
+
+    attrs = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)[0]['attributes']
+    assert attrs['gen_ai.request.model'] == 'function:success_response:'
+    assert 'model_request_parameters' not in attrs
+
+
+@pytest.mark.skipif(not logfire_imports_successful(), reason='logfire not installed')
 async def test_first_failed_instrumented_stream(capfire: CaptureLogfire) -> None:
     fallback_model = FallbackModel(failure_model_stream, success_model_stream)
     agent = Agent(model=fallback_model, capabilities=[Instrumentation(settings=InstrumentationSettings())])

--- a/tests/models/test_instrumented.py
+++ b/tests/models/test_instrumented.py
@@ -2167,6 +2167,41 @@ async def test_instrumented_model_tolerates_lone_surrogates_in_request_parameter
     assert 'weather' in attrs['model_request_parameters']['function_tools'][0]['name']
 
 
+async def test_instrumented_model_excludes_request_parameters(capfire: CaptureLogfire):
+    """`include_model_request_parameters=False` omits the `model_request_parameters` span attribute.
+
+    `gen_ai.tool.definitions` is emitted independently of this setting, so the tools available for a
+    request are still recorded on the span.
+    """
+    tool_def = ToolDefinition(
+        name='get_weather',
+        description='Get the weather',
+        parameters_json_schema={'type': 'object', 'properties': {'city': {'type': 'string'}}},
+    )
+
+    model = InstrumentedModel(MyModel(), InstrumentationSettings(include_model_request_parameters=False))
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('Hello')], timestamp=IsDatetime())]
+    await model.request(
+        messages,
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(function_tools=[tool_def]),
+    )
+
+    attrs = capfire.exporter.exported_spans_as_dict(parse_json_attributes=True)[0]['attributes']
+    assert 'model_request_parameters' not in attrs
+    assert 'model_request_parameters' not in attrs['logfire.json_schema']['properties']
+    assert attrs['gen_ai.tool.definitions'] == snapshot(
+        [
+            {
+                'type': 'function',
+                'name': 'get_weather',
+                'description': 'Get the weather',
+                'parameters': {'type': 'object', 'properties': {'city': {'type': 'string'}}},
+            }
+        ]
+    )
+
+
 async def test_instrumented_model_request_error(capfire: CaptureLogfire):
     """Test _instrument() when the wrapped model raises before finish() is called."""
 


### PR DESCRIPTION
- Closes #5760

## Summary

The `model_request_parameters` span attribute serializes the entire `ModelRequestParameters` dataclass on every model-invoke span, including per-tool fields that are **not** sent to the model — `ToolDefinition.metadata` (documented internal) and `ToolDefinition.return_schema` (only sent when `include_return_schema` resolves true). For toolsets with large output schemas (e.g. MCP), this attribute can reach multiple MiB per span and strain span export to the point of OOM.

This adds `InstrumentationSettings.include_model_request_parameters` (default `True`, **no behavior change**). Setting it to `False` omits the `model_request_parameters` attribute entirely. Per the team discussion on the issue, this is a single whole-attribute toggle rather than field-level stripping — a silently-partial serialization would misrepresent the request.

The OpenTelemetry-spec `gen_ai.tool.definitions` attribute (tool name, description, parameters) is emitted regardless of this setting, so observability platforms that read the available tools for a request are unaffected when the flag is off.

## Changes

- `InstrumentationSettings.include_model_request_parameters` field + `__init__` kwarg + docstring.
- `open_model_request_span` gates both the attribute and its `logfire.json_schema` property on the setting; `handle_messages` mirrors the schema gate.
- `FallbackModel` only refreshes `model_request_parameters` if it was emitted at span open, so a fallback can't re-add it past the setting.
- Docs: "Excluding model request parameters" section in `docs/logfire.md`.
- Tests in `test_instrumented.py` and `test_fallback.py`.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

