### PR TITLE
fix(openai): normalize vendor-prefixed OpenAI model IDs in model_profile (#6517)

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/profiles/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/profiles/openai.py
@@ -125,6 +125,26 @@ with no `reasoning.effort` set, and can be disabled exactly when it accepts `eff
 The full resolved matrix is pinned in `tests/profiles/test_openai.py`."""
 
 
+def _normalize_model_name(model_name: str) -> str:
+    """Normalize vendor- or provider-prefixed model names to bare OpenAI model names.
+
+    Handles prefixes like 'openai.gpt-4o', 'openai/gpt-4o', 'azure/gpt-4o',
+    'openrouter/openai/gpt-4o', and fine-tuning prefixes 'ft:gpt-4o:...'.
+    """
+    if model_name.startswith('ft:'):
+        parts = model_name.split(':')
+        if len(parts) >= 2:
+            model_name = parts[1]
+
+    if '/' in model_name:
+        model_name = model_name.rsplit('/', 1)[-1]
+
+    if model_name.startswith('openai.'):
+        model_name = model_name.removeprefix('openai.')
+
+    return model_name
+
+
 def _reasoning_support(model_name: str) -> _ReasoningSupport:
     return next(
         (support for prefix, support in _REASONING_SUPPORT_BY_PREFIX.items() if model_name.startswith(prefix)),
@@ -281,6 +301,7 @@ def validate_openai_profile(profile: ModelProfile) -> None:
 
 def openai_model_profile(model_name: str) -> ModelProfile:
     """Get the model profile for an OpenAI model."""
+    model_name = _normalize_model_name(model_name)
     reasoning = _reasoning_support(model_name)
 
     # `phase` is supported by gpt-5.3-codex, gpt-5.4 and later mainline models, including gpt-5.6

--- a/tests/profiles/test_openai.py
+++ b/tests/profiles/test_openai.py
@@ -110,6 +110,27 @@ def test_reasoning_matrix(case: ReasoningCase):
     assert profile.get('thinking_always_enabled', False) is (case.enabled_by_default and not case.can_be_disabled)
 
 
+def test_vendor_prefixed_model_profiles():
+    """Verify that vendor- or provider-prefixed model names match their bare equivalents."""
+    cases = [
+        ('gpt-5.6-sol', 'openai.gpt-5.6-sol'),
+        ('gpt-5.6-sol', 'openai/gpt-5.6-sol'),
+        ('gpt-5.6-sol', 'bedrock/openai.gpt-5.6-sol'),
+        ('gpt-4o', 'azure/gpt-4o'),
+        ('gpt-4o', 'vllm/gpt-4o'),
+        ('gpt-4o', 'openrouter/openai/gpt-4o'),
+        ('gpt-4o', 'ft:gpt-4o:my-org:custom-name'),
+        ('gpt-oss-120b', 'openai.gpt-oss-120b'),
+        ('gpt-oss-120b', 'openai/gpt-oss-120b'),
+        ('o3-mini', 'openai.o3-mini'),
+        ('o3-mini', 'openai/o3-mini'),
+    ]
+    for bare_name, prefixed_name in cases:
+        bare_profile = openai_model_profile(bare_name)
+        prefixed_profile = openai_model_profile(prefixed_name)
+        assert bare_profile == prefixed_profile, f'Mismatch for {prefixed_name} vs {bare_name}'
+
+
 class TestEncryptedReasoningContent:
     """Tests for encrypted reasoning content support."""
 


### PR DESCRIPTION
# Pull Request Description

## Description

Closes #6517

This PR resolves an issue where vendor- or provider-prefixed OpenAI model IDs (such as AWS Bedrock Mantle's `openai.gpt-5.6-sol`, OpenRouter's `openai/gpt-5.6-sol`, Azure's `azure/gpt-4o`, vLLM's `vllm/gpt-4o`, or fine-tuned model IDs `ft:gpt-4o:...`) failed to match their corresponding capability profiles in `openai_model_profile()`.

### Root Cause
1. `openai_model_profile()` and `_reasoning_support()` checked capability rules directly against the raw `model_name` string using `model_name.startswith(...)`.
2. Provider prefixes prevented exact prefix matches (wrongly disabling `supports_phase`, `supports_image_output`, `supports_tool_search`, and `openai_reasoning_enabled_by_default`).
3. The dot-separated vendor prefix `openai.` started with `'o'`, causing non-reasoning models (e.g., `openai.gpt-oss-120b`) to falsely match the bare `'o'` prefix rule for reasoning models.

### Proposed Changes
- Added a `_normalize_model_name(model_name: str) -> str` helper function in `pydantic_ai/profiles/openai.py` to strip fine-tuning (`ft:`), slash-separated (`provider/model`), and dot-separated (`openai.model`) prefixes before checking capability rules.
- Added comprehensive unit tests in `tests/profiles/test_openai.py` (`test_vendor_prefixed_model_profiles`) verifying that prefixed model IDs produce identical capability profiles to their bare equivalents.

## Testing
- Added `test_vendor_prefixed_model_profiles` to `tests/profiles/test_openai.py`.
- Verified all 42 tests in `tests/profiles/test_openai.py` pass (`42 passed`).
- Verified all profile tests pass (`156 passed, 66 skipped`).
- Verified code formatting and linting with `ruff check` and `ruff format`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

