### PR TITLE
Preserve failed/denied tool return outcome via `ToolMessage.error` in AG-UI adapter

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_adapter.py
@@ -97,6 +97,7 @@ try:
         rehydrate_tool_return_content,
         thinking_encrypted_metadata,
         tool_kind_encrypted_value_kwargs,
+        tool_return_error_kwargs,
         warn_tool_kind_not_persisted,
     )
 except ImportError as e:
@@ -479,17 +480,21 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                     # changing how it serializes to the provider) also keeps the return untyped.
                     tool_kind = None
                     outcome: Literal['success', 'failed', 'denied', 'interrupted'] = 'success'
-                    if tool_msg.error is None:
-                        encrypted_outcome = (
-                            parse_encrypted_outcome(tool_msg.encrypted_value) if use_encrypted_value else None
+                    encrypted_outcome = (
+                        parse_encrypted_outcome(tool_msg.encrypted_value) if use_encrypted_value else None
+                    )
+                    if encrypted_outcome is not None:
+                        outcome = encrypted_outcome
+                    elif tool_msg.error is not None:
+                        # The spec-level error slot, set by our own dump for failed/denied returns
+                        # and by AG-UI clients reporting a tool failure. Without the outcome claim
+                        # there is no way to tell denied from failed, so it reads as `'failed'`.
+                        outcome = 'failed'
+                    else:
+                        encrypted_tool_kind = (
+                            parse_encrypted_tool_kind(tool_msg.encrypted_value) if use_encrypted_value else None
                         )
-                        if encrypted_outcome is not None:
-                            outcome = encrypted_outcome
-                        else:
-                            encrypted_tool_kind = (
-                                parse_encrypted_tool_kind(tool_msg.encrypted_value) if use_encrypted_value else None
-                            )
-                            tool_kind = encrypted_tool_kind or tool_kinds.get(tool_call_id)
+                        tool_kind = encrypted_tool_kind or tool_kinds.get(tool_call_id)
 
                     builtin_id = parse_builtin_tool_call_id(tool_call_id)
                     if builtin_id is not None:
@@ -671,12 +676,15 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
                 flush_user_content()
                 # Tool-return files ride inline in `ToolMessage.content` (see `dump_tool_return_content`).
                 # A non-success outcome rides the `encrypted_value` carrier alongside `tool_kind`,
-                # since a `ToolMessage` has no outcome slot.
+                # since a `ToolMessage` has no outcome slot. A failed/denied return also sets the
+                # spec-level `error` slot so AG-UI clients (and versions below 0.1.11, which have no
+                # carrier) still see the error state instead of a clean success.
                 result.append(
                     ToolMessage(
                         id=_new_message_id(),
                         content=dump_tool_return_content(part.content),
                         tool_call_id=part.tool_call_id,
+                        **tool_return_error_kwargs(part.outcome, part.model_response_str()),
                         **tool_kind_encrypted_value_kwargs(
                             part.tool_kind, outcome=part.outcome, supported=use_encrypted_value
                         ),
@@ -850,9 +858,13 @@ class AGUIAdapter(UIAdapter[RunAgentInput, Message, BaseEvent, AgentDepsT, Outpu
         - `tool_kind` is not restored on error/denied tool returns (a typed return implies
           success to its readers), so those reload as plain `ToolReturnPart`.
         - A non-`'success'` `outcome` on a (native) tool return survives via the `encrypted_value`
-          carrier from 0.1.11 (`ToolMessage` has no outcome slot), and reloads as `'success'` below
-          that.
-        - `RetryPromptPart` becomes `ToolReturnPart` (or `UserPromptPart`) on reload.
+          carrier from 0.1.11 (`ToolMessage` has no outcome slot). A `'failed'`/`'denied'`
+          `ToolReturnPart` additionally sets the spec-level `ToolMessage.error`, so it survives on
+          any version, though `'denied'` reloads as `'failed'` below 0.1.11. An `'interrupted'`
+          outcome, or any non-`'success'` outcome on a native tool return, reloads as `'success'`
+          below 0.1.11.
+        - `RetryPromptPart` becomes `ToolReturnPart` with `outcome='failed'` (or `UserPromptPart`)
+          on reload.
         - `CachePoint` and `UploadedFile` content items are dropped (unless `preserve_file_data=True`).
         - `FileUrl.force_download` is dropped when `ag_ui_version < '0.1.15'` (before typed
           multimodal content gained a metadata carrier).

--- a/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/ui/ag_ui/_utils.py
@@ -181,6 +181,25 @@ def tool_kind_encrypted_value_kwargs(
     return {'encrypted_value': value} if value is not None else {}
 
 
+class _ToolErrorKwargs(TypedDict, total=False):
+    """`error` kwarg for a `ToolMessage`, absent when the return is not an error."""
+
+    error: str
+
+
+def tool_return_error_kwargs(
+    outcome: Literal['success', 'failed', 'denied', 'interrupted'], error: str
+) -> _ToolErrorKwargs:
+    """`ToolMessage` kwargs setting the spec-level `error` slot for a failed/denied return, or empty.
+
+    `error` is the AG-UI spec's carrier for tool failure, so clients that don't read the
+    `pydantic_ai` `encrypted_value` claim (and versions below 0.1.11, which don't have it) still
+    see the error state. An `'interrupted'` outcome is not an error and rides the claim only;
+    like the claim, the field is never written as a bare `null`.
+    """
+    return {'error': error} if outcome in ('failed', 'denied') else {}
+
+
 def warn_tool_kind_not_persisted(ag_ui_version: str) -> None:
     """Warn that typed tool parts' `tool_kind` will be lost when dumping below `ENCRYPTED_VALUE_VERSION`.
 

--- a/tests/test_ag_ui.py
+++ b/tests/test_ag_ui.py
@@ -1893,8 +1893,9 @@ def test_dump_load_roundtrip_non_success_outcome(outcome: Literal['failed', 'den
 
     `ToolMessage` has no outcome slot, so the claim rides the `encrypted_value` carrier like
     `tool_kind` does — losing it would change how the return serializes to the provider (e.g. a
-    native error channel) and break prompt-cache prefix stability. Below 0.1.11 there is no
-    carrier, so the outcome silently degrades to `'success'`.
+    native error channel) and break prompt-cache prefix stability. A failed/denied return also
+    sets the spec-level `ToolMessage.error`, so below 0.1.11 (no carrier) it still reloads as
+    `'failed'`; only `'interrupted'` (carrier-only) degrades to `'success'` there.
 
     Not VCR-backed: this pins local adapter serialization (including the exact wire payload)
     and makes no model request.
@@ -1916,6 +1917,10 @@ def test_dump_load_roundtrip_non_success_outcome(outcome: Literal['failed', 'den
     ag_ui_msgs = AGUIAdapter.dump_messages(original, ag_ui_version='0.1.13')
     tool_msg = next(msg for msg in ag_ui_msgs if isinstance(msg, ToolMessage))
     assert tool_msg.encrypted_value == f'{{"pydantic_ai": {{"outcome": "{outcome}"}}}}'
+    if outcome == 'interrupted':
+        assert 'error' not in tool_msg.model_fields_set
+    else:
+        assert tool_msg.error == 'The tool call did not produce a regular result.'
 
     reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
     reloaded_return = next(
@@ -1938,7 +1943,9 @@ def test_dump_load_roundtrip_non_success_outcome(outcome: Literal['failed', 'den
         for part in message.parts
         if isinstance(part, ToolReturnPart)
     )
-    assert old_return.outcome == 'success'
+    # Below 0.1.11 only the spec-level `error` slot survives: it can't distinguish denied from
+    # failed, and `'interrupted'` (carrier-only) degrades to `'success'`.
+    assert old_return.outcome == ('success' if outcome == 'interrupted' else 'failed')
 
 
 def test_dump_load_roundtrip_native_tool_return_outcome() -> None:
@@ -1989,6 +1996,35 @@ def test_load_forged_encrypted_outcome_stays_success() -> None:
     return_part = loaded[1].parts[0]
     assert isinstance(return_part, ToolReturnPart)
     assert return_part.outcome == 'success'
+
+
+def test_load_client_tool_message_error_reads_as_failed() -> None:
+    """A client-authored `ToolMessage` with the spec-level `error` slot set loads as a failed return.
+
+    AG-UI clients report tool failure via `ToolMessage.error` and don't write the `pydantic_ai`
+    `encrypted_value` claim; without this mapping the failure would reload as a clean success.
+
+    Not VCR-backed: this pins local handling of client input and makes no model request.
+    """
+    loaded = AGUIAdapter.load_messages(
+        [
+            AssistantMessage(
+                id='msg-1',
+                tool_calls=[ToolCall(id='c1', function=FunctionCall(name='my_tool', arguments='{}'))],
+            ),
+            ToolMessage(
+                id='msg-2',
+                tool_call_id='c1',
+                content='Connection timed out',
+                error='Connection timed out',
+            ),
+        ]
+    )
+
+    return_part = loaded[1].parts[0]
+    assert isinstance(return_part, ToolReturnPart)
+    assert return_part.outcome == 'failed'
+    assert return_part.content == 'Connection timed out'
 
 
 def test_load_tool_kind_falls_back_to_call_claim() -> None:
@@ -2498,11 +2534,13 @@ def test_dump_load_roundtrip_retry_prompt_with_tool() -> None:
     reloaded = AGUIAdapter.load_messages(ag_ui_msgs)
     _sync_timestamps(original, reloaded)
 
-    # RetryPromptPart becomes ToolReturnPart on reload (same tool_call_id mapping)
+    # RetryPromptPart becomes ToolReturnPart on reload (same tool_call_id mapping); the dumped
+    # `ToolMessage.error` marks it as a failure, so the outcome doesn't upgrade to 'success'
     assert len(reloaded) == 4
     retry_part = message_part(reloaded, ToolReturnPart, message_index=2)
     assert retry_part.tool_name == 'my_tool'
     assert retry_part.tool_call_id == 'call_1'
+    assert retry_part.outcome == 'failed'
 
 
 def test_dump_load_roundtrip_retry_prompt_without_tool() -> None:


### PR DESCRIPTION
- Closes #5870

`AGUIAdapter` now uses the spec-level `ToolMessage.error` slot for tool failure state, in both directions:

- **Dump:** a `ToolReturnPart` with `outcome='failed'` or `'denied'` sets `error` on the emitted `ToolMessage` (in addition to the existing `encrypted_value` outcome claim), so AG-UI clients and pre-0.1.11 versions see the error state instead of a clean success.
- **Load:** a `ToolMessage` with `error` set reloads as `outcome='failed'` (or the exact outcome when the `encrypted_value` claim is present) instead of hard-defaulting to `'success'`. This also fixes the `RetryPromptPart` dump path, whose `error` was previously ignored on reload.

Net effect: failed/denied outcomes now survive round-trips on any ag-ui-protocol version (`'denied'` degrades to `'failed'` below 0.1.11), and client-reported tool errors are no longer upgraded to successes. `dump_messages` docstring updated accordingly.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

LG Richard


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

