### PR TITLE
Stream Temporal agent events to a frontend via Workflow Streams

### DIFF
--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -198,6 +198,59 @@ As the streaming model request activity, workflow, and workflow execution call a
 - To get data from the workflow call site or workflow to the event stream handler, you can use a [dependencies object](#agent-run-context-and-dependencies).
 - To get data from the event stream handler to the workflow, workflow call site, or a frontend, you need to use an external system that the event stream handler can write to and the event consumer can read from, like a message queue. You can use the dependency object to make sure the same connection string or other unique ID is available in all the places that need it.
 
+#### Streaming events to a frontend with Workflow Streams
+
+Rather than standing up a separate message queue, you can use Temporal's built-in [Workflow Streams](https://docs.temporal.io/develop/python/workflows/workflow-streams) as the transport: the parent workflow itself becomes the durable, offset-addressed channel that an external consumer subscribes to.
+
+Set `event_stream_topic` on the `TemporalAgent` and construct a [`WorkflowStream`][temporalio.contrib.workflow_streams.WorkflowStream] in your workflow's `@workflow.init`. Every event is then published to that topic from within the activity, and any external process with the workflow ID can subscribe and observe events in real time (for example, to relay them over Server-Sent Events to a browser). Setting `event_stream_topic` enables streaming on its own; if you also set an `event_stream_handler`, it still receives every event.
+
+```python {test="skip"}
+from temporalio import workflow
+from temporalio.contrib.workflow_streams import WorkflowStream
+
+with workflow.unsafe.imports_passed_through():
+    from pydantic_ai import Agent
+    from pydantic_ai.durable_exec.temporal import TemporalAgent
+
+agent = Agent('openai:gpt-5.2', name='assistant')
+temporal_agent = TemporalAgent(agent, event_stream_topic='agent_events')
+
+
+@workflow.defn
+class AssistantWorkflow:
+    @workflow.init
+    def __init__(self, prompt: str) -> None:
+        # Hosts the stream that the agent's activities publish to. Without this,
+        # published events are silently dropped.
+        self.stream = WorkflowStream()
+
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        result = await temporal_agent.run(prompt)
+        return result.output
+```
+
+An external consumer subscribes to the same workflow to receive events as they arrive:
+
+```python {test="skip"}
+from temporalio.client import Client
+from temporalio.contrib.workflow_streams import WorkflowStreamClient
+
+from pydantic_ai.messages import AgentStreamEvent
+
+
+async def relay_events(client: Client, workflow_id: str) -> None:
+    stream = WorkflowStreamClient.create(client, workflow_id)
+    async for item in stream.subscribe(['agent_events'], result_type=AgentStreamEvent):  # type: ignore[arg-type]
+        event = item.data
+        ...  # e.g. forward `event` to the frontend over SSE
+```
+
+!!! note "Caveats"
+    - Workflow Streams add roughly 100ms of latency per roundtrip and their cost scales with the number of durable batches; they're suited to driving a UI, not ultra-low-latency use cases like real-time voice.
+    - Delivery is at-least-once: if an activity is retried, its events are re-published, so consumers should tolerate duplicates. The workflow's final result remains authoritative.
+    - Live events reach external consumers only. `run_stream_events()` is still unavailable inside the workflow.
+
 ### Model Selection at Runtime
 
 [`Agent.run(model=...)`][pydantic_ai.agent.Agent.run] normally supports both model strings (like `'openai:gpt-5.2'`) and model instances. However, `TemporalAgent` does not support arbitrary model instances because they cannot be serialized for Temporal's replay mechanism.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -42,6 +42,7 @@ from pydantic_ai.tools import (
 )
 
 from .._runtime_toolsets import reject_unsupported_runtime_toolsets
+from ._event_stream import make_workflow_stream_event_handler
 from ._model import TemporalModel, TemporalProviderFactory
 from ._run_context import TemporalRunContext, deserialize_run_context
 from ._toolset import TemporalWrapperToolset, temporalize_toolset
@@ -66,6 +67,8 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         models: Mapping[str, Model] | None = None,
         provider_factory: TemporalProviderFactory | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
+        event_stream_topic: str | None = None,
+        event_stream_batch_interval: timedelta = timedelta(milliseconds=100),
         activity_config: ActivityConfig | None = None,
         model_activity_config: ActivityConfig | None = None,
         toolset_activity_config: dict[str, ActivityConfig] | None = None,
@@ -102,6 +105,13 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 The callable receives the provider name and the current run context, allowing custom configuration such as injecting API keys stored on `deps`.
                 Note: This factory is only used inside Temporal workflows. Outside workflows, model strings are resolved using the default provider behavior.
             event_stream_handler: Optional event stream handler to use instead of the one set on the wrapped agent.
+            event_stream_topic: If set, every `AgentStreamEvent` is published to this topic on the parent workflow's
+                [`WorkflowStream`][temporalio.contrib.workflow_streams.WorkflowStream] so an external consumer can subscribe
+                to the workflow and observe events in real time. This enables streaming (it implies an event stream handler);
+                if an `event_stream_handler` is also set (here or on the wrapped agent), it still receives every event.
+                The workflow must construct a `WorkflowStream` in its `@workflow.init` for events to be delivered.
+            event_stream_batch_interval: How often the Workflow Stream client flushes buffered events to the workflow when
+                `event_stream_topic` is set. Defaults to 100ms.
             activity_config: The base Temporal activity config to use for all activities. If no config is provided, a `start_to_close_timeout` of 60 seconds is used.
             model_activity_config: The Temporal activity config to use for model request activities. This is merged with the base activity config.
             toolset_activity_config: The Temporal activity config to use for get-tools and call-tool activities for specific toolsets identified by ID. This is merged with the base activity config.
@@ -119,7 +129,16 @@ class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         super().__init__(wrapped)
 
         self._name = name
-        self._event_stream_handler = event_stream_handler
+        if event_stream_topic is not None:
+            # Publish every event to the workflow stream as a side effect, forwarding to any
+            # user-supplied handler (set here or on the wrapped agent) so it still sees every event.
+            self._event_stream_handler = make_workflow_stream_event_handler(
+                event_stream_topic,
+                event_stream_batch_interval,
+                inner=event_stream_handler or super().event_stream_handler,
+            )
+        else:
+            self._event_stream_handler = event_stream_handler
         self.run_context_type = run_context_type
 
         if self.name is None:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_event_stream.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_event_stream.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterable, AsyncIterator
+from datetime import timedelta
+
+from temporalio.contrib.workflow_streams import WorkflowStreamClient
+
+from pydantic_ai import messages as _messages
+from pydantic_ai.agent import EventStreamHandler
+from pydantic_ai.tools import AgentDepsT, RunContext
+
+
+def make_workflow_stream_event_handler(
+    topic: str,
+    batch_interval: timedelta,
+    inner: EventStreamHandler[AgentDepsT] | None,
+) -> EventStreamHandler[AgentDepsT]:
+    """Build an event stream handler that publishes events to a Temporal Workflow Stream.
+
+    The returned handler is used inside the Temporal activities that run the agent's model
+    request stream and its per-event handling. It publishes every `AgentStreamEvent` to `topic`
+    on the parent workflow's [`WorkflowStream`][temporalio.contrib.workflow_streams.WorkflowStream]
+    via [`WorkflowStreamClient.from_within_activity`][temporalio.contrib.workflow_streams.WorkflowStreamClient.from_within_activity],
+    so an external consumer (e.g. an HTTP layer driving a UI) can subscribe to the workflow and
+    observe events in real time.
+
+    Publishing is a side effect: each event is forwarded to `inner` (if set) unchanged, so a
+    user-supplied `event_stream_handler` still sees every event.
+
+    Args:
+        topic: The Workflow Stream topic to publish events to.
+        batch_interval: How often the client flushes buffered events to the workflow.
+        inner: An optional user-supplied handler to forward events to after publishing.
+    """
+
+    async def handler(
+        run_context: RunContext[AgentDepsT],
+        stream: AsyncIterable[_messages.AgentStreamEvent],
+    ) -> None:
+        client = WorkflowStreamClient.from_within_activity(batch_interval=batch_interval)
+        topic_handle = client.topic(topic)
+        async with client:  # background flusher; flushes remaining events on exit
+
+            async def republish() -> AsyncIterator[_messages.AgentStreamEvent]:
+                async for event in stream:
+                    topic_handle.publish(event)
+                    yield event
+
+            if inner is not None:
+                await inner(run_context, republish())
+            else:
+                async for _ in republish():
+                    pass
+
+    return handler

--- a/pydantic_ai_slim/pyproject.toml
+++ b/pydantic_ai_slim/pyproject.toml
@@ -118,7 +118,7 @@ web = ["starlette>=0.46.2", "httpx>=0.27.0", "uvicorn>=0.38.0"]
 # Retries
 retries = ["tenacity>=8.2.3"]
 # Temporal
-temporal = ["temporalio>=1.24.0"]
+temporal = ["temporalio>=1.27.0"]
 # DBOS
 dbos = ["dbos>=2.10.0"]
 # Prefect

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -85,6 +85,7 @@ try:
     from temporalio.common import RetryPolicy
     from temporalio.contrib.opentelemetry import TracingInterceptor
     from temporalio.contrib.pydantic import PydanticPayloadConverter, pydantic_data_converter
+    from temporalio.contrib.workflow_streams import WorkflowStream, WorkflowStreamClient
     from temporalio.converter import DataConverter, DefaultPayloadConverter, PayloadCodec
     from temporalio.exceptions import ApplicationError
     from temporalio.testing import WorkflowEnvironment
@@ -2288,6 +2289,93 @@ async def test_temporal_agent_run_in_workflow_with_event_stream_handler(allow_mo
                 id=SimpleAgentWorkflowWithEventStreamHandler.__name__,
                 task_queue=TASK_QUEUE,
             )
+
+
+async def _streaming_stream_function(messages: list[ModelMessage], agent_info: AgentInfo) -> AsyncIterator[str]:
+    yield 'The capital '
+    yield 'of Mexico '
+    yield 'is Mexico City.'
+
+
+streaming_stream_model = FunctionModel(stream_function=_streaming_stream_function, model_name='streaming')
+
+# Populated (in the activity process) by the user-supplied handler below, to prove that setting
+# `event_stream_topic` still forwards every event to a user handler (the "tee").
+teed_events: list[AgentStreamEvent] = []
+
+
+async def teed_event_stream_handler(
+    ctx: RunContext,
+    stream: AsyncIterable[AgentStreamEvent],
+) -> None:
+    async for event in stream:
+        teed_events.append(event)
+
+
+streaming_agent = Agent(streaming_stream_model, name='streaming_agent')
+# Setting `event_stream_topic` publishes every event to the workflow stream; the user handler still
+# receives them all.
+streaming_temporal_agent = TemporalAgent(
+    streaming_agent,
+    event_stream_handler=teed_event_stream_handler,
+    event_stream_topic='agent_events',
+    activity_config=BASE_ACTIVITY_CONFIG,
+)
+
+
+@workflow.defn
+class StreamingWorkflow:
+    @workflow.init
+    def __init__(self, prompt: str) -> None:
+        # Hosts the stream that the agent's activities publish to.
+        self.stream = WorkflowStream()
+
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        result = await streaming_temporal_agent.run(prompt)
+        return result.output
+
+
+async def test_temporal_agent_streaming_to_workflow_stream(allow_model_requests: None, client: Client):
+    teed_events.clear()
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[StreamingWorkflow],
+        plugins=[AgentPlugin(streaming_temporal_agent)],
+    ):
+        handle = await client.start_workflow(
+            StreamingWorkflow.run,
+            args=['What is the capital of Mexico?'],
+            id=StreamingWorkflow.__name__,
+            task_queue=TASK_QUEUE,
+        )
+
+        # An external consumer subscribes to the same workflow to receive events in real time.
+        stream_client = WorkflowStreamClient.create(client, StreamingWorkflow.__name__)
+        collected: list[AgentStreamEvent] = []
+
+        async def collect() -> None:
+            async for item in stream_client.subscribe(
+                ['agent_events'],
+                from_offset=0,
+                result_type=AgentStreamEvent,  # type: ignore[arg-type]
+                poll_cooldown=timedelta(milliseconds=50),
+            ):
+                collected.append(item.data)
+                if isinstance(item.data, PartEndEvent):
+                    break
+
+        collect_task = asyncio.create_task(collect())
+        output = await handle.result()
+        await asyncio.wait_for(collect_task, timeout=10.0)
+
+    assert output == snapshot('The capital of Mexico is Mexico City.')
+    # The external subscriber observed the streamed model events...
+    assert any(isinstance(event, PartStartEvent) for event in collected)
+    assert any(isinstance(event, PartDeltaEvent) for event in collected)
+    # ...and the user-supplied handler saw them too (the topic tees, it doesn't replace).
+    assert any(isinstance(event, PartStartEvent) for event in teed_events)
 
 
 # Unregistered model instance for testing error case

--- a/uv.lock
+++ b/uv.lock
@@ -5714,7 +5714,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'ui'", specifier = ">=0.46.2" },
     { name = "starlette", marker = "extra == 'web'", specifier = ">=0.46.2" },
     { name = "tavily-python", marker = "extra == 'tavily'", specifier = ">=0.5.0" },
-    { name = "temporalio", marker = "extra == 'temporal'", specifier = ">=1.24.0" },
+    { name = "temporalio", marker = "extra == 'temporal'", specifier = ">=1.27.0" },
     { name = "tenacity", marker = "extra == 'retries'", specifier = ">=8.2.3" },
     { name = "tiktoken", marker = "extra == 'openai'", specifier = ">=0.12.0" },
     { name = "typing-inspection", specifier = ">=0.4.0" },
@@ -7369,7 +7369,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.24.0"
+version = "1.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nexus-rpc" },
@@ -7378,13 +7378,13 @@ dependencies = [
     { name = "types-protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/b1/7d9b3104ab7994e7d49e765b92495aaff44810b1e066c874c284a93ebd55/temporalio-1.24.0.tar.gz", hash = "sha256:e534e2e71b4a721193ec4ff3dae521146d093554bd47a64f5605d4ca33e56718", size = 2040485, upload-time = "2026-03-23T15:33:33.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/b0/ad8fc3cd7425c6551a637bf23c798e8fdd8eb7a3ec4fee4f46f7678ba8d2/temporalio-1.30.0.tar.gz", hash = "sha256:7c025919511bb465392d547e48ccb85fd560a995db4ebcc82fdb43cddf088e6f", size = 2686876, upload-time = "2026-07-02T21:04:46.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/a9/30517c21d6155bce1c3dc0e420db48da0231230dbc683f40ab6d5fe22b37/temporalio-1.24.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7f11e7b4f4d09bafba499b43188353e23dc128b1fe3f3160014476e3dce70760", size = 12223918, upload-time = "2026-03-23T15:33:05.045Z" },
-    { url = "https://files.pythonhosted.org/packages/73/d0/11aa103bde794524008c1850a84e06cde98698395ca1f8b12e1bd2390aa8/temporalio-1.24.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:5cff75a0ca922575b808a7fca1b0de38f6eea061f49e026664b8be9d5bb06ab8", size = 11708887, upload-time = "2026-03-23T15:33:11.67Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/f4/774b56100e6bb94e3757ec96fb5c2bc62d42defc7d6de0ee35a12273827a/temporalio-1.24.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee7c13b6724dd0c304aa846aecf6da72a8550f4ade40a0a7f6dcc1c92ef35710", size = 12028303, upload-time = "2026-03-23T15:33:18.022Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/91/c05d0e9c2432fe8b1ea0d6fae321866ee49a320ad5e494e6ec9424ca5c28/temporalio-1.24.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa71b9bfa42f951dd04ade97ce7f92ecedee8903047b4b41b122bb8cbd87a337", size = 12375155, upload-time = "2026-03-23T15:33:24.234Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/97/5c939e4609c164c8690a3b5a135eb828d531de8ef63ff447a2a439c0b0fb/temporalio-1.24.0-cp310-abi3-win_amd64.whl", hash = "sha256:52f6833647eceddbebcc376e2ea663a9f73b2b3a42675f503aeb27c98fd4daeb", size = 12720174, upload-time = "2026-03-23T15:33:30.826Z" },
+    { url = "https://files.pythonhosted.org/packages/02/39/842fdffe93388dd30ac12a53a698f71cbfb68b3bc938f30f3e5d6a36d4ad/temporalio-1.30.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6773a6b708dee7675fcbb681bf28e48337ce43b8467ceba8f903e78ae68909f8", size = 14520026, upload-time = "2026-07-02T21:04:31.384Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f3/a2237d5265eb29de591abeac7610a48616b590a1b923b4919f60ee81adfa/temporalio-1.30.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:4038c3ce2d9acc12fef31dd16ef9be8cc7f721672da5662aa05e3942d0b5c9d1", size = 14018523, upload-time = "2026-07-02T21:04:34.405Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/57/dc648d812f4c688bd246a616f0d65c5f03b33675df2effb1b480e1df6d21/temporalio-1.30.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:108d1a56e174eabc18add58316084cdead230e239d3df22bbe999d6954986591", size = 14330502, upload-time = "2026-07-02T21:04:37.39Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e1/dbd57de0f5090891850c2ee5490319834a12b704076b11f32a4a149998d4/temporalio-1.30.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47b156138de30c2cd6723d5bfc06a30abcf680344c5481abb31f2a98a9b1f809", size = 14833364, upload-time = "2026-07-02T21:04:40.454Z" },
+    { url = "https://files.pythonhosted.org/packages/30/2a/6d41289c11465ba276a8b417f31d2e469f0fe4b8afacd61d5244151c5fce/temporalio-1.30.0-cp310-abi3-win_amd64.whl", hash = "sha256:3adee28d5ec47bd6309a5eeef7b00126373f119bc5c1b058a34de098542f4da7", size = 15181893, upload-time = "2026-07-02T21:04:43.609Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Streaming inside a Temporal workflow runs the agent's `event_stream_handler` inside an activity, so the [docs](https://ai.pydantic.dev/durable_execution/temporal/#streaming) currently tell users that getting events out to a workflow call site or frontend "requires an external system... like a message queue."

This PR adds native support for using Temporal's built-in [Workflow Streams](https://docs.temporal.io/develop/python/workflows/workflow-streams) as that transport, so no separate queue is needed. Set `event_stream_topic` on `TemporalAgent` and every `AgentStreamEvent` is published to that topic on the parent workflow's `WorkflowStream` (via `WorkflowStreamClient.from_within_activity()`). An external consumer with the workflow ID can then subscribe and observe events in real time — e.g. to relay them over SSE to a browser.

Motivated by temporalio/sdk-python#1661, which asks whether Workflow Streams is the intended bridge for this. It is — this wires it in directly.

## Design

All agent stream events already funnel through the single `event_stream_handler` extension point, which the Temporal integration routes into activities in two places (model-delta events in `request_stream_activity`, tool/agent events in `event_stream_handler_activity`). So the bridge is just a wrapper around that handler that publishes each event as a side effect:

- New `event_stream_topic` / `event_stream_batch_interval` params on `TemporalAgent`.
- When a topic is set, `self._event_stream_handler` is wrapped with a publishing handler (`_event_stream.py`) that forwards to any user-supplied handler, so setting the topic **tees** rather than replacing an existing `event_stream_handler`.
- Setting the topic implies an event stream handler, so it enables streaming on its own.
- The workflow must host a `WorkflowStream()` in its `@workflow.init` for events to be delivered.

Because `CompletedStreamedResponse` emits nothing by default, model-delta events are handled only inside the model-request activity and tool/agent events only via the per-event activity, so each event is published exactly once (no double-publishing).

## Caveats (documented)

- ~100ms latency per roundtrip; cost scales with durable batches. Good for driving a UI, not ultra-low-latency use cases like voice.
- At-least-once: an activity retry re-publishes its events, so consumers should tolerate duplicates. The workflow's final result stays authoritative.
- Live events reach external consumers only; `run_stream_events()` remains unavailable inside the workflow.

## Dependency

Bumps the `temporal` extra to `temporalio>=1.27.0` (first release with `workflow_streams.from_within_activity`).

## Tests

Adds `test_temporal_agent_streaming_to_workflow_stream`: a `FunctionModel`-streamed agent in a workflow hosting `WorkflowStream()`, asserting an external subscriber observes the streamed events **and** a user-supplied handler still receives them (the tee). Runs against the existing local dev-server fixture; no cassette needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

