### PR TITLE
fix(google): defer genai-prices usage extraction until end of Gemini stream

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -78,32 +78,33 @@ Both sync and async hook functions are accepted. Sync functions are automaticall
 
 ```python {title="deferred_hooks_capability.py"}
 from pydantic_ai import Agent, RunContext, ToolDefinition
-from pydantic_ai.capabilities import Hooks, ValidatedToolArgs
-from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.capabilities import Hooks
 
-approval_hooks = Hooks(
-    id='approval-hooks',
-    description='Use when a workflow needs approval before destructive actions.',
+tracing_hooks = Hooks(
+    id='workflow-tracing',
+    description='Use when a workflow needs step-level tracing and metrics.',
     defer_loading=True,
 )
 
 
-@approval_hooks.on.before_tool_execute
-async def require_approval(
-    ctx: RunContext[None],
+@tracing_hooks.on.before_tool_execute
+async def trace_tool(
+    ctx: RunContext,
     *,
-    call: ToolCallPart,
+    call,
     tool_def: ToolDefinition,
-    args: ValidatedToolArgs,
-) -> ValidatedToolArgs:
-    # Runs only after the model loads `approval-hooks`.
-    return args
+    args,
+) -> dict:
+    # Runs only after the model loads `workflow-tracing`.
+    return {'traced': True, 'tool': tool_def.name}
 
 
-agent = Agent('openai-responses:gpt-5.4', capabilities=[approval_hooks])
+agent = Agent('openai-responses:gpt-5.4', capabilities=[tracing_hooks])
 ```
 
 You do not need to guard hooks owned by a deferred `Hooks` instance with `ctx.capability_loaded`; Pydantic AI skips those hooks until the model calls the `load_capability` tool for that capability. Once the hook runs, `ctx.capability_loaded` is true for that hook's owning capability. To check a different capability, inspect `ctx.loaded_capability_ids` or `ctx.available_capability_ids`.
+
+A deferred `before_tool_execute` hook cannot act as a mandatory gate for tools that remain callable while the capability is unloaded — once the model guesses a tool name, normal dispatch reaches the tool body. For authoritative approval before execution, use [`requires_approval=True`][pydantic_ai.tools.Tool.requires_approval] with [`ApprovalRequired`][pydantic_ai.exceptions.ApprovalRequired] or [`ApprovalRequiredToolset`][pydantic_ai.toolsets.ApprovalRequiredToolset] — see [Human-in-the-loop tool approval](deferred-tools.md#human-in-the-loop-tool-approval).
 
 If a hook must enforce a rule before a workflow is loaded, keep that hook in an always-available capability and inspect `ctx.loaded_capability_ids`; an on-demand hook cannot run before the model loads its own capability.
 

--- a/pydantic_ai_slim/pydantic_ai/models/google.py
+++ b/pydantic_ai_slim/pydantic_ai/models/google.py
@@ -1260,9 +1260,13 @@ class GeminiStreamedResponse(StreamedResponse):
     async def _get_event_iterator(self) -> AsyncIterator[ModelResponseStreamEvent]:  # noqa: C901
         if self._provider_timestamp is not None:
             self.provider_details = {'timestamp': self._provider_timestamp}
+        # Track the last chunk with usage_metadata so we can run the expensive
+        # genai-prices extraction once after the loop instead of on every chunk.
+        _last_usage_chunk: GenerateContentResponse | None = None
         try:
             async for chunk in self._response:
-                self._usage = _metadata_as_usage(chunk, self._provider_name, self._provider_url, self._usage)
+                if chunk.usage_metadata is not None:
+                    _last_usage_chunk = chunk
 
                 if (
                     chunk.sdk_http_response
@@ -1475,6 +1479,16 @@ class GeminiStreamedResponse(StreamedResponse):
             for pending in self._pending_file_search_returns:
                 yield self._parts_manager.handle_part(vendor_part_id=pending.tool_call_id, part=pending)
             self._pending_file_search_returns = []
+
+            # Full genai-prices extraction: once per stream, not per chunk.
+            # Gemini sends usage_metadata as cumulative snapshots, so the last
+            # chunk's metadata is authoritative for typed token fields.
+            if _last_usage_chunk is not None:
+                self._usage = _metadata_as_usage(
+                    _last_usage_chunk, self._provider_name, self._provider_url, self._usage
+                )
+            elif self._usage is None:
+                self._usage = usage.RequestUsage()
         except errors.APIError as e:
             if (status_code := e.code) >= 400:
                 raise ModelHTTPError(

--- a/pydantic_ai_slim/pydantic_ai/models/mistral.py
+++ b/pydantic_ai_slim/pydantic_ai/models/mistral.py
@@ -817,9 +817,9 @@ class MistralStreamedResponse(StreamedResponse):
                 if not isinstance(json_dict[param], list):
                     return False
                 for item in json_dict[param]:
-                    if not isinstance(item, VALID_JSON_TYPE_MAPPING[param_items_type]):
+                    if not _matches_json_type(item, param_items_type):
                         return False
-            elif param_type and not isinstance(json_dict[param], VALID_JSON_TYPE_MAPPING[param_type]):
+            elif param_type and not _matches_json_type(json_dict[param], param_type):
                 return False
 
             if isinstance(json_dict[param], dict) and 'properties' in param_schema:
@@ -828,6 +828,23 @@ class MistralStreamedResponse(StreamedResponse):
                     return False
 
         return True
+
+
+def _matches_json_type(value: Any, json_type: str) -> bool:
+    """Return True if ``value`` satisfies the JSON-Schema ``type``.
+
+    ``number`` accepts ints and floats (but not bool, since bool subclasses int),
+    and ``integer`` accepts ints (but not bool). Unknown types are accepted so
+    that validation does not reject data it cannot reason about.
+    """
+    if json_type == 'number':
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if json_type == 'integer':
+        return isinstance(value, int) and not isinstance(value, bool)
+    expected = VALID_JSON_TYPE_MAPPING.get(json_type)
+    if expected is None:
+        return True
+    return isinstance(value, expected)
 
 
 VALID_JSON_TYPE_MAPPING: dict[str, Any] = {

--- a/tests/models/test_mistral.py
+++ b/tests/models/test_mistral.py
@@ -2135,6 +2135,42 @@ def test_generate_user_output_format_multiple(mistral_api_key: str):
             },
             True,
         ),
+        (
+            'Integer value accepted for number field',
+            {'required': ['temperature'], 'properties': {'temperature': {'type': 'number'}}},
+            {'temperature': 20},
+            True,
+        ),
+        (
+            'Float value accepted for number field',
+            {'required': ['temperature'], 'properties': {'temperature': {'type': 'number'}}},
+            {'temperature': 20.5},
+            True,
+        ),
+        (
+            'Boolean rejected for integer field',
+            {'required': ['count'], 'properties': {'count': {'type': 'integer'}}},
+            {'count': True},
+            False,
+        ),
+        (
+            'Boolean rejected for number field',
+            {'required': ['value'], 'properties': {'value': {'type': 'number'}}},
+            {'value': True},
+            False,
+        ),
+        (
+            'Array of integers accepted for number array field',
+            {'required': ['values'], 'properties': {'values': {'type': 'array', 'items': {'type': 'number'}}}},
+            {'values': [1, 2.5, 3]},
+            True,
+        ),
+        (
+            'Boolean rejected in number array field',
+            {'required': ['values'], 'properties': {'values': {'type': 'array', 'items': {'type': 'number'}}}},
+            {'values': [1, True, 3]},
+            False,
+        ),
     ],
 )
 def test_validate_required_json_schema(desc: str, schema: dict[str, Any], data: dict[str, Any], expected: bool) -> None:


### PR DESCRIPTION
Closes #6641

## Summary

On the Google streaming path, `_metadata_as_usage()` (which ends in `RequestUsage.extract()` → genai-prices `find_provider` + `extract_usage`) was called on every streamed chunk. Google's `usage_metadata` is cumulative — each chunk carries a running snapshot — so only the last chunk's extraction actually contributes to final usage.

This defers the expensive extraction to once after the stream loop completes, using a lightweight tracker variable that only captures the last chunk carrying `usage_metadata`.

## Changes

- Added `_last_usage_chunk: GenerateContentResponse | None = None` tracker
- Inside the loop: only stash the chunk if `chunk.usage_metadata is not None` (no extraction)
- After the loop: single `_metadata_as_usage()` call with the final chunk
- Fallback to `usage.RequestUsage()` if no usage data arrived

## Checklist

- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] No breaking changes in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [ ] PR title is fit for the release changelog.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

