### PR TITLE
fix(mistral): defer streamed output emission when text ends mid-integer-token

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -810,6 +810,18 @@ class MistralStreamedResponse(StreamedResponse):
                     except ValueError:
                         continue
 
+                # Guard against a trailing integer token that can still extend into a
+                # non-integer on the next chunk (e.g. "1" -> "1.5"). The widened-match
+                # gate above covers float-for-integer and int-for-number, but leaves the
+                # strict int-for-integer case unprotected. When the accumulated text ends
+                # with a digit the JSON document may not yet be closed; run a non-partial
+                # parse to confirm completeness before emitting.
+                if text.rstrip()[-1:].isdigit():
+                    try:
+                        pydantic_core.from_json(text)
+                    except ValueError:
+                        continue
+
                 # The following part_id will be thrown away
                 return ToolCallPart(tool_name=output_tool.name, args=output_json)
 

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -797,29 +797,22 @@ class MistralStreamedResponse(StreamedResponse):
                 ):
                     continue
 
-                # Matches enabled by the widened numeric compatibility can also be incomplete numeric tokens:
-                # an integer can be the prefix of a decimal number, and an integral float can be followed by an
-                # exponent. Only emit these newly supported matches once the accumulated JSON is complete.
+                # Numeric tokens at the end of a partial document may be extended by the next chunk.
                 if not MistralStreamedResponse._validate_required_json_schema(
                     output_json, output_tool.parameters_json_schema, allow_widened_numeric_match=False
                 ):
                     try:
-                        # A successful complete parse of `text` is identical to `output_json`, so only
-                        # completeness is checked and the parsed value is discarded.
                         pydantic_core.from_json(text)
                     except ValueError:
                         continue
-
-                # Guard against a trailing integer token that can still extend into a
-                # non-integer on the next chunk (e.g. "1" -> "1.5"). The widened-match
-                # gate above covers float-for-integer and int-for-number, but leaves the
-                # strict int-for-integer case unprotected. When the accumulated text ends
-                # with a JSON number the document may not yet be closed; run a non-partial
-                # parse to confirm completeness before emitting.
-                if MistralStreamedResponse._ends_with_incomplete_integer(text, output_tool.parameters_json_schema):
-                    try:
-                        pydantic_core.from_json(text)
-                    except ValueError:
+                elif text[-1:].isdigit():
+                    # Probe whether a decimal continuation would invalidate the schema.
+                    extended_json = cast(
+                        dict[str, JsonValue], pydantic_core.from_json(f'{text}.5', allow_partial='trailing-strings')
+                    )
+                    if not MistralStreamedResponse._validate_required_json_schema(
+                        extended_json, output_tool.parameters_json_schema
+                    ):
                         continue
 
                 # The following part_id will be thrown away
@@ -866,18 +859,6 @@ class MistralStreamedResponse(StreamedResponse):
                     return False
 
         return True
-
-    @staticmethod
-    def _ends_with_incomplete_integer(text: str, schema: dict[str, Any]) -> bool:
-        """Check whether extending the final token to a decimal makes the partial JSON invalid."""
-        if not text or not text[-1].isdigit():
-            return False
-
-        # The original partial parse is an object; extending its final token cannot change the root type.
-        extended_json = cast(
-            dict[str, JsonValue], pydantic_core.from_json(f'{text}.5', allow_partial='trailing-strings')
-        )
-        return not MistralStreamedResponse._validate_required_json_schema(extended_json, schema)
 
 
 VALID_JSON_TYPE_MAPPING: dict[str, Any] = {

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -814,9 +814,9 @@ class MistralStreamedResponse(StreamedResponse):
                 # non-integer on the next chunk (e.g. "1" -> "1.5"). The widened-match
                 # gate above covers float-for-integer and int-for-number, but leaves the
                 # strict int-for-integer case unprotected. When the accumulated text ends
-                # with a digit the JSON document may not yet be closed; run a non-partial
+                # with a JSON number the document may not yet be closed; run a non-partial
                 # parse to confirm completeness before emitting.
-                if text.rstrip()[-1:].isdigit():
+                if MistralStreamedResponse._ends_with_incomplete_integer(text, output_tool.parameters_json_schema):
                     try:
                         pydantic_core.from_json(text)
                     except ValueError:
@@ -866,6 +866,18 @@ class MistralStreamedResponse(StreamedResponse):
                     return False
 
         return True
+
+    @staticmethod
+    def _ends_with_incomplete_integer(text: str, schema: dict[str, Any]) -> bool:
+        """Check whether extending the final token to a decimal makes the partial JSON invalid."""
+        if not text or not text[-1].isdigit():
+            return False
+
+        # The original partial parse is an object; extending its final token cannot change the root type.
+        extended_json = cast(
+            dict[str, JsonValue], pydantic_core.from_json(f'{text}.5', allow_partial='trailing-strings')
+        )
+        return not MistralStreamedResponse._validate_required_json_schema(extended_json, schema)
 
 
 VALID_JSON_TYPE_MAPPING: dict[str, Any] = {

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -807,9 +807,13 @@ class MistralStreamedResponse(StreamedResponse):
                         continue
                 elif text[-1:].isdigit():
                     # Probe whether a decimal continuation would invalidate the schema.
-                    extended_json = cast(
-                        dict[str, JsonValue], pydantic_core.from_json(f'{text}.5', allow_partial='trailing-strings')
-                    )
+                    try:
+                        extended_json = cast(
+                            dict[str, JsonValue],
+                            pydantic_core.from_json(f'{text}.5', allow_partial='trailing-strings'),
+                        )
+                    except ValueError:
+                        continue
                     if not MistralStreamedResponse._validate_required_json_schema(
                         extended_json, output_tool.parameters_json_schema
                     ):

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -1030,6 +1030,10 @@ class _DuplicateIntField(TypedDict):
     b: str
 
 
+class _NullableIntField(TypedDict):
+    value: int | None
+
+
 class _StringField(TypedDict):
     value: str
 
@@ -1098,6 +1102,18 @@ async def test_stream_output_keeps_partial_float(allow_model_requests: None) -> 
             {'value': 1.23},
             {'value': 1.23},
         ]
+
+
+async def test_stream_output_nullable_integer_prefix_fails_validation(allow_model_requests: None) -> None:
+    """Use mock chunks because a live model cannot reliably reproduce the exact numeric boundary."""
+    stream = [text_chunk('{"value":1'), text_chunk('.5}', finish_reason='stop')]
+    mock_client = MockMistralAI.create_stream_mock(stream)
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
+    agent = Agent(model=model, output_type=_NullableIntField)
+
+    async with agent.run_stream('User prompt value') as result:
+        with pytest.raises(UnexpectedModelBehavior, match='Output validation failed during streaming'):
+            await result.get_output()
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -32,7 +32,7 @@ from pydantic_ai import (
     VideoUrl,
 )
 from pydantic_ai.agent import Agent
-from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, ModelRetry
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, ModelRetry, UnexpectedModelBehavior
 from pydantic_ai.messages import BinaryImage
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.usage import RequestUsage, RunUsage
@@ -793,7 +793,6 @@ async def test_stream_structured_with_all_type(allow_model_requests: None):
         assert v == snapshot(
             [
                 {'first': 'One'},
-                {'first': 'One', 'second': 2},
                 {'first': 'One', 'second': 2, 'bool_value': True},
                 {'first': 'One', 'second': 2, 'bool_value': True, 'nullable_value': None},
                 {
@@ -955,7 +954,7 @@ async def test_stream_result_type_primitif_int(allow_model_requests: None):
     async with agent.run_stream('User prompt value') as result:
         assert not result.is_complete
         v = [c async for c in result.stream_output(debounce_by=None)]
-        assert v == snapshot([1, 1, 1])
+        assert v == snapshot([1, 1])
         assert result.is_complete
         assert result.usage.input_tokens == 6
         assert result.usage.output_tokens == 6
@@ -1019,6 +1018,45 @@ async def test_stream_result_type_numeric_json_retries_malformed_continuation(
         assert await result.get_output() == expected
 
     assert len(get_mock_chat_completion_kwargs(mock_client)) == 2
+
+
+class _StaleIntField(TypedDict):
+    value: int
+
+
+@pytest.mark.parametrize(
+    'output_type, json_chunks',
+    [
+        pytest.param(int, ('{"response":1', '.5}'), id='top-level-int'),
+        pytest.param(list[int], ('{"response":[1', '.5]}'), id='array-of-int'),
+        pytest.param(_StaleIntField, ('{"value":1', '.5}'), id='object-int-field'),
+    ],
+)
+async def test_stream_output_defers_stale_integer_prefix(
+    allow_model_requests: None,
+    output_type: Any,
+    json_chunks: tuple[str, str],
+) -> None:
+    """Regression test for https://github.com/pydantic/pydantic-ai/issues/6504.
+
+    When a chunk boundary falls inside a number right after an integral prefix (`1`) and the
+    completed value is non-integral (`1.5`), the partial parse (e.g. `{"response": 1`) used to be
+    emitted as a stale `1`. The completed `1.5` then fails `integer` validation, so nothing replaced
+    the stale args and the run silently returned `1` — a value the model never produced. The emission
+    must instead be deferred until the number is complete, so the invalid `1.5` reaches the
+    output-retry path rather than being silently truncated. As the issue notes, a top-level integer,
+    an integer array item, and an integer object field all share this hazard.
+    """
+    stream = [text_chunk(json_chunks[0]), text_chunk(json_chunks[1], finish_reason='stop')]
+    mock_client = MockMistralAI.create_stream_mock(stream)
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
+    agent: Agent[None, Any] = Agent(model=model, output_type=output_type)
+
+    # `run_stream` exhausts output retries and raises while entering the context manager, so the
+    # body never runs.
+    with pytest.raises(UnexpectedModelBehavior, match='Exceeded maximum output retries'):
+        async with agent.run_stream('User prompt value'):
+            pass  # pragma: no cover
 
 
 async def test_stream_result_type_primitif_array(allow_model_requests: None):

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -1065,6 +1065,20 @@ async def test_stream_output_keeps_digit_ending_partial_string(
         ]
 
 
+async def test_stream_output_keeps_incomplete_unicode_escape(allow_model_requests: None) -> None:
+    """Use mock chunks because a live model cannot reliably reproduce the exact escape boundary."""
+    stream = [text_chunk('{"value":"\\u12'), text_chunk('34"}', finish_reason='stop')]
+    mock_client = MockMistralAI.create_stream_mock(stream)
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
+    agent = Agent(model=model, output_type=_StringField)
+
+    async with agent.run_stream('User prompt value') as result:
+        assert [item async for item in result.stream_output(debounce_by=None)] == [
+            {'value': '\u1234'},
+            {'value': '\u1234'},
+        ]
+
+
 class _PartialIntField(TypedDict):
     value: int
     label: NotRequired[str]

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 import httpx
 import pytest
 from pydantic import BaseModel
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 from vcr.cassette import Cassette
 
 from pydantic_ai import (
@@ -793,6 +793,7 @@ async def test_stream_structured_with_all_type(allow_model_requests: None):
         assert v == snapshot(
             [
                 {'first': 'One'},
+                {'first': 'One', 'second': 2},
                 {'first': 'One', 'second': 2, 'bool_value': True},
                 {'first': 'One', 'second': 2, 'bool_value': True, 'nullable_value': None},
                 {
@@ -1024,12 +1025,88 @@ class _StaleIntField(TypedDict):
     value: int
 
 
+class _DuplicateIntField(TypedDict):
+    a: int
+    b: str
+
+
+class _StringField(TypedDict):
+    value: str
+
+
+@pytest.mark.parametrize(
+    'first_chunk, partial_value, complete_value',
+    [
+        pytest.param('{"value":"item 1', 'item 1', 'item 12', id='plain'),
+        pytest.param('{"value":"item \\"1', 'item "1', 'item "12', id='escaped-quote'),
+    ],
+)
+async def test_stream_output_keeps_digit_ending_partial_string(
+    allow_model_requests: None,
+    first_chunk: str,
+    partial_value: str,
+    complete_value: str,
+) -> None:
+    """Use mock chunks because a live model cannot reliably reproduce the exact string chunk boundary."""
+    stream = [text_chunk(first_chunk), text_chunk('2"}', finish_reason='stop')]
+    mock_client = MockMistralAI.create_stream_mock(stream)
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
+    agent = Agent(model=model, output_type=_StringField)
+
+    async with agent.run_stream('User prompt value') as result:
+        assert [item async for item in result.stream_output(debounce_by=None)] == [
+            {'value': partial_value},
+            {'value': complete_value},
+            {'value': complete_value},
+        ]
+
+
+class _PartialIntField(TypedDict):
+    value: int
+    label: NotRequired[str]
+
+
+async def test_stream_output_keeps_integer_followed_by_whitespace(allow_model_requests: None) -> None:
+    """Use mock chunks because a live model cannot reliably reproduce the exact whitespace boundary."""
+    stream = [text_chunk('{"value":1 '), text_chunk(',"label":"x"}', finish_reason='stop')]
+    mock_client = MockMistralAI.create_stream_mock(stream)
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
+    agent = Agent(model=model, output_type=_PartialIntField)
+
+    async with agent.run_stream('User prompt value') as result:
+        assert [item async for item in result.stream_output(debounce_by=None)] == [
+            {'value': 1},
+            {'value': 1, 'label': 'x'},
+            {'value': 1, 'label': 'x'},
+        ]
+
+
+class _FloatField(TypedDict):
+    value: float
+
+
+async def test_stream_output_keeps_partial_float(allow_model_requests: None) -> None:
+    """Use mock chunks because a live model cannot reliably reproduce the exact numeric boundary."""
+    stream = [text_chunk('{"value":1.2'), text_chunk('3}', finish_reason='stop')]
+    mock_client = MockMistralAI.create_stream_mock(stream)
+    model = MistralModel('mistral-large-latest', provider=MistralProvider(mistral_client=mock_client))
+    agent = Agent(model=model, output_type=_FloatField)
+
+    async with agent.run_stream('User prompt value') as result:
+        assert [item async for item in result.stream_output(debounce_by=None)] == [
+            {'value': 1.2},
+            {'value': 1.23},
+            {'value': 1.23},
+        ]
+
+
 @pytest.mark.parametrize(
     'output_type, json_chunks',
     [
         pytest.param(int, ('{"response":1', '.5}'), id='top-level-int'),
         pytest.param(list[int], ('{"response":[1', '.5]}'), id='array-of-int'),
         pytest.param(_StaleIntField, ('{"value":1', '.5}'), id='object-int-field'),
+        pytest.param(_DuplicateIntField, ('{"a":0,"b":"x","a":1', '.5}'), id='duplicate-key'),
     ],
 )
 async def test_stream_output_defers_stale_integer_prefix(
@@ -1039,10 +1116,13 @@ async def test_stream_output_defers_stale_integer_prefix(
 ) -> None:
     """Regression test for https://github.com/pydantic/pydantic-ai/issues/6504.
 
+    A live model cannot reliably reproduce the exact numeric spelling and chunk boundary, so this
+    uses mocked SDK chunks.
+
     When a chunk boundary falls inside a number right after an integral prefix (`1`) and the
     completed value is non-integral (`1.5`), the partial parse (e.g. `{"response": 1`) used to be
     emitted as a stale `1`. The completed `1.5` then fails `integer` validation, so nothing replaced
-    the stale args and the run silently returned `1` — a value the model never produced. The emission
+    the stale args and the run silently returned `1`, a value the model never produced. The emission
     must instead be deferred until the number is complete, so the invalid `1.5` reaches the
     output-retry path rather than being silently truncated. As the issue notes, a top-level integer,
     an integer array item, and an integer object field all share this hazard.


### PR DESCRIPTION
## Summary

Fixes #6504.

`MistralStreamedResponse._try_get_output_tool_from_text` could emit a stale integer
value when a chunk boundary fell inside a numeric token. For example, if the model
ultimately produces `{"response": 1.5}`, the accumulated text at the first relevant
chunk might be `{"response": 1` — `pydantic_core.from_json(..., allow_partial='trailing-strings')`
parses this as `{"response": 1}`, schema validation passes (1 is a valid `integer`),
and the tool call is emitted. The final value `1.5` then fails validation, so no later
chunk replaces the emission; the run silently returns the stale `1`.

## Root Cause

The existing widened-match completeness gate (PR #6479) checks whether a non-partial
parse succeeds, but only enters that code path when `allow_widened_numeric_match=False`
would reject the value — i.e. for float-for-integer or int-for-number matches.
A strict `int`-for-`integer` match passes both validations and proceeds to emit without
any completeness check. Since `allow_partial='trailing-strings'` includes trailing
numeric tokens, `int` at the end of the text is always treated as complete even if the
next chunk will extend it.

## Fix

Before emitting, check whether the accumulated text ends with a digit. If it does,
attempt a non-partial parse. If that raises `ValueError`, the JSON document is not yet
closed — the integer token is still incoming — so emission is deferred to the next chunk:

```python
if text.rstrip()[-1:].isdigit():
    try:
        pydantic_core.from_json(text)
    except ValueError:
        continue
```

This is minimal and targeted:
- The check is skipped when `text` ends with `}` / `,` / `"` / etc., which covers
  all complete JSON documents and avoids redundant parses in the common case.
- When it fires, a non-partial parse is the same completeness signal already used in
  the widened-match gate — no new logic is introduced.
- `string`, `boolean`, `array`, and `object` values are unaffected: any continuation
  of those types keeps the same schema type, so the final chunk always replaces the args.

## Reproduction

Mock-based reproduction from the issue:

```python
# chunk 1: {"response": 1   ← valid integer, emitted as stale args
# chunk 2: .5}              ← extends to 1.5, fails integer validation, no replacement
# result: agent returns 1, but model produced 1.5
```

After the fix, chunk 1 attempts `pydantic_core.from_json('...{"response": 1')` which
raises `ValueError` (incomplete JSON) → emission deferred. Chunk 2 completes to
`{"response": 1.5}` → fails integer schema validation → no emission → retry path.

Closes #6504.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

