### PR TITLE
docs(models): correct `FallbackModel` finish-reason note to match code

### DIFF
--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -407,14 +407,16 @@ print(result.output)
     To keep exception-based fallback alongside a response handler, pass them together as a list — see the [mixed example below](#combining-handlers).
 
 !!! note
-    Note that the [agent loop](../agent.md) raises on empty or thinking-only responses: a
-    `'length'` finish reason raises [`UnexpectedModelBehavior`][pydantic_ai.exceptions.UnexpectedModelBehavior]
+    Note that the [agent loop](../agent.md) can raise on empty, thinking-only, or non-empty
+    responses: a `'length'` finish reason raises [`UnexpectedModelBehavior`][pydantic_ai.exceptions.UnexpectedModelBehavior]
     when the model produced no actionable output (typically because it hit the token limit mid-thinking),
-    and an empty response with a `'content_filter'` finish reason raises
-    [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError]. Non-empty responses with either
-    finish reason are returned as-is. These exceptions are raised from the agent loop rather than from
-    `model.request()`, so they are **not** caught by `FallbackModel`'s default `fallback_on=(ModelAPIError,)`
-    (and `ContentFilterError` does not inherit from [`ModelAPIError`][pydantic_ai.exceptions.ModelAPIError]).
+    an empty response with a `'content_filter'` finish reason raises
+    [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError], and a non-empty response truncated
+    mid-tool-call raises [`IncompleteToolCall`][pydantic_ai.exceptions.IncompleteToolCall] (also a subclass
+    of `UnexpectedModelBehavior`). Otherwise non-empty responses are returned as-is. These exceptions are
+    raised from the agent loop rather than from `model.request()`, so they are **not** caught by
+    `FallbackModel`'s default `fallback_on=(ModelAPIError,)` (and `ContentFilterError` does not inherit
+    from [`ModelAPIError`][pydantic_ai.exceptions.ModelAPIError]).
     To fall back on them, add a response handler (see the [example above](#finish-reason-example)) that
     inspects [`finish_reason`][pydantic_ai.messages.ModelResponse.finish_reason]. To also raise on
     `content_filter` responses that still carry partial or refusal text, add the

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -407,11 +407,18 @@ print(result.output)
     To keep exception-based fallback alongside a response handler, pass them together as a list — see the [mixed example below](#combining-handlers).
 
 !!! note
-    Note that Pydantic AI already handles some finish reasons automatically in the [agent loop](../agent.md):
-    responses with a `'length'` or `'content_filter'` finish reason raise exceptions (which `FallbackModel`
-    catches by default), and empty responses are retried. A response handler is useful for custom
-    checks beyond these built-in behaviors. To also raise on `content_filter` responses that still carry
-    partial or refusal text, add the [`RaiseContentFilterError`][pydantic_ai.capabilities.RaiseContentFilterError] capability.
+    Note that the [agent loop](../agent.md) only raises on empty or thinking-only responses: a
+    `'length'` finish reason raises [`UnexpectedModelBehavior`][pydantic_ai.exceptions.UnexpectedModelBehavior]
+    when the model produced no actionable output (typically because it hit the token limit mid-thinking),
+    and an empty response with a `'content_filter'` finish reason raises
+    [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError]. Non-empty responses with either
+    finish reason are returned as-is. These exceptions are raised from the agent loop rather than from
+    `model.request()`, so they are **not** caught by `FallbackModel`'s default `fallback_on=(ModelAPIError,)`
+    (and `ContentFilterError` does not inherit from [`ModelAPIError`][pydantic_ai.exceptions.ModelAPIError]).
+    To fall back on them, add a response handler (see the [example above](#finish-reason-example)) that
+    inspects [`finish_reason`][pydantic_ai.messages.ModelResponse.finish_reason]. To also raise on
+    `content_filter` responses that still carry partial or refusal text, add the
+    [`RaiseContentFilterError`][pydantic_ai.capabilities.RaiseContentFilterError] capability.
 
 #### Native Tool Failure Example
 

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -407,19 +407,28 @@ print(result.output)
     To keep exception-based fallback alongside a response handler, pass them together as a list — see the [mixed example below](#combining-handlers).
 
 !!! note
-    Note that the [agent loop](../agent.md) can raise on empty, thinking-only, or non-empty
-    responses: a `'length'` finish reason raises [`UnexpectedModelBehavior`][pydantic_ai.exceptions.UnexpectedModelBehavior]
-    when the model produced no actionable output (typically because it hit the token limit mid-thinking),
-    an empty response with a `'content_filter'` finish reason raises
-    [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError], and a non-empty response truncated
-    mid-tool-call raises [`IncompleteToolCall`][pydantic_ai.exceptions.IncompleteToolCall] (also a subclass
-    of `UnexpectedModelBehavior`). Otherwise non-empty responses are returned as-is. These exceptions are
-    raised from the agent loop rather than from `model.request()`, so they are **not** caught by
-    `FallbackModel`'s default `fallback_on=(ModelAPIError,)` (and `ContentFilterError` does not inherit
-    from [`ModelAPIError`][pydantic_ai.exceptions.ModelAPIError]).
-    To fall back on them, add a response handler (see the [example above](#finish-reason-example)) that
-    inspects [`finish_reason`][pydantic_ai.messages.ModelResponse.finish_reason]. To also raise on
-    `content_filter` responses that still carry partial or refusal text, add the
+    The [agent loop](../agent.md) only acts on a finish reason when the response has no actionable
+    output. A `'length'` finish reason on an empty or thinking-only response raises
+    [`UnexpectedModelBehavior`][pydantic_ai.exceptions.UnexpectedModelBehavior] (typically the model hit
+    the token limit mid-thinking), and an empty response with a `'content_filter'` finish reason raises
+    [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError]. Other empty or thinking-only
+    responses are re-prompted, up to the output retry limit. Non-empty responses are handled normally
+    regardless of finish reason — a tool call truncated mid-arguments is re-prompted like any other
+    invalid-arguments failure, and only once its retry budget is exhausted does it surface as
+    [`IncompleteToolCall`][pydantic_ai.exceptions.IncompleteToolCall] (a subclass of
+    `UnexpectedModelBehavior`).
+
+    All of these are raised from the agent loop, after `model.request()` has already returned
+    successfully, so no exception-based `fallback_on` can catch them — not the default
+    `fallback_on=(ModelAPIError,)` (which wouldn't match anyway, as `ContentFilterError` inherits from
+    `UnexpectedModelBehavior`, not [`ModelAPIError`][pydantic_ai.exceptions.ModelAPIError]), and not an
+    explicit `fallback_on=(ContentFilterError,)` either. To fall back on a bad finish reason instead,
+    use a response handler (see the [example above](#finish-reason-example)) that inspects
+    [`finish_reason`][pydantic_ai.messages.ModelResponse.finish_reason]: it rejects the response inside
+    `FallbackModel` before the agent loop sees it, so the next model is tried instead of an exception
+    being raised. Note that it rejects *every* response with that finish reason, including non-empty
+    ones the agent loop would have accepted. To instead raise on `content_filter` responses that still
+    carry partial or refusal text, add the
     [`RaiseContentFilterError`][pydantic_ai.capabilities.RaiseContentFilterError] capability.
 
 #### Native Tool Failure Example

--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -407,7 +407,7 @@ print(result.output)
     To keep exception-based fallback alongside a response handler, pass them together as a list — see the [mixed example below](#combining-handlers).
 
 !!! note
-    Note that the [agent loop](../agent.md) only raises on empty or thinking-only responses: a
+    Note that the [agent loop](../agent.md) raises on empty or thinking-only responses: a
     `'length'` finish reason raises [`UnexpectedModelBehavior`][pydantic_ai.exceptions.UnexpectedModelBehavior]
     when the model produced no actionable output (typically because it hit the token limit mid-thinking),
     and an empty response with a `'content_filter'` finish reason raises


### PR DESCRIPTION
Closes #6565

The finish-reason note in docs/models/overview.md claimed that length and content_filter finish reasons raise exceptions which FallbackModel catches by default. That does not match the code:

- The agent loop only raises on empty or thinking-only responses (_agent_graph.py, `if is_empty or is_thinking_only:`). A length finish reason raises UnexpectedModelBehavior, and an empty response with content_filter raises ContentFilterError. Non-empty responses with either finish reason are returned as-is.
- Both exceptions are raised from the agent graph, after model.request() returns successfully, so FallbackModel never sees them — its exception handlers only wrap the model request.
- ContentFilterError inherits from UnexpectedModelBehavior then AgentRunError, not from ModelAPIError, so even a fallback_on that explicitly listed ModelAPIError would not match it.

The rewritten note states the real behavior and points users at the response-handler example just above (for falling back on finish_reason) and at the RaiseContentFilterError capability (for raising on non-empty content_filter responses). All claims were verified against the current code on main; this is a docs-only change.

This contribution was prepared with assistance from an AI agent (Claude / glm-5.2).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

