### PR TITLE
docs: clarify finish-reason handling vs FallbackModel defaults

### DIFF
--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -407,10 +407,21 @@ print(result.output)
     To keep exception-based fallback alongside a response handler, pass them together as a list — see the [mixed example below](#combining-handlers).
 
 !!! note
-    Note that Pydantic AI already handles some finish reasons automatically in the [agent loop](../agent.md):
-    responses with a `'length'` or `'content_filter'` finish reason raise exceptions (which `FallbackModel`
-    catches by default), and empty responses are retried. A response handler is useful for custom
-    checks beyond these built-in behaviors.
+    Note that Pydantic AI handles some finish reasons in the [agent loop](../agent.md), but this is
+    **not** the same as `FallbackModel` automatically switching models:
+
+    - For **empty** (or non-actionable) responses, a `'content_filter'` finish reason raises
+      [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError] and a `'length'` finish
+      reason raises [`UnexpectedModelBehavior`][pydantic_ai.exceptions.UnexpectedModelBehavior].
+    - Those exceptions are raised **after** `model.request()` returns, so default
+      `FallbackModel` (which only falls back on [`ModelAPIError`][pydantic_ai.exceptions.ModelAPIError]
+      from inside the model call) does **not** catch them.
+    - **Non-empty** responses with `'length'` or `'content_filter'` are returned as successful
+      output by default; use a [response handler](#response-based-fallback) (as in the example above)
+      if you want those finish reasons to trigger fallback.
+
+    Empty responses may still be retried by the agent loop. A response handler is useful for
+    finish-reason checks and other content-based fallback beyond API errors.
 
 #### Native Tool Failure Example
 


### PR DESCRIPTION
## Summary

Corrects an inaccurate note in `docs/models/overview.md` about `'length'` / `'content_filter'` finish reasons and `FallbackModel`.

The previous text claimed those finish reasons raise exceptions which `FallbackModel` catches by default. In the current architecture:

- raises for empty/non-actionable responses happen in the agent graph after `model.request()` returns
- default `FallbackModel` only falls back on `ModelAPIError` from inside the model call
- non-empty responses with those finish reasons are returned successfully by default

The note now matches the implementation and points users at response-based fallback (as already documented in the same section). Related discussion: #5221. Fixes #6565.

## Test plan

- [x] Docs-only change; reviewed against agent-graph finish-reason handling
- [ ] Docs site preview (if required by CI)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

