### PR TITLE
Fix hosted `tool_search` replay with null call IDs

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -4784,7 +4784,8 @@ def _lacks_tool_search_output_identity(part: NativeToolSearchReturnPart) -> bool
     one proven against the live API for such histories; fabricating an output item
     risks colliding with server-side state the call already references.
     """
-    return 'id' not in (part.provider_details or {})
+    output_id = (part.provider_details or {}).get('id')
+    return not (isinstance(output_id, str) and output_id)
 
 
 def _build_tool_search_output_param(

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3704,6 +3704,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
             # `TextPart.provider_details` on `output_text.done`.
             _phase_by_item: dict[str, Literal['commentary', 'final_answer']] = {}
             mcp_list_tools_return_ids: set[str] = set()
+
             if self._provider_timestamp is not None:  # pragma: no branch
                 self.provider_details = {'timestamp': self._provider_timestamp}
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2994,12 +2994,12 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     from_same_provider = item.provider_name == self.system or (
                         item.provider_name is None and message.provider_name == self.system
                     )
-                    # Two distinct gates. `should_send_item_id` controls echoing server item IDs
-                    # (`rs_...`, `ts_...`) back to OpenAI; for most native tool items the ID *is*
-                    # the replay payload (their state lives server-side), so it also decides
-                    # whether those items are sent at all. Hosted tool-search items carry their
-                    # state inline, so they replay on `from_same_provider` alone and this flag
-                    # only strips their IDs (see the `openai_send_reasoning_ids` docstring).
+                    # Two distinct gates. For native tool items whose state lives server-side
+                    # (web search, code interpreter, image generation, MCP), the item ID *is*
+                    # the replay payload, so `should_send_item_id` decides whether those items
+                    # are sent at all. Hosted tool-search items carry their state inline, so
+                    # they replay on `from_same_provider` alone and this flag only strips their
+                    # IDs (see the `openai_send_reasoning_ids` docstring).
                     should_send_item_id = send_item_ids and from_same_provider
 
                     if isinstance(item, TextPart):

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2079,6 +2079,23 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         items: list[ModelResponsePart] = []
         refusal_text: str | None = None
         unambiguous_tool_search_output = _unambiguous_null_id_tool_search_output(response)
+        server_tool_search_call_ids = {
+            item.call_id or item.id
+            for item in response.output
+            if isinstance(item, responses.ResponseToolSearchCall) and item.execution == 'server'
+        }
+        tool_search_outputs = {
+            item.call_id: item
+            for item in response.output
+            if isinstance(item, responses.ResponseToolSearchOutputItem)
+            and item.execution == 'server'
+            and item.call_id is not None
+            and item.call_id in server_tool_search_call_ids
+        }
+        if unambiguous_tool_search_output is not None:
+            output_item, call_id = unambiguous_tool_search_output
+            tool_search_outputs[call_id] = output_item
+        paired_tool_search_output_ids = {item.id for item in tool_search_outputs.values()}
         for item in response.output:
             if isinstance(item, responses.ResponseReasoningItem):
                 signature = item.encrypted_content
@@ -2173,18 +2190,13 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     # `ToolReturnPart` is produced by the tool runner, not here.
                     items.append(_map_client_tool_search_call(item, self.system))
                 else:
-                    items.append(_map_tool_search_call(item, self.system))
+                    call_part = _map_tool_search_call(item, self.system)
+                    items.append(call_part)
+                    if output_item := tool_search_outputs.get(call_part.tool_call_id):
+                        items.append(_build_tool_search_return_part(call_part.tool_call_id, output_item, self.system))
             elif isinstance(item, responses.ResponseToolSearchOutputItem):
-                if item.execution == 'server':
-                    inferred_call_id = (
-                        unambiguous_tool_search_output[1]
-                        if unambiguous_tool_search_output is not None
-                        and unambiguous_tool_search_output[0].id == item.id
-                        else None
-                    )
-                    items.append(
-                        _build_tool_search_return_part(item.call_id or inferred_call_id or item.id, item, self.system)
-                    )
+                if item.execution == 'server' and item.id not in paired_tool_search_output_ids:
+                    items.append(_build_tool_search_return_part(item.call_id or item.id, item, self.system))
             elif isinstance(item, responses.response_output_item.ImageGenerationCall):
                 call_part, return_part, file_part = _map_image_generation_tool_call(item, self.system)
                 items.append(call_part)

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -648,6 +648,7 @@ class OpenAIResponsesModelSettings(OpenAIChatModelSettings, total=False):
     for more details.
     """
 
+    # TODO(v3): rename to `openai_send_item_ids`; this gates far more than reasoning IDs (see docstring).
     openai_send_reasoning_ids: bool
     """Whether to send the unique IDs of reasoning, text, and function call parts from the message history to the model. Enabled by default for reasoning models.
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2078,25 +2078,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         """Process a non-streamed response, and prepare a message to return."""
         items: list[ModelResponsePart] = []
         refusal_text: str | None = None
-        null_id_tool_search_calls = [
-            output_item
-            for output_item in response.output
-            if isinstance(output_item, responses.ResponseToolSearchCall)
-            and output_item.execution == 'server'
-            and output_item.call_id is None
-        ]
-        null_id_tool_search_outputs = [
-            output_item
-            for output_item in response.output
-            if isinstance(output_item, responses.ResponseToolSearchOutputItem)
-            and output_item.execution == 'server'
-            and output_item.call_id is None
-        ]
-        null_id_tool_search_call_id = (
-            null_id_tool_search_calls[0].id
-            if len(null_id_tool_search_calls) == len(null_id_tool_search_outputs) == 1
-            else None
-        )
+        unambiguous_tool_search_output = _unambiguous_null_id_tool_search_output(response)
         for item in response.output:
             if isinstance(item, responses.ResponseReasoningItem):
                 signature = item.encrypted_content
@@ -2194,10 +2176,14 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     items.append(_map_tool_search_call(item, self.system))
             elif isinstance(item, responses.ResponseToolSearchOutputItem):
                 if item.execution == 'server':
+                    inferred_call_id = (
+                        unambiguous_tool_search_output[1]
+                        if unambiguous_tool_search_output is not None
+                        and unambiguous_tool_search_output[0].id == item.id
+                        else None
+                    )
                     items.append(
-                        _build_tool_search_return_part(
-                            item.call_id or null_id_tool_search_call_id or item.id, item, self.system
-                        )
+                        _build_tool_search_return_part(item.call_id or inferred_call_id or item.id, item, self.system)
                     )
             elif isinstance(item, responses.response_output_item.ImageGenerationCall):
                 call_part, return_part, file_part = _map_image_generation_tool_call(item, self.system)
@@ -3175,7 +3161,11 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                     openai_messages.append(mcp_call_item)
 
                     elif isinstance(item, NativeToolReturnPart):
-                        if from_same_provider and isinstance(item, NativeToolSearchReturnPart):
+                        if (
+                            from_same_provider
+                            and isinstance(item, NativeToolSearchReturnPart)
+                            and not _is_legacy_synthetic_tool_search_return(item)
+                        ):
                             call_id, status, provider_details = _tool_search_replay_details(item)
                             tool_search_output = _build_tool_search_output_param(
                                 item,
@@ -3702,9 +3692,6 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
             # `TextPart.provider_details` on `output_text.done`.
             _phase_by_item: dict[str, Literal['commentary', 'final_answer']] = {}
             mcp_list_tools_return_ids: set[str] = set()
-            pending_null_id_tool_search_calls: list[str] = []
-            tool_search_output_call_ids: dict[str, str] = {}
-
             if self._provider_timestamp is not None:  # pragma: no branch
                 self.provider_details = {'timestamp': self._provider_timestamp}
 
@@ -3726,6 +3713,22 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                     # `in_progress`/`queued`) or only reaches a terminal event. `cancel_suspended_response`
                     # relies on it to cancel the server-side job.
                     self._track_background(chunk.response)
+                if (
+                    isinstance(
+                        chunk,
+                        (
+                            responses.ResponseCompletedEvent,
+                            responses.ResponseFailedEvent,
+                            responses.ResponseIncompleteEvent,
+                        ),
+                    )
+                    and (unambiguous_output := _unambiguous_null_id_tool_search_output(chunk.response)) is not None
+                ):
+                    output_item, call_id = unambiguous_output
+                    yield self._parts_manager.handle_part(
+                        vendor_part_id=f'{output_item.id}-return',
+                        part=_build_tool_search_return_part(call_id, output_item, self.provider_name),
+                    )
                 # NOTE: You can inspect the builtin tools used checking the `ResponseCompletedEvent`.
                 if isinstance(chunk, responses.ResponseCompletedEvent):
                     # Only the return part is backfilled; the call part is already emitted via `output_item.added`.
@@ -3831,8 +3834,6 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                             )
                         else:
                             call_part = _map_tool_search_call(chunk.item, self.provider_name)
-                            if chunk.item.call_id is None:
-                                pending_null_id_tool_search_calls.append(call_part.tool_call_id)
                             yield self._parts_manager.handle_part(
                                 vendor_part_id=f'{chunk.item.id}-call', part=replace(call_part, args=None)
                             )
@@ -3842,15 +3843,10 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                             vendor_part_id=f'{chunk.item.id}-call', part=replace(call_part, args=None)
                         )
                     elif isinstance(chunk.item, responses.ResponseToolSearchOutputItem):
-                        # Added carries the full discovered-tools payload; emit the return
-                        # part here. Done repeats the same item — handled as a no-op
-                        # below to avoid double-emission.
-                        call_id = chunk.item.call_id or (
-                            pending_null_id_tool_search_calls.pop()
-                            if len(pending_null_id_tool_search_calls) == 1
-                            else chunk.item.id
-                        )
-                        tool_search_output_call_ids[chunk.item.id] = call_id
+                        # Added carries the discovered-tools payload. Keep its own item
+                        # identity until a terminal response proves a single call/output
+                        # association; Done replaces this part with final status and tools.
+                        call_id = chunk.item.call_id or chunk.item.id
                         yield self._parts_manager.handle_part(
                             vendor_part_id=f'{chunk.item.id}-return',
                             part=_build_tool_search_return_part(call_id, chunk.item, self.provider_name),
@@ -3978,7 +3974,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                             if maybe_event is not None:  # pragma: no branch
                                 yield maybe_event
                     elif isinstance(chunk.item, responses.ResponseToolSearchOutputItem):
-                        call_id = tool_search_output_call_ids.get(chunk.item.id, chunk.item.call_id or chunk.item.id)
+                        call_id = chunk.item.call_id or chunk.item.id
                         yield self._parts_manager.handle_part(
                             vendor_part_id=f'{chunk.item.id}-return',
                             part=_build_tool_search_return_part(call_id, chunk.item, self.provider_name),
@@ -4714,6 +4710,27 @@ def _normalize_tool_search_args(raw: Any) -> ToolSearchArgs:
     raise UnexpectedModelBehavior(f'Unrecognized tool_search arguments shape: {raw!r}')
 
 
+def _unambiguous_null_id_tool_search_output(
+    response: responses.Response,
+) -> tuple[responses.ResponseToolSearchOutputItem, str] | None:
+    """Associate hosted null-ID items only when the whole response has one of each."""
+    calls = [
+        item
+        for item in response.output
+        if isinstance(item, responses.ResponseToolSearchCall) and item.execution == 'server' and item.call_id is None
+    ]
+    outputs = [
+        item
+        for item in response.output
+        if isinstance(item, responses.ResponseToolSearchOutputItem)
+        and item.execution == 'server'
+        and item.call_id is None
+    ]
+    if len(calls) == len(outputs) == 1:
+        return outputs[0], calls[0].id
+    return None
+
+
 def _map_tool_search_call(item: ResponseToolSearchCall, provider_name: str) -> NativeToolSearchCallPart:
     """Map an OpenAI server-executed tool-search call without fabricating its output."""
     call_id = item.call_id or item.id
@@ -4738,6 +4755,13 @@ def _tool_search_replay_details(
     if status not in ('in_progress', 'completed', 'incomplete'):
         status = 'completed'
     return call_id, status, provider_details
+
+
+def _is_legacy_synthetic_tool_search_return(part: NativeToolSearchReturnPart) -> bool:
+    """Identify pre-fix empty placeholders that did not come from an output item."""
+    provider_details = part.provider_details or {}
+    has_output_identity = any(key in provider_details for key in ('id', 'call_id', 'execution'))
+    return not part.discovered_tools and not has_output_identity
 
 
 def _build_tool_search_output_param(

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3187,7 +3187,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                 model_request_parameters,
                                 self._map_tool_definition,
                             )
-                            output_id = provider_details.get('id') if provider_details else None
+                            output_id = provider_details.get('id')
                             if should_send_item_id and isinstance(output_id, str):
                                 tool_search_output['id'] = output_id
                             openai_messages.append(tool_search_output)
@@ -4758,23 +4758,25 @@ def _map_tool_search_call(item: ResponseToolSearchCall, provider_name: str) -> N
 
 def _tool_search_replay_details(
     part: NativeToolCallPart | NativeToolSearchReturnPart,
-) -> tuple[str | None, Literal['in_progress', 'completed', 'incomplete'], dict[str, Any] | None]:
+) -> tuple[str | None, Literal['in_progress', 'completed', 'incomplete'], dict[str, Any]]:
     """Read provider-native tool-search identity and status with backward-compatible defaults."""
-    provider_details = part.provider_details
-    call_id = provider_details.get('call_id', part.tool_call_id) if provider_details else part.tool_call_id
+    details = part.provider_details or {}
+    call_id = details.get('call_id', part.tool_call_id)
     if not isinstance(call_id, str | None):
         call_id = part.tool_call_id
-    status = provider_details.get('status') if provider_details else None
+    status = details.get('status')
     if status not in ('in_progress', 'completed', 'incomplete'):
         status = 'completed'
-    return call_id, status, provider_details
+    return call_id, status, details
 
 
 def _is_legacy_synthetic_tool_search_return(part: NativeToolSearchReturnPart) -> bool:
-    """Identify pre-fix empty placeholders that did not come from an output item."""
-    provider_details = part.provider_details or {}
-    has_output_identity = any(key in provider_details for key in ('id', 'call_id', 'execution'))
-    return not part.discovered_tools and not has_output_identity
+    """Identify pre-fix empty placeholders that did not come from an output item.
+
+    Parts built from a real `tool_search_output` item always carry its `id` in
+    `provider_details` (see `_build_tool_search_return_part`).
+    """
+    return not part.discovered_tools and 'id' not in (part.provider_details or {})
 
 
 def _build_tool_search_output_param(

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3176,7 +3176,7 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                         if (
                             from_same_provider
                             and isinstance(item, NativeToolSearchReturnPart)
-                            and not _is_legacy_synthetic_tool_search_return(item)
+                            and not _lacks_tool_search_output_identity(item)
                         ):
                             call_id, status, provider_details = _tool_search_replay_details(item)
                             tool_search_output = _build_tool_search_output_param(
@@ -3859,11 +3859,13 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                         # Added carries the discovered-tools payload. Keep its own item
                         # identity until a terminal response proves a single call/output
                         # association; Done replaces this part with final status and tools.
-                        call_id = chunk.item.call_id or chunk.item.id
-                        yield self._parts_manager.handle_part(
-                            vendor_part_id=f'{chunk.item.id}-return',
-                            part=_build_tool_search_return_part(call_id, chunk.item, self.provider_name),
-                        )
+                        # Client-execution outputs are dropped for parity with `_process_response`.
+                        if chunk.item.execution == 'server':
+                            call_id = chunk.item.call_id or chunk.item.id
+                            yield self._parts_manager.handle_part(
+                                vendor_part_id=f'{chunk.item.id}-return',
+                                part=_build_tool_search_return_part(call_id, chunk.item, self.provider_name),
+                            )
                     elif isinstance(chunk.item, responses.ResponseCodeInterpreterToolCall):
                         call_part, _, _ = _map_code_interpreter_tool_call(chunk.item, self.provider_name)
 
@@ -3987,11 +3989,13 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                             if maybe_event is not None:  # pragma: no branch
                                 yield maybe_event
                     elif isinstance(chunk.item, responses.ResponseToolSearchOutputItem):
-                        call_id = chunk.item.call_id or chunk.item.id
-                        yield self._parts_manager.handle_part(
-                            vendor_part_id=f'{chunk.item.id}-return',
-                            part=_build_tool_search_return_part(call_id, chunk.item, self.provider_name),
-                        )
+                        # Same server-execution gate as the Added handler and `_process_response`.
+                        if chunk.item.execution == 'server':
+                            call_id = chunk.item.call_id or chunk.item.id
+                            yield self._parts_manager.handle_part(
+                                vendor_part_id=f'{chunk.item.id}-return',
+                                part=_build_tool_search_return_part(call_id, chunk.item, self.provider_name),
+                            )
                     elif isinstance(chunk.item, responses.ResponseFileSearchToolCall):
                         call_part, return_part = _map_file_search_tool_call(chunk.item, self.provider_name)
 
@@ -4770,13 +4774,17 @@ def _tool_search_replay_details(
     return call_id, status, details
 
 
-def _is_legacy_synthetic_tool_search_return(part: NativeToolSearchReturnPart) -> bool:
-    """Identify pre-fix empty placeholders that did not come from an output item.
+def _lacks_tool_search_output_identity(part: NativeToolSearchReturnPart) -> bool:
+    """Identify return parts that did not come from a preserved `tool_search_output` item.
 
-    Parts built from a real `tool_search_output` item always carry its `id` in
-    `provider_details` (see `_build_tool_search_return_part`).
+    Parts built from a real output item always carry its `id` in `provider_details`
+    (see `_build_tool_search_return_part`). Parts without it are pre-fix history
+    (only `status` was stashed) or metadata-stripped round-trips. For those, replay
+    falls back to sending the call only, the shape pre-fix code sent and the only
+    one proven against the live API for such histories; fabricating an output item
+    risks colliding with server-side state the call already references.
     """
-    return not part.discovered_tools and 'id' not in (part.provider_details or {})
+    return 'id' not in (part.provider_details or {})
 
 
 def _build_tool_search_output_param(

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -2078,14 +2078,25 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
         """Process a non-streamed response, and prepare a message to return."""
         items: list[ModelResponsePart] = []
         refusal_text: str | None = None
-        # Index tool_search_output items by call_id so we can pair them with the
-        # corresponding tool_search_call when we encounter it (they may come in either
-        # order).
-        tool_search_outputs: dict[str, responses.ResponseToolSearchOutputItem] = {
-            output_item.call_id: output_item
+        null_id_tool_search_calls = [
+            output_item
             for output_item in response.output
-            if isinstance(output_item, responses.ResponseToolSearchOutputItem) and output_item.call_id is not None
-        }
+            if isinstance(output_item, responses.ResponseToolSearchCall)
+            and output_item.execution == 'server'
+            and output_item.call_id is None
+        ]
+        null_id_tool_search_outputs = [
+            output_item
+            for output_item in response.output
+            if isinstance(output_item, responses.ResponseToolSearchOutputItem)
+            and output_item.execution == 'server'
+            and output_item.call_id is None
+        ]
+        null_id_tool_search_call_id = (
+            null_id_tool_search_calls[0].id
+            if len(null_id_tool_search_calls) == len(null_id_tool_search_outputs) == 1
+            else None
+        )
         for item in response.output:
             if isinstance(item, responses.ResponseReasoningItem):
                 signature = item.encrypted_content
@@ -2180,13 +2191,14 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     # `ToolReturnPart` is produced by the tool runner, not here.
                     items.append(_map_client_tool_search_call(item, self.system))
                 else:
-                    output_item = tool_search_outputs.get(item.call_id) if item.call_id else None
-                    call_part, return_part = _map_tool_search_call(item, output_item, self.system)
-                    items.append(call_part)
-                    items.append(return_part)
+                    items.append(_map_tool_search_call(item, self.system))
             elif isinstance(item, responses.ResponseToolSearchOutputItem):
-                # The output item is paired with its call via `tool_search_outputs`; skip here.
-                pass
+                if item.execution == 'server':
+                    items.append(
+                        _build_tool_search_return_part(
+                            item.call_id or null_id_tool_search_call_id or item.id, item, self.system
+                        )
+                    )
             elif isinstance(item, responses.response_output_item.ImageGenerationCall):
                 call_part, return_part, file_part = _map_image_generation_tool_call(item, self.system)
                 items.append(call_part)
@@ -2935,8 +2947,13 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                             # `tool_search_output` so the provider rehydrates the
                             # discovered-tool state tied to the `tool_search_call`.
                             openai_messages.append(
-                                _build_client_tool_search_output_param(
-                                    part, call_id, model_request_parameters, self._map_tool_definition
+                                _build_tool_search_output_param(
+                                    part,
+                                    call_id,
+                                    'client',
+                                    'completed',
+                                    model_request_parameters,
+                                    self._map_tool_definition,
                                 )
                             )
                         else:
@@ -2970,10 +2987,10 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                 file_search_item: responses.ResponseFileSearchToolCallParam | None = None
                 code_interpreter_item: responses.ResponseCodeInterpreterToolCallParam | None = None
                 for item in message.parts:
-                    should_send_item_id = send_item_ids and (
-                        item.provider_name == self.system
-                        or (item.provider_name is None and message.provider_name == self.system)
+                    from_same_provider = item.provider_name == self.system or (
+                        item.provider_name is None and message.provider_name == self.system
                     )
+                    should_send_item_id = send_item_ids and from_same_provider
 
                     if isinstance(item, TextPart):
                         phase = (item.provider_details or {}).get('phase')
@@ -3059,7 +3076,19 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                 param['namespace'] = synthesized_ns
                             openai_messages.append(param)
                     elif isinstance(item, NativeToolCallPart):
-                        if should_send_item_id:  # pragma: no branch
+                        if from_same_provider and item.tool_name == ToolSearchTool.kind and item.tool_call_id:
+                            call_id, status, _ = _tool_search_replay_details(item)
+                            tool_search_call = responses.response_input_item_param.ToolSearchCall(
+                                call_id=call_id,
+                                arguments=item.args_as_dict() or {},
+                                type='tool_search_call',
+                                execution='server',
+                                status=status,
+                            )
+                            if should_send_item_id and item.id:
+                                tool_search_call['id'] = item.id
+                            openai_messages.append(tool_search_call)
+                        elif should_send_item_id:  # pragma: no branch
                             if (
                                 item.tool_name == CodeExecutionTool.kind
                                 and item.tool_call_id
@@ -3114,17 +3143,6 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                     },
                                 )
                                 openai_messages.append(image_generation_item)
-                            elif item.tool_name == ToolSearchTool.kind and item.tool_call_id:
-                                openai_messages.append(
-                                    responses.response_input_item_param.ToolSearchCall(
-                                        id=item.id or item.tool_call_id,
-                                        call_id=item.tool_call_id,
-                                        arguments=item.args_as_dict() or {},
-                                        type='tool_search_call',
-                                        execution='server',
-                                        status='completed',
-                                    )
-                                )
                             elif (  # pragma: no branch
                                 item.tool_name.startswith(MCPServerTool.kind)
                                 and item.tool_call_id
@@ -3157,7 +3175,21 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                     openai_messages.append(mcp_call_item)
 
                     elif isinstance(item, NativeToolReturnPart):
-                        if should_send_item_id:  # pragma: no branch
+                        if from_same_provider and isinstance(item, NativeToolSearchReturnPart):
+                            call_id, status, provider_details = _tool_search_replay_details(item)
+                            tool_search_output = _build_tool_search_output_param(
+                                item,
+                                call_id,
+                                'server',
+                                status,
+                                model_request_parameters,
+                                self._map_tool_definition,
+                            )
+                            output_id = provider_details.get('id') if provider_details else None
+                            if should_send_item_id and isinstance(output_id, str):
+                                tool_search_output['id'] = output_id
+                            openai_messages.append(tool_search_output)
+                        elif should_send_item_id:  # pragma: no branch
                             status = item.content.get('status') if _is_str_dict(item.content) else None
                             kind_to_item = {
                                 CodeExecutionTool.kind: code_interpreter_item,
@@ -3171,11 +3203,6 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                                 pass
                             elif item.tool_name.startswith(MCPServerTool.kind):
                                 # MCP call result does not need to be sent back, just the fields off of `NativeToolCallPart`.
-                                pass
-                            elif item.tool_name == ToolSearchTool.kind:  # pragma: no branch
-                                # Tool search output (discovered tool definitions) is
-                                # reconstructed server-side from the `tool_search_call` —
-                                # same pattern as web search — so nothing to send back.
                                 pass
                     elif isinstance(item, FilePart):
                         # This was generated by the `ImageGenerationTool` or `CodeExecutionTool`,
@@ -3675,6 +3702,8 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
             # `TextPart.provider_details` on `output_text.done`.
             _phase_by_item: dict[str, Literal['commentary', 'final_answer']] = {}
             mcp_list_tools_return_ids: set[str] = set()
+            pending_null_id_tool_search_calls: list[str] = []
+            tool_search_output_call_ids: dict[str, str] = {}
 
             if self._provider_timestamp is not None:  # pragma: no branch
                 self.provider_details = {'timestamp': self._provider_timestamp}
@@ -3801,7 +3830,9 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                                 provider_name=self.provider_name,
                             )
                         else:
-                            call_part, _ = _map_tool_search_call(chunk.item, None, self.provider_name)
+                            call_part = _map_tool_search_call(chunk.item, self.provider_name)
+                            if chunk.item.call_id is None:
+                                pending_null_id_tool_search_calls.append(call_part.tool_call_id)
                             yield self._parts_manager.handle_part(
                                 vendor_part_id=f'{chunk.item.id}-call', part=replace(call_part, args=None)
                             )
@@ -3814,12 +3845,15 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                         # Added carries the full discovered-tools payload; emit the return
                         # part here. Done repeats the same item — handled as a no-op
                         # below to avoid double-emission.
-                        call_id = chunk.item.call_id or chunk.item.id
+                        call_id = chunk.item.call_id or (
+                            pending_null_id_tool_search_calls.pop()
+                            if len(pending_null_id_tool_search_calls) == 1
+                            else chunk.item.id
+                        )
+                        tool_search_output_call_ids[chunk.item.id] = call_id
                         yield self._parts_manager.handle_part(
                             vendor_part_id=f'{chunk.item.id}-return',
-                            part=_build_tool_search_return_part(
-                                call_id, chunk.item.status or 'completed', chunk.item, self.provider_name
-                            ),
+                            part=_build_tool_search_return_part(call_id, chunk.item, self.provider_name),
                         )
                     elif isinstance(chunk.item, responses.ResponseCodeInterpreterToolCall):
                         call_part, _, _ = _map_code_interpreter_tool_call(chunk.item, self.provider_name)
@@ -3934,18 +3968,21 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                             if maybe_event is not None:  # pragma: no branch
                                 yield maybe_event
                         else:
-                            call_part, _ = _map_tool_search_call(chunk.item, None, self.provider_name)
+                            call_part = _map_tool_search_call(chunk.item, self.provider_name)
 
                             maybe_event = self._parts_manager.handle_tool_call_delta(
                                 vendor_part_id=f'{chunk.item.id}-call',
                                 args=cast('str | dict[str, Any] | None', call_part.args),
+                                provider_details=call_part.provider_details,
                             )
                             if maybe_event is not None:  # pragma: no branch
                                 yield maybe_event
                     elif isinstance(chunk.item, responses.ResponseToolSearchOutputItem):
-                        # Already emitted on the matching Added event — the Done payload
-                        # is a duplicate.
-                        pass
+                        call_id = tool_search_output_call_ids.get(chunk.item.id, chunk.item.call_id or chunk.item.id)
+                        yield self._parts_manager.handle_part(
+                            vendor_part_id=f'{chunk.item.id}-return',
+                            part=_build_tool_search_return_part(call_id, chunk.item, self.provider_name),
+                        )
                     elif isinstance(chunk.item, responses.ResponseFileSearchToolCall):
                         call_part, return_part = _map_file_search_tool_call(chunk.item, self.provider_name)
 
@@ -4677,37 +4714,45 @@ def _normalize_tool_search_args(raw: Any) -> ToolSearchArgs:
     raise UnexpectedModelBehavior(f'Unrecognized tool_search arguments shape: {raw!r}')
 
 
-def _map_tool_search_call(
-    item: ResponseToolSearchCall,
-    output_item: responses.ResponseToolSearchOutputItem | None,
-    provider_name: str,
-) -> tuple[NativeToolSearchCallPart, NativeToolSearchReturnPart]:
-    """Map OpenAI native tool search (server-executed) into typed builtin call/return parts.
-
-    Mirrors `_map_web_search_tool_call`: call and result are both server-side, so we
-    emit both parts in the same response.
-    """
+def _map_tool_search_call(item: ResponseToolSearchCall, provider_name: str) -> NativeToolSearchCallPart:
+    """Map an OpenAI server-executed tool-search call without fabricating its output."""
     call_id = item.call_id or item.id
-    call_part = NativeToolSearchCallPart(
+    return NativeToolSearchCallPart(
         provider_name=provider_name,
         args=_normalize_tool_search_args(item.arguments),
         tool_call_id=call_id,
         id=item.id,
+        provider_details={'call_id': item.call_id, 'execution': item.execution, 'status': item.status},
     )
-    return call_part, _build_tool_search_return_part(call_id, item.status, output_item, provider_name)
 
 
-def _build_client_tool_search_output_param(
-    part: ToolSearchReturnPart,
-    call_id: str,
+def _tool_search_replay_details(
+    part: NativeToolCallPart | NativeToolSearchReturnPart,
+) -> tuple[str | None, Literal['in_progress', 'completed', 'incomplete'], dict[str, Any] | None]:
+    """Read provider-native tool-search identity and status with backward-compatible defaults."""
+    provider_details = part.provider_details
+    call_id = provider_details.get('call_id', part.tool_call_id) if provider_details else part.tool_call_id
+    if not isinstance(call_id, str | None):
+        call_id = part.tool_call_id
+    status = provider_details.get('status') if provider_details else None
+    if status not in ('in_progress', 'completed', 'incomplete'):
+        status = 'completed'
+    return call_id, status, provider_details
+
+
+def _build_tool_search_output_param(
+    part: ToolSearchReturnPart | NativeToolSearchReturnPart,
+    call_id: str | None,
+    execution: Literal['server', 'client'],
+    status: Literal['in_progress', 'completed', 'incomplete'],
     model_request_parameters: ModelRequestParameters,
     map_tool_definition: Callable[[ToolDefinition], responses.FunctionToolParam],
 ) -> ResponseToolSearchOutputItemParamParam:
-    """Build a `tool_search_output` replay param for a local `search_tools` return.
+    """Build a `tool_search_output` replay param from normalized discovery state.
 
     Looks up each discovered tool name in `function_tools` and emits a
     `FunctionToolParam` so OpenAI sees the same `Tool` definitions it originally
-    loaded in the prior turn — the shape of `ResponseToolSearchOutputItemParamParam`.
+    loaded in the prior turn. The shape is `ResponseToolSearchOutputItemParamParam`.
     Reads the typed
     [`ToolSearchReturnContent`][pydantic_ai.messages.ToolSearchReturnContent]
     off of `part.content`; the tool-return value is the contract. Uses the same
@@ -4723,10 +4768,10 @@ def _build_client_tool_search_output_param(
     ]
     return {
         'type': 'tool_search_output',
-        'execution': 'client',
+        'execution': execution,
         'tools': tool_params,
         'call_id': call_id,
-        'status': 'completed',
+        'status': status,
     }
 
 
@@ -4763,33 +4808,36 @@ def _map_client_tool_search_call(item: ResponseToolSearchCall, provider_name: st
 
 def _build_tool_search_return_part(
     call_id: str,
-    status: str,
-    output_item: responses.ResponseToolSearchOutputItem | None,
+    output_item: responses.ResponseToolSearchOutputItem,
     provider_name: str,
 ) -> NativeToolSearchReturnPart:
-    """Build the typed return part for an OpenAI tool search, with or without output.
+    """Build the typed return part for an actual OpenAI tool-search output.
 
     Writes the cross-provider
     [`ToolSearchReturnContent`][pydantic_ai.messages.ToolSearchReturnContent]
     to `content` (carrying only the matched tool names — the full
     [`ToolDefinition`][pydantic_ai.tools.ToolDefinition] is injected on the
     next request via defer-loading, so description is redundant here) and
-    stashes the `status` field on `provider_details`.
+    stashes the provider item identity and state on `provider_details` for replay.
     """
     matches: list[ToolSearchMatch] = []
-    if output_item is not None:
-        # `output_item.tools` is a union of OpenAI Responses tool variants; only
-        # function tools carry a stable `name` field. Other variants (file_search,
-        # image generation, etc.) can't appear here in practice but aren't
-        # statically excluded from the union, so we filter by type.
-        for t in output_item.tools:
-            if isinstance(t, responses.FunctionTool):
-                matches.append({'name': t.name})
+    # `output_item.tools` is a union of OpenAI Responses tool variants; only
+    # function tools carry a stable `name` field. Other variants (file_search,
+    # image generation, etc.) can't appear here in practice but aren't
+    # statically excluded from the union, so we filter by type.
+    for t in output_item.tools:
+        if isinstance(t, responses.FunctionTool):
+            matches.append({'name': t.name})
     return NativeToolSearchReturnPart(
         provider_name=provider_name,
         content={'discovered_tools': matches},
         tool_call_id=call_id,
-        provider_details={'status': status},
+        provider_details={
+            'id': output_item.id,
+            'call_id': output_item.call_id,
+            'execution': output_item.execution,
+            'status': output_item.status,
+        },
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -655,6 +655,11 @@ class OpenAIResponsesModelSettings(OpenAIChatModelSettings, total=False):
     if the message history you're sending does not match exactly what was received from the Responses API in a previous response,
     for example if you're using a [history processor](../../message-history.md#processing-message-history).
     In that case, you'll want to disable this.
+
+    Most server-side tool items (web search, code interpreter, image generation) are replayed *by* their ID,
+    so disabling this also stops them from being sent back entirely. Hosted tool-search items are the exception:
+    they carry their state (the query and discovered tools) inline, so they are still replayed with the IDs
+    omitted, and previously discovered tools stay callable.
     """
 
     openai_truncation: Literal['disabled', 'auto']
@@ -2988,6 +2993,12 @@ class OpenAIResponsesModel(Model[AsyncOpenAI]):
                     from_same_provider = item.provider_name == self.system or (
                         item.provider_name is None and message.provider_name == self.system
                     )
+                    # Two distinct gates. `should_send_item_id` controls echoing server item IDs
+                    # (`rs_...`, `ts_...`) back to OpenAI; for most native tool items the ID *is*
+                    # the replay payload (their state lives server-side), so it also decides
+                    # whether those items are sent at all. Hosted tool-search items carry their
+                    # state inline, so they replay on `from_same_provider` alone and this flag
+                    # only strips their IDs (see the `openai_send_reasoning_ids` docstring).
                     should_send_item_id = send_item_ids and from_same_provider
 
                     if isinstance(item, TextPart):

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -3795,7 +3795,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                         self.provider_response_id = chunk.response.id
                     self._store_conversation_id(chunk.response)
 
-                elif isinstance(chunk, responses.ResponseFailedEvent):  # pragma: no cover
+                elif isinstance(chunk, responses.ResponseFailedEvent):
                     self._usage += self._map_usage(chunk.response)
                     self._set_state(chunk.response.status)
 
@@ -3814,7 +3814,7 @@ class OpenAIResponsesStreamedResponse(StreamedResponse):
                     self._usage += self._map_usage(chunk.response)
                     self._set_state(chunk.response.status)
 
-                elif isinstance(chunk, responses.ResponseIncompleteEvent):  # pragma: no cover
+                elif isinstance(chunk, responses.ResponseIncompleteEvent):
                     self._usage += self._map_usage(chunk.response)
                     self._set_state(chunk.response.status)
 

--- a/tests/cassettes/test_tool_search/test_openai_hosted_tool_search_stateless_continuation.yaml
+++ b/tests/cassettes/test_tool_search/test_openai_hosted_tool_search_stateless_continuation.yaml
@@ -1,0 +1,589 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '546'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: Use hosted tool search to load get_exchange_rate. Do not call it yet. Reply only with "loaded".
+        role: user
+      model: gpt-5.4
+      stream: false
+      tool_choice: auto
+      tools:
+      - type: tool_search
+      - defer_loading: true
+        description: Look up an exchange rate.
+        name: get_exchange_rate
+        parameters:
+          additionalProperties: false
+          properties:
+            pair:
+              type: string
+          required:
+          - pair
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '2647'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '1490'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1784534985
+      created_at: 1784534984
+      error: null
+      frequency_penalty: 0.0
+      id: resp_0e6a0bc81f6d8648006a5dd7c81aec819aac90d05ad9e9c63e
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.4-2026-03-05
+      moderation: null
+      object: response
+      output:
+      - arguments:
+          paths:
+          - get_exchange_rate
+        call_id: null
+        execution: server
+        id: tsc_0e6a0bc81f6d8648006a5dd7c8d3ec819a904686d7dca65cb4
+        status: completed
+        type: tool_search_call
+      - call_id: null
+        execution: server
+        id: tso_0e6a0bc81f6d8648006a5dd7c8eb74819a96ec6c4cfaef7135
+        status: completed
+        tools:
+        - defer_loading: true
+          description: Look up an exchange rate.
+          name: get_exchange_rate
+          output_schema: null
+          parameters:
+            additionalProperties: false
+            properties:
+              pair:
+                type: string
+            required:
+            - pair
+            type: object
+          strict: true
+          type: function
+        type: tool_search_output
+      - content:
+        - annotations: []
+          logprobs: []
+          text: loaded
+          type: output_text
+        id: msg_0e6a0bc81f6d8648006a5dd7c942d8819aa78a5c7a2b0b9618
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        context: current_turn
+        effort: none
+        mode: standard
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools:
+      - defer_loading: true
+        description: Look up an exchange rate.
+        name: get_exchange_rate
+        output_schema: null
+        parameters:
+          additionalProperties: false
+          properties:
+            pair:
+              type: string
+          required:
+          - pair
+          type: object
+        strict: true
+        type: function
+      - description: null
+        parameters: null
+        type: tool_search
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 570
+        input_tokens_details:
+          cache_write_tokens: 0
+          cached_tokens: 0
+        output_tokens: 26
+        output_tokens_details:
+          reasoning_tokens: 21
+        total_tokens: 596
+      user: null
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '1515'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: Use hosted tool search to load get_exchange_rate. Do not call it yet. Reply only with "loaded".
+        role: user
+      - arguments:
+          queries:
+          - get_exchange_rate
+        call_id: null
+        execution: server
+        id: tsc_0e6a0bc81f6d8648006a5dd7c8d3ec819a904686d7dca65cb4
+        status: completed
+        type: tool_search_call
+      - call_id: null
+        execution: server
+        id: tso_0e6a0bc81f6d8648006a5dd7c8eb74819a96ec6c4cfaef7135
+        status: completed
+        tools:
+        - defer_loading: true
+          description: Look up an exchange rate.
+          name: get_exchange_rate
+          parameters:
+            additionalProperties: false
+            properties:
+              pair:
+                type: string
+            required:
+            - pair
+            type: object
+          strict: true
+          type: function
+        type: tool_search_output
+      - content:
+        - annotations: []
+          text: loaded
+          type: output_text
+        id: msg_0e6a0bc81f6d8648006a5dd7c942d8819aa78a5c7a2b0b9618
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      - content: Call get_exchange_rate with pair="USD/EUR". Do not search again.
+        role: user
+      model: gpt-5.4
+      stream: false
+      tool_choice: auto
+      tools:
+      - type: tool_search
+      - defer_loading: true
+        description: Look up an exchange rate.
+        name: get_exchange_rate
+        parameters:
+          additionalProperties: false
+          properties:
+            pair:
+              type: string
+          required:
+          - pair
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '2082'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '3024'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1784534988
+      created_at: 1784534986
+      error: null
+      frequency_penalty: 0.0
+      id: resp_0e6a0bc81f6d8648006a5dd7ca082c819aa0f46f329a2ffd5a
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.4-2026-03-05
+      moderation: null
+      object: response
+      output:
+      - arguments: '{"pair":"USD/EUR"}'
+        call_id: call_CyqoMGFYNESobWGrep6xELj2
+        id: fc_0e6a0bc81f6d8648006a5dd7cab830819aaf0ece9351ad0579
+        name: get_exchange_rate
+        namespace: get_exchange_rate
+        status: completed
+        type: function_call
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        context: current_turn
+        effort: none
+        mode: standard
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools:
+      - description: null
+        parameters: null
+        type: tool_search
+      - description: Look up an exchange rate.
+        name: get_exchange_rate
+        tools:
+        - description: Look up an exchange rate.
+          name: get_exchange_rate
+          output_schema: null
+          parameters:
+            additionalProperties: false
+            properties:
+              pair:
+                type: string
+            required:
+            - pair
+            type: object
+          strict: true
+          type: function
+        type: namespace
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 220
+        input_tokens_details:
+          cache_write_tokens: 0
+          cached_tokens: 0
+        output_tokens: 22
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 242
+      user: null
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '1856'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: Use hosted tool search to load get_exchange_rate. Do not call it yet. Reply only with "loaded".
+        role: user
+      - arguments:
+          queries:
+          - get_exchange_rate
+        call_id: null
+        execution: server
+        id: tsc_0e6a0bc81f6d8648006a5dd7c8d3ec819a904686d7dca65cb4
+        status: completed
+        type: tool_search_call
+      - call_id: null
+        execution: server
+        id: tso_0e6a0bc81f6d8648006a5dd7c8eb74819a96ec6c4cfaef7135
+        status: completed
+        tools:
+        - defer_loading: true
+          description: Look up an exchange rate.
+          name: get_exchange_rate
+          parameters:
+            additionalProperties: false
+            properties:
+              pair:
+                type: string
+            required:
+            - pair
+            type: object
+          strict: true
+          type: function
+        type: tool_search_output
+      - content:
+        - annotations: []
+          text: loaded
+          type: output_text
+        id: msg_0e6a0bc81f6d8648006a5dd7c942d8819aa78a5c7a2b0b9618
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      - content: Call get_exchange_rate with pair="USD/EUR". Do not search again.
+        role: user
+      - arguments: '{"pair":"USD/EUR"}'
+        call_id: call_CyqoMGFYNESobWGrep6xELj2
+        id: fc_0e6a0bc81f6d8648006a5dd7cab830819aaf0ece9351ad0579
+        name: get_exchange_rate
+        namespace: get_exchange_rate
+        type: function_call
+      - call_id: call_CyqoMGFYNESobWGrep6xELj2
+        output: 'USD/EUR: 0.92'
+        type: function_call_output
+      model: gpt-5.4
+      stream: false
+      tool_choice: auto
+      tools:
+      - type: tool_search
+      - defer_loading: true
+        description: Look up an exchange rate.
+        name: get_exchange_rate
+        parameters:
+          additionalProperties: false
+          properties:
+            pair:
+              type: string
+          required:
+          - pair
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '2075'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '1336'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1784534990
+      created_at: 1784534989
+      error: null
+      frequency_penalty: 0.0
+      id: resp_0e6a0bc81f6d8648006a5dd7cd8838819a8457a786decb28c7
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.4-2026-03-05
+      moderation: null
+      object: response
+      output:
+      - content:
+        - annotations: []
+          logprobs: []
+          text: 'USD/EUR: 0.92'
+          type: output_text
+        id: msg_0e6a0bc81f6d8648006a5dd7ce45f4819ab50bb11510b25898
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        context: current_turn
+        effort: none
+        mode: standard
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools:
+      - description: null
+        parameters: null
+        type: tool_search
+      - description: Look up an exchange rate.
+        name: get_exchange_rate
+        tools:
+        - description: Look up an exchange rate.
+          name: get_exchange_rate
+          output_schema: null
+          parameters:
+            additionalProperties: false
+            properties:
+              pair:
+                type: string
+            required:
+            - pair
+            type: object
+          strict: true
+          type: function
+        type: namespace
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 264
+        input_tokens_details:
+          cache_write_tokens: 0
+          cached_tokens: 0
+        output_tokens: 12
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 276
+      user: null
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_tool_search/test_openai_hosted_tool_search_stateless_continuation_without_item_ids.yaml
+++ b/tests/cassettes/test_tool_search/test_openai_hosted_tool_search_stateless_continuation_without_item_ids.yaml
@@ -1,0 +1,572 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '546'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: Use hosted tool search to load get_exchange_rate. Do not call it yet. Reply only with "loaded".
+        role: user
+      model: gpt-5.4
+      stream: false
+      tool_choice: auto
+      tools:
+      - type: tool_search
+      - defer_loading: true
+        description: Look up an exchange rate.
+        name: get_exchange_rate
+        parameters:
+          additionalProperties: false
+          properties:
+            pair:
+              type: string
+          required:
+          - pair
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '2647'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '1381'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1784608874
+      created_at: 1784608872
+      error: null
+      frequency_penalty: 0.0
+      id: resp_0638f0bdb2b29dee006a5ef868cbd4819aac88ca9f87f53636
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.4-2026-03-05
+      moderation: null
+      object: response
+      output:
+      - arguments:
+          paths:
+          - get_exchange_rate
+        call_id: null
+        execution: server
+        id: tsc_0638f0bdb2b29dee006a5ef8695c90819ab439a5999c0a4214
+        status: completed
+        type: tool_search_call
+      - call_id: null
+        execution: server
+        id: tso_0638f0bdb2b29dee006a5ef8697e98819a84d00c05e9b6c650
+        status: completed
+        tools:
+        - defer_loading: true
+          description: Look up an exchange rate.
+          name: get_exchange_rate
+          output_schema: null
+          parameters:
+            additionalProperties: false
+            properties:
+              pair:
+                type: string
+            required:
+            - pair
+            type: object
+          strict: true
+          type: function
+        type: tool_search_output
+      - content:
+        - annotations: []
+          logprobs: []
+          text: loaded
+          type: output_text
+        id: msg_0638f0bdb2b29dee006a5ef869cb90819a82b693dbd1723446
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        context: current_turn
+        effort: none
+        mode: standard
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools:
+      - defer_loading: true
+        description: Look up an exchange rate.
+        name: get_exchange_rate
+        output_schema: null
+        parameters:
+          additionalProperties: false
+          properties:
+            pair:
+              type: string
+          required:
+          - pair
+          type: object
+        strict: true
+        type: function
+      - description: null
+        parameters: null
+        type: tool_search
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 570
+        input_tokens_details:
+          cache_write_tokens: 0
+          cached_tokens: 0
+        output_tokens: 26
+        output_tokens_details:
+          reasoning_tokens: 21
+        total_tokens: 596
+      user: null
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '1227'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: Use hosted tool search to load get_exchange_rate. Do not call it yet. Reply only with "loaded".
+        role: user
+      - arguments:
+          queries:
+          - get_exchange_rate
+        call_id: null
+        execution: server
+        status: completed
+        type: tool_search_call
+      - call_id: null
+        execution: server
+        status: completed
+        tools:
+        - defer_loading: true
+          description: Look up an exchange rate.
+          name: get_exchange_rate
+          parameters:
+            additionalProperties: false
+            properties:
+              pair:
+                type: string
+            required:
+            - pair
+            type: object
+          strict: true
+          type: function
+        type: tool_search_output
+      - content: loaded
+        phase: final_answer
+        role: assistant
+      - content: Call get_exchange_rate with pair="USD/EUR". Do not search again.
+        role: user
+      model: gpt-5.4
+      stream: false
+      tool_choice: auto
+      tools:
+      - type: tool_search
+      - defer_loading: true
+        description: Look up an exchange rate.
+        name: get_exchange_rate
+        parameters:
+          additionalProperties: false
+          properties:
+            pair:
+              type: string
+          required:
+          - pair
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '2082'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '1476'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1784608875
+      created_at: 1784608874
+      error: null
+      frequency_penalty: 0.0
+      id: resp_0ec1d76061a7f8a5006a5ef86aadf0819bb4e38d8a6aa79e75
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.4-2026-03-05
+      moderation: null
+      object: response
+      output:
+      - arguments: '{"pair":"USD/EUR"}'
+        call_id: call_L0QXbnYLas6bnb1Ccv58TIsW
+        id: fc_0ec1d76061a7f8a5006a5ef86bd214819b833dd89b6e7bae9f
+        name: get_exchange_rate
+        namespace: get_exchange_rate
+        status: completed
+        type: function_call
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        context: current_turn
+        effort: none
+        mode: standard
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools:
+      - description: null
+        parameters: null
+        type: tool_search
+      - description: Look up an exchange rate.
+        name: get_exchange_rate
+        tools:
+        - description: Look up an exchange rate.
+          name: get_exchange_rate
+          output_schema: null
+          parameters:
+            additionalProperties: false
+            properties:
+              pair:
+                type: string
+            required:
+            - pair
+            type: object
+          strict: true
+          type: function
+        type: namespace
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 220
+        input_tokens_details:
+          cache_write_tokens: 0
+          cached_tokens: 0
+        output_tokens: 22
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 242
+      user: null
+    status:
+      code: 200
+      message: OK
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br
+      connection:
+      - keep-alive
+      content-length:
+      - '1505'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      include:
+      - reasoning.encrypted_content
+      input:
+      - content: Use hosted tool search to load get_exchange_rate. Do not call it yet. Reply only with "loaded".
+        role: user
+      - arguments:
+          queries:
+          - get_exchange_rate
+        call_id: null
+        execution: server
+        status: completed
+        type: tool_search_call
+      - call_id: null
+        execution: server
+        status: completed
+        tools:
+        - defer_loading: true
+          description: Look up an exchange rate.
+          name: get_exchange_rate
+          parameters:
+            additionalProperties: false
+            properties:
+              pair:
+                type: string
+            required:
+            - pair
+            type: object
+          strict: true
+          type: function
+        type: tool_search_output
+      - content: loaded
+        phase: final_answer
+        role: assistant
+      - content: Call get_exchange_rate with pair="USD/EUR". Do not search again.
+        role: user
+      - arguments: '{"pair":"USD/EUR"}'
+        call_id: call_L0QXbnYLas6bnb1Ccv58TIsW
+        name: get_exchange_rate
+        namespace: get_exchange_rate
+        type: function_call
+      - call_id: call_L0QXbnYLas6bnb1Ccv58TIsW
+        output: 'USD/EUR: 0.92'
+        type: function_call_output
+      model: gpt-5.4
+      stream: false
+      tool_choice: auto
+      tools:
+      - type: tool_search
+      - defer_loading: true
+        description: Look up an exchange rate.
+        name: get_exchange_rate
+        parameters:
+          additionalProperties: false
+          properties:
+            pair:
+              type: string
+          required:
+          - pair
+          type: object
+        strict: true
+        type: function
+    uri: https://api.openai.com/v1/responses
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '2075'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '915'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      background: false
+      billing:
+        payer: developer
+      completed_at: 1784608877
+      created_at: 1784608876
+      error: null
+      frequency_penalty: 0.0
+      id: resp_08a7e275f7184d92006a5ef86c78288198ab24b99bd7311090
+      incomplete_details: null
+      instructions: null
+      max_output_tokens: null
+      max_tool_calls: null
+      metadata: {}
+      model: gpt-5.4-2026-03-05
+      moderation: null
+      object: response
+      output:
+      - content:
+        - annotations: []
+          logprobs: []
+          text: 'USD/EUR: 0.92'
+          type: output_text
+        id: msg_08a7e275f7184d92006a5ef86cfc0c8198a6c4d42588a468bb
+        phase: final_answer
+        role: assistant
+        status: completed
+        type: message
+      parallel_tool_calls: true
+      presence_penalty: 0.0
+      previous_response_id: null
+      prompt_cache_key: null
+      prompt_cache_retention: 24h
+      reasoning:
+        context: current_turn
+        effort: none
+        mode: standard
+        summary: null
+      safety_identifier: null
+      service_tier: default
+      status: completed
+      store: true
+      temperature: 1.0
+      text:
+        format:
+          type: text
+        verbosity: medium
+      tool_choice: auto
+      tool_usage:
+        image_gen:
+          input_tokens: 0
+          input_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          output_tokens: 0
+          output_tokens_details:
+            image_tokens: 0
+            text_tokens: 0
+          total_tokens: 0
+        web_search:
+          num_requests: 0
+      tools:
+      - description: null
+        parameters: null
+        type: tool_search
+      - description: Look up an exchange rate.
+        name: get_exchange_rate
+        tools:
+        - description: Look up an exchange rate.
+          name: get_exchange_rate
+          output_schema: null
+          parameters:
+            additionalProperties: false
+            properties:
+              pair:
+                type: string
+            required:
+            - pair
+            type: object
+          strict: true
+          type: function
+        type: namespace
+      top_logprobs: 0
+      top_p: 0.98
+      truncation: disabled
+      usage:
+        input_tokens: 264
+        input_tokens_details:
+          cache_write_tokens: 0
+          cached_tokens: 0
+        output_tokens: 12
+        output_tokens_details:
+          reasoning_tokens: 0
+        total_tokens: 276
+      user: null
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3636,6 +3636,48 @@ async def test_openai_hosted_tool_search_stateless_continuation(
 
 
 @pytest.mark.vcr
+async def test_openai_hosted_tool_search_stateless_continuation_without_item_ids(
+    allow_model_requests: None, openai_api_key: str
+) -> None:
+    """The identity-less replay shape (`openai_send_reasoning_ids=False`) stays callable.
+
+    With ids stripped, the replayed `tool_search_call` and `tool_search_output` carry
+    `call_id: null` and no `id`; the API accepts the pair and the loaded tool remains
+    callable without a fresh search.
+    """
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(api_key=openai_api_key))
+    agent = Agent(model=model)
+
+    @agent.tool_plain(defer_loading=True)
+    def get_exchange_rate(pair: str) -> str:
+        """Look up an exchange rate."""
+        return f'{pair}: 0.92'
+
+    first = await agent.run(
+        'Use hosted tool search to load get_exchange_rate. Do not call it yet. Reply only with "loaded".'
+    )
+    assert first.output == 'loaded'
+
+    second = await agent.run(
+        'Call get_exchange_rate with pair="USD/EUR". Do not search again.',
+        message_history=first.all_messages(),
+        model_settings=OpenAIResponsesModelSettings(openai_send_reasoning_ids=False),
+    )
+    assert not any(
+        isinstance(part, NativeToolSearchCallPart | NativeToolSearchReturnPart)
+        for message in second.new_messages()
+        for part in message.parts
+    )
+    rate_returns = [
+        part
+        for part in iter_message_parts(second.new_messages(), ModelRequest, ToolReturnPart)
+        if part.tool_name == 'get_exchange_rate'
+    ]
+    assert len(rate_returns) == 1
+    assert rate_returns[0].content == 'USD/EUR: 0.92'
+
+
+@pytest.mark.vcr
 async def test_openai_native_tool_search_gpt_5_6(allow_model_requests: None, openai_api_key: str) -> None:
     """End-to-end against live OpenAI Responses: GPT-5.6 supports the native `tool_search`
     tool with `defer_loading`, backing `supports_tool_search` in its model profile — the

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3430,15 +3430,21 @@ async def test_openai_replays_hosted_tool_search_call_and_output(
     [[], [{'name': 'get_exchange_rate'}]],
     ids=['empty', 'discovered'],
 )
+@pytest.mark.parametrize(
+    'return_details',
+    [{'status': 'completed'}, {'id': None, 'status': 'completed'}, {'id': 1, 'status': 'completed'}],
+    ids=['status-only', 'null-id', 'non-str-id'],
+)
 async def test_openai_replays_legacy_tool_search_history_call_only(
-    send_item_ids: bool, discovered_tools: list[ToolSearchMatch]
+    send_item_ids: bool, discovered_tools: list[ToolSearchMatch], return_details: dict[str, Any]
 ) -> None:
-    """Pre-fix histories (status-only `provider_details`) replay the call item alone.
+    """Returns without a real preserved output identity replay the call item alone.
 
-    An empty legacy return cannot be told apart from a missing output, and a non-empty
-    one references server-side state its call already carries, so both degrade to the
-    pre-fix call-only wire shape. This pins the request payload because cassette
-    matching does not compare request bodies.
+    Pre-fix histories stashed only `status`; mangled round-trips can carry a null or
+    non-string `id`. An empty such return cannot be told apart from a missing output,
+    and a non-empty one references server-side state its call already carries, so all
+    degrade to the pre-fix call-only wire shape. This pins the request payload because
+    cassette matching does not compare request bodies.
     """
     legacy_history: list[ModelMessage] = [
         ModelResponse(
@@ -3453,7 +3459,7 @@ async def test_openai_replays_legacy_tool_search_history_call_only(
                     content={'discovered_tools': discovered_tools},
                     tool_call_id='ts_old',
                     provider_name='openai',
-                    provider_details={'status': 'completed'},
+                    provider_details=return_details,
                 ),
             ],
             provider_name='openai',

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3135,6 +3135,26 @@ def _openai_hosted_tool_search_items() -> tuple[list[ResponseToolSearchCall], li
     return calls, outputs
 
 
+def _openai_hosted_tool_search_parameters() -> ModelRequestParameters:
+    return ModelRequestParameters(
+        function_tools=[
+            ToolDefinition(
+                name='get_exchange_rate',
+                description='Look up an exchange rate.',
+                with_native=ToolSearchTool.kind,
+                defer_loading=True,
+            ),
+            ToolDefinition(
+                name='stock_lookup',
+                description='Look up a stock price.',
+                with_native=ToolSearchTool.kind,
+                defer_loading=True,
+            ),
+        ],
+        native_tools=[ToolSearchTool()],
+    )
+
+
 @pytest.mark.parametrize('call_id', [None, 'call_a'], ids=['null-id', 'explicit-id'])
 def test_openai_preserves_unmatched_hosted_tool_search_output(call_id: str | None) -> None:
     """An actual output is retained even when no matching call is present."""
@@ -3150,8 +3170,8 @@ def test_openai_preserves_unmatched_hosted_tool_search_output(call_id: str | Non
     assert return_part.tool_call_id == (call_id or 'tso_a')
 
 
-def test_openai_does_not_guess_ambiguous_hosted_tool_search_pairing() -> None:
-    """Multiple null-ID pairs retain item identities because OpenAI supplies no correlation."""
+async def test_openai_does_not_guess_ambiguous_hosted_tool_search_pairing() -> None:
+    """Ambiguous null-ID pairs retain and replay every provider item without guessed correlation."""
     model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
     calls, outputs = _openai_hosted_tool_search_items()
 
@@ -3164,6 +3184,18 @@ def test_openai_does_not_guess_ambiguous_hosted_tool_search_pairing() -> None:
         part for part in ambiguous.parts if isinstance(part, NativeToolSearchCallPart | NativeToolSearchReturnPart)
     ]
     assert [part.tool_call_id for part in ambiguous_parts] == ['ts_a', 'tso_a', 'ts_b', 'tso_b']
+
+    _, replayed_items = await model._map_messages(  # pyright: ignore[reportPrivateUsage]
+        [ambiguous],
+        OpenAIResponsesModelSettings(openai_send_reasoning_ids=True),
+        _openai_hosted_tool_search_parameters(),
+    )
+    assert [(item.get('type'), item.get('id'), item.get('call_id')) for item in replayed_items] == [
+        ('tool_search_call', 'ts_a', None),
+        ('tool_search_output', 'tso_a', None),
+        ('tool_search_call', 'ts_b', None),
+        ('tool_search_output', 'tso_b', None),
+    ]
 
 
 def test_openai_ignores_client_tool_search_output() -> None:
@@ -3179,12 +3211,19 @@ def test_openai_ignores_client_tool_search_output() -> None:
     assert response.parts == []
 
 
-async def test_openai_hosted_tool_search_null_id_streaming_parity(allow_model_requests: None) -> None:
-    """Multiple null-ID pairs use the same conservative identity policy in both modes."""
+@pytest.mark.parametrize(
+    ('pair_count', 'expected_ids'),
+    [(1, ['ts_a', 'ts_a']), (2, ['ts_a', 'tso_a', 'ts_b', 'tso_b'])],
+    ids=['singleton', 'ambiguous'],
+)
+async def test_openai_hosted_tool_search_null_id_streaming_parity(
+    allow_model_requests: None, pair_count: int, expected_ids: list[str]
+) -> None:
+    """Single and ambiguous null-ID responses converge to the same history in both modes."""
     from openai.types import responses as resp
 
     calls, outputs = _openai_hosted_tool_search_items()
-    final_items = [calls[0], outputs[0], calls[1], outputs[1]]
+    final_items = [item for pair in zip(calls[:pair_count], outputs[:pair_count]) for item in pair]
     completed_response = response_message(final_items).model_copy(update={'status': 'completed'})
     created_response = response_message([]).model_copy(update={'status': 'in_progress'})
     stream: list[resp.ResponseStreamEvent] = [
@@ -3240,12 +3279,7 @@ async def test_openai_hosted_tool_search_null_id_streaming_parity(allow_model_re
     assert (
         [part.tool_call_id for part in streamed_parts]
         == [part.tool_call_id for part in non_streamed_parts]
-        == [
-            'ts_a',
-            'tso_a',
-            'ts_b',
-            'tso_b',
-        ]
+        == expected_ids
     )
 
 
@@ -3294,26 +3328,10 @@ async def test_openai_replays_hosted_tool_search_call_and_output(
             provider_name='openai',
         )
     ]
-    params = ModelRequestParameters(
-        function_tools=[
-            ToolDefinition(
-                name='get_exchange_rate',
-                description='Look up an exchange rate.',
-                with_native=ToolSearchTool.kind,
-                defer_loading=True,
-            ),
-            ToolDefinition(
-                name='stock_lookup',
-                description='Look up a stock price.',
-                with_native=ToolSearchTool.kind,
-                defer_loading=True,
-            ),
-        ],
-        native_tools=[ToolSearchTool()],
-    )
-
     _, openai_messages = await model._map_messages(  # pyright: ignore[reportPrivateUsage]
-        history, OpenAIResponsesModelSettings(openai_send_reasoning_ids=send_item_ids), params
+        history,
+        OpenAIResponsesModelSettings(openai_send_reasoning_ids=send_item_ids),
+        _openai_hosted_tool_search_parameters(),
     )
 
     expected_call: dict[str, Any] = {

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3643,7 +3643,9 @@ async def test_openai_hosted_tool_search_stateless_continuation_without_item_ids
 
     With ids stripped, the replayed `tool_search_call` and `tool_search_output` carry
     `call_id: null` and no `id`; the API accepts the pair and the loaded tool remains
-    callable without a fresh search.
+    callable without a fresh search. The recording is what proves API acceptance (the
+    cassette assertions below guard it against drifting on re-record); the current
+    code's payload is pinned by `test_openai_replays_hosted_tool_search_call_and_output`.
     """
     model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(api_key=openai_api_key))
     agent = Agent(model=model)
@@ -3675,6 +3677,24 @@ async def test_openai_hosted_tool_search_stateless_continuation_without_item_ids
     ]
     assert len(rate_returns) == 1
     assert rate_returns[0].content == 'USD/EUR: 0.92'
+
+    cassette_path = (
+        Path(__file__).parent
+        / 'cassettes'
+        / 'test_tool_search'
+        / 'test_openai_hosted_tool_search_stateless_continuation_without_item_ids.yaml'
+    )
+    cassette = cast(dict[str, Any], yaml.safe_load(cassette_path.read_text(encoding='utf-8')))
+    interactions = cast(list[dict[str, Any]], cassette['interactions'])
+    replayed = [
+        item
+        for item in interactions[1]['request']['parsed_body']['input']
+        if item.get('type') in ('tool_search_call', 'tool_search_output')
+    ]
+    assert [(item['type'], 'id' in item, item.get('call_id')) for item in replayed] == [
+        ('tool_search_call', False, None),
+        ('tool_search_output', False, None),
+    ]
 
 
 @pytest.mark.vcr

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3001,20 +3001,22 @@ def test_openai_map_tool_search_call_unit():
     assert mixed.content == {'discovered_tools': [{'name': 'real'}]}
 
 
-def test_openai_processes_hosted_tool_search_output_with_null_call_ids() -> None:
-    """The hosted output is authoritative even though OpenAI provides no correlation ID."""
+@pytest.mark.parametrize('call_id', [None, 'call_1'], ids=['null-id', 'explicit-id'])
+@pytest.mark.parametrize('output_first', [False, True], ids=['call-first', 'output-first'])
+def test_openai_processes_hosted_tool_search_call_and_output(call_id: str | None, output_first: bool) -> None:
+    """A matched output follows its call regardless of provider item order."""
     model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
     call = ResponseToolSearchCall(
         id='ts_1',
         arguments={'paths': ['get_exchange_rate', 'stock_lookup']},
-        call_id=None,
+        call_id=call_id,
         execution='server',
         status='completed',
         type='tool_search_call',
     )
     output = ResponseToolSearchOutputItem(
         id='tso_1',
-        call_id=None,
+        call_id=call_id,
         execution='server',
         status='completed',
         tools=[
@@ -3024,19 +3026,20 @@ def test_openai_processes_hosted_tool_search_output_with_null_call_ids() -> None
         type='tool_search_output',
     )
 
+    response_items = [output, call] if output_first else [call, output]
     response = model._process_response(  # pyright: ignore[reportPrivateUsage]
-        response_message([call, output]), OpenAIResponsesModelSettings(), ModelRequestParameters()
+        response_message(response_items), OpenAIResponsesModelSettings(), ModelRequestParameters()
     )
 
     [call_part, return_part] = response.parts
     assert isinstance(call_part, NativeToolSearchCallPart)
     assert isinstance(return_part, NativeToolSearchReturnPart)
-    assert call_part.tool_call_id == return_part.tool_call_id == 'ts_1'
-    assert call_part.provider_details == {'call_id': None, 'execution': 'server', 'status': 'completed'}
+    assert call_part.tool_call_id == return_part.tool_call_id == (call_id or 'ts_1')
+    assert call_part.provider_details == {'call_id': call_id, 'execution': 'server', 'status': 'completed'}
     assert return_part.content == {'discovered_tools': [{'name': 'get_exchange_rate'}, {'name': 'stock_lookup'}]}
     assert return_part.provider_details == {
         'id': 'tso_1',
-        'call_id': None,
+        'call_id': call_id,
         'execution': 'server',
         'status': 'completed',
     }
@@ -3132,17 +3135,25 @@ def _openai_hosted_tool_search_items() -> tuple[list[ResponseToolSearchCall], li
     return calls, outputs
 
 
-def test_openai_preserves_unmatched_and_ambiguous_hosted_tool_search_outputs() -> None:
-    """Actual outputs are retained without guessing a null-ID pairing."""
+@pytest.mark.parametrize('call_id', [None, 'call_a'], ids=['null-id', 'explicit-id'])
+def test_openai_preserves_unmatched_hosted_tool_search_output(call_id: str | None) -> None:
+    """An actual output is retained even when no matching call is present."""
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
+    _, outputs = _openai_hosted_tool_search_items()
+    output = outputs[0].model_copy(update={'call_id': call_id})
+
+    response = model._process_response(  # pyright: ignore[reportPrivateUsage]
+        response_message([output]), OpenAIResponsesModelSettings(), ModelRequestParameters()
+    )
+    [return_part] = response.parts
+    assert isinstance(return_part, NativeToolSearchReturnPart)
+    assert return_part.tool_call_id == (call_id or 'tso_a')
+
+
+def test_openai_does_not_guess_ambiguous_hosted_tool_search_pairing() -> None:
+    """Multiple null-ID pairs retain item identities because OpenAI supplies no correlation."""
     model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
     calls, outputs = _openai_hosted_tool_search_items()
-
-    output_only = model._process_response(  # pyright: ignore[reportPrivateUsage]
-        response_message([outputs[0]]), OpenAIResponsesModelSettings(), ModelRequestParameters()
-    )
-    [output_only_part] = output_only.parts
-    assert isinstance(output_only_part, NativeToolSearchReturnPart)
-    assert output_only_part.tool_call_id == 'tso_a'
 
     ambiguous = model._process_response(  # pyright: ignore[reportPrivateUsage]
         response_message([calls[0], outputs[0], calls[1], outputs[1]]),
@@ -3153,6 +3164,19 @@ def test_openai_preserves_unmatched_and_ambiguous_hosted_tool_search_outputs() -
         part for part in ambiguous.parts if isinstance(part, NativeToolSearchCallPart | NativeToolSearchReturnPart)
     ]
     assert [part.tool_call_id for part in ambiguous_parts] == ['ts_a', 'tso_a', 'ts_b', 'tso_b']
+
+
+def test_openai_ignores_client_tool_search_output() -> None:
+    """Client outputs are supplied by Pydantic AI and do not belong in model responses."""
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
+    _, outputs = _openai_hosted_tool_search_items()
+    client_output = outputs[0].model_copy(update={'execution': 'client'})
+
+    response = model._process_response(  # pyright: ignore[reportPrivateUsage]
+        response_message([client_output]), OpenAIResponsesModelSettings(), ModelRequestParameters()
+    )
+
+    assert response.parts == []
 
 
 async def test_openai_hosted_tool_search_null_id_streaming_parity(allow_model_requests: None) -> None:
@@ -3240,7 +3264,10 @@ async def test_openai_replays_hosted_tool_search_call_and_output(
     output_status: Literal['in_progress', 'completed'],
     discovered_names: list[str],
 ) -> None:
-    """Stateless replay sends the authoritative output and keeps hosted `call_id` null."""
+    """Replay the authoritative output while keeping hosted `call_id` null.
+
+    This pins the request payload because cassette matching does not compare request bodies.
+    """
     model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
     history: list[ModelMessage] = [
         ModelResponse(
@@ -3324,7 +3351,10 @@ async def test_openai_replays_hosted_tool_search_call_and_output(
 
 @pytest.mark.parametrize('send_item_ids', [False, True])
 async def test_openai_does_not_replay_legacy_synthetic_tool_search_output(send_item_ids: bool) -> None:
-    """Persisted pre-fix empty returns mean unknown output, not authoritative emptiness."""
+    """Keep a persisted pre-fix empty return distinct from an authoritative empty output.
+
+    This pins the request payload because cassette matching does not compare request bodies.
+    """
     legacy_history: list[ModelMessage] = [
         ModelResponse(
             parts=[
@@ -3355,6 +3385,31 @@ async def test_openai_does_not_replay_legacy_synthetic_tool_search_output(send_i
 
     assert len(openai_messages) == 1
     assert openai_messages[0].get('type') == 'tool_search_call'
+
+
+async def test_openai_replay_falls_back_from_invalid_provider_call_id() -> None:
+    """Malformed persisted provider metadata must not leak into the request payload."""
+    history: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                NativeToolSearchCallPart(
+                    args={'queries': []},
+                    tool_call_id='ts_1',
+                    id='ts_1',
+                    provider_name='openai',
+                    provider_details={'call_id': 1},
+                )
+            ],
+            provider_name='openai',
+        )
+    ]
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
+
+    _, [tool_search_call] = await model._map_messages(  # pyright: ignore[reportPrivateUsage]
+        history, OpenAIResponsesModelSettings(), ModelRequestParameters(native_tools=[ToolSearchTool()])
+    )
+
+    assert tool_search_call.get('call_id') == 'ts_1'
 
 
 @pytest.mark.vcr

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -12,7 +12,7 @@ import json
 import os
 import re
 from collections.abc import AsyncIterable, AsyncIterator, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Literal, TypeVar, cast
 
@@ -3211,20 +3211,63 @@ def test_openai_ignores_client_tool_search_output() -> None:
     assert response.parts == []
 
 
+async def test_openai_streaming_ignores_client_tool_search_output(allow_model_requests: None) -> None:
+    """Streaming drops client-execution output items, matching `_process_response`."""
+    from openai.types import responses as resp
+
+    _, outputs = _openai_hosted_tool_search_items()
+    client_output = outputs[0].model_copy(update={'execution': 'client'})
+    final_response = response_message([client_output]).model_copy(update={'status': 'completed'})
+    created_response = response_message([]).model_copy(update={'status': 'in_progress'})
+    stream: list[resp.ResponseStreamEvent] = [
+        resp.ResponseCreatedEvent(response=created_response, type='response.created', sequence_number=0),
+        resp.ResponseOutputItemAddedEvent(
+            item=client_output.model_copy(update={'status': 'in_progress'}),
+            output_index=0,
+            type='response.output_item.added',
+            sequence_number=1,
+        ),
+        resp.ResponseOutputItemDoneEvent(
+            item=client_output, output_index=0, type='response.output_item.done', sequence_number=2
+        ),
+        resp.ResponseCompletedEvent(response=final_response, type='response.completed', sequence_number=3),
+    ]
+
+    mock_client = MockOpenAIResponses.create_mock_stream(stream)
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=mock_client))
+    async with model.request_stream(
+        [ModelRequest(parts=[UserPromptPart(content='test')])],
+        OpenAIResponsesModelSettings(),
+        ModelRequestParameters(),
+    ) as streamed_response:
+        async for _ in streamed_response:
+            pass
+
+    assert streamed_response.get().parts == []
+
+
+@pytest.mark.parametrize('terminal_status', ['completed', 'failed', 'incomplete'])
 @pytest.mark.parametrize(
     ('pair_count', 'expected_ids'),
     [(1, ['ts_a', 'ts_a']), (2, ['ts_a', 'tso_a', 'ts_b', 'tso_b'])],
     ids=['singleton', 'ambiguous'],
 )
 async def test_openai_hosted_tool_search_null_id_streaming_parity(
-    allow_model_requests: None, pair_count: int, expected_ids: list[str]
+    allow_model_requests: None,
+    pair_count: int,
+    expected_ids: list[str],
+    terminal_status: Literal['completed', 'failed', 'incomplete'],
 ) -> None:
-    """Single and ambiguous null-ID responses converge to the same history in both modes."""
+    """Single and ambiguous null-ID responses converge to identical parts in both modes.
+
+    Every terminal event variant runs the singleton backfill, so failed and incomplete
+    streams re-key the return part just like completed ones.
+    """
     from openai.types import responses as resp
 
     calls, outputs = _openai_hosted_tool_search_items()
     final_items = [item for pair in zip(calls[:pair_count], outputs[:pair_count]) for item in pair]
-    completed_response = response_message(final_items).model_copy(update={'status': 'completed'})
+    completed_response = response_message(final_items).model_copy(update={'status': terminal_status})
     created_response = response_message([]).model_copy(update={'status': 'in_progress'})
     stream: list[resp.ResponseStreamEvent] = [
         resp.ResponseCreatedEvent(response=created_response, type='response.created', sequence_number=0)
@@ -3249,13 +3292,19 @@ async def test_openai_hosted_tool_search_null_id_streaming_parity(
             ]
         )
         sequence_number += 2
-    stream.append(
-        resp.ResponseCompletedEvent(
-            response=completed_response,
-            type='response.completed',
-            sequence_number=sequence_number,
+    if terminal_status == 'completed':
+        terminal: resp.ResponseStreamEvent = resp.ResponseCompletedEvent(
+            response=completed_response, type='response.completed', sequence_number=sequence_number
         )
-    )
+    elif terminal_status == 'failed':
+        terminal = resp.ResponseFailedEvent(
+            response=completed_response, type='response.failed', sequence_number=sequence_number
+        )
+    else:
+        terminal = resp.ResponseIncompleteEvent(
+            response=completed_response, type='response.incomplete', sequence_number=sequence_number
+        )
+    stream.append(terminal)
 
     mock_client = MockOpenAIResponses.create_mock_stream(stream)
     model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=mock_client))
@@ -3276,11 +3325,19 @@ async def test_openai_hosted_tool_search_null_id_streaming_parity(
     non_streamed_parts = [
         part for part in non_streamed.parts if isinstance(part, NativeToolSearchCallPart | NativeToolSearchReturnPart)
     ]
-    assert (
-        [part.tool_call_id for part in streamed_parts]
-        == [part.tool_call_id for part in non_streamed_parts]
-        == expected_ids
-    )
+    assert [part.tool_call_id for part in streamed_parts] == expected_ids
+
+    def normalized(
+        parts: list[NativeToolSearchCallPart | NativeToolSearchReturnPart],
+    ) -> list[NativeToolSearchCallPart | NativeToolSearchReturnPart]:
+        # Return parts stamp a construction-time timestamp; align it so the equality
+        # check covers every other field.
+        return [
+            replace(part, timestamp=non_streamed.timestamp) if isinstance(part, NativeToolSearchReturnPart) else part
+            for part in parts
+        ]
+
+    assert normalized(streamed_parts) == normalized(non_streamed_parts)
 
 
 @pytest.mark.parametrize('send_item_ids', [False, True])
@@ -3368,10 +3425,20 @@ async def test_openai_replays_hosted_tool_search_call_and_output(
 
 
 @pytest.mark.parametrize('send_item_ids', [False, True])
-async def test_openai_does_not_replay_legacy_synthetic_tool_search_output(send_item_ids: bool) -> None:
-    """Keep a persisted pre-fix empty return distinct from an authoritative empty output.
+@pytest.mark.parametrize(
+    'discovered_tools',
+    [[], [{'name': 'get_exchange_rate'}]],
+    ids=['empty', 'discovered'],
+)
+async def test_openai_replays_legacy_tool_search_history_call_only(
+    send_item_ids: bool, discovered_tools: list[ToolSearchMatch]
+) -> None:
+    """Pre-fix histories (status-only `provider_details`) replay the call item alone.
 
-    This pins the request payload because cassette matching does not compare request bodies.
+    An empty legacy return cannot be told apart from a missing output, and a non-empty
+    one references server-side state its call already carries, so both degrade to the
+    pre-fix call-only wire shape. This pins the request payload because cassette
+    matching does not compare request bodies.
     """
     legacy_history: list[ModelMessage] = [
         ModelResponse(
@@ -3383,7 +3450,7 @@ async def test_openai_does_not_replay_legacy_synthetic_tool_search_output(send_i
                     provider_name='openai',
                 ),
                 NativeToolSearchReturnPart(
-                    content={'discovered_tools': []},
+                    content={'discovered_tools': discovered_tools},
                     tool_call_id='ts_old',
                     provider_name='openai',
                     provider_details={'status': 'completed'},
@@ -3401,8 +3468,16 @@ async def test_openai_does_not_replay_legacy_synthetic_tool_search_output(send_i
         ModelRequestParameters(native_tools=[ToolSearchTool()]),
     )
 
-    assert len(openai_messages) == 1
-    assert openai_messages[0].get('type') == 'tool_search_call'
+    expected_call: dict[str, Any] = {
+        'call_id': 'ts_old',
+        'arguments': {'queries': ['get_exchange_rate']},
+        'type': 'tool_search_call',
+        'execution': 'server',
+        'status': 'completed',
+    }
+    if send_item_ids:
+        expected_call['id'] = 'ts_old'
+    assert openai_messages == [expected_call]
 
 
 async def test_openai_replay_falls_back_from_invalid_provider_call_id() -> None:

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -14,7 +14,7 @@ import re
 from collections.abc import AsyncIterable, AsyncIterator, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, Literal, TypeVar, cast
 
 import pytest
 import yaml
@@ -2967,7 +2967,8 @@ def test_openai_map_tool_search_call_unit():
         ],
         type='tool_search_output',
     )
-    call_part, return_part = _map_tool_search_call(call, output, 'openai')
+    call_part = _map_tool_search_call(call, 'openai')
+    return_part = _build_tool_search_return_part('call_1', output, 'openai')
     assert isinstance(call_part, NativeToolSearchCallPart)
     assert call_part.tool_name == 'tool_search'
     # OpenAI server-executed `tool_search.arguments` carries `paths`; the adapter
@@ -2975,12 +2976,12 @@ def test_openai_map_tool_search_call_unit():
     assert call_part.args == {'queries': ['get_exchange_rate']}
     assert isinstance(return_part, NativeToolSearchReturnPart)
     assert return_part.content == {'discovered_tools': [{'name': 'get_exchange_rate'}]}
-    assert return_part.provider_details == {'status': 'completed'}
-
-    # No output item → empty discovery (streaming start case).
-    empty_return = _build_tool_search_return_part('call_1', 'in_progress', None, 'openai')
-    assert empty_return.content == {'discovered_tools': []}
-    assert empty_return.provider_details == {'status': 'in_progress'}
+    assert return_part.provider_details == {
+        'id': 'tso_1',
+        'call_id': 'call_1',
+        'execution': 'server',
+        'status': 'completed',
+    }
 
     # Non-function tools in the output don't have a `name` attribute and are skipped.
 
@@ -2996,16 +2997,195 @@ def test_openai_map_tool_search_call_unit():
         ],
         type='tool_search_output',
     )
-    mixed = _build_tool_search_return_part('call_mix', 'completed', mixed_output, 'openai')
+    mixed = _build_tool_search_return_part('call_mix', mixed_output, 'openai')
     assert mixed.content == {'discovered_tools': [{'name': 'real'}]}
+
+
+def test_openai_processes_hosted_tool_search_output_with_null_call_ids() -> None:
+    """The hosted output is authoritative even though OpenAI provides no correlation ID."""
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
+    call = ResponseToolSearchCall(
+        id='ts_1',
+        arguments={'paths': ['get_exchange_rate', 'stock_lookup']},
+        call_id=None,
+        execution='server',
+        status='completed',
+        type='tool_search_call',
+    )
+    output = ResponseToolSearchOutputItem(
+        id='tso_1',
+        call_id=None,
+        execution='server',
+        status='completed',
+        tools=[
+            FunctionTool(name='get_exchange_rate', description='', parameters={}, strict=False, type='function'),
+            FunctionTool(name='stock_lookup', description='', parameters={}, strict=False, type='function'),
+        ],
+        type='tool_search_output',
+    )
+
+    response = model._process_response(  # pyright: ignore[reportPrivateUsage]
+        response_message([call, output]), OpenAIResponsesModelSettings(), ModelRequestParameters()
+    )
+
+    [call_part, return_part] = response.parts
+    assert isinstance(call_part, NativeToolSearchCallPart)
+    assert isinstance(return_part, NativeToolSearchReturnPart)
+    assert call_part.tool_call_id == return_part.tool_call_id == 'ts_1'
+    assert call_part.provider_details == {'call_id': None, 'execution': 'server', 'status': 'completed'}
+    assert return_part.content == {'discovered_tools': [{'name': 'get_exchange_rate'}, {'name': 'stock_lookup'}]}
+    assert return_part.provider_details == {
+        'id': 'tso_1',
+        'call_id': None,
+        'execution': 'server',
+        'status': 'completed',
+    }
+
+
+@pytest.mark.parametrize(
+    ('call_status', 'output_status'),
+    [('completed', 'completed'), ('incomplete', 'in_progress')],
+)
+def test_openai_preserves_empty_hosted_tool_search_output(
+    call_status: Literal['completed', 'incomplete'],
+    output_status: Literal['completed', 'in_progress'],
+) -> None:
+    """Completed emptiness and in-progress partial state retain their actual statuses."""
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
+    call = ResponseToolSearchCall(
+        id='ts_1',
+        arguments={},
+        call_id=None,
+        execution='server',
+        status=call_status,
+        type='tool_search_call',
+    )
+    output = ResponseToolSearchOutputItem(
+        id='tso_1',
+        call_id=None,
+        execution='server',
+        status=output_status,
+        tools=[],
+        type='tool_search_output',
+    )
+
+    response = model._process_response(  # pyright: ignore[reportPrivateUsage]
+        response_message([call, output]), OpenAIResponsesModelSettings(), ModelRequestParameters()
+    )
+
+    [call_part, return_part] = response.parts
+    assert isinstance(call_part, NativeToolSearchCallPart)
+    assert isinstance(return_part, NativeToolSearchReturnPart)
+    assert return_part.content == {'discovered_tools': []}
+    assert call_part.provider_details == {'call_id': None, 'execution': 'server', 'status': call_status}
+    assert return_part.provider_details == {
+        'id': 'tso_1',
+        'call_id': None,
+        'execution': 'server',
+        'status': output_status,
+    }
+
+
+def test_openai_does_not_fabricate_missing_hosted_tool_search_output() -> None:
+    """A call without an output must stay distinct from a completed empty search."""
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
+    call = ResponseToolSearchCall(
+        id='ts_1',
+        arguments={},
+        call_id=None,
+        execution='server',
+        status='incomplete',
+        type='tool_search_call',
+    )
+
+    response = model._process_response(  # pyright: ignore[reportPrivateUsage]
+        response_message([call]), OpenAIResponsesModelSettings(), ModelRequestParameters()
+    )
+
+    [call_part] = response.parts
+    assert isinstance(call_part, NativeToolSearchCallPart)
+
+
+@pytest.mark.parametrize('send_item_ids', [False, True])
+async def test_openai_replays_hosted_tool_search_call_and_output(send_item_ids: bool) -> None:
+    """Stateless replay sends the authoritative output and keeps hosted `call_id` null."""
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
+    history: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                NativeToolSearchCallPart(
+                    args={'queries': ['get_exchange_rate']},
+                    tool_call_id='ts_1',
+                    id='ts_1',
+                    provider_name='openai',
+                    provider_details={'call_id': None, 'execution': 'server', 'status': 'completed'},
+                ),
+                NativeToolSearchReturnPart(
+                    content={'discovered_tools': [{'name': 'get_exchange_rate'}]},
+                    tool_call_id='ts_1',
+                    provider_name='openai',
+                    provider_details={
+                        'id': 'tso_1',
+                        'call_id': None,
+                        'execution': 'server',
+                        'status': 'completed',
+                    },
+                ),
+            ],
+            provider_name='openai',
+        )
+    ]
+    params = ModelRequestParameters(
+        function_tools=[
+            ToolDefinition(
+                name='get_exchange_rate',
+                description='Look up an exchange rate.',
+                with_native=ToolSearchTool.kind,
+                defer_loading=True,
+            )
+        ],
+        native_tools=[ToolSearchTool()],
+    )
+
+    _, openai_messages = await model._map_messages(  # pyright: ignore[reportPrivateUsage]
+        history, OpenAIResponsesModelSettings(openai_send_reasoning_ids=send_item_ids), params
+    )
+
+    expected_call: dict[str, Any] = {
+        'call_id': None,
+        'arguments': {'queries': ['get_exchange_rate']},
+        'type': 'tool_search_call',
+        'execution': 'server',
+        'status': 'completed',
+    }
+    expected_output: dict[str, Any] = {
+        'call_id': None,
+        'execution': 'server',
+        'status': 'completed',
+        'tools': [
+            {
+                'name': 'get_exchange_rate',
+                'parameters': {'type': 'object', 'properties': {}},
+                'type': 'function',
+                'description': 'Look up an exchange rate.',
+                'strict': False,
+                'defer_loading': True,
+            }
+        ],
+        'type': 'tool_search_output',
+    }
+    if send_item_ids:
+        expected_call['id'] = 'ts_1'
+        expected_output['id'] = 'tso_1'
+    assert openai_messages == [expected_call, expected_output]
 
 
 @pytest.mark.vcr
 async def test_openai_native_tool_search_round_trip(allow_model_requests: None, openai_api_key: str) -> None:
     """End-to-end against live OpenAI Responses: native server-executed `tool_search`
     populates `NativeToolCallPart` / `NativeToolReturnPart`, the model invokes the
-    discovered deferred tool by its plain name, and the second-turn replay carries
-    `defer_loading: true` on the corpus function tool plus a `tool_search_call` item.
+    discovered deferred tool by its plain name, and stateless replay preserves the
+    discovered-tool output.
     """
 
     model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(api_key=openai_api_key))
@@ -3028,11 +3208,20 @@ async def test_openai_native_tool_search_round_trip(allow_model_requests: None, 
         for m in result.all_messages()
         for p in m.parts
     )
-    assert any(
-        isinstance(p, NativeToolReturnPart) and p.tool_name == 'tool_search'
-        for m in result.all_messages()
-        for p in m.parts
-    )
+    search_returns = [
+        part
+        for message in result.all_messages()
+        for part in message.parts
+        if isinstance(part, NativeToolSearchReturnPart)
+    ]
+    assert len(search_returns) == 1
+    assert search_returns[0].content == {'discovered_tools': [{'name': 'get_exchange_rate'}]}
+    assert search_returns[0].provider_details == {
+        'id': 'tso_0ab095b1426acab50069f17095e2b08196922f617e9b78df21',
+        'call_id': None,
+        'execution': 'server',
+        'status': 'completed',
+    }
 
     rate_returns = [
         p
@@ -3059,8 +3248,9 @@ async def test_openai_native_tool_search_round_trip(allow_model_requests: None, 
     }
     assert deferred_names == {'get_exchange_rate', 'stock_lookup'}
     assert any(t.get('type') == 'tool_search' for t in cast(list[dict[str, Any]], first_request['tools']))
-    # Second-turn replay carries the native tool_search_call back; the deferred corpus
-    # is preserved with `defer_loading: true`.
+    # The direct request-mapping test pins the second-turn call/output body because the
+    # cassette matcher does not compare request bodies. Here we only verify the deferred
+    # corpus remains present in the recorded integration flow.
     second_request = cast(dict[str, Any], interactions[1]['request']['parsed_body'])
     second_input_types = {
         cast(str, item.get('type'))
@@ -3074,6 +3264,45 @@ async def test_openai_native_tool_search_round_trip(allow_model_requests: None, 
         if t.get('defer_loading') is True
     }
     assert 'get_exchange_rate' in second_deferred
+
+
+@pytest.mark.vcr
+async def test_openai_hosted_tool_search_stateless_continuation(
+    allow_model_requests: None, openai_api_key: str
+) -> None:
+    """A tool loaded without being called remains callable through stateless history replay."""
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(api_key=openai_api_key))
+    agent = Agent(model=model)
+
+    @agent.tool_plain(defer_loading=True)
+    def get_exchange_rate(pair: str) -> str:
+        """Look up an exchange rate."""
+        return f'{pair}: 0.92'
+
+    first = await agent.run(
+        'Use hosted tool search to load get_exchange_rate. Do not call it yet. Reply only with "loaded".'
+    )
+    assert first.output == 'loaded'
+    first_search_returns = [
+        part
+        for message in first.all_messages()
+        for part in message.parts
+        if isinstance(part, NativeToolSearchReturnPart)
+    ]
+    assert len(first_search_returns) == 1
+    assert first_search_returns[0].content == {'discovered_tools': [{'name': 'get_exchange_rate'}]}
+
+    second = await agent.run(
+        'Call get_exchange_rate with pair="USD/EUR". Do not search again.',
+        message_history=first.all_messages(),
+    )
+    rate_returns = [
+        part
+        for part in iter_message_parts(second.new_messages(), ModelRequest, ToolReturnPart)
+        if part.tool_name == 'get_exchange_rate'
+    ]
+    assert len(rate_returns) == 1
+    assert rate_returns[0].content == 'USD/EUR: 0.92'
 
 
 @pytest.mark.vcr
@@ -3290,7 +3519,15 @@ async def test_openai_native_tool_search_streaming(allow_model_requests: None, o
     builtin_return_parts = [
         p for m in agent_run.result.all_messages() for p in m.parts if isinstance(p, NativeToolSearchReturnPart)
     ]
-    assert builtin_call_parts and builtin_return_parts
+    assert len(builtin_call_parts) == len(builtin_return_parts) == 1
+    assert builtin_call_parts[0].tool_call_id == builtin_return_parts[0].tool_call_id
+    assert builtin_return_parts[0].content == {'discovered_tools': [{'name': 'get_exchange_rate'}]}
+    assert builtin_return_parts[0].provider_details == {
+        'id': 'tso_060f468708eb0ff90069f3e2f20c84819385b1d75b9c1ffc7d',
+        'call_id': None,
+        'execution': 'server',
+        'status': 'completed',
+    }
 
     rate_returns = [
         p

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3106,8 +3106,140 @@ def test_openai_does_not_fabricate_missing_hosted_tool_search_output() -> None:
     assert isinstance(call_part, NativeToolSearchCallPart)
 
 
+def _openai_hosted_tool_search_items() -> tuple[list[ResponseToolSearchCall], list[ResponseToolSearchOutputItem]]:
+    calls = [
+        ResponseToolSearchCall(
+            id=f'ts_{suffix}',
+            arguments={'paths': [name]},
+            call_id=None,
+            execution='server',
+            status='completed',
+            type='tool_search_call',
+        )
+        for suffix, name in [('a', 'get_exchange_rate'), ('b', 'stock_lookup')]
+    ]
+    outputs = [
+        ResponseToolSearchOutputItem(
+            id=f'tso_{suffix}',
+            call_id=None,
+            execution='server',
+            status='completed',
+            tools=[FunctionTool(name=name, description='', parameters={}, strict=False, type='function')],
+            type='tool_search_output',
+        )
+        for suffix, name in [('a', 'get_exchange_rate'), ('b', 'stock_lookup')]
+    ]
+    return calls, outputs
+
+
+def test_openai_preserves_unmatched_and_ambiguous_hosted_tool_search_outputs() -> None:
+    """Actual outputs are retained without guessing a null-ID pairing."""
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
+    calls, outputs = _openai_hosted_tool_search_items()
+
+    output_only = model._process_response(  # pyright: ignore[reportPrivateUsage]
+        response_message([outputs[0]]), OpenAIResponsesModelSettings(), ModelRequestParameters()
+    )
+    [output_only_part] = output_only.parts
+    assert isinstance(output_only_part, NativeToolSearchReturnPart)
+    assert output_only_part.tool_call_id == 'tso_a'
+
+    ambiguous = model._process_response(  # pyright: ignore[reportPrivateUsage]
+        response_message([calls[0], outputs[0], calls[1], outputs[1]]),
+        OpenAIResponsesModelSettings(),
+        ModelRequestParameters(),
+    )
+    ambiguous_parts = [
+        part for part in ambiguous.parts if isinstance(part, NativeToolSearchCallPart | NativeToolSearchReturnPart)
+    ]
+    assert [part.tool_call_id for part in ambiguous_parts] == ['ts_a', 'tso_a', 'ts_b', 'tso_b']
+
+
+async def test_openai_hosted_tool_search_null_id_streaming_parity(allow_model_requests: None) -> None:
+    """Multiple null-ID pairs use the same conservative identity policy in both modes."""
+    from openai.types import responses as resp
+
+    calls, outputs = _openai_hosted_tool_search_items()
+    final_items = [calls[0], outputs[0], calls[1], outputs[1]]
+    completed_response = response_message(final_items).model_copy(update={'status': 'completed'})
+    created_response = response_message([]).model_copy(update={'status': 'in_progress'})
+    stream: list[resp.ResponseStreamEvent] = [
+        resp.ResponseCreatedEvent(response=created_response, type='response.created', sequence_number=0)
+    ]
+    sequence_number = 1
+    for output_index, item in enumerate(final_items):
+        added_item = item.model_copy(update={'status': 'in_progress'})
+        stream.extend(
+            [
+                resp.ResponseOutputItemAddedEvent(
+                    item=added_item,
+                    output_index=output_index,
+                    type='response.output_item.added',
+                    sequence_number=sequence_number,
+                ),
+                resp.ResponseOutputItemDoneEvent(
+                    item=item,
+                    output_index=output_index,
+                    type='response.output_item.done',
+                    sequence_number=sequence_number + 1,
+                ),
+            ]
+        )
+        sequence_number += 2
+    stream.append(
+        resp.ResponseCompletedEvent(
+            response=completed_response,
+            type='response.completed',
+            sequence_number=sequence_number,
+        )
+    )
+
+    mock_client = MockOpenAIResponses.create_mock_stream(stream)
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=mock_client))
+    async with model.request_stream(
+        [ModelRequest(parts=[UserPromptPart(content='test')])],
+        OpenAIResponsesModelSettings(),
+        ModelRequestParameters(),
+    ) as streamed_response:
+        assert [event async for event in streamed_response]
+
+    streamed = streamed_response.get()
+    non_streamed = model._process_response(  # pyright: ignore[reportPrivateUsage]
+        completed_response, OpenAIResponsesModelSettings(), ModelRequestParameters()
+    )
+    streamed_parts = [
+        part for part in streamed.parts if isinstance(part, NativeToolSearchCallPart | NativeToolSearchReturnPart)
+    ]
+    non_streamed_parts = [
+        part for part in non_streamed.parts if isinstance(part, NativeToolSearchCallPart | NativeToolSearchReturnPart)
+    ]
+    assert (
+        [part.tool_call_id for part in streamed_parts]
+        == [part.tool_call_id for part in non_streamed_parts]
+        == [
+            'ts_a',
+            'tso_a',
+            'ts_b',
+            'tso_b',
+        ]
+    )
+
+
 @pytest.mark.parametrize('send_item_ids', [False, True])
-async def test_openai_replays_hosted_tool_search_call_and_output(send_item_ids: bool) -> None:
+@pytest.mark.parametrize(
+    ('call_status', 'output_status', 'discovered_names'),
+    [
+        ('completed', 'completed', ['get_exchange_rate', 'stock_lookup']),
+        ('completed', 'completed', []),
+        ('incomplete', 'in_progress', []),
+    ],
+)
+async def test_openai_replays_hosted_tool_search_call_and_output(
+    send_item_ids: bool,
+    call_status: Literal['completed', 'incomplete'],
+    output_status: Literal['in_progress', 'completed'],
+    discovered_names: list[str],
+) -> None:
     """Stateless replay sends the authoritative output and keeps hosted `call_id` null."""
     model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
     history: list[ModelMessage] = [
@@ -3118,17 +3250,17 @@ async def test_openai_replays_hosted_tool_search_call_and_output(send_item_ids: 
                     tool_call_id='ts_1',
                     id='ts_1',
                     provider_name='openai',
-                    provider_details={'call_id': None, 'execution': 'server', 'status': 'completed'},
+                    provider_details={'call_id': None, 'execution': 'server', 'status': call_status},
                 ),
                 NativeToolSearchReturnPart(
-                    content={'discovered_tools': [{'name': 'get_exchange_rate'}]},
+                    content={'discovered_tools': [{'name': name} for name in discovered_names]},
                     tool_call_id='ts_1',
                     provider_name='openai',
                     provider_details={
                         'id': 'tso_1',
                         'call_id': None,
                         'execution': 'server',
-                        'status': 'completed',
+                        'status': output_status,
                     },
                 ),
             ],
@@ -3142,7 +3274,13 @@ async def test_openai_replays_hosted_tool_search_call_and_output(send_item_ids: 
                 description='Look up an exchange rate.',
                 with_native=ToolSearchTool.kind,
                 defer_loading=True,
-            )
+            ),
+            ToolDefinition(
+                name='stock_lookup',
+                description='Look up a stock price.',
+                with_native=ToolSearchTool.kind,
+                defer_loading=True,
+            ),
         ],
         native_tools=[ToolSearchTool()],
     )
@@ -3156,21 +3294,25 @@ async def test_openai_replays_hosted_tool_search_call_and_output(send_item_ids: 
         'arguments': {'queries': ['get_exchange_rate']},
         'type': 'tool_search_call',
         'execution': 'server',
-        'status': 'completed',
+        'status': call_status,
     }
     expected_output: dict[str, Any] = {
         'call_id': None,
         'execution': 'server',
-        'status': 'completed',
+        'status': output_status,
         'tools': [
             {
-                'name': 'get_exchange_rate',
+                'name': name,
                 'parameters': {'type': 'object', 'properties': {}},
                 'type': 'function',
-                'description': 'Look up an exchange rate.',
+                'description': {
+                    'get_exchange_rate': 'Look up an exchange rate.',
+                    'stock_lookup': 'Look up a stock price.',
+                }[name],
                 'strict': False,
                 'defer_loading': True,
             }
+            for name in discovered_names
         ],
         'type': 'tool_search_output',
     }
@@ -3178,6 +3320,41 @@ async def test_openai_replays_hosted_tool_search_call_and_output(send_item_ids: 
         expected_call['id'] = 'ts_1'
         expected_output['id'] = 'tso_1'
     assert openai_messages == [expected_call, expected_output]
+
+
+@pytest.mark.parametrize('send_item_ids', [False, True])
+async def test_openai_does_not_replay_legacy_synthetic_tool_search_output(send_item_ids: bool) -> None:
+    """Persisted pre-fix empty returns mean unknown output, not authoritative emptiness."""
+    legacy_history: list[ModelMessage] = [
+        ModelResponse(
+            parts=[
+                NativeToolSearchCallPart(
+                    args={'queries': ['get_exchange_rate']},
+                    tool_call_id='ts_old',
+                    id='ts_old',
+                    provider_name='openai',
+                ),
+                NativeToolSearchReturnPart(
+                    content={'discovered_tools': []},
+                    tool_call_id='ts_old',
+                    provider_name='openai',
+                    provider_details={'status': 'completed'},
+                ),
+            ],
+            provider_name='openai',
+        )
+    ]
+    history = ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(legacy_history))
+    model = OpenAIResponsesModel('gpt-5.4', provider=OpenAIProvider(openai_client=MockOpenAIResponses.create_mock(())))
+
+    _, openai_messages = await model._map_messages(  # pyright: ignore[reportPrivateUsage]
+        history,
+        OpenAIResponsesModelSettings(openai_send_reasoning_ids=send_item_ids),
+        ModelRequestParameters(native_tools=[ToolSearchTool()]),
+    )
+
+    assert len(openai_messages) == 1
+    assert openai_messages[0].get('type') == 'tool_search_call'
 
 
 @pytest.mark.vcr
@@ -3252,12 +3429,6 @@ async def test_openai_native_tool_search_round_trip(allow_model_requests: None, 
     # cassette matcher does not compare request bodies. Here we only verify the deferred
     # corpus remains present in the recorded integration flow.
     second_request = cast(dict[str, Any], interactions[1]['request']['parsed_body'])
-    second_input_types = {
-        cast(str, item.get('type'))
-        for item in cast(list[dict[str, Any]], second_request['input'])
-        if isinstance(item, dict)
-    }
-    assert 'tool_search_call' in second_input_types
     second_deferred = {
         cast(str, t['name'])
         for t in cast(list[dict[str, Any]], second_request['tools'])
@@ -3295,6 +3466,11 @@ async def test_openai_hosted_tool_search_stateless_continuation(
     second = await agent.run(
         'Call get_exchange_rate with pair="USD/EUR". Do not search again.',
         message_history=first.all_messages(),
+    )
+    assert not any(
+        isinstance(part, NativeToolSearchCallPart | NativeToolSearchReturnPart)
+        for message in second.new_messages()
+        for part in message.parts
     )
     rate_returns = [
         part
@@ -3537,7 +3713,14 @@ async def test_openai_native_tool_search_streaming(allow_model_requests: None, o
     assert len(rate_returns) == 1
     assert rate_returns[0].content == '1 USD = 0.92 EUR'
 
-    assert streamed_events, 'expected streaming events from the request stream'
+    assert any(
+        isinstance(event, PartStartEvent) and isinstance(event.part, NativeToolSearchCallPart)
+        for event in streamed_events
+    )
+    assert any(
+        isinstance(event, PartStartEvent) and isinstance(event.part, NativeToolSearchReturnPart)
+        for event in streamed_events
+    )
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
<!-- Thank you for contributing to Pydantic AI! -->

<!-- Please read the contributing guide: https://ai.pydantic.dev/contributing/ -->

<!-- For non-trivial changes, link an issue that a maintainer has agreed on -->
<!-- and assigned to you. Unassigned PRs may be auto-closed. -->
<!-- Trivial fixes (typos, broken links, small doc improvements) do not need an issue. -->

<!-- Adding a capability? Most capabilities belong in Pydantic AI Harness, not here. -->
<!-- See: https://pydantic.dev/docs/ai/harness/#what-goes-where -->

- Closes #6573

### What changed

Preserve hosted `tool_search_output` items and replay them with their discovered tool definitions. Keep OpenAI null `call_id` values on the wire, preserve empty and incomplete states, avoid unsupported pairing for ambiguous multiple searches, and retain legacy call-only behavior when old history cannot distinguish a missing output from an empty one.

Because OpenAI supplies no correlation for multiple null-ID searches, this deliberately avoids positional/FIFO pairing: ambiguous items retain their provider identities and replay unchanged, while singleton streams are paired only at terminal response time.

Adds a recorded stateless continuation test plus focused parser, replay, streaming parity, and persisted-history regressions.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

