### PR TITLE
fix(bedrock): handle citationsContent blocks instead of silently dropping them (#6455)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -763,6 +763,17 @@ class BedrockConverseModel(Model[BaseClient]):
                                 provider_details={'status': tool_result['status']} if 'status' in tool_result else {},
                             )
                         )
+                elif citations_content := item.get('citationsContent'):
+                    cited_text = ' '.join(
+                        c['text'] for c in citations_content.get('content', []) if 'text' in c
+                    )
+                    if cited_text:
+                        items.append(
+                            TextPart(
+                                content=cited_text,
+                                provider_details={'citations': citations_content.get('citations', [])},
+                            )
+                        )
 
         u = _map_usage(response['usage'], self._provider.name, self.base_url, self.model_name)
         response_id = response.get('ResponseMetadata', {}).get('RequestId', None)
@@ -1631,6 +1642,15 @@ class BedrockStreamedResponse(StreamedResponse):
                                     return_part.content = tr_content[0].get('json')
 
                                 # Don't yield anything yet - we wait for content block end
+                        if citation_delta := delta.get('citation'):
+                            cited_text = ' '.join(
+                                c.get('text', '') for c in citation_delta.get('content', [])
+                            )
+                            if cited_text:
+                                for event in self._parts_manager.handle_text_delta(
+                                    vendor_part_id=index, content=cited_text
+                                ):
+                                    yield event
 
                     case {'contentBlockStop': content_block_stop}:
                         index = content_block_stop['contentBlockIndex']


### PR DESCRIPTION
## Summary

Closes #6455 — Bedrock Converse's `citationsContent` blocks (document-grounded responses with citation metadata) are silently dropped by both the non-streaming and streaming response parsers. The model's generated text and the citation list are lost.

## Fix

Two sites, matching the issue's suggested fix shape:

**Non-streaming** (`_process_response`, line ~755): when an item has `citationsContent`, emit the `content[*].text` as a `TextPart` with the citation metadata preserved on `provider_details={'citations': [...]}`.

**Streaming** (`_get_event_iterator`, `contentBlockDelta` branch): handle `delta['citation']` by extracting the cited text and emitting it through `handle_text_delta`.

The raw Bedrock citation structure (title, source, sourceContent, location) is stashed on `provider_details` rather than mapped to a unified type, per the issue's out-of-scope note — the cross-provider `Citation` type is tracked on #3126 / #3885.

## Before / after

```
Before — parts: 1, texts: ['According to multiple sources,']
After  — parts: 2, texts: ['According to multiple sources,', ' the Eiffel Tower is in Paris.']
         citation_parts[0].provider_details['citations'][0]['title'] == 'Wikipedia'
```

## Test plan

- [x] 162 existing `test_bedrock.py` tests pass
- [x] No existing test asserts the current drop behavior (confirmed by grep for `citation`/`CitationsContent`/`searchResult` — zero matches)
- [x] Verified the `botocore` service model (`ContentBlock` union) lists `citationsContent` as a valid shape; `ContentBlockDelta` lists `citation`

## Files

- `pydantic_ai_slim/pydantic_ai/models/bedrock.py` (+20)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

