### PR TITLE
Add regression tests for mid-stream `usage` on the Google streaming path

### DIFF
--- a/tests/models/cassettes/test_google/test_google_stream_usage_is_live_mid_stream.yaml
+++ b/tests/models/cassettes/test_google/test_google_stream_usage_is_live_mid_stream.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, br, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '164'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+    method: POST
+    parsed_body:
+      contents:
+      - parts:
+        - text: Count from 1 to 30, one number per line, digits only.
+        role: user
+      generationConfig:
+        responseModalities:
+        - TEXT
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+  response:
+    body:
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"1\\n2\\n3\\n4\\n5\\n6\\n7\\n8\\n9\\n10\\n11\\n12\\n13\\n1\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 18,\"candidatesTokenCount\": 31,\"totalTokenCount\":
+        84,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 18}],\"thoughtsTokenCount\": 35,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"ru1garvBEoOiqtsP2fznmQw\"}\r\n\r\ndata: {\"candidates\":
+        [{\"content\": {\"parts\": [{\"text\": \"4\\n15\\n16\\n17\\n18\\n19\\n20\\n21\\n22\\n23\\n24\\n25\\n26\\n27\\n28\\n29\\n3\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 18,\"candidatesTokenCount\": 79,\"totalTokenCount\":
+        132,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 18}],\"thoughtsTokenCount\": 35,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"ru1garvBEoOiqtsP2fznmQw\"}\r\n\r\ndata: {\"candidates\":
+        [{\"content\": {\"parts\": [{\"text\": \"0\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 18,\"candidatesTokenCount\": 80,\"totalTokenCount\": 133,\"promptTokensDetails\": [{\"modality\":
+        \"TEXT\",\"tokenCount\": 18}],\"thoughtsTokenCount\": 35,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
+        \"ru1garvBEoOiqtsP2fznmQw\"}\r\n\r\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-disposition:
+      - attachment
+      content-type:
+      - text/event-stream
+      server-timing:
+      - gfet4t7; dur=859
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -4452,7 +4452,8 @@ async def test_google_stream_usage_limit_stops_stream_early(
 
     async def counting_stream() -> AsyncIterator[GenerateContentResponse]:
         nonlocal chunks_yielded
-        for chunk in chunks:
+        # The limit abandons the stream on the third chunk, so this loop never runs to completion.
+        for chunk in chunks:  # pragma: no branch
             chunks_yielded += 1
             yield chunk
 

--- a/tests/models/test_google.py
+++ b/tests/models/test_google.py
@@ -52,6 +52,7 @@ from pydantic_ai import (
     UsageLimitExceeded,
     UserPromptPart,
     VideoUrl,
+    capture_run_messages,
 )
 from pydantic_ai._utils import PeekableAsyncStream
 from pydantic_ai.agent import Agent
@@ -4282,15 +4283,16 @@ def _usage_chunk(
     return GenerateContentResponse.model_validate(data)
 
 
-async def _stream_gemini_usage(chunks: list[GenerateContentResponse]) -> RequestUsage:
-    async def response_iterator() -> AsyncIterator[GenerateContentResponse]:
-        for chunk in chunks:
-            yield chunk
+async def _aiter_chunks(chunks: list[GenerateContentResponse]) -> AsyncIterator[GenerateContentResponse]:
+    for chunk in chunks:
+        yield chunk
 
+
+async def _stream_gemini_usage(chunks: list[GenerateContentResponse]) -> RequestUsage:
     streamed_response = GeminiStreamedResponse(
         model_request_parameters=ModelRequestParameters(),
         _model_name='gemini-test',
-        _response=cast(Any, PeekableAsyncStream(response_iterator())),
+        _response=cast(Any, PeekableAsyncStream(_aiter_chunks(chunks))),
         _timestamp=IsDatetime(),
         _provider_name='google',
         _provider_url='',
@@ -4373,6 +4375,143 @@ async def test_gemini_streamed_response_usage_retained_across_chunks(case: _Usag
     without the cross-chunk merge.
     """
     assert await _stream_gemini_usage(case.make_chunks()) == case.expected
+
+
+async def test_google_stream_usage_is_live_mid_stream(allow_model_requests: None, google_provider: GoogleProvider):
+    """`usage` reflects the tokens billed so far while the response is still streaming.
+
+    Gemini reports `usage_metadata` on every chunk as a running total, and each one is extracted as it
+    arrives, so a caller reading `usage` part-way through a stream does not see zeros. Recorded
+    against the real API because that is what makes the guarantee true: the assertion below only
+    holds because the wire really does carry cumulative usage on every event, and an implementation
+    that extracted once at the end of the stream would read `(0, 0)` everywhere but the last entry.
+    See https://github.com/pydantic/pydantic-ai/issues/6641.
+    """
+    model = GoogleModel('gemini-2.5-flash', provider=google_provider)
+
+    agent = Agent(model=model)
+    usage_seen: list[tuple[int, int]] = []
+    async with agent.run_stream('Count from 1 to 30, one number per line, digits only.') as result:
+        async for _ in result.stream_text(debounce_by=None):
+            usage_seen.append((result.usage.input_tokens, result.usage.output_tokens))
+
+    # The prompt is long-running on purpose: a response arriving in a single frame would leave only a
+    # final reading, which a defer-to-end-of-stream implementation reproduces exactly. This guard
+    # fails if a re-recording ever collapses to one frame, rather than passing vacuously.
+    assert len(usage_seen) > 1
+    assert usage_seen == snapshot([(18, 66), (18, 114), (18, 115)])
+
+
+async def test_google_stream_usage_retains_dropped_field_mid_stream(
+    allow_model_requests: None, google_provider: GoogleProvider, mocker: MockerFixture
+):
+    """A field an earlier chunk carried survives at every mid-stream read once a later chunk drops it.
+
+    This is the https://github.com/pydantic/pydantic-ai/issues/5205 cross-chunk merge, asserted while
+    the stream is still arriving rather than only once it is exhausted, jointly with the liveness of
+    `output_tokens`. Those two properties together are what an implementation that batches or defers
+    extraction has to preserve, and pinning them separately leaves room to satisfy each alone while
+    under-reporting a dropped field part-way through.
+
+    Not a VCR test: the direct Gemini APIs always carry the field on the final usage chunk, so a real
+    recording cannot express a later chunk dropping it. `test_google_stream_usage_is_live_mid_stream`
+    covers the liveness half against a real recording.
+    """
+    chunks = [
+        _usage_chunk(candidates=5, cached=16365, text='x'),
+        _usage_chunk(candidates=10, text='x'),
+        _usage_chunk(candidates=15, text='x'),
+    ]
+    model = GoogleModel('gemini-2.5-flash', provider=google_provider)
+    mocker.patch.object(model.client.aio.models, 'generate_content_stream', return_value=_aiter_chunks(chunks))
+
+    agent = Agent(model=model)
+    usage_seen: list[tuple[int, int]] = []
+    async with agent.run_stream('Hello') as result:
+        async for _ in result.stream_text(debounce_by=None):
+            usage_seen.append((result.usage.output_tokens, result.usage.cache_read_tokens))
+
+    assert usage_seen == snapshot([(5, 16365), (10, 16365), (15, 16365)])
+
+
+async def test_google_stream_usage_limit_stops_stream_early(
+    allow_model_requests: None, google_provider: GoogleProvider, mocker: MockerFixture
+):
+    """An output-token limit aborts a Gemini stream while chunks are still arriving.
+
+    `test_stream_text_enforces_output_token_limit_mid_stream` covers the same guarantee generically
+    over `FunctionModel`, where the harness supplies the token counts. This pins it on a real model
+    whose counts come from extracting Gemini's cumulative per-chunk `usage_metadata`, which is the
+    path that has to stay live for the limit to fire before the response finishes streaming.
+
+    Not a VCR test: it asserts the stream is abandoned part-way through, which needs a chunk source
+    that can report how far it got.
+    """
+    chunks = [_usage_chunk(candidates=candidates, text='x') for candidates in (5, 10, 15, 20)]
+    chunks_yielded = 0
+
+    async def counting_stream() -> AsyncIterator[GenerateContentResponse]:
+        nonlocal chunks_yielded
+        for chunk in chunks:
+            chunks_yielded += 1
+            yield chunk
+
+    model = GoogleModel('gemini-2.5-flash', provider=google_provider)
+    mocker.patch.object(model.client.aio.models, 'generate_content_stream', return_value=counting_stream())
+
+    agent = Agent(model=model)
+    with pytest.raises(UsageLimitExceeded, match='Exceeded the output_tokens_limit of 12'):
+        async with agent.run_stream('Hello', usage_limits=UsageLimits(output_tokens_limit=12)) as result:
+            async for _ in result.stream_text(debounce_by=None):
+                pass
+
+    # Pins where the limit trips, not just that it tripped: summing the cumulative snapshots instead
+    # of replacing them would cross 12 at the second chunk and abort there, which a `< len(chunks)`
+    # bound would still accept while the reported total was wrong.
+    assert chunks_yielded == snapshot(3)
+
+
+async def test_google_stream_usage_survives_mid_stream_error(
+    allow_model_requests: None, google_provider: GoogleProvider, mocker: MockerFixture
+):
+    """Usage received before a mid-stream provider error reaches the reported response.
+
+    The partial response is still recorded, with `state='interrupted'`, so the tokens the provider
+    already billed for have to survive the error path rather than resetting to zero.
+
+    Not a VCR test: cassettes replay a complete response, so an error part-way through a stream that
+    has already delivered usage can't be recorded.
+    """
+
+    async def failing_stream() -> AsyncIterator[GenerateContentResponse]:
+        yield _usage_chunk(candidates=5, text='hel')
+        yield _usage_chunk(candidates=10, text='lo')
+        raise errors.ServerError(500, {'error': {'message': 'boom', 'status': 'INTERNAL'}})
+
+    model = GoogleModel('gemini-2.5-flash', provider=google_provider)
+    mocker.patch.object(model.client.aio.models, 'generate_content_stream', return_value=failing_stream())
+
+    agent = Agent(model=model)
+    with capture_run_messages() as messages:
+        with pytest.raises(ModelHTTPError):
+            async with agent.run_stream('Hello') as result:
+                async for _ in result.stream_text(debounce_by=None):
+                    pass
+
+    assert messages[-1] == snapshot(
+        ModelResponse(
+            parts=[TextPart(content='hello')],
+            usage=RequestUsage(input_tokens=20025, output_tokens=10),
+            model_name='gemini-test',
+            timestamp=IsDatetime(),
+            provider_name='google',
+            provider_url='https://generativelanguage.googleapis.com/',
+            provider_response_id='resp-1',
+            run_id=IsStr(),
+            conversation_id=IsStr(),
+            state='interrupted',
+        )
+    )
 
 
 async def _cleanup_file_search_store(store: Any, client: Any) -> None:  # pragma: lax no cover


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

David directed the approach and approved opening this. He did not review the wording of this description or line-edit the diff.

- Relates to https://github.com/pydantic/pydantic-ai/issues/6641

This PR does **not** close that issue. #6641 proposed deferring genai-prices usage extraction on the Google streaming path from per chunk to once per stream. That optimization was investigated and declined (measured at roughly 6% of the per-chunk loop, about 0.02% of stream wall time, and only reachable by breaking behavior). The issue is being closed separately with the full analysis.

What lands here is only the regression tests that pin the behavior the proposed optimization would have broken. They stand on their own as coverage.

### Tests added

`tests/models/test_google.py`:

- **`test_google_stream_usage_is_live_mid_stream`** (VCR) - reading `result.usage` inside a `run_stream` loop reflects the tokens billed so far, rather than zeros until the stream ends. Recorded against the real API, because the wire behavior is what makes the guarantee true: the cassette carries three SSE frames each with its own cumulative `usageMetadata`, and the snapshot `[(18, 66), (18, 114), (18, 115)]` is exactly what a defer-to-end-of-stream implementation would fail, since that would read `[(0, 0), (0, 0), (18, 115)]`. A `len(usage_seen) > 1` guard sits above the snapshot so a future re-recording that collapses to a single frame fails loudly instead of passing vacuously.
- **`test_google_stream_usage_retains_dropped_field_mid_stream`** - a field an earlier chunk carried survives at every mid-stream read once a later chunk drops it, jointly with `output_tokens` liveness. This is the https://github.com/pydantic/pydantic-ai/issues/5205 merge asserted mid-stream rather than only at exhaustion; pinning the two properties separately leaves room to satisfy each alone while under-reporting a dropped field part way through.
- **`test_google_stream_usage_limit_stops_stream_early`** - an `output_tokens_limit` abandons the stream part way through rather than being caught only after the whole response has streamed. `test_stream_text_enforces_output_token_limit_mid_stream` in `tests/test_usage_limits.py` already covers this generically over `FunctionModel`, where the harness supplies the token counts; this pins it on a real model whose counts come from extracting Gemini's cumulative per-chunk `usage_metadata`. It asserts the exact chunk the limit trips on, because a looser bound would stay green if a regression summed the cumulative snapshots instead of replacing them.
- **`test_google_stream_usage_survives_mid_stream_error`** - usage received before a mid-stream provider error reaches the recorded response, which comes back with `state='interrupted'` and its usage intact rather than zeroed. No test asserted usage on a response recorded after a mid-stream provider error before this, for any provider.

The three non-recorded tests each carry a note on why they are not VCR tests, per `tests/AGENTS.md`: a later chunk dropping a field, a stream abandoned part way through, and an error arriving after usage was already delivered are all things a complete recording cannot express.

### Deliberately not done

The stream-usage cluster stays in `tests/models/test_google.py` rather than moving to `tests/models/google/test_stream_usage.py`. Draining the per-provider monoliths is the repo's direction and the cut here is clean, but the move would drag a pre-existing parametrized test, five helpers and a fixture relocation into what is otherwise a focused regression-pin diff. Happy to do it separately.

### Refactor

`_stream_gemini_usage` (the helper behind the existing https://github.com/pydantic/pydantic-ai/issues/5205 regression test) now builds its chunk iterator through a small `_aiter_chunks` generator, shared with the new liveness test. No behavior change to the existing test.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

