### PR TITLE
fix(groq,huggingface): skip bare assistant message for empty ModelResponse

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/groq.py
+++ b/pydantic_ai_slim/pydantic_ai/models/groq.py
@@ -558,14 +558,15 @@ class GroqModel(Model[AsyncGroq]):
                         pass
                     else:
                         assert_never(item)
-                message_param = chat.ChatCompletionAssistantMessageParam(role='assistant')
-                if texts:
-                    # Note: model responses from this model should only have one text item, so the following
-                    # shouldn't merge multiple texts into one unless you switch models between runs:
-                    message_param['content'] = '\n\n'.join(texts)
-                if tool_calls:
-                    message_param['tool_calls'] = tool_calls
-                groq_messages.append(message_param)
+                if texts or tool_calls:
+                    message_param = chat.ChatCompletionAssistantMessageParam(role='assistant')
+                    if texts:
+                        # Note: model responses from this model should only have one text item, so the following
+                        # shouldn't merge multiple texts into one unless you switch models between runs:
+                        message_param['content'] = '\n\n'.join(texts)
+                    if tool_calls:
+                        message_param['tool_calls'] = tool_calls
+                    groq_messages.append(message_param)
             else:
                 assert_never(message)
         if instruction_parts := self._get_instruction_parts(messages, model_request_parameters):

--- a/pydantic_ai_slim/pydantic_ai/models/huggingface.py
+++ b/pydantic_ai_slim/pydantic_ai/models/huggingface.py
@@ -408,14 +408,15 @@ class HuggingFaceModel(Model[AsyncInferenceClient]):
                         pass
                     else:
                         assert_never(item)
-                message_param = ChatCompletionInputMessage(role='assistant')
-                if texts:
-                    # Note: model responses from this model should only have one text item, so the following
-                    # shouldn't merge multiple texts into one unless you switch models between runs:
-                    message_param['content'] = '\n\n'.join(texts)
-                if tool_calls:
-                    message_param['tool_calls'] = tool_calls
-                hf_messages.append(message_param)
+                if texts or tool_calls:
+                    message_param = ChatCompletionInputMessage(role='assistant')
+                    if texts:
+                        # Note: model responses from this model should only have one text item, so the following
+                        # shouldn't merge multiple texts into one unless you switch models between runs:
+                        message_param['content'] = '\n\n'.join(texts)
+                    if tool_calls:
+                        message_param['tool_calls'] = tool_calls
+                    hf_messages.append(message_param)
             else:
                 assert_never(message)
         if instruction_parts := self._get_instruction_parts(messages, model_request_parameters):


### PR DESCRIPTION
## Summary

Fixes #6364.

`GroqModel._map_messages` and `HuggingFaceModel._map_messages` unconditionally appended
an assistant message for every `ModelResponse`, even when `parts` was empty.
A bare `{'role': 'assistant'}` is rejected with HTTP 400 by the Chat Completions API.

This breaks the empty-response retry flow: the agent records `ModelResponse(parts=[])`
and on the next request the adapter turns it into an invalid bare message, crashing
instead of recovering.

The OpenAI, Anthropic, Mistral, and Cohere adapters already guard this (tracked
in #6302 and #6138). This PR mirrors the same fix for the two adapters that were missed.

## Fix

Wrap the `message_param` construction and `append` in `if texts or tool_calls:`.
Empty `ModelResponse` objects produce neither, so they are silently skipped — matching
the OpenAI adapter behaviour.

## Files changed
- `pydantic_ai_slim/pydantic_ai/models/groq.py`
- `pydantic_ai_slim/pydantic_ai/models/huggingface.py`

Closes #6364.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

