### PR TITLE
Add opt-in `expose_resources` to `MCPToolset` to expose MCP resources as model-callable tools

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -376,7 +376,7 @@ agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 
 ## Resources
 
-MCP servers can provide [resources](https://modelcontextprotocol.io/docs/concepts/resources) — files, data, or content that can be accessed by the client. Resources in MCP are application-driven, with host applications determining how to incorporate context manually based on their needs. They are _not_ exposed to the LLM automatically (unless a tool returns a `ResourceLink` or `EmbeddedResource`).
+MCP servers can provide [resources](https://modelcontextprotocol.io/docs/concepts/resources) — files, data, or content that can be accessed by the client. Resources in MCP are application-driven, with host applications determining how to incorporate context manually based on their needs. They are not exposed to the model _by default_ (unless a tool returns a `ResourceLink` or `EmbeddedResource`), but you can opt in to [exposing them as model-callable tools](#exposing-resources-to-the-model).
 
 `MCPToolset` exposes methods to discover and read resources:
 
@@ -434,6 +434,38 @@ if __name__ == '__main__':
 ```
 
 _(This example is complete, it can be run "as is")_
+
+### Exposing resources to the model
+
+In addition to reading resources yourself, you can let the model discover and read them mid-run by passing [`expose_resources=True`][pydantic_ai.mcp.MCPToolset.expose_resources]. This adds two synthesized tools to the toolset, alongside the server's own tools:
+
+- `list_mcp_resources` — lists the concrete resources the server advertises, with each resource's `uri`, `name`, `description`, `mime_type`, and any [`annotations`](https://modelcontextprotocol.io/specification/2025-11-25/server/resources#annotations).
+- `read_mcp_resource` — reads a single resource by `uri`.
+
+This is useful when a server exposes context as resources (for example, "skills" served as resources) and you want the model to pull them on demand rather than injecting their content out-of-band.
+
+Reusing the `mcp_resource_server.py` server from above, the model can now list and read resources during a run:
+
+```python {title="mcp_expose_resources.py" requires="mcp_resource_server.py" test="skip"}
+from fastmcp.client.transports import StdioTransport
+
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPToolset
+
+toolset = MCPToolset(
+    StdioTransport(command='python', args=['-m', 'mcp_resource_server']),
+    expose_resources=True,
+)
+agent = Agent('openai:gpt-5', toolsets=[toolset])
+# The model can now call `list_mcp_resources` and `read_mcp_resource` mid-run, e.g. to
+# fetch `resource://user_name.txt` before answering a question that depends on it.
+result = agent.run_sync('Greet the user by name.')
+```
+
+The flag is off by default, so existing toolsets are unaffected. Only concrete resources are exposed — resource _templates_ are not. Annotations are surfaced in the `list_mcp_resources` output so the model can prioritize, but are not used to filter what's exposed. If the server does not advertise the `resources` capability, no tools are added even when `expose_resources=True`.
+
+!!! note
+    Because these tools are client-side projections over [`read_resource()`][pydantic_ai.mcp.MCPToolset.read_resource], they bypass [`process_tool_call`][pydantic_ai.mcp.MCPToolset.process_tool_call] (which wraps server tool calls). A bad URI passed to `read_mcp_resource` honors [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior] like any other tool.
 
 ## HTTP authentication
 

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -401,7 +401,7 @@ agent = Agent('openai:gpt-5.2', toolsets=[toolset])
 
 ## Resources
 
-MCP servers can provide [resources](https://modelcontextprotocol.io/docs/concepts/resources) — files, data, or content that can be accessed by the client. Resources in MCP are application-driven, with host applications determining how to incorporate context manually based on their needs. They are _not_ exposed to the LLM automatically (unless a tool returns a `ResourceLink` or `EmbeddedResource`).
+MCP servers can provide [resources](https://modelcontextprotocol.io/docs/concepts/resources) — files, data, or content that can be accessed by the client. Resources in MCP are application-driven, with host applications determining how to incorporate context manually based on their needs. They are not exposed to the model _by default_ (unless a tool returns a `ResourceLink` or `EmbeddedResource`), but you can opt in to [exposing them as model-callable tools](#exposing-resources-to-the-model).
 
 `MCPToolset` exposes methods to discover and read resources:
 
@@ -459,6 +459,38 @@ if __name__ == '__main__':
 ```
 
 _(This example is complete, it can be run "as is")_
+
+### Exposing resources to the model
+
+In addition to reading resources yourself, you can let the model discover and read them mid-run by passing [`expose_resources=True`][pydantic_ai.mcp.MCPToolset.expose_resources]. This adds two synthesized tools to the toolset, alongside the server's own tools:
+
+- `list_mcp_resources` — lists the concrete resources the server advertises, with each resource's `uri`, `name`, `description`, `mime_type`, and any [`annotations`](https://modelcontextprotocol.io/specification/2026-07-28/server/resources#annotations).
+- `read_mcp_resource` — reads a single resource by `uri`.
+
+This is useful when a server exposes context as resources (for example, "skills" served as resources) and you want the model to pull them on demand rather than injecting their content out-of-band.
+
+Reusing the `mcp_resource_server.py` server from above, the model can now list and read resources during a run:
+
+```python {title="mcp_expose_resources.py" requires="mcp_resource_server.py" test="skip"}
+from fastmcp.client.transports import StdioTransport
+
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPToolset
+
+toolset = MCPToolset(
+    StdioTransport(command='python', args=['-m', 'mcp_resource_server']),
+    expose_resources=True,
+)
+agent = Agent('openai:gpt-5', toolsets=[toolset])
+# The model can now call `list_mcp_resources` and `read_mcp_resource` mid-run, e.g. to
+# fetch `resource://user_name.txt` before answering a question that depends on it.
+result = agent.run_sync('Greet the user by name.')
+```
+
+The flag is off by default, so existing toolsets are unaffected. Only concrete resources are exposed — resource _templates_ are not. Annotations are surfaced in the `list_mcp_resources` output so the model can prioritize, but are not used to filter what's exposed. If the server does not advertise the `resources` capability, no tools are added even when `expose_resources=True`.
+
+!!! note
+    Because these tools are client-side projections over [`read_resource()`][pydantic_ai.mcp.MCPToolset.read_resource], they bypass [`process_tool_call`][pydantic_ai.mcp.MCPToolset.process_tool_call] (which wraps server tool calls). A bad URI passed to `read_mcp_resource` honors [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior] like any other tool.
 
 ## HTTP authentication
 

--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -465,7 +465,7 @@ _(This example is complete, it can be run "as is")_
 In addition to reading resources yourself, you can let the model discover and read them mid-run by passing [`expose_resources=True`][pydantic_ai.mcp.MCPToolset.expose_resources]. This adds two synthesized tools to the toolset, alongside the server's own tools:
 
 - `list_mcp_resources` — lists the concrete resources the server advertises, with each resource's `uri`, `name`, `description`, `mime_type`, and any [`annotations`](https://modelcontextprotocol.io/specification/2026-07-28/server/resources#annotations).
-- `read_mcp_resource` — reads a single resource by `uri`.
+- `read_mcp_resource` — reads a single one of those resources by `uri`.
 
 This is useful when a server exposes context as resources (for example, "skills" served as resources) and you want the model to pull them on demand rather than injecting their content out-of-band.
 
@@ -487,10 +487,10 @@ agent = Agent('openai:gpt-5', toolsets=[toolset])
 result = agent.run_sync('Greet the user by name.')
 ```
 
-The flag is off by default, so existing toolsets are unaffected. Only concrete resources are exposed — resource _templates_ are not. Annotations are surfaced in the `list_mcp_resources` output so the model can prioritize, but are not used to filter what's exposed. If the server does not advertise the `resources` capability, no tools are added even when `expose_resources=True`.
+The flag is off by default, so existing toolsets are unaffected. Only concrete resources are exposed — resource _templates_ are not, and `read_mcp_resource` is restricted to the URIs the server advertises, so the model cannot reach a template-backed resource by guessing a URI that `list_mcp_resources` never disclosed. Annotations are surfaced in the `list_mcp_resources` output so the model can prioritize, but are not used to filter what's exposed. If the server does not advertise the `resources` capability, no tools are added even when `expose_resources=True`.
 
 !!! note
-    Because these tools are client-side projections over [`read_resource()`][pydantic_ai.mcp.MCPToolset.read_resource], they bypass [`process_tool_call`][pydantic_ai.mcp.MCPToolset.process_tool_call] (which wraps server tool calls). A bad URI passed to `read_mcp_resource` honors [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior] like any other tool.
+    Although these tools are client-side projections over [`list_resources()`][pydantic_ai.mcp.MCPToolset.list_resources] and [`read_resource()`][pydantic_ai.mcp.MCPToolset.read_resource] rather than server tools, they are still passed to [`process_tool_call`][pydantic_ai.mcp.MCPToolset.process_tool_call] if you've set one, so a callback that gates or logs tool calls sees them too. The `metadata` argument of its `call_tool` delegate is ignored, as a resource read has no server-side metadata channel. A URI that isn't advertised by the server, or a malformed one, honors [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior] like any other tool.
 
 ## HTTP authentication
 

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -18,7 +18,7 @@ import pydantic_core
 from pydantic import AnyUrl, Field
 from typing_extensions import Self, assert_never
 
-from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
+from pydantic_ai.tools import AgentDepsT, ObjectJsonSchema, RunContext, ToolDefinition
 
 from .direct import model_request
 from .toolsets.abstract import AbstractToolset, ToolsetTool
@@ -590,6 +590,103 @@ TOOL_SCHEMA_VALIDATOR = pydantic_core.SchemaValidator(
     )
 )
 
+LIST_MCP_RESOURCES_TOOL_NAME = 'list_mcp_resources'
+READ_MCP_RESOURCE_TOOL_NAME = 'read_mcp_resource'
+
+# Unlike server tools (validated server-side, so `TOOL_SCHEMA_VALIDATOR` is a pass-through), the
+# synthesized `read_mcp_resource` tool is executed locally, so its `uri` argument needs real
+# validation here — a missing or non-string `uri` should surface as a retryable error to the model.
+READ_MCP_RESOURCE_SCHEMA_VALIDATOR = pydantic_core.SchemaValidator(
+    schema=pydantic_core.core_schema.typed_dict_schema(
+        {'uri': pydantic_core.core_schema.typed_dict_field(pydantic_core.core_schema.str_schema())}
+    )
+)
+
+_LIST_MCP_RESOURCES_PARAMETERS: ObjectJsonSchema = {
+    'type': 'object',
+    'properties': {},
+    'additionalProperties': False,
+}
+_READ_MCP_RESOURCE_PARAMETERS: ObjectJsonSchema = {
+    'type': 'object',
+    'properties': {
+        'uri': {
+            'type': 'string',
+            'description': (
+                'The URI of the resource to read, e.g. "resource://product_name.txt". '
+                f'Use `{LIST_MCP_RESOURCES_TOOL_NAME}` to discover valid URIs.'
+            ),
+        }
+    },
+    'required': ['uri'],
+    'additionalProperties': False,
+}
+
+
+def _resource_tool_defs(include_return_schema: bool | None) -> list[ToolDefinition]:
+    """Build the `ToolDefinition`s for the synthesized MCP resource tools.
+
+    The `metadata['mcp_resource_tool']` marker is what `MCPToolset.call_tool` dispatches on, so
+    these tools are executed against the client's resource methods rather than forwarded to the
+    server as regular tool calls. The marker deliberately omits the `'task'` key so these tools
+    never enter the server-side task machinery.
+
+    Both tools carry a `readOnlyHint` annotation (in the same shape server tools use — a dumped
+    [`ToolAnnotations`][mcp.types.ToolAnnotations]): reading resources never mutates server state,
+    so consumers that gate on annotations (e.g. an approval predicate) treat them as read-only.
+    """
+    read_only_annotations = mcp_types.ToolAnnotations(readOnlyHint=True).model_dump()
+    return [
+        ToolDefinition(
+            name=LIST_MCP_RESOURCES_TOOL_NAME,
+            description=(
+                'List the resources available on the MCP server. Returns a list of objects with '
+                '`uri`, `name`, `description`, `mime_type`, and (when present) `annotations`. Call '
+                f'`{READ_MCP_RESOURCE_TOOL_NAME}` with a `uri` to read one.'
+            ),
+            parameters_json_schema=_LIST_MCP_RESOURCES_PARAMETERS,
+            metadata={'mcp_resource_tool': True, 'annotations': read_only_annotations},
+            include_return_schema=include_return_schema,
+        ),
+        ToolDefinition(
+            name=READ_MCP_RESOURCE_TOOL_NAME,
+            description=(
+                'Read the contents of a single MCP resource by its URI. Text resources return a '
+                'string; binary resources return their content. Use '
+                f'`{LIST_MCP_RESOURCES_TOOL_NAME}` to discover valid URIs.'
+            ),
+            parameters_json_schema=_READ_MCP_RESOURCE_PARAMETERS,
+            metadata={'mcp_resource_tool': True, 'annotations': read_only_annotations},
+            include_return_schema=include_return_schema,
+        ),
+    ]
+
+
+def _resource_to_model_dict(resource: Resource) -> dict[str, Any]:
+    """Project a `Resource` to a compact, JSON-serializable dict for the `list_mcp_resources` tool.
+
+    Only the fields the model needs to decide what to read are included (`uri`, `name`,
+    `description`, `mime_type`), plus an `annotations` sub-dict (`audience`, `priority`,
+    `last_modified`) when the resource carries annotations. UI/host-only fields (`title`, `size`,
+    `icons`, `metadata`) are omitted to keep the payload compact. The `Any` covers the
+    heterogeneous JSON values (str, float, list, nested dict); all are JSON-serializable so the
+    return round-trips through durable-execution serialization.
+    """
+    result: dict[str, Any] = {
+        'uri': resource.uri,
+        'name': resource.name,
+        'description': resource.description,
+        'mime_type': resource.mime_type,
+    }
+    if resource.annotations is not None:
+        result['annotations'] = {
+            'audience': resource.annotations.audience,
+            'priority': resource.annotations.priority,
+            'last_modified': resource.annotations.last_modified,
+        }
+    return result
+
+
 # Environment variable expansion pattern
 # Supports both ${VAR_NAME} and ${VAR_NAME:-default} syntax
 # Group 1: variable name
@@ -771,6 +868,29 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
     used.
     """
 
+    expose_resources: bool
+    """Whether to expose the server's resources to the model as callable tools.
+
+    Defaults to `False`. When `True`, and the server advertises the `resources` capability, two
+    synthesized tools are added to the toolset alongside the server's own tools:
+
+    - `list_mcp_resources` — lists the concrete resources the server advertises (with their `uri`,
+      `name`, `description`, `mime_type`, and any `annotations`).
+    - `read_mcp_resource` — reads a single resource by `uri`.
+
+    This lets the model discover and read MCP resources mid-run, rather than requiring the
+    application to inject resource content out-of-band. Resource *templates* are not exposed. If
+    the server does not advertise the `resources` capability, no tools are added even when this is
+    `True`.
+
+    These synthesized tools are client-side projections over
+    [`list_resources()`][pydantic_ai.mcp.MCPToolset.list_resources] /
+    [`read_resource()`][pydantic_ai.mcp.MCPToolset.read_resource], so they bypass
+    [`process_tool_call`][pydantic_ai.mcp.MCPToolset.process_tool_call] (which wraps server tool
+    calls). A bad URI passed to `read_mcp_resource` honors
+    [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior] like any other tool.
+    """
+
     process_tool_call: ProcessToolCallback | None
     """Hook to wrap tool calls — useful for adding request-level metadata, custom retry policies,
     or telemetry. See [`ProcessToolCallback`][pydantic_ai.mcp.ProcessToolCallback].
@@ -822,6 +942,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         cache_prompts: bool = True,
         include_instructions: bool = False,
         include_return_schema: bool | None = None,
+        expose_resources: bool = False,
         # Sampling — high-level shortcut and low-level escape hatch
         sampling_model: models.Model | None = None,
         sampling_handler: SamplingHandler[Any, Any] | None = None,
@@ -866,6 +987,9 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 [`MCPToolset.include_instructions`][pydantic_ai.mcp.MCPToolset.include_instructions].
             include_return_schema: Whether to include return schemas in tool definitions. See
                 [`MCPToolset.include_return_schema`][pydantic_ai.mcp.MCPToolset.include_return_schema].
+            expose_resources: Whether to expose the server's resources to the model as callable
+                `list_mcp_resources` / `read_mcp_resource` tools. See
+                [`MCPToolset.expose_resources`][pydantic_ai.mcp.MCPToolset.expose_resources].
             sampling_model: A Pydantic AI model the server may sample from. Mutually exclusive with
                 `sampling_handler`.
             sampling_handler: A FastMCP-shaped sampling handler. Use for full control over the
@@ -981,6 +1105,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         self.cache_prompts = cache_prompts
         self.include_instructions = include_instructions
         self.include_return_schema = include_return_schema
+        self.expose_resources = expose_resources
         self.sampling_model = sampling_model
         self.log_level = log_level
 
@@ -1156,6 +1281,27 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 max_retries=max_retries,
                 args_validator=TOOL_SCHEMA_VALIDATOR,
             )
+
+        # Synthesize model-callable resource tools when opted in and the server supports resources.
+        # `list_tools()` above has already entered the session, so `capabilities` is populated.
+        if self.expose_resources and self.capabilities.resources:
+            for tool_def in _resource_tool_defs(self.include_return_schema):
+                if tool_def.name in tools:
+                    raise exceptions.UserError(
+                        f'Cannot expose MCP resources as tool {tool_def.name!r}: the server already '
+                        f'defines a tool with that name. Set `expose_resources=False` or rename the '
+                        f'server tool.'
+                    )
+                tools[tool_def.name] = ToolsetTool[AgentDepsT](
+                    toolset=self,
+                    tool_def=tool_def,
+                    max_retries=max_retries,
+                    args_validator=(
+                        READ_MCP_RESOURCE_SCHEMA_VALIDATOR
+                        if tool_def.name == READ_MCP_RESOURCE_TOOL_NAME
+                        else TOOL_SCHEMA_VALIDATOR
+                    ),
+                )
         return tools
 
     def tool_for_tool_def(self, tool_def: ToolDefinition) -> ToolsetTool[AgentDepsT]:
@@ -1242,6 +1388,14 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         ctx: RunContext[Any],
         tool: ToolsetTool[Any],
     ) -> Any:
+        # Synthesized resource tools are client-side projections over `list_resources()` /
+        # `read_resource()`; they don't exist on the server, so they must be dispatched here before
+        # the server-tool path (`direct_call_tool` unconditionally forwards `name` to the server).
+        # We key on the `mcp_resource_tool` marker rather than the name so a server tool that shares
+        # the name can never be misrouted (and `get_tools` would have raised on that collision).
+        if (tool.tool_def.metadata or {}).get('mcp_resource_tool'):
+            return await self._call_resource_tool(name, tool_args)
+
         # Server-side task-augmented execution per MCP SEP-1686 is governed entirely by the tool's
         # `execution.taskSupport`: 'required'/'optional' → task path; 'forbidden' or absent → regular path.
         use_task = bool((tool.tool_def.metadata or {}).get('task'))
@@ -1250,6 +1404,25 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 ctx, functools.partial(self.direct_call_tool, use_task=use_task), name, tool_args
             )
         return await self.direct_call_tool(name, tool_args, use_task=use_task)
+
+    async def _call_resource_tool(self, name: str, tool_args: dict[str, Any]) -> Any:
+        """Dispatch a synthesized resource tool to the client-side resource methods.
+
+        `read_mcp_resource` honors [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior]
+        on a bad URI (wrapping `MCPError` as `ModelRetry` under `'retry'`), consistent with server
+        tools. `tool_args['uri']` is guaranteed present and a `str` by the tool's args validator.
+        """
+        if name == LIST_MCP_RESOURCES_TOOL_NAME:
+            return [_resource_to_model_dict(resource) for resource in await self.list_resources()]
+        elif name == READ_MCP_RESOURCE_TOOL_NAME:
+            try:
+                return await self.read_resource(tool_args['uri'])
+            except MCPError as e:
+                if self.tool_error_behavior == 'retry':
+                    raise exceptions.ModelRetry(message=str(e)) from e
+                raise
+        else:  # pragma: no cover - only the two names above carry the `mcp_resource_tool` marker
+            raise ValueError(f'Unknown MCP resource tool: {name!r}')
 
     async def list_prompts(self) -> list[Prompt]:
         """Retrieve the prompts currently exposed by the server.

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -1641,21 +1641,23 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
     async def _call_resource_tool(self, name: str, tool_args: dict[str, Any]) -> Any:
         """Dispatch a synthesized resource tool to the client-side resource methods.
 
-        `read_mcp_resource` honors [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior]
-        on a bad URI (wrapping `MCPError` as `ModelRetry` under `'retry'`), consistent with server
-        tools. `tool_args['uri']` is guaranteed present and a `str` by the tool's args validator.
+        An `MCPError` (e.g. a bad URI, or a server error listing resources) is routed through
+        [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior] like server tools,
+        so it becomes a `ModelRetry` under `'retry'` or a `ToolFailed` under `'failed'` rather than
+        escaping the toolset. `tool_args['uri']` is guaranteed present and a `str` by the tool's
+        args validator.
         """
-        if name == LIST_MCP_RESOURCES_TOOL_NAME:
-            return [_resource_to_model_dict(resource) for resource in await self.list_resources()]
-        elif name == READ_MCP_RESOURCE_TOOL_NAME:
-            try:
+        try:
+            if name == LIST_MCP_RESOURCES_TOOL_NAME:
+                return [_resource_to_model_dict(resource) for resource in await self.list_resources()]
+            elif name == READ_MCP_RESOURCE_TOOL_NAME:
                 return await self.read_resource(tool_args['uri'])
-            except MCPError as e:
-                if self.tool_error_behavior == 'retry':
-                    raise exceptions.ModelRetry(message=str(e)) from e
+            else:  # pragma: no cover - only the two names above carry the `mcp_resource_tool` marker
+                raise ValueError(f'Unknown MCP resource tool: {name!r}')
+        except MCPError as e:
+            if self.tool_error_behavior == 'error':
                 raise
-        else:  # pragma: no cover - only the two names above carry the `mcp_resource_tool` marker
-            raise ValueError(f'Unknown MCP resource tool: {name!r}')
+            _raise_mcp_tool_error(str(e), self.tool_error_behavior, cause=e)
 
     async def list_prompts(self) -> list[Prompt]:
         """Retrieve the prompts currently exposed by the server.

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -932,18 +932,21 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
 
     - `list_mcp_resources` — lists the concrete resources the server advertises (with their `uri`,
       `name`, `description`, `mime_type`, and any `annotations`).
-    - `read_mcp_resource` — reads a single resource by `uri`.
+    - `read_mcp_resource` — reads a single one of those resources by `uri`.
 
     This lets the model discover and read MCP resources mid-run, rather than requiring the
-    application to inject resource content out-of-band. Resource *templates* are not exposed. If
-    the server does not advertise the `resources` capability, no tools are added even when this is
-    `True`.
+    application to inject resource content out-of-band. Resource *templates* are not exposed, and a
+    read is restricted to the URIs the server advertises, so a template-backed URI the listing
+    never disclosed cannot be reached by guessing it. If the server does not advertise the
+    `resources` capability, no tools are added even when this is `True`.
 
     These synthesized tools are client-side projections over
     [`list_resources()`][pydantic_ai.mcp.MCPToolset.list_resources] /
-    [`read_resource()`][pydantic_ai.mcp.MCPToolset.read_resource], so they bypass
-    [`process_tool_call`][pydantic_ai.mcp.MCPToolset.process_tool_call] (which wraps server tool
-    calls). A bad URI passed to `read_mcp_resource` honors
+    [`read_resource()`][pydantic_ai.mcp.MCPToolset.read_resource] rather than server tools, but they
+    are still passed to [`process_tool_call`][pydantic_ai.mcp.MCPToolset.process_tool_call] if one is
+    set, so a callback that gates or logs tool calls sees them too (its `call_tool` delegate ignores
+    `metadata`, as a resource read has no server-side metadata channel). An unadvertised or
+    malformed URI passed to `read_mcp_resource` honors
     [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior] like any other tool.
     """
 
@@ -1627,6 +1630,17 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         # We key on the `mcp_resource_tool` marker rather than the name so a server tool that shares
         # the name can never be misrouted (and `get_tools` would have raised on that collision).
         if (tool.tool_def.metadata or {}).get('mcp_resource_tool'):
+            # Still routed through `process_tool_call`: applications use that callback to gate,
+            # deny, or log tool calls, so exempting these two would let a model reach a resource
+            # the callback would have refused. The delegate accepts (and ignores) `metadata` to
+            # satisfy `CallToolFunc` -- a resource read has no server-side metadata channel.
+            async def call_resource_tool(
+                name: str, args: dict[str, Any], *, metadata: dict[str, Any] | None = None
+            ) -> ToolResult:
+                return await self._call_resource_tool(name, args)
+
+            if self.process_tool_call is not None:
+                return await self.process_tool_call(ctx, call_resource_tool, name, tool_args)
             return await self._call_resource_tool(name, tool_args)
 
         # `get_tools()` resolves the server's `execution.taskSupport` and the client's
@@ -1646,12 +1660,33 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         so it becomes a `ModelRetry` under `'retry'` or a `ToolFailed` under `'failed'` rather than
         escaping the toolset. `tool_args['uri']` is guaranteed present and a `str` by the tool's
         args validator.
+
+        A read is restricted to the URIs `list_resources()` advertises, so the tool can only reach
+        what `list_mcp_resources` disclosed. Without the check a model could read a guessed
+        template-backed URI (a server resolves `resource://{name}/profile.json` for any `name`),
+        which the feature does not expose. `list_resources()` is cached by default, so the guard
+        usually costs no extra round-trip.
         """
         try:
             if name == LIST_MCP_RESOURCES_TOOL_NAME:
                 return [_resource_to_model_dict(resource) for resource in await self.list_resources()]
             elif name == READ_MCP_RESOURCE_TOOL_NAME:
-                return await self.read_resource(tool_args['uri'])
+                uri = tool_args['uri']
+                # Parse before the advertised-URI check so a malformed URI keeps reporting itself as
+                # malformed rather than as unadvertised.
+                try:
+                    AnyUrl(uri)
+                except ValidationError as e:
+                    raise MCPError(f'Invalid resource URI {uri!r}', code=mcp_types.INVALID_PARAMS) from e
+                if not any(str(resource.uri) == uri for resource in await self.list_resources()):
+                    # Raised as an `MCPError` so it maps through `tool_error_behavior` exactly like a
+                    # server-reported unknown-resource error, rather than by a different rule.
+                    raise MCPError(
+                        f'Resource {uri!r} is not one of the resources advertised by the server; '
+                        f'call {LIST_MCP_RESOURCES_TOOL_NAME!r} for the available URIs.',
+                        code=mcp_types.INVALID_PARAMS,
+                    )
+                return await self.read_resource(uri)
             else:  # pragma: no cover - only the two names above carry the `mcp_resource_tool` marker
                 raise ValueError(f'Unknown MCP resource tool: {name!r}')
         except MCPError as e:

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -18,7 +18,7 @@ import pydantic_core
 from pydantic import AnyUrl, Field, TypeAdapter
 from typing_extensions import Self, assert_never
 
-from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
+from pydantic_ai.tools import AgentDepsT, ObjectJsonSchema, RunContext, ToolDefinition
 
 from .direct import model_request
 from .toolsets.abstract import AbstractToolset, ToolsetTool
@@ -168,7 +168,7 @@ class MCPError(RuntimeError):
 class ResourceAnnotations:
     """Additional properties describing MCP entities.
 
-    See the [resource annotations in the MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/server/resources#annotations).
+    See the [resource annotations in the MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/server/resources#annotations).
     """
 
     audience: list[mcp_types.Role] | None = None
@@ -246,7 +246,7 @@ class BaseResource(ABC):
 class Resource(BaseResource):
     """A resource that can be read from an MCP server.
 
-    See the [resources in the MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/server/resources).
+    See the [resources in the MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/server/resources).
     """
 
     uri: str
@@ -290,7 +290,7 @@ class Resource(BaseResource):
 class ResourceTemplate(BaseResource):
     """A template for parameterized resources on an MCP server.
 
-    See the [resource templates in the MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/server/resources#resource-templates).
+    See the [resource templates in the MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/server/resources#resource-templates).
     """
 
     uri_template: str
@@ -336,7 +336,7 @@ class ResourceLink:
     Note: resource links returned by tools are not guaranteed to appear in the results of
     `resources/list` requests.
 
-    See the [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/server/resources).
+    See the [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/server/resources).
     """
 
     uri: str
@@ -493,7 +493,7 @@ class EmbeddedResource:
     Contains the actual resource content alongside its metadata, unlike
     [`ResourceLink`][pydantic_ai.mcp.ResourceLink] which is only a reference.
 
-    See the [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/server/resources).
+    See the [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/server/resources).
     """
 
     uri: str
@@ -634,6 +634,105 @@ TOOL_SCHEMA_VALIDATOR = pydantic_core.SchemaValidator(
         pydantic_core.core_schema.str_schema(), pydantic_core.core_schema.any_schema()
     )
 )
+
+LIST_MCP_RESOURCES_TOOL_NAME = 'list_mcp_resources'
+READ_MCP_RESOURCE_TOOL_NAME = 'read_mcp_resource'
+
+# Unlike server tools (validated server-side, so `TOOL_SCHEMA_VALIDATOR` is a pass-through), the
+# synthesized `read_mcp_resource` tool is executed locally, so its `uri` argument needs real
+# validation here — a missing or non-string `uri` should surface as a retryable error to the model.
+READ_MCP_RESOURCE_SCHEMA_VALIDATOR = pydantic_core.SchemaValidator(
+    schema=pydantic_core.core_schema.typed_dict_schema(
+        {'uri': pydantic_core.core_schema.typed_dict_field(pydantic_core.core_schema.str_schema())}
+    )
+)
+
+_LIST_MCP_RESOURCES_PARAMETERS: ObjectJsonSchema = {
+    'type': 'object',
+    'properties': {},
+    'additionalProperties': False,
+}
+_READ_MCP_RESOURCE_PARAMETERS: ObjectJsonSchema = {
+    'type': 'object',
+    'properties': {
+        'uri': {
+            'type': 'string',
+            'description': (
+                'The URI of the resource to read, e.g. "resource://product_name.txt". '
+                f'Use `{LIST_MCP_RESOURCES_TOOL_NAME}` to discover valid URIs.'
+            ),
+        }
+    },
+    'required': ['uri'],
+    'additionalProperties': False,
+}
+
+
+def _resource_tool_defs(include_return_schema: bool | None) -> list[ToolDefinition]:
+    """Build the `ToolDefinition`s for the synthesized MCP resource tools.
+
+    The `metadata['mcp_resource_tool']` marker is what `MCPToolset.call_tool` dispatches on, so
+    these tools are executed against the client's resource methods rather than forwarded to the
+    server as regular tool calls. The marker deliberately omits the `'task'` key so these tools
+    never enter the server-side task machinery.
+
+    Both tools carry a `readOnlyHint` annotation (in the same shape server tools use — a dumped
+    [`ToolAnnotations`][mcp.types.ToolAnnotations]): reading resources never mutates server state,
+    so consumers that gate on annotations (e.g. an approval predicate) treat them as read-only.
+    """
+    # `by_alias` pins the keys to the wire (camelCase) spelling on either SDK generation, matching
+    # the server-tool annotations in `get_tools`; this dict is a public surface read by key.
+    read_only_annotations = mcp_types.ToolAnnotations(readOnlyHint=True).model_dump(by_alias=True)
+    return [
+        ToolDefinition(
+            name=LIST_MCP_RESOURCES_TOOL_NAME,
+            description=(
+                'List the resources available on the MCP server. Returns a list of objects with '
+                '`uri`, `name`, `description`, `mime_type`, and (when present) `annotations`. Call '
+                f'`{READ_MCP_RESOURCE_TOOL_NAME}` with a `uri` to read one.'
+            ),
+            parameters_json_schema=_LIST_MCP_RESOURCES_PARAMETERS,
+            metadata={'mcp_resource_tool': True, 'annotations': read_only_annotations},
+            include_return_schema=include_return_schema,
+        ),
+        ToolDefinition(
+            name=READ_MCP_RESOURCE_TOOL_NAME,
+            description=(
+                'Read the contents of a single MCP resource by its URI. Text resources return a '
+                'string; binary resources return their content. Use '
+                f'`{LIST_MCP_RESOURCES_TOOL_NAME}` to discover valid URIs.'
+            ),
+            parameters_json_schema=_READ_MCP_RESOURCE_PARAMETERS,
+            metadata={'mcp_resource_tool': True, 'annotations': read_only_annotations},
+            include_return_schema=include_return_schema,
+        ),
+    ]
+
+
+def _resource_to_model_dict(resource: Resource) -> dict[str, Any]:
+    """Project a `Resource` to a compact, JSON-serializable dict for the `list_mcp_resources` tool.
+
+    Only the fields the model needs to decide what to read are included (`uri`, `name`,
+    `description`, `mime_type`), plus an `annotations` sub-dict (`audience`, `priority`,
+    `last_modified`) when the resource carries annotations. UI/host-only fields (`title`, `size`,
+    `icons`, `metadata`) are omitted to keep the payload compact. The `Any` covers the
+    heterogeneous JSON values (str, float, list, nested dict); all are JSON-serializable so the
+    return round-trips through durable-execution serialization.
+    """
+    result: dict[str, Any] = {
+        'uri': resource.uri,
+        'name': resource.name,
+        'description': resource.description,
+        'mime_type': resource.mime_type,
+    }
+    if resource.annotations is not None:
+        result['annotations'] = {
+            'audience': resource.annotations.audience,
+            'priority': resource.annotations.priority,
+            'last_modified': resource.annotations.last_modified,
+        }
+    return result
+
 
 # Environment variable expansion pattern
 # Supports both ${VAR_NAME} and ${VAR_NAME:-default} syntax
@@ -825,6 +924,29 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
     used.
     """
 
+    expose_resources: bool
+    """Whether to expose the server's resources to the model as callable tools.
+
+    Defaults to `False`. When `True`, and the server advertises the `resources` capability, two
+    synthesized tools are added to the toolset alongside the server's own tools:
+
+    - `list_mcp_resources` — lists the concrete resources the server advertises (with their `uri`,
+      `name`, `description`, `mime_type`, and any `annotations`).
+    - `read_mcp_resource` — reads a single resource by `uri`.
+
+    This lets the model discover and read MCP resources mid-run, rather than requiring the
+    application to inject resource content out-of-band. Resource *templates* are not exposed. If
+    the server does not advertise the `resources` capability, no tools are added even when this is
+    `True`.
+
+    These synthesized tools are client-side projections over
+    [`list_resources()`][pydantic_ai.mcp.MCPToolset.list_resources] /
+    [`read_resource()`][pydantic_ai.mcp.MCPToolset.read_resource], so they bypass
+    [`process_tool_call`][pydantic_ai.mcp.MCPToolset.process_tool_call] (which wraps server tool
+    calls). A bad URI passed to `read_mcp_resource` honors
+    [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior] like any other tool.
+    """
+
     process_tool_call: ProcessToolCallback | None
     """Hook to wrap tool calls — useful for adding request-level metadata, custom retry policies,
     or telemetry. See [`ProcessToolCallback`][pydantic_ai.mcp.ProcessToolCallback].
@@ -880,6 +1002,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         cache_prompts: bool = True,
         include_instructions: bool = False,
         include_return_schema: bool | None = None,
+        expose_resources: bool = False,
         # Sampling — high-level shortcut and low-level escape hatch
         sampling_model: models.Model | None = None,
         sampling_handler: SamplingHandler[Any, Any] | None = None,
@@ -928,6 +1051,9 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 [`MCPToolset.include_instructions`][pydantic_ai.mcp.MCPToolset.include_instructions].
             include_return_schema: Whether to include return schemas in tool definitions. See
                 [`MCPToolset.include_return_schema`][pydantic_ai.mcp.MCPToolset.include_return_schema].
+            expose_resources: Whether to expose the server's resources to the model as callable
+                `list_mcp_resources` / `read_mcp_resource` tools. See
+                [`MCPToolset.expose_resources`][pydantic_ai.mcp.MCPToolset.expose_resources].
             sampling_model: A Pydantic AI model the server may sample from. Mutually exclusive with
                 `sampling_handler`.
             sampling_handler: A FastMCP-shaped sampling handler. Use for full control over the
@@ -1059,6 +1185,7 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         self.cache_prompts = cache_prompts
         self.include_instructions = include_instructions
         self.include_return_schema = include_return_schema
+        self.expose_resources = expose_resources
         self.sampling_model = sampling_model
         self.log_level = log_level
 
@@ -1322,6 +1449,33 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 ),
                 ctx=ctx,
             )
+
+        # Synthesize model-callable resource tools when opted in and the server supports resources.
+        # `capabilities` is only populated while the session is entered, and `get_tools` doesn't
+        # enter it itself (nor does the Temporal `get_tools` activity), so enter here to read it.
+        # `__aenter__` is ref-counted, so this is a cheap no-op when the caller already holds it.
+        if self.expose_resources:
+            async with self:
+                supports_resources = bool(self.capabilities.resources)
+            if not supports_resources:
+                return tools
+            for tool_def in _resource_tool_defs(self.include_return_schema):
+                if tool_def.name in tools:
+                    raise exceptions.UserError(
+                        f'Cannot expose MCP resources as tool {tool_def.name!r}: the server already '
+                        f'defines a tool with that name. Set `expose_resources=False` or rename the '
+                        f'server tool.'
+                    )
+                tools[tool_def.name] = ToolsetTool[AgentDepsT](
+                    toolset=self,
+                    tool_def=tool_def,
+                    max_retries=self.max_retries if self.max_retries is not None else ctx.max_retries,
+                    args_validator=(
+                        READ_MCP_RESOURCE_SCHEMA_VALIDATOR
+                        if tool_def.name == READ_MCP_RESOURCE_TOOL_NAME
+                        else TOOL_SCHEMA_VALIDATOR
+                    ),
+                )
         return tools
 
     def tool_for_tool_def(self, tool_def: ToolDefinition, *, ctx: RunContext[AgentDepsT]) -> ToolsetTool[AgentDepsT]:
@@ -1467,6 +1621,14 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
         ctx: RunContext[Any],
         tool: ToolsetTool[Any],
     ) -> Any:
+        # Synthesized resource tools are client-side projections over `list_resources()` /
+        # `read_resource()`; they don't exist on the server, so they must be dispatched here before
+        # the server-tool path (`direct_call_tool` unconditionally forwards `name` to the server).
+        # We key on the `mcp_resource_tool` marker rather than the name so a server tool that shares
+        # the name can never be misrouted (and `get_tools` would have raised on that collision).
+        if (tool.tool_def.metadata or {}).get('mcp_resource_tool'):
+            return await self._call_resource_tool(name, tool_args)
+
         # `get_tools()` resolves the server's `execution.taskSupport` and the client's
         # `prefer_tasks` preference into the effective task path for this tool.
         use_task = bool((tool.tool_def.metadata or {}).get('task'))
@@ -1475,6 +1637,25 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
                 ctx, functools.partial(self.direct_call_tool, use_task=use_task), name, tool_args
             )
         return await self.direct_call_tool(name, tool_args, use_task=use_task)
+
+    async def _call_resource_tool(self, name: str, tool_args: dict[str, Any]) -> Any:
+        """Dispatch a synthesized resource tool to the client-side resource methods.
+
+        `read_mcp_resource` honors [`tool_error_behavior`][pydantic_ai.mcp.MCPToolset.tool_error_behavior]
+        on a bad URI (wrapping `MCPError` as `ModelRetry` under `'retry'`), consistent with server
+        tools. `tool_args['uri']` is guaranteed present and a `str` by the tool's args validator.
+        """
+        if name == LIST_MCP_RESOURCES_TOOL_NAME:
+            return [_resource_to_model_dict(resource) for resource in await self.list_resources()]
+        elif name == READ_MCP_RESOURCE_TOOL_NAME:
+            try:
+                return await self.read_resource(tool_args['uri'])
+            except MCPError as e:
+                if self.tool_error_behavior == 'retry':
+                    raise exceptions.ModelRetry(message=str(e)) from e
+                raise
+        else:  # pragma: no cover - only the two names above carry the `mcp_resource_tool` marker
+            raise ValueError(f'Unknown MCP resource tool: {name!r}')
 
     async def list_prompts(self) -> list[Prompt]:
         """Retrieve the prompts currently exposed by the server.

--- a/pydantic_ai_slim/pydantic_ai/mcp.py
+++ b/pydantic_ai_slim/pydantic_ai/mcp.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn, Protocol, T
 
 import anyio
 import pydantic_core
-from pydantic import AnyUrl, Field, TypeAdapter
+from pydantic import AnyUrl, Field, TypeAdapter, ValidationError
 from typing_extensions import Self, assert_never
 
 from pydantic_ai.tools import AgentDepsT, ObjectJsonSchema, RunContext, ToolDefinition
@@ -1782,9 +1782,16 @@ class MCPToolset(AbstractToolset[AgentDepsT]):
             MCPError: If the server returns an error.
         """
         resource_uri = uri if isinstance(uri, str) else uri.uri
+        try:
+            parsed_uri = AnyUrl(resource_uri)
+        except ValidationError as e:
+            # A caller-supplied string that isn't a valid URL (e.g. a model calling `read_mcp_resource`
+            # with `"not a url"`) would otherwise escape as a raw `ValidationError`. Surface it as an
+            # `MCPError` so it honors the method's documented contract and `tool_error_behavior`.
+            raise MCPError(f'Invalid resource URI {resource_uri!r}', code=mcp_types.INVALID_PARAMS) from e
         async with self:
             try:
-                contents = await self.client.read_resource(AnyUrl(resource_uri))
+                contents = await self.client.read_resource(parsed_uri)
             except McpError as e:
                 raise MCPError.from_mcp_sdk(e) from e
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -22,11 +22,14 @@ import anyio
 import httpx
 import pytest
 from inline_snapshot import snapshot
+from pydantic_core import ValidationError
 
-from pydantic_ai import models
+from pydantic_ai import Agent, models
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._utils import BaseExceptionGroup
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, UserError
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
@@ -57,6 +60,8 @@ with try_import() as imports_successful:
     from pydantic import AnyUrl
 
     from pydantic_ai.mcp import (
+        LIST_MCP_RESOURCES_TOOL_NAME,
+        READ_MCP_RESOURCE_TOOL_NAME,
         MCPError,
         MCPToolset,
         Prompt,
@@ -69,7 +74,7 @@ with try_import() as imports_successful:
         _make_httpx_client_factory,  # pyright: ignore[reportPrivateUsage]
         load_mcp_toolsets,
     )
-    from pydantic_ai.messages import TextContent
+    from pydantic_ai.messages import BinaryContent, TextContent
 
 
 pytestmark = [
@@ -298,6 +303,14 @@ async def fastmcp_server() -> FastMCP[None]:
     @server.resource('resource://{name}/profile.json')
     async def profile(name: str) -> str:
         return f'{{"name": "{name}"}}'
+
+    @server.resource(
+        'resource://product_name.txt',
+        mime_type='text/plain',
+        annotations=Annotations(audience=['user', 'assistant'], priority=0.5),
+    )
+    async def product_name() -> str:
+        return 'Pydantic AI'
 
     _register_prompts(server)
     return server
@@ -616,6 +629,205 @@ class TestMCPToolsetIntegration:
             toolset._server_capabilities = ServerCapabilities()  # pyright: ignore[reportPrivateUsage]
             assert await toolset.list_resources() == []
             assert await toolset.list_resource_templates() == []
+
+    # --- `expose_resources`: MCP resources as model-callable tools ---
+    # These use the in-process `fastmcp_server` (no HTTP), so they aren't VCR tests; the behavior
+    # is pure client/server projection with no provider involved.
+
+    async def test_expose_resources_default_off(self, fastmcp_server: FastMCP[None], run_context: RunContext):
+        """Backward compatibility: without the flag, no resource tools are synthesized."""
+        toolset = MCPToolset(fastmcp_server)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+        assert LIST_MCP_RESOURCES_TOOL_NAME not in tools
+        assert READ_MCP_RESOURCE_TOOL_NAME not in tools
+
+    async def test_expose_resources_adds_synthesized_tools(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext
+    ):
+        """With the flag on, both resource tools appear alongside the server's own tools, with the
+        expected parameter schemas (`read_mcp_resource` requires a string `uri`)."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+        # Server tools are still present.
+        assert 'echo' in tools
+        # Both resource tools are flagged read-only so approval predicates that gate on the MCP
+        # `readOnlyHint` annotation don't force human approval for a resource read.
+        for name in (LIST_MCP_RESOURCES_TOOL_NAME, READ_MCP_RESOURCE_TOOL_NAME):
+            annotations = (tools[name].tool_def.metadata or {}).get('annotations') or {}
+            assert annotations.get('readOnlyHint') is True
+        assert tools[LIST_MCP_RESOURCES_TOOL_NAME].tool_def.parameters_json_schema == snapshot(
+            {'type': 'object', 'properties': {}, 'additionalProperties': False}
+        )
+        assert tools[READ_MCP_RESOURCE_TOOL_NAME].tool_def.parameters_json_schema == snapshot(
+            {
+                'type': 'object',
+                'properties': {
+                    'uri': {
+                        'type': 'string',
+                        'description': 'The URI of the resource to read, e.g. "resource://product_name.txt". Use `list_mcp_resources` to discover valid URIs.',
+                    }
+                },
+                'required': ['uri'],
+                'additionalProperties': False,
+            }
+        )
+        # The `read_mcp_resource` args validator enforces a required string `uri` (unlike server
+        # tools, which use the pass-through validator because they're validated server-side).
+        read_tool = tools[READ_MCP_RESOURCE_TOOL_NAME]
+        with pytest.raises(ValidationError):
+            read_tool.args_validator.validate_python({})
+        with pytest.raises(ValidationError):
+            read_tool.args_validator.validate_python({'uri': 123})
+        assert read_tool.args_validator.validate_python({'uri': 'resource://greeting.txt'}) == {
+            'uri': 'resource://greeting.txt'
+        }
+
+    async def test_list_mcp_resources_tool_returns_projected_dicts(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext
+    ):
+        """The `list_mcp_resources` tool returns compact dicts (surfacing annotations) and excludes
+        resource templates — locking the v1 boundary (concrete resources only)."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(
+                LIST_MCP_RESOURCES_TOOL_NAME, {}, run_context, tools[LIST_MCP_RESOURCES_TOOL_NAME]
+            )
+        by_uri = {r['uri']: r for r in result}
+        # Annotated resource surfaces its annotations sub-dict.
+        assert by_uri['resource://product_name.txt'] == snapshot(
+            {
+                'uri': 'resource://product_name.txt',
+                'name': 'product_name',
+                'description': None,
+                'mime_type': 'text/plain',
+                'annotations': {'audience': ['user', 'assistant'], 'priority': 0.5, 'last_modified': None},
+            }
+        )
+        # Concrete resource without annotations omits the `annotations` key.
+        assert 'annotations' not in by_uri['resource://greeting.txt']
+        # The `{name}/profile.json` template is a resource template, not a concrete resource, so it
+        # must NOT appear in `list_mcp_resources`.
+        assert not any('{name}' in uri for uri in by_uri)
+
+    async def test_read_mcp_resource_tool_text(self, fastmcp_server: FastMCP[None], run_context: RunContext):
+        """The `read_mcp_resource` tool returns a text resource as a string."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(
+                READ_MCP_RESOURCE_TOOL_NAME,
+                {'uri': 'resource://greeting.txt'},
+                run_context,
+                tools[READ_MCP_RESOURCE_TOOL_NAME],
+            )
+        assert result == 'Hello, world!'
+
+    async def test_read_mcp_resource_tool_binary(self, fastmcp_server: FastMCP[None], run_context: RunContext):
+        """The `read_mcp_resource` tool returns a binary resource as `BinaryContent`."""
+
+        @fastmcp_server.resource('resource://blob.bin', mime_type='application/octet-stream')
+        async def blob() -> bytes:
+            return b'binary-bytes'
+
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(
+                READ_MCP_RESOURCE_TOOL_NAME,
+                {'uri': 'resource://blob.bin'},
+                run_context,
+                tools[READ_MCP_RESOURCE_TOOL_NAME],
+            )
+        assert isinstance(result, BinaryContent)
+        assert result.data == b'binary-bytes'
+        assert result.media_type == 'application/octet-stream'
+
+    async def test_read_mcp_resource_tool_bad_uri_retries(self, fastmcp_server: FastMCP[None], run_context: RunContext):
+        """A bad URI honors `tool_error_behavior`: `ModelRetry` by default so the model can
+        self-correct, and the underlying `MCPError` when `tool_error_behavior='error'`."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            with pytest.raises(ModelRetry):
+                await toolset.call_tool(
+                    READ_MCP_RESOURCE_TOOL_NAME,
+                    {'uri': 'resource://does-not-exist.txt'},
+                    run_context,
+                    tools[READ_MCP_RESOURCE_TOOL_NAME],
+                )
+
+        error_toolset = MCPToolset(fastmcp_server, expose_resources=True, tool_error_behavior='error')
+        async with error_toolset:
+            tools = await error_toolset.get_tools(run_context)
+            with pytest.raises(MCPError):
+                await error_toolset.call_tool(
+                    READ_MCP_RESOURCE_TOOL_NAME,
+                    {'uri': 'resource://does-not-exist.txt'},
+                    run_context,
+                    tools[READ_MCP_RESOURCE_TOOL_NAME],
+                )
+
+    async def test_expose_resources_no_capability(self, fastmcp_server: FastMCP[None], run_context: RunContext):
+        """`expose_resources=True` is a no-op when the server doesn't advertise the `resources`
+        capability — no resource tools are synthesized."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            toolset._server_capabilities = ServerCapabilities(tools=True)  # pyright: ignore[reportPrivateUsage]
+            tools = await toolset.get_tools(run_context)
+        assert LIST_MCP_RESOURCES_TOOL_NAME not in tools
+        assert READ_MCP_RESOURCE_TOOL_NAME not in tools
+
+    async def test_expose_resources_name_collision(self, run_context: RunContext):
+        """If a server tool already owns a synthesized name, `get_tools` raises a `UserError`
+        rather than silently shadowing the server tool."""
+        server: FastMCP[None] = FastMCP('collision_server')
+
+        @server.tool(name=READ_MCP_RESOURCE_TOOL_NAME)
+        async def read_mcp_resource() -> str:
+            """A server tool that collides with the synthesized resource tool name."""
+            return 'server tool'
+
+        @server.resource('resource://greeting.txt')
+        async def greeting() -> str:
+            return 'Hello, world!'
+
+        toolset = MCPToolset(server, expose_resources=True)
+        async with toolset:
+            with pytest.raises(UserError, match='the server already defines a tool with that name'):
+                await toolset.get_tools(run_context)
+
+    async def test_expose_resources_end_to_end(self, fastmcp_server: FastMCP[None]):
+        """The model can call `read_mcp_resource` mid-run and receive the resource content — the
+        scenario the feature exists for."""
+        tool_call_uri = 'resource://greeting.txt'
+
+        async def call_read_resource(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            # First turn: the model calls `read_mcp_resource`. Second turn (after the tool return):
+            # it reports what it read.
+            if not any(isinstance(m, ModelResponse) for m in messages):
+                assert {LIST_MCP_RESOURCES_TOOL_NAME, READ_MCP_RESOURCE_TOOL_NAME} <= {
+                    t.name for t in info.function_tools
+                }
+                return ModelResponse(
+                    parts=[ToolCallPart(tool_name=READ_MCP_RESOURCE_TOOL_NAME, args={'uri': tool_call_uri})]
+                )
+            return ModelResponse(parts=[TextPart(content='done')])
+
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        agent = Agent(FunctionModel(call_read_resource), toolsets=[toolset])
+        result = await agent.run('read the greeting resource')
+        assert result.output == 'done'
+        # The resource content reached the message history via the tool return.
+        tool_returns = [
+            part.content
+            for message in result.all_messages()
+            for part in getattr(message, 'parts', [])
+            if type(part).__name__ == 'ToolReturnPart' and part.tool_name == READ_MCP_RESOURCE_TOOL_NAME
+        ]
+        assert tool_returns == ['Hello, world!']
 
     async def test_list_prompts_returns_pai_types(self, fastmcp_server: FastMCP[None]):
         toolset = MCPToolset(fastmcp_server)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1104,6 +1104,22 @@ class TestMCPToolsetIntegration:
                     LIST_MCP_RESOURCES_TOOL_NAME, {}, run_context, tools[LIST_MCP_RESOURCES_TOOL_NAME]
                 )
 
+    async def test_read_mcp_resource_tool_invalid_uri_retries(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext
+    ):
+        """A `uri` that passes the `str` schema but isn't a valid URL (e.g. `'not a url'`) is a
+        retryable tool error, not an unhandled `ValidationError` from `AnyUrl` that aborts the run."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            with pytest.raises(ModelRetry, match="Invalid resource URI 'not a url'"):
+                await toolset.call_tool(
+                    READ_MCP_RESOURCE_TOOL_NAME,
+                    {'uri': 'not a url'},
+                    run_context,
+                    tools[READ_MCP_RESOURCE_TOOL_NAME],
+                )
+
     async def test_expose_resources_no_capability(self, fastmcp_server: FastMCP[None], run_context: RunContext):
         """`expose_resources=True` is a no-op when the server doesn't advertise the `resources`
         capability — no resource tools are synthesized."""
@@ -1952,6 +1968,15 @@ class TestResourceMethodErrorPaths:
             toolset.client.read_resource = AsyncMock(side_effect=make_mcp_error(-32002, 'not found'))
             with pytest.raises(MCPError, match='not found'):
                 await toolset.read_resource('resource://missing')
+
+    async def test_read_resource_wraps_invalid_uri(self, fastmcp_server: FastMCP[None]):
+        """A `uri` that isn't a valid URL is surfaced as `MCPError` (from the `AnyUrl` parse),
+        honoring the method's documented `Raises: MCPError` contract rather than escaping as a raw
+        `ValidationError`."""
+        toolset = MCPToolset(fastmcp_server)
+        async with toolset:
+            with pytest.raises(MCPError, match="Invalid resource URI 'not a url'"):
+                await toolset.read_resource('not a url')
 
 
 class TestLoadMCPToolsets:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -26,11 +26,14 @@ import httpx
 import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel
+from pydantic_core import ValidationError
 
 from pydantic_ai import Agent, ToolsetTool, models
 from pydantic_ai._run_context import RunContext
 from pydantic_ai._utils import BaseExceptionGroup
 from pydantic_ai.exceptions import ModelRetry, ToolFailed, UserError
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RunUsage
@@ -79,6 +82,8 @@ with try_import() as imports_successful:
 
     from pydantic_ai._mcp_compat import is_mcp_sdk_v2, wire_name
     from pydantic_ai.mcp import (
+        LIST_MCP_RESOURCES_TOOL_NAME,
+        READ_MCP_RESOURCE_TOOL_NAME,
         MCPError,
         MCPToolset,
         Prompt,
@@ -91,7 +96,7 @@ with try_import() as imports_successful:
         _make_httpx_client_factory,  # pyright: ignore[reportPrivateUsage]
         load_mcp_toolsets,
     )
-    from pydantic_ai.messages import TextContent
+    from pydantic_ai.messages import BinaryContent, TextContent
 
 
 pytestmark = [
@@ -431,6 +436,14 @@ async def fastmcp_server() -> FastMCP[None]:
     @server.resource('resource://{name}/profile.json')
     async def profile(name: str) -> str:
         return f'{{"name": "{name}"}}'
+
+    @server.resource(
+        'resource://product_name.txt',
+        mime_type='text/plain',
+        annotations=Annotations(audience=['user', 'assistant'], priority=0.5),
+    )
+    async def product_name() -> str:
+        return 'Pydantic AI'
 
     _register_prompts(server)
     return server
@@ -930,6 +943,208 @@ class TestMCPToolsetIntegration:
             toolset._server_capabilities = ServerCapabilities()  # pyright: ignore[reportPrivateUsage]
             assert await toolset.list_resources() == []
             assert await toolset.list_resource_templates() == []
+
+    # --- `expose_resources`: MCP resources as model-callable tools ---
+    # These use the in-process `fastmcp_server` (no HTTP), so they aren't VCR tests; the behavior
+    # is pure client/server projection with no provider involved.
+
+    async def test_expose_resources_default_off(self, fastmcp_server: FastMCP[None], run_context: RunContext):
+        """Backward compatibility: without the flag, no resource tools are synthesized."""
+        toolset = MCPToolset(fastmcp_server)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+        assert LIST_MCP_RESOURCES_TOOL_NAME not in tools
+        assert READ_MCP_RESOURCE_TOOL_NAME not in tools
+
+    async def test_expose_resources_adds_synthesized_tools(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext
+    ):
+        """With the flag on, both resource tools appear alongside the server's own tools, with the
+        expected parameter schemas (`read_mcp_resource` requires a string `uri`)."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+        # Server tools are still present.
+        assert 'echo' in tools
+        # Both resource tools are flagged read-only so approval predicates that gate on the MCP
+        # `readOnlyHint` annotation don't force human approval for a resource read.
+        for name in (LIST_MCP_RESOURCES_TOOL_NAME, READ_MCP_RESOURCE_TOOL_NAME):
+            metadata: dict[str, Any] = tools[name].tool_def.metadata or {}
+            annotations: dict[str, Any] = metadata.get('annotations') or {}
+            assert annotations.get('readOnlyHint') is True
+        assert tools[LIST_MCP_RESOURCES_TOOL_NAME].tool_def.parameters_json_schema == snapshot(
+            {'type': 'object', 'properties': {}, 'additionalProperties': False}
+        )
+        assert tools[READ_MCP_RESOURCE_TOOL_NAME].tool_def.parameters_json_schema == snapshot(
+            {
+                'type': 'object',
+                'properties': {
+                    'uri': {
+                        'type': 'string',
+                        'description': 'The URI of the resource to read, e.g. "resource://product_name.txt". Use `list_mcp_resources` to discover valid URIs.',
+                    }
+                },
+                'required': ['uri'],
+                'additionalProperties': False,
+            }
+        )
+        # The `read_mcp_resource` args validator enforces a required string `uri` (unlike server
+        # tools, which use the pass-through validator because they're validated server-side).
+        read_tool = tools[READ_MCP_RESOURCE_TOOL_NAME]
+        with pytest.raises(ValidationError):
+            read_tool.args_validator.validate_python({})
+        with pytest.raises(ValidationError):
+            read_tool.args_validator.validate_python({'uri': 123})
+        assert read_tool.args_validator.validate_python({'uri': 'resource://greeting.txt'}) == {
+            'uri': 'resource://greeting.txt'
+        }
+
+    async def test_list_mcp_resources_tool_returns_projected_dicts(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext
+    ):
+        """The `list_mcp_resources` tool returns compact dicts (surfacing annotations) and excludes
+        resource templates — locking the v1 boundary (concrete resources only)."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(
+                LIST_MCP_RESOURCES_TOOL_NAME, {}, run_context, tools[LIST_MCP_RESOURCES_TOOL_NAME]
+            )
+        by_uri = {r['uri']: r for r in result}
+        # Annotated resource surfaces its annotations sub-dict.
+        assert by_uri['resource://product_name.txt'] == snapshot(
+            {
+                'uri': 'resource://product_name.txt',
+                'name': 'product_name',
+                'description': None,
+                'mime_type': 'text/plain',
+                'annotations': {'audience': ['user', 'assistant'], 'priority': 0.5, 'last_modified': None},
+            }
+        )
+        # Concrete resource without annotations omits the `annotations` key.
+        assert 'annotations' not in by_uri['resource://greeting.txt']
+        # The `{name}/profile.json` template is a resource template, not a concrete resource, so it
+        # must NOT appear in `list_mcp_resources`.
+        assert not any('{name}' in uri for uri in by_uri)
+
+    async def test_read_mcp_resource_tool_text(self, fastmcp_server: FastMCP[None], run_context: RunContext):
+        """The `read_mcp_resource` tool returns a text resource as a string."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(
+                READ_MCP_RESOURCE_TOOL_NAME,
+                {'uri': 'resource://product_name.txt'},
+                run_context,
+                tools[READ_MCP_RESOURCE_TOOL_NAME],
+            )
+        assert result == 'Pydantic AI'
+
+    async def test_read_mcp_resource_tool_binary(self, fastmcp_server: FastMCP[None], run_context: RunContext):
+        """The `read_mcp_resource` tool returns a binary resource as `BinaryContent`."""
+
+        @fastmcp_server.resource('resource://blob.bin', mime_type='application/octet-stream')
+        async def blob() -> bytes:
+            return b'binary-bytes'
+
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            result = await toolset.call_tool(
+                READ_MCP_RESOURCE_TOOL_NAME,
+                {'uri': 'resource://blob.bin'},
+                run_context,
+                tools[READ_MCP_RESOURCE_TOOL_NAME],
+            )
+        assert isinstance(result, BinaryContent)
+        assert result.data == b'binary-bytes'
+        assert result.media_type == 'application/octet-stream'
+
+    async def test_read_mcp_resource_tool_bad_uri_retries(self, fastmcp_server: FastMCP[None], run_context: RunContext):
+        """A bad URI honors `tool_error_behavior`: `ModelRetry` by default so the model can
+        self-correct, and the underlying `MCPError` when `tool_error_behavior='error'`."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            with pytest.raises(ModelRetry):
+                await toolset.call_tool(
+                    READ_MCP_RESOURCE_TOOL_NAME,
+                    {'uri': 'resource://does-not-exist.txt'},
+                    run_context,
+                    tools[READ_MCP_RESOURCE_TOOL_NAME],
+                )
+
+        error_toolset = MCPToolset(fastmcp_server, expose_resources=True, tool_error_behavior='error')
+        async with error_toolset:
+            tools = await error_toolset.get_tools(run_context)
+            with pytest.raises(MCPError):
+                await error_toolset.call_tool(
+                    READ_MCP_RESOURCE_TOOL_NAME,
+                    {'uri': 'resource://does-not-exist.txt'},
+                    run_context,
+                    tools[READ_MCP_RESOURCE_TOOL_NAME],
+                )
+
+    async def test_expose_resources_no_capability(self, fastmcp_server: FastMCP[None], run_context: RunContext):
+        """`expose_resources=True` is a no-op when the server doesn't advertise the `resources`
+        capability — no resource tools are synthesized."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            toolset._server_capabilities = ServerCapabilities(tools=True)  # pyright: ignore[reportPrivateUsage]
+            tools = await toolset.get_tools(run_context)
+        assert LIST_MCP_RESOURCES_TOOL_NAME not in tools
+        assert READ_MCP_RESOURCE_TOOL_NAME not in tools
+
+    async def test_expose_resources_name_collision(self, run_context: RunContext):
+        """If a server tool already owns a synthesized name, `get_tools` raises a `UserError`
+        rather than silently shadowing the server tool."""
+        server: FastMCP[None] = FastMCP('collision_server')
+
+        # Both bodies exist only to shape the server's advertised surface (a colliding tool name and
+        # the `resources` capability); `get_tools` raises on the collision before either is invoked.
+        @server.tool(name=READ_MCP_RESOURCE_TOOL_NAME)
+        async def read_mcp_resource() -> str:  # pragma: no cover
+            """A server tool that collides with the synthesized resource tool name."""
+            return 'server tool'
+
+        @server.resource('resource://greeting.txt')
+        async def greeting() -> str:  # pragma: no cover
+            return 'Hello, world!'
+
+        toolset = MCPToolset(server, expose_resources=True)
+        async with toolset:
+            with pytest.raises(UserError, match='the server already defines a tool with that name'):
+                await toolset.get_tools(run_context)
+
+    async def test_expose_resources_end_to_end(self, fastmcp_server: FastMCP[None]):
+        """The model can call `read_mcp_resource` mid-run and receive the resource content — the
+        scenario the feature exists for."""
+        tool_call_uri = 'resource://greeting.txt'
+
+        async def call_read_resource(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            # First turn: the model calls `read_mcp_resource`. Second turn (after the tool return):
+            # it reports what it read.
+            if not any(isinstance(m, ModelResponse) for m in messages):
+                assert {LIST_MCP_RESOURCES_TOOL_NAME, READ_MCP_RESOURCE_TOOL_NAME} <= {
+                    t.name for t in info.function_tools
+                }
+                return ModelResponse(
+                    parts=[ToolCallPart(tool_name=READ_MCP_RESOURCE_TOOL_NAME, args={'uri': tool_call_uri})]
+                )
+            return ModelResponse(parts=[TextPart(content='done')])
+
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        agent = Agent(FunctionModel(call_read_resource), toolsets=[toolset])
+        result = await agent.run('read the greeting resource')
+        assert result.output == 'done'
+        # The resource content reached the message history via the tool return.
+        tool_returns = [
+            part.content
+            for message in result.all_messages()
+            for part in getattr(message, 'parts', [])
+            if type(part).__name__ == 'ToolReturnPart' and part.tool_name == READ_MCP_RESOURCE_TOOL_NAME
+        ]
+        assert tool_returns == ['Hello, world!']
 
     async def test_list_prompts_returns_pai_types(self, fastmcp_server: FastMCP[None]):
         toolset = MCPToolset(fastmcp_server)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1060,13 +1060,28 @@ class TestMCPToolsetIntegration:
         assert result.data == b'binary-bytes'
         assert result.media_type == 'application/octet-stream'
 
-    async def test_read_mcp_resource_tool_bad_uri_retries(self, fastmcp_server: FastMCP[None], run_context: RunContext):
-        """A bad URI honors `tool_error_behavior`: `ModelRetry` by default so the model can
-        self-correct, and the underlying `MCPError` when `tool_error_behavior='error'`."""
-        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+    @pytest.mark.parametrize(
+        'tool_error_behavior,expected_exception',
+        [
+            pytest.param('retry', ModelRetry, id='retry'),
+            pytest.param('failed', ToolFailed, id='failed'),
+            pytest.param('error', MCPError, id='error'),
+        ],
+    )
+    async def test_read_mcp_resource_tool_bad_uri_honors_error_behavior(
+        self,
+        fastmcp_server: FastMCP[None],
+        run_context: RunContext,
+        tool_error_behavior: Literal['retry', 'failed', 'error'],
+        expected_exception: type[Exception],
+    ):
+        """A bad URI is routed through `tool_error_behavior` like a server tool: `ModelRetry` by
+        default so the model can self-correct, `ToolFailed` under `'failed'`, and the raw `MCPError`
+        under `'error'` (rather than escaping the toolset unmapped)."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True, tool_error_behavior=tool_error_behavior)
         async with toolset:
             tools = await toolset.get_tools(run_context)
-            with pytest.raises(ModelRetry):
+            with pytest.raises(expected_exception):
                 await toolset.call_tool(
                     READ_MCP_RESOURCE_TOOL_NAME,
                     {'uri': 'resource://does-not-exist.txt'},
@@ -1074,15 +1089,19 @@ class TestMCPToolsetIntegration:
                     tools[READ_MCP_RESOURCE_TOOL_NAME],
                 )
 
-        error_toolset = MCPToolset(fastmcp_server, expose_resources=True, tool_error_behavior='error')
-        async with error_toolset:
-            tools = await error_toolset.get_tools(run_context)
-            with pytest.raises(MCPError):
-                await error_toolset.call_tool(
-                    READ_MCP_RESOURCE_TOOL_NAME,
-                    {'uri': 'resource://does-not-exist.txt'},
-                    run_context,
-                    tools[READ_MCP_RESOURCE_TOOL_NAME],
+    async def test_list_mcp_resources_tool_honors_error_behavior(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext
+    ):
+        """An `MCPError` raised while listing resources is routed through `tool_error_behavior`
+        (here `'failed'` → `ToolFailed`) instead of aborting the run — the `list` path previously
+        had no `MCPError` handling at all, so even the default `'retry'` let it escape."""
+        toolset = MCPToolset(fastmcp_server, expose_resources=True, tool_error_behavior='failed')
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            toolset.list_resources = AsyncMock(side_effect=MCPError('list boom', code=-32603))
+            with pytest.raises(ToolFailed, match='list boom'):
+                await toolset.call_tool(
+                    LIST_MCP_RESOURCES_TOOL_NAME, {}, run_context, tools[LIST_MCP_RESOURCES_TOOL_NAME]
                 )
 
     async def test_expose_resources_no_capability(self, fastmcp_server: FastMCP[None], run_context: RunContext):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -84,6 +84,7 @@ with try_import() as imports_successful:
     from pydantic_ai.mcp import (
         LIST_MCP_RESOURCES_TOOL_NAME,
         READ_MCP_RESOURCE_TOOL_NAME,
+        CallToolFunc,
         MCPError,
         MCPToolset,
         Prompt,
@@ -93,6 +94,7 @@ with try_import() as imports_successful:
         ResourceAnnotations,
         ResourceTemplate,
         ServerCapabilities,
+        ToolResult,
         _make_httpx_client_factory,  # pyright: ignore[reportPrivateUsage]
         load_mcp_toolsets,
     )
@@ -1119,6 +1121,89 @@ class TestMCPToolsetIntegration:
                     run_context,
                     tools[READ_MCP_RESOURCE_TOOL_NAME],
                 )
+
+    async def test_read_mcp_resource_tool_rejects_unadvertised_template_uri(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext
+    ):
+        """A template-backed URI the listing never advertised is refused rather than read.
+
+        The server resolves `resource://{name}/profile.json` for any `name` (see
+        `test_read_resource_template_instance`, which reads one directly), so without this guard a
+        model could reach a resource `list_mcp_resources` never disclosed by guessing its URI.
+        """
+        toolset = MCPToolset(fastmcp_server, expose_resources=True)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            # Not advertised: `list_resources()` exposes concrete resources only.
+            assert 'resource://alice/profile.json' not in [str(r.uri) for r in await toolset.list_resources()]
+            with pytest.raises(ModelRetry, match='is not one of the resources advertised by the server'):
+                await toolset.call_tool(
+                    READ_MCP_RESOURCE_TOOL_NAME,
+                    {'uri': 'resource://alice/profile.json'},
+                    run_context,
+                    tools[READ_MCP_RESOURCE_TOOL_NAME],
+                )
+
+    async def test_resource_tools_go_through_process_tool_call(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext
+    ):
+        """Both synthesized tools are passed to `process_tool_call`, and the delegate still reads.
+
+        Applications use the callback to gate, deny, or log tool calls, so a resource read must not
+        skip it.
+        """
+        seen: list[str] = []
+
+        async def hook(
+            ctx: RunContext[Any], call_tool: CallToolFunc, name: str, tool_args: dict[str, Any]
+        ) -> ToolResult:
+            seen.append(name)
+            return await call_tool(name, tool_args)
+
+        toolset = MCPToolset(fastmcp_server, expose_resources=True, process_tool_call=hook)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            listed = await toolset.call_tool(
+                LIST_MCP_RESOURCES_TOOL_NAME, {}, run_context, tools[LIST_MCP_RESOURCES_TOOL_NAME]
+            )
+            read = await toolset.call_tool(
+                READ_MCP_RESOURCE_TOOL_NAME,
+                {'uri': 'resource://product_name.txt'},
+                run_context,
+                tools[READ_MCP_RESOURCE_TOOL_NAME],
+            )
+        assert seen == [LIST_MCP_RESOURCES_TOOL_NAME, READ_MCP_RESOURCE_TOOL_NAME]
+        # The delegate really dispatched to the resource methods rather than returning `None`.
+        assert isinstance(listed, list)
+        assert read == 'Pydantic AI'
+
+    async def test_process_tool_call_can_deny_a_resource_read(
+        self, fastmcp_server: FastMCP[None], run_context: RunContext
+    ):
+        """A callback that refuses a resource read prevents the read from happening.
+
+        This is the point of routing these tools through the hook: a denial has to actually stop the
+        resource from being reached, not just observe the attempt.
+        """
+        read_resource = AsyncMock(side_effect=AssertionError('read_resource must not be reached'))
+
+        async def deny(
+            ctx: RunContext[Any], call_tool: CallToolFunc, name: str, tool_args: dict[str, Any]
+        ) -> ToolResult:
+            raise ModelRetry('resource reads are not allowed')
+
+        toolset = MCPToolset(fastmcp_server, expose_resources=True, process_tool_call=deny)
+        async with toolset:
+            tools = await toolset.get_tools(run_context)
+            toolset.read_resource = read_resource
+            with pytest.raises(ModelRetry, match='resource reads are not allowed'):
+                await toolset.call_tool(
+                    READ_MCP_RESOURCE_TOOL_NAME,
+                    {'uri': 'resource://product_name.txt'},
+                    run_context,
+                    tools[READ_MCP_RESOURCE_TOOL_NAME],
+                )
+        read_resource.assert_not_awaited()
 
     async def test_expose_resources_no_capability(self, fastmcp_server: FastMCP[None], run_context: RunContext):
         """`expose_resources=True` is a no-op when the server doesn't advertise the `resources`

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -996,6 +996,58 @@ async def test_temporal_mcp_get_tools_not_cached_when_disabled(allow_model_reque
         mcp_replay_holder['agent'] = _make_mcp_replay_agent()
 
 
+def _call_read_mcp_resource_then_finish(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    """Read an MCP resource on the first request, then report the content on the second."""
+    tool_returned = any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts)
+    if tool_returned:
+        return ModelResponse(parts=[TextPart('done')])
+    return ModelResponse(parts=[ToolCallPart('read_mcp_resource', {'uri': 'resource://product_name.txt'})])
+
+
+_expose_resources_agent = TemporalAgent(
+    Agent(
+        FunctionModel(_call_read_mcp_resource_then_finish),
+        name='expose_resources_agent',
+        toolsets=[
+            MCPToolset(
+                StdioTransport(command='python', args=['-m', 'tests.mcp_server']),
+                id='mcp',
+                init_timeout=20,
+                expose_resources=True,
+            )
+        ],
+    ),
+    activity_config=BASE_ACTIVITY_CONFIG,
+)
+
+
+@workflow.defn
+class ExposeResourcesWorkflow:
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        result = await _expose_resources_agent.run(prompt)
+        return result.output
+
+
+async def test_temporal_expose_resources(allow_model_requests: None, client: Client):
+    """`expose_resources=True` works across the Temporal activity boundary: the synthesized
+    `read_mcp_resource` tool's `metadata` marker survives `ToolDefinition` serialization, and its
+    string return round-trips through the activity's data converter."""
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[ExposeResourcesWorkflow],
+        plugins=[AgentPlugin(_expose_resources_agent)],
+    ):
+        output = await client.execute_workflow(
+            ExposeResourcesWorkflow.run,
+            args=['read the product name resource'],
+            id=f'{ExposeResourcesWorkflow.__name__}',
+            task_queue=TASK_QUEUE,
+        )
+    assert output == 'done'
+
+
 async def test_complex_agent_run(allow_model_requests: None):
     events: list[AgentStreamEvent] = []
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1542,6 +1542,67 @@ async def test_temporal_mcp_get_tools_not_cached_when_disabled(allow_model_reque
         mcp_replay_holder['agent'] = _make_mcp_replay_agent()
 
 
+def _call_read_mcp_resource_then_finish(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    """Read an MCP resource on the first request, then echo the content back on the second.
+
+    Echoing the tool return (rather than a fixed string) is what makes the run output carry the
+    resource content, so a value the activity's data converter dropped, emptied, or mangled fails
+    the assertion instead of passing silently.
+    """
+    tool_returns = [part.content for message in messages for part in message.parts if isinstance(part, ToolReturnPart)]
+    if tool_returns:
+        return ModelResponse(parts=[TextPart(repr(tool_returns[-1]))])
+    return ModelResponse(parts=[ToolCallPart('read_mcp_resource', {'uri': 'resource://product_name.txt'})])
+
+
+_expose_resources_agent = TemporalAgent(  # pyright: ignore[reportDeprecated]
+    Agent(
+        FunctionModel(_call_read_mcp_resource_then_finish),
+        name='expose_resources_agent',
+        toolsets=[
+            MCPToolset(
+                StdioTransport(command='python', args=['-m', 'tests.mcp_server']),
+                id='mcp',
+                init_timeout=20,
+                expose_resources=True,
+            )
+        ],
+    ),
+    activity_config=BASE_ACTIVITY_CONFIG,
+)
+
+
+@workflow.defn
+class ExposeResourcesWorkflow:
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        result = await _expose_resources_agent.run(prompt)
+        return result.output
+
+
+async def test_temporal_expose_resources(allow_model_requests: None, client: Client):
+    """`expose_resources=True` works across the Temporal activity boundary: the synthesized
+    `read_mcp_resource` tool's `metadata` marker survives `ToolDefinition` serialization, and its
+    string return round-trips through the activity's data converter.
+
+    The model echoes the tool return, so the asserted output pins the resource content itself
+    (exact string, trailing newline included) rather than merely that some tool return arrived.
+    """
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[ExposeResourcesWorkflow],
+        plugins=[AgentPlugin(_expose_resources_agent)],
+    ):
+        output = await client.execute_workflow(
+            ExposeResourcesWorkflow.run,
+            args=['read the product name resource'],
+            id=f'{ExposeResourcesWorkflow.__name__}',
+            task_queue=TASK_QUEUE,
+        )
+    assert output == snapshot("'Pydantic AI\\n'")
+
+
 async def test_complex_agent_run(allow_model_requests: None):
     events: list[AgentStreamEvent] = []
 


### PR DESCRIPTION
- Closes #6350

Adds an opt-in `expose_resources` flag to `MCPToolset`. When enabled, it synthesizes two model-callable tools — `list_mcp_resources` and `read_mcp_resource` — from the server's resource API, so the model can discover and read MCP resources mid-run rather than requiring the application to inject resource content out-of-band (the FastMCP-skills case in the issue).

- Off by default; a no-op when the server doesn't advertise the `resources` capability.
- Only concrete resources are exposed — resource **templates** and annotation-based **filtering** are deliberately deferred as clean additive follow-ups (see the issue's open questions).
- The synthesized tools reuse the existing `list_resources()` / `read_resource()` methods, are marked `readOnlyHint` (so approval predicates that gate on annotations don't force human-in-the-loop for a resource read), honor `tool_error_behavior` on a bad URI, and bypass `process_tool_call` (which wraps server tool calls).
- Name collisions with a server tool raise a `UserError` at `get_tools` time rather than silently shadowing the server tool.
- No durable-exec wrapper changes needed (they delegate generically at the `ToolDefinition` level); a Temporal test covers the activity boundary.

Docs updated in `docs/mcp/client.md`.

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

