### PR TITLE
Fix flaky `test_collect_baselines_stops_after_time_budget` from global `time.monotonic` patch

### DIFF
--- a/.github/scripts/test_ci_duration.py
+++ b/.github/scripts/test_ci_duration.py
@@ -4,6 +4,8 @@ import sys
 import urllib.error
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
 
 import ci_duration
@@ -147,7 +149,7 @@ def test_collect_baselines_skips_unavailable_historical_run():
     assert baselines['job=test / runner=github-hosted / py=3.10 / extra=all-extras'].sample_size == 10
 
 
-def test_collect_baselines_stops_after_time_budget():
+def test_collect_baselines_stops_after_time_budget(monkeypatch: pytest.MonkeyPatch):
     class StubGitHubClient(ci_duration.GitHubClient):
         def request_paginated(self, path: str, *, max_items: int | None = None) -> list[ci_duration.JsonObject]:
             if path == 'actions/workflows/ci.yml/runs?branch=main&event=push&status=success':
@@ -162,18 +164,10 @@ def test_collect_baselines_stops_after_time_budget():
                 return []
             raise RuntimeError(f'Unexpected path: {path}')
 
-    monotonic_values = [0.0, ci_duration.BASELINE_COLLECTION_MAX_SECONDS]
-    original_monotonic = ci_duration.time.monotonic
+    # Force the deadline into the past so the first loop guard always trips, rather than patching the
+    # process-global time.monotonic (which any concurrent caller in the worker can desync).
+    monkeypatch.setattr(ci_duration, 'BASELINE_COLLECTION_MAX_SECONDS', -1.0)
 
-    def monotonic() -> float:
-        if monotonic_values:
-            return monotonic_values.pop(0)
-        return ci_duration.BASELINE_COLLECTION_MAX_SECONDS
-
-    ci_duration.time.monotonic = monotonic
-    try:
-        baselines = ci_duration.collect_baselines(StubGitHubClient('pydantic/pydantic-ai', 'token'), 'current-sha')
-    finally:
-        ci_duration.time.monotonic = original_monotonic
+    baselines = ci_duration.collect_baselines(StubGitHubClient('pydantic/pydantic-ai', 'token'), 'current-sha')
 
     assert baselines == {}


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

Fixes a pre-existing flake in the CI-duration telemetry test suite (infra tooling, unrelated to product code). It intermittently reds an unrelated PR's `all-extras` shard with:

```
RuntimeError: Unexpected path: actions/runs/1/attempts/1/jobs
```

### Root cause

`test_collect_baselines_stops_after_time_budget` replaced the **process-global** clock via `ci_duration.time.monotonic = monotonic`, where `ci_duration.time` *is* the stdlib `time` module — so this patched `time.monotonic` for the entire xdist worker. The stub fed a fixed 2-element queue `[0.0, BASELINE_COLLECTION_MAX_SECONDS]`, relying on `collect_baselines()` making exactly two `monotonic()` calls (deadline setup + the loop guard).

In isolation that deterministically returns `{}`. But because the patch is global, **any other code in the worker** calling `time.monotonic()` during those microseconds (a logfire background thread, coverage, etc.) pops an extra value and desyncs the queue: the deadline setup then reads `90` (deadline `180`), the guard reads the exhausted-queue fallback `90`, `90 >= 180` is `False`, the loop does **not** break, and it requests `actions/runs/1/attempts/1/jobs` — which the stub doesn't mock → `RuntimeError`.

### Fix

Stop patching the shared clock entirely. Instead force the deadline into the past by monkeypatching the constant: `monkeypatch.setattr(ci_duration, 'BASELINE_COLLECTION_MAX_SECONDS', -1.0)`. With the real (monotonic, non-decreasing) clock, `deadline = now - 1`, so the first loop guard always trips → `break` → returns `{}`. The existing `assert baselines == {}` still holds and no jobs request is ever made, so the stub's mocked paths remain sufficient. Immune to any concurrent `monotonic()` caller.

The sibling `test_collect_baselines_skips_unavailable_historical_run` shares the `Unexpected path` guard but does **not** patch the clock, so it isn't affected — left untouched.

Introduced in #5941 (baseline collection, on top of #5923's CI duration telemetry).

- Closes #<!-- no issue: pre-existing infra-test flake -->

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

