### PR TITLE
Fix tool retry counts across skipped steps

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -675,7 +675,9 @@ class ToolManager(Generic[AgentDepsT]):
             self.failed_tools.add(name)
             raise
 
-        self.succeeded_tools.add(name)
+        # Gated like `failed_tools` above: raw-mode (streaming) callers leave retry-budget state untouched.
+        if wrap_validation_errors:
+            self.succeeded_tools.add(name)
         return result
 
     async def handle_output_tool_call(
@@ -741,10 +743,13 @@ class ToolManager(Generic[AgentDepsT]):
             )
         except SkipToolExecution as e:
             usage.tool_calls += 1
-            self.succeeded_tools.add(validated.call.tool_name)
-            return e.result
+            tool_result = e.result
 
-        self.succeeded_tools.add(validated.call.tool_name)
+        # Only record success when wrapping is requested, mirroring the `failed_tools` gating:
+        # raw-mode callers (e.g. sandboxed dispatch) leave retry-budget state untouched, so a
+        # nested success must not reset the tool's carried retry count in the next run step.
+        if wrap_validation_errors:
+            self.succeeded_tools.add(validated.call.tool_name)
         return tool_result
 
     async def _raw_execute(

--- a/pydantic_ai_slim/pydantic_ai/tool_manager.py
+++ b/pydantic_ai_slim/pydantic_ai/tool_manager.py
@@ -88,6 +88,8 @@ class ToolManager(Generic[AgentDepsT]):
     by (`tool_def.name`)."""
     failed_tools: set[str] = field(default_factory=set[str])
     """Names of tools that failed in this run step."""
+    succeeded_tools: set[str] = field(default_factory=set[str])
+    """Names of tools that succeeded in this run step."""
     default_max_retries: int = 1
     """Default number of times to retry a tool"""
 
@@ -115,9 +117,16 @@ class ToolManager(Generic[AgentDepsT]):
                 return self
 
             retries = {
-                failed_tool_name: self.ctx.retries.get(failed_tool_name, 0) + 1
-                for failed_tool_name in self.failed_tools
+                tool_name: count
+                for tool_name, count in self.ctx.retries.items()
+                if tool_name not in self.succeeded_tools
             }
+            retries.update(
+                {
+                    failed_tool_name: self.ctx.retries.get(failed_tool_name, 0) + 1
+                    for failed_tool_name in self.failed_tools
+                }
+            )
             ctx = replace(ctx, retries=retries)
 
         toolset = await self.toolset.for_run_step(ctx)
@@ -666,6 +675,7 @@ class ToolManager(Generic[AgentDepsT]):
             self.failed_tools.add(name)
             raise
 
+        self.succeeded_tools.add(name)
         return result
 
     async def handle_output_tool_call(
@@ -731,8 +741,10 @@ class ToolManager(Generic[AgentDepsT]):
             )
         except SkipToolExecution as e:
             usage.tool_calls += 1
+            self.succeeded_tools.add(validated.call.tool_name)
             return e.result
 
+        self.succeeded_tools.add(validated.call.tool_name)
         return tool_result
 
     async def _raw_execute(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -969,6 +969,60 @@ def test_tool_output_max_retries_per_tool():
     )
 
 
+def test_tool_retry_budget_survives_interleaved_tool_calls():
+    """A tool's retry budget accumulates across steps even when other tool calls are interleaved between its failures.
+
+    Regression test for #6581: retry counts were rebuilt each step from only the tools that failed that
+    step, so a repeatedly failing tool that wasn't called in an intervening step had its count reset to 0
+    and looped forever instead of hitting `max_retries`.
+    """
+    flaky_retries: list[int] = []
+
+    def call_flaky_then_other(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        step = sum(isinstance(m, ModelResponse) for m in messages)
+        return ModelResponse(parts=[ToolCallPart('flaky_tool' if step % 2 == 0 else 'other_tool', {})])
+
+    agent = Agent(FunctionModel(call_flaky_then_other), retries=2)
+
+    @agent.tool
+    def flaky_tool(ctx: RunContext[object]) -> str:
+        flaky_retries.append(ctx.retry)
+        raise ModelRetry('always fails')
+
+    @agent.tool_plain
+    def other_tool() -> str:
+        return 'ok'
+
+    with pytest.raises(UnexpectedModelBehavior, match="Tool 'flaky_tool' exceeded max retries count of 2"):
+        agent.run_sync('go')
+
+    assert flaky_retries == [0, 1, 2]
+
+
+def test_tool_retry_count_resets_after_successful_call():
+    """A tool's retry count resets to 0 after it succeeds, then re-accumulates on the next failure."""
+    retries_seen: list[int] = []
+
+    def keep_calling(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        step = sum(isinstance(m, ModelResponse) for m in messages)
+        if step < 4:
+            return ModelResponse(parts=[ToolCallPart('sometimes_tool', {})])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent = Agent(FunctionModel(keep_calling), retries=2)
+
+    @agent.tool
+    def sometimes_tool(ctx: RunContext[object]) -> str:
+        retries_seen.append(ctx.retry)
+        if len(retries_seen) % 2 == 1:
+            raise ModelRetry('fails on odd calls')
+        return 'ok'
+
+    result = agent.run_sync('go')
+    assert result.output == 'done'
+    assert retries_seen == [0, 1, 0, 1]
+
+
 class TestPartialOutput:
     """Tests for `ctx.partial_output` flag in output validators and output functions."""
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -851,6 +851,48 @@ async def test_tool_manager_retry_count_survives_interleaved_successful_step():
     assert retry_values == [0, 1, 2]
 
 
+async def test_tool_manager_retry_count_increments_when_same_tool_fails_and_succeeds_in_one_step():
+    """A tool that both fails and succeeds in a single step still counts the failure toward its retry budget.
+
+    Pins the parallel same-tool contract from #2311/#2317: within one step the failing call increments the
+    count (failure wins), rather than the successful call resetting it. A "success wins" rule — dropping any
+    tool that appears in `succeeded_tools` even when it also failed — would reintroduce the #6581 unbounded
+    loop for a model that pairs a succeeding and a failing call to the same tool on every step.
+    """
+
+    @dataclass
+    class TestDeps:
+        pass
+
+    toolset = FunctionToolset[TestDeps](max_retries=2)
+    calls = 0
+
+    @toolset.tool
+    def flaky_tool(ctx: RunContext[Any], x: int) -> int:
+        """Fails on its first call in the step, succeeds on the second."""
+        nonlocal calls
+        calls += 1
+        if calls % 2 == 1:
+            raise ModelRetry('This call fails')
+        return x * 2
+
+    step_0_context = build_run_context(TestDeps())
+    step_0_tool_manager = await ToolManager[TestDeps](toolset).for_run_step(step_0_context)
+
+    # Same step: the tool fails once and succeeds once, landing in both failed_tools and succeeded_tools.
+    with pytest.raises(ToolRetryError):
+        await step_0_tool_manager.handle_call(ToolCallPart(tool_name='flaky_tool', args={'x': 1}))
+    assert await step_0_tool_manager.handle_call(ToolCallPart(tool_name='flaky_tool', args={'x': 3})) == 6
+    assert step_0_tool_manager.failed_tools == {'flaky_tool'}
+    assert step_0_tool_manager.succeeded_tools == {'flaky_tool'}
+
+    # Failure wins: the count carries forward as 1, not dropped by the same-step success.
+    step_1_context = build_run_context(TestDeps(), run_step=1)
+    step_1_tool_manager = await step_0_tool_manager.for_run_step(step_1_context)
+    assert step_1_tool_manager.ctx is not None
+    assert step_1_tool_manager.ctx.retries == {'flaky_tool': 1}
+
+
 async def test_handle_call_wrap_validation_errors_false():
     """`handle_call(wrap_validation_errors=False)` propagates raw errors and leaves retry-budget state untouched.
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -867,8 +867,8 @@ async def test_tool_manager_retry_count_increments_when_same_tool_fails_and_succ
     toolset = FunctionToolset[TestDeps](max_retries=2)
     calls = 0
 
-    @toolset.tool
-    def flaky_tool(ctx: RunContext[Any], x: int) -> int:
+    @toolset.tool_plain
+    def flaky_tool(x: int) -> int:
         """Fails on its first call in the step, succeeds on the second."""
         nonlocal calls
         calls += 1

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -922,6 +922,9 @@ async def test_handle_call_wrap_validation_errors_false():
         )
         == 10
     )
+    # The raw-mode success leaves retry-budget state untouched: it is not recorded in
+    # succeeded_tools, so it can't reset a carried retry count in the next run step.
+    assert tool_manager.succeeded_tools == set()
 
     # Pydantic ValidationError on bad args propagates raw, not as ToolRetryError.
     with pytest.raises(ValidationError):

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -797,6 +797,60 @@ async def test_tool_manager_retry_logic():
         await another_tool_manager.handle_call(ToolCallPart(tool_name='failing_tool', args={'x': 1}))
 
 
+async def test_tool_manager_retry_count_survives_interleaved_successful_step():
+    """Retry counts carry over when a failed tool is skipped in an intervening step."""
+
+    @dataclass
+    class TestDeps:
+        pass
+
+    toolset = FunctionToolset[TestDeps](max_retries=2)
+    retry_values: list[int] = []
+
+    @toolset.tool
+    def failing_tool(ctx: RunContext[Any], x: int) -> int:
+        """A tool that always fails."""
+        retry_values.append(ctx.retry)
+        raise ModelRetry('This tool always fails')
+
+    @toolset.tool_plain
+    def other_tool(x: int) -> int:
+        """A tool that works."""
+        return x * 2
+
+    step_0_context = build_run_context(TestDeps())
+    step_0_tool_manager = await ToolManager[TestDeps](toolset).for_run_step(step_0_context)
+
+    with pytest.raises(ToolRetryError):
+        await step_0_tool_manager.handle_call(ToolCallPart(tool_name='failing_tool', args={'x': 1}))
+
+    step_1_context = build_run_context(TestDeps(), run_step=1)
+    step_1_tool_manager = await step_0_tool_manager.for_run_step(step_1_context)
+    assert step_1_tool_manager.ctx is not None
+    assert step_1_tool_manager.ctx.retries == {'failing_tool': 1}
+
+    result = await step_1_tool_manager.handle_call(ToolCallPart(tool_name='other_tool', args={'x': 3}))
+    assert result == 6
+
+    step_2_context = build_run_context(TestDeps(), run_step=2)
+    step_2_tool_manager = await step_1_tool_manager.for_run_step(step_2_context)
+    assert step_2_tool_manager.ctx is not None
+    assert step_2_tool_manager.ctx.retries == {'failing_tool': 1}
+
+    with pytest.raises(ToolRetryError):
+        await step_2_tool_manager.handle_call(ToolCallPart(tool_name='failing_tool', args={'x': 1}))
+
+    step_3_context = build_run_context(TestDeps(), run_step=3)
+    step_3_tool_manager = await step_2_tool_manager.for_run_step(step_3_context)
+    assert step_3_tool_manager.ctx is not None
+    assert step_3_tool_manager.ctx.retries == {'failing_tool': 2}
+
+    with pytest.raises(UnexpectedModelBehavior, match="Tool 'failing_tool' exceeded max retries count of 2"):
+        await step_3_tool_manager.handle_call(ToolCallPart(tool_name='failing_tool', args={'x': 1}))
+
+    assert retry_values == [0, 1, 2]
+
+
 async def test_handle_call_wrap_validation_errors_false():
     """`handle_call(wrap_validation_errors=False)` propagates raw errors and leaves retry-budget state untouched.
 


### PR DESCRIPTION
- Closes #6581

## Summary

- Preserve retry counts for tools that were not called in an intervening run step.
- Track tools that actually succeeded in a step, so successful calls still reset prior retry counts.
- Add regression coverage for a failing tool whose retries are interleaved with a different successful tool.

## Testing

- `uv run pytest tests/test_toolsets.py::test_tool_manager_retry_logic tests/test_toolsets.py::test_tool_manager_retry_count_survives_interleaved_successful_step tests/test_toolsets.py::test_tool_manager_multiple_failed_tools -q`
- `uv run pytest tests/test_toolsets.py -q`
- `uv run ruff check pydantic_ai_slim/pydantic_ai/tool_manager.py tests/test_toolsets.py`
- `uv run ruff format --check pydantic_ai_slim/pydantic_ai/tool_manager.py tests/test_toolsets.py`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_slim/pydantic_ai/tool_manager.py tests/test_toolsets.py`
- `git diff --check`

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

