### PR TITLE
Preserve $ref sibling keywords when inlining $defs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/_json_schema.py
+++ b/pydantic_ai_slim/pydantic_ai/_json_schema.py
@@ -103,7 +103,11 @@ class JsonSchemaTransformer(ABC):
                 def_schema = self.defs.get(key)
                 if def_schema is None:  # pragma: no cover
                     raise UserError(f'Could not find $ref definition for {key}')
-                schema = def_schema
+                # Preserve keywords that sit alongside the $ref (e.g. a field-level
+                # `description`/`default` that overrides the referenced model's);
+                # inlining the def by itself would otherwise drop them.
+                siblings = {k: v for k, v in schema.items() if k != '$ref'}
+                schema = {**def_schema, **siblings} if siblings else def_schema
 
         # Handle the schema based on its type / structure
         type_ = schema.get('type')

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -253,3 +253,26 @@ def test_typeless_anyof_member_still_recursed():
 
     # Single-member union collapses into the member, which is still transformed.
     assert result == {'type': 'integer'}
+
+
+def test_inline_defs_preserves_ref_sibling_keywords():
+    """Keywords alongside a `$ref` (e.g. a field-level description/default) must survive inlining."""
+    from pydantic_ai._json_schema import InlineDefsJsonSchemaTransformer
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'field': {'$ref': '#/$defs/Foo', 'description': 'field-level description', 'default': None},
+        },
+        '$defs': {'Foo': {'type': 'object', 'properties': {'x': {'type': 'integer'}}}},
+    }
+
+    result = InlineDefsJsonSchemaTransformer(deepcopy(schema)).walk()
+    field = result['properties']['field']
+
+    # The referenced definition is inlined...
+    assert field['type'] == 'object'
+    assert field['properties'] == {'x': {'type': 'integer'}}
+    # ...and the sibling keywords are preserved rather than dropped.
+    assert field['description'] == 'field-level description'
+    assert field['default'] is None


### PR DESCRIPTION
Fixes #6591

### What's broken

`InlineDefsJsonSchemaTransformer` (Bedrock, OpenRouter, any `prefer_inlined_defs=True`) inlines `$ref`s by replacing the schema outright (`schema = def_schema`), dropping keywords that sat next to the `$ref`. Pydantic emits `{"$ref": ..., "description": ...}` for nested-model fields, so a field-level `description`/`default` is silently dropped from the schema sent to the model. Full reproducible example in #6591.

### Fix

Merge the non-`$ref` sibling keywords over the inlined definition, siblings taking precedence:

```python
siblings = {k: v for k, v in schema.items() if k != '$ref'}
schema = {**def_schema, **siblings} if siblings else def_schema
```

### Tests

Adds `test_inline_defs_preserves_ref_sibling_keywords` to `tests/test_json_schema.py`; the full file passes (12). The no-sibling path is unchanged.