### PR TITLE
Apply tool timeouts in `ToolManager` so all toolsets honor them

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_tool_timeout.py
+++ b/pydantic_ai_slim/pydantic_ai/_tool_timeout.py
@@ -1,0 +1,23 @@
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+import anyio
+
+from .exceptions import ModelRetry
+
+T = TypeVar('T')
+
+
+async def run_with_tool_timeout(call: Callable[[], Awaitable[T]], timeout: float | None) -> T:
+    """Run a tool call and turn only the configured deadline into a retry."""
+    if timeout is None:
+        return await call()
+
+    scope: anyio.CancelScope | None = None
+    try:
+        with anyio.fail_after(timeout) as scope:
+            return await call()
+    except TimeoutError:
+        if scope is None or not scope.cancel_called:
+            raise
+        raise ModelRetry(f'Timed out after {timeout} seconds.') from None

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1501,7 +1501,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
             toolset,
             root_capability=run_capability,
             default_max_retries=effective_tool_retries_resolved,
-            timeout=self._tool_timeout,
+            default_timeout=self._tool_timeout,
         )
 
         # Build instructions with per-run capability contributions

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1498,7 +1498,10 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         )
         toolset = await toolset.for_run(initial_ctx)
         tool_manager = ToolManager[AgentDepsT](
-            toolset, root_capability=run_capability, default_max_retries=effective_tool_retries_resolved
+            toolset,
+            root_capability=run_capability,
+            default_max_retries=effective_tool_retries_resolved,
+            timeout=self._tool_timeout,
         )
 
         # Build instructions with per-run capability contributions
@@ -2879,6 +2882,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                     return await output_cap.prepare_output_tools(output_ctx, tool_defs)
 
                 output_toolset = PreparedToolset(output_toolset, _dispatch_prepare_output_tools)
+
             toolset = CombinedToolset([output_toolset, toolset])
 
         return toolset

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -2882,7 +2882,6 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                     return await output_cap.prepare_output_tools(output_ctx, tool_defs)
 
                 output_toolset = PreparedToolset(output_toolset, _dispatch_prepare_output_tools)
-
             toolset = CombinedToolset([output_toolset, toolset])
 
         return toolset

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -476,15 +476,29 @@ class DurableMCPToolset(DurableToolsetBase[AgentDepsT]):
         self._resolve_tool_config = resolve_tool_config
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
-        if not self._in_durable_context() or self._get_tools_operation is None:
+        if not self._in_durable_context():
             return await self.wrapped.get_tools(ctx)
-        cache_key = self.id or ''
-        if self._mcp_toolset.cache_tools and (cached := ctx._mcp_tool_defs_cache.get(cache_key)) is not None:  # pyright: ignore[reportPrivateUsage]
-            return {name: self._mcp_toolset.tool_for_tool_def(tool_def, ctx=ctx) for name, tool_def in cached.items()}
-        tool_defs = await self._get_tools_operation(ctx)
-        if self._mcp_toolset.cache_tools:
-            ctx._mcp_tool_defs_cache[cache_key] = tool_defs  # pyright: ignore[reportPrivateUsage]
-        return {name: self._mcp_toolset.tool_for_tool_def(tool_def, ctx=ctx) for name, tool_def in tool_defs.items()}
+
+        if self._get_tools_operation is None:
+            tools = await self.wrapped.get_tools(ctx)
+        else:
+            cache_key = self.id or ''
+            if self._mcp_toolset.cache_tools and (cached := ctx._mcp_tool_defs_cache.get(cache_key)) is not None:  # pyright: ignore[reportPrivateUsage]
+                tool_defs = cached
+            else:
+                tool_defs = await self._get_tools_operation(ctx)
+                if self._mcp_toolset.cache_tools:
+                    ctx._mcp_tool_defs_cache[cache_key] = tool_defs  # pyright: ignore[reportPrivateUsage]
+            tools = {
+                name: self._mcp_toolset.tool_for_tool_def(tool_def, ctx=ctx) for name, tool_def in tool_defs.items()
+            }
+
+        return {
+            name: replace(tool, timeout_managed_by_toolset=True)
+            if self._resolve_tool_config(tool, name) is not False
+            else tool
+            for name, tool in tools.items()
+        }
 
     async def get_instructions(self, ctx: RunContext[AgentDepsT]) -> Instructions:
         if not self._mcp_toolset.include_instructions:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -16,6 +16,7 @@ from pydantic_ai.messages import InstructionPart, ToolReturn, ToolReturnContent
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 from pydantic_ai.toolsets.external import TOOL_SCHEMA_VALIDATOR
+from pydantic_ai.toolsets.function import FunctionToolsetTool
 
 if TYPE_CHECKING:
     from pydantic_ai.mcp import MCPToolset
@@ -351,6 +352,15 @@ class DurableFunctionToolset(DurableToolsetBase[AgentDepsT]):
         )
         self._call_tool_operation = call_tool_operation
         self._resolve_tool_config = resolve_tool_config
+
+    async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
+        tools = await self.wrapped.get_tools(ctx)
+        if not self._in_durable_context():
+            return tools
+        return {
+            name: replace(tool, timeout_managed_by_toolset=True) if isinstance(tool, FunctionToolsetTool) else tool
+            for name, tool in tools.items()
+        }
 
     async def call_tool(
         self, name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT], tool: ToolsetTool[AgentDepsT]

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -10,6 +10,7 @@ from typing_extensions import Self, assert_never
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool, WrapperToolset
 from pydantic_ai._enqueue import PendingMessage
+from pydantic_ai._tool_timeout import run_with_tool_timeout
 from pydantic_ai._utils import is_str_dict
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry, ToolFailed, UserError
 from pydantic_ai.messages import InstructionPart, ToolReturn, ToolReturnContent
@@ -81,7 +82,12 @@ async def get_dynamic_tools(toolset: AbstractToolset[AgentDepsT], ctx: RunContex
 
 
 async def call_dynamic_tool(
-    toolset: AbstractToolset[AgentDepsT], name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]
+    toolset: AbstractToolset[AgentDepsT],
+    name: str,
+    tool_args: dict[str, Any],
+    ctx: RunContext[AgentDepsT],
+    *,
+    timeout: float | None = None,
 ) -> Any:
     """Resolve a dynamic toolset fresh, re-validate the tool args, and call the tool.
 
@@ -99,7 +105,7 @@ async def call_dynamic_tool(
                 'The dynamic toolset function may have returned a different toolset than expected.'
             )
         args = tool.args_validator.validate_python(tool_args)
-        return await run_toolset.call_tool(name, args, ctx, tool)
+        return await run_with_tool_timeout(lambda: run_toolset.call_tool(name, args, ctx, tool), timeout)
 
 
 @dataclass
@@ -421,16 +427,19 @@ class DurableDynamicToolset(DurableToolsetBase[AgentDepsT]):
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         result = await self._get_tools_operation(ctx)
         self._run_instructions = result.instructions
-        return {
-            name: ToolsetTool(
+        tools: dict[str, ToolsetTool[AgentDepsT]] = {}
+        for name, info in result.tools.items():
+            tool = ToolsetTool(
                 toolset=self,
                 tool_def=info.tool_def,
                 max_retries=info.max_retries,
                 # Only parse here; the real tool validates again inside the durable unit.
                 args_validator=TOOL_SCHEMA_VALIDATOR,
             )
-            for name, info in result.tools.items()
-        }
+            if self._resolve_tool_config(tool, name) is not False:
+                tool = replace(tool, timeout_managed_by_toolset=True)
+            tools[name] = tool
+        return tools
 
     async def get_instructions(self, ctx: RunContext[AgentDepsT]) -> Instructions:
         # Set by `get_tools`, which the framework runs earlier in each step.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_dynamic_toolset.py
@@ -32,11 +32,22 @@ def dbosify_dynamic_toolset(
         return await get_dynamic_tools(wrapped, guard_enqueue_in_workflow(ctx))
 
     @DBOS.step(name=f'{name}.call_tool', **(step_config or {}))
-    async def call_tool_step(tool_name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]) -> CallToolResult:
+    async def call_tool_step(
+        tool_name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[AgentDepsT],
+        tool: ToolsetTool[AgentDepsT],
+    ) -> CallToolResult:
         # DBOS has no selective non-retryable-exception support, so control-flow
         # exceptions must cross the step boundary as successful values.
         return await wrap_tool_call_result(
-            call_dynamic_tool(wrapped, tool_name, tool_args, guard_enqueue_in_workflow(ctx))
+            call_dynamic_tool(
+                wrapped,
+                tool_name,
+                tool_args,
+                guard_enqueue_in_workflow(ctx),
+                timeout=tool.tool_def.timeout,
+            )
         )
 
     async def call_tool_operation(
@@ -48,7 +59,7 @@ def dbosify_dynamic_toolset(
     ) -> Any:
         # A recovering workflow may replay outputs this step recorded before it wrapped
         # control-flow exceptions as values; those recordings are the raw tool result.
-        return unwrap_recorded_tool_call_result(await call_tool_step(name, tool_args, ctx))
+        return unwrap_recorded_tool_call_result(await call_tool_step(name, tool_args, ctx, tool))
 
     return DurableDynamicToolset(
         wrapped,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
@@ -6,6 +6,7 @@ from typing import Any
 from dbos import DBOS
 
 from pydantic_ai import ToolsetTool
+from pydantic_ai._tool_timeout import run_with_tool_timeout
 from pydantic_ai.durable_exec._toolset import (
     CallToolResult,
     DurableMCPToolset,
@@ -45,7 +46,10 @@ def dbosify_mcp_toolset(
         # DBOS has no selective non-retryable-exception support, so control-flow
         # exceptions must cross the step boundary as successful values.
         return await wrap_tool_call_result(
-            wrapped.call_tool(tool_name, tool_args, guard_enqueue_in_workflow(ctx), tool)
+            run_with_tool_timeout(
+                lambda: wrapped.call_tool(tool_name, tool_args, guard_enqueue_in_workflow(ctx), tool),
+                tool.tool_def.timeout,
+            )
         )
 
     async def call_tool_operation(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_dynamic_toolset.py
@@ -36,9 +36,16 @@ def prefectify_dynamic_toolset(
         return await get_dynamic_tools(wrapped, ctx)
 
     @task
-    async def call_tool_task(tool_name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]) -> Any:
+    async def call_tool_task(
+        tool_name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[AgentDepsT],
+        tool: ToolsetTool[AgentDepsT],
+    ) -> Any:
         task_ctx = guard_task_enqueue(ctx)
-        return await wrap_tool_call_result(call_dynamic_tool(wrapped, tool_name, tool_args, task_ctx))
+        return await wrap_tool_call_result(
+            call_dynamic_tool(wrapped, tool_name, tool_args, task_ctx, timeout=tool.tool_def.timeout)
+        )
 
     async def call_tool_operation(
         name: str,
@@ -48,7 +55,9 @@ def prefectify_dynamic_toolset(
         config: Mapping[str, Any],
     ) -> Any:
         merged_config = with_non_retryable_errors(cast('TaskConfig', base_config | dict(config)))
-        result = await call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(name, tool_args, ctx)
+        result = await call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(
+            name, tool_args, ctx, tool
+        )
         # A persisted cache entry written before this task wrapped control-flow exceptions (still
         # reachable under a custom `cache_policy` that omits `TASK_SOURCE`) holds the raw result.
         return unwrap_recorded_tool_call_result(result)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import replace
 from typing import Any, cast
 
 from prefect import task
@@ -17,7 +16,6 @@ from pydantic_ai.durable_exec._toolset import (
     wrap_tool_call_result,
 )
 from pydantic_ai.tools import AgentDepsT, RunContext
-from pydantic_ai.toolsets.function import FunctionToolsetTool
 
 from ._toolset import guard_task_enqueue, resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
@@ -32,8 +30,6 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
         task_ctx = guard_task_enqueue(ctx)
-        assert isinstance(tool, FunctionToolsetTool)
-        tool = replace(tool, enforce_timeout=True)
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import Any, cast
 
 from prefect import task
@@ -16,6 +17,7 @@ from pydantic_ai.durable_exec._toolset import (
     wrap_tool_call_result,
 )
 from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.toolsets.function import FunctionToolsetTool
 
 from ._toolset import guard_task_enqueue, resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
@@ -30,6 +32,8 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
         task_ctx = guard_task_enqueue(ctx)
+        assert isinstance(tool, FunctionToolsetTool)
+        tool = replace(tool, enforce_timeout=True)
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
@@ -8,6 +8,7 @@ from prefect.context import FlowRunContext
 from typing_extensions import deprecated
 
 from pydantic_ai import ToolsetTool
+from pydantic_ai._tool_timeout import run_with_tool_timeout
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.durable_exec._toolset import (
     CallToolOperation,
@@ -34,7 +35,11 @@ def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfi
     ) -> Any:
         # The context is guarded because a `process_tool_call=` hook receives it and could enqueue.
         task_ctx = guard_task_enqueue(ctx)
-        return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
+        return await wrap_tool_call_result(
+            run_with_tool_timeout(
+                lambda: wrapped.call_tool(tool_name, tool_args, task_ctx, tool), tool.tool_def.timeout
+            )
+        )
 
     async def call_tool_operation(
         name: str,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_dynamic_toolset.py
@@ -18,7 +18,7 @@ from pydantic_ai.durable_exec._toolset import (
     wrap_tool_call_result,
 )
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
 from ._activity_execution import execute_activity
@@ -63,7 +63,11 @@ def temporalize_dynamic_toolset(
     async def call_tool_activity(params: CallToolParams, deps: AgentDepsT) -> CallToolResult:
         async with heartbeating():
             ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
-            return await wrap_tool_call_result(call_dynamic_tool(toolset, params.name, params.tool_args, ctx))
+            tool_def = params.tool_def
+            assert isinstance(tool_def, ToolDefinition)
+            return await wrap_tool_call_result(
+                call_dynamic_tool(toolset, params.name, params.tool_args, ctx, timeout=tool_def.timeout)
+            )
 
     call_tool_activity.__annotations__['deps'] = deps_type
     registered_call_tool = activity.defn(name=f'{activity_name_prefix}__dynamic_toolset__{toolset.id}__call_tool')(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_mcp_toolset.py
@@ -7,6 +7,7 @@ from temporalio import activity, workflow
 from temporalio.workflow import ActivityConfig
 
 from pydantic_ai import ToolsetTool
+from pydantic_ai._tool_timeout import run_with_tool_timeout
 from pydantic_ai.durable_exec._toolset import (
     CallToolResult,
     DurableMCPToolset,
@@ -60,10 +61,14 @@ def temporalize_mcp_toolset(
     async def call_tool_activity(params: CallToolParams, deps: AgentDepsT) -> CallToolResult:
         async with heartbeating():
             ctx = deserialize_run_context(run_context_type, params.serialized_run_context, deps=deps, agent=agent)
-            assert isinstance(params.tool_def, ToolDefinition)
+            tool_def = params.tool_def
+            assert isinstance(tool_def, ToolDefinition)
             return await wrap_tool_call_result(
-                toolset.call_tool(
-                    params.name, params.tool_args, ctx, toolset.tool_for_tool_def(params.tool_def, ctx=ctx)
+                run_with_tool_timeout(
+                    lambda: toolset.call_tool(
+                        params.name, params.tool_args, ctx, toolset.tool_for_tool_def(tool_def, ctx=ctx)
+                    ),
+                    tool_def.timeout,
                 )
             )
 

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -7,7 +7,6 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Generic, Literal
 
-import anyio
 from pydantic import ValidationError
 
 from . import messages as _messages
@@ -18,6 +17,7 @@ from ._output import (
     run_output_validate_hooks,
 )
 from ._run_context import AgentDepsT, RunContext
+from ._tool_timeout import run_with_tool_timeout
 from .exceptions import (
     ApprovalRequired,
     CallDeferred,
@@ -940,26 +940,10 @@ class ToolManager(Generic[AgentDepsT]):
         if not tool.timeout_managed_by_toolset:
             timeout = tool.tool_def.timeout if tool.tool_def.timeout is not None else self.default_timeout
 
-        async def call_tool() -> Any:
-            return await self.toolset.call_tool(
-                name,
-                validated_args,
-                validated.ctx,
-                tool,
-            )
-
         try:
-            if timeout is None:
-                tool_result = await call_tool()
-            else:
-                scope: anyio.CancelScope | None = None
-                try:
-                    with anyio.fail_after(timeout) as scope:
-                        tool_result = await call_tool()
-                except TimeoutError:
-                    if scope is None or not scope.cancel_called:
-                        raise
-                    raise ModelRetry(f'Timed out after {timeout} seconds.') from None
+            tool_result = await run_with_tool_timeout(
+                lambda: self.toolset.call_tool(name, validated_args, validated.ctx, tool), timeout
+            )
         except ToolFailed as e:
             if not wrap_validation_errors:
                 raise

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -177,12 +177,20 @@ class ToolManager(Generic[AgentDepsT]):
             ctx = replace(ctx, retries=retries)
 
         toolset = await self.toolset.for_run_step(ctx)
+        tools = await toolset.get_tools(ctx)
+        if self.default_timeout is not None:
+            tools = {
+                name: replace(tool, tool_def=replace(tool.tool_def, timeout=self.default_timeout))
+                if tool.timeout_managed_by_toolset and tool.tool_def.timeout is None
+                else tool
+                for name, tool in tools.items()
+            }
 
         new_tm = self.__class__(
             toolset=toolset,
             root_capability=self.root_capability,
             ctx=ctx,
-            tools=await toolset.get_tools(ctx),
+            tools=tools,
             default_max_retries=self.default_max_retries,
             default_timeout=self.default_timeout,
         )
@@ -928,9 +936,9 @@ class ToolManager(Generic[AgentDepsT]):
         tool = validated.tool
         validated_args = validated.validated_args
 
-        timeout = tool.tool_def.timeout
-        if timeout is None:
-            timeout = self.default_timeout
+        timeout = None
+        if not tool.timeout_managed_by_toolset:
+            timeout = tool.tool_def.timeout if tool.tool_def.timeout is not None else self.default_timeout
 
         async def call_tool() -> Any:
             return await self.toolset.call_tool(

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -137,8 +137,8 @@ class ToolManager(Generic[AgentDepsT]):
     """Names of tools that succeeded in this run step."""
     default_max_retries: int = 1
     """Default number of times to retry a tool"""
-    timeout: float | None = None
-    """Tool timeout set on the agent to be applied to all tools being executed by the tool manager."""
+    default_timeout: float | None = None
+    """Agent-level fallback timeout for tools without a configured timeout."""
 
     @classmethod
     @contextmanager
@@ -184,7 +184,7 @@ class ToolManager(Generic[AgentDepsT]):
             ctx=ctx,
             tools=await toolset.get_tools(ctx),
             default_max_retries=self.default_max_retries,
-            timeout=self.timeout,
+            default_timeout=self.default_timeout,
         )
         # Make the prepared ToolManager accessible from RunContext so that
         # wrapper toolsets (e.g. CodeModeToolset) can dispatch tool calls
@@ -925,22 +925,33 @@ class ToolManager(Generic[AgentDepsT]):
         assert validated.validated_args is not None
 
         name = validated.call.tool_name
+        tool = validated.tool
+        validated_args = validated.validated_args
 
-        # A tool's own timeout (which a toolset may have already resolved from its own default) takes
-        # precedence over the agent-level one. Applying it here rather than in `FunctionToolset` means
-        # every toolset is covered, including ones that implement `call_tool` themselves.
-        timeout = validated.tool.tool_def.timeout
+        timeout = tool.tool_def.timeout
         if timeout is None:
-            timeout = self.timeout
+            timeout = self.default_timeout
+
+        async def call_tool() -> Any:
+            return await self.toolset.call_tool(
+                name,
+                validated_args,
+                validated.ctx,
+                tool,
+            )
 
         try:
-            with anyio.fail_after(timeout):
-                tool_result = await self.toolset.call_tool(
-                    name,
-                    validated.validated_args,
-                    validated.ctx,
-                    validated.tool,
-                )
+            if timeout is None:
+                tool_result = await call_tool()
+            else:
+                scope: anyio.CancelScope | None = None
+                try:
+                    with anyio.fail_after(timeout) as scope:
+                        tool_result = await call_tool()
+                except TimeoutError:
+                    if scope is None or not scope.cancel_called:
+                        raise
+                    raise ModelRetry(f'Timed out after {timeout} seconds.') from None
         except ToolFailed as e:
             if not wrap_validation_errors:
                 raise
@@ -948,11 +959,9 @@ class ToolManager(Generic[AgentDepsT]):
         except ModelRetry as e:
             if not wrap_validation_errors:
                 raise
-            self._check_max_retries(name, validated.tool.max_retries, e)
+            self._check_max_retries(name, tool.max_retries, e)
             self.failed_tools.add(name)
             raise self._wrap_error_as_retry(name, validated.call, e) from e
-        except TimeoutError:
-            raise ModelRetry(f'Timed out after {timeout} seconds.') from None
 
         usage.tool_calls += 1
 

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -7,6 +7,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Generic, Literal
 
+import anyio
 from pydantic import ValidationError
 
 from . import messages as _messages
@@ -136,6 +137,8 @@ class ToolManager(Generic[AgentDepsT]):
     """Names of tools that succeeded in this run step."""
     default_max_retries: int = 1
     """Default number of times to retry a tool"""
+    timeout: float | None = None
+    """Tool timeout set on the agent to be applied to all tools being executed by the tool manager."""
 
     @classmethod
     @contextmanager
@@ -922,13 +925,16 @@ class ToolManager(Generic[AgentDepsT]):
 
         name = validated.call.tool_name
 
+        # All tool calls go from here and we can apply the fail_after right here as long as we know what the tool timeout is
+
         try:
-            tool_result = await self.toolset.call_tool(
-                name,
-                validated.validated_args,
-                validated.ctx,
-                validated.tool,
-            )
+            with anyio.fail_after(self.timeout):
+                tool_result = await self.toolset.call_tool(
+                    name,
+                    validated.validated_args,
+                    validated.ctx,
+                    validated.tool,
+                )
         except ToolFailed as e:
             if not wrap_validation_errors:
                 raise
@@ -939,6 +945,8 @@ class ToolManager(Generic[AgentDepsT]):
             self._check_max_retries(name, validated.tool.max_retries, e)
             self.failed_tools.add(name)
             raise self._wrap_error_as_retry(name, validated.call, e) from e
+        except TimeoutError:
+            raise ModelRetry(f'Timed out after {self.timeout} seconds.') from None
 
         usage.tool_calls += 1
 

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -184,6 +184,7 @@ class ToolManager(Generic[AgentDepsT]):
             ctx=ctx,
             tools=await toolset.get_tools(ctx),
             default_max_retries=self.default_max_retries,
+            timeout=self.timeout,
         )
         # Make the prepared ToolManager accessible from RunContext so that
         # wrapper toolsets (e.g. CodeModeToolset) can dispatch tool calls
@@ -925,10 +926,15 @@ class ToolManager(Generic[AgentDepsT]):
 
         name = validated.call.tool_name
 
-        # All tool calls go from here and we can apply the fail_after right here as long as we know what the tool timeout is
+        # A tool's own timeout (which a toolset may have already resolved from its own default) takes
+        # precedence over the agent-level one. Applying it here rather than in `FunctionToolset` means
+        # every toolset is covered, including ones that implement `call_tool` themselves.
+        timeout = validated.tool.tool_def.timeout
+        if timeout is None:
+            timeout = self.timeout
 
         try:
-            with anyio.fail_after(self.timeout):
+            with anyio.fail_after(timeout):
                 tool_result = await self.toolset.call_tool(
                     name,
                     validated.validated_args,
@@ -946,7 +952,7 @@ class ToolManager(Generic[AgentDepsT]):
             self.failed_tools.add(name)
             raise self._wrap_error_as_retry(name, validated.call, e) from e
         except TimeoutError:
-            raise ModelRetry(f'Timed out after {self.timeout} seconds.') from None
+            raise ModelRetry(f'Timed out after {timeout} seconds.') from None
 
         usage.tool_calls += 1
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/abstract.py
@@ -71,6 +71,12 @@ class ToolsetTool(Generic[AgentDepsT]):
     try again, or [`ToolFailed`][pydantic_ai.exceptions.ToolFailed] to report a terminal failure the model
     should adapt to instead of retrying. Return `None` on success.
     """
+    timeout_managed_by_toolset: bool = False
+    """Whether the toolset owns this tool's timeout deadline instead of `ToolManager`.
+
+    Durable wrappers set this to `True` so the deadline starts inside the task or activity that
+    runs the tool, rather than while the workflow or flow is still dispatching it.
+    """
 
 
 class AbstractToolset(ABC, Generic[AgentDepsT]):

--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -86,6 +86,7 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
                     max_retries=tool.max_retries,
                     args_validator=tool.args_validator,
                     args_validator_func=tool.args_validator_func,
+                    timeout_managed_by_toolset=tool.timeout_managed_by_toolset,
                     source_toolset=toolset,
                     source_tool=tool,
                 )

--- a/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/combined.py
@@ -96,7 +96,10 @@ class CombinedToolset(AbstractToolset[AgentDepsT]):
         self, name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT], tool: ToolsetTool[AgentDepsT]
     ) -> Any:
         assert isinstance(tool, _CombinedToolsetTool)
-        return await tool.source_toolset.call_tool(name, tool_args, ctx, tool.source_tool)
+        source_tool = tool.source_tool
+        if source_tool.timeout_managed_by_toolset:
+            source_tool = replace(source_tool, tool_def=replace(source_tool.tool_def, timeout=tool.tool_def.timeout))
+        return await tool.source_toolset.call_tool(name, tool_args, ctx, source_tool)
 
     def apply(self, visitor: Callable[[AbstractToolset[AgentDepsT]], None]) -> None:
         for toolset in self.toolsets:

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -4,13 +4,13 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
 from typing import Any, overload
 
-import anyio
 from pydantic.json_schema import GenerateJsonSchema
 
 from .._instructions import prepare_instructions
 from .._run_context import AgentDepsT, RunContext
 from .._system_prompt import SystemPromptRunner
-from ..exceptions import ModelRetry, UserError
+from .._tool_timeout import run_with_tool_timeout
+from ..exceptions import UserError
 from ..messages import InstructionPart
 from ..tools import (
     ArgsValidatorFunc,
@@ -687,14 +687,4 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         assert isinstance(tool, FunctionToolsetTool)
 
         timeout = tool.tool_def.timeout if tool.timeout_managed_by_toolset else None
-        if timeout is None:
-            return await tool.call_func(tool_args, ctx)
-
-        scope: anyio.CancelScope | None = None
-        try:
-            with anyio.fail_after(timeout) as scope:
-                return await tool.call_func(tool_args, ctx)
-        except TimeoutError:
-            if scope is None or not scope.cancel_called:
-                raise
-            raise ModelRetry(f'Timed out after {timeout} seconds.') from None
+        return await run_with_tool_timeout(lambda: tool.call_func(tool_args, ctx), timeout)

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -34,8 +34,6 @@ class FunctionToolsetTool(ToolsetTool[AgentDepsT]):
 
     call_func: Callable[[dict[str, Any], RunContext[AgentDepsT]], Awaitable[Any]]
     is_async: bool
-    enforce_timeout: bool = False
-    """Whether this call runs outside `ToolManager`, as in a durable task or activity."""
     original_name: str | None = None
     """The name the toolset holds this tool under, which a `prepare` function may have renamed in `tool_def.name`.
 
@@ -659,7 +657,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             tool_def,
             max_retries if max_retries is not None else ctx.max_retries,
             original_name,
-            enforce_timeout=True,
+            timeout_managed_by_toolset=True,
         )
 
     def _tool_for(
@@ -669,7 +667,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         max_retries: int,
         original_name: str,
         *,
-        enforce_timeout: bool = False,
+        timeout_managed_by_toolset: bool = False,
     ) -> FunctionToolsetTool[AgentDepsT]:
         return FunctionToolsetTool(
             toolset=self,
@@ -679,8 +677,8 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             args_validator_func=tool.args_validator,
             call_func=tool.function_schema.call,
             is_async=tool.function_schema.is_async,
-            enforce_timeout=enforce_timeout,
             original_name=original_name,
+            timeout_managed_by_toolset=timeout_managed_by_toolset,
         )
 
     async def call_tool(
@@ -688,7 +686,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
     ) -> Any:
         assert isinstance(tool, FunctionToolsetTool)
 
-        timeout = tool.tool_def.timeout if tool.enforce_timeout else None
+        timeout = tool.tool_def.timeout if tool.timeout_managed_by_toolset else None
         if timeout is None:
             return await tool.call_func(tool_args, ctx)
 

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -4,13 +4,12 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
 from typing import Any, overload
 
-import anyio
 from pydantic.json_schema import GenerateJsonSchema
 
 from .._instructions import prepare_instructions
 from .._run_context import AgentDepsT, RunContext
 from .._system_prompt import SystemPromptRunner
-from ..exceptions import ModelRetry, UserError
+from ..exceptions import UserError
 from ..messages import InstructionPart
 from ..tools import (
     ArgsValidatorFunc,
@@ -34,12 +33,6 @@ class FunctionToolsetTool(ToolsetTool[AgentDepsT]):
 
     call_func: Callable[[dict[str, Any], RunContext[AgentDepsT]], Awaitable[Any]]
     is_async: bool
-    timeout: float | None = None
-    """Timeout in seconds for tool execution.
-
-    If the tool takes longer than this, a retry prompt is returned to the model.
-    Defaults to None (no timeout).
-    """
     original_name: str | None = None
     """The name the toolset holds this tool under, which a `prepare` function may have renamed in `tool_def.name`.
 
@@ -671,7 +664,6 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             args_validator_func=tool.args_validator,
             call_func=tool.function_schema.call,
             is_async=tool.function_schema.is_async,
-            timeout=tool_def.timeout,
             original_name=original_name,
         )
 
@@ -680,13 +672,4 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
     ) -> Any:
         assert isinstance(tool, FunctionToolsetTool)
 
-        # Per-tool timeout takes precedence over toolset timeout
-        timeout = tool.timeout if tool.timeout is not None else self.timeout
-        if timeout is not None:
-            try:
-                with anyio.fail_after(timeout):
-                    return await tool.call_func(tool_args, ctx)
-            except TimeoutError:
-                raise ModelRetry(f'Timed out after {timeout} seconds.') from None
-        else:
-            return await tool.call_func(tool_args, ctx)
+        return await tool.call_func(tool_args, ctx)

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -4,12 +4,13 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
 from typing import Any, overload
 
+import anyio
 from pydantic.json_schema import GenerateJsonSchema
 
 from .._instructions import prepare_instructions
 from .._run_context import AgentDepsT, RunContext
 from .._system_prompt import SystemPromptRunner
-from ..exceptions import UserError
+from ..exceptions import ModelRetry, UserError
 from ..messages import InstructionPart
 from ..tools import (
     ArgsValidatorFunc,
@@ -33,6 +34,8 @@ class FunctionToolsetTool(ToolsetTool[AgentDepsT]):
 
     call_func: Callable[[dict[str, Any], RunContext[AgentDepsT]], Awaitable[Any]]
     is_async: bool
+    enforce_timeout: bool = False
+    """Whether this call runs outside `ToolManager`, as in a durable task or activity."""
     original_name: str | None = None
     """The name the toolset holds this tool under, which a `prepare` function may have renamed in `tool_def.name`.
 
@@ -613,10 +616,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             tool_def = await tool.prepare_tool_def(run_context)
             if not tool_def:
                 continue
-
-            # The toolset-level timeout applies to tools that don't set their own. `ToolManager`
-            # reads the resolved value off the tool def and applies it around the call.
-            if tool_def.timeout is None:
+            if tool_def.timeout is None and self.timeout is not None:
                 tool_def = replace(tool_def, timeout=self.timeout)
 
             new_name = tool_def.name
@@ -655,11 +655,21 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
         tool = self.tools[original_name]
         max_retries = tool.max_retries if tool.max_retries is not None else self.max_retries
         return self._tool_for(
-            tool, tool_def, max_retries if max_retries is not None else ctx.max_retries, original_name
+            tool,
+            tool_def,
+            max_retries if max_retries is not None else ctx.max_retries,
+            original_name,
+            enforce_timeout=True,
         )
 
     def _tool_for(
-        self, tool: Tool[AgentDepsT], tool_def: ToolDefinition, max_retries: int, original_name: str
+        self,
+        tool: Tool[AgentDepsT],
+        tool_def: ToolDefinition,
+        max_retries: int,
+        original_name: str,
+        *,
+        enforce_timeout: bool = False,
     ) -> FunctionToolsetTool[AgentDepsT]:
         return FunctionToolsetTool(
             toolset=self,
@@ -669,6 +679,7 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             args_validator_func=tool.args_validator,
             call_func=tool.function_schema.call,
             is_async=tool.function_schema.is_async,
+            enforce_timeout=enforce_timeout,
             original_name=original_name,
         )
 
@@ -677,4 +688,15 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
     ) -> Any:
         assert isinstance(tool, FunctionToolsetTool)
 
-        return await tool.call_func(tool_args, ctx)
+        timeout = tool.tool_def.timeout if tool.enforce_timeout else None
+        if timeout is None:
+            return await tool.call_func(tool_args, ctx)
+
+        scope: anyio.CancelScope | None = None
+        try:
+            with anyio.fail_after(timeout) as scope:
+                return await tool.call_func(tool_args, ctx)
+        except TimeoutError:
+            if scope is None or not scope.cancel_called:
+                raise
+            raise ModelRetry(f'Timed out after {timeout} seconds.') from None

--- a/pydantic_ai_slim/pydantic_ai/toolsets/function.py
+++ b/pydantic_ai_slim/pydantic_ai/toolsets/function.py
@@ -614,6 +614,11 @@ class FunctionToolset(AbstractToolset[AgentDepsT]):
             if not tool_def:
                 continue
 
+            # The toolset-level timeout applies to tools that don't set their own. `ToolManager`
+            # reads the resolved value off the tool def and applies it around the call.
+            if tool_def.timeout is None:
+                tool_def = replace(tool_def, timeout=self.timeout)
+
             new_name = tool_def.name
             if new_name in tools:
                 if new_name != original_name:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2066,6 +2066,7 @@ async def test_dbos_mcptoolset_returns_cached_tool_defs(dbos: DBOS):
     # inheriting the agent-level retry count from the run context (rather than a hard-coded default).
     assert tools['foo'].tool_def.name == 'foo'
     assert tools['foo'].max_retries == 5
+    assert tools['foo'].timeout_managed_by_toolset is True
 
 
 _mcp_task_dbos_agent = DBOSAgent(  # pyright: ignore[reportDeprecated]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -27,6 +27,7 @@ from inline_snapshot import snapshot
 from pydantic_ai import Agent, ToolsetTool, models
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._utils import BaseExceptionGroup
+from pydantic_ai.capabilities import PrepareTools
 from pydantic_ai.exceptions import ModelRetry, ToolFailed
 from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, RetryPromptPart, TextPart, ToolCallPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
@@ -451,7 +452,14 @@ class TestMCPToolsetIntegration:
                 )
             return ModelResponse(parts=[TextPart(content='done')])
 
-        agent = Agent(FunctionModel(model_logic), toolsets=[MCPToolset(fastmcp_server)], tool_timeout=0.01)
+        async def prepare_tools(_ctx: RunContext, tool_defs: list[ToolDefinition]) -> list[ToolDefinition]:
+            return [replace(tool_def, timeout=0.01 if tool_def.name == 'slow' else 1) for tool_def in tool_defs]
+
+        agent = Agent(
+            FunctionModel(model_logic),
+            toolsets=[MCPToolset(fastmcp_server)],
+            capabilities=[PrepareTools(prepare_tools)],
+        )
         result = await agent.run('test timeout recovery')
 
         assert result.output == 'done'

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -28,6 +28,8 @@ from pydantic_ai import Agent, ToolsetTool, models
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._utils import BaseExceptionGroup
 from pydantic_ai.exceptions import ModelRetry, ToolFailed
+from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, RetryPromptPart, TextPart, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RunUsage
@@ -275,6 +277,12 @@ async def fastmcp_server() -> FastMCP[None]:
         raise ValueError('boom')
 
     @server.tool()
+    async def slow() -> str:
+        """Sleep long enough for tool timeout tests."""
+        await anyio.sleep(1)
+        return 'slow'  # pragma: no cover
+
+    @server.tool()
     async def image_tool() -> ImageContent:
         """A tool that returns an image content block."""
         encoded = base64.b64encode(b'fake_image_bytes').decode('utf-8')
@@ -428,6 +436,33 @@ class TestMCPToolsetIntegration:
             assert {'echo', 'add', 'boom'} <= set(tools_first)
             # Second call should hit the cache (covers the cached-return branch).
             assert tools_first['echo'].tool_def.description == tools_second['echo'].tool_def.description
+
+    async def test_timeout_keeps_session_usable(self, fastmcp_server: FastMCP[None]):
+        model_calls = 0
+
+        async def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            nonlocal model_calls
+            model_calls += 1
+            if model_calls == 1:
+                return ModelResponse(parts=[ToolCallPart(tool_name='slow', args={}, tool_call_id='slow')])
+            if model_calls == 2:
+                return ModelResponse(
+                    parts=[ToolCallPart(tool_name='echo', args={'message': 'still connected'}, tool_call_id='echo')]
+                )
+            return ModelResponse(parts=[TextPart(content='done')])
+
+        agent = Agent(FunctionModel(model_logic), toolsets=[MCPToolset(fastmcp_server)], tool_timeout=0.01)
+        result = await agent.run('test timeout recovery')
+
+        assert result.output == 'done'
+        retry_parts = [
+            part
+            for message in result.all_messages()
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+            if isinstance(part, RetryPromptPart)
+        ]
+        assert [part.content for part in retry_parts] == ['Timed out after 0.01 seconds.']
 
     async def test_get_instructions_when_enabled(self, fastmcp_server: FastMCP[None], run_context: RunContext):
         toolset = MCPToolset(fastmcp_server, include_instructions=True)

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from typing import Any, Literal
 from unittest.mock import MagicMock
 
+import anyio
 import pytest
 from pydantic import BaseModel, Field
 from pydantic.errors import PydanticUserError
@@ -3002,6 +3003,33 @@ async def test_prefect_mcp_task_wrapped_call_rejects_enqueue(monkeypatch: pytest
     outside_context = RunContext(deps=None, model=TestModel(), usage=RunUsage(), pending_messages=[])
     assert await durable.call_tool('hook', {}, outside_context, tool) == 'done'
     assert len(outside_context.pending_messages or []) == 1
+
+
+async def test_prefect_mcp_timeout_runs_inside_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    mcp_toolset = MCPToolset(StdioTransport(command='python', args=['-m', 'tests.mcp_server']), id='timeout_mcp')
+
+    async def slow_call_tool(
+        tool_name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
+    ) -> Any:
+        await anyio.sleep(1)
+        return 'done'  # pragma: no cover
+
+    monkeypatch.setattr(mcp_toolset, 'call_tool', slow_call_tool)
+    durable = prefectify_mcp_toolset(mcp_toolset, task_config={})
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+    tool = ToolsetTool(
+        toolset=durable,
+        tool_def=ToolDefinition(name='slow', timeout=0.01),
+        max_retries=1,
+        args_validator=TOOL_SCHEMA_VALIDATOR,
+    )
+
+    @flow
+    async def run_tool() -> Any:
+        return await durable.call_tool('slow', {}, ctx, tool)
+
+    with pytest.raises(ModelRetry, match=r'Timed out after 0\.01 seconds'):
+        await run_tool()
 
 
 async def test_prefect_mcp_tool_metadata_configures_task(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -3032,6 +3032,19 @@ async def test_prefect_mcp_timeout_runs_inside_task(monkeypatch: pytest.MonkeyPa
         await run_tool()
 
 
+async def test_prefect_mcp_get_tools_is_transparent_outside_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    mcp_toolset = MCPToolset(StdioTransport(command='python', args=['-m', 'tests.mcp_server']), id='outside_mcp')
+    expected: dict[str, ToolsetTool[None]] = {}
+
+    async def get_tools(ctx: RunContext[None]) -> dict[str, ToolsetTool[None]]:
+        return expected
+
+    monkeypatch.setattr(mcp_toolset, 'get_tools', get_tools)
+    durable = prefectify_mcp_toolset(mcp_toolset, task_config={})
+
+    assert await durable.get_tools(RunContext(deps=None, model=TestModel(), usage=RunUsage())) is expected
+
+
 async def test_prefect_mcp_tool_metadata_configures_task(monkeypatch: pytest.MonkeyPatch) -> None:
     """`metadata={'prefect': ...}` on an MCP tool reaches the task, as the Prefect docs promise.
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3093,6 +3093,7 @@ async def test_tool_timeout_triggers_retry():
         return 'done'  # pragma: no cover
 
     result = await agent.run('call slow_tool')
+    assert result.output == 'Tool timed out, giving up'
 
     # Check that retry prompt was sent to the model
     retry_parts = [
@@ -3311,6 +3312,7 @@ async def test_agent_level_tool_timeout():
         return 'done'  # pragma: no cover
 
     result = await agent.run('call slow_tool')
+    assert result.output == 'done'
 
     # Check that retry prompt was sent
     retry_parts = [
@@ -3384,6 +3386,7 @@ async def test_toolset_timeout_applies_without_agent_timeout():
     agent = Agent(FunctionModel(model_logic), toolsets=[toolset])
 
     result = await agent.run('call slow_tool')
+    assert result.output == 'done'
 
     retry_parts = [
         part

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3339,6 +3339,85 @@ async def test_per_tool_timeout_overrides_agent_timeout():
     assert 'Timed out after 0.1 seconds' in retry_parts[0].content
 
 
+@pytest.mark.anyio
+async def test_toolset_timeout_applies_without_agent_timeout():
+    """A `FunctionToolset`'s own timeout is honored when the agent sets no `tool_timeout`.
+
+    The agent-level timeout reaches `ToolManager` directly, so it can mask a toolset-level
+    one that isn't plumbed through; running without `tool_timeout` pins the toolset default
+    on its own.
+    """
+    import asyncio
+
+    call_count = 0
+
+    async def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return ModelResponse(parts=[ToolCallPart(tool_name='slow_tool', args={}, tool_call_id='call-1')])
+        return ModelResponse(parts=[TextPart(content='done')])
+
+    toolset = FunctionToolset(timeout=0.1)
+
+    @toolset.tool_plain
+    async def slow_tool() -> str:
+        await asyncio.sleep(1.0)  # 1 second, but toolset timeout is 0.1s
+        return 'done'  # pragma: no cover
+
+    agent = Agent(FunctionModel(model_logic), toolsets=[toolset])
+
+    result = await agent.run('call slow_tool')
+
+    retry_parts = [
+        part
+        for msg in result.all_messages()
+        if isinstance(msg, ModelRequest)
+        for part in msg.parts
+        if isinstance(part, RetryPromptPart) and 'Timed out' in str(part.content)
+    ]
+    assert len(retry_parts) == 1
+    assert 'Timed out after 0.1 seconds' in retry_parts[0].content
+    assert retry_parts[0].tool_name == 'slow_tool'
+
+
+@pytest.mark.anyio
+async def test_per_tool_timeout_overrides_toolset_timeout():
+    """A tool's own timeout wins over the timeout its toolset defaults to."""
+    import asyncio
+
+    call_count = 0
+
+    async def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return ModelResponse(parts=[ToolCallPart(tool_name='slow_tool', args={}, tool_call_id='call-1')])
+        return ModelResponse(parts=[TextPart(content='done')])
+
+    # Generous toolset default, but the tool pins a much shorter one.
+    toolset = FunctionToolset(timeout=10.0)
+
+    @toolset.tool_plain(timeout=0.1)
+    async def slow_tool() -> str:
+        await asyncio.sleep(1.0)
+        return 'done'  # pragma: no cover
+
+    agent = Agent(FunctionModel(model_logic), toolsets=[toolset])
+
+    result = await agent.run('call slow_tool')
+
+    retry_parts = [
+        part
+        for msg in result.all_messages()
+        if isinstance(msg, ModelRequest)
+        for part in msg.parts
+        if isinstance(part, RetryPromptPart) and 'Timed out' in str(part.content)
+    ]
+    assert len(retry_parts) == 1
+    assert 'Timed out after 0.1 seconds' in retry_parts[0].content
+
+
 def test_agent_tool_timeout_passed_to_toolset():
     """Test that agent-level tool_timeout is passed to FunctionToolset as timeout."""
     agent = Agent(TestModel(), tool_timeout=30.0)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3164,6 +3164,23 @@ async def test_no_timeout_by_default():
 
 
 @pytest.mark.anyio
+async def test_no_timeout_preserves_tool_timeout_error():
+    """A tool's own `TimeoutError` is not mistaken for a configured tool timeout.
+
+    This uses `TestModel` because the behavior is local exception handling that a provider
+    recording cannot exercise.
+    """
+    agent = Agent(TestModel())
+
+    @agent.tool_plain
+    async def failing_tool() -> str:
+        raise TimeoutError('inner operation timed out')
+
+    with pytest.raises(TimeoutError, match='inner operation timed out'):
+        await agent.run('call failing_tool')
+
+
+@pytest.mark.anyio
 async def test_tool_timeout_retry_counts_as_failed():
     """Test that timeout counts toward tool retry limit."""
     import asyncio
@@ -3319,24 +3336,23 @@ async def test_per_tool_timeout_overrides_agent_timeout():
             return ModelResponse(parts=[ToolCallPart(tool_name='fast_timeout_tool', args={}, tool_call_id='call-1')])
         return ModelResponse(parts=[TextPart(content='done')])
 
-    # Agent has generous 10s timeout, but per-tool timeout is only 0.1s
-    agent = Agent(FunctionModel(model_logic), tool_timeout=10.0)
+    # The per-tool timeout is longer than the agent fallback. If the two deadlines were
+    # nested, the agent timeout would incorrectly win.
+    agent = Agent(FunctionModel(model_logic), tool_timeout=0.01)
 
-    @agent.tool_plain(timeout=0.1)  # Per-tool timeout overrides agent timeout
+    @agent.tool_plain(timeout=0.2)
     async def fast_timeout_tool() -> str:
-        await asyncio.sleep(1.0)  # 1 second, per-tool timeout is 0.1s
+        await asyncio.sleep(0.05)
         return 'done'  # pragma: no cover
 
     result = await agent.run('call fast_timeout_tool')
 
-    # Should timeout because per-tool timeout (0.1s) is applied, not agent timeout (10s)
     retry_parts = [
         part
         for part in iter_message_parts(result.all_messages(), ModelRequest, RetryPromptPart)
         if 'Timed out' in str(part.content)
     ]
-    assert len(retry_parts) == 1
-    assert 'Timed out after 0.1 seconds' in retry_parts[0].content
+    assert retry_parts == []
 
 
 @pytest.mark.anyio
@@ -3395,12 +3411,13 @@ async def test_per_tool_timeout_overrides_toolset_timeout():
             return ModelResponse(parts=[ToolCallPart(tool_name='slow_tool', args={}, tool_call_id='call-1')])
         return ModelResponse(parts=[TextPart(content='done')])
 
-    # Generous toolset default, but the tool pins a much shorter one.
-    toolset = FunctionToolset(timeout=10.0)
+    # The per-tool timeout is longer than the toolset default. If the two deadlines were
+    # nested, the toolset timeout would incorrectly win.
+    toolset = FunctionToolset(timeout=0.01)
 
-    @toolset.tool_plain(timeout=0.1)
+    @toolset.tool_plain(timeout=0.2)
     async def slow_tool() -> str:
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(0.05)
         return 'done'  # pragma: no cover
 
     agent = Agent(FunctionModel(model_logic), toolsets=[toolset])
@@ -3414,8 +3431,41 @@ async def test_per_tool_timeout_overrides_toolset_timeout():
         for part in msg.parts
         if isinstance(part, RetryPromptPart) and 'Timed out' in str(part.content)
     ]
-    assert len(retry_parts) == 1
-    assert 'Timed out after 0.1 seconds' in retry_parts[0].content
+    assert retry_parts == []
+
+
+@pytest.mark.anyio
+async def test_toolset_timeout_overrides_agent_timeout():
+    """A `FunctionToolset` timeout wins over the agent-level fallback."""
+    import asyncio
+
+    call_count = 0
+
+    async def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return ModelResponse(parts=[ToolCallPart(tool_name='slow_tool', args={}, tool_call_id='call-1')])
+        return ModelResponse(parts=[TextPart(content='done')])
+
+    toolset = FunctionToolset(timeout=0.2)
+
+    @toolset.tool_plain
+    async def slow_tool() -> str:
+        await asyncio.sleep(0.05)
+        return 'done'  # pragma: no cover
+
+    agent = Agent(FunctionModel(model_logic), toolsets=[toolset], tool_timeout=0.01)
+    result = await agent.run('call slow_tool')
+
+    retry_parts = [
+        part
+        for msg in result.all_messages()
+        if isinstance(msg, ModelRequest)
+        for part in msg.parts
+        if isinstance(part, RetryPromptPart) and 'Timed out' in str(part.content)
+    ]
+    assert retry_parts == []
 
 
 def test_agent_tool_timeout_passed_to_toolset():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3343,7 +3343,7 @@ async def test_per_tool_timeout_overrides_agent_timeout():
     @agent.tool_plain(timeout=0.2)
     async def fast_timeout_tool() -> str:
         await asyncio.sleep(0.05)
-        return 'done'  # pragma: no cover
+        return 'done'
 
     result = await agent.run('call fast_timeout_tool')
 
@@ -3418,7 +3418,7 @@ async def test_per_tool_timeout_overrides_toolset_timeout():
     @toolset.tool_plain(timeout=0.2)
     async def slow_tool() -> str:
         await asyncio.sleep(0.05)
-        return 'done'  # pragma: no cover
+        return 'done'
 
     agent = Agent(FunctionModel(model_logic), toolsets=[toolset])
 
@@ -3453,7 +3453,7 @@ async def test_toolset_timeout_overrides_agent_timeout():
     @toolset.tool_plain
     async def slow_tool() -> str:
         await asyncio.sleep(0.05)
-        return 'done'  # pragma: no cover
+        return 'done'
 
     agent = Agent(FunctionModel(model_logic), toolsets=[toolset], tool_timeout=0.01)
     result = await agent.run('call slow_tool')

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import re
 import sys
 from collections import defaultdict
@@ -2857,3 +2858,82 @@ def test_apply_walks_combined_and_wrapper_toolsets():
     combined.apply(visited.append)
     assert inner1 in visited
     assert inner2 in visited
+
+
+async def test_toolset_timeout():
+    """Agent-level `tool_timeout` must be honored by non-`FunctionToolset` toolsets.
+
+    The timeout is currently implemented only in `FunctionToolset.call_tool`, so a toolset
+    that implements `call_tool` itself (like MCP or CodeMode) never times out. `SlowToolset`
+    stands in for those: it delegates `get_tools` to a wrapped `FunctionToolset` but runs the
+    call directly, bypassing that timeout. This is a regression test for that gap.
+    """
+    from pydantic_ai.messages import ModelMessage
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+    class SlowToolset(WrapperToolset[Any]):
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[Any], tool: ToolsetTool[Any]
+        ) -> Any:
+            # 1 second, but agent tool_timeout is 0.1s
+            # await anyio.sleep(1.0)
+            await asyncio.sleep(1.0)
+            return 'done'  # pragma: no cover
+
+    inner = FunctionToolset[None]()
+
+    @inner.tool_plain
+    async def slow_tool() -> str: ...  # pragma: no cover
+
+    call_count = 0
+
+    async def model_logic(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return ModelResponse(parts=[ToolCallPart(tool_name='slow_tool', args={}, tool_call_id='call-1')])
+        return ModelResponse(parts=[TextPart(content='Tool timed out, giving up')])
+
+    agent = Agent(FunctionModel(model_logic), toolsets=[SlowToolset(inner)], tool_timeout=0.1)
+
+    result = await agent.run('call slow_tool')
+
+    assert result.all_messages() == snapshot(
+        [
+            ModelRequest(
+                parts=[UserPromptPart(content='call slow_tool', timestamp=IsDatetime())],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[ToolCallPart(tool_name='slow_tool', args={}, tool_call_id='call-1')],
+                usage=RequestUsage(input_tokens=52, output_tokens=2),
+                model_name='function:model_logic:',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelRequest(
+                parts=[
+                    RetryPromptPart(
+                        content='Tool slow_tool timed out',
+                        tool_name='slow_tool',
+                        tool_call_id='call-1',
+                        timestamp=IsDatetime(),
+                    )
+                ],
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+            ModelResponse(
+                parts=[TextPart(content='Tool timed out, giving up')],
+                usage=RequestUsage(input_tokens=63, output_tokens=7),
+                model_name='function:model_logic:',
+                timestamp=IsDatetime(),
+                run_id=IsStr(),
+                conversation_id=IsStr(),
+            ),
+        ]
+    )

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -34,7 +34,12 @@ from pydantic_ai import (
 )
 from pydantic_ai._run_context import RunContext
 from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.durable_exec._toolset import DurableFunctionToolset
+from pydantic_ai.durable_exec._toolset import (
+    DurableDynamicToolset,
+    DurableFunctionToolset,
+    call_dynamic_tool,
+    get_dynamic_tools,
+)
 from pydantic_ai.exceptions import (
     CallDeferred,
     ModelRetry,
@@ -1002,7 +1007,9 @@ async def test_durable_function_timeout_starts_inside_operation(
         resolve_tool_config=lambda tool, name: {},
         lifecycle='enter-always',
     )
-    tool_manager = await ToolManager(durable_toolset, default_timeout=manager_timeout).for_run_step(ctx)
+    tool_manager = await ToolManager(CombinedToolset([durable_toolset]), default_timeout=manager_timeout).for_run_step(
+        ctx
+    )
 
     result = await tool_manager.handle_call(ToolCallPart(tool_name='fast_tool', args={}))
 
@@ -1036,6 +1043,47 @@ async def test_function_toolset_timeout_can_be_overridden_by_prepared_toolset():
         await tool_manager.handle_call(ToolCallPart(tool_name='prefix_slow_tool', args={}))
 
     assert seen_timeouts == [0.01]
+
+
+async def test_durable_dynamic_timeout_starts_inside_operation():
+    """The manager's fallback timeout reaches the dynamically resolved tool inside the durable unit."""
+    ctx = build_run_context(None, max_retries=1)
+    called = False
+    toolset = FunctionToolset[None]()
+
+    @toolset.tool_plain
+    async def slow_tool() -> str:
+        nonlocal called
+        called = True
+        await anyio.sleep(1)
+        return 'done'  # pragma: no cover
+
+    dynamic = DynamicToolset[None](lambda ctx: toolset, id='dynamic')
+
+    async def call_tool_operation(
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[None],
+        tool: ToolsetTool[None],
+        config: Mapping[str, Any],
+    ) -> Any:
+        await anyio.sleep(0.02)
+        return await call_dynamic_tool(dynamic, name, tool_args, ctx, timeout=tool.tool_def.timeout)
+
+    durable = DurableDynamicToolset(
+        dynamic,
+        in_durable_context=lambda: True,
+        get_tools_operation=lambda ctx: get_dynamic_tools(dynamic, ctx),
+        call_tool_operation=call_tool_operation,
+        resolve_tool_config=lambda tool, name: {},
+        lifecycle='enter-never',
+    )
+    tool_manager = await ToolManager(durable, default_timeout=0.01).for_run_step(ctx)
+
+    with pytest.raises(ToolRetryError, match=r'Timed out after 0\.01 seconds'):
+        await tool_manager.handle_call(ToolCallPart(tool_name='slow_tool', args={}))
+
+    assert called is True
 
 
 async def test_handle_call_wrap_validation_errors_false():

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import sys
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from datetime import timezone
 from typing import Any, TypeVar
@@ -33,6 +34,7 @@ from pydantic_ai import (
 )
 from pydantic_ai._run_context import RunContext
 from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.durable_exec._toolset import DurableFunctionToolset
 from pydantic_ai.exceptions import (
     CallDeferred,
     ModelRetry,
@@ -966,6 +968,48 @@ async def test_rebuilt_function_tool_preserves_tool_timeout_error():
 
     with pytest.raises(TimeoutError, match='inner operation timed out'):
         await toolset.call_tool('failing_tool', {}, ctx, rebuilt_tool)
+
+
+@pytest.mark.parametrize(
+    ('toolset_timeout', 'manager_timeout'),
+    [(0.01, None), (None, 0.01)],
+)
+async def test_durable_function_timeout_starts_inside_operation(
+    toolset_timeout: float | None, manager_timeout: float | None
+):
+    """Dispatch time does not consume a timeout owned by the durable task or activity."""
+    ctx = build_run_context(None)
+    toolset = FunctionToolset[None](timeout=toolset_timeout)
+
+    @toolset.tool_plain
+    async def fast_tool() -> str:
+        return 'done'
+
+    async def call_tool_operation(
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[None],
+        tool: ToolsetTool[None],
+        config: Mapping[str, Any],
+    ) -> Any:
+        await anyio.sleep(0.02)
+        return await toolset.call_tool(name, tool_args, ctx, tool)
+
+    durable_toolset = DurableFunctionToolset(
+        toolset,
+        in_durable_context=lambda: True,
+        call_tool_operation=call_tool_operation,
+        resolve_tool_config=lambda tool, name: {},
+        lifecycle='enter-always',
+    )
+    tool_manager = await ToolManager(durable_toolset, default_timeout=manager_timeout).for_run_step(ctx)
+
+    result = await tool_manager.handle_call(ToolCallPart(tool_name='fast_tool', args={}))
+
+    assert result == 'done'
+    assert tool_manager.tools is not None
+    assert tool_manager.tools['fast_tool'].tool_def.timeout == 0.01
+    assert tool_manager.tools['fast_tool'].timeout_managed_by_toolset is True
 
 
 async def test_function_toolset_timeout_can_be_overridden_by_prepared_toolset():

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -997,6 +997,7 @@ async def test_durable_function_timeout_starts_inside_operation(
         tool: ToolsetTool[None],
         config: Mapping[str, Any],
     ) -> Any:
+        assert tool.tool_def.timeout == 0.01
         await anyio.sleep(0.02)
         return await toolset.call_tool(name, tool_args, ctx, tool)
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -923,6 +923,61 @@ async def test_tool_manager_retry_count_increments_when_same_tool_fails_and_succ
     assert step_1_tool_manager.ctx.retries == {'flaky_tool': 1}
 
 
+async def test_tool_manager_timeout_uses_retry_handling():
+    """A deadline follows the same retry bookkeeping as a tool-raised `ModelRetry`.
+
+    This calls `ToolManager` directly because an agent's capability layer would otherwise
+    perform the bookkeeping and hide a regression at the manager boundary.
+    """
+    toolset = FunctionToolset[None](timeout=0.01)
+
+    @toolset.tool_plain
+    async def slow_tool() -> str:
+        await anyio.sleep(1)
+        return 'done'  # pragma: no cover
+
+    tool_manager = await ToolManager(toolset).for_run_step(build_run_context(None, max_retries=1))
+
+    with pytest.raises(ToolRetryError) as exc_info:
+        await tool_manager.handle_call(ToolCallPart(tool_name='slow_tool', args={}))
+
+    assert exc_info.value.tool_retry.content == 'Timed out after 0.01 seconds.'
+    assert tool_manager.failed_tools == {'slow_tool'}
+
+    next_tool_manager = await tool_manager.for_run_step(build_run_context(None, run_step=1, max_retries=1))
+    assert next_tool_manager.ctx is not None
+    assert next_tool_manager.ctx.retries == {'slow_tool': 1}
+
+    with pytest.raises(UnexpectedModelBehavior, match="Tool 'slow_tool' exceeded max retries count of 1"):
+        await next_tool_manager.handle_call(ToolCallPart(tool_name='slow_tool', args={}))
+
+
+async def test_function_toolset_timeout_can_be_overridden_by_prepared_toolset():
+    """Outer preparation sees and can override a `FunctionToolset` timeout.
+
+    This directly exercises toolset composition, which provider recordings cannot observe.
+    """
+    seen_timeouts: list[float | None] = []
+    toolset = FunctionToolset[None](timeout=0.01)
+
+    @toolset.tool_plain
+    async def slow_tool() -> str:
+        await anyio.sleep(1)
+        return 'done'  # pragma: no cover
+
+    def override_definition_timeout(_ctx: RunContext[None], tool_defs: list[ToolDefinition]) -> list[ToolDefinition]:
+        seen_timeouts.extend(tool_def.timeout for tool_def in tool_defs)
+        return [replace(tool_def, timeout=0.02) for tool_def in tool_defs]
+
+    prepared = CombinedToolset([toolset.prefixed('prefix')]).prepared(override_definition_timeout)
+    tool_manager = await ToolManager(prepared).for_run_step(build_run_context(None, max_retries=1))
+
+    with pytest.raises(ToolRetryError, match=r'Timed out after 0\.02 seconds'):
+        await tool_manager.handle_call(ToolCallPart(tool_name='prefix_slow_tool', args={}))
+
+    assert seen_timeouts == [0.01]
+
+
 async def test_handle_call_wrap_validation_errors_false():
     """`handle_call(wrap_validation_errors=False)` propagates raw errors and leaves retry-budget state untouched.
 
@@ -2929,3 +2984,27 @@ async def test_toolset_timeout():
             ),
         ]
     )
+
+
+async def test_toolset_timeout_preserves_call_timeout_error():
+    """A custom toolset's own `TimeoutError` is not mistaken for the agent deadline.
+
+    This uses a local wrapper because it verifies the `ToolManager` cancel-scope boundary,
+    which a provider recording cannot exercise.
+    """
+
+    class TimeoutErrorToolset(WrapperToolset[object]):
+        async def call_tool(
+            self, name: str, tool_args: dict[str, Any], ctx: RunContext[object], tool: ToolsetTool[object]
+        ) -> Any:
+            raise TimeoutError('inner operation timed out')
+
+    inner = FunctionToolset[object]()
+
+    @inner.tool_plain
+    async def failing_tool() -> str: ...  # pragma: no cover
+
+    agent = Agent(TestModel(), toolsets=[TimeoutErrorToolset(inner)], tool_timeout=1)
+
+    with pytest.raises(TimeoutError, match='inner operation timed out'):
+        await agent.run('call failing_tool')

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import re
 import sys
 from collections import defaultdict
@@ -44,6 +43,7 @@ from pydantic_ai.exceptions import (
 )
 from pydantic_ai.messages import (
     InstructionPart,
+    ModelMessage,
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
@@ -51,6 +51,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tool_manager import ToolManager
 from pydantic_ai.tools import DeferredToolResults, Tool, ToolDefinition
@@ -2521,10 +2522,6 @@ async def test_concurrent_runs_dont_share_state():
     """Multiple concurrent runs don't share state on stateful toolsets."""
     import asyncio
 
-    from pydantic_ai import Agent
-    from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
-    from pydantic_ai.models.function import AgentInfo, FunctionModel
-
     call_counts: list[int] = []
 
     class CountingToolset(AbstractToolset):
@@ -2861,23 +2858,18 @@ def test_apply_walks_combined_and_wrapper_toolsets():
 
 
 async def test_toolset_timeout():
-    """Agent-level `tool_timeout` must be honored by non-`FunctionToolset` toolsets.
+    """Agent-level `tool_timeout` is honored by toolsets that implement `call_tool` themselves.
 
-    The timeout is currently implemented only in `FunctionToolset.call_tool`, so a toolset
-    that implements `call_tool` itself (like MCP or CodeMode) never times out. `SlowToolset`
-    stands in for those: it delegates `get_tools` to a wrapped `FunctionToolset` but runs the
-    call directly, bypassing that timeout. This is a regression test for that gap.
+    The timeout is applied by `ToolManager` around every tool call, so a toolset that runs the
+    call itself (like MCP or CodeMode) is covered too. `SlowToolset` stands in for those: it
+    delegates `get_tools` to a wrapped `FunctionToolset` but runs the call directly.
     """
-    from pydantic_ai.messages import ModelMessage
-    from pydantic_ai.models.function import AgentInfo, FunctionModel
 
     class SlowToolset(WrapperToolset[Any]):
         async def call_tool(
             self, name: str, tool_args: dict[str, Any], ctx: RunContext[Any], tool: ToolsetTool[Any]
         ) -> Any:
-            # 1 second, but agent tool_timeout is 0.1s
-            # await anyio.sleep(1.0)
-            await asyncio.sleep(1.0)
+            await anyio.sleep(1.0)  # agent `tool_timeout` is 0.1s, so this is cancelled
             return 'done'  # pragma: no cover
 
     inner = FunctionToolset[None]()
@@ -2917,7 +2909,7 @@ async def test_toolset_timeout():
             ModelRequest(
                 parts=[
                     RetryPromptPart(
-                        content='Tool slow_tool timed out',
+                        content='Timed out after 0.1 seconds.',
                         tool_name='slow_tool',
                         tool_call_id='call-1',
                         timestamp=IsDatetime(),
@@ -2929,7 +2921,7 @@ async def test_toolset_timeout():
             ),
             ModelResponse(
                 parts=[TextPart(content='Tool timed out, giving up')],
-                usage=RequestUsage(input_tokens=63, output_tokens=7),
+                usage=RequestUsage(input_tokens=65, output_tokens=7),
                 model_name='function:model_logic:',
                 timestamp=IsDatetime(),
                 run_id=IsStr(),

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -952,6 +952,22 @@ async def test_tool_manager_timeout_uses_retry_handling():
         await next_tool_manager.handle_call(ToolCallPart(tool_name='slow_tool', args={}))
 
 
+async def test_rebuilt_function_tool_preserves_tool_timeout_error():
+    """A tool's own `TimeoutError` is not mistaken for its configured deadline."""
+    ctx = build_run_context(None)
+    toolset = FunctionToolset[None](timeout=1)
+
+    @toolset.tool_plain
+    async def failing_tool() -> str:
+        raise TimeoutError('inner operation timed out')
+
+    prepared_tool = (await toolset.get_tools(ctx))['failing_tool']
+    rebuilt_tool = toolset.tool_for_tool_def(prepared_tool.tool_def, ctx=ctx)
+
+    with pytest.raises(TimeoutError, match='inner operation timed out'):
+        await toolset.call_tool('failing_tool', {}, ctx, rebuilt_tool)
+
+
 async def test_function_toolset_timeout_can_be_overridden_by_prepared_toolset():
     """Outer preparation sees and can override a `FunctionToolset` timeout.
 


### PR DESCRIPTION
## Summary

- enforce prepared tool deadlines in `ToolManager`, covering MCP, code-mode, and custom toolsets
- preserve timeout ownership through composed and dynamically resolved toolsets
- start durable function, MCP, and dynamic-tool deadlines inside tasks, activities, and steps
- propagate tool-raised `TimeoutError` while converting only configured deadlines to `ModelRetry`

## Scope

No public API changes. One internal helper owns ordinary and durable deadlines; durable dispatch behavior is otherwise unchanged.

## Verification

Tool/toolset coverage and focused Prefect, DBOS, and Temporal tests pass. Real MCP coverage proves timeout recovery leaves the session usable. Focused lint, formatting, and type checks pass.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).