### PR TITLE
fix(anthropic): transform native output schema when reached via `profile={"default_structured_output_mode": "native"}`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -679,6 +679,14 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                     f'Anthropic does not support thinking and output tools at the same time. Use `output_type={suggested_output_type}(...)` instead.'
                 )
 
+        # Resolve 'auto' to the profile default here (a no-op if already resolved above) so the
+        # strict-forcing check below also applies when native mode is reached via the profile default
+        # rather than an explicit `NativeOutput(...)`; `super().prepare_request()` would otherwise only
+        # resolve it after `customize_request_parameters()` has already transformed the schema.
+        model_request_parameters = model_request_parameters.with_default_output_mode(
+            self.profile.get('default_structured_output_mode', 'tool')
+        )
+
         if model_request_parameters.output_mode == 'native':
             assert model_request_parameters.output_object is not None
             if model_request_parameters.output_object.strict is False:

--- a/tests/models/anthropic/cassettes/test_output/test_no_tools_profile_default_native_output.yaml
+++ b/tests/models/anthropic/cassettes/test_output/test_no_tools_profile_default_native_output.yaml
@@ -1,0 +1,85 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '523'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+    method: POST
+    parsed_body:
+      max_tokens: 4096
+      messages:
+      - content:
+        - text: Should we ship the feature? Give a confidence (0-1) and a short title.
+          type: text
+        role: user
+      model: claude-sonnet-4-5
+      output_config:
+        format:
+          schema:
+            additionalProperties: false
+            properties:
+              confidence:
+                description: '{maximum: 1.0, minimum: 0.0}'
+                type: number
+              title:
+                description: '{minLength: 1}'
+                type: string
+            required:
+            - confidence
+            - title
+            type: object
+          type: json_schema
+      stream: false
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '593'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-42a9d32f00962176fc9342a25fa4eee1-d9d63edddddcdb8d-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+    parsed_body:
+      content:
+      - text: '{"confidence": 0.5, "title": "Insufficient information to determine if feature should ship"}'
+        type: text
+      id: msg_011Cd4E22wowzk5fC77UWo6x
+      model: claude-sonnet-4-5-20250929
+      role: assistant
+      stop_details: null
+      stop_reason: end_turn
+      stop_sequence: null
+      type: message
+      usage:
+        cache_creation:
+          ephemeral_1h_input_tokens: 0
+          ephemeral_5m_input_tokens: 0
+        cache_creation_input_tokens: 0
+        cache_read_input_tokens: 0
+        inference_geo: not_available
+        input_tokens: 221
+        output_tokens: 25
+        service_tier: standard
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/anthropic/test_output.py
+++ b/tests/models/anthropic/test_output.py
@@ -199,6 +199,9 @@ def test_native_output_profile_default_transforms_schema(allow_model_requests: N
     'auto' to 'native', so schemas reaching native mode only via the profile default were sent to Anthropic
     untransformed, causing a 400 for constraints like `ge`/`min_length` that Anthropic's schema dialect
     doesn't support.
+
+    A mock test, not just the companion VCR test below, because the cassette matcher isn't sensitive to
+    request-body drift, so pinning the transformed schema directly is what actually catches a regression.
     """
     mock_client = MockAnthropic.create_mock(
         completion_message(

--- a/tests/models/anthropic/test_output.py
+++ b/tests/models/anthropic/test_output.py
@@ -192,6 +192,42 @@ def test_native_output_supported_model(
     assert completion_kwargs['betas'] is OMIT
 
 
+def test_native_output_profile_default_transforms_schema(allow_model_requests: None):
+    """profile default_structured_output_mode='native' (no explicit `NativeOutput`) → schema is still transformed.
+
+    Regression test for #6471: the strict-forcing check used to run before the profile default resolved
+    'auto' to 'native', so schemas reaching native mode only via the profile default were sent to Anthropic
+    untransformed, causing a 400 for constraints like `ge`/`min_length` that Anthropic's schema dialect
+    doesn't support.
+    """
+    mock_client = MockAnthropic.create_mock(
+        completion_message(
+            [BetaTextBlock(text='{"confidence": 0.9, "title": "Ship it"}', type='text')],
+            BetaUsage(input_tokens=5, output_tokens=10),
+        )
+    )
+    model = AnthropicModel(
+        'claude-sonnet-4-5',
+        provider=AnthropicProvider(anthropic_client=mock_client),
+        profile={'default_structured_output_mode': 'native'},
+    )
+
+    class Decision(BaseModel):
+        confidence: float = Field(ge=0.0, le=1.0)
+        title: str = Field(min_length=1)
+
+    agent = Agent(model, output_type=Decision)
+    agent.run_sync('Should we ship the feature?')
+
+    completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[-1]
+    output_schema = completion_kwargs['output_config']['format']['schema']
+
+    assert output_schema['additionalProperties'] is False
+    assert 'minimum' not in output_schema['properties']['confidence']
+    assert 'maximum' not in output_schema['properties']['confidence']
+    assert 'minLength' not in output_schema['properties']['title']
+
+
 # =============================================================================
 # COMPREHENSIVE INTEGRATION TESTS - All Combinations
 # =============================================================================
@@ -272,6 +308,32 @@ def test_no_tools_native_output_strict_false(
         match=r'Setting `strict=False` on `output_type=NativeOutput\(\.\.\.\)` is not allowed for Anthropic models.',
     ):
         agent.run_sync('Tell me about Rome')
+
+
+@pytest.mark.vcr
+def test_no_tools_profile_default_native_output(
+    allow_model_requests: None,
+    anthropic_api_key: str,
+) -> None:
+    """Agent with profile default_structured_output_mode='native' and constrained fields → no 400.
+
+    Regression test for #6471, reproducing the reporter's MRE against the live API: native mode reached
+    via the profile default (rather than an explicit `NativeOutput(...)`) must still transform the schema.
+    """
+    model = AnthropicModel(
+        'claude-sonnet-4-5',
+        provider=AnthropicProvider(api_key=anthropic_api_key),
+        profile={'default_structured_output_mode': 'native'},
+    )
+
+    class Decision(BaseModel):
+        confidence: float = Field(ge=0.0, le=1.0)
+        title: str = Field(min_length=1)
+
+    agent = Agent(model, output_type=Decision)
+    result = agent.run_sync('Should we ship the feature? Give a confidence (0-1) and a short title.')
+
+    assert isinstance(result.output, Decision)
 
 
 @pytest.mark.vcr

--- a/tests/models/anthropic/test_output.py
+++ b/tests/models/anthropic/test_output.py
@@ -222,10 +222,17 @@ def test_native_output_profile_default_transforms_schema(allow_model_requests: N
     completion_kwargs = get_mock_chat_completion_kwargs(mock_client)[-1]
     output_schema = completion_kwargs['output_config']['format']['schema']
 
-    assert output_schema['additionalProperties'] is False
-    assert 'minimum' not in output_schema['properties']['confidence']
-    assert 'maximum' not in output_schema['properties']['confidence']
-    assert 'minLength' not in output_schema['properties']['title']
+    assert output_schema == snapshot(
+        {
+            'type': 'object',
+            'properties': {
+                'confidence': {'type': 'number', 'description': '{maximum: 1.0, minimum: 0.0}'},
+                'title': {'type': 'string', 'description': '{minLength: 1}'},
+            },
+            'required': ['confidence', 'title'],
+            'additionalProperties': False,
+        }
+    )
 
 
 # =============================================================================


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-sonnet-5 on behalf of David.

- Closes #6471

## What

`AnthropicModel.prepare_request` force-sets `strict=True` on the output object when `output_mode == 'native'`, which makes `customize_request_parameters()` (called by the base `Model.prepare_request()`) apply Anthropic's `transform_schema()` and strip constraints (`minimum`, `maximum`, `minLength`, etc.) that Anthropic's schema dialect doesn't support.

That check ran *before* the base class resolved `output_mode='auto'` to the profile's `default_structured_output_mode`. An explicit `NativeOutput(...)` already has `output_mode='native'` at construction time, so it was unaffected. But `profile={'default_structured_output_mode': 'native'}` left `output_mode` as `'auto'` at the point of the check, so `strict` stayed `None`, the transformer left the schema untouched, and Anthropic rejected the raw Pydantic constraints with a 400.

The fix resolves `'auto'` to the profile default right after the existing thinking-specific output-mode resolution (which must still take precedence — thinking forces `native`/`prompted` over the profile default to avoid `tool_choice=required`, which Anthropic doesn't support with thinking) and before the strict-forcing check, mirroring the precedent already established in that same function.

## Testing

- `tests/models/anthropic/test_output.py::test_native_output_profile_default_transforms_schema` — mock-based unit test asserting the schema sent for profile-default native mode has constraints transformed away (`additionalProperties: False`, no raw `minimum`/`maximum`/`minLength`).
- `tests/models/anthropic/test_output.py::test_no_tools_profile_default_native_output` — VCR round-trip test against the live API reproducing the reporter's MRE (constrained `Decision` model, `profile={'default_structured_output_mode': 'native'}`), confirming no 400.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

