### PR TITLE
fix: raise ContentFilterError for stream completions on content filter block

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1130,6 +1130,21 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
             output_schema = ctx.deps.output_schema
 
             async def _run_stream() -> AsyncIterator[_messages.HandleResponseEvent]:  # noqa: C901
+                if self.model_response.finish_reason == 'content_filter':
+                    details = self.model_response.provider_details or {}
+                    body = _messages.ModelMessagesTypeAdapter.dump_json([self.model_response]).decode()
+
+                    if reason := details.get('finish_reason'):
+                        message = f"Content filter triggered. Finish reason: '{reason}'"
+                    elif reason := details.get('block_reason'):
+                        message = f"Content filter triggered. Block reason: '{reason}'"
+                    elif refusal := details.get('refusal'):
+                        message = f'Content filter triggered. Refusal: {refusal!r}'
+                    else:  # pragma: no cover
+                        message = 'Content filter triggered.'
+
+                    raise exceptions.ContentFilterError(message, body=body)
+
                 is_empty = not self.model_response.parts
                 is_thinking_only = not is_empty and all(
                     isinstance(p, _messages.ThinkingPart) for p in self.model_response.parts
@@ -1143,22 +1158,6 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                         raise exceptions.UnexpectedModelBehavior(
                             f'Model token limit ({ctx.state.last_max_tokens or "provider default"}) exceeded before any response was generated. Increase the `max_tokens` model setting, or simplify the prompt to result in a shorter response that will fit within the limit.'
                         )
-
-                    # Check for content filter on empty response
-                    if is_empty and self.model_response.finish_reason == 'content_filter':
-                        details = self.model_response.provider_details or {}
-                        body = _messages.ModelMessagesTypeAdapter.dump_json([self.model_response]).decode()
-
-                        if reason := details.get('finish_reason'):
-                            message = f"Content filter triggered. Finish reason: '{reason}'"
-                        elif reason := details.get('block_reason'):
-                            message = f"Content filter triggered. Block reason: '{reason}'"
-                        elif refusal := details.get('refusal'):
-                            message = f'Content filter triggered. Refusal: {refusal!r}'
-                        else:  # pragma: no cover
-                            message = 'Content filter triggered.'
-
-                        raise exceptions.ContentFilterError(message, body=body)
 
                     # If the output type allows None, an empty response is a valid result.
                     if is_empty and output_schema.allows_none:

--- a/pydantic_ai_slim/pydantic_ai/result.py
+++ b/pydantic_ai_slim/pydantic_ai/result.py
@@ -48,6 +48,23 @@ T = TypeVar('T')
 """An invariant TypeVar."""
 
 
+def _check_content_filter(response: _messages.ModelResponse) -> None:
+    if response.finish_reason == 'content_filter':
+        details = response.provider_details or {}
+        body = _messages.ModelMessagesTypeAdapter.dump_json([response]).decode()
+
+        if reason := details.get('finish_reason'):
+            message = f"Content filter triggered. Finish reason: '{reason}'"
+        elif reason := details.get('block_reason'):
+            message = f"Content filter triggered. Block reason: '{reason}'"
+        elif refusal := details.get('refusal'):
+            message = f'Content filter triggered. Refusal: {refusal!r}'
+        else:
+            message = 'Content filter triggered.'
+
+        raise exceptions.ContentFilterError(message, body=body)
+
+
 @dataclass(kw_only=True)
 class AgentStream(Generic[AgentDepsT, OutputDataT]):
     _raw_stream_response: models.StreamedResponse
@@ -222,6 +239,7 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
         self, message: _messages.ModelResponse, *, allow_partial: bool = False
     ) -> OutputDataT:
         """Validate a structured result message."""
+        _check_content_filter(message)
         final_result_event = self._raw_stream_response.final_result_event
         if final_result_event is None:
             raise exceptions.UnexpectedModelBehavior('Invalid response, unable to find output')  # pragma: no cover
@@ -382,6 +400,7 @@ class AgentStream(Generic[AgentDepsT, OutputDataT]):
                     event = await anext(base_iter)
 
                 except StopAsyncIteration:
+                    _check_content_filter(self.response)
                     return
 
             yield event
@@ -694,6 +713,30 @@ class StreamedRunResult(Generic[AgentDepsT, OutputDataT]):
         self.is_complete = True
         if message is not None:
             self._record_response(message)
+
+        # Check for content filter trigger
+        response = message
+        if response is None:
+            try:
+                response = self.response
+            except ValueError:
+                response = None
+
+        if response is not None and response.finish_reason == 'content_filter':
+            details = response.provider_details or {}
+            body = _messages.ModelMessagesTypeAdapter.dump_json([response]).decode()
+
+            if reason := details.get('finish_reason'):
+                msg = f"Content filter triggered. Finish reason: '{reason}'"
+            elif reason := details.get('block_reason'):
+                msg = f"Content filter triggered. Block reason: '{reason}'"
+            elif refusal := details.get('refusal'):
+                msg = f'Content filter triggered. Refusal: {refusal!r}'
+            else:  # pragma: no cover
+                msg = 'Content filter triggered.'
+
+            raise exceptions.ContentFilterError(msg, body=body)
+
         if self._on_complete is not None:
             await self._on_complete()
 

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -4902,7 +4902,7 @@ async def test_openai_response_filter_error(allow_model_requests: None):
 
 
 async def test_openai_response_filter_with_partial_content(allow_model_requests: None):
-    """Test that NO exception is raised if content is returned, even if finish_reason is content_filter."""
+    """Test that ContentFilterError is raised when finish_reason is content_filter."""
     c = completion_message(
         ChatCompletionMessage(content='Partial', role='assistant'),
     )
@@ -4912,8 +4912,8 @@ async def test_openai_response_filter_with_partial_content(allow_model_requests:
     m = OpenAIChatModel('gpt-5-mini', provider=OpenAIProvider(openai_client=mock_client))
     agent = Agent(m)
 
-    result = await agent.run('hello')
-    assert result.output == 'Partial'
+    with pytest.raises(ContentFilterError, match=r"Content filter triggered. Finish reason: 'content_filter'"):
+        await agent.run('hello')
 
 
 def test_azure_400_non_content_filter(allow_model_requests: None) -> None:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -10827,8 +10827,8 @@ async def test_central_content_filter_handling():
 
 async def test_central_content_filter_with_partial_content():
     """
-    Test that the agent graph returns partial content (does not raise exception)
-    even if finish_reason='content_filter', provided parts are not empty.
+    Test that the agent graph raises ContentFilterError if finish_reason='content_filter',
+    even if provided parts are not empty.
     """
 
     async def filtered_response(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -10839,9 +10839,8 @@ async def test_central_content_filter_with_partial_content():
     model = FunctionModel(function=filtered_response, model_name='test-model')
     agent = Agent(model)
 
-    # Should NOT raise ContentFilterError
-    result = await agent.run('Trigger filter')
-    assert result.output == 'Partially generated content...'
+    with pytest.raises(ContentFilterError, match=r"Content filter triggered."):
+        await agent.run('Trigger filter')
 
 
 async def test_agent_allows_none_output_empty_response():

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -12147,3 +12147,82 @@ async def test_image_output_validators_run_stream():
 
 
 # endregion
+
+
+async def test_run_stream_content_filter_error():
+    from pydantic_ai import Agent, ModelMessage, ModelResponse, TextPart, RequestUsage
+    from pydantic_ai.exceptions import ContentFilterError
+    from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
+    from pydantic_ai.messages import ModelResponseStreamEvent
+    from pydantic_ai._run_context import RunContext
+    from pydantic_ai.settings import ModelSettings
+    from typing import AsyncIterator, AsyncGenerator
+    from datetime import datetime
+    from contextlib import asynccontextmanager
+
+    class CustomStreamedResponse(StreamedResponse):
+        def __init__(self, model_request_parameters):
+            super().__init__(model_request_parameters=model_request_parameters)
+            self.parts = [TextPart('Partial output before block')]
+            self.finish_reason = 'content_filter'
+            self.provider_details = {'finish_reason': 'content_filter'}
+
+        async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+            self._usage = RequestUsage()
+            yield self._parts_manager.handle_part(
+                vendor_part_id=0,
+                part=self.parts[0],
+            )
+
+        @property
+        def model_name(self) -> str:
+            return 'custom-stream-model'
+
+        @property
+        def provider_name(self) -> str:
+            return 'test'
+
+        @property
+        def provider_url(self) -> str:
+            return 'https://test.example.com'
+
+        @property
+        def timestamp(self) -> datetime:
+            return datetime(2026, 1, 1)
+
+    class CustomStreamModel(Model):
+        @property
+        def system(self) -> str:
+            return 'test'
+
+        @property
+        def model_name(self) -> str:
+            return 'custom-stream-model'
+
+        @property
+        def base_url(self) -> str:
+            return 'https://test.example.com'
+
+        async def request(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+        ) -> ModelResponse:
+            return ModelResponse(parts=[TextPart('Partial output before block')], finish_reason='content_filter')
+
+        @asynccontextmanager
+        async def request_stream(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+            run_context: RunContext | None = None,
+        ) -> AsyncGenerator[StreamedResponse, None]:
+            yield CustomStreamedResponse(model_request_parameters=model_request_parameters)
+
+    agent = Agent(CustomStreamModel())
+    with pytest.raises(ContentFilterError, match="Content filter triggered. Finish reason: 'content_filter'"):
+        async with agent.run_stream('hello') as stream:
+            await stream.get_output()
+

--- a/tests/test_content_filter_challenge.py
+++ b/tests/test_content_filter_challenge.py
@@ -1,0 +1,172 @@
+import pytest
+from pydantic_ai import Agent, ModelMessage, ModelResponse, TextPart, ThinkingPart, ToolCallPart, RequestUsage
+from pydantic_ai.exceptions import ContentFilterError
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
+from pydantic_ai.messages import ModelResponseStreamEvent
+from pydantic_ai._run_context import RunContext
+from pydantic_ai.settings import ModelSettings
+from typing import AsyncIterator, AsyncGenerator
+from datetime import datetime
+from contextlib import asynccontextmanager
+
+# Tests for agent.run()
+
+async def test_run_content_filter_empty():
+    async def filtered_response(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[],
+            model_name='test-model',
+            finish_reason='content_filter',
+            provider_details={'finish_reason': 'content_filter'},
+        )
+
+    model = FunctionModel(function=filtered_response, model_name='test-model')
+    agent = Agent(model)
+
+    with pytest.raises(ContentFilterError, match="Content filter triggered. Finish reason: 'content_filter'"):
+        await agent.run('Trigger filter')
+
+async def test_run_content_filter_partial_text():
+    async def filtered_response(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[TextPart('Partially generated content...')],
+            model_name='test-model',
+            finish_reason='content_filter',
+            provider_details={'finish_reason': 'content_filter'},
+        )
+
+    model = FunctionModel(function=filtered_response, model_name='test-model')
+    agent = Agent(model)
+
+    with pytest.raises(ContentFilterError, match="Content filter triggered. Finish reason: 'content_filter'"):
+        await agent.run('Trigger filter')
+
+async def test_run_content_filter_thinking():
+    async def filtered_response(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[ThinkingPart('Thinking about this...', signature='thinking_sig')],
+            model_name='test-model',
+            finish_reason='content_filter',
+            provider_details={'finish_reason': 'content_filter'},
+        )
+
+    model = FunctionModel(function=filtered_response, model_name='test-model')
+    agent = Agent(model)
+
+    with pytest.raises(ContentFilterError, match="Content filter triggered. Finish reason: 'content_filter'"):
+        await agent.run('Trigger filter')
+
+async def test_run_content_filter_tool_call():
+    async def filtered_response(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[ToolCallPart('some_tool', {'arg': 1}, 'call_id')],
+            model_name='test-model',
+            finish_reason='content_filter',
+            provider_details={'finish_reason': 'content_filter'},
+        )
+
+    model = FunctionModel(function=filtered_response, model_name='test-model')
+    agent = Agent(model)
+
+    with pytest.raises(ContentFilterError, match="Content filter triggered. Finish reason: 'content_filter'"):
+        await agent.run('Trigger filter')
+
+
+# Tests for agent.run_stream()
+
+class ChallengeStreamedResponse(StreamedResponse):
+    def __init__(self, model_request_parameters, parts, finish_reason=None):
+        super().__init__(model_request_parameters=model_request_parameters)
+        self.parts = parts
+        self.finish_reason = finish_reason
+        if finish_reason:
+            self.provider_details = {'finish_reason': finish_reason}
+
+    async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+        self._usage = RequestUsage()
+        for idx, part in enumerate(self.parts):
+            yield self._parts_manager.handle_part(
+                vendor_part_id=idx,
+                part=part,
+            )
+
+    @property
+    def model_name(self) -> str:
+        return 'challenge-stream-model'
+
+    @property
+    def provider_name(self) -> str:
+        return 'test'
+
+    @property
+    def provider_url(self) -> str:
+        return 'https://test.example.com'
+
+    @property
+    def timestamp(self) -> datetime:
+        return datetime(2026, 1, 1)
+
+class ChallengeStreamModel(Model):
+    def __init__(self, parts, finish_reason=None):
+        super().__init__()
+        self.parts = parts
+        self.finish_reason = finish_reason
+
+    @property
+    def system(self) -> str:
+        return 'test'
+
+    @property
+    def model_name(self) -> str:
+        return 'challenge-stream-model'
+
+    @property
+    def base_url(self) -> str:
+        return 'https://test.example.com'
+
+    async def request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        return ModelResponse(parts=self.parts, finish_reason=self.finish_reason)
+
+    @asynccontextmanager
+    async def request_stream(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+        run_context: RunContext | None = None,
+    ) -> AsyncGenerator[StreamedResponse, None]:
+        yield ChallengeStreamedResponse(
+            model_request_parameters=model_request_parameters,
+            parts=self.parts,
+            finish_reason=self.finish_reason,
+        )
+
+async def test_stream_content_filter_empty():
+    model = ChallengeStreamModel(parts=[], finish_reason='content_filter')
+    agent = Agent(model)
+
+    with pytest.raises(ContentFilterError, match="Content filter triggered. Finish reason: 'content_filter'"):
+        async with agent.run_stream('Trigger filter') as stream:
+            await stream.get_output()
+
+async def test_stream_content_filter_partial_text():
+    model = ChallengeStreamModel(parts=[TextPart('Partially generated content...')], finish_reason='content_filter')
+    agent = Agent(model)
+
+    with pytest.raises(ContentFilterError, match="Content filter triggered. Finish reason: 'content_filter'"):
+        async with agent.run_stream('Trigger filter') as stream:
+            await stream.get_output()
+
+async def test_stream_content_filter_thinking():
+    model = ChallengeStreamModel(parts=[ThinkingPart('Thinking about this...', signature='thinking_sig')], finish_reason='content_filter')
+    agent = Agent(model)
+
+    with pytest.raises(ContentFilterError, match="Content filter triggered. Finish reason: 'content_filter'"):
+        async with agent.run_stream('Trigger filter') as stream:
+            await stream.get_output()

--- a/tests/test_content_filter_challenger.py
+++ b/tests/test_content_filter_challenger.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+from pydantic_ai import Agent, ModelMessage, ModelResponse, TextPart, ToolCallPart, ThinkingPart
+from pydantic_ai.exceptions import ContentFilterError
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+# Import the mock client helper from sibling models folder
+from .models.mock_openai import MockOpenAI
+
+async def test_content_filter_on_tool_call():
+    tool_executed = False
+
+    async def mock_model_func(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name='my_tool',
+                    args={'x': 42},
+                    tool_call_id='call_1',
+                )
+            ],
+            model_name='test-model',
+            finish_reason='content_filter',
+        )
+
+    model = FunctionModel(function=mock_model_func, model_name='test-model')
+    agent = Agent(model)
+
+    @agent.tool_plain
+    def my_tool(x: int) -> str:
+        nonlocal tool_executed
+        tool_executed = True
+        return f"Result: {x}"
+
+    with pytest.raises(ContentFilterError, match="Content filter triggered."):
+        await agent.run("Run tool")
+
+    assert not tool_executed, "Tool should not have been executed when content filter is triggered!"
+
+
+async def test_content_filter_on_thinking_only():
+    async def mock_model_func(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[ThinkingPart(content="I'm thinking about unsafe things...")],
+            model_name='test-model',
+            finish_reason='content_filter',
+        )
+
+    model = FunctionModel(function=mock_model_func, model_name='test-model')
+    agent = Agent(model)
+
+    with pytest.raises(ContentFilterError, match="Content filter triggered."):
+        await agent.run("Run model")
+
+
+async def test_content_filter_on_text_and_tool_call():
+    tool_executed = False
+
+    async def mock_model_func(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                TextPart(content="Partial content before block..."),
+                ToolCallPart(
+                    tool_name='my_tool',
+                    args={'x': 42},
+                    tool_call_id='call_1',
+                )
+            ],
+            model_name='test-model',
+            finish_reason='content_filter',
+        )
+
+    model = FunctionModel(function=mock_model_func, model_name='test-model')
+    agent = Agent(model)
+
+    @agent.tool_plain
+    def my_tool(x: int) -> str:
+        nonlocal tool_executed
+        tool_executed = True
+        return f"Result: {x}"
+
+    with pytest.raises(ContentFilterError, match="Content filter triggered."):
+        await agent.run("Run tool and text")
+
+    assert not tool_executed, "Tool should not have been executed when content filter is triggered!"
+
+
+async def test_content_filter_streaming(allow_model_requests: None):
+    from openai.types.chat import ChatCompletionChunk
+    from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice, ChoiceDelta
+    from openai.types.completion_usage import CompletionUsage
+
+    def chunk(delta: list[ChoiceDelta], finish_reason: str | None = None) -> ChatCompletionChunk:
+        return ChatCompletionChunk(
+            id='123',
+            choices=[
+                ChunkChoice(index=index, delta=d, finish_reason=finish_reason)
+                for index, d in enumerate(delta)
+            ],
+            created=1704067200,
+            model='gpt-4o-123',
+            object='chat.completion.chunk',
+            usage=CompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+        )
+
+    def text_chunk(text: str, finish_reason: str | None = None) -> ChatCompletionChunk:
+        return chunk([ChoiceDelta(content=text, role='assistant')], finish_reason=finish_reason)
+
+    stream = [
+        text_chunk('Some safe output...'),
+        text_chunk('Unsafe output starts...'),
+        text_chunk('', finish_reason='content_filter'),
+    ]
+    mock_client = MockOpenAI.create_mock_stream(stream)
+    m = OpenAIChatModel('gpt-5-mini', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m)
+
+    async with agent.run_stream('Trigger filter in stream') as result:
+        with pytest.raises(ContentFilterError, match="Content filter triggered."):
+            async for text in result.stream_text():
+                pass
+            await result.get_output()

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5218,4 +5218,94 @@ async def test_stream_wrap_model_request_readiness_wait_cancels_wrapper_task_on_
     assert cleanup_finished.is_set()
 
 
+async def test_stream_content_filter_partial_text():
+    from pydantic_ai.models import StreamedResponse, Model, ModelRequestParameters
+    from pydantic_ai.exceptions import ContentFilterError
+    from pydantic_ai.messages import PartDeltaEvent, PartStartEvent, TextPartDelta, ModelResponseStreamEvent
+    from pydantic_ai.settings import ModelSettings
+
+    class ChallengeStreamedResponse(StreamedResponse):
+        def __init__(self, model_request_parameters, parts, finish_reason_val):
+            super().__init__(model_request_parameters=model_request_parameters)
+            self.parts = parts
+            self.finish_reason_val = finish_reason_val
+            if finish_reason_val:
+                self.provider_details = {'finish_reason': finish_reason_val}
+
+        async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:
+            self._usage = RequestUsage()
+            for idx, part in enumerate(self.parts):
+                yield self._parts_manager.handle_part(
+                    vendor_part_id=idx,
+                    part=part,
+                )
+            self.finish_reason = self.finish_reason_val
+
+        async def close_stream(self) -> None:
+            pass
+
+        @property
+        def model_name(self) -> str:
+            return 'challenge'
+
+        @property
+        def provider_name(self) -> str:
+            return 'test'
+
+        @property
+        def provider_url(self) -> str:
+            return 'https://test.example.com'
+
+        @property
+        def timestamp(self) -> datetime.datetime:
+            return datetime.datetime.now(timezone.utc)
+
+    class ChallengeStreamModel(Model):
+        def __init__(self, parts, finish_reason):
+            super().__init__()
+            self.parts = parts
+            self.finish_reason_val = finish_reason
+
+        @property
+        def model_name(self) -> str:
+            return 'challenge'
+
+        @property
+        def system(self) -> str:
+            return 'challenge'
+
+        async def request(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+        ) -> ModelResponse:
+            return ModelResponse(
+                parts=self.parts,
+                finish_reason=self.finish_reason_val,
+                model_name=self.model_name,
+            )
+
+        @asynccontextmanager
+        async def request_stream(
+            self,
+            messages: list[ModelMessage],
+            model_settings: ModelSettings | None,
+            model_request_parameters: ModelRequestParameters,
+            run_context: RunContext[Any] | None = None,
+        ) -> AsyncGenerator[StreamedResponse, None]:
+            yield ChallengeStreamedResponse(
+                model_request_parameters=model_request_parameters,
+                parts=self.parts,
+                finish_reason_val=self.finish_reason_val,
+            )
+
+    model = ChallengeStreamModel(parts=[TextPart('Partially generated content...')], finish_reason='content_filter')
+    agent = Agent(model)
+
+    with pytest.raises(ContentFilterError, match=r"Content filter triggered. Finish reason: 'content_filter'"):
+        async with agent.run_stream('Trigger filter') as stream:
+            await stream.get_output()
+
+
 # endregion


### PR DESCRIPTION
Fixes #5221

This PR fixes two critical issues: 
1. Fixes failing test test_openai_response_filter_with_partial_content. 
2. Fixes safety bypass in streams by updating _marked_completed to raise ContentFilterError.