### PR TITLE
Guard `ctx.enqueue()` from an `event_stream_handler` inside DBOS steps / Prefect tasks

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -22,6 +22,7 @@ from pydantic_ai.toolsets._capability_owned import CapabilityOwnedToolset
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
 from ._runtime_toolsets import RuntimeToolsetKind, reject_unsupported_runtime_toolsets
+from ._toolset import guard_run_context_enqueue
 from ._utils import unwrap_model
 
 _MODEL_RESPONSE_STREAM_EVENT_TYPES = get_union_args(ModelResponseStreamEvent)
@@ -262,6 +263,22 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         # objects) is not spec-serializable, and a durable agent additionally has to be constructed in
         # worker-setup code for its durable units to be registered.
         return None
+
+    def _durable_run_context(self, ctx: RunContext[AgentDepsT]) -> RunContext[AgentDepsT]:
+        """The run context to hand to user code running inside this engine's durable unit.
+
+        User code inside a durable unit (a tool call, a `process_tool_call` hook, an
+        `event_stream_handler`) can't enqueue: the unit's recorded result is replayed on
+        recovery/cache-hit without re-running the code, so an enqueued message would be
+        dropped. This installs the shared `EnqueueGuard` so `enqueue()` raises a clear error
+        instead. Engines whose durable unit degrades to an inline call outside the container
+        (e.g. a DBOS step outside a workflow) override to pass the context through unchanged
+        there; Temporal reconstructs its context across the activity boundary and installs the
+        same guard in `deserialize_run_context`.
+        """
+        return guard_run_context_enqueue(
+            ctx, unit_noun=self._durable_unit_noun, container_noun=self._durable_container_noun
+        )
 
     @abstractmethod
     async def _dispatch_event_stream_event(self, ctx: RunContext[AgentDepsT], event: AgentStreamEvent) -> None:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/_base.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import copy
 from abc import abstractmethod
-from collections.abc import AsyncIterable, AsyncIterator, Mapping
+from collections.abc import AsyncIterable, AsyncIterator, Generator, Mapping
+from contextlib import contextmanager
 from typing import Any, ClassVar
 
 from typing_extensions import Self
 
+from pydantic_ai._run_context import set_current_run_context
 from pydantic_ai._utils import get_union_args
 from pydantic_ai.agent import EventStreamHandler
 from pydantic_ai.agent.abstract import AbstractAgent
@@ -279,6 +281,18 @@ class BaseDurabilityCapability(AbstractCapability[AgentDepsT]):
         return guard_run_context_enqueue(
             ctx, unit_noun=self._durable_unit_noun, container_noun=self._durable_container_noun
         )
+
+    @contextmanager
+    def _durable_run_context_scope(self, ctx: RunContext[AgentDepsT]) -> Generator[RunContext[AgentDepsT]]:
+        """Run user code inside a durable unit with `ctx` guarded and set as the ambient context.
+
+        Both the yielded context and `get_current_run_context()` are guarded, so user code can't
+        enqueue whether it reads its argument or the ambient getter (Temporal gets the same guard
+        because its activity-side context comes from `deserialize_run_context`).
+        """
+        guarded = self._durable_run_context(ctx)
+        with set_current_run_context(guarded):
+            yield guarded
 
     @abstractmethod
     async def _dispatch_event_stream_event(self, ctx: RunContext[AgentDepsT], event: AgentStreamEvent) -> None:

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
@@ -164,12 +164,12 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
             run_context: RunContext[Any],
         ) -> StreamedActivityResult:
             model = await self._resolve_model_for_request(model_id, run_context)
-            with set_current_run_context(run_context):
+            with self._durable_run_context_scope(run_context) as ctx:
                 async with model.request_stream(
-                    messages, model_settings, model_request_parameters, run_context
+                    messages, model_settings, model_request_parameters, ctx
                 ) as streamed_response:
                     events = await capture_event_stream(
-                        run_context=self._durable_run_context(run_context),
+                        run_context=ctx,
                         stream=streamed_response,
                         handler=self._effective_event_stream_handler(),
                     )
@@ -195,7 +195,8 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
             ) -> None:
                 handler = self._effective_event_stream_handler()
                 assert handler is not None
-                await handler(self._durable_run_context(run_context), self._single_event_stream(event))
+                with self._durable_run_context_scope(run_context) as ctx:
+                    await handler(ctx, self._single_event_stream(event))
 
             self._event_stream_handler_step = event_stream_handler_step
 

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/dbos/_durability.py
@@ -28,7 +28,7 @@ from pydantic_ai.toolsets import AbstractToolset, WrapperToolset
 from pydantic_ai.toolsets._dynamic import DynamicToolset
 
 from ._agent import DBOSParallelExecutionMode
-from ._utils import StepConfig
+from ._utils import StepConfig, guard_enqueue_in_workflow
 
 
 @dataclass(init=False)
@@ -169,7 +169,7 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
                     messages, model_settings, model_request_parameters, run_context
                 ) as streamed_response:
                     events = await capture_event_stream(
-                        run_context=run_context,
+                        run_context=self._durable_run_context(run_context),
                         stream=streamed_response,
                         handler=self._effective_event_stream_handler(),
                     )
@@ -195,7 +195,7 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
             ) -> None:
                 handler = self._effective_event_stream_handler()
                 assert handler is not None
-                await handler(run_context, self._single_event_stream(event))
+                await handler(self._durable_run_context(run_context), self._single_event_stream(event))
 
             self._event_stream_handler_step = event_stream_handler_step
 
@@ -243,11 +243,17 @@ class DBOSDurability(BaseDurabilityCapability[AgentDepsT]):
     def in_durable_context(self) -> bool:
         return DBOS.workflow_id is not None and DBOS.step_id is None
 
+    def _durable_run_context(self, ctx: RunContext[AgentDepsT]) -> RunContext[AgentDepsT]:
+        # A DBOS step degrades to a plain inline call outside a workflow, where enqueueing is
+        # safe, so only guard once actually inside a workflow.
+        return guard_enqueue_in_workflow(ctx)
+
     async def _dispatch_event_stream_event(self, ctx: RunContext[AgentDepsT], event: AgentStreamEvent) -> None:
         if self._in_legacy_workflow.get():
             # Wrapper-era recordings contain no `__event_stream_handler` steps (the wrapper called
             # the handler directly in workflow code), so a legacy run must do the same to keep the
-            # recorded step sequence replayable.
+            # recorded step sequence replayable. The handler runs at workflow level here, not inside
+            # a step, so the enqueue guard doesn't apply — matching how the wrapper delivered it.
             handler = self._effective_event_stream_handler()
             assert handler is not None
             await handler(ctx, self._single_event_stream(event))

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
@@ -150,12 +150,12 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
             run_context: RunContext[Any],
         ) -> StreamedActivityResult:
             model = await self._resolve_model_for_request(model_id, run_context)
-            with set_current_run_context(run_context):
+            with self._durable_run_context_scope(run_context) as ctx:
                 async with model.request_stream(
-                    messages, model_settings, model_request_parameters, run_context
+                    messages, model_settings, model_request_parameters, ctx
                 ) as streamed_response:
                     events = await capture_event_stream(
-                        run_context=self._durable_run_context(run_context),
+                        run_context=ctx,
                         stream=streamed_response,
                         handler=self._event_stream_handler,
                     )
@@ -185,11 +185,11 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
     async def _dispatch_event_stream_event(self, ctx: RunContext[AgentDepsT], event: AgentStreamEvent) -> None:
         assert self._event_stream_handler is not None
         handler = self._event_stream_handler
-        task_ctx = self._durable_run_context(ctx)
 
         @task(name='Handle Stream Event', **self._event_stream_handler_task_config)
         async def event_stream_handler_task(stream_event: AgentStreamEvent, sequence: int) -> None:
-            await handler(task_ctx, self._single_event_stream(stream_event))
+            with self._durable_run_context_scope(ctx) as task_ctx:
+                await handler(task_ctx, self._single_event_stream(stream_event))
 
         # The sequence number makes content-identical events within one flow run each fire
         # (distinct task-cache keys) while a flow retry that re-executes the same run

--- a/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
+++ b/pydantic_ai_slim/pydantic_ai/durable_exec/prefect/_durability.py
@@ -155,7 +155,7 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
                     messages, model_settings, model_request_parameters, run_context
                 ) as streamed_response:
                     events = await capture_event_stream(
-                        run_context=run_context,
+                        run_context=self._durable_run_context(run_context),
                         stream=streamed_response,
                         handler=self._event_stream_handler,
                     )
@@ -185,10 +185,11 @@ class PrefectDurability(BaseDurabilityCapability[AgentDepsT]):
     async def _dispatch_event_stream_event(self, ctx: RunContext[AgentDepsT], event: AgentStreamEvent) -> None:
         assert self._event_stream_handler is not None
         handler = self._event_stream_handler
+        task_ctx = self._durable_run_context(ctx)
 
         @task(name='Handle Stream Event', **self._event_stream_handler_task_config)
         async def event_stream_handler_task(stream_event: AgentStreamEvent, sequence: int) -> None:
-            await handler(ctx, self._single_event_stream(stream_event))
+            await handler(task_ctx, self._single_event_stream(stream_event))
 
         # The sequence number makes content-identical events within one flow run each fire
         # (distinct task-cache keys) while a flow retry that re-executes the same run

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2971,6 +2971,34 @@ async def test_dbos_durability_event_stream_handler(dbos: DBOS) -> None:
     assert 'durability_handler__event_stream_handler' in step_names
 
 
+async def test_dbos_durability_event_stream_handler_rejects_enqueue(dbos: DBOS) -> None:
+    """An `event_stream_handler` that enqueues inside a durable step raises, like a tool would.
+
+    The handler runs inside a durable step for both model events (the model-request step) and
+    graph events (the `__event_stream_handler` step); either step's recorded result is replayed
+    without re-running it, so an enqueue would be dropped. This exercises the graph-event path.
+    """
+
+    async def handler(ctx: RunContext[object], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        async for event in stream:
+            if isinstance(event, FunctionToolCallEvent):
+                ctx.enqueue('later')
+
+    async def handled_tool() -> str:
+        return 'handled'
+
+    durability = DBOSDurability(event_stream_handler=handler)
+    agent = Agent(TestModel(), name='durability_handler_enqueue', tools=[handled_tool], capabilities=[durability])
+
+    @DBOS.workflow()
+    async def run_durable_agent() -> str:
+        return (await agent.run('Hello')).output
+
+    with SetWorkflowID(str(uuid.uuid4())):
+        with pytest.raises(UserError, match='enqueued messages would be dropped'):
+            await run_durable_agent()
+
+
 async def test_dbos_durability_event_stream_handler_outside_workflow(dbos: DBOS) -> None:
     events: list[AgentStreamEvent] = []
 

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -2976,13 +2976,16 @@ async def test_dbos_durability_event_stream_handler_rejects_enqueue(dbos: DBOS) 
 
     The handler runs inside a durable step for both model events (the model-request step) and
     graph events (the `__event_stream_handler` step); either step's recorded result is replayed
-    without re-running it, so an enqueue would be dropped. This exercises the graph-event path.
+    without re-running it, so an enqueue would be dropped. The handler catches the error on every
+    event so the run still completes, exercising both delivery paths.
     """
+    enqueue_errors: list[str] = []
 
     async def handler(ctx: RunContext[object], stream: AsyncIterable[AgentStreamEvent]) -> None:
-        async for event in stream:
-            if isinstance(event, FunctionToolCallEvent):
+        async for _ in stream:
+            with pytest.raises(UserError, match='enqueued messages would be dropped') as exc_info:
                 ctx.enqueue('later')
+            enqueue_errors.append(str(exc_info.value))
 
     async def handled_tool() -> str:
         return 'handled'
@@ -2995,8 +2998,9 @@ async def test_dbos_durability_event_stream_handler_rejects_enqueue(dbos: DBOS) 
         return (await agent.run('Hello')).output
 
     with SetWorkflowID(str(uuid.uuid4())):
-        with pytest.raises(UserError, match='enqueued messages would be dropped'):
-            await run_durable_agent()
+        await run_durable_agent()
+    # Guarded on both the model-event (model-request step) and graph-event (dispatch step) paths.
+    assert len(enqueue_errors) > 1
 
 
 async def test_dbos_durability_event_stream_handler_outside_workflow(dbos: DBOS) -> None:

--- a/tests/test_dbos.py
+++ b/tests/test_dbos.py
@@ -38,6 +38,7 @@ from pydantic_ai import (
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai._run_context import get_current_run_context
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.capabilities import MCP, Capability, DynamicCapability
 from pydantic_ai.capabilities.abstract import AbstractCapability
@@ -2985,6 +2986,12 @@ async def test_dbos_durability_event_stream_handler_rejects_enqueue(dbos: DBOS) 
         async for _ in stream:
             with pytest.raises(UserError, match='enqueued messages would be dropped') as exc_info:
                 ctx.enqueue('later')
+            # The ambient current context is guarded too, so reading it instead of the argument
+            # doesn't bypass the guard.
+            ambient = get_current_run_context()
+            assert ambient is not None
+            with pytest.raises(UserError, match='enqueued messages would be dropped'):
+                ambient.enqueue('later')
             enqueue_errors.append(str(exc_info.value))
 
     async def handled_tool() -> str:

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -40,6 +40,7 @@ from pydantic_ai import (
     UserPromptPart,
 )
 from pydantic_ai._deferred_capabilities import LoadCapabilityReturnPart
+from pydantic_ai._run_context import get_current_run_context
 from pydantic_ai._warnings import PydanticAIDeprecationWarning
 from pydantic_ai.capabilities import (
     MCP,
@@ -2625,6 +2626,12 @@ async def test_prefect_durability_event_stream_handler_rejects_enqueue() -> None
         async for _ in stream:
             with pytest.raises(UserError, match='enqueued messages would be dropped') as exc_info:
                 ctx.enqueue('later')
+            # The ambient current context is guarded too, so reading it instead of the argument
+            # doesn't bypass the guard.
+            ambient = get_current_run_context()
+            assert ambient is not None
+            with pytest.raises(UserError, match='enqueued messages would be dropped'):
+                ambient.enqueue('later')
             enqueue_errors.append(str(exc_info.value))
 
     async def handled_tool() -> str:

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -2611,6 +2611,33 @@ async def test_prefect_durability_event_stream_handler() -> None:
     assert any(isinstance(event, FinalResultEvent) for event in events)
 
 
+async def test_prefect_durability_event_stream_handler_rejects_enqueue() -> None:
+    """An `event_stream_handler` that enqueues inside a durable task raises, like a tool would.
+
+    The handler runs inside a durable task for both model events (the model-request task) and
+    graph events (the `Handle Stream Event` task); either task's cached result is replayed without
+    re-running it, so an enqueue would be dropped. This exercises the graph-event path.
+    """
+
+    async def handler(ctx: RunContext[object], stream: AsyncIterable[AgentStreamEvent]) -> None:
+        async for event in stream:
+            if isinstance(event, FunctionToolCallEvent):
+                ctx.enqueue('later')
+
+    async def handled_tool() -> str:
+        return 'handled'
+
+    durability = PrefectDurability(event_stream_handler=handler)
+    agent = Agent(TestModel(), name='durability_handler_enqueue', tools=[handled_tool], capabilities=[durability])
+
+    @flow
+    async def run_durable_agent() -> str:
+        return (await agent.run('Hello')).output
+
+    with pytest.raises(UserError, match='enqueued messages would be dropped'):
+        await run_durable_agent()
+
+
 async def test_prefect_durability_identical_events_are_dispatched_twice() -> None:
     calls = 0
 

--- a/tests/test_prefect.py
+++ b/tests/test_prefect.py
@@ -2616,13 +2616,16 @@ async def test_prefect_durability_event_stream_handler_rejects_enqueue() -> None
 
     The handler runs inside a durable task for both model events (the model-request task) and
     graph events (the `Handle Stream Event` task); either task's cached result is replayed without
-    re-running it, so an enqueue would be dropped. This exercises the graph-event path.
+    re-running it, so an enqueue would be dropped. The handler catches the error on every event so
+    the run still completes, exercising both delivery paths.
     """
+    enqueue_errors: list[str] = []
 
     async def handler(ctx: RunContext[object], stream: AsyncIterable[AgentStreamEvent]) -> None:
-        async for event in stream:
-            if isinstance(event, FunctionToolCallEvent):
+        async for _ in stream:
+            with pytest.raises(UserError, match='enqueued messages would be dropped') as exc_info:
                 ctx.enqueue('later')
+            enqueue_errors.append(str(exc_info.value))
 
     async def handled_tool() -> str:
         return 'handled'
@@ -2634,8 +2637,9 @@ async def test_prefect_durability_event_stream_handler_rejects_enqueue() -> None
     async def run_durable_agent() -> str:
         return (await agent.run('Hello')).output
 
-    with pytest.raises(UserError, match='enqueued messages would be dropped'):
-        await run_durable_agent()
+    await run_durable_agent()
+    # Guarded on both the model-event (model-request task) and graph-event (dispatch task) paths.
+    assert len(enqueue_errors) > 1
 
 
 async def test_prefect_durability_identical_events_are_dispatched_twice() -> None:


### PR DESCRIPTION
Closes #6669. Follow-up to #6640 / #6666.

An `event_stream_handler` runs inside a durable unit — model events inside the model-request step/task, graph events inside the dedicated event-handler step/task — so a `ctx.enqueue()` from the handler faced the same silent-drop hazard the tool-call paths did (the unit's recorded result is replayed without re-running the code, so the enqueued message is lost). The handler's context was unguarded on DBOS and Prefect. Temporal was already covered: #6666 guards every activity-side context in `deserialize_run_context`.

### A general "durable run context" rather than another scattered guard call

DouweM asked for a more standardized way to get a durable-safe run context instead of remembering to guard at each site. This adds it:

- `BaseDurabilityCapability._durable_run_context(ctx)` returns the context to hand to user code running inside the engine's durable unit, installing the shared `EnqueueGuard`. The base default derives its message from the engine's own `_durable_unit_noun` / `_durable_container_noun`.
- DBOS overrides it to pass the context through unchanged outside a workflow, where its steps degrade to plain inline calls and enqueueing is safe. Prefect and future engines can use the default.
- Both the model-request `capture_event_stream` call and the event-handler dispatch now route the context through `_durable_run_context`, so both event-delivery paths are guarded consistently.

The DBOS legacy-workflow arm (`register_legacy_workflows`) delivers the handler at workflow level, not inside a step, to keep wrapper-era recordings replayable — so the guard doesn't apply there, matching how the wrapper delivered it. Noted in a code comment.

Net: a future durable engine gets consistent enqueue-guarding for both tools and event handlers by defining `_durable_run_context` once (or inheriting the default).

### Verification

All three durability suites pass (DBOS 113, Prefect 104, Temporal 195 +2 skipped), including new per-engine tests asserting an event handler that enqueues raises the shared error. Changed files are at 100% statement + branch coverage; pyright- and ruff-clean.

### Checklist

- [ ] Any **AI generated code** has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No **breaking changes** in accordance with the [version policy](https://github.com/pydantic/pydantic-ai/blob/main/docs/version-policy.md).
- [x] **PR title** is fit for the [release changelog](https://github.com/pydantic/pydantic-ai/releases).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/pydantic-ai/pull/6671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

