### PR TITLE
Use full issue/PR links in comments instead of `#nnnn` shorthand

### DIFF
--- a/agent_docs/documentation.md
+++ b/agent_docs/documentation.md
@@ -24,6 +24,8 @@
 - Use consistent terminology across code, docs, comments, and errors (e.g., `freeform` vs `free-form`, `messages` vs `last message`) — prevents user confusion and makes codebase searchable — Inconsistent terminology fragments documentation searches, confuses users trying to map concepts between docs and code, and signals poor API design quality
 <!-- rule:76 -->
 - Prefix future work with `TODO:` and link workarounds to upstream/internal issues — enables tracking and cleanup when conditions change — Explicit markers with tracking links prevent abandoned workarounds and make technical debt actionable and removable when upstream fixes land
+<!-- rule:611 -->
+- Reference issues and PRs in comments and docstrings with the full URL (`https://github.com/pydantic/pydantic-ai/issues/1234`), not the `#1234` shorthand — The shorthand isn't clickable outside GitHub's own rendering (IDEs, generated API docs, plain-text views), so a full link stays navigable wherever the code is read
 <!-- rule:386 -->
 - Keep docs and implementation in sync — when they conflict, explicitly decide which to update and fix it — Prevents user confusion and wasted debugging time when documented behavior doesn't match actual behavior; applies to params, config options, component characteristics, and especially test docstrings which must describe what's actually validated
 <!-- rule:106 -->

--- a/pydantic_ai_slim/pydantic_ai/_agent_graph.py
+++ b/pydantic_ai_slim/pydantic_ai/_agent_graph.py
@@ -903,7 +903,7 @@ class ModelRequestNode(AgentNode[DepsT, NodeRunEndT]):
             # absorbed the CancelledError (e.g. Temporal's cooperative cancellation),
             # the handler is parked on `stream_done.wait()`. Setting stream_done lets
             # it exit so cancel_and_drain's gather can complete. Harmless no-op when
-            # the task was actually cancelled — it's already unwinding. See #6422.
+            # the task was actually cancelled — it's already unwinding. See https://github.com/pydantic/pydantic-ai/issues/6422.
             stream_done.set()
             await cancel_and_drain(ready_waiter, wrap_task)
             raise

--- a/pydantic_ai_slim/pydantic_ai/_sync_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/_sync_stream.py
@@ -299,7 +299,7 @@ class SyncStreamBridge(Generic[StreamT]):
 
         Without this, a `KeyboardInterrupt` (Ctrl-C) or `SystemExit` landing while we're blocked on the
         event loop would unwind the caller while leaving the async code's pending tasks and open sockets
-        until garbage collection. See #5975.
+        until garbage collection. See https://github.com/pydantic/pydantic-ai/issues/5975.
         """
         if not self._finalizer.alive:
             raise RuntimeError('This synchronous stream is already closed.')

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -1288,7 +1288,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
         # Inject the loader only if a deferred capability is present AND `for_run` didn't already
         # return one, mirroring the `has_capability_type` guard used for instrumentation above.
         # Without it, a `for_run` result that already carries a loader would get double-wrapped
-        # (cf. #5047) — a second loader toolset then errors on the reserved `load_capability` name.
+        # (cf. https://github.com/pydantic/pydantic-ai/issues/5047) — a second loader toolset then errors on the reserved `load_capability` name.
         if any(
             capability.defer_loading is True for capability in capabilities_dict.values()
         ) and not has_capability_type([run_capability], DeferredCapabilityLoader):
@@ -1517,7 +1517,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 # instead of asserting on a not-yet-produced result, then set `_run_done` so
                 # it can exit and `cancel_and_drain`'s gather can complete (it discards the
                 # survivor's exception). Harmless no-op when `_wrap_task` really died
-                # cancelled — it's already unwinding. See #6422.
+                # cancelled — it's already unwinding. See https://github.com/pydantic/pydantic-ai/issues/6422.
                 _run_error = exc
                 _run_done.set()
                 await _utils.cancel_and_drain(_ready_waiter, _wrap_task)
@@ -2547,7 +2547,7 @@ class Agent(AbstractAgent[AgentDepsT, OutputDataT]):
                 # wrapped around the output toolset specifically — so the hook only sees output
                 # tools, and the filtered/modified defs flow into `ToolManager.tools` and the model
                 # request parameters together. Override `ctx.max_retries` to the agent's output
-                # retry budget (matches `_build_output_run_context`'s contract — see #4745).
+                # retry budget (matches `_build_output_run_context`'s contract — see https://github.com/pydantic/pydantic-ai/issues/4745).
                 # `output_toolset.max_retries` is set to `max_output_retries` at agent construction.
                 output_cap = run_capability
                 effective_max_output_retries = (

--- a/pydantic_ai_slim/pydantic_ai/agent/abstract.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/abstract.py
@@ -126,12 +126,12 @@ class _RunStreamEventsIterator(AsyncIterator[_messages.AgentStreamEvent | AgentR
 
     Lazily starts a background `run()` task on the first `__anext__()` and forwards its events over a memory
     object stream, ending with a single trailing `AgentRunResultEvent` that carries the run's result. Entering
-    the context manager without iterating therefore never starts a run (#6162).
+    the context manager without iterating therefore never starts a run (https://github.com/pydantic/pydantic-ai/issues/6162).
 
     This is a hand-written iterator class rather than an `async def` generator on purpose: generator cleanup
     runs by throwing `GeneratorExit` into the suspended frame during finalization, which on Python 3.10/3.11
     can resume the frame under a different `Context` and raise the `pydantic_ai.current_run_context` token
-    error (#5132). Driving cleanup explicitly through `aclose()` keeps teardown in the caller's task and
+    error (https://github.com/pydantic/pydantic-ai/issues/5132). Driving cleanup explicitly through `aclose()` keeps teardown in the caller's task and
     context.
     """
 

--- a/pydantic_ai_slim/pydantic_ai/models/anthropic.py
+++ b/pydantic_ai_slim/pydantic_ai/models/anthropic.py
@@ -275,7 +275,8 @@ LatestAnthropicModelNames = ModelParam
 """Anthropic model names from the installed SDK."""
 
 # TODO(anthropic): drop the `claude-sonnet-5` literal once the `anthropic` floor is bumped past the
-# SDK release that adds it to `ModelParam` (installed 0.109.0 still lags). See PR #5849 for the same
+# SDK release that adds it to `ModelParam` (installed 0.109.0 still lags). See
+# https://github.com/pydantic/pydantic-ai/pull/5849 for the same
 # bridge-then-drop pattern applied to `claude-fable-5`.
 AnthropicModelName = LatestAnthropicModelNames | Literal['claude-sonnet-5']
 """Possible Anthropic model names.
@@ -1298,7 +1299,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                 tool_version = self._get_code_execution_tool_version(model_settings)
                 tools.append(_map_code_execution_tool(tool_version))
                 # Cross-provider files are dropped silently here, not raised via
-                # `_validate_uploaded_file_provider`; intentional per #4338 (ignore over raise).
+                # `_validate_uploaded_file_provider`; intentional per https://github.com/pydantic/pydantic-ai/issues/4338 (ignore over raise).
                 if tool.files and any(file.provider_name == self.system for file in tool.files):
                     beta_features.add('files-api-2025-04-14')
             elif isinstance(tool, WebFetchTool):  # pragma: no branch
@@ -1440,7 +1441,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
         system_prompt_parts: list[str] = []
         anthropic_messages: list[BetaMessageParam] = []
         # Cross-provider files are dropped silently here, not raised via
-        # `_validate_uploaded_file_provider`; intentional per #4338 (ignore over raise).
+        # `_validate_uploaded_file_provider`; intentional per https://github.com/pydantic/pydantic-ai/issues/4338 (ignore over raise).
         pending_container_uploads = [
             file.file_id
             for tool in model_request_parameters.native_tools
@@ -1648,7 +1649,7 @@ class AnthropicModel(Model[AsyncAnthropicClient]):
                                     # Anthropic occasionally emits a `tool_search_tool_*` server tool use
                                     # in parallel with a client `tool_use` and ends the turn before
                                     # delivering the corresponding `tool_search_tool_*_tool_result` block
-                                    # (see anthropics/anthropic-sdk-python#1325). Direct API tolerates
+                                    # (see https://github.com/anthropics/anthropic-sdk-python/issues/1325). Direct API tolerates
                                     # the unpaired call on resend (the result arrives in the next turn),
                                     # but Bedrock 400s with `tool use ... was found without a corresponding
                                     # tool_search_tool_*_tool_result block`. Drop the orphaned call from the

--- a/pydantic_ai_slim/pydantic_ai/models/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/models/bedrock.py
@@ -1214,7 +1214,7 @@ class BedrockConverseModel(Model[BaseClient]):
         # `toolResult` block with other content: Anthropic rejects documents and video next to it, while
         # Llama and Mistral reject anything sharing the turn (the `toolResult` must be alone). When the
         # combined content isn't co-locatable (per `colocatable_content`), split the turns instead of
-        # merging. See #6081 and `bedrock_tool_result_colocatable_content`.
+        # merging. See https://github.com/pydantic/pydantic-ai/issues/6081 and `bedrock_tool_result_colocatable_content`.
         processed_messages: list[MessageUnionTypeDef] = []
         last_message: dict[str, Any] | None = None
         for current_message in bedrock_messages:

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -526,7 +526,7 @@ class GoogleModel(Model[Client]):
             # The fields are not supported by the Gemini API per https://github.com/googleapis/python-genai/blob/7e4ec284dc6e521949626f3ed54028163ef9121d/google/genai/models.py#L1195-L1214
             # The Vertex `countTokens` endpoint accepts native/server-side tools (e.g. Google Search grounding), so we
             # forward `tools` as-is to mirror the real request for an accurate count. This intentionally differs from
-            # `AnthropicModel.count_tokens`, which strips native tools because Anthropic's endpoint rejects them (#5704);
+            # `AnthropicModel.count_tokens`, which strips native tools because Anthropic's endpoint rejects them (https://github.com/pydantic/pydantic-ai/issues/5704);
             # don't copy that strip here.
             config.update(
                 system_instruction=generation_config.get('system_instruction'),
@@ -1897,7 +1897,7 @@ def _metadata_as_usage(
             details[f'{detail.modality.lower()}_{prefix}_tokens'] = detail.token_count
 
     # Gemini streams usage as cumulative snapshots, but a field reported on an earlier chunk can be
-    # absent from a later one (e.g. `cached_content_token_count` when streamed through a gateway, see #5205).
+    # absent from a later one (e.g. `cached_content_token_count` when streamed through a gateway, see https://github.com/pydantic/pydantic-ai/issues/5205).
     # Merge with the usage accumulated so far so those values survive instead of being overwritten with 0.
     if existing_usage:
         details = {**existing_usage.details, **details}

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2667,7 +2667,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                 container: responses.tool_param.CodeInterpreterContainerCodeInterpreterToolAuto = {'type': 'auto'}
                 if tool.files:
                     # Cross-provider files are dropped silently here, not raised via
-                    # `_validate_uploaded_file_provider`; intentional per #4338 (ignore over raise).
+                    # `_validate_uploaded_file_provider`; intentional per https://github.com/pydantic/pydantic-ai/issues/4338 (ignore over raise).
                     provider_file_ids = [file.file_id for file in tool.files if file.provider_name == self.system]
                     if provider_file_ids:
                         container['file_ids'] = provider_file_ids
@@ -3422,7 +3422,7 @@ class OpenAIStreamedResponse(StreamedResponse):
                     self._model_name = chunk.model
 
                 # Empty on the final usage-only chunk; `None` from OpenAI-compatible providers emitting
-                # malformed chunks that the openai SDK's loose constructor lets through (#5165).
+                # malformed chunks that the openai SDK's loose constructor lets through (https://github.com/pydantic/pydantic-ai/issues/5165).
                 if not chunk.choices:
                     continue
                 choice = chunk.choices[0]
@@ -3700,7 +3700,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                 # NOTE: You can inspect the builtin tools used checking the `ResponseCompletedEvent`.
                 if isinstance(chunk, responses.ResponseCompletedEvent):
                     # Only the return part is backfilled; the call part is already emitted via `output_item.added`.
-                    # Backfill mcp_list_tools results missing from streamed output_item.done events (see #5419).
+                    # Backfill mcp_list_tools results missing from streamed output_item.done events (see https://github.com/pydantic/pydantic-ai/issues/5419).
                     for item in chunk.response.output:
                         if (
                             isinstance(item, responses.response_output_item.McpListTools)

--- a/pydantic_ai_slim/pydantic_ai/models/openrouter.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openrouter.py
@@ -568,14 +568,14 @@ class _OpenRouterChatCompletion(_ChatCompletion):
 
 
 class _OpenRouterErrorResponse(BaseModel, extra='allow'):
-    """OpenRouter error response with null standard fields (see #3994)."""
+    """OpenRouter error response with null standard fields (see https://github.com/pydantic/pydantic-ai/issues/3994)."""
 
     error: _OpenRouterError
     model: str | None = None
 
 
 class _OpenRouterNestedCompletion(_OpenRouterChatCompletion):
-    """Completion nested in the `provider` field where provider name may be null (see #3994)."""
+    """Completion nested in the `provider` field where provider name may be null (see https://github.com/pydantic/pydantic-ai/issues/3994)."""
 
     provider: str = 'unknown'
     created: int = 0
@@ -587,7 +587,7 @@ class _OpenRouterNestedCompletion(_OpenRouterChatCompletion):
 
 
 class _OpenRouterNestedProviderResponse(BaseModel, extra='allow'):
-    """OpenRouter response where the real completion is nested in `provider` (see #3994)."""
+    """OpenRouter response where the real completion is nested in `provider` (see https://github.com/pydantic/pydantic-ai/issues/3994)."""
 
     provider: _OpenRouterNestedCompletion
 
@@ -969,7 +969,7 @@ class OpenRouterModel(OpenAIChatModel):
         try:
             validated = _OpenRouterChatCompletion.model_validate(response_dict)
         except ValidationError as exc:
-            # OpenRouter intermittently returns responses with null standard fields (#3994).
+            # OpenRouter intermittently returns responses with null standard fields (https://github.com/pydantic/pydantic-ai/issues/3994).
             # Try known quirky response shapes before giving up.
             try:
                 error_response = _OpenRouterErrorResponse.model_validate(response_dict)

--- a/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/bedrock.py
@@ -151,7 +151,7 @@ class BedrockModelProfile(ModelProfile, total=False):
     and video next to a `toolResult`, while Llama and Mistral reject *any* content sharing the turn (the
     `toolResult` must be alone). When a merge would co-locate a `toolResult` with a kind not listed here,
     the adapter splits the turns and separates them with a synthetic assistant message (Bedrock re-merges
-    consecutive same-role turns, so a bare split doesn't suffice). See #6081.
+    consecutive same-role turns, so a bare split doesn't suffice). See https://github.com/pydantic/pydantic-ai/issues/6081.
 
     Default: all kinds (no restriction); the model receives merged turns unchanged.
     """
@@ -256,7 +256,7 @@ def bedrock_anthropic_model_profile(model_name: str) -> ModelProfile | None:
             bedrock_supports_tool_caching=True,
             bedrock_supported_media_kinds_in_tool_returns=frozenset({'image', 'document'}),
             # Anthropic on Bedrock rejects a `toolResult` co-located with a document or video block, but
-            # accepts text and images alongside it. See #6081.
+            # accepts text and images alongside it. See https://github.com/pydantic/pydantic-ai/issues/6081.
             bedrock_tool_result_colocatable_content=frozenset({'text', 'image'}),
             bedrock_supports_leading_assistant_message=True,
             bedrock_thinking_variant='anthropic',
@@ -318,7 +318,7 @@ def bedrock_meta_model_profile(model_name: str) -> ModelProfile | None:
         _strip_builtin_tools(meta_model_profile(model_name)),
         BedrockModelProfile(
             # Llama on Bedrock requires a `toolResult` to be alone in its user message; it rejects
-            # any co-located text or attachment block. See #6081.
+            # any co-located text or attachment block. See https://github.com/pydantic/pydantic-ai/issues/6081.
             bedrock_tool_result_colocatable_content=frozenset(),
             # Llama on Bedrock accepts both images and documents inside a `toolResult`'s content; it has
             # no video support. Verified live against `us.meta.llama4-maverick-17b-instruct-v1:0`.
@@ -343,7 +343,7 @@ def bedrock_mistral_model_profile(model_name: str) -> ModelProfile | None:
             supports_json_schema_output=supports_structured_output,
             bedrock_supports_strict_tool_definition=supports_structured_output,
             # Mistral on Bedrock requires a `toolResult` to be alone in its user message; it rejects
-            # any co-located text or attachment block. See #6081.
+            # any co-located text or attachment block. See https://github.com/pydantic/pydantic-ai/issues/6081.
             bedrock_tool_result_colocatable_content=frozenset(),
             # Mistral (pixtral) on Bedrock accepts documents inside a `toolResult`'s content but rejects
             # images there — even though it accepts images in a plain user message — and has no video
@@ -449,7 +449,7 @@ def bedrock_writer_model_profile(model_name: str) -> ModelProfile | None:
         json_schema_transformer=BedrockJsonSchemaTransformer,
         # Writer Palmyra on Bedrock requires a `toolResult` to be alone in its user message; it rejects
         # any co-located text or attachment block (like Llama and Mistral). Verified live against
-        # `writer.palmyra-x4-v1:0` and `writer.palmyra-x5-v1:0`. See #6081.
+        # `writer.palmyra-x4-v1:0` and `writer.palmyra-x5-v1:0`. See https://github.com/pydantic/pydantic-ai/issues/6081.
         bedrock_tool_result_colocatable_content=frozenset(),
         # Writer Palmyra also rejects the `status` field on a `toolResult` block, unlike every other family.
         bedrock_supports_tool_result_status=False,

--- a/pydantic_ai_slim/pydantic_ai/providers/ollama.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/ollama.py
@@ -63,7 +63,7 @@ class OllamaProvider(Provider[AsyncOpenAI]):
 
         # `json_schema_transformer` is a fallback (upstream wins if it set one). The other Ollama-specific
         # overrides win on top of upstream — Ollama's /v1/chat/completions endpoint supports response_format
-        # with json_schema natively, but strict mode is not supported (issue #4116).
+        # with json_schema natively, but strict mode is not supported (https://github.com/pydantic/pydantic-ai/issues/4116).
         return merge_profile(
             OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
             profile,

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -619,11 +619,11 @@ class ToolManager(Generic[AgentDepsT]):
 
         # Output validators see the *global* output-retry budget (`max_output_retries`), so the same
         # validator stays consistent across the text path and across multiple `ToolOutput`s. Output
-        # functions, by contrast, see the *per-tool* `tool.max_retries` (the post-#4687 override) on
+        # functions, by contrast, see the *per-tool* `tool.max_retries` (the post-https://github.com/pydantic/pydantic-ai/issues/4687 override) on
         # `validated.ctx`. Termination on the tool path checks `retries[name] == tool.max_retries`
         # (see `_check_max_retries` below), so when `ToolOutput(max_retries=N)` exceeds
         # `max_output_retries`, the validator's `ctx.last_attempt` can fire before the run actually
-        # terminates. Tracked in #5238 — revisiting cleanly needs broader thought about
+        # terminates. Tracked in https://github.com/pydantic/pydantic-ai/issues/5238 — revisiting cleanly needs broader thought about
         # `ctx.retry`/`ctx.retries[name]` semantics and is intentionally out of scope here.
         assert toolset.max_retries is not None
         validator_ctx = replace(validated.ctx, retry=self.ctx.retry, max_retries=toolset.max_retries)

--- a/pydantic_ai_slim/pydantic_ai/tools.py
+++ b/pydantic_ai_slim/pydantic_ai/tools.py
@@ -788,7 +788,7 @@ class ToolDefinition:
 
     unless_native: Annotated[
         str | None,
-        # Old names were `prefer_builtin` and (after the builtin → native rename in #5338)
+        # Old names were `prefer_builtin` and (after the builtin → native rename in https://github.com/pydantic/pydantic-ai/issues/5338)
         # `prefer_native`; keep accepting both for serialized-history backward compat.
         Field(validation_alias=AliasChoices('unless_native', 'prefer_native', 'prefer_builtin')),
     ] = None

--- a/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/vercel_ai/_adapter.py
@@ -313,8 +313,9 @@ class VercelAIAdapter(UIAdapter[RequestData, UIMessage, BaseChunk, AgentDepsT, O
                     elif isinstance(part, FileUIPart):
                         provider_meta = load_provider_metadata(part.provider_metadata)
                         # Restoring client-supplied `vendor_metadata` is intentional (as the `UploadedFile` branch
-                        # already does, #5571/#5772): it carries only the requester's own request params and is
-                        # dict-validated by the constructors below.
+                        # already does — see https://github.com/pydantic/pydantic-ai/issues/5571 and
+                        # https://github.com/pydantic/pydantic-ai/issues/5772): it carries only the requester's own
+                        # request params and is dict-validated by the constructors below.
                         vendor_metadata = provider_meta.get('vendor_metadata')
                         force_download = provider_meta.get('force_download', False)
                         try:


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

Trivial cleanup — no issue.

### What

Replace the `#nnnn` issue/PR shorthand with full GitHub URLs in code comments and docstrings across the library, and add a CE rule in `agent_docs/documentation.md` recording the convention.

The shorthand only renders as a link inside GitHub's own UI; in IDEs, generated API docs, and plain-text views it's a dead reference. Full URLs stay navigable wherever the code is read. This matches the pre-existing dominant convention in the codebase (`See https://github.com/pydantic/pydantic-ai/issues/...`).

Comment-only + one docs rule — no logic, API, or test changes.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

