### PR TITLE
docs: correct `FallbackModel` note on `length`/`content_filter` finish reasons

### DIFF
--- a/docs/models/overview.md
+++ b/docs/models/overview.md
@@ -407,10 +407,14 @@ print(result.output)
     To keep exception-based fallback alongside a response handler, pass them together as a list — see the [mixed example below](#combining-handlers).
 
 !!! note
-    Note that Pydantic AI already handles some finish reasons automatically in the [agent loop](../agent.md):
-    responses with a `'length'` or `'content_filter'` finish reason raise exceptions (which `FallbackModel`
-    catches by default), and empty responses are retried. A response handler is useful for custom
-    checks beyond these built-in behaviors.
+    Pydantic AI raises for some finish reasons in the [agent loop](../agent.md), but only when the
+    response has no actionable content: an empty or thinking-only response with a `'length'` finish
+    reason raises [`UnexpectedModelBehavior`][pydantic_ai.exceptions.UnexpectedModelBehavior], and an
+    empty response with `'content_filter'` raises [`ContentFilterError`][pydantic_ai.exceptions.ContentFilterError].
+    A response that returns text is passed through even with these finish reasons. These exceptions
+    are raised after the model request completes, so they are **not** caught by `FallbackModel`'s
+    default `fallback_on=(ModelAPIError,)` — use a response handler, as above, to fall back on a
+    finish reason.
 
 #### Native Tool Failure Example
 


### PR DESCRIPTION
The `!!! note` in `docs/models/overview.md` (Finish Reason Example section) claimed that `'length'`/`'content_filter'` finish reasons raise exceptions "which `FallbackModel` catches by default". That's inaccurate on three counts, verified against the code:

- They only raise for **empty or thinking-only** responses (`_agent_graph.py`); a response that returns text passes through even with these finish reasons.
- They're raised in the agent loop **after** the model request completes, so `FallbackModel` (which wraps the request) never sees them.
- `ContentFilterError`/`UnexpectedModelBehavior` aren't `ModelAPIError` subclasses, so the default `fallback_on=(ModelAPIError,)` wouldn't catch them regardless.

This rewrites the note to match the actual behavior and points readers at the response handler shown just above it as the way to fall back on a finish reason. Docs-only; no code change.

- Closes #6565

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).
