### PR TITLE
Always fetch MCP instructions via a durable step under `DBOSDurability`

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -226,7 +226,6 @@ class DurableMCPToolset(DurableToolsetBase[AgentDepsT]):
         lifecycle: Lifecycle,
         durable_registrations: list[Any] | None = None,
         durable_config: Mapping[str, Any] | None = None,
-        instructions_local_first: bool = False,
     ):
         super().__init__(
             wrapped,
@@ -240,11 +239,6 @@ class DurableMCPToolset(DurableToolsetBase[AgentDepsT]):
         self._get_instructions_operation = get_instructions_operation
         self._call_tool_operation = call_tool_operation
         self._resolve_tool_config = resolve_tool_config
-        # An optimization only available to engines whose durable units share the process
-        # (DBOS): the wrapped MCP server instance may already hold cached instructions from a
-        # prior in-process operation, saving a durable-unit execution (and its checkpoint).
-        # Out-of-process engines (Temporal) must never touch the server from workflow code.
-        self._instructions_local_first = instructions_local_first
 
     async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
         if not self._in_durable_context() or self._get_tools_operation is None:
@@ -262,11 +256,9 @@ class DurableMCPToolset(DurableToolsetBase[AgentDepsT]):
             return None
         if not self._in_durable_context() or self._get_instructions_operation is None:  # pragma: no cover
             return await self._mcp_toolset.get_instructions(ctx)
-        if (
-            self._instructions_local_first
-            and (instructions := await self._mcp_toolset.get_instructions(ctx)) is not None
-        ):
-            return instructions
+        # Always route through the durable unit: deciding based on locally-cached state (e.g.
+        # instructions a warm in-process MCP server already holds) would make the durable
+        # schedule depend on process warmth and diverge on replay/recovery (#5884).
         return await self._get_instructions_operation(ctx)
 
     async def call_tool(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
@@ -60,7 +60,6 @@ def dbosify_mcp_toolset(
         resolve_tool_config=lambda tool, name: {},
         lifecycle='enter-never',
         durable_config=step_config,
-        instructions_local_first=True,
     )
 
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -11,7 +11,7 @@ import re
 import time
 import uuid
 import warnings
-from collections.abc import AsyncIterable, AsyncIterator, Generator, Iterator
+from collections.abc import AsyncIterable, AsyncIterator, Generator, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -1909,6 +1909,42 @@ async def test_dbos_mcp_toolset_get_instructions_falls_back_to_step(dbos: DBOS):
 
     instructions = await _uninit_instructions_toolset.get_instructions(run_context)
     assert instructions == InstructionPart(content='Be a helpful assistant.', dynamic=False)
+
+
+async def test_dbos_mcp_toolset_get_instructions_uses_step_when_server_warm(dbos: DBOS):
+    """A warm in-process MCP server must not short-circuit the `get_instructions` step (#5884).
+
+    Whether the step runs must not depend on process warmth: skipping it when the wrapped
+    server already holds instructions locally makes the durable schedule diverge between the
+    original execution and replay/recovery in a differently-warm process.
+    """
+    inner = MCPToolset(
+        StdioTransport(command='python', args=['-m', 'tests.mcp_server']),
+        include_instructions=True,
+        id='warm_instructions_test',
+    )
+    wrapper = dbosify_mcp_toolset(inner, step_name_prefix='warm_instructions_test', step_config={})
+    run_context = RunContext(deps=0, model=TestModel(), usage=RunUsage())
+
+    step_calls: list[str] = []
+    original_operation = wrapper._get_instructions_operation  # pyright: ignore[reportPrivateUsage]
+    assert original_operation is not None
+
+    async def recording_operation(
+        ctx: RunContext[object],
+    ) -> str | InstructionPart | Sequence[str | InstructionPart] | None:
+        step_calls.append('step')
+        return await original_operation(ctx)
+
+    wrapper._get_instructions_operation = recording_operation  # pyright: ignore[reportPrivateUsage]
+
+    # Hold the wrapped server entered so it can serve instructions locally (warm process).
+    async with inner:
+        assert await inner.get_instructions(run_context) is not None
+        instructions = await wrapper.get_instructions(run_context)
+
+    assert instructions == InstructionPart(content='Be a helpful assistant.', dynamic=False)
+    assert step_calls == ['step']
 
 
 # Exercises the `DBOSMCPToolset` wrapper's `get_instructions` step path with a real `MCPToolset`.

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1917,6 +1917,10 @@ async def test_dbos_mcp_toolset_get_instructions_uses_step_when_server_warm(dbos
     Whether the step runs must not depend on process warmth: skipping it when the wrapped
     server already holds instructions locally makes the durable schedule diverge between the
     original execution and replay/recovery in a differently-warm process.
+
+    Not a VCR test: what's asserted is *which side* serves the instructions (the DBOS step vs
+    the warm server's local cache) — invisible to a network cassette, since both paths issue
+    the same MCP traffic.
     """
     inner = MCPToolset(
         StdioTransport(command='python', args=['-m', 'tests.mcp_server']),


### PR DESCRIPTION
- Closes #5884

This fixes the supported capability path (`DBOSDurability`); the deprecated `DBOSAgent` wrapper path retains the old behavior and is left untouched — it is slated for removal in v3, so the wrapper-side sibling of this bug goes away with it.

## What this does

Removes the `instructions_local_first` short-circuit from the shared `DurableMCPToolset`: `get_instructions` now always routes through the engine's durable unit, matching Temporal.

`DBOSDurability` passed `instructions_local_first=True`, meaning MCP instructions were served directly from the wrapped in-process server whenever it happened to be warm (already entered, e.g. held open by another holder for the process lifetime), *skipping* the `get_instructions` step. That makes the durable schedule depend on process warmth — the exact replay-nondeterminism class from #5884 (#5875's `get_tools` sibling): a workflow recovered in a differently-warm process schedules a different step sequence and fails with `DBOSUnexpectedStepError`.

Note the window is narrower on the capability path than on the legacy wrapper path the issue describes (`MCPToolset` clears its cached instructions on final exit, unlike the legacy `MCPServer`), but it's real whenever the server instance is held entered elsewhere.

Outside a workflow nothing changes: DBOS steps degrade gracefully to plain calls, and the `get_instructions` step enters the server itself.

## Tests

- New regression test holds the wrapped MCP server entered (warm, serving instructions locally) and asserts `get_instructions` still routes through the step.
- Full DBOS suite green (93), plus Temporal (179) and Prefect (83) against the shared-signature change.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
