### PR TITLE
fix(azure): send `max_tokens` for Mistral models, not `max_completion_tokens`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/providers/azure.py
+++ b/pydantic_ai_slim/pydantic_ai/providers/azure.py
@@ -57,6 +57,16 @@ class AzureProvider(Provider[AsyncOpenAI]):
             'deepseek': deepseek_model_profile,
             'mistralai-': mistral_model_profile,
             'mistral': mistral_model_profile,
+            # `ministral`/`magistral` are Mistral-family model lines that don't share the
+            # `mistral`/`mistralai-` prefix. Bedrock already groups them under its `mistral`
+            # provider namespace (see `bedrock_mistral_model_profile`'s
+            # `models_that_support_structured_output` handling of `ministral-3`/`magistral-small`),
+            # so route them through `mistral_model_profile` here too — otherwise a deployment named
+            # e.g. `Ministral-3B` (the exact model from #6593) would fall through to the generic
+            # OpenAI profile and keep sending `max_completion_tokens`, which Azure's Mistral gateway
+            # rejects with a 422.
+            'ministral': mistral_model_profile,
+            'magistral': mistral_model_profile,
             'cohere-': cohere_model_profile,
             'grok': grok_model_profile,
         }
@@ -71,6 +81,13 @@ class AzureProvider(Provider[AsyncOpenAI]):
                     OpenAIModelProfile(json_schema_transformer=OpenAIJsonSchemaTransformer),
                     profile_func(model_name),
                 )
+                if profile_func is mistral_model_profile:
+                    # Azure AI Foundry's Mistral gateway rejects `max_completion_tokens` with 422
+                    # "Extra inputs are not permitted"; only the legacy `max_tokens` field is accepted.
+                    # Scoped to the Azure gateway (the reproduced case, #6593) rather than
+                    # `mistral_model_profile` itself, since other providers that merge that profile
+                    # haven't been confirmed to share the same limitation.
+                    base = merge_profile(base, OpenAIModelProfile(openai_chat_supports_max_completion_tokens=False))
                 break
         if base is None:
             # OpenAI models are unprefixed.

--- a/tests/profiles/test_resolution_matrix.py
+++ b/tests/profiles/test_resolution_matrix.py
@@ -1062,6 +1062,7 @@ def test_azure_mistral_prefix():
     assert _normalize(profile) == snapshot(
         {
             'json_schema_transformer': OpenAIJsonSchemaTransformer,
+            'openai_chat_supports_max_completion_tokens': False,
             'openai_chat_supports_document_input': False,
         }
     )

--- a/tests/providers/test_azure.py
+++ b/tests/providers/test_azure.py
@@ -1,4 +1,5 @@
 import os
+from typing import cast
 
 import pytest
 from pytest_mock import MockerFixture
@@ -13,15 +14,19 @@ from pydantic_ai.profiles.grok import grok_model_profile
 from pydantic_ai.profiles.meta import meta_model_profile
 from pydantic_ai.profiles.mistral import mistral_model_profile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer, openai_model_profile
+from pydantic_ai.settings import ModelSettings
 
 from .._inline_snapshot import snapshot
 from ..conftest import try_import
+from ..models.mock_openai import MockOpenAI, completion_message, get_mock_chat_completion_kwargs
 
 with try_import() as imports_successful:
     from openai import AsyncAzureOpenAI, AsyncOpenAI
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
 
     from pydantic_ai.models.openai import OpenAIChatModel
     from pydantic_ai.providers.azure import AzureProvider
+    from pydantic_ai.providers.openai import OpenAIProvider
 
 
 pytestmark = [
@@ -130,16 +135,36 @@ def test_azure_provider_model_profile(mocker: MockerFixture):
     mistral_model_profile_mock.assert_called_with('mistral-medium-2505')
     assert mistral_profile is not None
     assert mistral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    # Azure AI Foundry's Mistral gateway rejects `max_completion_tokens` with 422 (#6593); the
+    # override is applied by `AzureProvider.model_profile` itself, scoped to the Mistral prefixes.
+    assert mistral_profile.get('openai_chat_supports_max_completion_tokens', True) is False
 
     mistral_profile = provider.model_profile('mistralai-Mixtral-8x22B-Instruct-v0-1')
     mistral_model_profile_mock.assert_called_with('mixtral-8x22b-instruct-v0-1')
     assert mistral_profile is not None
     assert mistral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    assert mistral_profile.get('openai_chat_supports_max_completion_tokens', True) is False
+
+    # `ministral`/`magistral` are Mistral-family model lines (also grouped under Bedrock's `mistral`
+    # provider namespace) and must get the same Azure gateway override as `mistral`/`mistralai-`.
+    ministral_profile = provider.model_profile('Ministral-3B')
+    mistral_model_profile_mock.assert_called_with('ministral-3b')
+    assert ministral_profile is not None
+    assert ministral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    assert ministral_profile.get('openai_chat_supports_max_completion_tokens', True) is False
+
+    magistral_profile = provider.model_profile('magistral-small-2509')
+    mistral_model_profile_mock.assert_called_with('magistral-small-2509')
+    assert magistral_profile is not None
+    assert magistral_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    assert magistral_profile.get('openai_chat_supports_max_completion_tokens', True) is False
 
     cohere_profile = provider.model_profile('cohere-command-a')
     cohere_model_profile_mock.assert_called_with('command-a')
     assert cohere_profile is not None
     assert cohere_profile.get('json_schema_transformer', None) == OpenAIJsonSchemaTransformer
+    # The Azure-only override is scoped to the Mistral prefixes and must not leak to sibling gateways.
+    assert 'openai_chat_supports_max_completion_tokens' not in cohere_profile
 
     grok_profile = provider.model_profile('grok-3')
     grok_model_profile_mock.assert_called_with('grok-3')
@@ -234,3 +259,65 @@ def test_azure_provider_foundry_serverless_with_openai_model():
         ),
     )
     assert type(model.client) is AsyncOpenAI
+
+
+async def test_azure_mistral_max_tokens_uses_legacy_field(allow_model_requests: None) -> None:
+    """Azure AI Foundry's Mistral gateway rejects `max_completion_tokens` with 422 (#6593).
+
+    Unit test (not VCR): cassette matchers ignore the request body, so a VCR test would stay
+    green even if `max_tokens` were still routed to the wrong key. Goes through a real
+    `AzureProvider` (rather than a manually-injected `profile=`) so the assertion exercises the
+    actual gateway-composition path in `AzureProvider.model_profile`. Mirrors the gateway-specific
+    override OpenRouter applies for the same underlying limitation (#5926).
+    """
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel(
+        'mistral-medium-2505', provider=AzureProvider(openai_client=cast(AsyncAzureOpenAI, mock_client))
+    )
+    agent = Agent(m, model_settings=ModelSettings(max_tokens=256))
+
+    await agent.run('Hello')
+
+    kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert kwargs['max_tokens'] == 256
+    assert 'max_completion_tokens' not in kwargs
+
+
+async def test_azure_ministral_max_tokens_uses_legacy_field(allow_model_requests: None) -> None:
+    """Same as `test_azure_mistral_max_tokens_uses_legacy_field`, but for the exact deployment name
+    reported in #6593 (`Ministral-3B`), which doesn't share the `mistral`/`mistralai-` prefix and
+    would otherwise fall through to the generic OpenAI profile and keep sending
+    `max_completion_tokens`.
+    """
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('Ministral-3B', provider=AzureProvider(openai_client=cast(AsyncAzureOpenAI, mock_client)))
+    agent = Agent(m, model_settings=ModelSettings(max_tokens=256))
+
+    await agent.run('Hello')
+
+    kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert kwargs['max_tokens'] == 256
+    assert 'max_completion_tokens' not in kwargs
+
+
+async def test_non_azure_openai_provider_mistral_name_unaffected(allow_model_requests: None) -> None:
+    """A bare `OpenAIProvider` doesn't run Mistral family detection, so a Mistral-named model still
+    gets the default OpenAI profile and sends `max_completion_tokens`.
+
+    Confirms the Azure-only override doesn't leak into the generic `OpenAIProvider` path, and
+    documents that the reporter's exact repro in #6593 (a bare `OpenAIProvider` with an unprefixed
+    deployment name) isn't fixed by this change — it needs an explicit `profile=` until
+    `OpenAIProvider` family-detection is addressed separately.
+    """
+    c = completion_message(ChatCompletionMessage(content='world', role='assistant'))
+    mock_client = MockOpenAI.create_mock(c)
+    m = OpenAIChatModel('Ministral-3B', provider=OpenAIProvider(openai_client=mock_client))
+    agent = Agent(m, model_settings=ModelSettings(max_tokens=256))
+
+    await agent.run('Hello')
+
+    kwargs = get_mock_chat_completion_kwargs(mock_client)[0]
+    assert kwargs['max_completion_tokens'] == 256
+    assert 'max_tokens' not in kwargs


### PR DESCRIPTION
- Refs #6593

### Note on scope up front

This fixes Mistral models (including `ministral*`/`magistral*` names, like
the issue's own `Ministral-3B`) accessed through `AzureProvider`. Coverage is
scoped to the prefixes `mistral`, `mistralai-`, `ministral`, and `magistral`
(case-insensitive), matching the existing `AzureProvider.model_profile()`
matching style; `ministral`/`magistral` are included because Bedrock already
groups those model lines under its `mistral` provider namespace (see
`bedrock_mistral_model_profile`'s `models_that_support_structured_output`
handling of `ministral-3`/`magistral-small`), confirming they're the same
model family, not a hunch-based extension.

It does **not** fix the issue's literal repro, which goes through a bare
`OpenAIProvider` wrapping the client returned by
`AIProjectClient.get_openai_client()` — that path never runs Mistral family
detection at all, with or without this change, and still needs an explicit
`profile=OpenAIModelProfile(openai_chat_supports_max_completion_tokens=False)`
override. Fixing `OpenAIProvider` family detection is a separate, larger
design decision and is out of scope here. (The reporter's exact model name,
`Ministral-3B`, *is* covered when accessed through `AzureProvider` — see
`test_azure_ministral_max_tokens_uses_legacy_field` — but that's not the code
path the issue's repro actually uses.)

### Problem

When `OpenAIChatModel` is used with a Mistral model on Azure AI Foundry via
`AzureProvider`, `ModelSettings(max_tokens=N)` is mapped to the newer OpenAI
`max_completion_tokens` field. Azure AI Foundry's Mistral gateway strictly
validates the body and rejects it with 422:

```json
{"type":"extra_forbidden","loc":["body","max_completion_tokens"],"msg":"Extra inputs are not permitted"}
```

@Aayush-engineer's investigation on the issue traced this to two stacked
gaps: (1) the issue's own repro uses a bare `OpenAIProvider`, which never
does model-family detection at all, and (2) even `AzureProvider`, which does
merge `mistral_model_profile()` for Mistral-prefixed model names, doesn't
gain anything from that merge here because `mistral_model_profile()` never
set `openai_chat_supports_max_completion_tokens`.

This PR addresses gap (2), and extends the `AzureProvider` Mistral-family
detection to also match `ministral`/`magistral` prefixes, so the reporter's
own deployed model (`Ministral-3B`) is covered when accessed through
`AzureProvider` — not just the narrower `mistral`/`mistralai-`-prefixed
names.

### Fix

Sets `openai_chat_supports_max_completion_tokens=False` inside the Mistral
branch of `AzureProvider.model_profile()`'s merge, so only Azure's Mistral
gateway gets the override, and extends the branch's prefix matching to
include `ministral`/`magistral` alongside the existing `mistral`/`mistralai-`
prefixes. This follows the repo's contribution guidance to
configure provider-specific API features in `Provider.model_profile()`
rather than in model profile functions, and mirrors the shape of the
provider-level override `OpenRouterProvider.model_profile()` already applies
for the same kind of gateway quirk (#5926) — @Aayush-engineer flagged this
precedent and noted #5926 only added the override for OpenRouter, so Azure
was simply never covered when that flag was introduced; this isn't a
regression.

@Aayush-engineer's writeup weighed this against putting the override on
`mistral_model_profile()` itself (which would affect every gateway that
merges that profile — Groq, Fireworks, Together, Bedrock, native Mistral,
etc.) and left the choice open pending maintainer input. Per this repo's
guidance to keep bug fixes to the narrowest change that resolves the
reproduced behavior — and to only extend to sibling providers after
confirming by reproduction, not on a hunch — this PR takes the Azure-scoped
option. The other gateways are untouched; if any of them turn out to share
the same limitation, that should be reproduced and filed separately (or
folded in here if it doesn't expand scope).

### Tests

- `test_azure_mistral_max_tokens_uses_legacy_field` — goes through a real
  `AzureProvider` (no manually-injected `profile=`) so the assertion
  exercises the actual merge path; with `max_tokens=256`, the outbound
  request carries `max_tokens` and omits `max_completion_tokens`. Unit test
  rather than VCR because cassette matchers ignore the request body, so a
  VCR test would stay green even if the wrong field were still sent (same
  rationale as #5926).
- `test_azure_ministral_max_tokens_uses_legacy_field` — same as above, but
  using the issue reporter's exact deployment name, `Ministral-3B`, through
  `AzureProvider`. Confirmed as a regression check: with the `ministral`
  prefix removed from `AzureProvider.model_profile()`, this test fails with
  `KeyError: 'max_tokens'` (the request only carries `max_completion_tokens`,
  which is missing from the assertion's expected key) — restoring the
  prefix makes it pass again.
- `test_non_azure_openai_provider_mistral_name_unaffected` — reproduces the
  issue's literal repro shape (bare `OpenAIProvider`, Mistral-named model)
  and asserts it still sends `max_completion_tokens`, documenting that this
  path is unaffected by the fix.
- `test_azure_provider_model_profile` — asserts the flag is present for
  `mistral`/`mistralai-`-prefixed models, and now also for `ministral`- and
  `magistral`-prefixed models, and absent for a sibling prefix (Cohere), so
  the override doesn't leak beyond the Mistral family.
- Resolution-matrix snapshots: `test_azure_mistral_prefix` keeps the flag;
  `test_mistral_mistral_large` (native `MistralProvider`) and
  `test_bedrock_mistral_large` have no flag, since `mistral_model_profile()`
  itself is unchanged.
- Full suite (repo's own invocation, `uv run pytest -n auto
  --dist=loadgroup`): **8524 passed, 530 skipped, 3 xfailed, 0 failed**.
  Note: a plain single-process `uv run pytest -q` shows ~53 failures, all in
  `tests/test_temporal.py` — a pre-existing test-isolation artifact (those
  tests require `--dist=loadgroup` grouping and pass 106/106 when
  `tests/test_temporal.py` is run on its own); unrelated to this change.

**Test summary:** `uv run pytest -n auto --dist=loadgroup` → 8524 passed, 530 skipped, 3 xfailed, 0 failed. (Plain single-process pytest shows ~53 failures confined to tests/test_temporal.py — a known --dist=loadgroup isolation artifact that reconciles arithmetically (8471+53=8524) and passes 106/106 in isolation; unrelated to this change.)

### Credits

- Issue and repro: @Arun-Agentic-AI
- Root-cause analysis (OpenAIProvider bypass, Azure merge gap, OpenRouter/#5926
  precedent, workaround, and the two candidate fix directions): @Aayush-engineer

### Checklist

- [x] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

