### PR TITLE
Fix `DeferredToolResults` resume when an output tool call was settled in the same batch as deferred calls

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -249,7 +249,10 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
         if self.tool_call_results is not None:
             # The resume path must supply a result for every eligible call from the original response,
             # including `'unknown'` (hallucinated) ones, using the `'skip'` sentinel for any call that
-            # was already handled in a prior step. The check below relies on that convention.
+            # was already handled in a prior step. Non-eligible `'output'` calls settled in the original
+            # step also arrive as `'skip'` entries (from their retry/status parts in the trailing
+            # request), so results may cover more than the eligible calls but never more than the
+            # response's calls. The check below relies on that convention.
             self.executable_function_kinds = ('function', 'unknown', 'external', 'unapproved')
             eligible_calls = [
                 call
@@ -283,21 +286,15 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
         self.output_indices = [i for i in range(len(self.tool_calls)) if self.is_executable_output(i)]
         self.schema = self.ctx.deps.output_schema
 
-    def is_executable_output(self, index: int) -> bool:
-        if self.call_kinds[index] != 'output':
-            return False
+    def _is_resume_eligible(self, index: int) -> bool:
         # On resume, calls without a supplied result were executed in a previous step; skip.
-        if self.tool_call_results is not None and self.tool_calls[index].tool_call_id not in self.calls_to_run_results:
-            return False
-        return True
+        return self.tool_call_results is None or self.tool_calls[index].tool_call_id in self.calls_to_run_results
+
+    def is_executable_output(self, index: int) -> bool:
+        return self.call_kinds[index] == 'output' and self._is_resume_eligible(index)
 
     def is_executable_function(self, index: int) -> bool:
-        if self.call_kinds[index] not in self.executable_function_kinds:
-            return False
-        # On resume, calls without a supplied result were executed in a previous step; skip.
-        if self.tool_call_results is not None and self.tool_calls[index].tool_call_id not in self.calls_to_run_results:
-            return False
-        return True
+        return self.call_kinds[index] in self.executable_function_kinds and self._is_resume_eligible(index)
 
     async def run(self) -> AsyncIterator[_messages.HandleResponseEvent]:
         """Run the configured strategy, then apply retry-wins and resolve deferred calls."""

--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -266,7 +266,8 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
                 )
             result_tool_call_ids = set(self.tool_call_results.keys())
             eligible_call_ids = {call.tool_call_id for call in eligible_calls}
-            if eligible_call_ids != result_tool_call_ids:
+            response_tool_call_ids = {call.tool_call_id for call in self.tool_calls}
+            if not eligible_call_ids <= result_tool_call_ids or not result_tool_call_ids <= response_tool_call_ids:
                 raise exceptions.UserError(
                     'Tool call results need to be provided for all deferred tool calls. '
                     f'Expected: {eligible_call_ids}, got: {result_tool_call_ids}'
@@ -279,8 +280,16 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
             self.calls_to_run_results = {}
 
         self.function_indices = [i for i in range(len(self.tool_calls)) if self.is_executable_function(i)]
-        self.output_indices = [i for i in range(len(self.tool_calls)) if call_kinds[i] == 'output']
+        self.output_indices = [i for i in range(len(self.tool_calls)) if self.is_executable_output(i)]
         self.schema = self.ctx.deps.output_schema
+
+    def is_executable_output(self, index: int) -> bool:
+        if self.call_kinds[index] != 'output':
+            return False
+        # On resume, calls without a supplied result were executed in a previous step; skip.
+        if self.tool_call_results is not None and self.tool_calls[index].tool_call_id not in self.calls_to_run_results:
+            return False
+        return True
 
     def is_executable_function(self, index: int) -> bool:
         if self.call_kinds[index] not in self.executable_function_kinds:
@@ -881,9 +890,9 @@ class _EarlyProcessor(_ToolCallProcessor[DepsT, NodeRunEndT]):
     """`'early'`: run all output tools first; run function tools only if every output failed."""
 
     async def _run_strategy(self) -> AsyncIterator[_messages.HandleResponseEvent]:
-        for call in self.tool_calls_by_kind['output']:
+        for i in self.output_indices:
             # `_run_output` always yields ≥1 event, so the empty-iterator branch can't happen.
-            async for event in self._run_output(call):  # pragma: no branch
+            async for event in self._run_output(self.tool_calls[i]):  # pragma: no branch
                 yield event
         self.ctx.state.output_retries_used += self.output_retries_increment
 
@@ -920,7 +929,7 @@ class _GracefulProcessor(_ToolCallProcessor[DepsT, NodeRunEndT]):
                     yield event
 
         for i, call in enumerate(self.tool_calls):
-            if self.call_kinds[i] == 'output':
+            if self.is_executable_output(i):
                 async for event in flush_pending():
                     yield event
                 # `_run_output` always yields ≥1 event, so the empty-iterator branch can't happen.

--- a/pydantic_ai_slim/pydantic_ai/_tool_execution.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_execution.py
@@ -267,7 +267,7 @@ class _ToolCallProcessor(Generic[DepsT, NodeRunEndT], ABC):
             result_tool_call_ids = set(self.tool_call_results.keys())
             eligible_call_ids = {call.tool_call_id for call in eligible_calls}
             response_tool_call_ids = {call.tool_call_id for call in self.tool_calls}
-            if not eligible_call_ids <= result_tool_call_ids or not result_tool_call_ids <= response_tool_call_ids:
+            if not (eligible_call_ids <= result_tool_call_ids <= response_tool_call_ids):
                 raise exceptions.UserError(
                     'Tool call results need to be provided for all deferred tool calls. '
                     f'Expected: {eligible_call_ids}, got: {result_tool_call_ids}'

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -14,6 +14,7 @@ from typing_extensions import TypedDict
 
 from pydantic_ai import (
     Agent,
+    EndStrategy,
     ExternalToolset,
     FunctionToolset,
     ModelMessage,
@@ -1591,6 +1592,147 @@ def test_tool_raises_approval_required():
         ]
     )
     assert result.output == snapshot('Done!')
+
+
+@pytest.mark.parametrize('end_strategy', ['early', 'graceful', 'exhaustive'])
+def test_resume_deferred_tool_with_invalid_output_call(end_strategy: EndStrategy):
+    class MyOutput(BaseModel):
+        value: int
+
+    def llm(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if len(messages) == 1:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name='final_result',
+                        args={'value': 'not-an-int'},
+                        tool_call_id='output_call',
+                    ),
+                    ToolCallPart(
+                        tool_name='my_tool',
+                        args={'x': 1},
+                        tool_call_id='approval_call',
+                    ),
+                ]
+            )
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name='final_result', args={'value': 42}, tool_call_id='valid_output_call')]
+        )
+
+    agent = Agent(FunctionModel(llm), output_type=[MyOutput, DeferredToolRequests], end_strategy=end_strategy)
+
+    @agent.tool_plain(requires_approval=True)
+    def my_tool(x: int) -> int:
+        return x * 2
+
+    result = agent.run_sync('Hello')
+    assert result.output == snapshot(
+        DeferredToolRequests(approvals=[ToolCallPart(tool_name='my_tool', args={'x': 1}, tool_call_id='approval_call')])
+    )
+    message_history = result.all_messages()
+
+    with pytest.raises(UserError, match='Tool call results need to be provided for all deferred tool calls'):
+        agent.run_sync(
+            message_history=message_history,
+            deferred_tool_results=DeferredToolResults(approvals={'approval_call': True, 'bogus_call': True}),
+        )
+
+    result = agent.run_sync(
+        message_history=message_history,
+        deferred_tool_results=DeferredToolResults(approvals={'approval_call': True}),
+    )
+
+    assert result.output == MyOutput(value=42)
+    messages = result.all_messages()
+    retry_parts = [part for message in messages for part in message.parts if isinstance(part, RetryPromptPart)]
+    my_tool_returns = [
+        part
+        for message in messages
+        for part in message.parts
+        if isinstance(part, ToolReturnPart) and part.tool_name == 'my_tool'
+    ]
+    assert len(retry_parts) == 1
+    assert retry_parts[0].tool_call_id == 'output_call'
+    assert len(my_tool_returns) == 1
+    assert my_tool_returns[0].tool_call_id == 'approval_call'
+
+    if end_strategy == 'graceful':
+        assert messages == snapshot(
+            [
+                ModelRequest(
+                    parts=[UserPromptPart(content='Hello', timestamp=IsDatetime())],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(
+                            tool_name='final_result', args={'value': 'not-an-int'}, tool_call_id='output_call'
+                        ),
+                        ToolCallPart(tool_name='my_tool', args={'x': 1}, tool_call_id='approval_call'),
+                    ],
+                    usage=RequestUsage(input_tokens=51, output_tokens=9),
+                    model_name='function:llm:',
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelRequest(
+                    parts=[
+                        RetryPromptPart(
+                            content=[
+                                {
+                                    'type': 'int_parsing',
+                                    'loc': ('value',),
+                                    'msg': 'Input should be a valid integer, unable to parse string as an integer',
+                                    'input': 'not-an-int',
+                                }
+                            ],
+                            tool_name='final_result',
+                            tool_call_id='output_call',
+                            timestamp=IsDatetime(),
+                        )
+                    ],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name='my_tool', content=2, tool_call_id='approval_call', timestamp=IsDatetime()
+                        )
+                    ],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(tool_name='final_result', args={'value': 42}, tool_call_id='valid_output_call')
+                    ],
+                    usage=RequestUsage(input_tokens=90, output_tokens=13),
+                    model_name='function:llm:',
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name='final_result',
+                            content='Final result processed.',
+                            tool_call_id='valid_output_call',
+                            timestamp=IsDatetime(),
+                        )
+                    ],
+                    timestamp=IsDatetime(),
+                    run_id=IsStr(),
+                    conversation_id=IsStr(),
+                ),
+            ]
+        )
 
 
 def test_approval_required_with_user_prompt():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1596,6 +1596,11 @@ def test_tool_raises_approval_required():
 
 @pytest.mark.parametrize('end_strategy', ['early', 'graceful', 'exhaustive'])
 def test_resume_deferred_tool_with_invalid_output_call(end_strategy: EndStrategy):
+    """Not a VCR test: pins internal resume validation and message-history shape via `FunctionModel`,
+    which requires an exact parallel batch of an invalid output tool call and an approval-required
+    call that a live model wouldn't reliably produce (https://github.com/pydantic/pydantic-ai/issues/6486).
+    """
+
     class MyOutput(BaseModel):
         value: int
 


### PR DESCRIPTION
- Closes #6486

When a model response contains, in one parallel batch, an output tool call that fails validation alongside deferred (`requires_approval=True` or external) tool calls, the run correctly ends with `DeferredToolRequests` and the output call's `RetryPromptPart` lands in the trailing `ModelRequest`. But resuming with `deferred_tool_results=` then raised:

```
UserError: Tool call results need to be provided for all deferred tool calls. Expected: {'approval_call'}, got: {'approval_call', 'output_call'}
```

`_handle_deferred_tool_results` marks every `ToolReturnPart`/`RetryPromptPart` in the trailing request as `'skip'`, but the resume path's `executable_function_kinds` excludes `'output'`-kind calls from the eligible set, so the strict equality check rejected the `'skip'` entry for the already-settled output call.

Note that the scenario as described in #6486 (an inline-resolved capability-loader tool) does not reproduce — loader tools are `'function'`-kind, which is resume-eligible, so their `'skip'` entries already match. See [my comment on the issue](https://github.com/pydantic/pydantic-ai/issues/6486#issuecomment-4972851504) for the analysis; the confirmed variant fixed here is the `'output'`-kind one, which was reproduced end-to-end.

### Fix

Two parts, both in `_tool_execution.py`:

1. Relax the strict equality check: every eligible call must still have a result (and unknown IDs are still rejected), but entries for other calls from the same response — i.e. `'skip'` markers for output calls settled in the original step — are now accepted. (Supplying a real result for an already-executed call is still rejected upstream in `_handle_deferred_tool_results`.)
2. Introduce `is_executable_output()`, mirroring `is_executable_function()`, and use it in all three end strategies (`'early'`, `'graceful'`, `'exhaustive'`) so an already-settled output call is not re-executed on resume — previously it would have been re-validated, emitting a duplicate `RetryPromptPart` and burning output-retry budget.

The regression test is parametrized over all three end strategies and snapshots the full resumed message history for the default `'graceful'` strategy, asserting the original retry part is preserved exactly once.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

