### PR TITLE
fix: raise ContentFilterError for content_filter finish reason even with non-empty parts

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -1580,6 +1580,25 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                     isinstance(p, _messages.ThinkingPart) for p in self.model_response.parts
                 )
 
+                # Check for content filter — must fire regardless of whether parts
+                # are present.  OpenAI can return finish_reason='content_filter'
+                # together with non-empty text parts containing refusal text
+                # (see #5221).
+                if self.model_response.finish_reason == 'content_filter':
+                    details = self.model_response.provider_details or {}
+                    body = _messages.ModelMessagesTypeAdapter.dump_json([self.model_response]).decode()
+
+                    if reason := details.get('finish_reason'):
+                        message = f"Content filter triggered. Finish reason: '{reason}'"
+                    elif reason := details.get('block_reason'):
+                        message = f"Content filter triggered. Block reason: '{reason}'"
+                    elif refusal := details.get('refusal'):
+                        message = f'Content filter triggered. Refusal: {refusal!r}'
+                    else:
+                        message = 'Content filter triggered.'
+
+                    raise exceptions.ContentFilterError(message, body=body)
+
                 if is_empty or is_thinking_only:
                     # No actionable output was returned by the model.
 
@@ -1588,22 +1607,6 @@ class CallToolsNode(AgentNode[DepsT, NodeRunEndT]):
                         raise exceptions.UnexpectedModelBehavior(
                             f'Model token limit ({ctx.state.last_max_tokens or "provider default"}) exceeded before any response was generated. Increase the `max_tokens` model setting, or simplify the prompt to result in a shorter response that will fit within the limit.'
                         )
-
-                    # Check for content filter on empty response
-                    if is_empty and self.model_response.finish_reason == 'content_filter':
-                        details = self.model_response.provider_details or {}
-                        body = _messages.ModelMessagesTypeAdapter.dump_json([self.model_response]).decode()
-
-                        if reason := details.get('finish_reason'):
-                            message = f"Content filter triggered. Finish reason: '{reason}'"
-                        elif reason := details.get('block_reason'):
-                            message = f"Content filter triggered. Block reason: '{reason}'"
-                        elif refusal := details.get('refusal'):
-                            message = f'Content filter triggered. Refusal: {refusal!r}'
-                        else:  # pragma: no cover
-                            message = 'Content filter triggered.'
-
-                        raise exceptions.ContentFilterError(message, body=body)
 
                     # If the output type allows `None`, an empty or thinking-only response is a valid result:
                     # both signal that the model has no text output to give. Some models emit only thinking

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11744,8 +11744,12 @@ async def test_central_content_filter_handling():
 
 async def test_central_content_filter_with_partial_content():
     """
-    Test that the agent graph returns partial content (does not raise exception)
-    even if finish_reason='content_filter', provided parts are not empty.
+    Test that the agent graph raises ContentFilterError even when the
+    model returns non-empty text parts alongside finish_reason='content_filter'.
+
+    OpenAI can emit refusal text as a normal TextPart while still setting
+    finish_reason to 'content_filter' (see #5221).  The agent must not
+    silently return that text as valid output.
     """
 
     async def filtered_response(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -11756,9 +11760,8 @@ async def test_central_content_filter_with_partial_content():
     model = FunctionModel(function=filtered_response, model_name='test-model')
     agent = Agent(model)
 
-    # Should NOT raise ContentFilterError
-    result = await agent.run('Trigger filter')
-    assert result.output == 'Partially generated content...'
+    with pytest.raises(ContentFilterError, match='Content filter triggered.'):
+        await agent.run('Trigger filter')
 
 
 async def test_agent_allows_none_output_empty_response():


### PR DESCRIPTION
## Summary

Fixes #5221.

### Problem

OpenAI can return `finish_reason='content_filter'` alongside **non-empty** text parts containing refusal text (e.g. `"I'm sorry, but I cannot assist with that request."`). This happens primarily with:
- `AzureProvider` + `OpenAIResponsesModel` + web search tool
- Models like `o3-deep-research` that emit safety refusals as plain `ResponseOutputText`

Previously, `ContentFilterError` was only raised when `parts` was empty (`is_empty=True`). When refusal text populated the parts list, the check was bypassed entirely, and the refusal text was silently returned as valid agent output.

### Fix

Move the `content_filter` finish reason check **before** the `is_empty or is_thinking_only` guard in `CallToolsNode._run_stream()`, so it fires regardless of whether the model populated text parts.

### Changes
- **`pydantic_ai_slim/pydantic_ai/_agent_graph.py`**: Moved `content_filter` check to fire unconditionally before the empty/thinking-only block.
- **`tests/test_agent.py`**: Updated `test_central_content_filter_with_partial_content` to assert that `ContentFilterError` is raised even with non-empty parts (previously asserted the buggy behavior).

### Test Results
```
379 passed, 3 skipped (test_agent.py)
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

