### PR TITLE
Fix Bedrock `profile={'default_structured_output_mode': 'native'}` sending untransformed schema

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -565,6 +565,15 @@ class BedrockConverseModel(Model[BaseClient]):
                 raise UserError(
                     f'Bedrock does not support thinking and output tools at the same time. Use `output_type={suggested_output_type}(...)` instead.'
                 )
+
+        # Resolve 'auto' to the profile default here (a no-op if already resolved above) so the
+        # strict-forcing check below also applies when native mode is reached via the profile default
+        # rather than an explicit `NativeOutput(...)`; `super().prepare_request()` would otherwise only
+        # resolve it after `customize_request_parameters()` has already transformed the schema.
+        model_request_parameters = model_request_parameters.with_default_output_mode(
+            self.profile.get('default_structured_output_mode', 'tool')
+        )
+
         if (
             self.profile.get('supports_json_schema_output', False)
             and model_request_parameters.output_mode == 'native'

--- a/tests/models/bedrock/cassettes/test_native_output/test_bedrock_native_output_profile_default.yaml
+++ b/tests/models/bedrock/cassettes/test_native_output/test_bedrock_native_output_profile_default.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Should we ship the feature? Give a confidence (0-1) and a
+      short title."}]}], "system": [], "inferenceConfig": {}, "outputConfig": {"textFormat": {"type": "json_schema", "structure":
+      {"jsonSchema": {"name": "Decision", "schema": "{\"properties\":{\"confidence\":{\"type\":\"number\",\"description\":\"minimum=0.0,
+      maximum=1.0\"},\"title\":{\"minLength\":1,\"type\":\"string\"}},\"required\":[\"confidence\",\"title\"],\"type\":\"object\",\"additionalProperties\":false}"}}}}}'
+    headers:
+      amz-sdk-invocation-id:
+      - !!binary |
+        ZTNkMWQyYzctZTc5Mi00YmY4LThlMTAtMDA4MWY5NzA3ZDhi
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+      content-length:
+      - '527'
+      content-type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse
+  response:
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '427'
+      content-type:
+      - application/json
+    parsed_body:
+      metrics:
+        latencyMs: 1943
+      output:
+        message:
+          content:
+          - text: '{"confidence": 0.5, "title": "Insufficient information to recommend shipping"}'
+          role: assistant
+      stopReason: end_turn
+      usage:
+        cacheReadInputTokenCount: 0
+        cacheReadInputTokens: 0
+        cacheWriteInputTokenCount: 0
+        cacheWriteInputTokens: 0
+        inputTokens: 215
+        outputTokens: 22
+        serverToolUsage: {}
+        totalTokens: 237
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/bedrock/test_native_output.py
+++ b/tests/models/bedrock/test_native_output.py
@@ -8,12 +8,14 @@ error path.
 
 from __future__ import annotations as _annotations
 
+import json
 import re
 from enum import Enum
 from typing import Annotated
 
 import pytest
 from pydantic import BaseModel, Field
+from pytest_mock import MockerFixture
 
 from pydantic_ai import (
     ModelRequest,
@@ -532,3 +534,81 @@ async def test_bedrock_native_output_stream(
             ),
         ]
     )
+
+
+def test_bedrock_native_output_profile_default_transforms_schema(
+    allow_model_requests: None,
+    bedrock_provider: BedrockProvider,
+    mocker: MockerFixture,
+):
+    """profile default_structured_output_mode='native' (no explicit `NativeOutput`) → schema is still transformed.
+
+    Regression test for #6523: the strict-forcing check used to run before the profile default resolved
+    'auto' to 'native', so schemas reaching native mode only via the profile default were sent to Bedrock
+    untransformed, leaving `strict` unset and constraints like `ge` in place — which Bedrock's strict
+    schema dialect rejects with a 400.
+
+    A mock test, not just the companion VCR test below, because the cassette matcher isn't sensitive to
+    request-body drift, so pinning the transformed schema directly is what actually catches a regression.
+    """
+    model = BedrockConverseModel(
+        'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+        provider=bedrock_provider,
+        profile={'default_structured_output_mode': 'native'},
+    )
+
+    class Decision(BaseModel):
+        confidence: float = Field(ge=0.0, le=1.0)
+        title: str = Field(min_length=1)
+
+    agent = Agent(model, output_type=Decision)
+
+    mock_converse = mocker.patch.object(model.client, 'converse')
+    mock_converse.return_value = {
+        'output': {'message': {'role': 'assistant', 'content': [{'text': '{"confidence": 0.9, "title": "Ship it"}'}]}},
+        'stopReason': 'end_turn',
+        'usage': {'inputTokens': 5, 'outputTokens': 10},
+        'ResponseMetadata': {'HTTPStatusCode': 200},
+    }
+
+    agent.run_sync('Should we ship the feature?')
+
+    _, kwargs = mock_converse.call_args
+    output_schema = json.loads(kwargs['outputConfig']['textFormat']['structure']['jsonSchema']['schema'])
+
+    assert output_schema == snapshot(
+        {
+            'type': 'object',
+            'properties': {
+                'confidence': {'type': 'number', 'description': 'minimum=0.0, maximum=1.0'},
+                'title': {'type': 'string', 'minLength': 1},
+            },
+            'required': ['confidence', 'title'],
+            'additionalProperties': False,
+        }
+    )
+
+
+async def test_bedrock_native_output_profile_default(
+    allow_model_requests: None,
+    bedrock_provider: BedrockProvider,
+):
+    """Agent with profile default_structured_output_mode='native' and constrained fields → no 400.
+
+    Regression test for #6523, reproducing the reporter's MRE against the live API: native mode reached
+    via the profile default (rather than an explicit `NativeOutput(...)`) must still transform the schema.
+    """
+    model = BedrockConverseModel(
+        'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+        provider=bedrock_provider,
+        profile={'default_structured_output_mode': 'native'},
+    )
+
+    class Decision(BaseModel):
+        confidence: float = Field(ge=0.0, le=1.0)
+        title: str = Field(min_length=1)
+
+    agent = Agent(model, output_type=Decision)
+    result = await agent.run('Should we ship the feature? Give a confidence (0-1) and a short title.')
+
+    assert isinstance(result.output, Decision)


### PR DESCRIPTION
- Closes #6523

Mirrors #6521 (which fixed the identical defect for Anthropic, #6471) onto Bedrock.

### The defect

`BedrockConverseModel.prepare_request` force-sets `output_object.strict=True` gated on `model_request_parameters.output_mode == 'native'`, but that check ran while `output_mode` was still `'auto'` when native was reached via `profile={'default_structured_output_mode': 'native'}` (rather than an explicit `NativeOutput(...)`). The base `Model.prepare_request` calls `customize_request_parameters` — which runs `BedrockJsonSchemaTransformer.transform` (early-returns when `not self.strict`) — *before* it resolves `'auto'` via `with_default_output_mode`. Net: the profile-default native path sent the untransformed schema (raw `minimum`/`maximum`, no `additionalProperties: false`), which Bedrock's strict schema dialect rejects with a 400.

### The fix

Resolve `'auto'` to the profile default via `with_default_output_mode(...)` right after the existing thinking-block output-mode resolution and before the strict-forcing check — same shape as #6521. It's a no-op when `output_mode != 'auto'`, so it preserves the thinking block's earlier resolution and doesn't change any non-`auto` path.

### Tests

- `test_bedrock_native_output_profile_default_transforms_schema` — mock/construct regression-catcher that pins the transformed schema reaching the `converse` call (`minimum`/`maximum` folded into `description`, `minLength` kept — Bedrock accepts string constraints — and `additionalProperties: false` applied). This is what actually catches a regression, since the VCR matcher isn't body-sensitive.
- `test_bedrock_native_output_profile_default` — live VCR test against real Bedrock (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`) asserting `isinstance(result.output, Decision)` (no 400). The recorded request body shows the transformed schema on the wire.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

