### PR TITLE
Fix spurious OTel `Failed to detach context` error when a streamed run is interrupted mid-segment

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/_instrumentation.py
@@ -354,11 +354,19 @@ def capture_current_context() -> Callable[[], AbstractContextManager[None]]:
 
     @contextmanager
     def attach_captured_context() -> Generator[None]:
-        token = otel_context.attach(captured)
+        # Restore the previous context by re-`attach`ing it rather than `detach`ing the token: this CM is
+        # held across the `yield` in `_ContinuationStreamedResponse._get_event_iterator`, so when a streamed
+        # run is interrupted mid-segment the async generator is finalized (`GeneratorExit`) in a different
+        # contextvars `Context`, where `otel_context.detach(token)` -> `ContextVar.reset` raises
+        # `ValueError: ... created in a different Context`. OTel swallows it but logs a noisy
+        # 'Failed to detach context' (surfaced verbatim in the Pyodide output panel). `attach()` is a plain
+        # `set`, which never fails cross-context, so it restores `previous` silently. See #6569.
+        previous = otel_context.get_current()
+        otel_context.attach(captured)
         try:
             yield
         finally:
-            otel_context.detach(token)
+            otel_context.attach(previous)
 
     return attach_captured_context
 

--- a/tests/models/test_continuation_stream.py
+++ b/tests/models/test_continuation_stream.py
@@ -1,8 +1,10 @@
 """Unit tests for the streamed-continuation composite `_ContinuationStreamedResponse`.
 
-These drive the composite directly with a scripted fake model (no HTTP, no cassettes) to
+Most drive the composite directly with a scripted fake model (no HTTP, no cassettes) to
 pin down the provider-agnostic stitching behavior: part-index reindexing across segments,
 merged snapshots/usage, live state transitions, cancellation, and the continuation limit.
+A few exercise the composite through the full agent stack where the behavior under test
+only fires end-to-end (e.g. OTel context teardown on mid-segment interruption).
 
 These are unit tests rather than VCR tests for two reasons: `FunctionModel` can't emit a
 *suspended streaming* segment (the input a real continuation needs), and a cassette wouldn't
@@ -14,6 +16,7 @@ existing recording and pass green. Asserting the stitched indices directly is wh
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -23,7 +26,8 @@ from typing import Any
 import httpx
 import pytest
 
-from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai import Agent
+from pydantic_ai.exceptions import UnexpectedModelBehavior, UsageLimitExceeded
 from pydantic_ai.messages import (
     ModelMessage,
     ModelResponse,
@@ -33,8 +37,9 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import Model, ModelRequestParameters, StreamedResponse
 from pydantic_ai.models._continuation import _ContinuationStreamedResponse, merge_mode, merge_responses
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.settings import ModelSettings
-from pydantic_ai.usage import RequestUsage
+from pydantic_ai.usage import RequestUsage, UsageLimits
 
 pytestmark = pytest.mark.anyio
 
@@ -1189,3 +1194,28 @@ async def test_cancel_suppresses_non_httpx_segment_error() -> None:
 
     assert stream.get().state == 'interrupted'
     assert len(model.cancelled) == 1
+
+
+async def test_streamed_interruption_no_context_detach_error(caplog: pytest.LogCaptureFixture) -> None:
+    """Interrupting a streamed run mid-segment must not log a spurious OTel 'Failed to detach context'.
+
+    This is a public-API test rather than a direct-composite one because the teardown only fires through
+    the full agent stack: `_streaming_handler` captures the OTel context and the composite re-attaches it
+    (`segment_context`) around each segment. Interrupting the stream mid-segment (here via an output-token
+    limit) finalizes the composite's generator with `GeneratorExit` in a different contextvars `Context`;
+    before the fix, `attach_captured_context` detached its token there, which OTel swallows but logs at
+    ERROR under the `opentelemetry.context` logger. See #6569.
+    """
+
+    async def stream_function(_messages: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+        for i in range(50):
+            yield f'word{i} '
+
+    agent = Agent(FunctionModel(stream_function=stream_function))
+    with caplog.at_level(logging.ERROR, logger='opentelemetry.context'):
+        with pytest.raises(UsageLimitExceeded):
+            async with agent.run_stream('hi', usage_limits=UsageLimits(output_tokens_limit=5)) as result:
+                async for _ in result.stream_text(delta=True):
+                    pass
+
+    assert not any('Failed to detach context' in record.getMessage() for record in caplog.records)

--- a/tests/models/test_continuation_stream.py
+++ b/tests/models/test_continuation_stream.py
@@ -1208,8 +1208,12 @@ async def test_streamed_interruption_no_context_detach_error(caplog: pytest.LogC
     """
 
     async def stream_function(_messages: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
-        for i in range(50):
+        # Unbounded on purpose: the run is interrupted mid-stream by the output-token limit, so a
+        # bounded loop's completion branch would never be taken (a partial-branch coverage miss).
+        i = 0
+        while True:
             yield f'word{i} '
+            i += 1
 
     agent = Agent(FunctionModel(stream_function=stream_function))
     with caplog.at_level(logging.ERROR, logger='opentelemetry.context'):


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David. David has not reviewed this change; it was validated by an automated `/review-branch` pass.

- Closes #6569

## Problem

When a streamed run is interrupted mid-segment (e.g. a usage limit trips), an `ERROR opentelemetry.context Failed to detach context` is logged. In Pyodide/the playground this surfaces verbatim in the output panel as a scary secondary traceback.

Root cause: `capture_current_context().attach_captured_context` (in `_instrumentation.py`) is held across the `yield` in `_ContinuationStreamedResponse._get_event_iterator` (`with self.segment_context():`). On interruption the async generator is finalized (`GeneratorExit`) in a *different* contextvars `Context` than the one that entered the context manager, so `otel_context.detach(token)` → `ContextVar.reset(token)` raises `ValueError: <Token> was created in a different Context`. OTel swallows the error but logs it at ERROR.

## Fix

Restore the previous OTel context by re-`attach`ing it instead of `detach`ing the token:

```python
previous = otel_context.get_current()
otel_context.attach(captured)
try:
    yield
finally:
    otel_context.attach(previous)
```

`attach()` is a plain `ContextVar.set`, which never fails cross-context, so it restores `previous` silently. In the well-nested (non-interrupted) path it restores the exact same value `detach(token)` would.

## "Swapping `detach` → `attach` in a `finally` — can it mask the in-flight exception?"

No. `attach()` cannot raise (it's a `ContextVar.set`, not a `reset`), so the `finally` can't throw and can't discard the propagating exception. The regression test asserts the original `UsageLimitExceeded` still surfaces (`pytest.raises(UsageLimitExceeded)`) *and* that no `Failed to detach context` ERROR is logged.

## Alternative considered

The zero-deviation alternative is structural: don't straddle the `yield` at all — restructure `_get_event_iterator`'s per-segment `with self.segment_context()` so each attach/detach stays within one contextvars `Context`. That's a materially larger change than this one-symptom bug warrants; happy to take that route if a reviewer prefers no OTel-idiom deviation. (Wrapping `detach` in `try/except ValueError` was rejected — it keeps the fragile `detach` and swallows a real exception class.)

## Test

`tests/models/test_continuation_stream.py::test_streamed_interruption_no_context_detach_error` — a public-API regression (the teardown only fires through the full agent stack): it interrupts a streamed run via an output-token limit and asserts no `Failed to detach context` ERROR on the `opentelemetry.context` logger. Verified red-before-green — it fails against the pre-fix `detach(token)` body.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

