### PR TITLE
fix(openai): strip `openai.` vendor prefix in `openai_model_profile`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -281,6 +281,14 @@ def validate_openai_profile(profile: ModelProfile) -> None:
 
 def openai_model_profile(model_name: str) -> ModelProfile:
     """Get the model profile for an OpenAI model."""
+    # Bedrock Mantle (and other multi-vendor gateways) prefix OpenAI model IDs
+    # with `openai.` so they can disambiguate from other vendors served behind
+    # the same endpoint. Strip that prefix before matching capability prefixes,
+    # otherwise `gpt-5.6-sol` capabilities are silently mis-detected when the
+    # caller passes the prefixed form. See pydantic/pydantic-ai#6517.
+    if model_name.startswith('openai.'):
+        model_name = model_name.removeprefix('openai.')
+
     reasoning = _reasoning_support(model_name)
 
     # `phase` is supported by gpt-5.3-codex, gpt-5.4 and later mainline models, including gpt-5.6

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -110,6 +110,30 @@ def test_reasoning_matrix(case: ReasoningCase):
     assert profile.get('thinking_always_enabled', False) is (case.enabled_by_default and not case.can_be_disabled)
 
 
+@pytest.mark.parametrize(
+    ('prefixed', 'bare'),
+    [
+        ('openai.gpt-5.6-sol', 'gpt-5.6-sol'),
+        ('openai.gpt-5.4', 'gpt-5.4'),
+        ('openai.gpt-4o', 'gpt-4o'),
+        ('openai.gpt-5', 'gpt-5'),
+    ],
+    ids=lambda v: v,
+)
+def test_openai_model_profile_strips_vendor_prefix(prefixed: str, bare: str):
+    """A vendor-prefixed model id (e.g. Bedrock Mantle's `openai.` prefix) must
+    resolve to the same capability profile as the bare model name.
+
+    Regression test for #6517: without stripping, `openai.gpt-5.6-sol` missed
+    the `gpt-5.6` prefix (false negatives on phase/tool_search/image_output)
+    and collided with the `'o'` reasoning check (false positive on
+    `openai_supports_reasoning` for non-reasoning models like `gpt-oss-120b`).
+    """
+    prefixed_profile = openai_model_profile(prefixed)
+    bare_profile = openai_model_profile(bare)
+    assert dict(prefixed_profile) == dict(bare_profile)
+
+
 class TestEncryptedReasoningContent:
     """Tests for encrypted reasoning content support."""
 


### PR DESCRIPTION
Fixes #6517

`openai_model_profile` matches capability prefixes with `model_name.startswith(...)`, so vendor-prefixed ids like Bedrock Mantle's `openai.gpt-5.6-sol` (required because Mantle serves multiple vendors behind one endpoint) were mis-detected in two ways: false negatives where `phase`, `tool_search`, and `image_output` were silently disabled because the prefixed id missed the `gpt-5.6` prefix, and a false positive where `openai.` starts with `o` and collided with the o-series reasoning check (`'o'` prefix), flagging non-reasoning models like `gpt-oss-120b` as reasoning when prefixed.

This strips the `openai.` prefix up front so capability matching uses the bare model name. The change is one guard at the top of `openai_model_profile` plus a parametrized regression test asserting that prefixed ids resolve to the same profile as their bare equivalents across gpt-5.6-sol, gpt-5.4, gpt-4o, and gpt-5. Verified against the issue's reproduction: `openai_supports_phase`, `supports_image_output`, `thinking_always_enabled`, and `openai_supports_reasoning` now match between bare and prefixed forms, and `gpt-oss-120b` is no longer flagged as a reasoning model when prefixed.

Assisted-by: Hermes Agent

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

