### PR TITLE
Temporarily withdraw durable wrapper-agent deprecations

### DIFF
--- a/docs/durable_execution/dbos.md
+++ b/docs/durable_execution/dbos.md
@@ -108,11 +108,11 @@ Because the same agent works inside and outside a DBOS workflow, [`DBOSDurabilit
 
 For more information on how to use DBOS in Python applications, see their [Python SDK guide](https://docs.dbos.dev/python/programming-guide).
 
-### Wrapper-agent path (deprecated)
+### Wrapper-agent path
 
-!!! warning "Deprecated"
-    [`DBOSAgent`][pydantic_ai.durable_exec.dbos.DBOSAgent] is the original wrapper-agent path for DBOS integration and will be removed in v3. New code should use the [`DBOSDurability`][pydantic_ai.durable_exec.dbos.DBOSDurability] capability shown above.
+[`DBOSAgent`][pydantic_ai.durable_exec.dbos.DBOSAgent] remains supported as the wrapper-agent alternative to [`DBOSDurability`][pydantic_ai.durable_exec.dbos.DBOSDurability].
 
+!!! warning "Migration"
     **When migrating, you must wrap the run in a workflow yourself.** `DBOSAgent` wrapped `run` / `run_sync` as a DBOS workflow automatically; `DBOSDurability` deliberately does not — a run is only durable when `agent.run()` is called inside your own `@DBOS.workflow`. Porting the constructor arguments but calling `agent.run()` directly produces a run that works but is **not durable**.
 
 Any agent can be wrapped in a [`DBOSAgent`][pydantic_ai.durable_exec.dbos.DBOSAgent] to get a durable agent variant that routes model requests and MCP communication through DBOS steps:

--- a/docs/durable_execution/prefect.md
+++ b/docs/durable_execution/prefect.md
@@ -108,11 +108,11 @@ Because the same agent works inside and outside a Prefect flow, [`PrefectDurabil
 
 For more information on how to use Prefect in Python applications, see their [Python documentation](https://docs.prefect.io/v3/how-to-guides/workflows/write-and-run).
 
-### Wrapper-agent path (deprecated)
+### Wrapper-agent path
 
-!!! warning "Deprecated"
-    [`PrefectAgent`][pydantic_ai.durable_exec.prefect.PrefectAgent] is the original wrapper-agent path for Prefect integration and will be removed in v3. New code should use the [`PrefectDurability`][pydantic_ai.durable_exec.prefect.PrefectDurability] capability shown above.
+[`PrefectAgent`][pydantic_ai.durable_exec.prefect.PrefectAgent] remains supported as the wrapper-agent alternative to [`PrefectDurability`][pydantic_ai.durable_exec.prefect.PrefectDurability].
 
+!!! warning "Migration"
     **When migrating, you must wrap the run in a flow yourself.** `PrefectAgent` wrapped `run` / `run_sync` as a Prefect flow automatically; `PrefectDurability` deliberately does not — a run is only durable when `agent.run()` is called inside your own `@flow`. Porting the constructor arguments but calling `agent.run()` directly produces a run that works but is **not durable**.
 
 Any agent can be wrapped in a [`PrefectAgent`][pydantic_ai.durable_exec.prefect.PrefectAgent] to get a durable agent variant that routes model requests, tool calls, and MCP communication through Prefect tasks:

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -163,12 +163,10 @@ Because Temporal workflows need to be defined at the top level of the file and t
 
 For more information on how to use Temporal in Python applications, see their [Python SDK guide](https://docs.temporal.io/develop/python).
 
-### Wrapper-agent path (deprecated)
+### Wrapper-agent path
 
-!!! warning "Deprecated"
-    [`TemporalAgent`][pydantic_ai.durable_exec.temporal.TemporalAgent] is the original wrapper-agent path for Temporal integration and will be removed in v3. New code should use the [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability] capability shown above.
-
-    Migrating preserves activity names and payloads (as long as the agent's `name` and toolset `id`s stay the same), so workflows started under `TemporalAgent` will replay correctly after switching to `TemporalDurability` — there's no need to drain or version your workflows first.
+!!! warning "Migration compatibility"
+    Some workflow histories recorded with [`TemporalAgent`][pydantic_ai.durable_exec.temporal.TemporalAgent], including streamed model activity results, do not currently replay under [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability]. Continue using `TemporalAgent` for existing workflows until migration compatibility is restored.
 
 Any agent can be wrapped in a [`TemporalAgent`][pydantic_ai.durable_exec.temporal.TemporalAgent] to get a durable agent variant that can be used inside a Temporal workflow. At the time of wrapping, the agent's model and toolsets are frozen, activities are dynamically created for each, and the original model and toolsets are wrapped to call on the worker to execute the corresponding activities instead of directly performing the actions inside the workflow. The original agent can still be used as normal outside the Temporal workflow, but any changes to its model or toolsets after wrapping will not be reflected in the durable agent.
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/__init__.py
@@ -8,7 +8,7 @@ except ImportError as _import_error:
         'you can use the `dbos` optional group — `pip install "pydantic-ai-slim[dbos]"`'
     ) from _import_error
 
-from ._agent import DBOSAgent, DBOSParallelExecutionMode  # pyright: ignore[reportDeprecated]
+from ._agent import DBOSAgent, DBOSParallelExecutionMode
 from ._durability import DBOSDurability
 from ._model import DBOSModel
 from ._utils import StepConfig

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -6,7 +6,6 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from dbos import DBOS, DBOSConfiguredInstance
-from typing_extensions import deprecated
 
 from pydantic_ai import (
     AbstractToolset,
@@ -52,16 +51,6 @@ DBOSParallelExecutionMode = Literal['sequential', 'parallel_ordered_events']
 """
 
 
-@deprecated(
-    """`DBOSAgent` is deprecated in favor of the `DBOSDurability` capability. Migrate each constructor argument as follows:
-- With the capability, call `agent.run()` inside a `@DBOS.workflow`; the wrapper did this automatically.
-- `wrapped=` → use the wrapped agent's configuration on a regular `Agent(..., capabilities=[DBOSDurability(...)])`.
-- `name=` → set `name=` on `Agent`, or `name=` on `DBOSDurability`.
-- `event_stream_handler=` → pass `event_stream_handler=` to `DBOSDurability`; it runs inside steps, exactly like before.
-- `mcp_step_config=` → set `mcp_step_config=` on `DBOSDurability`.
-- `model_step_config=` → set `model_step_config=` on `DBOSDurability`.
-- `parallel_execution_mode=` → set `parallel_execution_mode=` on `DBOSDurability`."""
-)
 @DBOS.dbos_class()
 class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
     _parallel_execution_mode: ParallelExecutionMode
@@ -236,7 +225,7 @@ class DBOSAgent(WrapperAgent[AgentDepsT, OutputDataT], DBOSConfiguredInstance):
             spec: dict[str, Any] | AgentSpec | None = None,
         ) -> AgentRunResult[Any]:
             with self._dbos_overrides(toolsets, event_stream_handler=event_stream_handler):
-                return super(DBOSAgent, self).run_sync(  # pyright: ignore[reportDeprecated]
+                return super(DBOSAgent, self).run_sync(
                     user_prompt,
                     output_type=output_type,
                     message_history=message_history,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/__init__.py
@@ -6,7 +6,7 @@ except ImportError as _import_error:
         'you can use the `prefect` optional group — `pip install "pydantic-ai-slim[prefect]"`'
     ) from _import_error
 
-from ._agent import PrefectAgent  # pyright: ignore[reportDeprecated]
+from ._agent import PrefectAgent
 from ._cache_policies import DEFAULT_PYDANTIC_AI_CACHE_POLICY
 from ._durability import PrefectDurability
 from ._function_toolset import PrefectFunctionToolset

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, overload
 from prefect import flow, task
 from prefect.context import FlowRunContext
 from prefect.utilities.asyncutils import run_coro_as_sync
-from typing_extensions import deprecated
 
 from pydantic_ai import (
     AbstractToolset,
@@ -45,19 +44,6 @@ if TYPE_CHECKING:
 from ._types import TaskConfig, default_task_config
 
 
-@deprecated(
-    """`PrefectAgent` is deprecated in favor of the `PrefectDurability` capability. Migrate each constructor argument as follows:
-- With the capability, call `agent.run()` inside a `@flow`; the wrapper did this automatically.
-- `wrapped=` → use the wrapped agent's configuration on a regular `Agent(..., capabilities=[PrefectDurability(...)])`.
-- `name=` → set `name=` on `Agent`, or `name=` on `PrefectDurability`.
-- `event_stream_handler=` → pass `event_stream_handler=` to `PrefectDurability`; it runs inside tasks, exactly like before.
-- `mcp_task_config=` → set `mcp_task_config=` on `PrefectDurability`.
-- `model_task_config=` → set `model_task_config=` on `PrefectDurability`.
-- `tool_task_config=` → set `tool_task_config=` on `PrefectDurability`.
-- `tool_task_config_by_name=` → use per-tool `metadata={'prefect': ...}` or a `SetToolMetadata` capability.
-- `event_stream_handler_task_config=` → set `event_stream_handler_task_config=` on `PrefectDurability`.
-- `prefectify_toolset_func=` → not supported on the capability path; open an issue if you need it."""
-)
 class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
     def __init__(
         self,
@@ -495,7 +481,7 @@ class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 with self._prefect_overrides(toolsets, event_stream_handler=event_stream_handler):
                     # Using `run_coro_as_sync` from Prefect with async `run` to avoid event loop conflicts.
                     result = run_coro_as_sync(
-                        super(PrefectAgent, self).run(  # pyright: ignore[reportDeprecated]
+                        super(PrefectAgent, self).run(
                             user_prompt,
                             output_type=output_type,
                             message_history=message_history,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
@@ -34,7 +34,7 @@ def resolve_tool_task_config(
                     f'(`TaskConfig`) or `False`, got {type(metadata_config).__name__}.'
                 )
             return cast('TaskConfig', metadata_config)
-    # Fallback: per-tool dict passed to the deprecated `PrefectAgent`. An explicit `None`
+    # Fallback: per-tool dict passed to `PrefectAgent`. An explicit `None`
     # disables wrapping; a missing key means "use the base config".
     if tool_name in tool_task_config:
         fallback = tool_task_config[tool_name]

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py
@@ -22,7 +22,7 @@ from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
 
 from ...agent.abstract import AbstractAgent
 from ...exceptions import AgentRunError, UserError
-from ._agent import TemporalAgent  # pyright: ignore[reportDeprecated]
+from ._agent import TemporalAgent
 from ._durability import TemporalDurability
 from ._logfire import LogfirePlugin
 from ._run_context import TemporalRunContext
@@ -162,10 +162,7 @@ class PydanticAIPlugin(SimplePlugin):
                     f'__pydantic_ai_agents__ must be a Sequence of TemporalAgent instances, got {type(agents)}'
                 )
             for agent in agents:  # type: ignore[reportUnknownVariableType]
-                if isinstance(agent, TemporalAgent):  # pyright: ignore[reportDeprecated]
-                    # Deprecated path: `TemporalAgent` is being phased out in favor of
-                    # `capabilities=[TemporalDurability(...)]` on a regular `Agent`. Kept
-                    # working so existing workers keep loading without changes.
+                if isinstance(agent, TemporalAgent):
                     activities.extend(agent.temporal_activities)  # type: ignore[reportUnknownMemberType]
                 elif isinstance(agent, AbstractAgent):
                     durability = TemporalDurability.from_agent(agent)  # type: ignore[reportUnknownArgumentType]
@@ -191,12 +188,12 @@ class AgentPlugin(SimplePlugin):
     Accepts either a regular `Agent` carrying a
     [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability]
     capability (whose chain is walked to find the bound capability), or the
-    deprecated [`TemporalAgent`][pydantic_ai.durable_exec.temporal.TemporalAgent]
+    [`TemporalAgent`][pydantic_ai.durable_exec.temporal.TemporalAgent]
     wrapper, and registers the agent's activities on the worker.
     """
 
     def __init__(self, agent: AbstractAgent[Any, Any]):
-        if isinstance(agent, TemporalAgent):  # pyright: ignore[reportDeprecated]
+        if isinstance(agent, TemporalAgent):
             activities = agent.temporal_activities
         else:
             durability = TemporalDurability.from_agent(agent)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -15,7 +15,6 @@ from pydantic_core import PydanticSerializationError
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 from temporalio.workflow import ActivityConfig
-from typing_extensions import deprecated
 
 from pydantic_ai import (
     AbstractToolset,
@@ -59,20 +58,6 @@ class _EventStreamHandlerParams:
     serialized_run_context: Any
 
 
-@deprecated(
-    """`TemporalAgent` is deprecated in favor of the `TemporalDurability` capability. Migrate each constructor argument as follows:
-- `wrapped=` → use the wrapped agent's configuration on a regular `Agent(..., capabilities=[TemporalDurability(...)])`.
-- `name=` → set `name=` on `Agent`, or `name=` on `TemporalDurability`.
-- `models=` → set `models=` on `TemporalDurability`.
-- `provider_factory=` → use a deps-aware `ResolveModelId` capability.
-- `event_stream_handler=` → pass `event_stream_handler=` to `TemporalDurability`; it runs inside activities, exactly like before; for streams that don't need to run inside activities, register a `ProcessEventStream` capability instead.
-- `activity_config=` → set `activity_config=` on `TemporalDurability`.
-- `model_activity_config=` → set `model_activity_config=` on `TemporalDurability`.
-- `toolset_activity_config=` → set `toolset_activity_config=` on `TemporalDurability`.
-- `tool_activity_config=` → use per-tool `metadata={'temporal': ...}` or a `SetToolMetadata` capability.
-- `run_context_type=` → set `run_context_type=` on `TemporalDurability`.
-- `temporalize_toolset_func=` → not supported on the capability path; open an issue if you need it."""
-)
 class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):
     def __init__(
         self,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_workflow.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_workflow.py
@@ -9,7 +9,7 @@ class PydanticAIWorkflow:
 
     Accepts any `AbstractAgent` — either a regular `Agent` carrying a
     [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability]
-    capability, or the deprecated
+    capability, or the
     [`TemporalAgent`][pydantic_ai.durable_exec.temporal.TemporalAgent] wrapper.
     [`PydanticAIPlugin`][pydantic_ai.durable_exec.temporal.PydanticAIPlugin]
     walks the sequence and registers each agent's activities with the worker.

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -1,8 +1,3 @@
-# pyright: reportDeprecated=false
-# `DBOSAgent` (the wrapper-agent path) is deprecated in favor of the
-# `DBOSDurability` capability, but this file still exercises both paths in
-# parallel for parity. Silenced at file level rather than annotating every
-# individual usage.
 from __future__ import annotations
 
 import asyncio
@@ -10,7 +5,6 @@ import os
 import re
 import time
 import uuid
-import warnings
 from collections.abc import AsyncIterable, AsyncIterator, Generator, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -94,18 +88,10 @@ from pydantic_ai.toolsets._dynamic import DynamicToolset
 from ._inline_snapshot import snapshot
 from .continuation_utils import ScriptedContinuationModel, StreamSegment, scripted_response
 
-# `DBOSAgent` is deprecated in favor of `capabilities=[DBOSDurability(...)]`.
-# These tests exercise the wrapper-agent path on purpose; suppress the warning here
-# rather than globally in `pyproject.toml`. The `pytestmark` entry below covers warnings
-# emitted *inside* test functions; the `filterwarnings` call below covers warnings emitted
-# at module import time (e.g. `simple_dbos_agent = DBOSAgent(...)`).
-warnings.filterwarnings('ignore', message='`DBOSAgent` is deprecated', category=DeprecationWarning)
-
 pytestmark = [
     pytest.mark.anyio,
     pytest.mark.vcr,
     pytest.mark.xdist_group(name='dbos'),
-    pytest.mark.filterwarnings('ignore:`DBOSAgent` is deprecated:DeprecationWarning'),
 ]
 
 # We need to use a custom cached HTTP client here as the default one created for OpenAIProvider will be closed automatically

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1,8 +1,3 @@
-# pyright: reportDeprecated=false
-# `PrefectAgent` (the wrapper-agent path) is deprecated in favor of the
-# `PrefectDurability` capability, but this file still exercises both paths in
-# parallel for parity. Silenced at file level rather than annotating every
-# individual usage.
 from __future__ import annotations
 
 import os
@@ -97,13 +92,7 @@ from ._inline_snapshot import snapshot
 from .conftest import IsDatetime, IsSameStr, IsStr
 from .continuation_utils import ScriptedContinuationModel, StreamSegment, scripted_response
 
-# `PrefectAgent` is deprecated in favor of `capabilities=[PrefectDurability(...)]`, and
-# the legacy `MCPServer*` / `FastMCPToolset` classes are deprecated in favor of `MCPToolset`.
-# These tests exercise the wrapper-agent path on purpose; suppress the warnings here
-# rather than globally in `pyproject.toml`. The `pytestmark` entries below cover warnings
-# emitted *inside* test functions; the `filterwarnings` calls below cover warnings emitted
-# at module import time (e.g. module-level construction of `PrefectAgent`).
-warnings.filterwarnings('ignore', message='`PrefectAgent` is deprecated', category=DeprecationWarning)
+# The legacy `MCPServer*` / `FastMCPToolset` classes are deprecated in favor of `MCPToolset`.
 warnings.filterwarnings(
     'ignore',
     message=r'`(MCPServerStdio|MCPServerSSE|MCPServerStreamableHTTP|FastMCPToolset)` is deprecated',
@@ -114,7 +103,6 @@ pytestmark = [
     pytest.mark.anyio,
     pytest.mark.vcr,
     pytest.mark.xdist_group(name='prefect'),
-    pytest.mark.filterwarnings('ignore:`PrefectAgent` is deprecated:DeprecationWarning'),
     pytest.mark.filterwarnings(
         'ignore:`(MCPServerStdio|MCPServerSSE|MCPServerStreamableHTTP|FastMCPToolset)` is deprecated:DeprecationWarning'
     ),
@@ -1720,7 +1708,7 @@ def test_resolve_tool_task_config_reads_metadata() -> None:
         args_validator=None,  # pyright: ignore[reportArgumentType]
     )
 
-    # Metadata wins over the per-tool (deprecated `PrefectAgent`) dict.
+    # Metadata wins over the per-tool `PrefectAgent` dict.
     resolved = resolve_tool_task_config(tool, 'fn_tool', {'fn_tool': TaskConfig(timeout_seconds=1.0)})
     assert resolved is metadata_config
 

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,14 +1,9 @@
-# pyright: reportDeprecated=false
-# `TemporalAgent` (the wrapper-agent path) is deprecated in favor of the
-# `TemporalDurability` capability, but this file still exercises both paths in
-# parallel for parity. Silenced at file level rather than annotating every
-# individual usage.
 from __future__ import annotations
 
 import asyncio
 import os
 import re
-import warnings
+import uuid
 from collections.abc import AsyncIterable, AsyncIterator, Generator, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -61,6 +56,7 @@ from pydantic_ai import (
     WebSearchTool,
     WebSearchUserLocation,
 )
+from pydantic_ai.agent.abstract import AbstractAgent
 from pydantic_ai.capabilities import (
     MCP,
     Capability,
@@ -186,18 +182,10 @@ with workflow.unsafe.imports_passed_through():
     # Loads `vcr`, which Temporal doesn't like without passing through the import
     from .conftest import IsDatetime, IsInt, IsStr, message
 
-# `TemporalAgent` is deprecated in favor of `capabilities=[TemporalDurability(...)]`.
-# These tests exercise the wrapper-agent path on purpose; suppress the warning here
-# rather than globally in `pyproject.toml`. The `pytestmark` entry below covers warnings
-# emitted *inside* test functions; the `filterwarnings` call below covers warnings emitted
-# at module import time (e.g. module-level construction of `TemporalAgent`).
-warnings.filterwarnings('ignore', message='`TemporalAgent` is deprecated', category=DeprecationWarning)
-
 pytestmark = [
     pytest.mark.anyio,
     pytest.mark.vcr,
     pytest.mark.xdist_group(name='temporal'),
-    pytest.mark.filterwarnings('ignore:`TemporalAgent` is deprecated:DeprecationWarning'),
 ]
 
 
@@ -354,6 +342,88 @@ async def test_simple_agent_run_in_workflow(allow_model_requests: None, client: 
             task_queue=TASK_QUEUE,
         )
         assert output == snapshot('The capital of Mexico is Mexico City.')
+
+
+async def _migration_event_stream_handler(ctx: RunContext[None], stream: AsyncIterable[AgentStreamEvent]) -> None:
+    async for _ in stream:
+        pass
+
+
+_migration_agent_name = 'temporal_agent_migration'
+_legacy_migration_agent = TemporalAgent(
+    Agent(TestModel(custom_output_text='migrated'), name=_migration_agent_name, deps_type=type(None)),
+    activity_config=BASE_ACTIVITY_CONFIG,
+    event_stream_handler=_migration_event_stream_handler,
+)
+_capability_migration_agent = Agent(
+    TestModel(custom_output_text='migrated'),
+    name=_migration_agent_name,
+    deps_type=type(None),
+    capabilities=[
+        TemporalDurability(
+            activity_config=BASE_ACTIVITY_CONFIG,
+            event_stream_handler=_migration_event_stream_handler,
+        )
+    ],
+)
+_migration_agent: AbstractAgent[None, str] = _legacy_migration_agent
+
+
+@workflow.defn
+class TemporalAgentMigrationWorkflow:
+    @workflow.run
+    async def run(self, prompt: str) -> str:
+        return (await _migration_agent.run(prompt)).output
+
+
+@pytest.mark.xfail(
+    reason='TODO #6625: make histories recorded with TemporalAgent replay under TemporalDurability',
+    raises=RuntimeError,
+    strict=True,
+)
+async def test_temporal_agent_history_replays_after_migrating_to_durability(client: Client) -> None:
+    """A recorded wrapper-agent workflow must replay with the capability implementation.
+
+    This is an engine-level replay test rather than a provider VCR test: the compatibility
+    contract is the Temporal activity payload and result schema, independent of the provider.
+    """
+    global _migration_agent
+
+    _migration_agent = _legacy_migration_agent
+    workflow_id = f'{TemporalAgentMigrationWorkflow.__name__}-{uuid.uuid4()}'
+    async with Worker(
+        client,
+        task_queue=TASK_QUEUE,
+        workflows=[TemporalAgentMigrationWorkflow],
+        activities=_legacy_migration_agent.temporal_activities,
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ):
+        output = await client.execute_workflow(
+            TemporalAgentMigrationWorkflow.run,
+            args=['hello'],
+            id=workflow_id,
+            task_queue=TASK_QUEUE,
+        )
+        history = await client.get_workflow_handle(workflow_id).fetch_history()
+
+    assert output == 'migrated'
+
+    _migration_agent = _capability_migration_agent
+    try:
+        await Replayer(
+            workflows=[TemporalAgentMigrationWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            data_converter=pydantic_data_converter,
+        ).replay_workflow(history)
+    except RuntimeError as exc:
+        failure = str(exc)
+        assert 'Failed decoding arguments' in failure
+        assert '2 validation errors for StreamedActivityResult' in failure
+        assert 'response\\n  Field required' in failure
+        assert 'events\\n  Field required' in failure
+        raise
+    finally:
+        _migration_agent = _legacy_migration_agent
 
 
 class Deps(BaseModel):


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Follow-up to #4977.

The durable wrapper agents were deprecated in v2.14.0 while migration incompatibilities are still known. This patch release follow-up:

- withdraws the runtime and typing deprecations for `TemporalAgent`, `DBOSAgent`, and `PrefectAgent`
- removes the v3-removal guidance from their documentation while retaining migration caveats
- keeps the Temporal history migration regression as a strict xfail, with a TODO referencing this PR

The underlying migration and wrapper-agent issues are deliberately deferred to follow-up fixes.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

