### PR TITLE
docs: cover all compaction approaches and point third-party capabilities at first-party equivalents

### DIFF
--- a/docs/capabilities/compaction.md
+++ b/docs/capabilities/compaction.md
@@ -15,7 +15,7 @@ Each uses the corresponding provider API, so it's only available on that provide
 
 ## Model-agnostic compaction
 
-To compact on any model, edit the message history yourself with a [history processor](../message-history.md#processing-message-history) wrapped as a [`ProcessHistory`](process-history.md) capability — this works with every provider. Common patterns:
+To compact on any model, edit the message history yourself with a [history processor](../message-history.md#processing-message-history) wrapped as a [`ProcessHistory`][pydantic_ai.capabilities.ProcessHistory] capability — this works with every provider. Common patterns:
 
 - [Keep only recent messages](../message-history.md#keep-only-recent-messages) — a zero-cost sliding window over the most recent turns.
 - [Summarize old messages](../message-history.md#summarize-old-messages) — use a (cheaper) model to condense older messages into a summary.

--- a/docs/capabilities/compaction.md
+++ b/docs/capabilities/compaction.md
@@ -1,8 +1,25 @@
 # Compaction
 
-Compaction [capabilities](overview.md) manage conversation context size by compacting older messages into summaries. Compaction is provider-specific — each capability uses the corresponding provider API:
+As a conversation grows, its message history can approach the model's context window. *Compaction* keeps it in check by shrinking older messages — trimming, clearing, or summarizing them — while preserving recent context and tool-call integrity. Pydantic AI supports this at several levels, from provider-native APIs to model-agnostic history editing.
+
+## Provider-native compaction
+
+Some providers expose a built-in compaction API that runs on their side. Pydantic AI wraps these as [capabilities](overview.md):
 
 | Provider | Capability | Details |
 |----------|-----------|---------|
 | OpenAI Responses API | [`OpenAICompaction`][pydantic_ai.models.openai.OpenAICompaction] | [OpenAI compaction](../models/openai.md#message-compaction) |
 | Anthropic | [`AnthropicCompaction`][pydantic_ai.models.anthropic.AnthropicCompaction] | [Anthropic compaction](../models/anthropic.md#message-compaction) |
+
+Each uses the corresponding provider API, so it's only available on that provider.
+
+## Model-agnostic compaction
+
+To compact on any model, edit the message history yourself with a [history processor](../message-history.md#processing-message-history) wrapped as a [`ProcessHistory`](process-history.md) capability — this works with every provider. Common patterns:
+
+- [Keep only recent messages](../message-history.md#keep-only-recent-messages) — a zero-cost sliding window over the most recent turns.
+- [Summarize old messages](../message-history.md#summarize-old-messages) — use a (cheaper) model to condense older messages into a summary.
+
+## Pydantic AI Harness
+
+[Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/) packages a menu of ready-made, model-agnostic [compaction strategies](https://pydantic.dev/docs/ai/harness/compaction/): mostly zero-LLM history editing — sliding-window trimming, clearing old tool results, deduplicating repeated file reads, clamping oversized message parts — plus LLM summarization for when that's not enough, and a `TieredCompaction` orchestrator (the recommended default) that escalates from cheap to expensive strategies only as far as needed to fit the target.

--- a/docs/capabilities/overview.md
+++ b/docs/capabilities/overview.md
@@ -48,7 +48,7 @@ Pydantic AI ships with several capabilities that cover common needs:
 
 The **Spec** column indicates whether the capability can be used in [agent specs](../agent-spec.md) (YAML/JSON). Capabilities marked **—** take non-serializable arguments (callables, toolset objects) and can only be used in Python code.
 
-Provider-specific [compaction](compaction.md) capabilities ([`OpenAICompaction`][pydantic_ai.models.openai.OpenAICompaction], [`AnthropicCompaction`][pydantic_ai.models.anthropic.AnthropicCompaction]) live in the corresponding model modules. The [durable execution](../durable_execution/overview.md) integrations also ship as capabilities — [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability], [`DBOSDurability`][pydantic_ai.durable_exec.dbos.DBOSDurability], and [`PrefectDurability`][pydantic_ai.durable_exec.prefect.PrefectDurability] — in the `pydantic_ai.durable_exec` subpackages.
+[Compaction](compaction.md) keeps conversations within the context window through several approaches; the provider-native [`OpenAICompaction`][pydantic_ai.models.openai.OpenAICompaction] and [`AnthropicCompaction`][pydantic_ai.models.anthropic.AnthropicCompaction] capabilities live in the corresponding model modules. The [durable execution](../durable_execution/overview.md) integrations also ship as capabilities — [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability], [`DBOSDurability`][pydantic_ai.durable_exec.dbos.DBOSDurability], and [`PrefectDurability`][pydantic_ai.durable_exec.prefect.PrefectDurability] — in the `pydantic_ai.durable_exec` subpackages.
 
 ```python {title="native_capabilities.py"}
 from pydantic_ai import Agent

--- a/docs/capabilities/third-party.md
+++ b/docs/capabilities/third-party.md
@@ -2,39 +2,41 @@
 
 [Capabilities](overview.md) are the recommended way for third-party packages to extend Pydantic AI, since they can bundle tools with hooks, instructions, and model settings. See [Extensibility](../extensibility.md) for the full ecosystem, including [third-party toolsets](../toolsets.md#third-party-toolsets) that can also be wrapped as capabilities.
 
+Many of the use cases below are also covered by first-party capabilities in Pydantic AI itself or [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/), the official capability library. Where that's the case, we point to the built-in option first, and list the community packages as alternatives.
+
 ## Task Management
 
-Capabilities for task planning and progress tracking help agents organize complex work:
+For model-owned task planning and progress tracking, [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/) ships [`Planning`](https://pydantic.dev/docs/ai/harness/planning/), a cache-friendly self-updating task plan. As a community alternative with subtask, dependency, and PostgreSQL persistence support:
 
 * [`pydantic-ai-todo`](https://github.com/vstorm-co/pydantic-ai-todo) - `TodoCapability` with `add_todo`, `read_todos`, `write_todos`, `update_todo_status`, and `remove_todo` tools. Supports subtasks, dependencies, and PostgreSQL persistence. Also available as a lower-level `TodoToolset`.
 
 ## Context Management
 
-Capabilities for managing long conversations help agents stay within context limits:
+Pydantic AI has [built-in compaction](compaction.md) — provider-native APIs and model-agnostic history summarization — and [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/compaction/) adds a full menu of compaction strategies. As a community alternative:
 
 * [`summarization-pydantic-ai`](https://github.com/vstorm-co/summarization-pydantic-ai) - Four capabilities for managing long conversations: `ContextManagerCapability` (real-time token tracking, auto-compression at a configurable threshold, and large tool-output truncation); `SummarizationCapability` (LLM-powered history compression); `SlidingWindowCapability` (zero-cost message trimming); `LimitWarnerCapability` (injects a finish-soon hint before hard context limits). Also available as standalone `history_processors`: `SummarizationProcessor`, `SlidingWindowProcessor`, and `LimitWarnerProcessor`.
 
 ## Multi-Agent Orchestration
 
-Capabilities for spawning and delegating to specialized subagents help agents tackle complex, parallelizable work:
+Pydantic AI supports [multi-agent patterns](../multi-agent-applications.md) directly, and [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/subagents/) ships [`SubAgents`](https://pydantic.dev/docs/ai/harness/subagents/) for delegating self-contained tasks to named child agents. As a community alternative:
 
 * [`subagents-pydantic-ai`](https://github.com/vstorm-co/subagents-pydantic-ai) - `SubAgentCapability` adds tools for multi-agent delegation: `task` (spawn a subagent), `check_task`, `wait_tasks`, `list_active_tasks`, `soft_cancel_task`, `hard_cancel_task`, and `answer_subagent`. Supports sync, async, and auto execution modes, nested subagents, and runtime agent creation. Also available as a lower-level toolset via `create_subagent_toolset`.
 
 ## Guardrails & Safety
 
-Capabilities for cost control, input/output filtering, and tool permissions help keep agents safe and within budget:
+[Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/guardrails/) provides input and output guardrails that validate or block requests and responses, and Pydantic AI enforces cost and token budgets via [`UsageLimits`](../agent.md#usage-limits). As a community alternative bundling several ready-made shields:
 
 * [`pydantic-ai-shields`](https://github.com/vstorm-co/pydantic-ai-shields) - Ready-to-use guardrail capabilities: `CostTracking` (tracks token usage and USD cost per run, raises `BudgetExceededError` on budget overrun); `ToolGuard` (block or require approval for specific tools); `InputGuard` and `OutputGuard` (custom sync or async validation functions); `PromptInjection`, `PiiDetector`, `SecretRedaction`, `BlockedKeywords`, and `NoRefusals` content shields.
 
 ## File Operations & Sandboxing
 
-Capabilities for filesystem access and sandboxed code execution help agents work with files and run code safely:
+[Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/) ships sandboxed [`FileSystem`](https://pydantic.dev/docs/ai/harness/filesystem/) and [`Shell`](https://pydantic.dev/docs/ai/harness/shell/) capabilities, plus [`CodeMode`](https://pydantic.dev/docs/ai/harness/code-mode/) for running tool calls as sandboxed Python. As a community alternative:
 
 * [`pydantic-ai-backend`](https://github.com/vstorm-co/pydantic-ai-backend) - `ConsoleCapability` registers `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, and `execute` tools with a fine-grained permission system. Backends include `StateBackend` (in-memory, for testing), `LocalBackend` (real filesystem), `DockerSandbox` (isolated container execution), and `CompositeBackend` (routing across backends). Also available as a lower-level `ConsoleToolset`.
 
 ## Agent Skills
 
-Capabilities that implement [Agent Skills](https://agentskills.io) support help agents efficiently discover and perform specific tasks:
+Pydantic AI supports [Agent Skills natively](on-demand.md#loading-skills-from-markdown-files) through [on-demand capabilities](on-demand.md), which collapse a skill to a one-line catalog entry until the model loads it. As a community alternative:
 
 * [`pydantic-ai-skills`](https://github.com/DougTrajano/pydantic-ai-skills) - `SkillsCapability` implements Agent Skills support with progressive disclosure (load skills on-demand to reduce tokens). Supports filesystem and programmatic skills; compatible with [agentskills.io](https://agentskills.io).
 
@@ -45,7 +47,5 @@ Capabilities for querying and analyzing structured data help agents answer quest
 * [`pydantic-ai-chdb`](https://github.com/chdb-io/pydantic-ai-chdb) - `ChDBCapability` gives agents analytical SQL over local files (Parquet/CSV/JSON), object storage, and remote databases with [chDB](https://clickhouse.com/docs/en/chdb), the in-process ClickHouse engine — the engine itself needs no server or connection string to run (remote sources are reached via ClickHouse table functions, which take their own credentials). Registers `run_select_query` (read-only ClickHouse SQL with parameter binding), `list_databases`, `list_tables`, `describe_table`, `get_sample_data`, `list_functions`, and `attach_file` (opt-in writable sessions) tools plus schema-first instructions. Sessions default to the engine-level `readonly=2` setting with capped results, and typed engine errors are mapped to [`ModelRetry`][pydantic_ai.exceptions.ModelRetry] so the model can correct its queries. Works with [agent specs](../agent-spec.md) out of the box, so it can be loaded via [`from_spec`][pydantic_ai.capabilities.AbstractCapability.from_spec] / [`Agent.from_spec`][pydantic_ai.agent.Agent.from_spec]. Also available as a lower-level [toolset](../toolsets.md) via [`ChDBCapability(...).get_toolset()`][pydantic_ai.capabilities.AbstractCapability.get_toolset].
 
 To add your package to this page, open a pull request.
-
-
 
 To publish your own capability package, see [Publishing capabilities](custom.md#publishing-capabilities) and [Extensibility](../extensibility.md).

--- a/docs/capabilities/third-party.md
+++ b/docs/capabilities/third-party.md
@@ -24,7 +24,7 @@ Pydantic AI supports [multi-agent patterns](../multi-agent-applications.md) dire
 
 ## Guardrails & Safety
 
-[Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/guardrails/) provides input and output guardrails that validate or block requests and responses, and Pydantic AI enforces cost and token budgets via [`UsageLimits`](../agent.md#usage-limits). As a community alternative bundling several ready-made shields:
+[Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/guardrails/) provides input and output guardrails that validate or block requests and responses, and Pydantic AI enforces usage, token, and request limits via [`UsageLimits`](../agent.md#usage-limits). As a community alternative bundling several ready-made shields, including USD cost tracking:
 
 * [`pydantic-ai-shields`](https://github.com/vstorm-co/pydantic-ai-shields) - Ready-to-use guardrail capabilities: `CostTracking` (tracks token usage and USD cost per run, raises `BudgetExceededError` on budget overrun); `ToolGuard` (block or require approval for specific tools); `InputGuard` and `OutputGuard` (custom sync or async validation functions); `PromptInjection`, `PiiDetector`, `SecretRedaction`, `BlockedKeywords`, and `NoRefusals` content shields.
 

--- a/docs/capabilities/third-party.md
+++ b/docs/capabilities/third-party.md
@@ -20,7 +20,7 @@ Pydantic AI has [built-in compaction](compaction.md) — provider-native APIs an
 
 Pydantic AI supports [multi-agent patterns](../multi-agent-applications.md) directly, and [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/subagents/) ships [`SubAgents`](https://pydantic.dev/docs/ai/harness/subagents/) for delegating self-contained tasks to named child agents. As a community alternative:
 
-* [`subagents-pydantic-ai`](https://github.com/vstorm-co/subagents-pydantic-ai) - `SubAgentCapability` adds tools for multi-agent delegation: `task` (spawn a subagent), `check_task`, `wait_tasks`, `list_active_tasks`, `soft_cancel_task`, `hard_cancel_task`, and `answer_subagent`. Supports sync, async, and auto execution modes, nested subagents, and runtime agent creation. Also available as a lower-level toolset via `create_subagent_toolset`.
+* [`subagents-pydantic-ai`](https://github.com/vstorm-co/subagents-pydantic-ai) - `SubAgentCapability` adds tools for multi-agent delegation: `task` (spawn a subagent), `check_task`, `wait_tasks`, `list_active_tasks`, `soft_cancel_task`, `hard_cancel_task`, and `answer_subagent`. Supports sync, async, and auto-execution modes, nested subagents, and runtime agent creation. Also available as a lower-level toolset via `create_subagent_toolset`.
 
 ## Guardrails & Safety
 

--- a/docs/message-history.md
+++ b/docs/message-history.md
@@ -727,7 +727,7 @@ This allows for more sophisticated message processing based on the current state
 
 #### Summarize Old Messages
 
-Use an LLM to summarize older messages to preserve context while reducing tokens.
+Use an LLM to summarize older messages to preserve context while reducing tokens. This is one of several ways to keep a conversation within the context window — see [Compaction](capabilities/compaction.md) for the full picture, including provider-native compaction and ready-made strategies from [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/compaction/).
 
 ```python {title="summarize_old_messages.py"}
 from pydantic_ai import Agent, ModelMessage

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -94,10 +94,6 @@
         "slug": "capabilities/custom"
       },
       {
-        "label": "Third-Party Capabilities",
-        "slug": "capabilities/third-party"
-      },
-      {
         "label": "Thinking",
         "slug": "capabilities/thinking"
       },
@@ -213,6 +209,10 @@
             "slug": "durable_execution/airflow"
           }
         ]
+      },
+      {
+        "label": "Third-Party Capabilities",
+        "slug": "capabilities/third-party"
       }
     ]
   },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,6 @@ nav:
           - Overview: capabilities/overview.md
           - On-Demand Capabilities: capabilities/on-demand.md
           - Building Custom Capabilities: capabilities/custom.md
-          - Third-Party Capabilities: capabilities/third-party.md
           - Thinking: capabilities/thinking.md
           - Instrumentation: capabilities/instrumentation.md
           - Web Search: capabilities/web-search.md
@@ -86,6 +85,7 @@ nav:
               - Restate: durable_execution/restate.md
               - Kitaru: durable_execution/kitaru.md
               - Apache Airflow: durable_execution/airflow.md
+          - Third-Party Capabilities: capabilities/third-party.md
       - MCP:
           - Overview: mcp/overview.md
           - mcp/client.md


### PR DESCRIPTION
Follow-up to #6621 (the Capabilities top-level section).

The Compaction page implied compaction is provider-specific (OpenAI/Anthropic only), and the Third-Party Capabilities page listed community packages for use cases we already cover first-party, without saying so. This corrects both.

### Compaction page
Reframed `docs/capabilities/compaction.md` into the three approaches we actually support:
- **Provider-native** — `OpenAICompaction` / `AnthropicCompaction` (existing table).
- **Model-agnostic** — `ProcessHistory` history processors (keep-recent / summarize), works on any model. Previously not surfaced here.
- **Pydantic AI Harness** — the `pydantic_ai_harness.compaction` menu (zero-LLM strategies, `SummarizingCompaction`, `TieredCompaction`).

### Third-party capabilities page
Each category now leads with the first-party equivalent (Harness or core) and frames the community package as an alternative, instead of implying we lack the feature: Task Management → Harness `Planning`; Context Management → core Compaction + Harness compaction; Multi-Agent → multi-agent patterns + Harness `SubAgents`; Guardrails → Harness guardrails + `UsageLimits`; File Ops → Harness `FileSystem`/`Shell`/`CodeMode`; Agent Skills → core on-demand skills. Data & Analytics keeps its generic intro (no first-party equivalent).

Also moved the page to the bottom of the Capabilities sidebar (`nav.json` + `mkdocs.yml`); slug unchanged, so no redirects needed.

### Cross-links
Softened the overview's compaction line and added a pointer from message-history's "Summarize Old Messages" to the Compaction page.

All linked Harness sub-page URLs verified live (200); `mkdocs build --no-strict` is clean.

- Closes #<!-- no issue; doc improvement -->

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

