### PR TITLE
feat: export PendingMessage and AgentInstructions from public modules

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/__init__.py
@@ -1,6 +1,8 @@
 from importlib.metadata import version as _metadata_version
 
 from ._template import TemplateStr
+from ._enqueue import PendingMessage
+from ._instructions import AgentInstructions
 from .agent import (
     Agent,
     AgentModelSettings,
@@ -176,6 +178,8 @@ __all__ = (
     'ModelRequestNode',
     'UserPromptNode',
     'capture_run_messages',
+    'PendingMessage',
+    'AgentInstructions',
     'InstrumentationSettings',
     # embeddings
     'Embedder',

--- a/pydantic_ai_slim/pydantic_ai/agent/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/agent/__init__.py
@@ -133,6 +133,7 @@ __all__ = (
     'UserPromptNode',
     'WrapperAgent',
     'capture_run_messages',
+    'AgentInstructions',
     'PydanticAIDeprecationWarning',
     'ToolsPrepareFunc',
 )


### PR DESCRIPTION
## Summary
`PendingMessage` and `AgentInstructions` already appear in **public** API signatures:

- `AgentRun.pending_messages` → `list[PendingMessage]`
- `AbstractCapability.get_instructions` → `AgentInstructions[...] | None`

…but were only importable from private modules (`pydantic_ai._enqueue`, `pydantic_ai._instructions`).

## Change
- Re-export `PendingMessage` and `AgentInstructions` from `pydantic_ai`
- Also list `AgentInstructions` in `pydantic_ai.agent.__all__` (already imported there)

Same treatment as `HistoryProcessor` in #6346.

## Test plan
```python
from pydantic_ai import PendingMessage, AgentInstructions
from pydantic_ai.agent import AgentInstructions as AI2
```

Closes #6589.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

