### PR TITLE
Raise a consistent `ctx.enqueue()` error inside durable units across Temporal, DBOS, and Prefect

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_toolset.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias, cast
 
 from pydantic import Discriminator, Tag
@@ -191,11 +191,11 @@ def unwrap_tool_call_result(result: CallToolResult) -> Any:
 
 
 class EnqueueGuard(list[PendingMessage]):
-    """Replaces `ctx.pending_messages` inside durable-unit-wrapped tools, where enqueueing can't be supported.
+    """Replaces `ctx.pending_messages` inside a durable unit, where enqueueing can't be supported.
 
-    A durable unit's recorded output is replayed on recovery (DBOS) or cache hit (Prefect)
-    without re-executing the tool, so messages enqueued inside it would be silently dropped;
-    enqueueing raises the engine's explanatory `UserError` instead.
+    A durable unit's recorded output is replayed on recovery (DBOS), cache hit (Prefect), or
+    across the activity boundary (Temporal) without re-running the code, so messages enqueued
+    inside it would be silently dropped; enqueueing raises an explanatory `UserError` instead.
     """
 
     def __init__(self, message: str):
@@ -204,6 +204,32 @@ class EnqueueGuard(list[PendingMessage]):
 
     def append(self, pending: PendingMessage) -> None:
         raise UserError(self._message)
+
+
+def enqueue_not_supported_message(unit_noun: str, container_noun: str) -> str:
+    """The shared `ctx.enqueue()` error, worded for one engine's durable unit and container.
+
+    `unit_noun` is the engine's durable unit (`'activity'`/`'step'`/`'task'`) and
+    `container_noun` is its durable container (`'workflow'`/`'flow'`), so every engine
+    raises the same explanation with its own vocabulary.
+    """
+    return (
+        f'`ctx.enqueue()` is not supported inside a durable {unit_noun}: the durable runtime replays '
+        f"the {unit_noun}'s recorded result without re-running your code, so the enqueued messages "
+        f'would be dropped. Enqueue messages from {container_noun}-level code instead.'
+    )
+
+
+def guard_run_context_enqueue(
+    ctx: RunContext[AgentDepsT], *, unit_noun: str, container_noun: str
+) -> RunContext[AgentDepsT]:
+    """Return a copy of `ctx` whose `enqueue()` raises, for running user code inside a durable unit.
+
+    Used by the in-process engines (DBOS steps, Prefect tasks) that pass the live context into
+    the durable unit. Temporal reconstructs its context across the activity boundary and installs
+    the same guard in `deserialize_run_context` instead.
+    """
+    return replace(ctx, pending_messages=EnqueueGuard(enqueue_not_supported_message(unit_noun, container_noun)))
 
 
 def unwrap_recorded_tool_call_result(result: Any) -> Any:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_utils.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_utils.py
@@ -1,9 +1,7 @@
-from dataclasses import replace
-
 from dbos import DBOS
 from typing_extensions import TypedDict
 
-from pydantic_ai.durable_exec._toolset import EnqueueGuard
+from pydantic_ai.durable_exec._toolset import guard_run_context_enqueue
 from pydantic_ai.tools import AgentDepsT, RunContext
 
 
@@ -25,11 +23,4 @@ def guard_enqueue_in_workflow(ctx: RunContext[AgentDepsT]) -> RunContext[AgentDe
     """
     if DBOS.workflow_id is None:
         return ctx
-    return replace(
-        ctx,
-        pending_messages=EnqueueGuard(
-            '`ctx.enqueue()` is not supported inside DBOS step-wrapped tools because workflow '
-            'recovery replays the recorded step output and would drop the enqueued messages. '
-            'Enqueue messages from workflow-level code instead.'
-        ),
-    )
+    return guard_run_context_enqueue(ctx, unit_noun='step', container_noun='workflow')

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_dynamic_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_dynamic_toolset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import replace
 from typing import Any, cast
 
 from prefect import task
@@ -19,7 +18,7 @@ from pydantic_ai.durable_exec._toolset import (
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
-from ._toolset import enqueue_guard, resolve_tool_task_config, with_non_retryable_errors
+from ._toolset import guard_task_enqueue, resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 
@@ -38,7 +37,7 @@ def prefectify_dynamic_toolset(
 
     @task
     async def call_tool_task(tool_name: str, tool_args: dict[str, Any], ctx: RunContext[AgentDepsT]) -> Any:
-        task_ctx = replace(ctx, pending_messages=enqueue_guard())
+        task_ctx = guard_task_enqueue(ctx)
         return await wrap_tool_call_result(call_dynamic_tool(wrapped, tool_name, tool_args, task_ctx))
 
     async def call_tool_operation(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_function_toolset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import replace
 from typing import Any, cast
 
 from prefect import task
@@ -18,7 +17,7 @@ from pydantic_ai.durable_exec._toolset import (
 )
 from pydantic_ai.tools import AgentDepsT, RunContext
 
-from ._toolset import enqueue_guard, resolve_tool_task_config, with_non_retryable_errors
+from ._toolset import guard_task_enqueue, resolve_tool_task_config, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 
@@ -30,7 +29,7 @@ def _call_tool_operation(wrapped: FunctionToolset[AgentDepsT], base_config: Task
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
-        task_ctx = replace(ctx, pending_messages=enqueue_guard())
+        task_ctx = guard_task_enqueue(ctx)
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_mcp_toolset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from prefect import task
@@ -18,7 +17,7 @@ from pydantic_ai.durable_exec._toolset import (
 )
 from pydantic_ai.tools import AgentDepsT, RunContext
 
-from ._toolset import enqueue_guard, with_non_retryable_errors
+from ._toolset import guard_task_enqueue, with_non_retryable_errors
 from ._types import TaskConfig, default_task_config
 
 if TYPE_CHECKING:
@@ -34,7 +33,7 @@ def _call_tool_operation(wrapped: MCPToolset[AgentDepsT], base_config: TaskConfi
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
         # The context is guarded because a `process_tool_call=` hook receives it and could enqueue.
-        task_ctx = replace(ctx, pending_messages=enqueue_guard())
+        task_ctx = guard_task_enqueue(ctx)
         return await wrap_tool_call_result(wrapped.call_tool(tool_name, tool_args, task_ctx, tool))
 
     async def call_tool_operation(

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_toolset.py
@@ -5,19 +5,17 @@ from collections.abc import Mapping
 from typing import Any, Literal, cast
 
 from pydantic_ai import AbstractToolset, FunctionToolset, ToolsetTool
-from pydantic_ai.durable_exec._toolset import EnqueueGuard
+from pydantic_ai.durable_exec._toolset import guard_run_context_enqueue
 from pydantic_ai.exceptions import UnexpectedModelBehavior, UserError
-from pydantic_ai.tools import AgentDepsT
+from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
 from ._types import TaskConfig
 
 
-def enqueue_guard() -> EnqueueGuard:
-    return EnqueueGuard(
-        '`ctx.enqueue()` is not supported inside Prefect task-wrapped tools because task-cache replay '
-        'would drop the enqueued messages. Enqueue messages from flow-level code instead.'
-    )
+def guard_task_enqueue(ctx: RunContext[AgentDepsT]) -> RunContext[AgentDepsT]:
+    """Make `ctx.enqueue()` raise inside a Prefect task-wrapped tool call."""
+    return guard_run_context_enqueue(ctx, unit_noun='task', container_noun='flow')
 
 
 def with_non_retryable_errors(config: TaskConfig) -> TaskConfig:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_run_context.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/_run_context.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import TypeAdapter
 from typing_extensions import TypeVar
 
+from pydantic_ai.durable_exec._toolset import EnqueueGuard, enqueue_not_supported_message
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage, UsageLimits
@@ -106,4 +107,9 @@ def deserialize_run_context(
     if agent is not None:
         ctx.__dict__['agent'] = agent
         ctx.__dict__['root_capability'] = agent.root_capability
+    # `pending_messages` isn't serialized across the activity boundary, and any code running inside
+    # an activity (a tool, a `process_tool_call` hook, an `event_stream_handler`) is in a durable
+    # unit whose result is replayed without re-running it, so an enqueue would be dropped. Install
+    # the same guard the in-process engines use so `ctx.enqueue()` raises the shared explanation.
+    ctx.__dict__['pending_messages'] = EnqueueGuard(enqueue_not_supported_message('activity', 'workflow'))
     return ctx

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2380,7 +2380,7 @@ async def test_dbos_mcp_step_rejects_enqueue_in_workflow(dbos: DBOS, monkeypatch
     async def run_workflow() -> None:
         await durable.call_tool('hook', {}, run_context, tool)
 
-    with pytest.raises(UserError, match='recovery replays the recorded step output'):
+    with pytest.raises(UserError, match='enqueued messages would be dropped'):
         await run_workflow()
 
     # Outside a workflow the step degrades to a plain call and enqueueing keeps working.
@@ -2413,7 +2413,7 @@ async def test_dbos_dynamic_tool_rejects_enqueue_in_workflow(dbos: DBOS) -> None
     async def run_workflow() -> None:
         await agent.run('run')
 
-    with pytest.raises(UserError, match='recovery replays the recorded step output'):
+    with pytest.raises(UserError, match='enqueued messages would be dropped'):
         await run_workflow()
 
     await agent.run('run')

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -2652,7 +2652,7 @@ async def test_prefect_task_wrapped_tool_rejects_enqueue() -> None:
     async def run_agent() -> None:
         await agent.run('run')
 
-    with pytest.raises(UserError, match='task-cache replay would drop the enqueued messages'):
+    with pytest.raises(UserError, match='enqueued messages would be dropped'):
         await run_agent()
 
     # Outside a flow the tool runs inline and enqueueing keeps working.
@@ -2683,7 +2683,7 @@ async def test_prefect_mcp_task_wrapped_call_rejects_enqueue(monkeypatch: pytest
     async def run_tool() -> None:
         await durable.call_tool('hook', {}, ctx, tool)
 
-    with pytest.raises(UserError, match='task-cache replay would drop the enqueued messages'):
+    with pytest.raises(UserError, match='enqueued messages would be dropped'):
         await run_tool()
 
     # Outside a flow the call runs inline and enqueueing keeps working.

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -3771,6 +3771,25 @@ def test_temporal_run_context_excludes_agent():
     assert agent.name == 'test_agent'
 
 
+def test_temporal_run_context_enqueue_raises_inside_activity():
+    """`ctx.enqueue()` inside a Temporal activity raises the shared durable explanation.
+
+    `pending_messages` isn't serialized across the activity boundary, so any code running
+    activity-side (a tool, a `process_tool_call` hook, an `event_stream_handler`) is in a
+    durable unit whose result is replayed without re-running it; an enqueue would be dropped.
+    """
+    from pydantic_ai.durable_exec.temporal._run_context import deserialize_run_context
+
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage(), run_id='run-123')
+    serialized = TemporalRunContext.serialize_run_context(ctx)
+    reconstructed = deserialize_run_context(TemporalRunContext, serialized, deps=None, agent=None)
+
+    with pytest.raises(UserError, match='enqueued messages would be dropped'):
+        reconstructed.enqueue('later')
+    # An empty enqueue stays a no-op, matching a normal run.
+    assert reconstructed.enqueue() is None
+
+
 def test_temporal_run_context_serializes_usage():
     ctx = RunContext(
         deps=None,


### PR DESCRIPTION
Follow-up to #6640.

`ctx.enqueue()` can't be honored inside any engine's durable unit — the recorded result is replayed on recovery (DBOS), cache hit (Prefect), or across the activity boundary (Temporal) without re-running the code, so the enqueued messages would be silently dropped. #6640 made DBOS and Prefect raise a tailored `UserError` for this, but:

- Each engine hardcoded its own wording, so the same situation produced three different (or missing) messages.
- Temporal raised nothing tailored. Because `pending_messages` isn't serialized across the activity boundary, `ctx.enqueue()` inside a Temporal activity actually hit `TemporalRunContext`'s attribute guard and raised a *misleading* error telling the user to subclass `TemporalRunContext` to "make the attribute available" — which wouldn't have made enqueue work.

### Changes

- **Shared message + guard** in `durable_exec/_toolset.py`:
  - `enqueue_not_supported_message(unit_noun, container_noun)` builds one explanation, worded with each engine's own vocabulary (`step`/`workflow`, `task`/`flow`, `activity`/`workflow`).
  - `guard_run_context_enqueue(ctx, *, unit_noun, container_noun)` installs the `EnqueueGuard` for the in-process engines.
- **DBOS** and **Prefect** delegate to the shared helpers; the per-engine `enqueue_guard()` factory and hardcoded `EnqueueGuard(...)` strings are gone. DBOS keeps its "outside a workflow, steps degrade to plain calls" gate.
- **Temporal** installs the guard once, in `deserialize_run_context`, so any activity-side user code — a tool, a `process_tool_call=` hook, or an `event_stream_handler` — raises the shared error instead of the misleading attribute error. A single choke point means a future activity type is covered automatically.

The net effect is one consistent, engine-appropriate error across all three integrations, and a future durable engine gets the same behavior by calling one helper.

### Note for review

This guards enqueue at the **tool-call** boundary for DBOS/Prefect (matching #6640), and — because Temporal reconstructs its context once per activity — incidentally also covers Temporal's `event_stream_handler` activity. The equivalent DBOS/Prefect event-handler step/task is a smaller, separate instance of the same class (an event handler that enqueues inside a durable unit would also be dropped); I left it out of this change to keep it focused, and can follow up if you'd like it guarded uniformly.

### Verification

All three durability suites pass on the rebased branch (DBOS 112, Prefect 103, Temporal 195 +2 skipped). Changed files are at 100% statement + branch coverage under their own suites; pyright- and ruff-clean.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

