### PR TITLE
Route Gemini Live realtime through the Pydantic AI Gateway

### DIFF
--- a/docs/realtime/gemini.md
+++ b/docs/realtime/gemini.md
@@ -71,6 +71,29 @@ custom Google Cloud credentials, project, or region.
 Gemini uses `google_input_transcription`, enabled by default; there is no separate transcription
 model. See [Transcribing user input](index.md#transcribing-user-input).
 
+### Routing through the gateway
+
+Route a session through the [Pydantic AI Gateway](../gateway.md) by naming the upstream provider. The
+gateway credentials come from [`gateway_provider`][pydantic_ai.providers.gateway.gateway_provider]:
+
+```python {test="skip" lint="skip"}
+from pydantic_ai.realtime.google import GoogleRealtimeModel
+
+model = GoogleRealtimeModel('gemini-live-2.5-flash', provider='gateway/google')
+```
+
+Or infer it from a gateway-prefixed identifier:
+
+```python {test="skip" lint="skip"}
+from pydantic_ai.realtime import infer_realtime_model
+
+model = infer_realtime_model('gateway/google:gemini-live-2.5-flash')
+```
+
+The gateway proxies Gemini Live over **Vertex** (the `google-vertex` route), so the provider row it
+routes to must be in a region that supports the Live API. `gateway/google-cloud` is an alias for the
+same route. See the shared [gateway notes](index.md#gateway) for trace propagation over the handshake.
+
 ### Session resumption
 
 Set `google_enable_session_resumption=True` together with

--- a/docs/realtime/index.md
+++ b/docs/realtime/index.md
@@ -817,11 +817,12 @@ if model.profile['supports_interruption']:
 
 #### Routing through a gateway
 
-Gateway routing currently covers OpenAI realtime.
+Gateway routing covers OpenAI realtime (`gateway/openai`) and Gemini Live (`gateway/google`, which
+proxies the Vertex upstream — see [Gemini gateway](gemini.md#routing-through-the-gateway)).
 
 Realtime models take a `provider=` just like standard models, so you can route a session through the
-[Pydantic AI Gateway](../gateway.md) (or any OpenAI-compatible endpoint that
-exposes a realtime API) by naming the upstream provider:
+[Pydantic AI Gateway](../gateway.md) (or, for OpenAI, any OpenAI-compatible endpoint that exposes a
+realtime API) by naming the upstream provider:
 
 ```python {test="skip" lint="skip"}
 from pydantic_ai.realtime.openai import OpenAIRealtimeModel

--- a/pydantic_ai_slim/pydantic_ai/realtime/__init__.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/__init__.py
@@ -90,10 +90,10 @@ def infer_realtime_model(model: KnownRealtimeModelName | str) -> RealtimeModel:
     """Infer a realtime model from a `provider:model` identifier.
 
     Accepts a bare provider (`openai`, `azure`, `xai`, `google`) or a
-    [Pydantic AI Gateway](../gateway.md) route (`gateway/openai:gpt-realtime`), which connects
-    through the gateway's built-in provider — the provider string is passed to the realtime model as
-    its `provider`, so authentication and the base URL come from
-    [`gateway_provider`][pydantic_ai.providers.gateway.gateway_provider].
+    [Pydantic AI Gateway](../gateway.md) route (`gateway/openai:gpt-realtime`,
+    `gateway/google:gemini-live-2.5-flash`), which connects through the gateway's built-in provider —
+    the provider string is passed to the realtime model as its `provider`, so authentication and the
+    base URL come from [`gateway_provider`][pydantic_ai.providers.gateway.gateway_provider].
     """
     provider, separator, model_name = model.partition(':')
     if not separator or not model_name:
@@ -101,8 +101,7 @@ def infer_realtime_model(model: KnownRealtimeModelName | str) -> RealtimeModel:
     # `gateway/openai` routes the OpenAI realtime protocol through the Pydantic AI Gateway: the
     # provider string is passed straight to `OpenAIRealtimeModel`, whose handshake reads the gateway
     # base URL and bearer key from `gateway_provider` and already carries the same trace context the
-    # gateway's HTTP request hook would add. Other upstreams aren't proxied for realtime today (xAI
-    # isn't a gateway upstream, and Gemini Live doesn't use the OpenAI protocol).
+    # gateway's HTTP request hook would add. xAI isn't a gateway upstream, so it has no route.
     if provider in ('openai', 'gateway/openai'):
         from .openai import OpenAIRealtimeModel
 
@@ -115,14 +114,17 @@ def infer_realtime_model(model: KnownRealtimeModelName | str) -> RealtimeModel:
         from .xai import XaiRealtimeModel
 
         return XaiRealtimeModel(model_name)
-    if provider == 'google':
+    # `gateway/google` (and its `gateway/google-cloud` alias) route Gemini Live through the gateway's
+    # Vertex upstream: the provider string flows into `GoogleRealtimeModel`, which resolves it via
+    # `gateway_provider` and adds the gateway's bearer auth to the `google-genai` WebSocket handshake.
+    if provider in ('google', 'gateway/google', 'gateway/google-cloud'):
         from .google import GoogleRealtimeModel
 
-        return GoogleRealtimeModel(model_name)
+        return GoogleRealtimeModel(model_name, provider=provider)
     raise UserError(
         f'Unknown realtime model provider {provider!r}. Supported providers are `openai`, `azure`, '
-        '`xai`, and `google`, or `gateway/openai` to route OpenAI realtime '
-        'through the Pydantic AI Gateway.'
+        '`xai`, and `google`, or `gateway/openai` / `gateway/google` to route OpenAI or Gemini Live '
+        'realtime through the Pydantic AI Gateway.'
     )
 
 

--- a/pydantic_ai_slim/pydantic_ai/realtime/google.py
+++ b/pydantic_ai_slim/pydantic_ai/realtime/google.py
@@ -19,7 +19,7 @@ from __future__ import annotations as _annotations
 import json
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Generator, Sequence
-from contextlib import AbstractAsyncContextManager, asynccontextmanager, contextmanager
+from contextlib import AbstractAsyncContextManager, ExitStack, asynccontextmanager, contextmanager
 from dataclasses import InitVar, dataclass, field
 from typing import Any, Literal, cast
 from weakref import WeakKeyDictionary
@@ -81,6 +81,7 @@ from ..models.google import (
 from ..native_tools import AbstractNativeTool, CodeExecutionTool, WebFetchTool, WebSearchTool
 from ..profiles import DEFAULT_THINKING_TAGS
 from ..providers import Provider, infer_provider
+from ..providers.gateway import is_gateway_provider
 from ..settings import ThinkingEffort, ThinkingLevel
 from ..tools import ToolDefinition
 from ..usage import RequestUsage
@@ -550,6 +551,36 @@ def _ws_trace_context(client: Client) -> Generator[None]:
             headers.pop(key, None)
 
 
+@contextmanager
+def _ws_gateway_auth(client: Client) -> Generator[None]:
+    """Add the Pydantic AI Gateway bearer auth to the Gemini Live handshake headers for the connect only.
+
+    The gateway authenticates on `Authorization: Bearer <key>`, added to REST calls by its `httpx`
+    request hook. That hook can't cover the Live handshake: `google-genai` dials the WebSocket with the
+    `websockets` library, bypassing the provider's `httpx` client, and on the Vertex Express-mode client
+    the gateway `GoogleCloudProvider` builds, the SDK carries the key only as `x-goog-api-key`. So the
+    gateway key (`client._api_client.api_key`) is mirrored into an `Authorization` header on the shared
+    HTTP options — which the SDK forwards as the handshake's `additional_headers` — and removed after the
+    connect so the shared client's later REST requests fall back to the request hook. A pre-existing
+    `Authorization` header (or an absent key) is left untouched. Guarded like `_single_ws_user_agent`:
+    custom/fake clients without the private HTTP options simply skip injection.
+    """
+    raw_headers = getattr(getattr(getattr(client, '_api_client', None), '_http_options', None), 'headers', None)
+    api_key = getattr(getattr(client, '_api_client', None), 'api_key', None)
+    if not isinstance(raw_headers, dict) or not api_key:
+        yield
+        return
+    headers = cast('dict[str, str]', raw_headers)
+    if 'Authorization' in headers:
+        yield
+        return
+    headers['Authorization'] = f'Bearer {api_key}'
+    try:
+        yield
+    finally:
+        headers.pop('Authorization', None)
+
+
 @dataclass
 class GoogleRealtimeModel(RealtimeModel):
     """Gemini Live API model.
@@ -583,11 +614,13 @@ class GoogleRealtimeModel(RealtimeModel):
     settings: RealtimeModelSettings | None = field(default=None, kw_only=True)
     reconnect: ReconnectPolicy | None = None
     _provider: Provider[Client] = field(init=False, repr=False)
+    _gateway: bool = field(init=False, default=False, repr=False)
 
     def __post_init__(self, provider: Provider[Client] | str) -> None:
         if isinstance(provider, str):
             provider = cast('Provider[Client]', infer_provider(provider))
         self._provider = provider
+        self._gateway = is_gateway_provider(provider)
 
     @property
     def client(self) -> Client:
@@ -798,7 +831,13 @@ class GoogleRealtimeModel(RealtimeModel):
             )
             opening = client.aio.live.connect(model=self.model, config=config)
             async with _ws_connect_lock(client):
-                with _single_ws_user_agent(client), _ws_trace_context(client):
+                with ExitStack() as stack:
+                    stack.enter_context(_single_ws_user_agent(client))
+                    stack.enter_context(_ws_trace_context(client))
+                    # A gateway provider dials the WS itself and can't run the gateway's httpx auth hook,
+                    # so the bearer key is added to the handshake headers only when routing through it.
+                    if self._gateway:
+                        stack.enter_context(_ws_gateway_auth(client))
                     session = await opening.__aenter__()
             cm = opening
             return session

--- a/tests/realtime/test_google.py
+++ b/tests/realtime/test_google.py
@@ -69,6 +69,7 @@ with try_import() as imports_successful:
     from google.genai import Client, errors as genai_errors, types as genai_types
     from google.genai.live import AsyncSession, ConnectionClosed
 
+    from pydantic_ai.providers.gateway import gateway_provider
     from pydantic_ai.providers.google import GoogleProvider
     from pydantic_ai.realtime import google as rt_google
     from pydantic_ai.realtime.google import (
@@ -291,6 +292,126 @@ async def test_connect_serializes_shared_client_header_mutations(monkeypatch: py
     assert {captured['traceparent'] for captured in handshake_headers} == {'trace-1', 'trace-2'}
     assert all(sum(key.lower() == 'user-agent' for key in captured) == 1 for captured in handshake_headers)
     assert headers == original_headers
+
+
+class _StopDial(Exception):
+    """Raised from the fake handshake to short-circuit `connect` once headers are captured."""
+
+
+class _FakeWSConnect:
+    async def __aenter__(self) -> None:
+        raise _StopDial()
+
+    async def __aexit__(self, *exc: object) -> bool:  # pragma: no cover - never entered
+        return False
+
+
+def _capture_ws_connect(captured: dict[str, Any]) -> Any:
+    """A stand-in for `google.genai.live.ws_connect` that records the dialed URI and headers."""
+
+    def ws_connect(uri: str, *, additional_headers: dict[str, str] | None = None, **kwargs: Any) -> _FakeWSConnect:
+        captured['uri'] = uri
+        captured['headers'] = dict(additional_headers or {})
+        return _FakeWSConnect()
+
+    return ws_connect
+
+
+async def test_gateway_handshake_carries_bearer_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A gateway provider dials the Live WebSocket through the SDK, which forwards the client's HTTP
+    # headers as the handshake's `additional_headers`. The gateway authenticates on `Authorization:
+    # Bearer <key>` — added to REST calls by its httpx hook, which can't reach this `websockets` dial —
+    # so `connect` must inject the gateway key into the handshake headers itself. Driven end-to-end
+    # through `connect` (patching the SDK's `ws_connect`, as the cassette engine does) so the real URL
+    # derivation and header stack are exercised, not a hand-built dict.
+    provider = gateway_provider('google', api_key='gw-key', base_url='https://gateway.pydantic.dev/proxy')
+    model = GoogleRealtimeModel('gemini-live-2.5-flash', provider=provider)
+    assert model._gateway is True  # pyright: ignore[reportPrivateUsage]
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr('google.genai.live.ws_connect', _capture_ws_connect(captured))
+    with pytest.raises(_StopDial):
+        async with _connect(model, 'hi'):
+            pass  # pragma: no cover - the dial short-circuits before yielding
+
+    # The SDK swaps https→wss and appends the Vertex BidiGenerateContent path onto the gateway base URL;
+    # the gateway's platform relay accepts exactly this URL and derives the billed model from the setup
+    # frame, so pydantic-ai does not rewrite it.
+    assert captured['uri'] == snapshot(
+        'wss://gateway.pydantic.dev/proxy/google-vertex/ws/google.cloud.aiplatform.v1beta1.LlmBidiService/BidiGenerateContent'
+    )
+    assert captured['headers'].get('Authorization') == 'Bearer gw-key'
+    # `_single_ws_user_agent` still runs, so the handshake carries exactly one user-agent header.
+    assert sum(key.lower() == 'user-agent' for key in captured['headers']) == 1
+    # The injected `Authorization` is removed after the connect so the shared client's later REST
+    # requests fall back to the gateway's httpx hook rather than carrying a stale bearer header.
+    rest_headers = provider.client._api_client._http_options.headers  # pyright: ignore[reportPrivateUsage]
+    assert rest_headers is not None and 'Authorization' not in rest_headers
+
+
+async def test_non_gateway_handshake_has_no_bearer_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A plain `GoogleProvider` is not a gateway provider, so `connect` leaves the handshake auth to the
+    # SDK (the API key travels as `x-goog-api-key`) and adds no `Authorization` header.
+    model = GoogleRealtimeModel(provider=GoogleProvider(api_key='k'))
+    assert model._gateway is False  # pyright: ignore[reportPrivateUsage]
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr('google.genai.live.ws_connect', _capture_ws_connect(captured))
+    with pytest.raises(_StopDial):
+        async with _connect(model, 'hi'):
+            pass  # pragma: no cover - the dial short-circuits before yielding
+
+    assert 'Authorization' not in captured['headers']
+
+
+def test_ws_gateway_auth_injects_and_restores_bearer() -> None:
+    # `google-genai` forwards the client's HTTP headers as the Live handshake headers, so the gateway
+    # bearer key is injected into them for the connect only, then removed so the shared client's later
+    # REST requests fall back to the gateway's httpx hook. The header dict is the SDK's private one, so
+    # this is a direct unit test.
+    from types import SimpleNamespace
+
+    headers = {'user-agent': 'solo'}
+    client = SimpleNamespace(
+        _api_client=SimpleNamespace(api_key='gw-key', _http_options=SimpleNamespace(headers=headers))
+    )
+    with rt_google._ws_gateway_auth(cast('Any', client)):  # pyright: ignore[reportPrivateUsage]
+        assert headers == {'user-agent': 'solo', 'Authorization': 'Bearer gw-key'}
+    assert headers == {'user-agent': 'solo'}
+
+
+def test_ws_gateway_auth_noop_without_api_key() -> None:
+    # No key to mirror (e.g. an ADC gateway client), so the handshake headers are left untouched.
+    from types import SimpleNamespace
+
+    headers = {'user-agent': 'solo'}
+    client = SimpleNamespace(_api_client=SimpleNamespace(api_key=None, _http_options=SimpleNamespace(headers=headers)))
+    with rt_google._ws_gateway_auth(cast('Any', client)):  # pyright: ignore[reportPrivateUsage]
+        assert headers == {'user-agent': 'solo'}
+    assert headers == {'user-agent': 'solo'}
+
+
+def test_ws_gateway_auth_noop_with_existing_authorization() -> None:
+    # A caller-supplied `Authorization` header wins: the gateway key is not layered on top of it.
+    from types import SimpleNamespace
+
+    headers = {'Authorization': 'Bearer caller'}
+    client = SimpleNamespace(
+        _api_client=SimpleNamespace(api_key='gw-key', _http_options=SimpleNamespace(headers=headers))
+    )
+    with rt_google._ws_gateway_auth(cast('Any', client)):  # pyright: ignore[reportPrivateUsage]
+        assert headers == {'Authorization': 'Bearer caller'}
+    assert headers == {'Authorization': 'Bearer caller'}
+
+
+def test_ws_gateway_auth_noop_without_http_options() -> None:
+    # A custom/fake client without the SDK's private HTTP options simply skips injection.
+    from types import SimpleNamespace
+
+    client = SimpleNamespace(_api_client=None)
+    with rt_google._ws_gateway_auth(cast('Any', client)):  # pyright: ignore[reportPrivateUsage]
+        assert client._api_client is None
+    assert client._api_client is None
 
 
 # --- provider resolution & capabilities --------------------------------------

--- a/tests/realtime/test_inference.py
+++ b/tests/realtime/test_inference.py
@@ -64,6 +64,26 @@ def test_infer_realtime_model_gateway_openai(env: TestEnv) -> None:
     assert direct_model._realtime_url().split('?', 1)[0] == 'wss://api.openai.com/v1/realtime'  # pyright: ignore[reportPrivateUsage]
 
 
+@pytest.mark.skipif(not imports_successful(), reason='xai-sdk / google-genai not installed')
+def test_infer_realtime_model_gateway_google(env: TestEnv) -> None:
+    # `gateway/google:...` (and its `gateway/google-cloud` alias) route Gemini Live through the gateway's
+    # Vertex upstream: a `GoogleRealtimeModel` whose provider derives its base URL and key from
+    # `gateway_provider`, with the gateway's bearer auth added to the WebSocket handshake.
+    env.set('PYDANTIC_AI_GATEWAY_API_KEY', 'test')
+    env.set('PYDANTIC_AI_GATEWAY_BASE_URL', 'https://gateway.pydantic.dev/proxy')
+
+    for route in ('gateway/google', 'gateway/google-cloud'):
+        model = infer_realtime_model(f'{route}:gemini-live-2.5-flash')
+        # Name-check the class (rather than importing it) to keep this dispatch test light.
+        assert type(model).__name__ == 'GoogleRealtimeModel'
+        assert model.model_name == 'gemini-live-2.5-flash'
+        # Both shorthands collapse onto the gateway's Google Cloud (Vertex) route, so the handshake
+        # connects through the gateway rather than directly to Vertex.
+        assert getattr(model, '_provider').base_url == 'https://gateway.pydantic.dev/proxy/google-vertex'
+        # `_gateway` gates the handshake bearer-auth injection in `connect`.
+        assert getattr(model, '_gateway') is True
+
+
 def test_azure_rejects_non_azure_provider(env: TestEnv) -> None:
     env.set('OPENAI_API_KEY', 'test')
 
@@ -86,7 +106,7 @@ async def test_agent_realtime_session_infers_string_model() -> None:
         async with agent.realtime_session(model='unknown:voice'):
             pass  # pragma: no cover
 
-    # A non-OpenAI gateway route is rejected: xAI isn't a gateway upstream and Gemini Live isn't the
-    # OpenAI protocol, so only `gateway/openai` is proxied for realtime.
-    with pytest.raises(UserError, match='gateway/openai'):
-        infer_realtime_model('gateway/google:gemini-2.5-flash-native-audio-latest')
+    # A gateway route with no realtime support is rejected before any provider is built: Groq is a
+    # gateway upstream but has no realtime model, so `gateway/groq` isn't a supported realtime route.
+    with pytest.raises(UserError, match='Unknown realtime model provider'):
+        infer_realtime_model('gateway/groq:whisper-voice')

--- a/tests/realtime/test_openai.py
+++ b/tests/realtime/test_openai.py
@@ -106,12 +106,12 @@ def _wav_bytes(pcm: bytes, sample_rate: int = 24000) -> bytes:
 
 
 def test_map_transcription_usage() -> None:
-    assert rt_openai._map_transcription_usage(None) is None
-    assert rt_openai._map_transcription_usage(UsageTranscriptTextUsageDuration(type='duration', seconds=0.5)) is None
-    assert rt_openai._map_transcription_usage(
+    assert rt_openai._map_transcription_usage(None) is None  # pyright: ignore[reportPrivateUsage]
+    assert rt_openai._map_transcription_usage(UsageTranscriptTextUsageDuration(type='duration', seconds=0.5)) is None  # pyright: ignore[reportPrivateUsage]
+    assert rt_openai._map_transcription_usage(  # pyright: ignore[reportPrivateUsage]
         UsageTranscriptTextUsageDuration(type='duration', seconds=3)
     ) == RequestUsage(details={'input_transcription_seconds': 3})
-    assert rt_openai._map_transcription_usage(
+    assert rt_openai._map_transcription_usage(  # pyright: ignore[reportPrivateUsage]
         UsageTranscriptTextUsageTokens(
             type='tokens',
             input_tokens=5,
@@ -126,7 +126,7 @@ def test_map_transcription_usage() -> None:
             'input_transcription_text_tokens': 1,
         }
     )
-    assert rt_openai._map_transcription_usage(
+    assert rt_openai._map_transcription_usage(  # pyright: ignore[reportPrivateUsage]
         UsageTranscriptTextUsageTokens(
             type='tokens', input_tokens=5, output_tokens=2, total_tokens=7, input_token_details=None
         )
@@ -145,13 +145,13 @@ def test_map_transcription_usage() -> None:
 )
 def test_map_usage_rejects_malformed_constructed_details(usage: RealtimeResponseUsage) -> None:
     with pytest.raises(ValueError, match='must be an object'):
-        rt_openai._map_usage(usage)
+        rt_openai._map_usage(usage)  # pyright: ignore[reportPrivateUsage]
 
 
 def test_map_transcription_usage_rejects_malformed_constructed_details() -> None:
     usage = UsageTranscriptTextUsageTokens.construct(type='tokens', input_token_details='bad')
     with pytest.raises(ValueError, match='must be an object'):
-        rt_openai._map_transcription_usage(usage)
+        rt_openai._map_transcription_usage(usage)  # pyright: ignore[reportPrivateUsage]
 
 
 def test_merge_realtime_profile_skips_empty_layers_and_applies_overrides() -> None:
@@ -188,9 +188,9 @@ def test_realtime_url_for_gateway_provider(monkeypatch: pytest.MonkeyPatch):
     )
     plain_model = OpenAIRealtimeModel('gpt-realtime', provider=OpenAIProvider(api_key='k'))
 
-    assert '/v1/realtime' in string_model._realtime_url()
-    assert '/v1/realtime' in instance_model._realtime_url()
-    assert plain_model._realtime_url().count('/v1') == 1
+    assert '/v1/realtime' in string_model._realtime_url()  # pyright: ignore[reportPrivateUsage]
+    assert '/v1/realtime' in instance_model._realtime_url()  # pyright: ignore[reportPrivateUsage]
+    assert plain_model._realtime_url().count('/v1') == 1  # pyright: ignore[reportPrivateUsage]
 
 
 def test_map_audio_delta() -> None:
@@ -960,7 +960,11 @@ async def test_connection_iter_recovers_from_malformed_frame(monkeypatch: pytest
         # A `duration` transcription usage with no numeric `seconds` (the SDK's lenient union fallback would
         # otherwise construct the wrong variant and crash on `usage.seconds`).
         json.dumps(
-            {'type': 'conversation.item.input_audio_transcription.completed', 'transcript': 'hi', 'usage': {'type': 'duration'}}
+            {
+                'type': 'conversation.item.input_audio_transcription.completed',
+                'transcript': 'hi',
+                'usage': {'type': 'duration'},
+            }
         ),
         json.dumps(
             {
@@ -970,7 +974,11 @@ async def test_connection_iter_recovers_from_malformed_frame(monkeypatch: pytest
             }
         ),
         json.dumps(
-            {'type': 'conversation.item.input_audio_transcription.completed', 'transcript': 'hi', 'usage': {'type': 'mystery'}}
+            {
+                'type': 'conversation.item.input_audio_transcription.completed',
+                'transcript': 'hi',
+                'usage': {'type': 'mystery'},
+            }
         ),
     ]
     good = json.dumps({'type': 'response.output_audio.delta', 'delta': base64.b64encode(b'\x09').decode('ascii')})
@@ -1703,7 +1711,11 @@ async def test_transcription_completed_token_usage_emits_run_level_usage() -> No
             'type': 'conversation.item.input_audio_transcription.completed',
             'item_id': 'u1',
             'transcript': 'hi',
-            'usage': {'type': 'tokens', 'total_tokens': 5, 'input_token_details': {'audio_tokens': 4, 'text_tokens': 1}},
+            'usage': {
+                'type': 'tokens',
+                'total_tokens': 5,
+                'input_token_details': {'audio_tokens': 4, 'text_tokens': 1},
+            },
         }
     )
     ws = FakeWebSocket([frame])


### PR DESCRIPTION
Stacked on #6324 (base: `realtime-v1` — retarget to `main` after it merges). Follow-up to the scoping deferred there: the router comment previously read "only `gateway/openai` is proxied for realtime"; this PR adds the Gemini Live path.

> [!IMPORTANT]
> **Draft until the companion platform relay change lands** — this code is inert on its own. The gateway's realtime relay currently exact-matches `/proxy/{gemini,google-vertex}/v1/realtime` and requires `?model=`; the `google-genai` SDK dials `/proxy/google-vertex/ws/google.cloud.aiplatform.v1beta1.LlmBidiService/BidiGenerateContent` with no query param. The platform side (scoped, cross-ref pydantic/platform#25528 discussion context) will accept the SDK-shaped path, derive the billed model from the first `setup` frame, and rewrite `setup.model` to the full Vertex resource path from the provider row's service account + region.

## What this does

- `infer_realtime_model` accepts `gateway/google:...` and `gateway/google-cloud:...`, dispatching to `GoogleRealtimeModel` with the provider string passed through (resolved via `gateway_provider`, base URL `…/proxy/google-vertex`).
- `GoogleRealtimeModel` gains a `_gateway` flag from the existing `is_gateway_provider` registry (mirroring `OpenAIRealtimeModel`).
- **No URL rewriting**: the SDK's own derivation from the provider base URL produces exactly the URL the relay will accept.
- The one real gap was auth: the gateway authenticates on `Authorization: Bearer <key>`, normally added by its httpx request hook — which can't reach the SDK's `websockets`-library handshake, where the key travels only as `x-goog-api-key` (which the relay ignores). New `_ws_gateway_auth` contextmanager mirrors the neighbouring `_single_ws_user_agent`/`_ws_trace_context` helpers: inject the bearer header into the shared HTTP-options headers inside the `_ws_connect_lock` window, restore after, defensive no-ops for missing key / pre-existing `Authorization` / fake clients.

## Tests

- Positive dispatch tests for both routes (mirroring the `gateway/openai` ones); the obsolete `gateway/google`-is-rejected guard is replaced with a `gateway/groq` case.
- Handshake test drives the public `connect()` with `google.genai.live.ws_connect` patched (the cassette engine's seam), asserting the exact dialed URI, the bearer header, single user-agent, and post-connect header restoration; plus the negative (direct providers carry no `Authorization`) and unit coverage of every defensive branch.
- `tests/realtime/`: 502 passed; changed files at 100% coverage; lint/typecheck clean.

## Verification plan (blocked on the platform PR)

The gateway's Gemini Live relay has no e2e coverage and the built-in Google provider's region (`global`) doesn't serve the Live API — so live verification uses a BYOK `google-vertex` provider row with a service account in a Live-capable region (`us-central1`, base_url `https://us-central1-aiplatform.googleapis.com`), running a full session (audio both ways, tool round-trip, usage metering) through the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

