### PR TITLE
Make `sentence-transformers` CI coverage hermetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,14 +154,16 @@ jobs:
 
       - run: uv sync --only-dev
 
-      - name: cache HuggingFace models
+      # Cache only the immutable model used by `TestSentenceTransformers`. The old
+      # shared HF cache could be populated first by a matrix job that never downloaded
+      # this model, permanently turning an exact cache hit into a cold model cache.
+      - name: restore sentence-transformers test model
+        id: sentence-transformers-cache
         if: matrix.python-version != '3.14' && matrix.install.name == 'all-extras'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.cache/huggingface
-          key: hf-${{ runner.os }}-${{ hashFiles('**/uv.lock') }}
-          restore-keys: |
-            hf-${{ runner.os }}-
+          path: ~/.cache/huggingface/hub/models--sentence-transformers-testing--stsb-bert-tiny-safetensors
+          key: hf-${{ runner.os }}-stsb-bert-tiny-safetensors-f3cb857cba53019a20df283396bcca179cf051a4
 
       # The Temporal tests download the dev-server binary on first use (see `temporal_env` in
       # tests/test_temporal.py); cache it so a CDN hiccup can't fail the suite at setup (#5399).
@@ -176,15 +178,20 @@ jobs:
 
       # Warm the HF cache out-of-band (retried, non-fatal) so the sentence-transformers
       # test model is on disk when the ST tests load it offline (see the
-      # `stsb_bert_tiny_model` fixture). Download the snapshot without constructing
-      # the model here, since the tests construct it themselves. On a sustained HF
-      # outage the cache stays cold and those tests skip instead of erroring the job.
+      # `stsb_bert_tiny_model` fixture). On a cache miss, construct the pinned model
+      # once to prove the downloaded snapshot is usable before saving it. On a
+      # sustained HF outage the real-model smoke tests skip; deterministic adapter
+      # tests still preserve coverage.
       - name: pre-download sentence-transformers test model
-        if: matrix.install.name == 'all-extras' && matrix.python-version != '3.14'
+        id: sentence-transformers-download
+        if: >-
+          matrix.install.name == 'all-extras'
+          && matrix.python-version != '3.14'
+          && steps.sentence-transformers-cache.outputs.cache-hit != 'true'
         continue-on-error: true
         run: |
           for i in 1 2 3; do
-            if uv run --all-extras python -c "from huggingface_hub import snapshot_download; snapshot_download('sentence-transformers-testing/stsb-bert-tiny-safetensors')"; then
+            if uv run --all-extras python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors', revision='f3cb857cba53019a20df283396bcca179cf051a4')"; then
               exit 0
             fi
             echo "HF model download attempt $i failed; retrying in 15s..."
@@ -192,6 +199,18 @@ jobs:
           done
           echo "sentence-transformers test model unavailable after retries; ST tests will skip"
           exit 1
+
+      # A failed non-fatal download must not become an immutable exact cache hit.
+      - name: save sentence-transformers test model
+        if: >-
+          matrix.install.name == 'all-extras'
+          && matrix.python-version != '3.14'
+          && steps.sentence-transformers-cache.outputs.cache-hit != 'true'
+          && steps.sentence-transformers-download.outcome == 'success'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/huggingface/hub/models--sentence-transformers-testing--stsb-bert-tiny-safetensors
+          key: ${{ steps.sentence-transformers-cache.outputs.cache-primary-key }}
 
       # `-n logical`, not `-n auto`: xdist `auto` counts *physical* cores, which
       # under-subscribes Ubicloud's hyperthreaded vCPUs (premium-4 -> 2 workers
@@ -243,14 +262,13 @@ jobs:
 
       - run: mkdir .coverage
 
-      - name: cache HuggingFace models
+      - name: restore sentence-transformers test model
+        id: sentence-transformers-cache
         if: matrix.python-version != '3.14'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.cache/huggingface
-          key: hf-${{ runner.os }}-${{ hashFiles('**/uv.lock') }}
-          restore-keys: |
-            hf-${{ runner.os }}-
+          path: ~/.cache/huggingface/hub/models--sentence-transformers-testing--stsb-bert-tiny-safetensors
+          key: hf-${{ runner.os }}-stsb-bert-tiny-safetensors-f3cb857cba53019a20df283396bcca179cf051a4
 
       # See the matching step in the `test` job. Separate `lowest-` key: this job may resolve a
       # different temporalio version than the frozen lockfile, wanting a different binary. A stale
@@ -271,11 +289,14 @@ jobs:
       # Warm the HF cache out-of-band (see the `test` job) so the ST tests load
       # the model offline from disk instead of revalidating it against HF Hub.
       - name: pre-download sentence-transformers test model
-        if: matrix.python-version != '3.14'
+        id: sentence-transformers-download
+        if: >-
+          matrix.python-version != '3.14'
+          && steps.sentence-transformers-cache.outputs.cache-hit != 'true'
         continue-on-error: true
         run: |
           for i in 1 2 3; do
-            if uv run --no-sync python -c "from huggingface_hub import snapshot_download; snapshot_download('sentence-transformers-testing/stsb-bert-tiny-safetensors')"; then
+            if uv run --no-sync python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors', revision='f3cb857cba53019a20df283396bcca179cf051a4')"; then
               exit 0
             fi
             echo "HF model download attempt $i failed; retrying in 15s..."
@@ -283,6 +304,16 @@ jobs:
           done
           echo "sentence-transformers test model unavailable after retries; ST tests will skip"
           exit 1
+
+      - name: save sentence-transformers test model
+        if: >-
+          matrix.python-version != '3.14'
+          && steps.sentence-transformers-cache.outputs.cache-hit != 'true'
+          && steps.sentence-transformers-download.outcome == 'success'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/huggingface/hub/models--sentence-transformers-testing--stsb-bert-tiny-safetensors
+          key: ${{ steps.sentence-transformers-cache.outputs.cache-primary-key }}
 
       # `-n logical` (see note on the `test` job): use all vCPUs on Ubicloud.
       - run: uv run --no-sync coverage run -m pytest --durations=100 -n logical --dist=loadgroup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,11 +177,14 @@ jobs:
             temporal-cli-${{ runner.os }}-${{ runner.arch }}-locked-
 
       # Warm the HF cache out-of-band (retried, non-fatal) so the sentence-transformers
-      # test model is on disk when the ST tests load it offline (see the
-      # `stsb_bert_tiny_model` fixture). On a cache miss, construct the pinned model
-      # once to prove the downloaded snapshot is usable before saving it. On a
-      # sustained HF outage the real-model smoke tests skip; deterministic adapter
-      # tests still preserve coverage.
+      # test model is on disk when the ST tests load it: the pinned revision is then
+      # served from cache without revalidating against the Hub (see the
+      # `stsb_bert_tiny_model` fixture). On a cache miss, fetch the full pinned
+      # snapshot — this job and `test-lowest-versions` share the cache key, so the
+      # cached snapshot must not depend on which resolution flavor warmed it — then
+      # construct the model once to prove it is usable before saving. On a sustained
+      # HF outage the real-model smoke tests skip; deterministic adapter tests still
+      # preserve coverage.
       - name: pre-download sentence-transformers test model
         id: sentence-transformers-download
         if: >-
@@ -191,7 +194,7 @@ jobs:
         continue-on-error: true
         run: |
           for i in 1 2 3; do
-            if uv run --all-extras python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors', revision='f3cb857cba53019a20df283396bcca179cf051a4')"; then
+            if uv run --all-extras python -c "from huggingface_hub import snapshot_download; from sentence_transformers import SentenceTransformer; snapshot_download('sentence-transformers-testing/stsb-bert-tiny-safetensors', revision='f3cb857cba53019a20df283396bcca179cf051a4'); SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors', revision='f3cb857cba53019a20df283396bcca179cf051a4')"; then
               exit 0
             fi
             echo "HF model download attempt $i failed; retrying in 15s..."
@@ -286,8 +289,8 @@ jobs:
         env:
           UV_FROZEN: "0"
 
-      # Warm the HF cache out-of-band (see the `test` job) so the ST tests load
-      # the model offline from disk instead of revalidating it against HF Hub.
+      # Warm the HF cache out-of-band: full pinned snapshot, then a validation
+      # construct (see the matching step in the `test` job for the full rationale).
       - name: pre-download sentence-transformers test model
         id: sentence-transformers-download
         if: >-
@@ -296,7 +299,7 @@ jobs:
         continue-on-error: true
         run: |
           for i in 1 2 3; do
-            if uv run --no-sync python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors', revision='f3cb857cba53019a20df283396bcca179cf051a4')"; then
+            if uv run --no-sync python -c "from huggingface_hub import snapshot_download; from sentence_transformers import SentenceTransformer; snapshot_download('sentence-transformers-testing/stsb-bert-tiny-safetensors', revision='f3cb857cba53019a20df283396bcca179cf051a4'); SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors', revision='f3cb857cba53019a20df283396bcca179cf051a4')"; then
               exit 0
             fi
             echo "HF model download attempt $i failed; retrying in 15s..."

--- a/pydantic_ai_slim/pydantic_ai/embeddings/sentence_transformers.py
+++ b/pydantic_ai_slim/pydantic_ai/embeddings/sentence_transformers.py
@@ -176,5 +176,5 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel):
     async def _get_model(self) -> SentenceTransformer:
         if self._model is None:
             # This may download the model from Hugging Face, so we do it in a thread
-            self._model = await _utils.run_in_executor(SentenceTransformer, self.model_name)  # pragma: no cover
+            self._model = await _utils.run_in_executor(SentenceTransformer, self.model_name)
         return self._model

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1593,24 +1593,21 @@ class TestGoogle:
 class TestSentenceTransformers:
     @pytest.fixture(scope='session')
     def stsb_bert_tiny_model(self):
-        # Load offline so sentence-transformers never revalidates the model against
-        # the HF Hub (a recurring source of 429 flakes). Scoped to just this load:
-        # a job-wide HF_HUB_OFFLINE would also block the HuggingFace VCR tests, whose
-        # cassette replay still trips huggingface_hub's offline check. CI warms the
-        # cache out-of-band (see ci.yml) so the load hits disk.
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setenv('HF_HUB_OFFLINE', '1')
-            try:
-                model = SentenceTransformer(STSB_BERT_TINY_MODEL, revision=STSB_BERT_TINY_REVISION)
-            except OSError as e:  # pragma: no cover
-                # A cold HF cache under offline mode (or an unreachable/rate-limited
-                # Hub) raises OSError; skip rather than fail so a HF outage never reds
-                # the whole suite. CI keeps the cache warm (see ci.yml) so this is a
-                # last-resort net, not the normal path.
-                pytest.skip(f'sentence-transformers test model unavailable (HF Hub): {e}')
-        # Under HF_HUB_OFFLINE the model card isn't fetched, so `model_id` is unset
-        # and the model would report its name as 'unknown'. Set it explicitly to
-        # match the name users get online (a no-op when the card did load).
+        # The pinned commit revision makes a warm HF cache authoritative:
+        # huggingface_hub serves pinned files straight from disk without contacting
+        # the Hub, so no revalidation requests and none of the 429/504 flakes they
+        # cause. CI warms the cache out-of-band (see ci.yml); a cold cache downloads
+        # the model here on first use.
+        try:
+            model = SentenceTransformer(STSB_BERT_TINY_MODEL, revision=STSB_BERT_TINY_REVISION)
+        except OSError as e:  # pragma: lax no cover
+            # A cold cache with the Hub unreachable raises OSError; skip rather than
+            # fail so a HF outage never reds the whole suite. `lax` because this runs
+            # only during such outages: coverage must tolerate both outcomes.
+            pytest.skip(f'sentence-transformers test model unavailable (HF Hub): {e}')
+        # If the model card didn't load, `model_id` is unset and the model reports
+        # its name as 'unknown'. Set it explicitly so the reported name is
+        # deterministic (a no-op when the card did load).
         model.model_card_data.model_id = STSB_BERT_TINY_MODEL
         model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
         return model

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -81,9 +81,18 @@ with try_import() as voyageai_imports_successful:
     from pydantic_ai.providers.voyageai import VoyageAIProvider
 
 with try_import() as sentence_transformers_imports_successful:
+    import torch
     from sentence_transformers import SentenceTransformer
 
-    from pydantic_ai.embeddings.sentence_transformers import SentenceTransformerEmbeddingModel
+    import pydantic_ai.embeddings.sentence_transformers as sentence_transformers_module
+    from pydantic_ai.embeddings.sentence_transformers import (
+        SentenceTransformerEmbeddingModel,
+        SentenceTransformersEmbeddingSettings,
+    )
+
+
+STSB_BERT_TINY_MODEL = 'sentence-transformers-testing/stsb-bert-tiny-safetensors'
+STSB_BERT_TINY_REVISION = 'f3cb857cba53019a20df283396bcca179cf051a4'
 
 
 @pytest.mark.skipif(not openai_imports_successful(), reason='OpenAI not installed')
@@ -1592,7 +1601,7 @@ class TestSentenceTransformers:
         with pytest.MonkeyPatch.context() as mp:
             mp.setenv('HF_HUB_OFFLINE', '1')
             try:
-                model = SentenceTransformer('sentence-transformers-testing/stsb-bert-tiny-safetensors')
+                model = SentenceTransformer(STSB_BERT_TINY_MODEL, revision=STSB_BERT_TINY_REVISION)
             except OSError as e:  # pragma: no cover
                 # A cold HF cache under offline mode (or an unreachable/rate-limited
                 # Hub) raises OSError; skip rather than fail so a HF outage never reds
@@ -1602,7 +1611,7 @@ class TestSentenceTransformers:
         # Under HF_HUB_OFFLINE the model card isn't fetched, so `model_id` is unset
         # and the model would report its name as 'unknown'. Set it explicitly to
         # match the name users get online (a no-op when the card did load).
-        model.model_card_data.model_id = 'sentence-transformers-testing/stsb-bert-tiny-safetensors'
+        model.model_card_data.model_id = STSB_BERT_TINY_MODEL
         model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
         return model
 
@@ -1616,6 +1625,87 @@ class TestSentenceTransformers:
         assert model.model_name == 'all-MiniLM-L6-v2'
         assert model.system == 'sentence-transformers'
         assert model.base_url is None
+
+    async def test_adapter_without_downloaded_model(self, monkeypatch: pytest.MonkeyPatch):
+        """VCR cannot exercise a local adapter, so cover it without a downloaded model."""
+        st_model = MagicMock(spec=SentenceTransformer)
+        st_model.model_card_data = MagicMock()
+        st_model.model_card_data.model_id = 'test-model'
+        st_model.encode_query.return_value.tolist.return_value = [[0.1, 0.2]]
+        st_model.encode_document.return_value.tolist.return_value = [[0.3, 0.4], [0.5, 0.6]]
+        st_model.get_max_seq_length.return_value = 512
+        st_model.tokenize.return_value = {'input_ids': torch.tensor([[1, 2, 3]])}
+
+        def preserve_model(model: SentenceTransformer) -> SentenceTransformer:
+            return model
+
+        monkeypatch.setattr(sentence_transformers_module, 'deepcopy', preserve_model)
+
+        model = SentenceTransformerEmbeddingModel(
+            st_model,
+            settings=SentenceTransformersEmbeddingSettings(
+                dimensions=2,
+                sentence_transformers_batch_size=2,
+                sentence_transformers_device='cpu',
+                sentence_transformers_normalize_embeddings=True,
+            ),
+        )
+        embedder = Embedder(model)
+
+        query_result = await embedder.embed_query('hello')
+        assert query_result == snapshot(
+            EmbeddingResult(
+                embeddings=[[0.1, 0.2]],
+                inputs=['hello'],
+                input_type='query',
+                model_name='test-model',
+                provider_name='sentence-transformers',
+                timestamp=IsDatetime(),
+            )
+        )
+        st_model.encode_query.assert_called_once_with(
+            ['hello'],
+            show_progress_bar=False,
+            convert_to_numpy=True,
+            convert_to_tensor=False,
+            device='cpu',
+            normalize_embeddings=True,
+            truncate_dim=2,
+            batch_size=2,
+        )
+
+        documents_result = await embedder.embed_documents(['hello', 'world'])
+        assert documents_result == snapshot(
+            EmbeddingResult(
+                embeddings=[[0.3, 0.4], [0.5, 0.6]],
+                inputs=['hello', 'world'],
+                input_type='document',
+                model_name='test-model',
+                provider_name='sentence-transformers',
+                timestamp=IsDatetime(),
+            )
+        )
+        st_model.encode_document.assert_called_once_with(
+            ['hello', 'world'],
+            show_progress_bar=False,
+            convert_to_numpy=True,
+            convert_to_tensor=False,
+            device='cpu',
+            normalize_embeddings=True,
+            truncate_dim=2,
+            batch_size=2,
+        )
+        assert await embedder.max_input_tokens() == 512
+        assert await embedder.count_tokens('hello') == 3
+
+        loaded_model = MagicMock(spec=SentenceTransformer)
+        loaded_model.get_max_seq_length.return_value = 256
+        constructor = MagicMock(return_value=loaded_model)
+        monkeypatch.setattr(sentence_transformers_module, 'SentenceTransformer', constructor)
+
+        lazy_embedder = Embedder(SentenceTransformerEmbeddingModel('lazy-model'))
+        assert await lazy_embedder.max_input_tokens() == 256
+        constructor.assert_called_once_with('lazy-model')
 
     async def test_query(self, embedder: Embedder):
         result = await embedder.embed_query('Hello, world!')

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -100,15 +101,55 @@ STSB_BERT_TINY_MODEL = 'sentence-transformers-testing/stsb-bert-tiny-safetensors
 STSB_BERT_TINY_REVISION = 'f3cb857cba53019a20df283396bcca179cf051a4'
 
 
+def _hf_hub_unavailable(exc: BaseException) -> bool:
+    """Whether an exception from a SentenceTransformer load means the HF Hub is
+    unavailable (worth skipping the real-model smoke tests) rather than a genuine
+    integration defect (which must fail loudly). Shapes verified against real outages.
+    """
+    if isinstance(exc, httpx.HTTPError):
+        # Raw httpx errors (e.g. connect timeouts) escape huggingface_hub 1.x
+        # unwrapped, and the only httpx traffic in a model load is Hub traffic.
+        return True
+    if isinstance(exc, RuntimeError):
+        # After a connection error, huggingface_hub 1.x retries on an httpx client
+        # it just closed, surfacing httpx's RuntimeError instead of its own error.
+        return 'client has been closed' in str(exc)
+    # huggingface_hub's own errors (HfHubHTTPError for 429/5xx responses,
+    # LocalEntryNotFoundError, ...) are OSError subclasses; transformers wraps
+    # connection failures in a plain OSError whose message points at the Hub.
+    return type(exc).__module__.startswith('huggingface_hub') or 'huggingface.co' in str(exc)
+
+
+def test_hf_hub_unavailable_classifier():
+    class FakeHubError(OSError):
+        pass
+
+    FakeHubError.__module__ = 'huggingface_hub.errors'
+
+    assert _hf_hub_unavailable(httpx.ConnectTimeout('timed out'))
+    assert _hf_hub_unavailable(RuntimeError('Cannot send a request, as the client has been closed.'))
+    assert _hf_hub_unavailable(FakeHubError('504 Server Error'))
+    assert _hf_hub_unavailable(OSError("We couldn't connect to 'https://huggingface.co' to load the files"))
+    assert not _hf_hub_unavailable(RuntimeError('CUDA error: device-side assert triggered'))
+    assert not _hf_hub_unavailable(OSError('Unable to load weights from pytorch checkpoint file'))
+
+
 def test_stsb_model_pin_matches_ci():
     """Drift between this pin and ci.yml silently reintroduces per-run Hub downloads:
     the stale cache key keeps exact-hitting, so CI never caches the new revision."""
     ci_yml = Path(__file__).parent.parent / '.github' / 'workflows' / 'ci.yml'
     if not ci_yml.is_file():  # pragma: lax no cover
         pytest.skip('not running from a repo checkout')
-    content = ci_yml.read_text()
-    assert STSB_BERT_TINY_MODEL in content
-    assert STSB_BERT_TINY_REVISION in content, 'update the HF cache keys and warmup commands in ci.yml'
+    stsb_lines = [line for line in ci_yml.read_text().splitlines() if 'stsb-bert-tiny' in line]
+    cache_keys = [line for line in stsb_lines if 'key:' in line]
+    warmups = [line for line in stsb_lines if 'snapshot_download' in line]
+    assert len(cache_keys) >= 2, 'expected a model cache key in both test jobs in ci.yml'
+    assert len(warmups) >= 2, 'expected a model warmup command in both test jobs in ci.yml'
+    assert all(STSB_BERT_TINY_MODEL in line for line in warmups)
+    for line in cache_keys + warmups:
+        assert STSB_BERT_TINY_REVISION in line, f'stale or missing revision pin in ci.yml: {line.strip()}'
+    stray = {sha for line in stsb_lines for sha in re.findall(r'[0-9a-f]{40}', line)} - {STSB_BERT_TINY_REVISION}
+    assert not stray, f'stale revision pins left in ci.yml: {stray}'
 
 
 @pytest.mark.skipif(not openai_imports_successful(), reason='OpenAI not installed')
@@ -1618,12 +1659,13 @@ class TestSentenceTransformers:
         try:
             model = SentenceTransformer(STSB_BERT_TINY_MODEL, revision=STSB_BERT_TINY_REVISION)
         except (OSError, RuntimeError, httpx.HTTPError) as e:  # pragma: lax no cover
-            # With the Hub unavailable, failures surface as OSError (HTTP-status
-            # errors), raw httpx errors (connect timeouts), or RuntimeError
-            # (huggingface_hub 1.x retries on a client it just closed after a
-            # connection error). Skip rather than fail so a HF outage never reds the
-            # whole suite. `lax` because this path runs only during outages:
-            # coverage must tolerate both outcomes.
+            # Skip only when the Hub is unavailable (see `_hf_hub_unavailable`) so a
+            # HF outage never reds the whole suite; anything else (corrupt cache,
+            # dependency mismatch, model-construction regression) fails loudly.
+            # `lax` because this path runs only during outages: coverage must
+            # tolerate both outcomes.
+            if not _hf_hub_unavailable(e):
+                raise
             pytest.skip(f'sentence-transformers test model unavailable (HF Hub): {e}')
         # If the model card didn't load, `model_id` is unset and the model reports
         # its name as 'unknown'. Set it explicitly so the reported name is

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -5,10 +5,12 @@ import sys
 from collections.abc import Iterator
 from dataclasses import dataclass
 from decimal import Decimal
+from pathlib import Path
 from typing import Any, Literal, get_args
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
 
+import httpx
 import pytest
 
 from ._inline_snapshot import snapshot
@@ -92,7 +94,21 @@ with try_import() as sentence_transformers_imports_successful:
 
 
 STSB_BERT_TINY_MODEL = 'sentence-transformers-testing/stsb-bert-tiny-safetensors'
+# Pinned so a warm HF cache is served without revalidating files against the Hub.
+# Keep in sync with the HF cache keys and warmup commands in .github/workflows/ci.yml;
+# `test_stsb_model_pin_matches_ci` guards against drift.
 STSB_BERT_TINY_REVISION = 'f3cb857cba53019a20df283396bcca179cf051a4'
+
+
+def test_stsb_model_pin_matches_ci():
+    """Drift between this pin and ci.yml silently reintroduces per-run Hub downloads:
+    the stale cache key keeps exact-hitting, so CI never caches the new revision."""
+    ci_yml = Path(__file__).parent.parent / '.github' / 'workflows' / 'ci.yml'
+    if not ci_yml.is_file():  # pragma: lax no cover
+        pytest.skip('not running from a repo checkout')
+    content = ci_yml.read_text()
+    assert STSB_BERT_TINY_MODEL in content
+    assert STSB_BERT_TINY_REVISION in content, 'update the HF cache keys and warmup commands in ci.yml'
 
 
 @pytest.mark.skipif(not openai_imports_successful(), reason='OpenAI not installed')
@@ -1593,17 +1609,21 @@ class TestGoogle:
 class TestSentenceTransformers:
     @pytest.fixture(scope='session')
     def stsb_bert_tiny_model(self):
-        # The pinned commit revision makes a warm HF cache authoritative:
-        # huggingface_hub serves pinned files straight from disk without contacting
-        # the Hub, so no revalidation requests and none of the 429/504 flakes they
-        # cause. CI warms the cache out-of-band (see ci.yml); a cold cache downloads
-        # the model here on first use.
+        # The pinned commit revision lets huggingface_hub serve every model file
+        # straight from a warm cache without revalidating it against the Hub.
+        # Construction still fires a few metadata requests (model card, repo tree,
+        # adapter probe); those tolerate Hub HTTP errors, and connection-level
+        # failures fall through to the skip below. CI warms the cache out-of-band
+        # (see ci.yml); a cold cache downloads the model here on first use.
         try:
             model = SentenceTransformer(STSB_BERT_TINY_MODEL, revision=STSB_BERT_TINY_REVISION)
-        except OSError as e:  # pragma: lax no cover
-            # A cold cache with the Hub unreachable raises OSError; skip rather than
-            # fail so a HF outage never reds the whole suite. `lax` because this runs
-            # only during such outages: coverage must tolerate both outcomes.
+        except (OSError, RuntimeError, httpx.HTTPError) as e:  # pragma: lax no cover
+            # With the Hub unavailable, failures surface as OSError (HTTP-status
+            # errors), raw httpx errors (connect timeouts), or RuntimeError
+            # (huggingface_hub 1.x retries on a client it just closed after a
+            # connection error). Skip rather than fail so a HF outage never reds the
+            # whole suite. `lax` because this path runs only during outages:
+            # coverage must tolerate both outcomes.
             pytest.skip(f'sentence-transformers test model unavailable (HF Hub): {e}')
         # If the model card didn't load, `model_id` is unset and the model reports
         # its name as 'unknown'. Set it explicitly so the reported name is

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -104,39 +104,72 @@ STSB_BERT_TINY_REVISION = 'f3cb857cba53019a20df283396bcca179cf051a4'
 def _hf_hub_unavailable(exc: BaseException) -> bool:
     """Whether an exception from a SentenceTransformer load means the HF Hub is
     unavailable (worth skipping the real-model smoke tests) rather than a genuine
-    integration defect (which must fail loudly). Shapes verified against real outages.
+    integration defect or a bad model pin (which must fail loudly). Shapes verified
+    against real outage and bad-pin probes.
     """
-    if isinstance(exc, httpx.HTTPError):
-        # Raw httpx errors (e.g. connect timeouts) escape huggingface_hub 1.x
-        # unwrapped, and the only httpx traffic in a model load is Hub traffic.
+    if isinstance(exc, httpx.TransportError):
+        # Transport-level httpx errors (e.g. connect timeouts) escape
+        # huggingface_hub 1.x unwrapped, and the only httpx traffic in a model
+        # load is Hub traffic. Status-level httpx errors are not outage proof.
         return True
     if isinstance(exc, RuntimeError):
         # After a connection error, huggingface_hub 1.x retries on an httpx client
         # it just closed, surfacing httpx's RuntimeError instead of its own error.
         return 'client has been closed' in str(exc)
-    # huggingface_hub's own errors (HfHubHTTPError for 429/5xx responses,
-    # LocalEntryNotFoundError, ...) are OSError subclasses; transformers wraps
-    # connection failures in a plain OSError whose message points at the Hub.
-    return type(exc).__module__.startswith('huggingface_hub') or 'huggingface.co' in str(exc)
+    if type(exc).__module__.startswith('huggingface_hub'):
+        # huggingface_hub errors are OSError subclasses. Ones carrying an HTTP
+        # response are an outage only for transient statuses; 401/403/404 mean a
+        # bad pin or an auth problem. Ones without a response (e.g.
+        # LocalEntryNotFoundError) mean the Hub couldn't be reached at all.
+        status = getattr(getattr(exc, 'response', None), 'status_code', None)
+        return status is None or status == 429 or status >= 500
+    # transformers wraps connection failures in a plain OSError: "We couldn't
+    # connect to 'https://huggingface.co' to load the files [...]". Other OSError
+    # shapes (corrupt cache, invalid model identifier) must propagate.
+    return "couldn't connect" in str(exc).lower()
 
 
 def test_hf_hub_unavailable_classifier():
+    """Exercises the fixture's outage-classification guard on synthetic exceptions:
+    no HTTP is involved (hence no VCR), just shapes captured from real probes."""
+
+    class FakeResponse:
+        def __init__(self, status_code: int):
+            self.status_code = status_code
+
     class FakeHubError(OSError):
-        pass
+        def __init__(self, msg: str, status_code: int | None = None):
+            super().__init__(msg)
+            self.response = FakeResponse(status_code) if status_code is not None else None
 
     FakeHubError.__module__ = 'huggingface_hub.errors'
 
+    # Hub unavailability: skip the real-model smoke tests.
     assert _hf_hub_unavailable(httpx.ConnectTimeout('timed out'))
     assert _hf_hub_unavailable(RuntimeError('Cannot send a request, as the client has been closed.'))
-    assert _hf_hub_unavailable(FakeHubError('504 Server Error'))
+    assert _hf_hub_unavailable(FakeHubError('504 Server Error', 504))
+    assert _hf_hub_unavailable(FakeHubError('429 Too Many Requests', 429))
+    assert _hf_hub_unavailable(FakeHubError('cannot find the requested files in the disk cache'))
     assert _hf_hub_unavailable(OSError("We couldn't connect to 'https://huggingface.co' to load the files"))
+    # Anything else fails loudly: bad pins, auth problems, local defects.
+    assert not _hf_hub_unavailable(FakeHubError('401 Unauthorized', 401))
+    assert not _hf_hub_unavailable(FakeHubError('404 Repository Not Found', 404))
+    assert not _hf_hub_unavailable(
+        httpx.HTTPStatusError('404', request=httpx.Request('GET', 'https://x'), response=httpx.Response(404))
+    )
     assert not _hf_hub_unavailable(RuntimeError('CUDA error: device-side assert triggered'))
     assert not _hf_hub_unavailable(OSError('Unable to load weights from pytorch checkpoint file'))
+    assert not _hf_hub_unavailable(
+        OSError(
+            "xyz is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'"
+        )
+    )
 
 
 def test_stsb_model_pin_matches_ci():
-    """Drift between this pin and ci.yml silently reintroduces per-run Hub downloads:
-    the stale cache key keeps exact-hitting, so CI never caches the new revision."""
+    """Parses CI configuration only, no network or VCR involved: drift between this
+    pin and ci.yml silently reintroduces per-run Hub downloads, because the stale
+    cache key keeps exact-hitting, so CI never caches the new revision."""
     ci_yml = Path(__file__).parent.parent / '.github' / 'workflows' / 'ci.yml'
     if not ci_yml.is_file():  # pragma: lax no cover
         pytest.skip('not running from a repo checkout')
@@ -1660,10 +1693,10 @@ class TestSentenceTransformers:
             model = SentenceTransformer(STSB_BERT_TINY_MODEL, revision=STSB_BERT_TINY_REVISION)
         except (OSError, RuntimeError, httpx.HTTPError) as e:  # pragma: lax no cover
             # Skip only when the Hub is unavailable (see `_hf_hub_unavailable`) so a
-            # HF outage never reds the whole suite; anything else (corrupt cache,
-            # dependency mismatch, model-construction regression) fails loudly.
-            # `lax` because this path runs only during outages: coverage must
-            # tolerate both outcomes.
+            # HF outage never reds the whole suite; anything else (bad pin, auth
+            # problem, corrupt cache, dependency mismatch) fails loudly. `lax`
+            # because this path runs only during outages: coverage must tolerate
+            # both outcomes.
             if not _hf_hub_unavailable(e):
                 raise
             pytest.skip(f'sentence-transformers test model unavailable (HF Hub): {e}')


### PR DESCRIPTION
Follow-up to #5389. This fixes the reproduced main-branch coverage failure from [run 29482569757](https://github.com/pydantic/pydantic-ai/actions/runs/29482569757).

### Problem

The shared Hugging Face cache key could be created by a matrix job that never installed or downloaded SentenceTransformers. Because GitHub caches are immutable, later relevant jobs restored an exact but model-less cache. During a Hugging Face outage, the real-model tests skipped and the adapter's 18 executable lines disappeared from aggregate coverage.

### Fix

- cache only the pinned `stsb-bert-tiny-safetensors` model revision
- split restore and save, and save only after fetching the full pinned snapshot and constructing the model successfully (full snapshot because the `test` and `test-lowest-versions` jobs share the cache key while resolving different library versions)
- omit broad restore prefixes so old unrelated caches cannot be restored
- cover the adapter's query, document, token-count, max-token, and lazy-loading paths with a deterministic public-API test, and remove the now-covered `pragma: no cover` from the lazy load (`strict-no-cover` rejects covered pragmas)
- mark the fixture's skip path `pragma: lax no cover`: it executes only during a Hugging Face outage, and coverage must tolerate both outcomes
- broaden the fixture's skip net to `except (OSError, RuntimeError, httpx.HTTPError)`: only HTTP-status outages (e.g. the 504s of the original incident) surface as `OSError`; connect-refused outages surface as `RuntimeError` (huggingface_hub 1.x retries on a client it just closed after a connection error) and connect timeouts as raw `httpx` errors — both reproduced against real sockets, and both previously **errored** the suite instead of skipping (pre-existing hole, same on `main`)
- add `test_stsb_model_pin_matches_ci`, guarding the revision pin against drift: the SHA is hardcoded in the test constant and in ci.yml's cache keys and warmup commands, and bumping only the constant would silently reintroduce per-run Hub downloads behind a stale exact-hit cache
- retain the real tiny-model tests as integration smoke tests

The fixture's `HF_HUB_OFFLINE` monkeypatch was dropped: `huggingface_hub` binds that variable into `constants` at import time (the sole env read across huggingface_hub/transformers/sentence-transformers), and the test module imports `sentence_transformers` at collection — so a per-fixture `setenv` is provably inert (verified empirically: a cold-cache load under the monkeypatch still downloads). What protects warm-cache loads is the pinned commit revision: huggingface_hub's commit-hash fast path serves every model file from disk. Construction still fires a few metadata requests (model card, repo tree, adapter probe); those tolerate Hub HTTP errors, and connection-level failures are caught by the broadened skip net.

### Resulting invariant

CI stays green in every combination of cache state and Hub availability:

| Cache | Hub | Behavior |
| --- | --- | --- |
| warm | up | model files from disk; all 6 tests run |
| warm | 5xx/429 | metadata requests degrade gracefully; all 6 tests run (verified via injected 504s) |
| warm | connect-refused / timeout | real-model tests skip; adapter coverage preserved |
| cold | up | model downloads once; cache saved only after a validated full-snapshot fetch |
| cold | down (any flavor) | real-model tests skip; deterministic test keeps the adapter at 100%; `lax no cover` keeps `strict-no-cover` quiet |

### Validation

- warm cache — 7 passed; adapter 100% lines+branches; `strict-no-cover` ✅
- simulated offline outage (empty `HF_HOME` + import-time `HF_HUB_OFFLINE=1`) — 3 passed, 4 skipped; adapter still 100%; no missing lines in the skipped test class (excluded via the `@pytest.mark.skipif` exclude pattern); `strict-no-cover` ✅
- real-socket outage (cold cache against a connection-refused endpoint) — 3 passed, 4 skipped; previously this errored with `RuntimeError`
- the new ci.yml warmup command executed locally into a fresh cache — full 13-file snapshot fetched, model constructed
- Ruff lint and format checks, Pyright, workflow YAML and zizmor checks, full pre-commit hooks
- three independent adversarial reviews (coverage semantics, Hugging Face runtime behavior across the resolved version matrix incl. lowest-versions, repo conventions and cache design) — all findings addressed above
- CI green on the pragma fixes: [run 29488299474](https://github.com/pydantic/pydantic-ai/actions/runs/29488299474)

Notes for reviewers: #6464 touches the same fixture lines with an overlapping goal (a deterministic test of the skip path) — whichever PR lands second needs a small manual resolution. This PR is otherwise distinct from #6464, which does not cover the adapter paths responsible for the 99.98% aggregate coverage failure.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
