### PR TITLE
fix(openai): strip vendor prefix from model ids in openai_model_profile

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -132,6 +132,14 @@ def _reasoning_support(model_name: str) -> _ReasoningSupport:
     )
 
 
+# Vendor namespace prefixes that some OpenAI-compatible backends prepend to the
+# underlying OpenAI model id. AWS Bedrock Mantle, for example, serves OpenAI
+# models as `openai.<model>` because it fronts multiple vendors behind a single
+# endpoint. These are stripped in `openai_model_profile` before capability
+# detection so the real OpenAI family is what gets matched.
+_VENDOR_MODEL_PREFIXES: tuple[str, ...] = ('openai.',)
+
+
 class OpenAIModelProfile(ModelProfile, total=False):
     """Profile for models used with `OpenAIChatModel`.
 
@@ -281,6 +289,19 @@ def validate_openai_profile(profile: ModelProfile) -> None:
 
 def openai_model_profile(model_name: str) -> ModelProfile:
     """Get the model profile for an OpenAI model."""
+    # Some OpenAI-compatible backends namespace model ids with a vendor prefix
+    # (e.g. AWS Bedrock Mantle serves OpenAI models as `openai.gpt-5.6-sol`).
+    # The capability checks below use `model_name.startswith(...)`, so a prefix
+    # like `openai.` would both shadow the real family (`gpt-5.6` no longer
+    # matches) and collide with unrelated checks (the `o`-series prefix matches
+    # the leading `o` of `openai.`). Strip the known vendor namespace so the
+    # underlying OpenAI model id is what's matched. See:
+    # https://github.com/pydantic/pydantic-ai/issues/6517
+    for vendor_prefix in _VENDOR_MODEL_PREFIXES:
+        if model_name.startswith(vendor_prefix):
+            model_name = model_name[len(vendor_prefix) :]
+            break
+
     reasoning = _reasoning_support(model_name)
 
     # `phase` is supported by gpt-5.3-codex, gpt-5.4 and later mainline models, including gpt-5.6

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -225,3 +225,29 @@ def test_json_schema_transformer_removes_unsupported_regex_lookarounds():
             'additionalProperties': False,
         }
     )
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    [
+        'gpt-5.6-sol',
+        'gpt-5.5',
+        'gpt-5.4',
+        'gpt-5.3-codex',
+        'gpt-oss-120b',
+        'o3',
+    ],
+)
+def test_vendor_prefixed_model_id_matches_bare_profile(model_name: str):
+    """A vendor-namespaced id (e.g. Bedrock Mantle's `openai.<model>`) resolves
+    to the same profile as the underlying bare OpenAI model id.
+
+    Regression test for https://github.com/pydantic/pydantic-ai/issues/6517:
+    previously the `openai.` prefix shadowed the real family (so e.g.
+    `openai.gpt-5.6-sol` lost `openai_supports_phase`) and collided with the
+    `o`-series prefix check (so e.g. `openai.gpt-oss-120b` was wrongly flagged
+    as a reasoning model).
+    """
+    prefixed = openai_model_profile(f'openai.{model_name}')
+    bare = openai_model_profile(model_name)
+    assert dict(prefixed) == dict(bare)


### PR DESCRIPTION
Some OpenAI-compatible backends namespace model ids with a vendor prefix. AWS Bedrock Mantle serves OpenAI models as 'openai.<model>' because it fronts multiple vendors behind one endpoint. openai_model_profile() detects capabilities via model_name.startswith(...), so a prefix like 'openai.' broke detection two ways: it shadowed the real family so 'openai.gpt-5.6-sol' lost openai_supports_phase and supports_image_output, and it collided with the o-series reasoning prefix so 'openai.gpt-oss-120b' was wrongly flagged as a reasoning model.

This strips the known vendor namespace before capability detection, so the profile for 'openai.gpt-5.6-sol' equals the profile for 'gpt-5.6-sol'. Adds regression tests covering the prefixed and bare cases for phase, image output, and reasoning.

Fixes #6517

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

