### PR TITLE
Round-trip tool control-flow exceptions on DBOS/Prefect, fix Prefect replay edges, and add `register_legacy_workflows` to `DBOSDurability` for clean `DBOSAgent` migration

### DIFF
--- a/docs/durable_execution/dbos.md
+++ b/docs/durable_execution/dbos.md
@@ -115,7 +115,7 @@ For more information on how to use DBOS in Python applications, see their [Pytho
 
     **When migrating, you must wrap the run in a workflow yourself.** `DBOSAgent` wrapped `run` / `run_sync` as a DBOS workflow automatically; `DBOSDurability` deliberately does not — a run is only durable when `agent.run()` is called inside your own `@DBOS.workflow`. Porting the constructor arguments but calling `agent.run()` directly produces a run that works but is **not durable**.
 
-    **Unlike [Temporal](temporal.md#wrapper-agent-path-deprecated), migrating is not safe for in-flight workflows.** `DBOSAgent` registered the `{agent name}.run` / `{agent name}.run_sync` workflows itself; once you migrate, those workflows no longer exist, so DBOS cannot recover runs that were interrupted under `DBOSAgent`. Let in-flight runs finish before deploying the migration, or keep an executor on the old application version until they have.
+    To recover in-flight wrapper-era workflows during migration, enable `register_legacy_workflows=True` on [`DBOSDurability`][pydantic_ai.durable_exec.dbos.DBOSDurability] and pin DBOS `application_version` across the deploy (version gating applies to any DBOS code change). Drop the flag once those workflows have drained.
 
 Any agent can be wrapped in a [`DBOSAgent`][pydantic_ai.durable_exec.dbos.DBOSAgent] to get a durable agent variant that routes model requests and MCP communication through DBOS steps:
 

--- a/docs/durable_execution/temporal.md
+++ b/docs/durable_execution/temporal.md
@@ -66,6 +66,8 @@ See the [Temporal documentation](https://docs.temporal.io/evaluate/understanding
 
 ## Durable Agent
 
+To make a run durable, call `agent.run()` inside a Temporal workflow executed on a worker; outside one, the agent runs as a normal, non-durable agent.
+
 Add durable execution to any [`Agent`][pydantic_ai.agent.Agent] by attaching the [`TemporalDurability`][pydantic_ai.durable_exec.temporal.TemporalDurability] [capability](../capabilities/overview.md). The agent stays a normal `Agent` everywhere — outside a workflow it behaves transparently, and inside a workflow the capability routes model requests, tool calls, and MCP server communication through Temporal activities.
 
 !!! warning "A run is durable only inside a workflow"

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -116,6 +116,7 @@ class RunContext(Generic[RunContextAgentDepsT]):
     and during agent construction.
     """
     pending_messages: list[PendingMessage] | None = field(default=None, repr=False)
+    _enqueue_error: str | None = field(default=None, repr=False)
     """Queue read and mutated by the internal `PendingMessageDrainCapability`.
 
     Set to the run's live queue during an agent run; `None` in synthetic contexts that aren't
@@ -323,6 +324,8 @@ class RunContext(Generic[RunContextAgentDepsT]):
                 to deliver the message.
         """
         if self.pending_messages is None:
+            if self._enqueue_error is not None:
+                raise UserError(self._enqueue_error)
             raise UserError(
                 '`enqueue` is only available during an agent run (from tools, capability hooks, or '
                 '`AgentRun.enqueue`). This `RunContext` has no pending-message queue to drain.'

--- a/pydantic_ai_slim/pydantic_ai/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/_run_context.py
@@ -116,7 +116,6 @@ class RunContext(Generic[RunContextAgentDepsT]):
     and during agent construction.
     """
     pending_messages: list[PendingMessage] | None = field(default=None, repr=False)
-    _enqueue_error: str | None = field(default=None, repr=False)
     """Queue read and mutated by the internal `PendingMessageDrainCapability`.
 
     Set to the run's live queue during an agent run; `None` in synthetic contexts that aren't
@@ -324,8 +323,6 @@ class RunContext(Generic[RunContextAgentDepsT]):
                 to deliver the message.
         """
         if self.pending_messages is None:
-            if self._enqueue_error is not None:
-                raise UserError(self._enqueue_error)
             raise UserError(
                 '`enqueue` is only available during an agent run (from tools, capability hooks, or '
                 '`AgentRun.enqueue`). This `RunContext` has no pending-message queue to drain.'

--- a/pydantic_ai_slim/pydantic_ai/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/_utils.py
@@ -435,12 +435,15 @@ def sanitize_tool_name(name: str) -> str:
     return TOOL_NAME_SANITIZER.sub('_', name)
 
 
+TOOL_CALL_ID_PREFIX = 'pyd_ai_'
+
+
 def generate_tool_call_id() -> str:
     """Generate a tool call id.
 
     Ensure that the tool call id is unique.
     """
-    return f'pyd_ai_{uuid.uuid4().hex}'
+    return f'{TOOL_CALL_ID_PREFIX}{uuid.uuid4().hex}'
 
 
 SourceT = TypeVar('SourceT', bound=AsyncIterable[Any], default=AsyncIterable[T])

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -149,10 +149,10 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
     def _effective_event_stream_handler(self) -> EventStreamHandler[AgentDepsT] | None:
         """The handler in-boundary event delivery targets for the current run.
 
-        Engines may override to consult per-run state — e.g. DBOS routes the
-        `event_stream_handler` recorded in a wrapper-era workflow's inputs through
-        the same steps as a constructor handler, so recovery replays the recorded
-        step sequence.
+        Engines may override to consult per-run state — e.g. DBOS honors the
+        `event_stream_handler` recorded in a wrapper-era workflow's inputs, delivering
+        it exactly the way the wrapper did so recovery replays the recorded step
+        sequence.
         """
         return self._event_stream_handler
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -146,9 +146,19 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
             tool_config_key=self._tool_config_key,
         )
 
+    def _effective_event_stream_handler(self) -> EventStreamHandler[AgentDepsT] | None:
+        """The handler in-boundary event delivery targets for the current run.
+
+        Engines may override to consult per-run state — e.g. DBOS routes the
+        `event_stream_handler` recorded in a wrapper-era workflow's inputs through
+        the same steps as a constructor handler, so recovery replays the recorded
+        step sequence.
+        """
+        return self._event_stream_handler
+
     @property
     def has_wrap_run_event_stream(self) -> bool:
-        return self._event_stream_handler is not None
+        return self._effective_event_stream_handler() is not None
 
     async def wrap_run_event_stream(
         self,
@@ -156,7 +166,7 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         *,
         stream: AsyncIterable[AgentStreamEvent],
     ) -> AsyncIterable[AgentStreamEvent]:
-        if self._event_stream_handler is None:
+        if self._effective_event_stream_handler() is None:
             async for event in stream:
                 yield event
             return

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -179,6 +179,18 @@ def unwrap_tool_call_result(result: CallToolResult) -> Any:
     assert_never(result)
 
 
+def unwrap_recorded_tool_call_result(result: Any) -> Any:
+    """Unwrap a durably-recorded tool result, passing raw pre-wrapper values through.
+
+    Engines that replay recorded step outputs on recovery (DBOS) may hold outputs recorded
+    before the step wrapped control-flow exceptions as values; those recordings are the raw
+    tool result and are returned unchanged.
+    """
+    if isinstance(result, _ToolReturn | _ToolContentResult | _ApprovalRequired | _CallDeferred | _ModelRetry):
+        return unwrap_tool_call_result(result)
+    return result
+
+
 def resolve_tool_durable_config(
     tool: ToolsetTool[Any] | None,
     tool_name: str,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -182,9 +182,9 @@ def unwrap_tool_call_result(result: CallToolResult) -> Any:
 def unwrap_recorded_tool_call_result(result: Any) -> Any:
     """Unwrap a durably-recorded tool result, passing raw pre-wrapper values through.
 
-    Engines that replay recorded step outputs on recovery (DBOS) may hold outputs recorded
-    before the step wrapped control-flow exceptions as values; those recordings are the raw
-    tool result and are returned unchanged.
+    Engines that replay recorded durable-unit outputs (DBOS step recovery, Prefect task
+    caches) may hold outputs recorded before the unit wrapped control-flow exceptions as
+    values; those recordings are the raw tool result and are returned unchanged.
     """
     if isinstance(result, _ToolReturn | _ToolContentResult | _ApprovalRequired | _CallDeferred | _ModelRetry):
         return unwrap_tool_call_result(result)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -451,7 +451,7 @@ class DurableMCPToolset(DurableToolsetBase[AgentDepsT]):
     async def call_tool(
         self, name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT], tool: ToolsetTool[AgentDepsT]
     ) -> Any:
-        if not self._in_durable_context():  # pragma: no cover
+        if not self._in_durable_context():
             return await self._mcp_toolset.call_tool(name, tool_args, ctx, tool)
         config = self._resolve_tool_config(tool, name)
         if config is False:  # pragma: no cover — no engine's resolver currently permits inline MCP tools

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -9,6 +9,7 @@ from pydantic import Discriminator, Tag
 from typing_extensions import Self, assert_never
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool, WrapperToolset
+from pydantic_ai._enqueue import PendingMessage
 from pydantic_ai._utils import is_str_dict
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry, UserError
 from pydantic_ai.messages import InstructionPart, ToolReturn, ToolReturnContent
@@ -177,6 +178,22 @@ def unwrap_tool_call_result(result: CallToolResult) -> Any:
     if isinstance(result, _ModelRetry):
         raise ModelRetry(result.message)
     assert_never(result)
+
+
+class EnqueueGuard(list[PendingMessage]):
+    """Replaces `ctx.pending_messages` inside durable-unit-wrapped tools, where enqueueing can't be supported.
+
+    A durable unit's recorded output is replayed on recovery (DBOS) or cache hit (Prefect)
+    without re-executing the tool, so messages enqueued inside it would be silently dropped;
+    enqueueing raises the engine's explanatory `UserError` instead.
+    """
+
+    def __init__(self, message: str):
+        super().__init__()
+        self._message = message
+
+    def append(self, pending: PendingMessage) -> None:
+        raise UserError(self._message)
 
 
 def unwrap_recorded_tool_call_result(result: Any) -> Any:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -58,7 +58,7 @@ DBOSParallelExecutionMode = Literal['sequential', 'parallel_ordered_events']
 - With the capability, call `agent.run()` inside a `@DBOS.workflow`; the wrapper did this automatically.
 - `wrapped=` → use the wrapped agent's configuration on a regular `Agent(..., capabilities=[DBOSDurability(...)])`.
 - `name=` → set `name=` on `Agent`, or `name=` on `DBOSDurability`.
-- `event_stream_handler=` → pass `event_stream_handler=` to `DBOSDurability`; it runs inside steps, exactly like before.
+- `event_stream_handler=` → pass `event_stream_handler=` to `DBOSDurability`; model events are still handled live inside model-request steps, and each tool event now runs in its own checkpointed step (the wrapper called it in workflow code).
 - `mcp_step_config=` → set `mcp_step_config=` on `DBOSDurability`.
 - `model_step_config=` → set `model_step_config=` on `DBOSDurability`.
 - `parallel_execution_mode=` → set `parallel_execution_mode=` on `DBOSDurability`.

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_agent.py
@@ -61,7 +61,8 @@ DBOSParallelExecutionMode = Literal['sequential', 'parallel_ordered_events']
 - `event_stream_handler=` → pass `event_stream_handler=` to `DBOSDurability`; it runs inside steps, exactly like before.
 - `mcp_step_config=` → set `mcp_step_config=` on `DBOSDurability`.
 - `model_step_config=` → set `model_step_config=` on `DBOSDurability`.
-- `parallel_execution_mode=` → set `parallel_execution_mode=` on `DBOSDurability`.""",
+- `parallel_execution_mode=` → set `parallel_execution_mode=` on `DBOSDurability`.
+Pass `register_legacy_workflows=True` to `DBOSDurability` and pin the DBOS application version so in-flight `DBOSAgent` workflows recover across the migration.""",
     category=PydanticAIDeprecationWarning,
 )
 @DBOS.dbos_class()

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, ClassVar, cast
 
@@ -116,6 +117,14 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
         self._event_stream_handler_step: Any = None
         self._legacy_run_workflow: Any = None
         self._legacy_run_sync_workflow: Any = None
+        # A wrapper-era workflow recorded `event_stream_handler=` as a workflow input; the legacy
+        # workflows stash it here so it's delivered through the same steps as a constructor handler.
+        self._legacy_run_event_stream_handler: ContextVar[EventStreamHandler[AgentDepsT] | None] = ContextVar(
+            '_legacy_run_event_stream_handler', default=None
+        )
+
+    def _effective_event_stream_handler(self) -> EventStreamHandler[AgentDepsT] | None:
+        return self._legacy_run_event_stream_handler.get() or self._event_stream_handler
 
     def _bind_to_agent(self, agent: AbstractAgent[AgentDepsT, Any]) -> None:
         # --- Model request steps ---
@@ -150,7 +159,7 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
                     events = await capture_event_stream(
                         run_context=run_context,
                         stream=streamed_response,
-                        handler=self._event_stream_handler,
+                        handler=self._effective_event_stream_handler(),
                     )
             return StreamedActivityResult(response=streamed_response.get(), events=events)
 
@@ -166,13 +175,17 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
 
         self._cancel_suspended_response_step = cancel_suspended_response_step
 
-        if self._event_stream_handler is not None:
-            handler = self._event_stream_handler
+        # Also registered under `register_legacy_workflows`: a recovered wrapper-era workflow's
+        # recorded inputs may carry a per-run handler, which must run inside this step for the
+        # recorded step sequence to replay.
+        if self._event_stream_handler is not None or self._register_legacy_workflows:
 
             @DBOS.step(name=f'{self.name}__event_stream_handler', **self._event_stream_handler_step_config)
             async def event_stream_handler_step(
                 event: _messages.AgentStreamEvent, run_context: RunContext[Any]
             ) -> None:
+                handler = self._effective_event_stream_handler()
+                assert handler is not None
                 await handler(run_context, self._single_event_stream(event))
 
             self._event_stream_handler_step = event_stream_handler_step
@@ -181,16 +194,32 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
         self._register_toolsets(agent)
 
         if self._register_legacy_workflows:
+            # `DBOSAgent.run` recorded `event_stream_handler=` as a workflow input and ran it inside
+            # the `__event_stream_handler` step; a recorded handler is routed the same way so
+            # recovery replays the recorded step sequence instead of re-running the handler (and its
+            # side effects) at graph level.
 
             @DBOS.workflow(name=f'{self.name}.run')
             async def legacy_run_workflow(*args: Any, **kwargs: Any) -> AgentRunResult[Any]:
-                return await agent.run(*args, **kwargs)
+                handler = kwargs.pop('event_stream_handler', None)
+                token = self._legacy_run_event_stream_handler.set(handler) if handler is not None else None
+                try:
+                    return await agent.run(*args, **kwargs)
+                finally:
+                    if token is not None:
+                        self._legacy_run_event_stream_handler.reset(token)
 
             self._legacy_run_workflow = legacy_run_workflow
 
             @DBOS.workflow(name=f'{self.name}.run_sync')
             def legacy_run_sync_workflow(*args: Any, **kwargs: Any) -> AgentRunResult[Any]:
-                return agent.run_sync(*args, **kwargs)
+                handler = kwargs.pop('event_stream_handler', None)
+                token = self._legacy_run_event_stream_handler.set(handler) if handler is not None else None
+                try:
+                    return agent.run_sync(*args, **kwargs)
+                finally:
+                    if token is not None:
+                        self._legacy_run_event_stream_handler.reset(token)
 
             self._legacy_run_sync_workflow = legacy_run_sync_workflow
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
@@ -117,16 +117,28 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
         self._event_stream_handler_step: Any = None
         self._legacy_run_workflow: Any = None
         self._legacy_run_sync_workflow: Any = None
+        self._init_legacy_context_vars()
+
+    def _init_legacy_context_vars(self) -> None:
         # A wrapper-era workflow recorded `event_stream_handler=` as a workflow input; the legacy
-        # workflows stash it here so it's delivered through the same steps as a constructor handler.
+        # workflows stash it here so the model-request steps deliver model events to it live,
+        # exactly like the wrapper's `ContextVar`-stashed per-run handler.
         self._legacy_run_event_stream_handler: ContextVar[EventStreamHandler[AgentDepsT] | None] = ContextVar(
             '_legacy_run_event_stream_handler', default=None
         )
+        # Whether the current run entered through a legacy `{name}.run`/`{name}.run_sync` workflow,
+        # whose recorded step sequence must be preserved on recovery.
+        self._in_legacy_workflow: ContextVar[bool] = ContextVar('_in_legacy_workflow', default=False)
 
     def _effective_event_stream_handler(self) -> EventStreamHandler[AgentDepsT] | None:
         return self._legacy_run_event_stream_handler.get() or self._event_stream_handler
 
     def _bind_to_agent(self, agent: AbstractAgent[AgentDepsT, Any]) -> None:
+        # `for_agent` shallow-copies the user's instance, so without fresh `ContextVar`s here,
+        # one capability instance attached to several agents would leak one agent's per-run
+        # legacy state into another's runs.
+        self._init_legacy_context_vars()
+
         # --- Model request steps ---
 
         @DBOS.step(name=f'{self.name}__model.request', **self._model_step_config)
@@ -175,10 +187,7 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
 
         self._cancel_suspended_response_step = cancel_suspended_response_step
 
-        # Also registered under `register_legacy_workflows`: a recovered wrapper-era workflow's
-        # recorded inputs may carry a per-run handler, which must run inside this step for the
-        # recorded step sequence to replay.
-        if self._event_stream_handler is not None or self._register_legacy_workflows:
+        if self._event_stream_handler is not None:
 
             @DBOS.step(name=f'{self.name}__event_stream_handler', **self._event_stream_handler_step_config)
             async def event_stream_handler_step(
@@ -194,18 +203,23 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
         self._register_toolsets(agent)
 
         if self._register_legacy_workflows:
-            # `DBOSAgent.run` recorded `event_stream_handler=` as a workflow input and ran it inside
-            # the `__event_stream_handler` step; a recorded handler is routed the same way so
-            # recovery replays the recorded step sequence instead of re-running the handler (and its
-            # side effects) at graph level.
+            # A wrapper-era workflow recorded only model and MCP steps: `DBOSAgent` delivered model
+            # events to the handler live inside the `__model.request_stream` step, and graph-level
+            # events with a *direct* workflow-level handler call that consumed no step at all.
+            # Legacy runs flag themselves via `_in_legacy_workflow` so `_dispatch_event_stream_event`
+            # mirrors that delivery — routing graph events through the `__event_stream_handler` step
+            # would insert step ids the recording doesn't have and fail recovery with
+            # `DBOSUnexpectedStepError`.
 
             @DBOS.workflow(name=f'{self.name}.run')
             async def legacy_run_workflow(*args: Any, **kwargs: Any) -> AgentRunResult[Any]:
                 handler = kwargs.pop('event_stream_handler', None)
+                legacy_token = self._in_legacy_workflow.set(True)
                 token = self._legacy_run_event_stream_handler.set(handler) if handler is not None else None
                 try:
                     return await agent.run(*args, **kwargs)
                 finally:
+                    self._in_legacy_workflow.reset(legacy_token)
                     if token is not None:
                         self._legacy_run_event_stream_handler.reset(token)
 
@@ -214,10 +228,12 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
             @DBOS.workflow(name=f'{self.name}.run_sync')
             def legacy_run_sync_workflow(*args: Any, **kwargs: Any) -> AgentRunResult[Any]:
                 handler = kwargs.pop('event_stream_handler', None)
+                legacy_token = self._in_legacy_workflow.set(True)
                 token = self._legacy_run_event_stream_handler.set(handler) if handler is not None else None
                 try:
                     return agent.run_sync(*args, **kwargs)
                 finally:
+                    self._in_legacy_workflow.reset(legacy_token)
                     if token is not None:
                         self._legacy_run_event_stream_handler.reset(token)
 
@@ -228,6 +244,14 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
         return DBOS.workflow_id is not None and DBOS.step_id is None
 
     async def _dispatch_event_stream_event(self, ctx: RunContext[AgentDepsT], event: AgentStreamEvent) -> None:
+        if self._in_legacy_workflow.get():
+            # Wrapper-era recordings contain no `__event_stream_handler` steps (the wrapper called
+            # the handler directly in workflow code), so a legacy run must do the same to keep the
+            # recorded step sequence replayable.
+            handler = self._effective_event_stream_handler()
+            assert handler is not None
+            await handler(ctx, self._single_event_stream(event))
+            return
         # Route the handler through a DBOS step so its side effects are checkpointed and
         # don't re-run when the workflow recovers.
         assert self._event_stream_handler_step is not None

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
@@ -19,7 +19,7 @@ from pydantic_ai.durable_exec._utils import (
     capture_event_stream,
 )
 from pydantic_ai.messages import AgentStreamEvent, ModelResponse
-from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models import CompletedStreamedResponse, Model, ModelRequestContext, ModelRequestParameters
 from pydantic_ai.run import AgentRunResult
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import AgentDepsT, RunContext
@@ -69,6 +69,7 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
         event_stream_handler_step_config: StepConfig | None = None,
         mcp_step_config: StepConfig | None = None,
         parallel_execution_mode: DBOSParallelExecutionMode = 'parallel_ordered_events',
+        register_legacy_workflows: bool = False,
     ):
         """Create a DBOSDurability capability.
 
@@ -99,17 +100,22 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
             parallel_execution_mode: Tool-call execution mode applied for the duration
                 of every run. Defaults to `'parallel_ordered_events'` so events
                 replay deterministically. Set to `'sequential'` for strict ordering.
+            register_legacy_workflows: Register the workflow names used by the deprecated
+                `DBOSAgent` so in-flight wrapper-era workflows can recover during migration.
         """
         super().__init__(models=models, event_stream_handler=event_stream_handler, name=name)
         self._model_step_config = model_step_config or {}
         self._event_stream_handler_step_config = event_stream_handler_step_config or {}
         self._mcp_step_config = mcp_step_config or {}
         self._parallel_execution_mode: ParallelExecutionMode = cast(ParallelExecutionMode, parallel_execution_mode)
+        self._register_legacy_workflows = register_legacy_workflows
         # Populated by for_agent when the capability is attached to an agent.
         self._request_step: Any = None
         self._request_stream_step: Any = None
         self._cancel_suspended_response_step: Any = None
         self._event_stream_handler_step: Any = None
+        self._legacy_run_workflow: Any = None
+        self._legacy_run_sync_workflow: Any = None
 
     def _bind_to_agent(self, agent: AbstractAgent[AgentDepsT, Any]) -> None:
         # --- Model request steps ---
@@ -173,6 +179,20 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
 
         # --- MCP toolset wrapping ---
         self._register_toolsets(agent)
+
+        if self._register_legacy_workflows:
+
+            @DBOS.workflow(name=f'{self.name}.run')
+            async def legacy_run_workflow(*args: Any, **kwargs: Any) -> AgentRunResult[Any]:
+                return await agent.run(*args, **kwargs)
+
+            self._legacy_run_workflow = legacy_run_workflow
+
+            @DBOS.workflow(name=f'{self.name}.run_sync')
+            def legacy_run_sync_workflow(*args: Any, **kwargs: Any) -> AgentRunResult[Any]:
+                return agent.run_sync(*args, **kwargs)
+
+            self._legacy_run_sync_workflow = legacy_run_sync_workflow
 
     @property
     def in_durable_context(self) -> bool:
@@ -239,9 +259,18 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
             )
 
         async def request_stream_segment(request: ModelRequestContext) -> StreamedActivityResult:
-            return await self._request_stream_step(
+            result = await self._request_stream_step(
                 model_id, request.messages, request.model_settings, request.model_request_parameters, ctx
             )
+            if isinstance(result, ModelResponse):
+                # Legacy-history-only: `DBOSAgent` recorded a bare response for stream steps.
+                stream = CompletedStreamedResponse(
+                    result,
+                    model_request_parameters=request.model_request_parameters,
+                    replay_events=True,
+                )
+                return StreamedActivityResult(response=result, events=[event async for event in stream])
+            return result
 
         async def cancel_suspended_response_segment(response: ModelResponse) -> None:
             await self._cancel_suspended_response_step(model_id, response, ctx)

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_dynamic_toolset.py
@@ -7,10 +7,13 @@ from dbos import DBOS
 
 from pydantic_ai import ToolsetTool
 from pydantic_ai.durable_exec._toolset import (
+    CallToolResult,
     DurableDynamicToolset,
     DynamicToolsResult,
     call_dynamic_tool,
     get_dynamic_tools,
+    unwrap_recorded_tool_call_result,
+    wrap_tool_call_result,
 )
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets._dynamic import DynamicToolset
@@ -28,8 +31,10 @@ def dbosify_dynamic_toolset(
         return await get_dynamic_tools(wrapped, ctx)
 
     @DBOS.step(name=f'{name}.call_tool', **(step_config or {}))
-    async def call_tool_step(tool_name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]) -> Any:
-        return await call_dynamic_tool(wrapped, tool_name, tool_args, ctx)
+    async def call_tool_step(tool_name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]) -> CallToolResult:
+        # DBOS has no selective non-retryable-exception support, so control-flow
+        # exceptions must cross the step boundary as successful values.
+        return await wrap_tool_call_result(call_dynamic_tool(wrapped, tool_name, tool_args, ctx))
 
     async def call_tool_operation(
         name: str,
@@ -38,7 +43,9 @@ def dbosify_dynamic_toolset(
         tool: ToolsetTool[AgentDepsT],
         config: Mapping[str, Any],
     ) -> Any:
-        return await call_tool_step(name, tool_args, ctx)
+        # A recovering workflow may replay outputs this step recorded before it wrapped
+        # control-flow exceptions as values; those recordings are the raw tool result.
+        return unwrap_recorded_tool_call_result(await call_tool_step(name, tool_args, ctx))
 
     return DurableDynamicToolset(
         wrapped,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_dynamic_toolset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import Any
 
 from dbos import DBOS
@@ -10,6 +11,7 @@ from pydantic_ai.durable_exec._toolset import (
     CallToolResult,
     DurableDynamicToolset,
     DynamicToolsResult,
+    EnqueueGuard,
     call_dynamic_tool,
     get_dynamic_tools,
     unwrap_recorded_tool_call_result,
@@ -32,6 +34,18 @@ def dbosify_dynamic_toolset(
 
     @DBOS.step(name=f'{name}.call_tool', **(step_config or {}))
     async def call_tool_step(tool_name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]) -> CallToolResult:
+        if DBOS.workflow_id is not None:
+            # Recovery replays this step's recorded output without re-executing the tool, so
+            # in-step enqueued messages would be silently dropped. Outside a workflow the step
+            # degrades to a plain call and enqueueing keeps working.
+            ctx = replace(
+                ctx,
+                pending_messages=EnqueueGuard(
+                    '`ctx.enqueue()` is not supported inside DBOS step-wrapped tools because workflow '
+                    'recovery replays the recorded step output and would drop the enqueued messages. '
+                    'Enqueue messages from workflow-level code instead.'
+                ),
+            )
         # DBOS has no selective non-retryable-exception support, so control-flow
         # exceptions must cross the step boundary as successful values.
         return await wrap_tool_call_result(call_dynamic_tool(wrapped, tool_name, tool_args, ctx))

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_dynamic_toolset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import replace
 from typing import Any
 
 from dbos import DBOS
@@ -11,7 +10,6 @@ from pydantic_ai.durable_exec._toolset import (
     CallToolResult,
     DurableDynamicToolset,
     DynamicToolsResult,
-    EnqueueGuard,
     call_dynamic_tool,
     get_dynamic_tools,
     unwrap_recorded_tool_call_result,
@@ -20,7 +18,7 @@ from pydantic_ai.durable_exec._toolset import (
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
-from ._utils import StepConfig
+from ._utils import StepConfig, guard_enqueue_in_workflow
 
 
 def dbosify_dynamic_toolset(
@@ -34,21 +32,11 @@ def dbosify_dynamic_toolset(
 
     @DBOS.step(name=f'{name}.call_tool', **(step_config or {}))
     async def call_tool_step(tool_name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]) -> CallToolResult:
-        if DBOS.workflow_id is not None:
-            # Recovery replays this step's recorded output without re-executing the tool, so
-            # in-step enqueued messages would be silently dropped. Outside a workflow the step
-            # degrades to a plain call and enqueueing keeps working.
-            ctx = replace(
-                ctx,
-                pending_messages=EnqueueGuard(
-                    '`ctx.enqueue()` is not supported inside DBOS step-wrapped tools because workflow '
-                    'recovery replays the recorded step output and would drop the enqueued messages. '
-                    'Enqueue messages from workflow-level code instead.'
-                ),
-            )
         # DBOS has no selective non-retryable-exception support, so control-flow
         # exceptions must cross the step boundary as successful values.
-        return await wrap_tool_call_result(call_dynamic_tool(wrapped, tool_name, tool_args, ctx))
+        return await wrap_tool_call_result(
+            call_dynamic_tool(wrapped, tool_name, tool_args, guard_enqueue_in_workflow(ctx))
+        )
 
     async def call_tool_operation(
         name: str,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
@@ -9,7 +9,7 @@ from pydantic_ai import ToolsetTool
 from pydantic_ai.durable_exec._toolset import (
     CallToolResult,
     DurableMCPToolset,
-    unwrap_tool_call_result,
+    unwrap_recorded_tool_call_result,
     wrap_tool_call_result,
 )
 from pydantic_ai.mcp import MCPToolset, ToolResult
@@ -51,7 +51,9 @@ def dbosify_mcp_toolset(
         tool: ToolsetTool[AgentDepsT],
         config: Mapping[str, Any],
     ) -> ToolResult:
-        return unwrap_tool_call_result(await call_tool_step(tool_name, tool_args, ctx, tool))
+        # A recovering workflow may replay outputs this step recorded before it wrapped
+        # control-flow exceptions as values; those recordings are the raw tool result.
+        return unwrap_recorded_tool_call_result(await call_tool_step(tool_name, tool_args, ctx, tool))
 
     return DurableMCPToolset(
         wrapped,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
@@ -15,7 +15,7 @@ from pydantic_ai.durable_exec._toolset import (
 from pydantic_ai.mcp import MCPToolset, ToolResult
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 
-from ._utils import StepConfig
+from ._utils import StepConfig, guard_enqueue_in_workflow
 
 
 def dbosify_mcp_toolset(
@@ -40,9 +40,12 @@ def dbosify_mcp_toolset(
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
     ) -> CallToolResult:
+        # The context is guarded because a `process_tool_call=` hook receives it and could enqueue.
         # DBOS has no selective non-retryable-exception support, so control-flow
         # exceptions must cross the step boundary as successful values.
-        return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, ctx, tool))
+        return await wrap_tool_call_result(
+            wrapped.call_tool(tool_name, tool_args, guard_enqueue_in_workflow(ctx), tool)
+        )
 
     async def call_tool_operation(
         tool_name: str,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_mcp_toolset.py
@@ -6,7 +6,12 @@ from typing import Any
 from dbos import DBOS
 
 from pydantic_ai import ToolsetTool
-from pydantic_ai.durable_exec._toolset import DurableMCPToolset
+from pydantic_ai.durable_exec._toolset import (
+    CallToolResult,
+    DurableMCPToolset,
+    unwrap_tool_call_result,
+    wrap_tool_call_result,
+)
 from pydantic_ai.mcp import MCPToolset, ToolResult
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition
 
@@ -34,8 +39,10 @@ def dbosify_mcp_toolset(
         tool_args: dict[str, Any],
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
-    ) -> ToolResult:
-        return await wrapped.call_tool(tool_name, tool_args, ctx, tool)
+    ) -> CallToolResult:
+        # DBOS has no selective non-retryable-exception support, so control-flow
+        # exceptions must cross the step boundary as successful values.
+        return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, ctx, tool))
 
     async def call_tool_operation(
         tool_name: str,
@@ -44,7 +51,7 @@ def dbosify_mcp_toolset(
         tool: ToolsetTool[AgentDepsT],
         config: Mapping[str, Any],
     ) -> ToolResult:
-        return await call_tool_step(tool_name, tool_args, ctx, tool)
+        return unwrap_tool_call_result(await call_tool_step(tool_name, tool_args, ctx, tool))
 
     return DurableMCPToolset(
         wrapped,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_utils.py
@@ -1,4 +1,10 @@
+from dataclasses import replace
+
+from dbos import DBOS
 from typing_extensions import TypedDict
+
+from pydantic_ai.durable_exec._toolset import EnqueueGuard
+from pydantic_ai.tools import AgentDepsT, RunContext
 
 
 class StepConfig(TypedDict, total=False):
@@ -8,3 +14,22 @@ class StepConfig(TypedDict, total=False):
     interval_seconds: float
     max_attempts: int
     backoff_rate: float
+
+
+def guard_enqueue_in_workflow(ctx: RunContext[AgentDepsT]) -> RunContext[AgentDepsT]:
+    """Make `ctx.enqueue()` raise inside a workflow's step-wrapped tool call.
+
+    Recovery replays a step's recorded output without re-executing the tool, so in-step
+    enqueued messages would be silently dropped. Outside a workflow, steps degrade to
+    plain calls and enqueueing keeps working, so the original context is returned.
+    """
+    if DBOS.workflow_id is None:
+        return ctx
+    return replace(
+        ctx,
+        pending_messages=EnqueueGuard(
+            '`ctx.enqueue()` is not supported inside DBOS step-wrapped tools because workflow '
+            'recovery replays the recorded step output and would drop the enqueued messages. '
+            'Enqueue messages from workflow-level code instead.'
+        ),
+    )

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_agent.py
@@ -57,7 +57,8 @@ from ._types import TaskConfig, default_task_config
 - `tool_task_config=` → set `tool_task_config=` on `PrefectDurability`.
 - `tool_task_config_by_name=` → use per-tool `metadata={'prefect': ...}` or a `SetToolMetadata` capability.
 - `event_stream_handler_task_config=` → set `event_stream_handler_task_config=` on `PrefectDurability`.
-- `prefectify_toolset_func=` → not supported on the capability path; open an issue if you need it.""",
+- `prefectify_toolset_func=` → not supported on the capability path; open an issue if you need it.
+In-flight flow runs will not resume from cache across the migration and re-execute live on retry; let them finish first if that matters.""",
     category=PydanticAIDeprecationWarning,
 )
 class PrefectAgent(WrapperAgent[AgentDepsT, OutputDataT]):

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
@@ -7,6 +7,7 @@ from prefect.utilities.hashing import hash_objects
 from pydantic import BaseModel
 
 from pydantic_ai import ToolsetTool
+from pydantic_ai._utils import TOOL_CALL_ID_PREFIX
 from pydantic_ai.tools import RunContext
 
 _NON_SERIALIZABLE = '<non-serializable>'
@@ -114,6 +115,8 @@ def _strip_cache_excluded_fields(
         for f in fields(obj):
             if f.name not in excluded_fields:
                 value = getattr(obj, f.name)
+                if f.name == 'tool_call_id' and isinstance(value, str) and value.startswith(TOOL_CALL_ID_PREFIX):
+                    value = '<framework-generated>'
                 result[f.name] = _strip_cache_excluded_fields(value)
         return result
     elif _is_dict(obj):

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_cache_policies.py
@@ -111,11 +111,17 @@ def _strip_cache_excluded_fields(
     if is_dataclass(obj) and not isinstance(obj, type):
         result: dict[str, Any] = {}
         module = type(obj).__module__
-        excluded_fields = _CACHE_EXCLUDED_FIELDS if module == 'pydantic_ai' or module.startswith('pydantic_ai.') else ()
+        is_framework = module == 'pydantic_ai' or module.startswith('pydantic_ai.')
+        excluded_fields = _CACHE_EXCLUDED_FIELDS if is_framework else ()
         for f in fields(obj):
             if f.name not in excluded_fields:
                 value = getattr(obj, f.name)
-                if f.name == 'tool_call_id' and isinstance(value, str) and value.startswith(TOOL_CALL_ID_PREFIX):
+                if (
+                    is_framework
+                    and f.name == 'tool_call_id'
+                    and isinstance(value, str)
+                    and value.startswith(TOOL_CALL_ID_PREFIX)
+                ):
                     value = '<framework-generated>'
                 result[f.name] = _strip_cache_excluded_fields(value)
         return result

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
@@ -185,6 +185,12 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
         async def event_stream_handler_task(stream_event: AgentStreamEvent, sequence: int) -> None:
             await handler(ctx, self._single_event_stream(stream_event))
 
+        # The sequence number makes content-identical events within one flow run each fire
+        # (distinct task-cache keys) while a flow retry that re-executes the same run
+        # reproduces the same numbers and replays from cache. `task_run_dynamic_keys` is
+        # Prefect's own per-flow-run counter store for task-call disambiguation, so a
+        # namespaced key gets exactly the retry-lineage lifetime Prefect's task naming
+        # relies on.
         flow_context = FlowRunContext.get()
         assert flow_context is not None
         sequence_key = f'pydantic_ai_event_sequence:{self.name}'

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
@@ -27,7 +27,7 @@ from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets import AbstractToolset, WrapperToolset
 
 from ._model import _stamp_response_provenance  # pyright: ignore[reportPrivateUsage]
-from ._toolset import prefectify_toolset as _default_prefectify_toolset
+from ._toolset import prefectify_toolset as _default_prefectify_toolset, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 
@@ -107,10 +107,15 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
         """
         super().__init__(models=models, event_stream_handler=event_stream_handler, name=name)
 
-        self._model_task_config = default_task_config | (model_task_config or {})
+        # Model and event-handler tasks compose the same non-retryable condition as tool tasks: a
+        # `UserError`/`UnexpectedModelBehavior` raised inside them (e.g. a model that can't be
+        # rebuilt on the worker) is a framework misconfiguration that retrying can't fix.
+        self._model_task_config = with_non_retryable_errors(default_task_config | (model_task_config or {}))
         self._mcp_task_config = default_task_config | (mcp_task_config or {})
         self._tool_task_config = default_task_config | (tool_task_config or {})
-        self._event_stream_handler_task_config = default_task_config | (event_stream_handler_task_config or {})
+        self._event_stream_handler_task_config = with_non_retryable_errors(
+            default_task_config | (event_stream_handler_task_config or {})
+        )
 
         # Populated by for_agent when the capability is attached to an agent.
         self._request_task: Any = None

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
@@ -182,10 +182,16 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
         handler = self._event_stream_handler
 
         @task(name='Handle Stream Event', **self._event_stream_handler_task_config)
-        async def event_stream_handler_task(stream_event: AgentStreamEvent) -> None:
+        async def event_stream_handler_task(stream_event: AgentStreamEvent, sequence: int) -> None:
             await handler(ctx, self._single_event_stream(stream_event))
 
-        await event_stream_handler_task(event)
+        flow_context = FlowRunContext.get()
+        assert flow_context is not None
+        sequence_key = f'pydantic_ai_event_sequence:{self.name}'
+        sequence = flow_context.task_run_dynamic_keys.get(sequence_key, 0)
+        assert isinstance(sequence, int)
+        flow_context.task_run_dynamic_keys[sequence_key] = sequence + 1
+        await event_stream_handler_task(event, sequence)
 
     def _wrap_leaf_toolset(self, ts: AbstractToolset[AgentDepsT]) -> WrapperToolset[AgentDepsT] | None:
         wrapped = _default_prefectify_toolset(ts, self._mcp_task_config, self._tool_task_config, {})

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_dynamic_toolset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import Any, cast
 
 from prefect import task
@@ -12,11 +13,13 @@ from pydantic_ai.durable_exec._toolset import (
     DynamicToolsResult,
     call_dynamic_tool,
     get_dynamic_tools,
+    unwrap_recorded_tool_call_result,
+    wrap_tool_call_result,
 )
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
-from ._toolset import resolve_tool_task_config
+from ._toolset import EnqueueGuard, resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 
@@ -35,7 +38,8 @@ def prefectify_dynamic_toolset(
 
     @task
     async def call_tool_task(tool_name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]) -> Any:
-        return await call_dynamic_tool(wrapped, tool_name, tool_args, ctx)
+        task_ctx = replace(ctx, pending_messages=EnqueueGuard())
+        return await wrap_tool_call_result(call_dynamic_tool(wrapped, tool_name, tool_args, task_ctx))
 
     async def call_tool_operation(
         name: str,
@@ -44,8 +48,11 @@ def prefectify_dynamic_toolset(
         tool: ToolsetTool[AgentDepsT],
         config: Mapping[str, Any],
     ) -> Any:
-        merged_config = cast('TaskConfig', base_config | dict(config))
-        return await call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(name, tool_args, ctx)
+        merged_config = with_non_retryable_errors(cast('TaskConfig', base_config | dict(config)))
+        result = await call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(name, tool_args, ctx)
+        # A persisted cache entry written before this task wrapped control-flow exceptions (still
+        # reachable under a custom `cache_policy` that omits `TASK_SOURCE`) holds the raw result.
+        return unwrap_recorded_tool_call_result(result)
 
     return DurableDynamicToolset(
         wrapped,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_dynamic_toolset.py
@@ -19,7 +19,7 @@ from pydantic_ai.durable_exec._toolset import (
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
-from ._toolset import EnqueueGuard, resolve_tool_task_config, with_non_retryable_errors
+from ._toolset import enqueue_guard, resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 
@@ -38,7 +38,7 @@ def prefectify_dynamic_toolset(
 
     @task
     async def call_tool_task(tool_name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]) -> Any:
-        task_ctx = replace(ctx, pending_messages=EnqueueGuard())
+        task_ctx = replace(ctx, pending_messages=enqueue_guard())
         return await wrap_tool_call_result(call_dynamic_tool(wrapped, tool_name, tool_args, task_ctx))
 
     async def call_tool_operation(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import Any, cast
 
 from prefect import task
@@ -9,10 +10,15 @@ from typing_extensions import deprecated
 
 from pydantic_ai import FunctionToolset, ToolsetTool
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
-from pydantic_ai.durable_exec._toolset import CallToolOperation, DurableFunctionToolset
+from pydantic_ai.durable_exec._toolset import (
+    CallToolOperation,
+    DurableFunctionToolset,
+    unwrap_tool_call_result,
+    wrap_tool_call_result,
+)
 from pydantic_ai.tools import AgentDepsT, RunContext
 
-from ._toolset import resolve_tool_task_config
+from ._toolset import resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 
@@ -24,7 +30,15 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
-        return await wrapped.call_tool(tool_name, tool_args, ctx, tool)
+        task_ctx = replace(
+            ctx,
+            pending_messages=None,
+            _enqueue_error=(
+                '`ctx.enqueue()` is not supported inside Prefect task-wrapped tools because task-cache replay '
+                'would drop the enqueued messages. Enqueue messages from flow-level code instead.'
+            ),
+        )
+        return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(
         name: str,
@@ -33,8 +47,11 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         tool: ToolsetTool[AgentDepsT],
         config: Mapping[str, Any],
     ) -> Any:
-        merged_config = cast('TaskConfig', base_config | dict(config))
-        return await call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(name, tool_args, ctx, tool)
+        merged_config = with_non_retryable_errors(cast('TaskConfig', base_config | dict(config)))
+        result = await call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(
+            name, tool_args, ctx, tool
+        )
+        return unwrap_tool_call_result(result)
 
     return call_tool_operation
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -9,7 +9,6 @@ from prefect.context import FlowRunContext
 from typing_extensions import deprecated
 
 from pydantic_ai import FunctionToolset, ToolsetTool
-from pydantic_ai._enqueue import PendingMessage
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.durable_exec._toolset import (
     CallToolOperation,
@@ -17,19 +16,10 @@ from pydantic_ai.durable_exec._toolset import (
     unwrap_recorded_tool_call_result,
     wrap_tool_call_result,
 )
-from pydantic_ai.exceptions import UserError
 from pydantic_ai.tools import AgentDepsT, RunContext
 
-from ._toolset import resolve_tool_task_config, with_non_retryable_errors
+from ._toolset import EnqueueGuard, resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
-
-
-class _EnqueueGuard(list[PendingMessage]):
-    def append(self, pending: PendingMessage) -> None:
-        raise UserError(
-            '`ctx.enqueue()` is not supported inside Prefect task-wrapped tools because task-cache replay '
-            'would drop the enqueued messages. Enqueue messages from flow-level code instead.'
-        )
 
 
 def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: TaskConfig) -> CallToolOperation:
@@ -40,7 +30,7 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
-        task_ctx = replace(ctx, pending_messages=_EnqueueGuard())
+        task_ctx = replace(ctx, pending_messages=EnqueueGuard())
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -14,7 +14,7 @@ from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.durable_exec._toolset import (
     CallToolOperation,
     DurableFunctionToolset,
-    unwrap_tool_call_result,
+    unwrap_recorded_tool_call_result,
     wrap_tool_call_result,
 )
 from pydantic_ai.exceptions import UserError
@@ -54,7 +54,9 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         result = await call_tool_task.with_options(name=f'Call Tool: {name}', **merged_config)(
             name, tool_args, ctx, tool
         )
-        return unwrap_tool_call_result(result)
+        # A persisted cache entry written before this task wrapped control-flow exceptions (still
+        # reachable under a custom `cache_policy` that omits `TASK_SOURCE`) holds the raw result.
+        return unwrap_recorded_tool_call_result(result)
 
     return call_tool_operation
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -18,7 +18,7 @@ from pydantic_ai.durable_exec._toolset import (
 )
 from pydantic_ai.tools import AgentDepsT, RunContext
 
-from ._toolset import EnqueueGuard, resolve_tool_task_config, with_non_retryable_errors
+from ._toolset import enqueue_guard, resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 
@@ -30,7 +30,7 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
-        task_ctx = replace(ctx, pending_messages=EnqueueGuard())
+        task_ctx = replace(ctx, pending_messages=enqueue_guard())
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -9,6 +9,7 @@ from prefect.context import FlowRunContext
 from typing_extensions import deprecated
 
 from pydantic_ai import FunctionToolset, ToolsetTool
+from pydantic_ai._enqueue import PendingMessage
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.durable_exec._toolset import (
     CallToolOperation,
@@ -16,10 +17,19 @@ from pydantic_ai.durable_exec._toolset import (
     unwrap_tool_call_result,
     wrap_tool_call_result,
 )
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.tools import AgentDepsT, RunContext
 
 from ._toolset import resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
+
+
+class _EnqueueGuard(list[PendingMessage]):
+    def append(self, pending: PendingMessage) -> None:
+        raise UserError(
+            '`ctx.enqueue()` is not supported inside Prefect task-wrapped tools because task-cache replay '
+            'would drop the enqueued messages. Enqueue messages from flow-level code instead.'
+        )
 
 
 def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: TaskConfig) -> CallToolOperation:
@@ -30,14 +40,7 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
-        task_ctx = replace(
-            ctx,
-            pending_messages=None,
-            _enqueue_error=(
-                '`ctx.enqueue()` is not supported inside Prefect task-wrapped tools because task-cache replay '
-                'would drop the enqueued messages. Enqueue messages from flow-level code instead.'
-            ),
-        )
+        task_ctx = replace(ctx, pending_messages=_EnqueueGuard())
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
@@ -12,7 +12,7 @@ from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.durable_exec._toolset import (
     CallToolOperation,
     DurableMCPToolset,
-    unwrap_tool_call_result,
+    unwrap_recorded_tool_call_result,
     wrap_tool_call_result,
 )
 from pydantic_ai.tools import AgentDepsT, RunContext
@@ -45,7 +45,9 @@ def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfi
         result = await call_tool_task.with_options(name=f'Call MCP Tool: {name}', **task_config)(
             name, tool_args, ctx, tool
         )
-        return unwrap_tool_call_result(result)
+        # A persisted cache entry written before this task wrapped control-flow exceptions (still
+        # reachable under a custom `cache_policy` that omits `TASK_SOURCE`) holds the raw result.
+        return unwrap_recorded_tool_call_result(result)
 
     return call_tool_operation
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
@@ -9,9 +9,15 @@ from typing_extensions import deprecated
 
 from pydantic_ai import ToolsetTool
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
-from pydantic_ai.durable_exec._toolset import CallToolOperation, DurableMCPToolset
+from pydantic_ai.durable_exec._toolset import (
+    CallToolOperation,
+    DurableMCPToolset,
+    unwrap_tool_call_result,
+    wrap_tool_call_result,
+)
 from pydantic_ai.tools import AgentDepsT, RunContext
 
+from ._toolset import with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 if TYPE_CHECKING:
@@ -25,8 +31,8 @@ def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfi
         tool_args: dict[str, Any],
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
-    ) -> ToolResult:
-        return await wrapped.call_tool(tool_name, tool_args, ctx, tool)
+    ) -> Any:
+        return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, ctx, tool))
 
     async def call_tool_operation(
         name: str,
@@ -35,9 +41,11 @@ def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfi
         tool: ToolsetTool[AgentDepsT],
         config: Mapping[str, Any],
     ) -> ToolResult:
-        return await call_tool_task.with_options(name=f'Call MCP Tool: {name}', **base_config)(
+        task_config = with_non_retryable_errors(base_config)
+        result = await call_tool_task.with_options(name=f'Call MCP Tool: {name}', **task_config)(
             name, tool_args, ctx, tool
         )
+        return unwrap_tool_call_result(result)
 
     return call_tool_operation
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from prefect import task
@@ -17,7 +18,7 @@ from pydantic_ai.durable_exec._toolset import (
 )
 from pydantic_ai.tools import AgentDepsT, RunContext
 
-from ._toolset import with_non_retryable_errors
+from ._toolset import enqueue_guard, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 if TYPE_CHECKING:
@@ -32,7 +33,9 @@ def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfi
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
-        return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, ctx, tool))
+        # The context is guarded because a `process_tool_call=` hook receives it and could enqueue.
+        task_ctx = replace(ctx, pending_messages=enqueue_guard())
+        return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(
         name: str,

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
@@ -1,14 +1,35 @@
 from __future__ import annotations
 
+import inspect
 from collections.abc import Mapping
 from typing import Any, Literal, cast
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool
-from pydantic_ai.exceptions import UserError
+from pydantic_ai.exceptions import UnexpectedModelBehavior, UserError
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
 from ._types import TaskConfig
+
+
+def with_non_retryable_errors(config: TaskConfig) -> TaskConfig:
+    """Ensure framework configuration errors are not retried by Prefect."""
+    config = config.copy()
+    configured_condition = config.get('retry_condition_fn')
+
+    async def retry_condition(task: Any, task_run: Any, state: Any) -> bool:
+        result = state.result(raise_on_failure=False)
+        if inspect.isawaitable(result):
+            result = await result
+        if isinstance(result, (UserError, UnexpectedModelBehavior)):
+            return False
+        if configured_condition is None:
+            return True
+        decision = configured_condition(task, task_run, state)
+        return await decision if inspect.isawaitable(decision) else decision
+
+    config['retry_condition_fn'] = retry_condition
+    return config
 
 
 def resolve_tool_task_config(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
@@ -5,11 +5,22 @@ from collections.abc import Mapping
 from typing import Any, Literal, cast
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool
+from pydantic_ai._enqueue import PendingMessage
 from pydantic_ai.exceptions import UnexpectedModelBehavior, UserError
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
 from ._types import TaskConfig
+
+
+class EnqueueGuard(list[PendingMessage]):
+    """Replaces `ctx.pending_messages` inside task-wrapped tools, where enqueueing can't be supported."""
+
+    def append(self, pending: PendingMessage) -> None:
+        raise UserError(
+            '`ctx.enqueue()` is not supported inside Prefect task-wrapped tools because task-cache replay '
+            'would drop the enqueued messages. Enqueue messages from flow-level code instead.'
+        )
 
 
 def with_non_retryable_errors(config: TaskConfig) -> TaskConfig:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from typing import Any, Literal, cast
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool
-from pydantic_ai._enqueue import PendingMessage
+from pydantic_ai.durable_exec._toolset import EnqueueGuard
 from pydantic_ai.exceptions import UnexpectedModelBehavior, UserError
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets._dynamic import DynamicToolset
@@ -13,14 +13,11 @@ from pydantic_ai.toolsets._dynamic import DynamicToolset
 from ._types import TaskConfig
 
 
-class EnqueueGuard(list[PendingMessage]):
-    """Replaces `ctx.pending_messages` inside task-wrapped tools, where enqueueing can't be supported."""
-
-    def append(self, pending: PendingMessage) -> None:
-        raise UserError(
-            '`ctx.enqueue()` is not supported inside Prefect task-wrapped tools because task-cache replay '
-            'would drop the enqueued messages. Enqueue messages from flow-level code instead.'
-        )
+def enqueue_guard() -> EnqueueGuard:
+    return EnqueueGuard(
+        '`ctx.enqueue()` is not supported inside Prefect task-wrapped tools because task-cache replay '
+        'would drop the enqueued messages. Enqueue messages from flow-level code instead.'
+    )
 
 
 def with_non_retryable_errors(config: TaskConfig) -> TaskConfig:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_types.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from prefect.cache_policies import CachePolicy
 from prefect.results import ResultStorage
+from prefect.tasks import RetryConditionCallable
 from typing_extensions import TypedDict
 
 from pydantic_ai.durable_exec.prefect._cache_policies import DEFAULT_PYDANTIC_AI_CACHE_POLICY
@@ -18,6 +19,9 @@ class TaskConfig(TypedDict, total=False):
 
     retry_delay_seconds: float | list[float]
     """Delay between retries in seconds. Can be a single value or a list for custom backoff."""
+
+    retry_condition_fn: RetryConditionCallable
+    """Predicate deciding whether a failed task should be retried."""
 
     timeout_seconds: float
     """Maximum time in seconds for the task to complete."""

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -72,7 +72,8 @@ class _EventStreamHandlerParams:
 - `toolset_activity_config=` → set `toolset_activity_config=` on `TemporalDurability`.
 - `tool_activity_config=` → use per-tool `metadata={'temporal': ...}` or a `SetToolMetadata` capability.
 - `run_context_type=` → set `run_context_type=` on `TemporalDurability`.
-- `temporalize_toolset_func=` → not supported on the capability path; open an issue if you need it.""",
+- `temporalize_toolset_func=` → not supported on the capability path; open an issue if you need it.
+Workflows started under `TemporalAgent` replay correctly after migrating when agent name, toolset IDs, and model registry keys are kept; no draining is needed.""",
     category=PydanticAIDeprecationWarning,
 )
 class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_agent.py
@@ -73,7 +73,7 @@ class _EventStreamHandlerParams:
 - `tool_activity_config=` → use per-tool `metadata={'temporal': ...}` or a `SetToolMetadata` capability.
 - `run_context_type=` → set `run_context_type=` on `TemporalDurability`.
 - `temporalize_toolset_func=` → not supported on the capability path; open an issue if you need it.
-Workflows started under `TemporalAgent` replay correctly after migrating when agent name, toolset IDs, and model registry keys are kept; no draining is needed.""",
+Workflows started under `TemporalAgent` replay correctly after migrating when agent name, toolset IDs, and model registry keys are kept and `event_stream_handler=` stays on `TemporalDurability`; no draining is needed.""",
     category=PydanticAIDeprecationWarning,
 )
 class TemporalAgent(WrapperAgent[AgentDepsT, OutputDataT]):

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2315,6 +2315,36 @@ async def test_dbos_dynamic_tool_model_retry_crosses_step_without_engine_retries
     assert await run_workflow() == 1
 
 
+async def test_dbos_dynamic_tool_rejects_enqueue_in_workflow(dbos: DBOS) -> None:
+    """`ctx.enqueue()` inside a step-wrapped dynamic tool raises instead of silently dropping.
+
+    Recovery replays the recorded step output without re-executing the tool, so in-step
+    enqueued messages would be lost. Outside a workflow the step degrades to a plain call
+    and enqueueing keeps working.
+    """
+
+    async def enqueue(ctx: RunContext[object]) -> str:
+        ctx.enqueue('later')
+        return 'done'
+
+    agent = Agent(
+        TestModel(),
+        deps_type=object,
+        name='dbos_dynamic_enqueue',
+        toolsets=[DynamicToolset(lambda ctx: FunctionToolset([enqueue]), id='enqueue_dynamic')],
+        capabilities=[DBOSDurability()],
+    )
+
+    @DBOS.workflow()
+    async def run_workflow() -> None:
+        await agent.run('run')
+
+    with pytest.raises(UserError, match='recovery replays the recorded step output'):
+        await run_workflow()
+
+    await agent.run('run')
+
+
 async def test_dbos_durability_parallel_mode_applies_inside_run(dbos: DBOS) -> None:
     """The configured parallel-execution mode is active for the duration of the run."""
     from pydantic_ai import tool_manager as _tm

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2342,6 +2342,11 @@ async def test_dbos_mcp_step_rejects_enqueue_in_workflow(dbos: DBOS, monkeypatch
     with pytest.raises(UserError, match='recovery replays the recorded step output'):
         await run_workflow()
 
+    # Outside a workflow the step degrades to a plain call and enqueueing keeps working.
+    outside_context = RunContext(deps=None, model=TestModel(), usage=RunUsage(), pending_messages=[])
+    assert await durable.call_tool('hook', {}, outside_context, tool) == 'done'
+    assert len(outside_context.pending_messages or []) == 1
+
 
 async def test_dbos_dynamic_tool_rejects_enqueue_in_workflow(dbos: DBOS) -> None:
     """`ctx.enqueue()` inside a step-wrapped dynamic tool raises instead of silently dropping.

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2157,17 +2157,66 @@ async def test_dbos_durability_accepts_legacy_stream_step_shape(dbos: DBOS) -> N
     assert await run_agent() == ('legacy stream', ['legacy stream'])
 
 
+# Module-level like real wrapper-era handlers: `DBOSAgent.run` recorded the handler as a
+# workflow input, so it had to be picklable by reference.
+_legacy_handler_events: list[tuple[AgentStreamEvent, bool]] = []
+
+
+async def _legacy_workflow_event_handler(ctx: RunContext[Any], stream: AsyncIterable[AgentStreamEvent]) -> None:
+    async for event in stream:
+        _legacy_handler_events.append((event, DBOS.step_id is not None))
+
+
 def test_dbos_durability_legacy_run_sync_workflow(dbos: DBOS) -> None:
-    """The opt-in legacy `run_sync` workflow executes the agent like `DBOSAgent.run_sync` did."""
+    """The opt-in legacy `run_sync` workflow executes the agent like `DBOSAgent.run_sync` did,
+    including routing a recorded per-run `event_stream_handler` input through steps."""
+    _legacy_handler_events.clear()
     agent = Agent(
-        _durability_fn_model,
+        TestModel(custom_output_text='legacy sync'),
         name='legacy_workflow_sync_compat',
         capabilities=[DBOSDurability(register_legacy_workflows=True)],
     )
     durability = DBOSDurability.from_agent(agent)
     assert durability is not None
-    result = durability._legacy_run_sync_workflow('legacy')  # pyright: ignore[reportPrivateUsage]
-    assert result.output == 'Echo: legacy'
+    result = durability._legacy_run_sync_workflow('legacy', event_stream_handler=_legacy_workflow_event_handler)  # pyright: ignore[reportPrivateUsage]
+    assert result.output == 'legacy sync'
+    assert _legacy_handler_events
+
+
+async def test_dbos_durability_legacy_workflow_routes_event_stream_handler_through_steps(dbos: DBOS) -> None:
+    """A per-run `event_stream_handler` recorded in a wrapper-era workflow's inputs runs inside steps.
+
+    `DBOSAgent.run` recorded the handler as a workflow input and invoked it inside the
+    `__event_stream_handler` step; the compat workflow must replay that recorded step
+    sequence rather than re-running the handler (and its side effects) at graph level.
+    """
+    _legacy_handler_events.clear()
+
+    async def handled_tool() -> str:
+        return 'handled'
+
+    agent = Agent(
+        TestModel(),
+        name='legacy_workflow_handler',
+        tools=[handled_tool],
+        capabilities=[DBOSDurability(register_legacy_workflows=True)],
+    )
+    durability = DBOSDurability.from_agent(agent)
+    assert durability is not None
+
+    wfid = str(uuid.uuid4())
+    with SetWorkflowID(wfid):
+        result = await durability._legacy_run_workflow('Hello', event_stream_handler=_legacy_workflow_event_handler)  # pyright: ignore[reportPrivateUsage]
+    assert result.output
+
+    events = [event for event, _ in _legacy_handler_events]
+    assert events
+    assert all(in_step for _, in_step in _legacy_handler_events)
+    assert sum(isinstance(event, FunctionToolCallEvent) for event in events) == 1
+
+    steps = await dbos.list_workflow_steps_async(wfid)
+    step_names = [step['function_name'] for step in steps]
+    assert 'legacy_workflow_handler__event_stream_handler' in step_names
 
 
 async def test_unwrap_recorded_tool_call_result_handles_both_generations() -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -57,6 +57,7 @@ from .conftest import IsDatetime, IsNow, IsStr
 try:
     from dbos import DBOS, DBOSConfig, SetWorkflowID
 
+    from pydantic_ai.durable_exec._toolset import unwrap_recorded_tool_call_result, wrap_tool_call_result
     from pydantic_ai.durable_exec.dbos import (
         DBOSAgent,  # pyright: ignore[reportDeprecated]
         DBOSDurability,
@@ -64,6 +65,7 @@ try:
         StepConfig,
     )
     from pydantic_ai.durable_exec.dbos._mcp_toolset import DBOSMCPToolset, dbosify_mcp_toolset
+    from pydantic_ai.toolsets.external import TOOL_SCHEMA_VALIDATOR
 
 except ImportError:  # pragma: lax no cover
     pytest.skip('DBOS is not installed', allow_module_level=True)
@@ -90,7 +92,7 @@ except ImportError:  # pragma: lax no cover
 from pydantic_ai import ExternalToolset, FunctionToolset
 from pydantic_ai.capabilities import ProcessEventStream, ResolveModelId, SelectModel, Toolset
 from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDefinition
-from pydantic_ai.toolsets import AbstractToolset
+from pydantic_ai.toolsets import AbstractToolset, ToolsetTool
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
 from ._inline_snapshot import snapshot
@@ -2153,6 +2155,77 @@ async def test_dbos_durability_accepts_legacy_stream_step_shape(dbos: DBOS) -> N
             return await result.get_output(), chunks
 
     assert await run_agent() == ('legacy stream', ['legacy stream'])
+
+
+def test_dbos_durability_legacy_run_sync_workflow(dbos: DBOS) -> None:
+    """The opt-in legacy `run_sync` workflow executes the agent like `DBOSAgent.run_sync` did."""
+    agent = Agent(
+        _durability_fn_model,
+        name='legacy_workflow_sync_compat',
+        capabilities=[DBOSDurability(register_legacy_workflows=True)],
+    )
+    durability = DBOSDurability.from_agent(agent)
+    assert durability is not None
+    result = durability._legacy_run_sync_workflow('legacy')  # pyright: ignore[reportPrivateUsage]
+    assert result.output == 'Echo: legacy'
+
+
+async def test_unwrap_recorded_tool_call_result_handles_both_generations() -> None:
+    """Recovery may replay step outputs recorded before control-flow wrapping (raw) or after (wrapped).
+
+    A unit test because a real recovery would need to kill and restart the process mid-workflow;
+    the step-recorded value is exactly what this helper receives on replay.
+    """
+
+    async def raise_model_retry() -> str:
+        raise ModelRetry('again')
+
+    wrapped_result = await wrap_tool_call_result(raise_model_retry())
+    with pytest.raises(ModelRetry, match='again'):
+        unwrap_recorded_tool_call_result(wrapped_result)
+
+    assert unwrap_recorded_tool_call_result('raw recorded output') == 'raw recorded output'
+
+
+async def test_dbos_mcp_model_retry_crosses_step_without_engine_retries(
+    dbos: DBOS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`ModelRetry` from an MCP tool crosses the step as a value; DBOS must not re-execute the call.
+
+    Previously the raw exception failed the step, so `retries_allowed` re-ran the side-effecting
+    MCP call and surfaced `DBOSMaxStepRetriesExceeded` instead of the agent's retry-prompt loop.
+    """
+    calls = 0
+    mcp_toolset = MCPToolset(StdioTransport(command='python', args=['-m', 'tests.mcp_server']), id='retry_mcp')
+
+    async def raise_model_retry(
+        tool_name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
+    ) -> Any:
+        nonlocal calls
+        calls += 1
+        raise ModelRetry('try again')
+
+    monkeypatch.setattr(mcp_toolset, 'call_tool', raise_model_retry)
+    durable = dbosify_mcp_toolset(
+        mcp_toolset,
+        step_name_prefix='retry_mcp_agent',
+        step_config=StepConfig(retries_allowed=True, max_attempts=3),
+    )
+    run_context = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+    tool = ToolsetTool(
+        toolset=durable,
+        tool_def=ToolDefinition(name='boom'),
+        max_retries=1,
+        args_validator=TOOL_SCHEMA_VALIDATOR,
+    )
+
+    @DBOS.workflow()
+    async def run_workflow() -> int:
+        with pytest.raises(ModelRetry, match='try again'):
+            await durable.call_tool('boom', {}, run_context, tool)
+        return calls
+
+    assert await run_workflow() == 1
 
 
 async def test_dbos_durability_parallel_mode_applies_inside_run(dbos: DBOS) -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -64,6 +64,7 @@ try:
         DBOSModel,
         StepConfig,
     )
+    from pydantic_ai.durable_exec.dbos._dynamic_toolset import dbosify_dynamic_toolset
     from pydantic_ai.durable_exec.dbos._mcp_toolset import DBOSMCPToolset, dbosify_mcp_toolset
     from pydantic_ai.toolsets.external import TOOL_SCHEMA_VALIDATOR
 
@@ -2169,7 +2170,7 @@ async def _legacy_workflow_event_handler(ctx: RunContext[Any], stream: AsyncIter
 
 def test_dbos_durability_legacy_run_sync_workflow(dbos: DBOS) -> None:
     """The opt-in legacy `run_sync` workflow executes the agent like `DBOSAgent.run_sync` did,
-    including routing a recorded per-run `event_stream_handler` input through steps."""
+    including honoring a recorded per-run `event_stream_handler` input."""
     _legacy_handler_events.clear()
     agent = Agent(
         TestModel(custom_output_text='legacy sync'),
@@ -2183,12 +2184,14 @@ def test_dbos_durability_legacy_run_sync_workflow(dbos: DBOS) -> None:
     assert _legacy_handler_events
 
 
-async def test_dbos_durability_legacy_workflow_routes_event_stream_handler_through_steps(dbos: DBOS) -> None:
-    """A per-run `event_stream_handler` recorded in a wrapper-era workflow's inputs runs inside steps.
+async def test_dbos_durability_legacy_workflow_matches_wrapper_step_sequence(dbos: DBOS) -> None:
+    """A legacy run delivers handler events exactly the way `DBOSAgent` did, so recovery replays.
 
-    `DBOSAgent.run` recorded the handler as a workflow input and invoked it inside the
-    `__event_stream_handler` step; the compat workflow must replay that recorded step
-    sequence rather than re-running the handler (and its side effects) at graph level.
+    Wrapper-era recordings contain only model and MCP steps: model events reached the handler
+    live inside the `__model.request_stream` step, and graph-level events through a direct
+    workflow-level call that consumed no step. Dispatching graph events through the capability's
+    `__event_stream_handler` step would insert step ids the recording doesn't have and fail
+    recovery with `DBOSUnexpectedStepError`.
     """
     _legacy_handler_events.clear()
 
@@ -2211,12 +2214,15 @@ async def test_dbos_durability_legacy_workflow_routes_event_stream_handler_throu
 
     events = [event for event, _ in _legacy_handler_events]
     assert events
-    assert all(in_step for _, in_step in _legacy_handler_events)
     assert sum(isinstance(event, FunctionToolCallEvent) for event in events) == 1
+    # Model events arrive live inside the model-request step; graph events at workflow level.
+    assert all(in_step for event, in_step in _legacy_handler_events if isinstance(event, PartStartEvent))
+    assert not any(in_step for event, in_step in _legacy_handler_events if isinstance(event, FunctionToolCallEvent))
 
     steps = await dbos.list_workflow_steps_async(wfid)
     step_names = [step['function_name'] for step in steps]
-    assert 'legacy_workflow_handler__event_stream_handler' in step_names
+    assert 'legacy_workflow_handler__model.request_stream' in step_names
+    assert 'legacy_workflow_handler__event_stream_handler' not in step_names
 
 
 async def test_unwrap_recorded_tool_call_result_handles_both_generations() -> None:
@@ -2272,6 +2278,38 @@ async def test_dbos_mcp_model_retry_crosses_step_without_engine_retries(
     async def run_workflow() -> int:
         with pytest.raises(ModelRetry, match='try again'):
             await durable.call_tool('boom', {}, run_context, tool)
+        return calls
+
+    assert await run_workflow() == 1
+
+
+async def test_dbos_dynamic_tool_model_retry_crosses_step_without_engine_retries(dbos: DBOS) -> None:
+    """`ModelRetry` from a `DynamicToolset` tool crosses the step as a value, like MCP and function tools."""
+    calls = 0
+
+    async def raise_model_retry() -> str:
+        nonlocal calls
+        calls += 1
+        raise ModelRetry('try again')
+
+    dynamic = DynamicToolset[None](lambda ctx: FunctionToolset([raise_model_retry]), id='retry_dynamic')
+    durable = dbosify_dynamic_toolset(
+        dynamic,
+        step_name_prefix='retry_dynamic_agent',
+        step_config=StepConfig(retries_allowed=True, max_attempts=3),
+    )
+    run_context = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+    tool = ToolsetTool(
+        toolset=durable,
+        tool_def=ToolDefinition(name='raise_model_retry'),
+        max_retries=1,
+        args_validator=TOOL_SCHEMA_VALIDATOR,
+    )
+
+    @DBOS.workflow()
+    async def run_workflow() -> int:
+        with pytest.raises(ModelRetry, match='try again'):
+            await durable.call_tool('raise_model_retry', {}, run_context, tool)
         return calls
 
     assert await run_workflow() == 1

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2315,6 +2315,34 @@ async def test_dbos_dynamic_tool_model_retry_crosses_step_without_engine_retries
     assert await run_workflow() == 1
 
 
+async def test_dbos_mcp_step_rejects_enqueue_in_workflow(dbos: DBOS, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The MCP step path guards enqueue too: a `process_tool_call=` hook receives the run context."""
+    mcp_toolset = MCPToolset(StdioTransport(command='python', args=['-m', 'tests.mcp_server']), id='enqueue_mcp')
+
+    async def enqueue_call_tool(
+        tool_name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
+    ) -> Any:
+        ctx.enqueue('later')
+        return 'done'
+
+    monkeypatch.setattr(mcp_toolset, 'call_tool', enqueue_call_tool)
+    durable = dbosify_mcp_toolset(mcp_toolset, step_name_prefix='enqueue_mcp_agent', step_config={})
+    run_context = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+    tool = ToolsetTool(
+        toolset=durable,
+        tool_def=ToolDefinition(name='hook'),
+        max_retries=1,
+        args_validator=TOOL_SCHEMA_VALIDATOR,
+    )
+
+    @DBOS.workflow()
+    async def run_workflow() -> None:
+        await durable.call_tool('hook', {}, run_context, tool)
+
+    with pytest.raises(UserError, match='recovery replays the recorded step output'):
+        await run_workflow()
+
+
 async def test_dbos_dynamic_tool_rejects_enqueue_in_workflow(dbos: DBOS) -> None:
     """`ctx.enqueue()` inside a step-wrapped dynamic tool raises instead of silently dropping.
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2114,6 +2114,47 @@ async def test_dbos_durability_simple_agent(dbos: DBOS) -> None:
     assert output == 'Echo: Hello DBOS'
 
 
+async def test_dbos_durability_registers_legacy_workflows_opt_in(dbos: DBOS) -> None:
+    agent = Agent(
+        _durability_fn_model,
+        name='legacy_workflow_compat',
+        capabilities=[DBOSDurability(register_legacy_workflows=True)],
+    )
+    durability = DBOSDurability.from_agent(agent)
+    assert durability is not None
+    assert durability._legacy_run_workflow is not None  # pyright: ignore[reportPrivateUsage]
+    assert durability._legacy_run_sync_workflow is not None  # pyright: ignore[reportPrivateUsage]
+
+    result = await durability._legacy_run_workflow('legacy')  # pyright: ignore[reportPrivateUsage]
+    assert result.output == 'Echo: legacy'
+
+    without_flag = Agent(_durability_fn_model, name='no_legacy_workflows', capabilities=[DBOSDurability()])
+    without_flag_durability = DBOSDurability.from_agent(without_flag)
+    assert without_flag_durability is not None
+    assert without_flag_durability._legacy_run_workflow is None  # pyright: ignore[reportPrivateUsage]
+    assert without_flag_durability._legacy_run_sync_workflow is None  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_dbos_durability_accepts_legacy_stream_step_shape(dbos: DBOS) -> None:
+    response = ModelResponse(parts=[TextPart(content='legacy stream')], model_name='legacy')
+    agent = Agent(TestModel(), name='legacy_stream_shape', capabilities=[DBOSDurability()])
+    durability = DBOSDurability.from_agent(agent)
+    assert durability is not None
+
+    async def legacy_stream_step(*args: Any) -> ModelResponse:
+        return response
+
+    durability._request_stream_step = legacy_stream_step  # pyright: ignore[reportPrivateUsage]
+
+    @DBOS.workflow()
+    async def run_agent() -> tuple[str, list[str]]:
+        async with agent.run_stream('stream') as result:
+            chunks = [chunk async for chunk in result.stream_text(debounce_by=None)]
+            return await result.get_output(), chunks
+
+    assert await run_agent() == ('legacy stream', ['legacy stream'])
+
+
 async def test_dbos_durability_parallel_mode_applies_inside_run(dbos: DBOS) -> None:
     """The configured parallel-execution mode is active for the duration of the run."""
     from pydantic_ai import tool_manager as _tm

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -1462,8 +1462,15 @@ def test_cache_policy_keeps_user_dataclass_fields():
         timestamp: str
         run_id: str
         conversation_id: str
+        tool_call_id: str
 
-    deps = CacheDeps(timestamp='user-time', run_id='user-run', conversation_id='user-conversation')
+    deps = CacheDeps(
+        timestamp='user-time',
+        run_id='user-run',
+        conversation_id='user-conversation',
+        # A user field whose value happens to look framework-generated must not be normalized.
+        tool_call_id='pyd_ai_user_value',
+    )
     ctx = RunContext(deps=deps, model=TestModel(), usage=RunUsage())
 
     projected = _strip_cache_excluded_fields(_replace_run_context({'ctx': ctx}))
@@ -1472,6 +1479,7 @@ def test_cache_policy_keeps_user_dataclass_fields():
         'timestamp': 'user-time',
         'run_id': 'user-run',
         'conversation_id': 'user-conversation',
+        'tool_call_id': 'pyd_ai_user_value',
     }
 
 
@@ -2619,6 +2627,32 @@ async def test_prefect_tool_model_retry_is_not_retried_by_task_engine() -> None:
         TestModel(),
         name='prefect_model_retry',
         tools=[retry_once],
+        capabilities=[PrefectDurability(tool_task_config={'retries': 3})],
+    )
+
+    @flow
+    async def run_agent() -> str:
+        return (await agent.run('run')).output
+
+    await run_agent()
+    assert calls == 2
+
+
+async def test_prefect_dynamic_tool_model_retry_is_not_retried_by_task_engine() -> None:
+    """`ModelRetry` from a `DynamicToolset` tool crosses the task as a value, like static tools."""
+    calls = 0
+
+    async def retry_once() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ModelRetry('again')
+        return 'done'
+
+    agent = Agent(
+        TestModel(),
+        name='prefect_dynamic_model_retry',
+        toolsets=[DynamicToolset(lambda ctx: FunctionToolset([retry_once]), id='dyn_retry')],
         capabilities=[PrefectDurability(tool_task_config={'retries': 3})],
     )
 

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -2587,13 +2587,8 @@ async def test_prefect_durability_identical_events_are_dispatched_twice() -> Non
 
 
 async def test_prefect_task_wrapped_tool_rejects_enqueue() -> None:
-    enqueued = False
-
     async def enqueue(ctx: RunContext[object]) -> str:
-        nonlocal enqueued
-        if not enqueued:
-            ctx.enqueue('later')
-            enqueued = True
+        ctx.enqueue('later')
         return 'done'
 
     durability: PrefectDurability[object] = PrefectDurability()
@@ -2606,7 +2601,7 @@ async def test_prefect_task_wrapped_tool_rejects_enqueue() -> None:
     with pytest.raises(UserError, match='task-cache replay would drop the enqueued messages'):
         await run_agent()
 
-    enqueued = False
+    # Outside a flow the tool runs inline and enqueueing keeps working.
     await agent.run('run')
 
 

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -2642,6 +2642,11 @@ async def test_prefect_mcp_task_wrapped_call_rejects_enqueue(monkeypatch: pytest
     with pytest.raises(UserError, match='task-cache replay would drop the enqueued messages'):
         await run_tool()
 
+    # Outside a flow the call runs inline and enqueueing keeps working.
+    outside_context = RunContext(deps=None, model=TestModel(), usage=RunUsage(), pending_messages=[])
+    assert await durable.call_tool('hook', {}, outside_context, tool) == 'done'
+    assert len(outside_context.pending_messages or []) == 1
+
 
 async def test_prefect_tool_model_retry_is_not_retried_by_task_engine() -> None:
     calls = 0

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -31,6 +31,7 @@ from pydantic_ai import (
     PartDeltaEvent,
     PartEndEvent,
     PartStartEvent,
+    RetryPromptPart,
     RunContext,
     TextPart,
     TextPartDelta,
@@ -1494,6 +1495,18 @@ def test_cache_policy_excludes_timestamps_on_parts_outside_messages_module():
     assert key_for(time1) == key_for(time2)
 
 
+def test_cache_policy_normalizes_only_framework_tool_call_ids():
+    cache_policy = PrefectAgentInputs()
+    mock_task_ctx = MagicMock()
+
+    def key_for(tool_call_id: str) -> str | None:
+        part = RetryPromptPart(content='retry', tool_name='tool', tool_call_id=tool_call_id)
+        return cache_policy.compute_key(task_ctx=mock_task_ctx, inputs={'messages': [part]}, flow_parameters={})
+
+    assert key_for('pyd_ai_first') == key_for('pyd_ai_second')
+    assert key_for('model-first') != key_for('model-second')
+
+
 def test_cache_policy_excludes_non_serializable_deps():
     """Non-serializable dependency values are excluded without dropping serializable siblings.
 
@@ -2541,6 +2554,84 @@ async def test_prefect_durability_event_stream_handler() -> None:
     assert sum(isinstance(event, FunctionToolResultEvent) for event in events) == 1
     assert any(isinstance(event, PartStartEvent) for event in events)
     assert any(isinstance(event, FinalResultEvent) for event in events)
+
+
+async def test_prefect_durability_identical_events_are_dispatched_twice() -> None:
+    calls = 0
+
+    async def handler(ctx: RunContext[object], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        nonlocal calls
+        async for event in stream:
+            calls += isinstance(event, FunctionToolCallEvent)
+
+    async def same_tool() -> str:
+        return 'same'
+
+    durability: PrefectDurability[object] = PrefectDurability(event_stream_handler=handler)
+    agent = Agent(
+        TestModel(),
+        deps_type=object,
+        name='duplicate_event_handler',
+        tools=[same_tool],
+        capabilities=[durability],
+    )
+
+    @flow
+    async def run_twice() -> None:
+        await agent.run('same')
+        await agent.run('same')
+
+    await run_twice()
+    assert calls == 2
+
+
+async def test_prefect_task_wrapped_tool_rejects_enqueue() -> None:
+    enqueued = False
+
+    async def enqueue(ctx: RunContext[object]) -> str:
+        nonlocal enqueued
+        if not enqueued:
+            ctx.enqueue('later')
+            enqueued = True
+        return 'done'
+
+    durability: PrefectDurability[object] = PrefectDurability()
+    agent = Agent(TestModel(), deps_type=object, name='prefect_enqueue', tools=[enqueue], capabilities=[durability])
+
+    @flow
+    async def run_agent() -> None:
+        await agent.run('run')
+
+    with pytest.raises(UserError, match='task-cache replay would drop the enqueued messages'):
+        await run_agent()
+
+    enqueued = False
+    await agent.run('run')
+
+
+async def test_prefect_tool_model_retry_is_not_retried_by_task_engine() -> None:
+    calls = 0
+
+    async def retry_once() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ModelRetry('again')
+        return 'done'
+
+    agent = Agent(
+        TestModel(),
+        name='prefect_model_retry',
+        tools=[retry_once],
+        capabilities=[PrefectDurability(tool_task_config={'retries': 3})],
+    )
+
+    @flow
+    async def run_agent() -> str:
+        return (await agent.run('run')).output
+
+    await run_agent()
+    assert calls == 2
 
 
 async def test_prefect_durability_event_stream_handler_outside_flow() -> None:

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -4,7 +4,7 @@ import os
 import threading
 import uuid
 import warnings
-from collections.abc import AsyncIterable, AsyncIterator, Generator, Iterator
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Generator, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -81,6 +81,7 @@ try:
         _replace_run_context,  # pyright: ignore[reportPrivateUsage]
         _strip_cache_excluded_fields,  # pyright: ignore[reportPrivateUsage]
     )
+    from pydantic_ai.durable_exec.prefect._toolset import with_non_retryable_errors
 except ImportError:  # pragma: lax no cover
     pytest.skip('Prefect is not installed', allow_module_level=True)
 
@@ -2632,6 +2633,41 @@ async def test_prefect_tool_model_retry_is_not_retried_by_task_engine() -> None:
 
     await run_agent()
     assert calls == 2
+
+
+async def test_prefect_with_non_retryable_errors_condition() -> None:
+    """Framework errors are never retried; other failures defer to the user's own condition.
+
+    A unit test on the condition itself: Prefect only invokes `retry_condition_fn` on real
+    task failures inside its engine, so driving every arm end-to-end would need one flow per
+    combination of failure type, result awaitability, and user-configured condition.
+    """
+
+    class _State:
+        def __init__(self, result: Any):
+            self._result = result
+
+        def result(self, raise_on_failure: bool = True) -> Any:
+            return self._result
+
+    def condition_of(config: TaskConfig) -> Callable[[Any, Any, Any], Any]:
+        condition = with_non_retryable_errors(config).get('retry_condition_fn')
+        assert condition is not None
+        return condition
+
+    condition = condition_of(TaskConfig())
+    assert await condition(None, None, _State(UserError('bad config'))) is False
+    assert await condition(None, None, _State(RuntimeError('boom'))) is True
+
+    def deny(task: Any, task_run: Any, state: Any) -> bool:
+        return False
+
+    assert await condition_of(TaskConfig(retry_condition_fn=deny))(None, None, _State(RuntimeError('boom'))) is False
+
+    async def allow(task: Any, task_run: Any, state: Any) -> bool:
+        return True
+
+    assert await condition_of(TaskConfig(retry_condition_fn=allow))(None, None, _State(RuntimeError('boom'))) is True
 
 
 async def test_prefect_durability_event_stream_handler_outside_flow() -> None:

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -58,8 +58,9 @@ from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.models.wrapper import WrapperModel
 from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDefinition
-from pydantic_ai.toolsets import AbstractToolset
+from pydantic_ai.toolsets import AbstractToolset, ToolsetTool
 from pydantic_ai.toolsets._dynamic import DynamicToolset
+from pydantic_ai.toolsets.external import TOOL_SCHEMA_VALIDATOR
 from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 
 try:
@@ -81,6 +82,7 @@ try:
         _replace_run_context,  # pyright: ignore[reportPrivateUsage]
         _strip_cache_excluded_fields,  # pyright: ignore[reportPrivateUsage]
     )
+    from pydantic_ai.durable_exec.prefect._mcp_toolset import prefectify_mcp_toolset
     from pydantic_ai.durable_exec.prefect._toolset import with_non_retryable_errors
 except ImportError:  # pragma: lax no cover
     pytest.skip('Prefect is not installed', allow_module_level=True)
@@ -2611,6 +2613,34 @@ async def test_prefect_task_wrapped_tool_rejects_enqueue() -> None:
 
     # Outside a flow the tool runs inline and enqueueing keeps working.
     await agent.run('run')
+
+
+async def test_prefect_mcp_task_wrapped_call_rejects_enqueue(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The MCP task path guards enqueue too: a `process_tool_call=` hook receives the run context."""
+    mcp_toolset = MCPToolset(StdioTransport(command='python', args=['-m', 'tests.mcp_server']), id='enqueue_mcp')
+
+    async def enqueue_call_tool(
+        tool_name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
+    ) -> Any:
+        ctx.enqueue('later')
+        return 'done'
+
+    monkeypatch.setattr(mcp_toolset, 'call_tool', enqueue_call_tool)
+    durable = prefectify_mcp_toolset(mcp_toolset, task_config={})
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+    tool = ToolsetTool(
+        toolset=durable,
+        tool_def=ToolDefinition(name='hook'),
+        max_retries=1,
+        args_validator=TOOL_SCHEMA_VALIDATOR,
+    )
+
+    @flow
+    async def run_tool() -> None:
+        await durable.call_tool('hook', {}, ctx, tool)
+
+    with pytest.raises(UserError, match='task-cache replay would drop the enqueued messages'):
+        await run_tool()
 
 
 async def test_prefect_tool_model_retry_is_not_retried_by_task_engine() -> None:

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -386,9 +386,21 @@ async def _migration_event_stream_handler(ctx: RunContext[None], stream: AsyncIt
         pass
 
 
+async def _migration_tool() -> str:
+    return 'tool result'
+
+
 _migration_agent_name = 'temporal_agent_migration'
+# A tool call makes the recorded history include graph-level `__event_stream_handler`
+# activities and a tool-call activity, so replay verifies the workflow-side event
+# dispatch sequence — not just the model activities.
 _legacy_migration_agent = TemporalAgent(  # pyright: ignore[reportDeprecated]
-    Agent(TestModel(custom_output_text='migrated'), name=_migration_agent_name, deps_type=type(None)),
+    Agent(
+        TestModel(custom_output_text='migrated'),
+        name=_migration_agent_name,
+        deps_type=type(None),
+        tools=[_migration_tool],
+    ),
     activity_config=BASE_ACTIVITY_CONFIG,
     event_stream_handler=_migration_event_stream_handler,
 )
@@ -396,6 +408,7 @@ _capability_migration_agent = Agent(
     TestModel(custom_output_text='migrated'),
     name=_migration_agent_name,
     deps_type=type(None),
+    tools=[_migration_tool],
     capabilities=[
         TemporalDurability(
             activity_config=BASE_ACTIVITY_CONFIG,


### PR DESCRIPTION
Follow-up to #6631 and #6623. After #6631 merged, an adversarial sweep hunted for more bugs of the same classes on durable-execution surfaces that PR didn't touch (cross-engine asymmetries, cache-key correctness, replay determinism, v2.13 API compat). It found five real defects — all pre-existing, none regressions — which the maintainer opted to fix in one PR rather than file as issues. This is that PR, plus the maintainer-approved DBOS migration-compat option and deprecation-warning updates.

### Fixes

- **Control-flow tool exceptions now round-trip as values on DBOS and Prefect.** `ModelRetry` / `ApprovalRequired` / `CallDeferred` escaping raw through a DBOS step or Prefect task got retry-classified by the engine: with `DBOSDurability(mcp_step_config={'retries_allowed': True, ...})`, a routine MCP tool error (which raises `ModelRetry` by default) re-executed the side-effecting call up to `max_attempts` times and then surfaced as `DBOSMaxStepRetriesExceeded` instead of the agent's retry-prompt loop; Prefect task retries re-executed the tool before the exception finally propagated. Both engines now use the shared `wrap_tool_call_result`/`unwrap_tool_call_result` machinery Temporal already used, so the durable unit records a successful value and the engine never classifies the exception. Prefect additionally gets `UserError`/`UnexpectedModelBehavior` marked non-retryable via a composing `retry_condition_fn` (mirroring Temporal's `with_non_retryable_errors`); DBOS has no selective non-retry support, which the value-round-trip makes moot for the control-flow cases.
- **Prefect flow-retry replay no longer breaks on framework-synthesized retry prompts.** Graph-built `RetryPromptPart`s get a fresh `pyd_ai_{uuid4}` `tool_call_id`, which legitimately participates in the task cache key — so on flow retry the rebuilt part's new UUID diverged the key and the flow re-executed model requests live instead of replaying. Framework-prefixed IDs on framework-owned parts are now normalized to a stable sentinel in the cache projection (model-provided IDs, which never carry the prefix, still fork the key).
- **`ctx.enqueue()` inside a Prefect task-wrapped tool now fails loudly with `UserError`.** Task caching persists only the tool's return value, so the enqueued messages silently vanished on flow-retry cache replay. Temporal already failed loudly (its serialized run context has no pending-messages channel) and DBOS re-executes tools inline; Prefect was the only engine with silent loss. Enqueueing from flow-level code keeps working.
- **Prefect per-event handler dispatch no longer cache-dedupes within one flow run.** Two content-identical events in the same flow run (e.g. across two `agent.run()` calls) hit the task cache and the handler silently never fired for the second. A per-flow-run sequence number now forks same-run duplicates while flow-retry replay still dedupes (re-execution reproduces the same sequence). The counter lives in Prefect's own per-flow-run `task_run_dynamic_keys` store, giving it exactly the retry-lineage lifetime Prefect's task naming relies on.
- **Opt-in clean `DBOSAgent` → `DBOSDurability` migration**: `DBOSDurability(register_legacy_workflows=True)` re-registers the `{agent name}.run` / `{agent name}.run_sync` workflow names the deprecated wrapper registered, so in-flight wrapper-era workflows recover across the migration deploy (step names and call order already match by design). The capability's stream-step consumption also accepts the wrapper-era recorded shape (bare `ModelResponse`) with the same legacy arm Temporal uses. The flag is documented as existing specifically for backward compatibility during migration — pin the DBOS `application_version` across the deploy and drop the flag once wrapper-era workflows have drained.
- **Deprecation warnings carry the migration-continuity story**, since people act on the warning rather than the docs: `TemporalAgent`'s notes that workflows replay across the migration (keep agent name, toolset IDs, model registry keys, and `event_stream_handler=` on `TemporalDurability`; no draining); `DBOSAgent`'s points at `register_legacy_workflows=True` + version pinning; `PrefectAgent`'s states that in-flight flow runs re-execute live on retry across the migration.
- **`temporal.md` docs parity**: the Durable Agent section now opens with the same normative "to make a run durable, call `agent.run()` inside a workflow; outside one it runs as a normal, non-durable agent" sentence the DBOS and Prefect docs lead with (from the #6620 discussion).

### Maintainer-side review round

A line-by-line review of the initial implementation added one fix and closed three test gaps:

- **Recovery compat for pre-wrapper recorded step outputs**: the new DBOS unwrap path ended in `assert_never`, so a workflow that recorded *raw* MCP step outputs under v2.14.x and recovers on upgraded code (with a pinned application version — exactly what the migration docs advise) would crash instead of replaying. `unwrap_recorded_tool_call_result` passes raw pre-wrapper recordings through; unit test covers both generations.
- Added the headline DBOS behavioral test (MCP `ModelRetry` under `retries_allowed=True`: the call executes once and `ModelRetry` surfaces, instead of DBOS re-executing it), execution coverage for the legacy `run_sync` workflow body, the `event_stream_handler=`-stays clause in `TemporalAgent`'s deprecation message, and the explanatory comment on the Prefect sequence-counter storage choice.

### Adversarial review round (fixes in `08cbf3e21`)

A final adversarial review against v2.14.1 source found that the earlier Macroscope-driven handler routing was built on a false premise, plus one more instance of the PR's headline defect class:

- **Legacy DBOS runs deliver handler events the way `DBOSAgent` actually did.** The wrapper never ran an `__event_stream_handler` step: model events reached the handler live inside `__model.request_stream`, and graph-level events through a direct workflow-level call that consumed no step (`_call_event_stream_handler_in_workflow`). Routing a recorded handler through the capability's per-event step would have *inserted* step ids wrapper-era recordings don't have and failed recovery with `DBOSUnexpectedStepError` — on exactly the in-flight-workflow scenario `register_legacy_workflows` exists for. Legacy `{name}.run`/`{name}.run_sync` runs now flag themselves via a `ContextVar`, and `_dispatch_event_stream_event` calls the handler directly at workflow level for those runs, keeping recorded sequences (model + MCP steps only) replayable. The test now locks in the wrapper-faithful sequence, and the `DBOSAgent` deprecation message no longer claims tool events ran "inside steps, exactly like before".
- **`DynamicToolset` tool calls now cross step/task boundaries as values on DBOS and Prefect too** (`ModelRetry`/`ApprovalRequired`/`CallDeferred`), matching Temporal and this PR's function/MCP paths — verified reproducible before the fix (a dynamic tool raising `ModelRetry` under `retries=3` executed 8× instead of 2×). The Prefect dynamic path also gets the non-retryable condition and the enqueue guard (hoisted to `prefect/_toolset.py` as `EnqueueGuard`).
- **Prefect model-request and event-handler tasks compose `with_non_retryable_errors`** as well, matching Temporal's non-retryable activity types (a `UserError` from e.g. a model that can't be rebuilt on the worker is not engine-retried).
- **`tool_call_id` cache-key normalization is gated to framework dataclasses**, as `_strip_cache_excluded_fields`'s docstring already promised — a user deps field with a `pyd_ai_`-prefixed value keeps forking the key.
- `for_agent`'s shallow copy shared one legacy-state `ContextVar` across all bound copies of a capability instance; `_bind_to_agent` now creates fresh ones per agent.

### Sibling sweep of the review-round defect classes (`a89e610df`)

Each round-3 bug class was swept against its remaining siblings:

- **False-premise class**: the Temporal "no draining" migration claim was verified rather than assumed — wrapper-vs-capability activity names are identical sets, `temporal/_model.py` is byte-identical to v2.14.1 (so the wrapper still produces real v2.14.1-shaped histories), and the existing engine-level replay test (`Replayer` over a recorded wrapper history) was extended with a **tool call**, so the recorded history now contains graph-level `__event_stream_handler` activities and a tool-call activity the capability replay must reproduce. It passes — the Temporal analog of the DBOS sequence bug does not exist.
- **Shared-mutable-state class**: `_toolsets_by_id` and `_models_by_id` are already reassigned per bound copy; the `ContextVar` was the only instance.
- **Silent-enqueue-drop class**: a dynamic tool's `ctx.enqueue()` inside a DBOS step worked live but was silently dropped on recovery replay. It now raises the same kind of explanatory `UserError` Prefect raises (guard generalized to `durable_exec/_toolset.py` as `EnqueueGuard`), applied only inside a workflow — outside, the step degrades to a plain call and enqueueing keeps working. The auto-review agent then caught the last member of the class (`9d9ba0c2a`): the **MCP** call paths forward the run context to a user-supplied `process_tool_call=` hook, so enqueueing is reachable there too — both engines' MCP boundaries now guard it as well (the DBOS gate-and-replace is hoisted to `guard_enqueue_in_workflow` in `dbos/_utils.py`). (Temporal's equivalent is already loud, just with a generic message — tailoring it needs a serializer change and stays follow-up material.)

### Verification

All three durability suites pass on the final head: DBOS 110, Prefect 101, Temporal 194 (+2 skipped). All changed files are at 100% statement + branch coverage under their own suites, and pyright- and ruff-clean.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


