### PR TITLE
Mark untyped arrays as not strict-compatible for OpenAI

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -359,6 +359,12 @@ _STRICT_COMPATIBLE_STRING_FORMATS = [
 
 _REGEX_LOOKAROUND_TOKENS = ('(?=', '(?!', '(?<=', '(?<!')
 
+_TYPE_BEARING_KEYS = ('type', '$ref', 'anyOf', 'oneOf', 'allOf', 'enum', 'const')
+"""Keywords whose presence means a schema node describes a concrete type.
+
+Used to tell whether an array's `items` actually types its elements. A node without any of these
+(e.g. `{}`, `True`, or `{'description': '...'}`) is untyped and rejected by OpenAI strict mode."""
+
 _sentinel = object()
 
 
@@ -491,12 +497,13 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
             # OpenAI strict mode requires an array to describe its elements' type, via either `items`
             # (list types) or `prefixItems` (tuple types). A bare `list` produces an empty `items: {}`,
             # `list[Any]` a boolean `items: true`, and a schema may omit `items` entirely; none of these
-            # give the element a `type`, so they're rejected by the API in strict mode and there's no way
-            # to repair them without inventing an element type. `items` counts as typed only when it's a
-            # non-empty schema object (a boolean node like `true`/`false` has no `type`).
+            # give the element a type, so they're rejected by the API in strict mode and there's no way
+            # to repair them without inventing an element type. `items` only types its elements when it's
+            # a schema object carrying a type-bearing keyword (a boolean node, `{}`, or a metadata-only
+            # node like `{'description': ...}` does not).
             # See https://github.com/pydantic/pydantic-ai/issues/4425
             items = schema.get('items')
-            has_typed_items = isinstance(items, dict) and bool(items)
+            has_typed_items = isinstance(items, dict) and any(key in items for key in _TYPE_BEARING_KEYS)
             if not has_typed_items and not schema.get('prefixItems'):
                 if self.strict is True:
                     raise UserError(

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -486,4 +486,19 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
                     for k in schema['properties'].keys():
                         if k not in required:
                             self.is_strict_compatible = False
+
+        if schema_type == 'array':
+            # OpenAI strict mode requires an array to describe its elements' type, via either `items`
+            # (list types) or `prefixItems` (tuple types). A bare `list` (no type param) produces an
+            # empty `items: {}` with neither, and a schema may omit `items` entirely; both are rejected
+            # by the API in strict mode and there's no way to repair them without inventing an element
+            # type. See https://github.com/pydantic/pydantic-ai/issues/4425
+            if not schema.get('items') and not schema.get('prefixItems'):
+                if self.strict is True:
+                    raise UserError(
+                        'OpenAI strict mode requires array items to have a type, but got an untyped array '
+                        '(e.g. a bare `list`). Add a type parameter such as `list[str]`, or set `strict=False`.'
+                    )
+                elif self.strict is None:  # pragma: no branch
+                    self.is_strict_compatible = False
         return schema

--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -489,11 +489,15 @@ class OpenAIJsonSchemaTransformer(JsonSchemaTransformer):
 
         if schema_type == 'array':
             # OpenAI strict mode requires an array to describe its elements' type, via either `items`
-            # (list types) or `prefixItems` (tuple types). A bare `list` (no type param) produces an
-            # empty `items: {}` with neither, and a schema may omit `items` entirely; both are rejected
-            # by the API in strict mode and there's no way to repair them without inventing an element
-            # type. See https://github.com/pydantic/pydantic-ai/issues/4425
-            if not schema.get('items') and not schema.get('prefixItems'):
+            # (list types) or `prefixItems` (tuple types). A bare `list` produces an empty `items: {}`,
+            # `list[Any]` a boolean `items: true`, and a schema may omit `items` entirely; none of these
+            # give the element a `type`, so they're rejected by the API in strict mode and there's no way
+            # to repair them without inventing an element type. `items` counts as typed only when it's a
+            # non-empty schema object (a boolean node like `true`/`false` has no `type`).
+            # See https://github.com/pydantic/pydantic-ai/issues/4425
+            items = schema.get('items')
+            has_typed_items = isinstance(items, dict) and bool(items)
+            if not has_typed_items and not schema.get('prefixItems'):
                 if self.strict is True:
                     raise UserError(
                         'OpenAI strict mode requires array items to have a type, but got an untyped array '

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -5437,13 +5437,15 @@ def test_transformer_adds_properties_to_object_schemas():
     [
         pytest.param({'type': 'array', 'items': {}}, id='empty-items'),
         pytest.param({'type': 'array'}, id='missing-items'),
+        pytest.param({'type': 'array', 'items': True}, id='boolean-items'),
     ],
 )
 def test_transformer_untyped_array_not_strict_compatible(array_schema: dict[str, Any]):
-    """An untyped array (bare `list` -> `items: {}`, or no `items` at all) isn't strict-compatible.
+    """An untyped array isn't strict-compatible.
 
-    OpenAI strict mode requires the `items` schema to have a `type`, so with `strict=None` we must
-    infer that the schema can't be sent in strict mode.
+    This covers a bare `list` (`items: {}`), no `items` key at all, and a boolean `items: true`
+    (JSON Schema shape for `list[Any]`). OpenAI strict mode requires the `items` schema to have a
+    `type`, so with `strict=None` we must infer that the schema can't be sent in strict mode.
     See https://github.com/pydantic/pydantic-ai/issues/4425
     """
     schema: dict[str, Any] = {

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -5438,14 +5438,16 @@ def test_transformer_adds_properties_to_object_schemas():
         pytest.param({'type': 'array', 'items': {}}, id='empty-items'),
         pytest.param({'type': 'array'}, id='missing-items'),
         pytest.param({'type': 'array', 'items': True}, id='boolean-items'),
+        pytest.param({'type': 'array', 'items': {'description': 'values'}}, id='metadata-only-items'),
     ],
 )
 def test_transformer_untyped_array_not_strict_compatible(array_schema: dict[str, Any]):
     """An untyped array isn't strict-compatible.
 
-    This covers a bare `list` (`items: {}`), no `items` key at all, and a boolean `items: true`
-    (JSON Schema shape for `list[Any]`). OpenAI strict mode requires the `items` schema to have a
-    `type`, so with `strict=None` we must infer that the schema can't be sent in strict mode.
+    This covers a bare `list` (`items: {}`), no `items` key at all, a boolean `items: true`
+    (JSON Schema shape for `list[Any]`), and a metadata-only `items` node with no type-bearing
+    keyword. OpenAI strict mode requires the `items` schema to have a `type`, so with `strict=None`
+    we must infer that the schema can't be sent in strict mode.
     See https://github.com/pydantic/pydantic-ai/issues/4425
     """
     schema: dict[str, Any] = {
@@ -5458,12 +5460,21 @@ def test_transformer_untyped_array_not_strict_compatible(array_schema: dict[str,
     assert transformer.is_strict_compatible is False
 
 
-def test_transformer_typed_array_strict_compatible():
-    """A typed array (e.g. `list[str]`) has a proper `items` schema and stays strict-compatible."""
+@pytest.mark.parametrize(
+    'items_schema',
+    [
+        pytest.param({'type': 'string'}, id='type'),
+        pytest.param({'$ref': '#/$defs/Foo'}, id='ref'),
+        pytest.param({'anyOf': [{'type': 'string'}, {'type': 'integer'}]}, id='anyOf'),
+    ],
+)
+def test_transformer_typed_array_strict_compatible(items_schema: dict[str, Any]):
+    """An array whose `items` carries a type-bearing keyword stays strict-compatible."""
     schema: dict[str, Any] = {
         'type': 'object',
-        'properties': {'items': {'type': 'array', 'items': {'type': 'string'}}},
-        'required': ['items'],
+        'properties': {'values': {'type': 'array', 'items': items_schema}},
+        'required': ['values'],
+        '$defs': {'Foo': {'type': 'object', 'properties': {'x': {'type': 'string'}}, 'required': ['x']}},
     }
     transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
     transformer.walk()

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -5432,6 +5432,54 @@ def test_transformer_adds_properties_to_object_schemas():
     assert result['properties'] == {}
 
 
+@pytest.mark.parametrize(
+    'array_schema',
+    [
+        pytest.param({'type': 'array', 'items': {}}, id='empty-items'),
+        pytest.param({'type': 'array'}, id='missing-items'),
+    ],
+)
+def test_transformer_untyped_array_not_strict_compatible(array_schema: dict[str, Any]):
+    """An untyped array (bare `list` -> `items: {}`, or no `items` at all) isn't strict-compatible.
+
+    OpenAI strict mode requires the `items` schema to have a `type`, so with `strict=None` we must
+    infer that the schema can't be sent in strict mode.
+    See https://github.com/pydantic/pydantic-ai/issues/4425
+    """
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'items': array_schema},
+        'required': ['items'],
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    transformer.walk()
+    assert transformer.is_strict_compatible is False
+
+
+def test_transformer_typed_array_strict_compatible():
+    """A typed array (e.g. `list[str]`) has a proper `items` schema and stays strict-compatible."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'items': {'type': 'array', 'items': {'type': 'string'}}},
+        'required': ['items'],
+    }
+    transformer = OpenAIJsonSchemaTransformer(schema, strict=None)
+    transformer.walk()
+    assert transformer.is_strict_compatible is True
+
+
+def test_transformer_untyped_array_explicit_strict_raises():
+    """With `strict=True` explicitly requested, an untyped array can't be repaired, so we raise a
+    clear error instead of letting OpenAI reject the request with an opaque 400."""
+    schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'items': {'type': 'array', 'items': {}}},
+        'required': ['items'],
+    }
+    with pytest.raises(UserError, match='OpenAI strict mode requires array items to have a type'):
+        OpenAIJsonSchemaTransformer(schema, strict=True).walk()
+
+
 def chunk_with_usage(
     delta: list[ChoiceDelta],
     finish_reason: FinishReason | None = None,


### PR DESCRIPTION
Fixes #4425.

## Problem

A bare `list` tool/output parameter (no type args) makes Pydantic emit `{"type": "array", "items": {}}`. OpenAI strict mode requires an array to describe its element type, so this untyped schema was sent with `strict=True` and rejected with a 400 (`schema must have a 'type' key`).

`OpenAIJsonSchemaTransformer` handled many strict-incompatible features but had no case for arrays that describe no element type, so nothing disabled strict mode or gave a helpful error.

## Fix

In `OpenAIJsonSchemaTransformer.transform`, detect arrays that describe no element type — i.e. **empty or missing `items`** *and* **no `prefixItems`**:

- **`strict=None`** (inferred): set `is_strict_compatible = False` so strict is turned off automatically instead of failing at the API.
- **`strict=True`** (explicitly requested): raise a clear `UserError` telling the user to add a type parameter (e.g. `list[str]`) or set `strict=False`, instead of surfacing an opaque 400.

Tuples (which use `prefixItems`) and typed lists (e.g. `list[str]`) stay strict-compatible.

## Relationship to #4427

This supersedes #4427 and closes the gaps raised in its review:

- ✅ Covers the **missing `items` key** case (`{"type": "array"}`), not just empty `items: {}` — requested by @DouweM and the review bots.
- ✅ Guards the inference branch with `elif self.strict is None:`, matching the surrounding checks.
- ✅ Handles the **explicit `strict=True`** path with a friendly `UserError` rather than letting an invalid schema reach OpenAI (the gap flagged by both the Devin bot and a later commenter).
- ✅ Correctly leaves **tuples** (`prefixItems`, no `items`) strict-compatible — a case the naive `if not items` condition would have wrongly rejected.

## Tests

- `test_transformer_untyped_array_not_strict_compatible` — parametrized over empty `items: {}` and missing `items`, both infer non-strict.
- `test_transformer_typed_array_strict_compatible` — `list[str]` stays strict-compatible.
- `test_transformer_untyped_array_explicit_strict_raises` — explicit `strict=True` raises `UserError`.
- Existing tuple/strict snapshot tests (`test_strict_schema`, `test_strict_mode_cannot_infer_strict`) still pass, confirming `prefixItems` isn't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

