### PR TITLE
fix(temporal): pass through `pydantic_monty` in workflow sandbox

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -74,6 +74,7 @@ def _workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner:
             'pydantic_ai',
             'pydantic',
             'pydantic_core',
+            'pydantic_monty',
             'logfire',
             'rich',
             'httpx',

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -89,6 +89,7 @@ try:
     from temporalio.exceptions import ApplicationError
     from temporalio.testing import WorkflowEnvironment
     from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
+    from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
     from temporalio.workflow import ActivityConfig
 
     from pydantic_ai.durable_exec.temporal import (
@@ -4513,6 +4514,18 @@ def test_pydantic_ai_plugin_no_converter_returns_pydantic_data_converter() -> No
     config: dict[str, Any] = {}
     result = plugin.configure_client(config)  # type: ignore[arg-type]
     assert result['data_converter'] is pydantic_data_converter
+
+
+def test_pydantic_ai_plugin_passes_pydantic_monty_through_sandbox() -> None:
+    runner = SandboxedWorkflowRunner()
+    config: dict[str, Any] = {'workflow_runner': runner}
+
+    result = PydanticAIPlugin().configure_worker(config)  # type: ignore[arg-type]
+
+    assert 'workflow_runner' in result
+    configured_runner = result['workflow_runner']
+    assert isinstance(configured_runner, SandboxedWorkflowRunner)
+    assert 'pydantic_monty' in configured_runner.restrictions.passthrough_modules
 
 
 def test_pydantic_ai_plugin_with_pydantic_payload_converter_unchanged() -> None:


### PR DESCRIPTION
- Related to #4050

Explicitly pass `pydantic_monty` through the Temporal workflow sandbox and pin the plugin configuration with a regression test.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

