### PR TITLE
Hoist `openai_moderation` to `OpenAIChatModelSettings` and expose Chat Completions moderation results in `provider_details`

### DIFF
--- a/docs/models/openai.md
+++ b/docs/models/openai.md
@@ -147,6 +147,28 @@ Caching requires a prefix of at least 1024 tokens; shorter prefixes are not cach
 
 When OpenAI reports prompt cache writes, Pydantic AI exposes them as [`result.usage.cache_write_tokens`][pydantic_ai.usage.RunUsage.cache_write_tokens]. Cache reads are available as [`result.usage.cache_read_tokens`][pydantic_ai.usage.RunUsage.cache_read_tokens]. For GPT-5.6 and later model families, OpenAI bills cache writes at 1.25 times the uncached input token rate.
 
+### Moderation
+
+Both the Responses and Chat Completions APIs can run [moderation](https://platform.openai.com/docs/guides/moderation) on the input and output of a request. Moderation is off by default; enable it with [`openai_moderation`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_moderation]:
+
+```python {test="skip"}
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIResponsesModel, OpenAIResponsesModelSettings
+
+model = OpenAIResponsesModel('gpt-5.2')
+settings = OpenAIResponsesModelSettings(
+    openai_moderation={'model': 'omni-moderation-latest'}
+)
+agent = Agent(model, model_settings=settings)
+
+result = agent.run_sync('Your prompt here')
+moderation = result.response.provider_details.get('moderation')
+```
+
+When the response includes moderation results, they are stored under the `'moderation'` key of [`ModelResponse.provider_details`][pydantic_ai.messages.ModelResponse.provider_details], with `input` and `output` entries each carrying the flagged status, per-category flags, and category scores.
+
+With [`OpenAIChatModel`](#chat-completions-api), use [`OpenAIChatModelSettings`][pydantic_ai.models.openai.OpenAIChatModelSettings] instead. The results are surfaced the same way on both the non-streaming and streaming paths, except that the Chat Completions API nests each entry one level deeper, under a `results` list.
+
 ## Responses API features
 
 The features below are specific to the Responses API and only available on [`OpenAIResponsesModel`][pydantic_ai.models.openai.OpenAIResponsesModel] (the default). For background on how the Responses API differs from Chat Completions, see the [OpenAI API docs](https://platform.openai.com/docs/guides/migrate-to-responses).
@@ -362,26 +384,6 @@ Because the request is queued server-side, the time to the first token is higher
 
 !!! note
     If a run is suspended mid-request (its final [`ModelResponse.state`][pydantic_ai.messages.ModelResponse.state] is `'suspended'`) and persisted in message history, passing that history back resumes the same background response rather than starting a new one. Resuming after the provider's retention window raises [`SuspendedResponseExpired`][pydantic_ai.exceptions.SuspendedResponseExpired]. Abandoning or cancelling the run cancels the server-side background job.
-
-### Moderation
-
-The Responses API can run [moderation](https://platform.openai.com/docs/guides/moderation) on the input and output of a request. Moderation is off by default; enable it with [`openai_moderation`][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_moderation]:
-
-```python {test="skip"}
-from pydantic_ai import Agent
-from pydantic_ai.models.openai import OpenAIResponsesModel, OpenAIResponsesModelSettings
-
-model = OpenAIResponsesModel('gpt-5.2')
-settings = OpenAIResponsesModelSettings(
-    openai_moderation={'model': 'omni-moderation-latest'}
-)
-agent = Agent(model, model_settings=settings)
-
-result = agent.run_sync('Your prompt here')
-moderation = result.response.provider_details.get('moderation')
-```
-
-When the response includes moderation results, they are stored under the `'moderation'` key of [`ModelResponse.provider_details`][pydantic_ai.messages.ModelResponse.provider_details], with `input` and `output` entries each containing the flagged status, per-category flags, and category scores.
 
 ## Chat Completions API
 

--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -150,6 +150,7 @@ try:
     from openai.types.chat.chat_completion_prediction_content_param import ChatCompletionPredictionContentParam
     from openai.types.chat.chat_completion_tool_choice_option_param import ChatCompletionToolChoiceOptionParam
     from openai.types.chat.completion_create_params import (
+        Moderation,
         WebSearchOptions,
         WebSearchOptionsUserLocation,
         WebSearchOptionsUserLocationApproximate,
@@ -164,7 +165,6 @@ try:
     from openai.types.responses.response_compaction_item_param_param import ResponseCompactionItemParamParam
     from openai.types.responses.response_create_params import (
         ContextManagement,
-        Moderation as ResponsesModeration,
         ToolChoice as ResponsesToolChoice,
     )
     from openai.types.responses.response_input_file_content_param import ResponseInputFileContentParam
@@ -608,6 +608,18 @@ class OpenAIChatModelSettings(ModelSettings, total=False):
     See [OpenAI's safety best practices](https://platform.openai.com/docs/guides/safety-best-practices#end-user-ids) for more details.
     """
 
+    openai_moderation: Moderation
+    """Run moderation on the input and output of the request, e.g. `{'model': 'omni-moderation-latest'}`.
+
+    Supported by both the Chat Completions API and the Responses API. In both cases, the moderation
+    results returned by the API are exposed in
+    [`ModelResponse.provider_details`][pydantic_ai.messages.ModelResponse.provider_details]
+    under the `'moderation'` key.
+
+    See the [OpenAI moderation documentation](https://platform.openai.com/docs/guides/moderation)
+    for more details.
+    """
+
     openai_service_tier: Literal['auto', 'default', 'flex', 'priority']
     """The service tier to use for the model request.
 
@@ -816,17 +828,6 @@ class OpenAIResponsesModelSettings(OpenAIChatModelSettings, total=False):
     When enabled, this setting passes `background=True` to the Responses API and opts into
     automatic polling for completion. If the response is still pending (`'queued'` or
     `'in_progress'`), the agent automatically polls for completion using `retrieve()`.
-    """
-
-    openai_moderation: ResponsesModeration
-    """Run moderation on the input and output of the request, e.g. `{'model': 'omni-moderation-latest'}`.
-
-    The moderation results returned by the API are exposed in
-    [`ModelResponse.provider_details`][pydantic_ai.messages.ModelResponse.provider_details]
-    under the `'moderation'` key.
-
-    See the [OpenAI moderation documentation](https://platform.openai.com/docs/guides/moderation)
-    for more details.
     """
 
 
@@ -1082,6 +1083,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                     logprobs=model_settings.get('openai_logprobs', OMIT),
                     top_logprobs=model_settings.get('openai_top_logprobs', OMIT),
                     store=model_settings.get('openai_store', OMIT),
+                    moderation=model_settings.get('openai_moderation', OMIT),
                     prompt_cache_key=model_settings.get('openai_prompt_cache_key', OMIT),
                     prompt_cache_retention=prompt_cache_retention,
                     prompt_cache_options=model_settings.get('openai_prompt_cache_options', OMIT),
@@ -1133,9 +1135,14 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
 
         choice = response.choices[0]
 
+        # Moderation is a top-level field, so it's read here rather than in the choice-scoped
+        # `_process_provider_details` hook that subclasses may override.
+        provider_details = self._process_provider_details(response) or {}
+        if response.moderation:
+            provider_details['moderation'] = response.moderation.model_dump()
+
         # Handle refusal responses (structured output safety filter)
         if choice.message.refusal:
-            provider_details = self._process_provider_details(response) or {}
             provider_details.pop('finish_reason', None)
             provider_details['refusal'] = choice.message.refusal
             if response.created:  # pragma: no branch
@@ -1177,10 +1184,7 @@ class OpenAIChatModel(Model[AsyncOpenAI]):
                 part.tool_call_id = _guard_tool_call_id(part)
                 items.append(part)
 
-        provider_details = self._process_provider_details(response)
         if response.created:  # pragma: no branch
-            if provider_details is None:
-                provider_details = {}
             provider_details['timestamp'] = number_to_datetime(response.created)
 
         return ModelResponse(
@@ -3534,6 +3538,13 @@ class OpenAIStreamedResponse(StreamedResponse):
                 if chunk.model:
                     self._model_name = chunk.model
 
+                # The moderation chunk carries no choices, so this has to happen before the guard below.
+                if chunk.moderation:
+                    self.provider_details = {
+                        **(self.provider_details or {}),
+                        'moderation': chunk.moderation.model_dump(),
+                    }
+
                 # Empty on the final usage-only chunk; `None` from OpenAI-compatible providers emitting
                 # malformed chunks that the openai SDK's loose constructor lets through (https://github.com/pydantic/pydantic-ai/issues/5165).
                 if not chunk.choices:
@@ -3553,9 +3564,8 @@ class OpenAIStreamedResponse(StreamedResponse):
                     self._refusal_text += choice.delta.refusal
                     continue
 
-                if raw_finish_reason := choice.finish_reason:
-                    if not self._has_refusal:
-                        self.finish_reason = self._map_finish_reason(raw_finish_reason)
+                if (raw_finish_reason := choice.finish_reason) and not self._has_refusal:
+                    self.finish_reason = self._map_finish_reason(raw_finish_reason)
 
                 if provider_details := self._map_provider_details(chunk):  # pragma: no branch
                     if self._has_refusal:

--- a/tests/models/cassettes/test_openai/test_openai_moderation.yaml
+++ b/tests/models/cassettes/test_openai/test_openai_moderation.yaml
@@ -1,0 +1,203 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '163'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the capital of France?
+        role: user
+      model: gpt-5
+      moderation:
+        model: omni-moderation-latest
+      stream: false
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-length:
+      - '3462'
+      content-type:
+      - application/json
+      openai-processing-ms:
+      - '1076'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    parsed_body:
+      choices:
+      - finish_reason: stop
+        index: 0
+        message:
+          annotations: []
+          content: Paris.
+          refusal: null
+          role: assistant
+      created: 1784728646
+      id: chatcmpl-E4Rjq0z4lSeAzdbyin5pCFXEyhSW9
+      model: gpt-5-2025-08-07
+      moderation:
+        input:
+          model: omni-moderation-latest
+          results:
+          - categories:
+              harassment: false
+              harassment/threatening: false
+              hate: false
+              hate/threatening: false
+              illicit: false
+              illicit/violent: false
+              self-harm: false
+              self-harm/instructions: false
+              self-harm/intent: false
+              sexual: false
+              sexual/minors: false
+              violence: false
+              violence/graphic: false
+            category_applied_input_types:
+              harassment:
+              - text
+              harassment/threatening:
+              - text
+              hate:
+              - text
+              hate/threatening:
+              - text
+              illicit:
+              - text
+              illicit/violent:
+              - text
+              self-harm:
+              - text
+              self-harm/instructions:
+              - text
+              self-harm/intent:
+              - text
+              sexual:
+              - text
+              sexual/minors:
+              - text
+              violence:
+              - text
+              violence/graphic:
+              - text
+            category_scores:
+              harassment: 1.5598027633743823e-05
+              harassment/threatening: 2.212566909570261e-06
+              hate: 2.7803096387751555e-05
+              hate/threatening: 1.0783312222985275e-06
+              illicit: 0.005284363395662242
+              illicit/violent: 3.514382632807918e-05
+              self-harm: 2.4682904407607285e-06
+              self-harm/instructions: 5.955139348629957e-07
+              self-harm/intent: 2.627477314480822e-06
+              sexual: 9.818326983657703e-07
+              sexual/minors: 1.9333584585546466e-07
+              violence: 6.814872211615988e-06
+              violence/graphic: 7.889262586245034e-07
+            flagged: false
+            model: omni-moderation-latest
+            type: moderation_result
+          type: moderation_results
+        output:
+          model: omni-moderation-latest
+          results:
+          - categories:
+              harassment: false
+              harassment/threatening: false
+              hate: false
+              hate/threatening: false
+              illicit: false
+              illicit/violent: false
+              self-harm: false
+              self-harm/instructions: false
+              self-harm/intent: false
+              sexual: false
+              sexual/minors: false
+              violence: false
+              violence/graphic: false
+            category_applied_input_types:
+              harassment:
+              - text
+              harassment/threatening:
+              - text
+              hate:
+              - text
+              hate/threatening:
+              - text
+              illicit:
+              - text
+              illicit/violent:
+              - text
+              self-harm:
+              - text
+              self-harm/instructions:
+              - text
+              self-harm/intent:
+              - text
+              sexual:
+              - text
+              sexual/minors:
+              - text
+              violence:
+              - text
+              violence/graphic:
+              - text
+            category_scores:
+              harassment: 5.0333557545281144e-05
+              harassment/threatening: 1.2533751425646102e-05
+              hate: 3.740956047302422e-05
+              hate/threatening: 1.6187581436151335e-06
+              illicit: 3.077430764601415e-05
+              illicit/violent: 1.442598644847886e-05
+              self-harm: 1.0391067562761452e-05
+              self-harm/instructions: 1.2805474213228684e-06
+              self-harm/intent: 1.6442494559854523e-06
+              sexual: 0.00012448433020883747
+              sexual/minors: 3.120191139396651e-06
+              violence: 0.0005852836038915696
+              violence/graphic: 1.2339457598623173e-05
+            flagged: false
+            model: omni-moderation-latest
+            type: moderation_result
+          type: moderation_results
+      object: chat.completion
+      service_tier: default
+      system_fingerprint: null
+      usage:
+        completion_tokens: 11
+        completion_tokens_details:
+          accepted_prediction_tokens: 0
+          audio_tokens: 0
+          reasoning_tokens: 0
+          rejected_prediction_tokens: 0
+        prompt_tokens: 13
+        prompt_tokens_details:
+          audio_tokens: 0
+          cached_tokens: 0
+        total_tokens: 24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/cassettes/test_openai/test_openai_moderation_stream.yaml
+++ b/tests/models/cassettes/test_openai/test_openai_moderation_stream.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '205'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    parsed_body:
+      messages:
+      - content: What is the capital of France?
+        role: user
+      model: gpt-5
+      moderation:
+        model: omni-moderation-latest
+      stream: true
+      stream_options:
+        include_usage: true
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: |+
+        data: {"id":"chatcmpl-E4Rjs6IxaJVge9Ntk5keJsaeDy6vS","object":"chat.completion.chunk","created":1784728648,"model":"gpt-5-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"finish_reason":null}],"usage":null,"obfuscation":"CVQ55DocFW"}
+
+        data: {"id":"chatcmpl-E4Rjs6IxaJVge9Ntk5keJsaeDy6vS","object":"chat.completion.chunk","created":1784728648,"model":"gpt-5-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"Paris"},"finish_reason":null}],"usage":null,"obfuscation":"EeXxvZr"}
+
+        data: {"id":"chatcmpl-E4Rjs6IxaJVge9Ntk5keJsaeDy6vS","object":"chat.completion.chunk","created":1784728648,"model":"gpt-5-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"."},"finish_reason":null}],"usage":null,"obfuscation":"vsPllEDPEHe"}
+
+        data: {"id":"chatcmpl-E4Rjs6IxaJVge9Ntk5keJsaeDy6vS","object":"chat.completion.chunk","created":1784728648,"model":"gpt-5-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":null,"obfuscation":"0eqq81"}
+
+        data: {"id":"chatcmpl-E4Rjs6IxaJVge9Ntk5keJsaeDy6vS","object":"chat.completion.chunk","created":1784728648,"model":"gpt-5-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":13,"completion_tokens":11,"total_tokens":24,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"uLVWXYc88DP"}
+
+        data: {"id":"chatcmpl-E4Rjs6IxaJVge9Ntk5keJsaeDy6vS","object":"chat.completion.chunk","created":1784728648,"model":"gpt-5-2025-08-07","service_tier":"default","system_fingerprint":null,"choices":[],"moderation":{"input":{"type":"moderation_results","model":"omni-moderation-latest","results":[{"type":"moderation_result","model":"omni-moderation-latest","flagged":false,"categories":{"harassment":false,"harassment/threatening":false,"sexual":false,"hate":false,"hate/threatening":false,"illicit":false,"illicit/violent":false,"self-harm/intent":false,"self-harm/instructions":false,"self-harm":false,"sexual/minors":false,"violence":false,"violence/graphic":false},"category_scores":{"harassment":0.000015598027633743823,"harassment/threatening":2.212566909570261e-6,"sexual":9.818326983657703e-7,"hate":0.000027803096387751555,"hate/threatening":1.0783312222985275e-6,"illicit":0.005284363395662242,"illicit/violent":0.00003514382632807918,"self-harm/intent":2.627477314480822e-6,"self-harm/instructions":5.955139348629957e-7,"self-harm":2.4682904407607285e-6,"sexual/minors":1.9333584585546466e-7,"violence":6.814872211615988e-6,"violence/graphic":7.889262586245034e-7},"category_applied_input_types":{"harassment":["text"],"harassment/threatening":["text"],"sexual":["text"],"hate":["text"],"hate/threatening":["text"],"illicit":["text"],"illicit/violent":["text"],"self-harm/intent":["text"],"self-harm/instructions":["text"],"self-harm":["text"],"sexual/minors":["text"],"violence":["text"],"violence/graphic":["text"]}}]},"output":{"type":"moderation_results","model":"omni-moderation-latest","results":[{"type":"moderation_result","model":"omni-moderation-latest","flagged":false,"categories":{"harassment":false,"harassment/threatening":false,"sexual":false,"hate":false,"hate/threatening":false,"illicit":false,"illicit/violent":false,"self-harm/intent":false,"self-harm/instructions":false,"self-harm":false,"sexual/minors":false,"violence":false,"violence/graphic":false},"category_scores":{"harassment":0.00007096703991005882,"harassment/threatening":5.829126566113866e-6,"sexual":0.000030061635882429376,"hate":0.000023413582477639402,"hate/threatening":6.240930669504435e-7,"illicit":0.0000115919343186331,"illicit/violent":6.922183404468203e-6,"self-harm/intent":9.818326983657703e-7,"self-harm/instructions":6.339210403977636e-7,"self-harm":7.602479448313689e-6,"sexual/minors":1.1843139025979655e-6,"violence":0.0005185157653543439,"violence/graphic":5.307507822667365e-6},"category_applied_input_types":{"harassment":["text"],"harassment/threatening":["text"],"sexual":["text"],"hate":["text"],"hate/threatening":["text"],"illicit":["text"],"illicit/violent":["text"],"self-harm/intent":["text"],"self-harm/instructions":["text"],"self-harm":["text"],"sexual/minors":["text"],"violence":["text"],"violence/graphic":["text"]}}]}},"usage":null,"obfuscation":"Lml3uvUFL"}
+
+        data: [DONE]
+
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      connection:
+      - keep-alive
+      content-type:
+      - text/event-stream; charset=utf-8
+      openai-processing-ms:
+      - '584'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1
+...

--- a/tests/models/test_openai.py
+++ b/tests/models/test_openai.py
@@ -2129,6 +2129,269 @@ async def test_user_id(allow_model_requests: None, openai_api_key: str):
     await agent.run('hello')
 
 
+async def test_openai_moderation(allow_model_requests: None, openai_api_key: str):
+    """Moderation results requested via `openai_moderation` are surfaced in `provider_details['moderation']`."""
+    model = OpenAIChatModel('gpt-5', provider=OpenAIProvider(api_key=openai_api_key))
+    settings = OpenAIChatModelSettings(openai_moderation={'model': 'omni-moderation-latest'})
+    agent = Agent(model=model, model_settings=settings)
+
+    result = await agent.run('What is the capital of France?')
+
+    response = message(result.all_messages(), ModelResponse, index=-1)
+    assert response.provider_details == snapshot(
+        {
+            'finish_reason': 'stop',
+            'moderation': {
+                'input': {
+                    'model': 'omni-moderation-latest',
+                    'results': [
+                        {
+                            'categories': {
+                                'harassment': False,
+                                'harassment/threatening': False,
+                                'sexual': False,
+                                'hate': False,
+                                'hate/threatening': False,
+                                'illicit': False,
+                                'illicit/violent': False,
+                                'self-harm/intent': False,
+                                'self-harm/instructions': False,
+                                'self-harm': False,
+                                'sexual/minors': False,
+                                'violence': False,
+                                'violence/graphic': False,
+                            },
+                            'category_applied_input_types': {
+                                'harassment': ['text'],
+                                'harassment/threatening': ['text'],
+                                'sexual': ['text'],
+                                'hate': ['text'],
+                                'hate/threatening': ['text'],
+                                'illicit': ['text'],
+                                'illicit/violent': ['text'],
+                                'self-harm/intent': ['text'],
+                                'self-harm/instructions': ['text'],
+                                'self-harm': ['text'],
+                                'sexual/minors': ['text'],
+                                'violence': ['text'],
+                                'violence/graphic': ['text'],
+                            },
+                            'category_scores': {
+                                'harassment': 1.5598027633743823e-05,
+                                'harassment/threatening': 2.212566909570261e-06,
+                                'sexual': 9.818326983657703e-07,
+                                'hate': 2.7803096387751555e-05,
+                                'hate/threatening': 1.0783312222985275e-06,
+                                'illicit': 0.005284363395662242,
+                                'illicit/violent': 3.514382632807918e-05,
+                                'self-harm/intent': 2.627477314480822e-06,
+                                'self-harm/instructions': 5.955139348629957e-07,
+                                'self-harm': 2.4682904407607285e-06,
+                                'sexual/minors': 1.9333584585546466e-07,
+                                'violence': 6.814872211615988e-06,
+                                'violence/graphic': 7.889262586245034e-07,
+                            },
+                            'flagged': False,
+                            'model': 'omni-moderation-latest',
+                            'type': 'moderation_result',
+                        }
+                    ],
+                    'type': 'moderation_results',
+                },
+                'output': {
+                    'model': 'omni-moderation-latest',
+                    'results': [
+                        {
+                            'categories': {
+                                'harassment': False,
+                                'harassment/threatening': False,
+                                'sexual': False,
+                                'hate': False,
+                                'hate/threatening': False,
+                                'illicit': False,
+                                'illicit/violent': False,
+                                'self-harm/intent': False,
+                                'self-harm/instructions': False,
+                                'self-harm': False,
+                                'sexual/minors': False,
+                                'violence': False,
+                                'violence/graphic': False,
+                            },
+                            'category_applied_input_types': {
+                                'harassment': ['text'],
+                                'harassment/threatening': ['text'],
+                                'sexual': ['text'],
+                                'hate': ['text'],
+                                'hate/threatening': ['text'],
+                                'illicit': ['text'],
+                                'illicit/violent': ['text'],
+                                'self-harm/intent': ['text'],
+                                'self-harm/instructions': ['text'],
+                                'self-harm': ['text'],
+                                'sexual/minors': ['text'],
+                                'violence': ['text'],
+                                'violence/graphic': ['text'],
+                            },
+                            'category_scores': {
+                                'harassment': 5.0333557545281144e-05,
+                                'harassment/threatening': 1.2533751425646102e-05,
+                                'sexual': 0.00012448433020883747,
+                                'hate': 3.740956047302422e-05,
+                                'hate/threatening': 1.6187581436151335e-06,
+                                'illicit': 3.077430764601415e-05,
+                                'illicit/violent': 1.442598644847886e-05,
+                                'self-harm/intent': 1.6442494559854523e-06,
+                                'self-harm/instructions': 1.2805474213228684e-06,
+                                'self-harm': 1.0391067562761452e-05,
+                                'sexual/minors': 3.120191139396651e-06,
+                                'violence': 0.0005852836038915696,
+                                'violence/graphic': 1.2339457598623173e-05,
+                            },
+                            'flagged': False,
+                            'model': 'omni-moderation-latest',
+                            'type': 'moderation_result',
+                        }
+                    ],
+                    'type': 'moderation_results',
+                },
+            },
+            'timestamp': IsDatetime(),
+        }
+    )
+
+
+async def test_openai_moderation_stream(allow_model_requests: None, openai_api_key: str):
+    """The streaming moderation chunk carries no choices, so it's read before the choice guard."""
+    model = OpenAIChatModel('gpt-5', provider=OpenAIProvider(api_key=openai_api_key))
+    settings = OpenAIChatModelSettings(openai_moderation={'model': 'omni-moderation-latest'})
+    agent = Agent(model=model, model_settings=settings)
+
+    async with agent.run_stream('What is the capital of France?') as result:
+        await result.get_output()
+
+    response = message(result.all_messages(), ModelResponse, index=-1)
+    assert response.provider_details == snapshot(
+        {
+            'timestamp': IsDatetime(),
+            'finish_reason': 'stop',
+            'moderation': {
+                'input': {
+                    'model': 'omni-moderation-latest',
+                    'results': [
+                        {
+                            'categories': {
+                                'harassment': False,
+                                'harassment/threatening': False,
+                                'sexual': False,
+                                'hate': False,
+                                'hate/threatening': False,
+                                'illicit': False,
+                                'illicit/violent': False,
+                                'self-harm/intent': False,
+                                'self-harm/instructions': False,
+                                'self-harm': False,
+                                'sexual/minors': False,
+                                'violence': False,
+                                'violence/graphic': False,
+                            },
+                            'category_applied_input_types': {
+                                'harassment': ['text'],
+                                'harassment/threatening': ['text'],
+                                'sexual': ['text'],
+                                'hate': ['text'],
+                                'hate/threatening': ['text'],
+                                'illicit': ['text'],
+                                'illicit/violent': ['text'],
+                                'self-harm/intent': ['text'],
+                                'self-harm/instructions': ['text'],
+                                'self-harm': ['text'],
+                                'sexual/minors': ['text'],
+                                'violence': ['text'],
+                                'violence/graphic': ['text'],
+                            },
+                            'category_scores': {
+                                'harassment': 1.5598027633743823e-05,
+                                'harassment/threatening': 2.212566909570261e-06,
+                                'sexual': 9.818326983657703e-07,
+                                'hate': 2.7803096387751555e-05,
+                                'hate/threatening': 1.0783312222985275e-06,
+                                'illicit': 0.005284363395662242,
+                                'illicit/violent': 3.514382632807918e-05,
+                                'self-harm/intent': 2.627477314480822e-06,
+                                'self-harm/instructions': 5.955139348629957e-07,
+                                'self-harm': 2.4682904407607285e-06,
+                                'sexual/minors': 1.9333584585546466e-07,
+                                'violence': 6.814872211615988e-06,
+                                'violence/graphic': 7.889262586245034e-07,
+                            },
+                            'flagged': False,
+                            'model': 'omni-moderation-latest',
+                            'type': 'moderation_result',
+                        }
+                    ],
+                    'type': 'moderation_results',
+                },
+                'output': {
+                    'model': 'omni-moderation-latest',
+                    'results': [
+                        {
+                            'categories': {
+                                'harassment': False,
+                                'harassment/threatening': False,
+                                'sexual': False,
+                                'hate': False,
+                                'hate/threatening': False,
+                                'illicit': False,
+                                'illicit/violent': False,
+                                'self-harm/intent': False,
+                                'self-harm/instructions': False,
+                                'self-harm': False,
+                                'sexual/minors': False,
+                                'violence': False,
+                                'violence/graphic': False,
+                            },
+                            'category_applied_input_types': {
+                                'harassment': ['text'],
+                                'harassment/threatening': ['text'],
+                                'sexual': ['text'],
+                                'hate': ['text'],
+                                'hate/threatening': ['text'],
+                                'illicit': ['text'],
+                                'illicit/violent': ['text'],
+                                'self-harm/intent': ['text'],
+                                'self-harm/instructions': ['text'],
+                                'self-harm': ['text'],
+                                'sexual/minors': ['text'],
+                                'violence': ['text'],
+                                'violence/graphic': ['text'],
+                            },
+                            'category_scores': {
+                                'harassment': 7.096703991005882e-05,
+                                'harassment/threatening': 5.829126566113866e-06,
+                                'sexual': 3.0061635882429376e-05,
+                                'hate': 2.3413582477639402e-05,
+                                'hate/threatening': 6.240930669504435e-07,
+                                'illicit': 1.15919343186331e-05,
+                                'illicit/violent': 6.922183404468203e-06,
+                                'self-harm/intent': 9.818326983657703e-07,
+                                'self-harm/instructions': 6.339210403977636e-07,
+                                'self-harm': 7.602479448313689e-06,
+                                'sexual/minors': 1.1843139025979655e-06,
+                                'violence': 0.0005185157653543439,
+                                'violence/graphic': 5.307507822667365e-06,
+                            },
+                            'flagged': False,
+                            'model': 'omni-moderation-latest',
+                            'type': 'moderation_result',
+                        }
+                    ],
+                    'type': 'moderation_results',
+                },
+            },
+        }
+    )
+
+
 @dataclass
 class MyDefaultDc:
     x: int = 1


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

David approved the design (the `openai_moderation` hoist) and the decision to ship; the implementation and its verification were AI-produced and independently checked, not read line-by-line by him.

- Closes #6634

## What this does

Surfaces OpenAI **Chat Completions** moderation results in [`ModelResponse.provider_details`][provider-details] under the `'moderation'` key, on both the non-streaming and streaming paths, and adds the typed request-side setting. This mirrors #6628, which did the same for the Responses API.

Previously `OpenAIChatModel` built `provider_details` only from `_process_provider_details(response)` (choice-scoped: logprobs + finish reason) plus timestamp/refusal, so the top-level `ChatCompletion.moderation` field was silently dropped even when the user requested moderation.

[provider-details]: https://ai.pydantic.dev/api/messages/#pydantic_ai.messages.ModelResponse.provider_details

## The `openai_moderation` hoist

`openai_moderation` moves **from `OpenAIResponsesModelSettings` up to `OpenAIChatModelSettings`**, so one setting serves both APIs and both `create()` calls consume it. This follows the existing in-file precedent for settings declared on the parent and consumed by both models: `openai_store`, `openai_logprobs`, `openai_top_logprobs`, `openai_user`, `openai_service_tier`.

This relocates public surface released in v2.15.0. It is non-breaking:

- `OpenAIResponsesModelSettings` subclasses `OpenAIChatModelSettings`, so it inherits the key — `OpenAIResponsesModelSettings(openai_moderation=...)` keeps working unchanged.
- The two SDK TypedDicts (`chat.completion_create_params.Moderation` and `responses.response_create_params.Moderation`) are distinct classes but structurally identical (`model: Required[str]`, `policy: Optional[ModerationPolicy]`), so a single shared declaration typechecks and the Responses `create(moderation=...)` call still passes Pyright.
- The docs cross-reference `[…][pydantic_ai.models.openai.OpenAIResponsesModelSettings.openai_moderation]` still resolves through the inherited member — verified with `mkdocs build` (no unresolved-reference warning; the rendered link points at the `OpenAIChatModelSettings.openai_moderation` anchor), same as the existing `OpenAIResponsesModelSettings.openai_store` reference on `main`.

There is deliberately no separate `openai_chat_moderation` name and no duplicate declaration.

## The streaming trap

The streaming moderation chunk arrives with **`choices == []`**. `OpenAIStreamedResponse._get_event_iterator` does `if not chunk.choices: continue` before any provider-details mapping, and `_map_provider_details` is choice-scoped (it receives `chunk.choices[0]`). So the read sits **above** that guard and cannot live in the mapping hook — a direct copy of the Responses implementation would silently drop the field on streaming.

On the non-streaming side the read is in `_process_response` alongside `timestamp`, rather than inside the overridable `_process_provider_details` hook, for the same reason: `moderation` is a top-level field, and subclasses (e.g. `OpenRouterModel`) override that hook and would drop it. The single existing hook call was hoisted above the refusal branch so the refusal and normal returns both carry moderation from one `if`.

One incidental edit: the new branch pushed `_get_event_iterator` to McCabe complexity 16 (limit 15), so the adjacent nested `if raw_finish_reason := …:` / `if not self._has_refusal:` pair was collapsed into one `and` condition — semantically identical.

## The two APIs return different payload shapes

Not a copy of the Responses wording — the payloads genuinely differ:

- **Responses**: `moderation.input` / `.output` carry the moderation-result fields flat.
- **Chat Completions**: `moderation.input` / `.output` are `type: 'moderation_results'` objects nesting the result one level deeper, under a `results` list.

`docs/models/openai.md` was corrected accordingly. The `### Moderation` section also moved out of the "Responses API features" block into `## Model settings`, next to `### Service tier` and `### Prompt caching` — the other settings that apply to both APIs.

## Tests

Real recorded VCR cassettes for both paths (`test_openai_moderation`, `test_openai_moderation_stream`), recorded live against `gpt-5` through the test functions themselves. The streaming cassette deliberately retains the choice-less moderation chunk, since it is the only chunk carrying the field — the VCR filters were checked to confirm nothing drops it.

## Deliberate scope calls

- **Recordings stay OpenAI-only.** `OpenAIChatModel` subclasses (Cerebras, Ollama, OpenRouter, Z.AI) inherit the read path for free, but their compatibility layers will not necessarily pass the `moderation` request param through, so recording against them would assert behavior we do not control.
- **Tests appended to `tests/models/test_openai.py`** rather than a new feature-centric file, so they sit diff-for-diff against `tests/models/test_openai_responses.py::test_openai_responses_moderation` for side-by-side review.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

