### PR TITLE
fix(openai): strip vendor namespace prefix from model name in openai_model_profile()

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -281,6 +281,16 @@ def validate_openai_profile(profile: ModelProfile) -> None:
 
 def openai_model_profile(model_name: str) -> ModelProfile:
     """Get the model profile for an OpenAI model."""
+    # Multi-vendor endpoints such as Bedrock Mantle prefix OpenAI model IDs with
+    # a vendor namespace (e.g. ``"openai.gpt-5.6-sol"``) so they can serve models
+    # from multiple providers behind one endpoint. Strip the namespace before the
+    # capability checks below, otherwise the ``startswith`` gates misfire: a
+    # prefixed ``"gpt-5.6-sol"`` loses ``phase``/``tool_search``/``image_output``
+    # support, and worse, ``"openai."`` itself starts with ``"o"`` and collides
+    # with the o-series reasoning prefix.
+    if model_name.startswith('openai.'):
+        model_name = model_name[len('openai.') :]
+
     reasoning = _reasoning_support(model_name)
 
     # `phase` is supported by gpt-5.3-codex, gpt-5.4 and later mainline models, including gpt-5.6

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -110,6 +110,28 @@ def test_reasoning_matrix(case: ReasoningCase):
     assert profile.get('thinking_always_enabled', False) is (case.enabled_by_default and not case.can_be_disabled)
 
 
+@pytest.mark.parametrize(
+    'prefixed,bare',
+    [
+        ('openai.gpt-5.6-sol', 'gpt-5.6-sol'),
+        ('openai.gpt-5.4', 'gpt-5.4'),
+        ('openai.gpt-4o', 'gpt-4o'),
+        ('openai.o3', 'o3'),
+    ],
+)
+def test_openai_model_profile_strips_vendor_namespace(prefixed: str, bare: str):
+    """Regression test for https://github.com/pydantic/pydantic-ai/issues/6517.
+
+    Multi-vendor endpoints (e.g. Bedrock Mantle) prefix model IDs with a vendor
+    namespace like ``"openai."``. The profile must resolve the same capabilities
+    as the bare name, otherwise ``phase``/``tool_search``/``image_output`` flip
+    off and ``"openai."`` collides with the o-series reasoning prefix.
+    """
+    prefixed_profile = dict(openai_model_profile(prefixed))
+    bare_profile = dict(openai_model_profile(bare))
+    assert prefixed_profile == bare_profile
+
+
 class TestEncryptedReasoningContent:
     """Tests for encrypted reasoning content support."""
 


### PR DESCRIPTION
Multi-vendor endpoints such as Bedrock Mantle prefix OpenAI model IDs with a vendor namespace (e.g. "openai.gpt-5.6-sol") so they can serve models from multiple providers behind one endpoint. The startswith-based capability gates in openai_model_profile() misfire on these prefixed IDs: phase, tool_search, and image_output support are dropped (false negatives), and "openai." collides with the o-series reasoning prefix so prefixed non-reasoning models like openai.gpt-oss-120b are misclassified as reasoning models (false positive).

This strips the leading "openai." vendor namespace before any capability detection, so the profile resolves identically to the bare model name. I added a parametrized regression test asserting openai_model_profile() returns the same profile for prefixed and bare names across reasoning (gpt-5.6-sol), opt-in (gpt-5.4), non-reasoning (gpt-4o), and o-series (o3) models; the test fails on three of four cases without the fix and passes with it.

Fixes #6517

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

