### PR TITLE
feat(usage): add `cache_hit_ratio` property to `RequestUsage` and `RunUsage`

### DIFF
--- a/docs/models/anthropic.md
+++ b/docs/models/anthropic.md
@@ -243,6 +243,7 @@ result2 = agent.run_sync(
 )
 print(f'Cache write: {result1.usage.cache_write_tokens}')
 print(f'Cache read: {result2.usage.cache_read_tokens}')
+print(f'Cache hit ratio: {result2.usage.cache_hit_ratio}')
 ```
 
 This is ideal for multi-turn conversations where the cache breakpoint should move forward as the conversation grows. You can also specify a custom TTL with `anthropic_cache='1h'`.

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -28,12 +28,21 @@ class UsageBase:
         # `request_tokens` is deprecated, but we still want to support deserializing model responses stored in a DB before the name was changed
         Field(validation_alias=AliasChoices('input_tokens', 'request_tokens')),
     ] = 0
-    """Number of input/prompt tokens."""
+    """Total number of input/prompt tokens, across all modalities.
+
+    Token counts form inclusive parent/child buckets, not disjoint ones: this total includes cached
+    tokens (`cache_read_tokens`, `cache_write_tokens`) and audio tokens (`input_audio_tokens`).
+    Usage extraction normalizes providers that report these separately (e.g. Anthropic and Bedrock,
+    whose raw `input_tokens` exclude cache reads/writes) so the convention holds everywhere.
+    """
 
     cache_write_tokens: int = 0
-    """Number of tokens written to the cache."""
+    """Number of tokens written to the cache. Included in `input_tokens`."""
     cache_read_tokens: int = 0
-    """Number of tokens read from the cache."""
+    """Number of tokens read from the cache, across all modalities (includes `cache_audio_read_tokens`).
+
+    Included in `input_tokens`.
+    """
 
     output_tokens: Annotated[
         int,
@@ -43,11 +52,11 @@ class UsageBase:
     """Number of output/completion tokens."""
 
     input_audio_tokens: int = 0
-    """Number of audio input tokens."""
+    """Number of audio input tokens. Included in `input_tokens`."""
     cache_audio_read_tokens: int = 0
-    """Number of audio tokens read from the cache."""
+    """Number of audio tokens read from the cache. Included in `cache_read_tokens` and `input_audio_tokens`."""
     output_audio_tokens: int = 0
-    """Number of audio output tokens."""
+    """Number of audio output tokens. Included in `output_tokens`."""
 
     details: Annotated[
         dict[str, int],
@@ -73,9 +82,11 @@ class UsageBase:
     def cache_hit_ratio(self) -> float:
         """Fraction of input tokens that were read from the provider's prompt cache.
 
-        Computed as `cache_read_tokens / input_tokens`. `input_tokens` includes cached reads for every provider, so the
-        ratio is comparable across providers: `0.0` means no prompt-cache hits, while values approaching `1.0` mean
-        nearly the entire prompt was served from cache. Returns `0.0` when there are no input tokens.
+        Computed as `cache_read_tokens / input_tokens`. Both counts span all modalities — cached audio tokens are
+        included in `cache_read_tokens` just as audio input tokens are included in `input_tokens` — and
+        `input_tokens` includes cached reads for every provider, so the ratio is comparable across providers:
+        `0.0` means no prompt-cache hits, while values approaching `1.0` mean nearly the entire prompt was served
+        from cache. Returns `0.0` when there are no input tokens.
 
         On [`RequestUsage`][pydantic_ai.usage.RequestUsage] this is the hit ratio of a single request; on
         [`RunUsage`][pydantic_ai.usage.RunUsage] it aggregates all requests in the run.

--- a/pydantic_ai_slim/pydantic_ai/usage.py
+++ b/pydantic_ai_slim/pydantic_ai/usage.py
@@ -69,6 +69,19 @@ class UsageBase:
         """Sum of `input_tokens + output_tokens`."""
         return self.input_tokens + self.output_tokens
 
+    @property
+    def cache_hit_ratio(self) -> float:
+        """Fraction of input tokens that were read from the provider's prompt cache.
+
+        Computed as `cache_read_tokens / input_tokens`. `input_tokens` includes cached reads for every provider, so the
+        ratio is comparable across providers: `0.0` means no prompt-cache hits, while values approaching `1.0` mean
+        nearly the entire prompt was served from cache. Returns `0.0` when there are no input tokens.
+
+        On [`RequestUsage`][pydantic_ai.usage.RequestUsage] this is the hit ratio of a single request; on
+        [`RunUsage`][pydantic_ai.usage.RunUsage] it aggregates all requests in the run.
+        """
+        return self.cache_read_tokens / self.input_tokens if self.input_tokens else 0.0
+
     def opentelemetry_attributes(self) -> dict[str, int]:
         """Get the token usage values as OpenTelemetry attributes."""
         result: dict[str, int] = {}

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -433,6 +433,7 @@ def test_request_usage_basics():
 
 
 def test_cache_hit_ratio():
+    """Pure arithmetic on usage fields -- no model request to record."""
     assert RequestUsage(input_tokens=1000, cache_read_tokens=900).cache_hit_ratio == 0.9
     assert RequestUsage().cache_hit_ratio == 0.0
     assert RequestUsage(input_tokens=1000).cache_hit_ratio == 0.0

--- a/tests/test_usage_limits.py
+++ b/tests/test_usage_limits.py
@@ -432,6 +432,17 @@ def test_request_usage_basics():
     assert usage.requests == 1
 
 
+def test_cache_hit_ratio():
+    assert RequestUsage(input_tokens=1000, cache_read_tokens=900).cache_hit_ratio == 0.9
+    assert RequestUsage().cache_hit_ratio == 0.0
+    assert RequestUsage(input_tokens=1000).cache_hit_ratio == 0.0
+
+    run_usage = RunUsage()
+    run_usage.incr(RequestUsage(input_tokens=1000, cache_read_tokens=900))
+    run_usage.incr(RequestUsage(input_tokens=500, cache_read_tokens=300))
+    assert run_usage.cache_hit_ratio == 0.8
+
+
 def test_add_usages():
     usage = RunUsage(
         requests=2,


### PR DESCRIPTION
- Part of #6528 (slice A — cache-efficiency data on the usage objects)

## What

Adds a `cache_hit_ratio` property to `UsageBase`, so it's available on both `RequestUsage` (per request) and `RunUsage` (aggregated over the run): the fraction of input tokens that were served from the provider's prompt cache, `cache_read_tokens / input_tokens` (`0.0` when there are no input tokens).

Also codifies the token-accounting convention the ratio relies on, which previously lived only implicitly in genai-prices' extraction behavior: **token counts are inclusive parent/child buckets, not disjoint ones.** The `UsageBase` field docstrings now state it explicitly:

- `input_tokens` is the all-modality total and includes `cache_read_tokens`, `cache_write_tokens`, and `input_audio_tokens`
- `cache_read_tokens` spans all modalities and includes `cache_audio_read_tokens`

This is what makes the ratio cross-provider comparable and modality-complete as-is: genai-prices normalizes providers whose raw counts exclude cache tokens (Anthropic, Bedrock) by mapping them additively into `input_tokens`; Google documents `promptTokenCount` as including cached content; OpenAI's `prompt_tokens_details` are subsets of `prompt_tokens`. Cached audio is included in both the numerator and denominator, so audio caching is covered without a separate formula.

Also surfaces the new property in the first prompt-caching example on the Anthropic model page.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
