### PR TITLE
Fix missing tool spans for validation failures

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from opentelemetry.baggage import set_baggage as _otel_set_baggage
 from opentelemetry.context import attach as _otel_attach, detach as _otel_detach
 from opentelemetry.trace import StatusCode
+from pydantic import ValidationError
 from pydantic_core import to_json
 
 from pydantic_ai._instrumentation import (
@@ -22,7 +23,7 @@ from pydantic_ai._instrumentation import (
     time_to_first_chunk_ctx,
 )
 from pydantic_ai._utils import UNSET, Unset
-from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ToolRetryError
+from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry, ToolRetryError
 from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart, tool_return_ta
 from pydantic_ai.tools import ToolDefinition
 
@@ -34,6 +35,7 @@ from .abstract import (
     WrapOutputProcessHandler,
     WrapRunHandler,
     WrapToolExecuteHandler,
+    WrapToolValidateHandler,
 )
 
 if TYPE_CHECKING:
@@ -407,6 +409,32 @@ class Instrumentation(AbstractCapability[Any]):
             serialize_result=lambda value: tool_return_ta.dump_json(value).decode(),
             handle_tool_control_flow=True,
         )
+
+    # ------------------------------------------------------------------
+    # wrap_tool_validate - tool validation span (failures only)
+    # ------------------------------------------------------------------
+
+    async def wrap_tool_validate(
+        self,
+        ctx: RunContext[AgentDepsT],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: str | dict[str, Any],
+        handler: WrapToolValidateHandler,
+    ) -> ValidatedToolArgs:
+        try:
+            return await handler(args)
+        except (ValidationError, ModelRetry) as exc:
+            async def raise_validation_error(error: ValidationError | ModelRetry = exc) -> None:
+                raise error
+
+            return await self._run_tool_span(
+                span_name=self._instrumentation_names.get_tool_span_name(call.tool_name),
+                attributes=self._tool_span_attributes(call),
+                action=raise_validation_error,
+                serialize_result=lambda value: tool_return_ta.dump_json(value).decode(),
+            )
 
     # ------------------------------------------------------------------
     # wrap_output_process — output tool execution span (tool-mode only)

--- a/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
+++ b/pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py
@@ -10,7 +10,7 @@ from opentelemetry.baggage import set_baggage as _otel_set_baggage
 from opentelemetry.context import attach as _otel_attach, detach as _otel_detach
 from opentelemetry.trace import StatusCode
 from pydantic import ValidationError
-from pydantic_core import to_json
+from pydantic_core import PydanticSerializationError, to_json
 
 from pydantic_ai._instrumentation import (
     DEFAULT_INSTRUMENTATION_VERSION,
@@ -284,7 +284,7 @@ class Instrumentation(AbstractCapability[Any]):
     # wrap_tool_execute — tool execution span
     # ------------------------------------------------------------------
 
-    def _tool_span_attributes(self, call: ToolCallPart) -> dict[str, Any]:
+    def _tool_span_attributes(self, call: ToolCallPart, *, allow_invalid_args: bool = False) -> dict[str, Any]:
         """Build the span attributes shared by `wrap_tool_execute` and `wrap_output_process`.
 
         Both spans use `gen_ai.operation.name='execute_tool'` and the same `gen_ai.tool.*`
@@ -293,11 +293,19 @@ class Instrumentation(AbstractCapability[Any]):
         """
         names = self._instrumentation_names
         include_content = self.settings.include_content
+        content_attributes: dict[str, Any] = {}
+        if include_content:
+            try:
+                content_attributes[names.tool_arguments_attr] = call.args_as_json_str()
+            except PydanticSerializationError:
+                if not allow_invalid_args:
+                    raise
+
         return {
             'gen_ai.operation.name': 'execute_tool',
             'gen_ai.tool.name': call.tool_name,
             'gen_ai.tool.call.id': call.tool_call_id,
-            **({names.tool_arguments_attr: call.args_as_json_str()} if include_content else {}),
+            **content_attributes,
             **get_agent_run_baggage_attributes(),
             'logfire.msg': f'running tool: {call.tool_name}',
             'logfire.json_schema': to_json(
@@ -327,6 +335,7 @@ class Instrumentation(AbstractCapability[Any]):
         action: Callable[[], Awaitable[Any]],
         serialize_result: Callable[[Any], str],
         handle_tool_control_flow: bool = False,
+        record_exception_details: bool = True,
     ) -> Any:
         """Open a `gen_ai`-flavoured tool/output span around `action`.
 
@@ -351,11 +360,23 @@ class Instrumentation(AbstractCapability[Any]):
             record_exception=False,
             set_status_on_exception=False,
         ) as span:
+            def record_exception(exc: BaseException) -> None:
+                if record_exception_details:
+                    span.record_exception(exc, escaped=True)
+                else:
+                    span.add_event(
+                        'exception',
+                        {
+                            'exception.type': f'{type(exc).__module__}.{type(exc).__qualname__}',
+                            'exception.escaped': True,
+                        },
+                    )
+
             try:
                 result = await action()
             except (CallDeferred, ApprovalRequired) as exc:
                 if not handle_tool_control_flow:
-                    span.record_exception(exc, escaped=True)
+                    record_exception(exc)
                     span.set_status(StatusCode.ERROR)
                     raise
                 # Deferrals are control flow, not errors: capture the deferral name (and
@@ -369,7 +390,7 @@ class Instrumentation(AbstractCapability[Any]):
                         metadata_str = repr(exc.metadata)
                     span.set_attribute(names.tool_deferral_metadata_attr, metadata_str)
                 if settings.version < 5:
-                    span.record_exception(exc, escaped=True)
+                    record_exception(exc)
                     span.set_status(StatusCode.ERROR)
                 raise
             except ToolRetryError as e:
@@ -377,11 +398,11 @@ class Instrumentation(AbstractCapability[Any]):
                     # Tool retries are surfaced as model-visible errors; record the prompt
                     # the model will see as the tool result before re-raising.
                     span.set_attribute(names.tool_result_attr, e.tool_retry.model_response())
-                span.record_exception(e, escaped=True)
+                record_exception(e)
                 span.set_status(StatusCode.ERROR)
                 raise
             except BaseException as e:
-                span.record_exception(e, escaped=True)
+                record_exception(e)
                 span.set_status(StatusCode.ERROR)
                 raise
 
@@ -431,9 +452,10 @@ class Instrumentation(AbstractCapability[Any]):
 
             return await self._run_tool_span(
                 span_name=self._instrumentation_names.get_tool_span_name(call.tool_name),
-                attributes=self._tool_span_attributes(call),
+                attributes=self._tool_span_attributes(call, allow_invalid_args=True),
                 action=raise_validation_error,
                 serialize_result=lambda value: tool_return_ta.dump_json(value).decode(),
+                record_exception_details=self.settings.include_content,
             )
 
     # ------------------------------------------------------------------

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -2,7 +2,7 @@ from __future__ import annotations as _annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import pytest
 from dirty_equals import IsJson, IsList
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from typing_extensions import NotRequired, Self, TypedDict
 
 from pydantic_ai import Agent, ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart, UserPromptPart
-from pydantic_ai._utils import get_traceparent
+from pydantic_ai._utils import get_traceparent, run_until_complete
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.capabilities.instrumentation import Instrumentation
@@ -19,7 +19,7 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.output import PromptedOutput, TextOutput
-from pydantic_ai.tools import DeferredToolRequests, RunContext
+from pydantic_ai.tools import DeferredToolRequests, RunContext, ToolDefinition
 from pydantic_ai.toolsets.abstract import ToolsetTool
 from pydantic_ai.toolsets.function import FunctionToolset
 from pydantic_ai.toolsets.wrapper import WrapperToolset
@@ -3391,7 +3391,13 @@ def test_deferral_model_retry_still_errors_v5(capfire: CaptureLogfire) -> None:
 
 
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
-def test_tool_arg_validation_failure_records_tool_span(capfire: CaptureLogfire) -> None:
+@pytest.mark.parametrize('include_content', [True, False])
+def test_tool_arg_validation_failure_records_tool_span(capfire: CaptureLogfire, include_content: bool) -> None:
+    """This uses an internal `FunctionModel` and span exporter to assert instrumentation details.
+
+    A VCR cassette would only replay provider responses; it could not verify the generated tool span events.
+    """
+
     def call_model(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
         response_count = sum(isinstance(message, ModelResponse) for message in messages)
         if response_count == 0:
@@ -3404,7 +3410,7 @@ def test_tool_arg_validation_failure_records_tool_span(capfire: CaptureLogfire) 
 
     agent = Agent(
         FunctionModel(call_model),
-        capabilities=[Instrumentation(settings=InstrumentationSettings(version=5))],
+        capabilities=[Instrumentation(settings=InstrumentationSettings(version=5, include_content=include_content))],
     )
 
     @agent.tool_plain
@@ -3415,20 +3421,74 @@ def test_tool_arg_validation_failure_records_tool_span(capfire: CaptureLogfire) 
 
     assert result.output == 'done'
     spans = strip_logfire_metrics(capfire.exporter.exported_spans_as_dict(parse_json_attributes=True))
-    tool_spans = {
-        span['attributes']['gen_ai.tool.call.id']: span for span in spans if span['name'] == 'execute_tool double'
-    }
+    tool_spans = [span for span in spans if span['name'] == 'execute_tool double']
+    assert len(tool_spans) == 2
+    tool_spans_by_call_id = {span['attributes']['gen_ai.tool.call.id']: span for span in tool_spans}
 
-    assert tool_spans.keys() == {'invalid-tool-call', 'valid-tool-call'}
+    assert tool_spans_by_call_id.keys() == {'invalid-tool-call', 'valid-tool-call'}
 
-    invalid_attrs = tool_spans['invalid-tool-call']['attributes']
-    assert invalid_attrs['gen_ai.tool.call.arguments'] == {'x': 'not an int'}
+    invalid_span = tool_spans_by_call_id['invalid-tool-call']
+    invalid_attrs = invalid_span['attributes']
+    if include_content:
+        assert invalid_attrs['gen_ai.tool.call.arguments'] == {'x': 'not an int'}
+    else:
+        assert 'gen_ai.tool.call.arguments' not in invalid_attrs
     assert invalid_attrs.get('logfire.level_num') == 17
-    assert any(event['name'] == 'exception' for event in tool_spans['invalid-tool-call']['events'])
+    exception_event = next(event for event in invalid_span['events'] if event['name'] == 'exception')
+    exception_attrs = exception_event['attributes']
+    assert exception_attrs['exception.type'].endswith('ValidationError')
+    if include_content:
+        assert 'not an int' in exception_attrs['exception.message']
+    else:
+        assert 'exception.message' not in exception_attrs
 
-    valid_attrs = tool_spans['valid-tool-call']['attributes']
-    assert valid_attrs['gen_ai.tool.call.arguments'] == {'x': 2}
+    valid_attrs = tool_spans_by_call_id['valid-tool-call']['attributes']
+    if include_content:
+        assert valid_attrs['gen_ai.tool.call.arguments'] == {'x': 2}
+    else:
+        assert 'gen_ai.tool.call.arguments' not in valid_attrs
     assert 'logfire.level_num' not in valid_attrs
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+def test_tool_arg_validation_span_skips_unserializable_args(capfire: CaptureLogfire) -> None:
+    """This calls the capability hook directly to pin instrumentation safety.
+
+    A provider VCR cassette cannot contain arbitrary Python objects, and `FunctionModel` usage estimation serializes
+    response args before validation hooks run.
+    """
+
+    invalid_input = object()
+
+    class Args(BaseModel):
+        x: int
+
+    with pytest.raises(ValueError) as exc_info:
+        Args(x=invalid_input)
+    validation_error = exc_info.value
+
+    async def handler(_args: str | dict[str, Any]) -> Any:
+        raise validation_error
+
+    instrumentation = Instrumentation(settings=InstrumentationSettings(version=5))
+    with pytest.raises(ValueError):
+        run_until_complete(
+            instrumentation.wrap_tool_validate(
+                cast(RunContext[Any], object()),
+                call=ToolCallPart('double', {'x': invalid_input}, tool_call_id='invalid-tool-call'),
+                tool_def=ToolDefinition(name='double'),
+                args={'x': invalid_input},
+                handler=handler,
+            )
+        )
+
+    spans = strip_logfire_metrics(capfire.exporter.exported_spans_as_dict(parse_json_attributes=True))
+    tool_spans = [span for span in spans if span['name'] == 'execute_tool double']
+    assert len(tool_spans) == 1
+    invalid_attrs = tool_spans[0]['attributes']
+    assert invalid_attrs['gen_ai.tool.call.id'] == 'invalid-tool-call'
+    assert 'gen_ai.tool.call.arguments' not in invalid_attrs
+    assert any(event['name'] == 'exception' for event in tool_spans[0]['events'])
 
 
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3391,6 +3391,47 @@ def test_deferral_model_retry_still_errors_v5(capfire: CaptureLogfire) -> None:
 
 
 @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+def test_tool_arg_validation_failure_records_tool_span(capfire: CaptureLogfire) -> None:
+    def call_model(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        response_count = sum(isinstance(message, ModelResponse) for message in messages)
+        if response_count == 0:
+            return ModelResponse(
+                parts=[ToolCallPart('double', {'x': 'not an int'}, tool_call_id='invalid-tool-call')]
+            )
+        if response_count == 1:
+            return ModelResponse(parts=[ToolCallPart('double', {'x': 2}, tool_call_id='valid-tool-call')])
+        return ModelResponse(parts=[TextPart(content='done')])
+
+    agent = Agent(
+        FunctionModel(call_model),
+        capabilities=[Instrumentation(settings=InstrumentationSettings(version=5))],
+    )
+
+    @agent.tool_plain
+    def double(x: int) -> str:
+        return str(x * 2)
+
+    result = agent.run_sync('run the tool')
+
+    assert result.output == 'done'
+    spans = strip_logfire_metrics(capfire.exporter.exported_spans_as_dict(parse_json_attributes=True))
+    tool_spans = {
+        span['attributes']['gen_ai.tool.call.id']: span for span in spans if span['name'] == 'execute_tool double'
+    }
+
+    assert tool_spans.keys() == {'invalid-tool-call', 'valid-tool-call'}
+
+    invalid_attrs = tool_spans['invalid-tool-call']['attributes']
+    assert invalid_attrs['gen_ai.tool.call.arguments'] == {'x': 'not an int'}
+    assert invalid_attrs.get('logfire.level_num') == 17
+    assert any(event['name'] == 'exception' for event in tool_spans['invalid-tool-call']['events'])
+
+    valid_attrs = tool_spans['valid-tool-call']['attributes']
+    assert valid_attrs['gen_ai.tool.call.arguments'] == {'x': 2}
+    assert 'logfire.level_num' not in valid_attrs
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
 def test_deferral_unexpected_exception_still_errors_v5(capfire: CaptureLogfire) -> None:
     """Test that unexpected exceptions on v5 still record the span as an error.
 


### PR DESCRIPTION
## Summary

- Restore instrumentation spans for tool argument validation failures.
- Record the validation exception on the tool span while preserving retry behavior.
- Add regression coverage for failed validation spans and existing retry instrumentation paths.

- Closes #6555

## Testing

- `uv run pytest tests/test_logfire.py::test_tool_arg_validation_failure_records_tool_span tests/test_logfire.py::test_deferral_model_retry_still_errors_v5 tests/test_logfire.py::test_include_tool_args_span_attributes`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py tests/test_logfire.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/capabilities/instrumentation.py`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

