### PR TITLE
Fix Vercel AI Starlette skip markers

### DIFF
--- a/tests/test_vercel_ai.py
+++ b/tests/test_vercel_ai.py
@@ -3736,7 +3736,7 @@ async def test_run_stream_with_explicit_deferred_tool_results():
     )
 
 
-@pytest.mark.skipif(not starlette_import_successful, reason='Starlette is not installed')
+@pytest.mark.skipif(not starlette_import_successful(), reason='Starlette is not installed')
 async def test_adapter_dispatch_request():
     agent = Agent(model=TestModel())
     request = SubmitMessage(
@@ -3812,7 +3812,7 @@ def test_manage_system_prompt_visible_in_vercel_adapter_signatures():
     assert dispatch_request_parameters['manage_system_prompt'].default == 'server'
 
 
-@pytest.mark.skipif(not starlette_import_successful, reason='Starlette is not installed')
+@pytest.mark.skipif(not starlette_import_successful(), reason='Starlette is not installed')
 async def test_dispatch_request_with_tool_approval():
     """Test that dispatch_request with sdk_version=6 enables tool approval."""
 
@@ -6585,7 +6585,7 @@ async def test_adapter_drops_uploaded_file_from_provider_metadata():
     assert any(isinstance(item, UploadedFile) for item in preserved_part.content)
 
 
-@pytest.mark.skipif(not starlette_import_successful, reason='Starlette is not installed')
+@pytest.mark.skipif(not starlette_import_successful(), reason='Starlette is not installed')
 @pytest.mark.parametrize('allow_uploaded_files', [True, False])
 async def test_from_request_threads_allow_uploaded_files(allow_uploaded_files: bool):
     """`allow_uploaded_files` passed to the public `from_request` entry point reaches the sanitizer.
@@ -6679,7 +6679,7 @@ def test_constructor_preserve_file_data_deprecated_alias():
         assert VercelAIAdapter(agent=agent, run_input=run_input).allow_uploaded_files is False
 
 
-@pytest.mark.skipif(not starlette_import_successful, reason='Starlette is not installed')
+@pytest.mark.skipif(not starlette_import_successful(), reason='Starlette is not installed')
 async def test_dispatch_request_preserve_file_data_deprecated_alias():
     """The deprecated `preserve_file_data` argument to `dispatch_request` maps onto `allow_uploaded_files`."""
     run_input = SubmitMessage(


### PR DESCRIPTION
## Summary

- Correct Starlette-dependent skip markers in Vercel AI adapter tests.
- Keep tests from importing Starlette-only paths when the dependency is unavailable.
- Preserve the existing test behavior for environments with Starlette installed.

No issue; small test marker fix.

## Testing

- `uv run pytest tests/test_vercel_ai.py::test_adapter_dispatch_request tests/test_vercel_ai.py::test_dispatch_request_with_tool_approval tests/test_vercel_ai.py::test_from_request_threads_allow_uploaded_files tests/test_vercel_ai.py::test_dispatch_request_preserve_file_data_deprecated_alias`
- `uv run ruff check tests/test_vercel_ai.py`
- `git diff --check`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

