### PR TITLE
Add .macroscope/ignore.md to skip generated files in review

### DIFF
--- a/.macroscope/ignore.md
+++ b/.macroscope/ignore.md
@@ -1,0 +1,19 @@
+# Repository-wide Macroscope ignore (code review + any check-run agents).
+#
+# One glob per line; `#` starts a comment; `**` spans directories. Files listed
+# here are dropped from the billed review diff, so Macroscope does not spend
+# credits reviewing generated, recorded, or vendored files that no human reads.
+
+# Recorded VCR cassettes: LLM/HTTP interaction recordings, regenerated in bulk
+# (~1000 files, ~200 MB), never hand-reviewed.
+**/cassettes/**
+
+# Lock files.
+**/*.lock
+**/package-lock.json
+
+# Compiled gh-aw workflows (generated from their `.md` sources).
+.github/workflows/*.lock.yml
+
+# Documentation images (binary, not reviewable as a diff).
+docs/img/**

--- a/.macroscope/ignore.md
+++ b/.macroscope/ignore.md
@@ -1,19 +1,165 @@
 # Repository-wide Macroscope ignore (code review + any check-run agents).
 #
-# One glob per line; `#` starts a comment; `**` spans directories. Files listed
-# here are dropped from the billed review diff, so Macroscope does not spend
-# credits reviewing generated, recorded, or vendored files that no human reads.
+# A custom ignore file REPLACES Macroscope's built-in defaults, so this copies
+# their default "base" patterns verbatim to preserve them, then adds this repo's
+# own recorded/generated files on top. https://docs.macroscope.com/
+#
+# Macroscope's default *test-file* patterns are deliberately NOT copied here: we
+# want Macroscope to review test code. Recorded cassettes and binary fixtures
+# under tests/ stay ignored via the base binary/data patterns plus the explicit
+# cassettes rule below, so only real test *code* is reviewed.
 
-# Recorded VCR cassettes: LLM/HTTP interaction recordings, regenerated in bulk
-# (~1000 files, ~200 MB), never hand-reviewed.
-**/cassettes/**
-
-# Lock files.
-**/*.lock
+# ---- Macroscope default base patterns (copied to preserve them) ----
+**/.git/**
+**/__pycache__/**
+**/.pytest_cache/**
+**/.mypy_cache/**
+**/.ruff_cache/**
+**/venv/**
+**/.venv/**
+**/node_modules/**
+**/site-packages/**
+**/.pnpm-store/**
+**/__Snapshots__/**
+**/__snapshots__/**
+**/.agents/skills/**
+**/.claude/skills/**
+**/.github/skills/**
+**/bower_components/**
+**/jspm_packages/**
+**/.next/**
+**/.svelte-kit/**
+**/vendor/**
+**/_vendor/**
+**/third_party/**
+**/Pods/**
+**/.bundle/**
+build/**
+env/**
+ENV/**
+**/target/**
+**/generated/**
+**/intermediates/**
+**/generated_sources/**
+**/generated-sources/**
+**/generated-src/**
+**/src/main/generated/**
+**/*.min.js
+**/*.min.css
+**/*_pb.d.ts
+**/*_pb.js
+**/*.pb.go
+**/*_pb2.py
+**/*_pb2_grpc.py
+**/*_pb2.pyi
+**/*.grpc.swift
+**/*.pb.swift
+**/*.sql.go
+**/*.designer.cs
+**/*.g.dart
+**/*.pb.dart
+**/*_pb.rb
+**/go.mod
+**/package.json
+**/*.pbxproj
+**/*.xcstrings
+**/*.strings
+**/*.properties
+**/pom.xml
+**/Package.swift
+**/bun.lock
+**/.eslintrc
+**/.eslintignore
+**/go.sum
 **/package-lock.json
+**/pnpm-lock.yaml
+**/yarn.lock
+**/Package.resolved
+**/*.jpg
+**/*.jpeg
+**/*.png
+**/*.gif
+**/*.svg
+**/*.ico
+**/*.webp
+**/*.bmp
+**/*.tiff
+**/*.woff
+**/*.woff2
+**/*.ttf
+**/*.eot
+**/*.otf
+**/*.mp3
+**/*.mp4
+**/*.wav
+**/*.avi
+**/*.mov
+**/*.mkv
+**/*.flac
+**/*.ogg
+**/*.srt
+**/*.zip
+**/*.tar
+**/*.gz
+**/*.rar
+**/*.7z
+**/*.bz2
+**/*.pdf
+**/*.doc
+**/*.docx
+**/*.xls
+**/*.xlsx
+**/*.ppt
+**/*.pptx
+**/*.db
+**/*.sqlite
+**/*.sqlite3
+**/*.parquet
+**/*.avro
+**/*.arrow
+**/*.npy
+**/*.pkl
+**/*.jsonl
+**/*.onnx
+**/*.tflite
+**/*.h5
+**/*.safetensors
+**/*.exe
+**/*.dll
+**/*.so
+**/*.dylib
+**/*.bin
+**/*.pyc
+**/*.class
+**/*.o
+**/*.a
+**/*.wasm
+**/*.cer
+**/*.pem
+**/*.p12
+**/*.stringsdict
+**/*.snap
+**/*.adoc
+**/*.arb
+**/*.lock
+**/*.po
+**/*.fbx
+**/*.log
+**/*.xib
+**/*.meta
+**/*.kml
+**/*.prefab
+**/*.eml
+**/*.csv
+**/*.grpc.reflection
+**/*.js.map
+
+# ---- This repo: recorded + generated files the defaults do not cover ----
+
+# Recorded VCR cassettes (LLM/HTTP recordings, ~1000 files / ~200 MB). These
+# live under tests/, so keep them ignored explicitly now that test code is
+# reviewed.
+**/cassettes/**
 
 # Compiled gh-aw workflows (generated from their `.md` sources).
 .github/workflows/*.lock.yml
-
-# Documentation images (binary, not reviewable as a diff).
-docs/img/**


### PR DESCRIPTION
Adds a repository-wide Macroscope ignore list so the AI code review does not spend credits reviewing generated / recorded / vendored files that no human reads.

Macroscope's managed review is billed per KB of diff reviewed, and the largest diffs here are mechanical:

- **`**/cassettes/**`** — recorded VCR cassettes: ~1,044 files / ~198 MB. A PR that re-records cassettes currently pays to have all of that "reviewed".
- **`**/*.lock`, `**/package-lock.json`** — lock files.
- **`.github/workflows/*.lock.yml`** — compiled gh-aw workflows (~0.9 MB, generated from their `.md` sources).
- **`docs/img/**`** — binary images (not reviewable as a diff).

Ignored files are dropped from the reviewed/billed diff for both code review and any check-run agents. No effect on CI or the actual test cassettes on disk.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

